### PR TITLE
docs(vault): post-merge handoff for PR #83

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-04-21
+last_updated: 2026-04-22
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -16,13 +16,13 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
-## Stream A — Rig screen Phase-2 UI (PR #83 + follow-on)
+## Stream A — Rig screen Phase-2 UI (post-PR #83)
 
 **Status:** PR [#83](https://github.com/agorokh/ac-copilot-trainer/pull/83)
-**end-to-end working** as of 2026-04-21 21:00 PT. Sidecar accepts the
-ESP32 with token, device emits `{v:1,type:"action",name:"toggleFocusPractice"}`
-every 10 s, display renders via `Arduino_Canvas`. User is doing code
-review and designing visuals.
+is merged to `main` (2026-04-22). End-to-end path is working: sidecar
+accepts ESP32 with token, device emits
+`{v:1,type:"action",name:"toggleFocusPractice"}` every 10 s, and display
+renders via `Arduino_Canvas`.
 
 **Next:** Phase-2 LVGL bring-up per
 [`01_Decisions/screen-ui-stack-lvgl-touch.md`](../01_Decisions/screen-ui-stack-lvgl-touch.md):
@@ -50,8 +50,6 @@ Porsche 911 GT3 R.
 
 ## Priority call
 
-Stream A is the user's hot path — physical device works for the first
-time and they want to push to real touch UI. Stream B (CSP apps) is the
-research/design phase happening in parallel. Stream C is pre-existing
-backlog; pick it up only after A reaches "real tile toggles
-focusPractice in-game".
+Stream A is the user's hot path: move from working transport to real touch
+UI (LVGL + tile actions). Stream B (CSP apps) is the research/design
+phase in parallel. Stream C remains pre-existing backlog.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-04-21
+last_updated: 2026-04-22
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -18,7 +18,7 @@ relates_to:
 
 # Next session handoff
 
-## Resume here (2026-04-21, end of day)
+## Resume here (2026-04-22, post-merge follow-up)
 
 **End-to-end rig screen ↔ sidecar is working.** PR [#83](https://github.com/agorokh/ac-copilot-trainer/pull/83)
 landed the sidecar `--external-bind`/`--token`, protocol v1 `{v,type}`
@@ -59,9 +59,11 @@ rig touchscreen to those CSP apps too).
    ADR (`01_Decisions/screen-and-csp-apps-integration.md`) will codify
    the strategy (read-only state scrape vs. cooperative same-VM call).
 
-4. **Once PR #83 merges:** the orchestrator should run post-merge steward
-   propagation against `main`; vault changes from this session are
-   already on the feat branch.
+4. **Post-merge stewardship (PR #83) ran on 2026-04-22** against `main`.
+   Classification highlights to review manually:
+   - dependency-related files changed
+   - `scripts/` changed
+   - `.github/workflows/` changed
 
 ## What was delivered today (2026-04-21)
 


### PR DESCRIPTION
## Summary
- update vault handoff notes for merged PR #83
- mark post-merge stewardship run as completed on 2026-04-22
- carry forward next concrete work items for screen Phase-2 and CSP integration

## Test plan
- [x] Run `scripts/post_merge_sync.sh sync 83`
- [x] Run `py -3 scripts/post_merge_classify.py --pr 83` (with `PYTHONUTF8=1`)
- [x] Run `scripts/post_merge_sync.sh vault 83`
- [x] Run lightweight vault follow-up check

## Summary by Sourcery

Documentation:
- Refresh current focus and next-session handoff notes to mark PR #83 as merged, confirm end-to-end rig-to-sidecar path is working, and clarify upcoming LVGL UI and CSP integration work items.