### PR TITLE
debug(#24): enable Draw3D coordinate diagnostics

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -39,7 +39,7 @@ local config = {
   autoLoadSetup = true,
   racingLineMode = "best",
   --- Verbose: log Draw3D/data counts every ~2s to `ac.log` (troubleshooting only).
-  enableDraw3DDiagnostics = false,
+  enableDraw3DDiagnostics = true,
   coachingHoldSeconds = 15,
   --- Optional `ws://127.0.0.1:8765` when Python sidecar is running (`pip install -e ".[coaching]"` then `python -m tools.ai_sidecar`). Applied once at script load; reload the app to change.
   wsSidecarUrl = "",


### PR DESCRIPTION
## Summary
Flips `enableDraw3DDiagnostics` to `true` so coordinate logging runs in-game.

Every 2s the AC log will show:
- `[COPILOT] carPos=X,Y,Z` — car world position
- `[COPILOT] bp[1] px=... py=... pz=...` — first brake point coords
- `[COPILOT] line[1] x=... y=... z=...` — racing line start
- `[COPILOT] line[mid] x=... y=... z=...` — racing line midpoint

**After testing:** flip back to `false` or remove this commit.

Fixes #24 (investigation)

## Test plan
- [ ] Deploy, drive 1 lap
- [ ] Check AC log for `[COPILOT]` lines
- [ ] Compare car position with brake point / line coords

🤖 Generated with [Claude Code](https://claude.com/claude-code)