### PR TITLE
docs(vault): post-merge handoff for PR #87

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-04-24T21:14:00Z
+last_updated: 2026-04-24T22:30:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -17,13 +17,6 @@ relates_to:
 # Current focus
 
 **Repo:** ac-copilot-trainer.
-
-## Stream T — Template-sync PR #87 (READY TO MERGE, 2026-04-24)
-
-**Status:** PR [#87](https://github.com/agorokh/ac-copilot-trainer/pull/87) **OPEN, ready to merge** (head `53bf74f`, 2026-04-24T20:49Z).
-Synced canonical template (52 commits since Apr 4) to fix orchestrator hook-drift bug (template-repo PR #92). Post-cooldown verification: **all checks green (build, docs, audit, CodeRabbit, Bugbot), 0 unresolved review threads, mergeStateStatus CLEAN**. See [`03_Investigations/template-sync-pr87-2026-04-24`](../03_Investigations/template-sync-pr87-2026-04-24.md) for full context.
-
-**Next:** Merge PR #87, then run post-merge skill to update this handoff.
 
 ## Stream A — Rig screen Phase-2 UI (PR #83 MERGED, building on top)
 
@@ -61,6 +54,7 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-04-24** — PR [#87](https://github.com/agorokh/ac-copilot-trainer/pull/87) **template sync to template-repo@061d9ab** MERGED at `ab13a71`. Fixes orchestrator hook-drift, ships 9 new skills, deterministic flow-control hooks, post-merge steward + `vault-automerge.yml`. Upstream tracker `agorokh/template-repo#97` for 17+ deferred items. Full context in [`03_Investigations/template-sync-pr87-2026-04-24`](../03_Investigations/template-sync-pr87-2026-04-24.md).
 - **2026-04-22** — Session MCP infra: installed TurboVault + 6 MCP servers; see `~/Projects/mcp-work/mcp-servers` + `docs.claude.md`.
 - **2026-04-22** — PR [#84](https://github.com/agorokh/ac-copilot-trainer/pull/84) vault post-merge handoff.
 - **2026-04-22** — PR [#83](https://github.com/agorokh/ac-copilot-trainer/pull/83) external WS + Lua bridge MERGED.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-04-24T21:14:00Z
+last_updated: 2026-04-24T22:30:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -25,27 +25,43 @@ relates_to:
 
 # Next session handoff
 
-## Resume here (2026-04-24, cooldown complete)
+## Resume here (2026-04-24, post-merge of PR #87)
 
-**Template-sync PR [#87](https://github.com/agorokh/ac-copilot-trainer/pull/87) is OPEN & READY TO MERGE** on branch `chore/template-sync-2026-04-24` at head `53bf74f` (2026-04-24T20:49Z). Session synced `template-repo@061d9ab` (template-2026.04, 52 commits) to fix hook-drift bug affecting orchestrator (template-repo PR #92). Pushed 3 commits:
-  - `e5b85d8` — template sync
-  - `2e4943c` — ruff pin + b64decode guard + ProjectTemplate path fix
-  - `53bf74f` — tighten b64decode to `validate=True` (Copilot round-3 feedback)
+**Template-sync PR [#87](https://github.com/agorokh/ac-copilot-trainer/pull/87) MERGED 2026-04-24T22:12:09Z** as squash commit `ab13a71` on `main`. Synced canonical template from `template-repo@76e62d2` to `template-repo@061d9ab` (template-2026.04, 52 upstream commits) and unblocked the `issue-driven-coding-orchestrator` hook-drift bug (template-repo PR #92). The merge bundled three template-sync commits plus two unrelated vault-SAVE commits (`8353a0c`, `325983b`) that landed on the same branch in the resolution loop — those are now on `main` as well.
 
-**Final CI status (post-cooldown verification):** 
-  - Build: ✅ SUCCESS
-  - Canonical docs: ✅ SUCCESS  
-  - pip-audit: ✅ SUCCESS
-  - CodeRabbit: ✅ SUCCESS
-  - Cursor Bugbot: ✅ SUCCESS
-  - Review threads: **0 unresolved** (25 total across 4 Copilot feedback rounds)
-  - Merge state: **CLEAN**
+**Active focus has not moved.** The hot path remains rig screen Phase-2 LVGL bring-up (Stream A, EPIC #59). Template-sync is meta/infra, not a new feature stream — see `Current Focus.md` Stream A for the next concrete moves.
 
-Upstream tracker filed: [agorokh/template-repo#97](https://github.com/agorokh/template-repo/issues/97) catalogs 17+ deferred items across 9 template files (3× P1, 2× P2). See [`template-sync-pr87-2026-04-24`](../03_Investigations/template-sync-pr87-2026-04-24.md) for full context.
+### Upstream tracker (READ THIS BEFORE NEXT TEMPLATE SYNC)
+
+[`agorokh/template-repo#97`](https://github.com/agorokh/template-repo/issues/97) catalogs **17+ items across 9 template files (3× P1, 2× P2)** that were *deferred* to upstream rather than fixed in this child repo to keep the sync diff template-only. Three P1s are real risks worth landing in template-repo before the next downstream sync:
+
+1. **`scripts/post_merge_sync.sh:125`** — `gh pr merge` is not a merge guarantee (returns 0 even on auto-merge defer). The steward currently trusts the exit code; if a vault PR ever fails to actually land, this is why.
+2. **`scripts/post_merge_sync.sh:170`** — force-deletes unrelated local branches when stale tracking is pruned. Could nuke a dev's WIP branch in edge cases.
+3. **`scripts/check_vault_follow_up.sh`** — runs as a pre-commit hook against `--cached`, so if the staged tree is empty (no `git add`) the guard passes silently and unstaged vault edits slip through.
+
+### Items fixed in PR #87 (not deferred)
+
+These three fixes live in `main` now and should NOT be re-flagged on the next sync:
+
+- `tools/process_miner/github_client.py:327` — `base64.b64decode(validate=True)` so the "text or None" contract holds for Git LFS and other non-base64 payloads (commit `53bf74f`).
+- `.pre-commit-config.yaml:21` — ruff-pre-commit bumped to `v0.15.12` to match `pyproject.toml ruff>=0.15.11` (commit `2e4943c`).
+- `.claude/agents/post-merge-steward.md:42-43` — canonical `ProjectTemplate` paths rewritten to `AcCopilotTrainer` (commit `2e4943c`; `copier_post_copy.py _rewrite_tree` didn't run because the sync came in as a merge PR rather than a `copier update`).
+
+### Post-merge classification (human attention)
+
+`scripts/post_merge_classify.py` flagged 5 areas. None block the rig screen work, but worth knowing:
+
+- **`pyproject.toml` deps drift** — new floors / added extras: `detect-secrets>=1.5.0`, `pyyaml>=6.0.3`, `pygments>=2.20.0`, `ruff>=0.15.11`. Two new opt-in extras: `[mining-semantic]` (sentence-transformers, ~80 MB model on first run) and `[training]` (torch/transformers/trl/peft/datasets — Tier 3 Phase 2+, NOT installed in CI). Run `pip install -e ".[dev]"` in the active venv to pick up the new dev floors.
+- **`.env.example` drift** — Doppler doc-block + `DISTILL_*` + `PROCESS_MINER_BOT_ALIASES_JSON` added; the AC-Copilot-specific Ollama vars (`AC_COPILOT_OLLAMA_*`) were *removed* from the example. Local `.env` files are unaffected, but if the team relies on `.env.example` as documentation, the Ollama section needs to be re-added (template doesn't know about our sidecar). **Action: consider re-adding the AC_COPILOT_OLLAMA_* block to `.env.example` as a project-specific override**, or document them in `AGENTS.md § Local development`.
+- **`Makefile`** — new targets: `ci-conventional`, `ci-secrets`, `init-knowledge`, `bootstrap-knowledge`, `merge-settings`. `ci-fast` now includes `ci-conventional` + `ci-secrets`. `ci-security` narrowed from `src tools` to just `src` (template asserts `tools/` and `scripts/` produce too much bandit noise).
+- **`scripts/`** — large surface added (hook_protect_main, hook_sensitive_file_guard, hook_bash_pre_tool, ci_policy, merge_settings, init_knowledge_db, bootstrap_knowledge, fleet_inventory_refresh, session_debrief, etc.). All template infrastructure; no manual run required, but the new Claude Code hooks WILL fire on the next bash/edit (deterministic flow control replacing the old "PASS" prompt hook).
+- **`.github/workflows/`** — added: `codeql.yml`, `pr-pain-detection.yml`, `qodo-review.yml`, `cross-repo-mining.yml`. Modified: `ci.yml`, `post-merge-notify.yml`, `process-miner.yml`, `security.yml`, `vault-automerge.yml`. Review for permissions/secrets usage on the next PR.
+
+### Prior streams (preserved from previous handoff)
 
 **PR [#83](https://github.com/agorokh/ac-copilot-trainer/pull/83) is MERGED** at head `caa8a9ad` (2026-04-22T17:20Z). Vault post-merge handoff PR [#84](https://github.com/agorokh/ac-copilot-trainer/pull/84) also merged (17:34Z). End-to-end rig screen ↔ sidecar path confirmed working pre-merge; device emits `{v:1,type:"action",name:"toggleFocusPractice"}` every 10 s over the hotspot.
 
-User then asked for **vault enrichment** as prep for the next phase (physical device screen development). This handoff reflects the post-enrichment state.
+User then asked for **vault enrichment** as prep for the next phase (physical device screen development). The Stream A pre-reads (rig network, install paths, ESP32 firmware, EPIC #59, Figma) remain the right pre-load for the next screen session.
 
 ## Pre-read before starting work
 
@@ -64,29 +80,29 @@ If you're working on screen firmware specifically, also:
 
 ## Concrete next moves
 
-1. **Merge PR [#87](https://github.com/agorokh/ac-copilot-trainer/pull/87)** — all checks green, 0 unresolved threads. Use `gh pr merge 87 --squash` or `--rebase` per preference. Then run `vault-memory` post-merge skill to update this handoff.
+1. **Close issue [#81](https://github.com/agorokh/ac-copilot-trainer/issues/81)** via `gh issue close 81 -c "Implementation landed in PR #83, merged 2026-04-22 at head caa8a9ad"`. (Leftover housekeeping from the PR #83 merge — still open per `Current Focus.md`.)
 
-2. **Close issue [#81](https://github.com/agorokh/ac-copilot-trainer/issues/81)** via `gh issue close 81 -c "Implementation landed in PR #83, merged 2026-04-22 at head caa8a9ad"`. (Leftover housekeeping from the merge.)
+2. **(Optional) `pip install -e ".[dev]"`** in the active venv to pick up new template dev floors (`detect-secrets`, `pyyaml`, `pygments>=2.20.0`, `ruff>=0.15.11`). The next time pre-commit or `make ci-fast` runs locally, it will need these.
 
-2. **Start the sidecar + hotspot** before any device test. PR [#78](https://github.com/agorokh/ac-copilot-trainer/pull/78) added **auto-launch** so the sidecar spawns when the trainer Lua loads; see [`pr-78-sidecar-autolaunch-lap-archive`](../03_Investigations/pr-78-sidecar-autolaunch-lap-archive.md). For rig testing outside of AC (firmware smoke):
+3. **Start the sidecar + hotspot** before any device test. PR [#78](https://github.com/agorokh/ac-copilot-trainer/pull/78) added **auto-launch** so the sidecar spawns when the trainer Lua loads; see [`pr-78-sidecar-autolaunch-lap-archive`](../03_Investigations/pr-78-sidecar-autolaunch-lap-archive.md). For rig testing outside of AC (firmware smoke):
    ```bash
    py -m tools.ai_sidecar --external-bind 0.0.0.0 --token <T>
    ```
    PC must have Windows Mobile Hotspot `AG_PC 7933` running. If PC rebooted, re-enable via the WinRT PowerShell snippet in [`glossary/rig-network`](glossary/rig-network.md).
 
-3. **Phase-2 firmware: bring up LVGL 8.3 + touch.** Follow [`screen-ui-stack-lvgl-touch`](../01_Decisions/screen-ui-stack-lvgl-touch.md):
+4. **Phase-2 firmware: bring up LVGL 8.3 + touch.** Follow [`screen-ui-stack-lvgl-touch`](../01_Decisions/screen-ui-stack-lvgl-touch.md):
    - `lib_deps += lvgl/lvgl @ ~8.3.11` in `firmware/screen/platformio.ini`.
    - Add `firmware/screen/include/board/JC3248W535_Touch.h` (40-line I²C reader — full snippet in the ADR).
    - Wire `lv_disp_drv_t.flush_cb` → `gfx->draw16bitBeRGBBitmap()` → `((Arduino_Canvas*)gfx)->flush()` once per ~16 ms.
    - Drop a one-screen "tap → toggle focusPractice" button — that's the end-to-end proof.
 
-4. **Port the Figma design** screen-by-screen to LVGL. Re-use the bundled fonts from `src/ac_copilot_trainer/content/fonts/` — convert to LVGL binaries via `lv_font_conv` (Michroma 20pt for numbers, Montserrat Reg/Bold for body, Syncopate Bold for brand footer). Tokens are in [`dashboard-visual-design-figma`](../01_Decisions/dashboard-visual-design-figma.md).
+5. **Port the Figma design** screen-by-screen to LVGL. Re-use the bundled fonts from `src/ac_copilot_trainer/content/fonts/` — convert to LVGL binaries via `lv_font_conv` (Michroma 20pt for numbers, Montserrat Reg/Bold for body, Syncopate Bold for brand footer). Tokens are in [`dashboard-visual-design-figma`](../01_Decisions/dashboard-visual-design-figma.md).
 
-5. **Add the PT/SX setup tiles.** Per [`screen-and-csp-apps-integration`](../01_Decisions/screen-and-csp-apps-integration.md): implement `src/ac_copilot_trainer/modules/setup_control.lua` that wraps `ac.getSetupSpinners()` / `ac.setSetupSpinnerValue()`, expose via WS types `setup.spinner.list/set/ack`. Rig tile renders top-3 spinners (TC, ABS, brake bias) as ± buttons.
+6. **Add the PT/SX setup tiles.** Per [`screen-and-csp-apps-integration`](../01_Decisions/screen-and-csp-apps-integration.md): implement `src/ac_copilot_trainer/modules/setup_control.lua` that wraps `ac.getSetupSpinners()` / `ac.setSetupSpinnerValue()`, expose via WS types `setup.spinner.list/set/ack`. Rig tile renders top-3 spinners (TC, ABS, brake bias) as ± buttons.
 
-6. **In-game verification** (once LVGL + setup tiles are in): AC running + trainer loaded + device on; tap a tile; confirm trainer state changes (focusPractice / spinner / etc.) — and watch the HUD re-render.
+7. **In-game verification** (once LVGL + setup tiles are in): AC running + trainer loaded + device on; tap a tile; confirm trainer state changes (focusPractice / spinner / etc.) — and watch the HUD re-render.
 
-7. **Later phases** (out of scope this week, tracked in EPIC #59): tyre-heatmap tile, coaching-summary tile reading from per-lap archive (schema v1, see [`pr-78-sidecar-autolaunch-lap-archive`](../03_Investigations/pr-78-sidecar-autolaunch-lap-archive.md)), real-time `corner_advice` passthrough (see [`pr-75-ollama-corner-coaching-protocol`](../03_Investigations/pr-75-ollama-corner-coaching-protocol.md)).
+8. **Later phases** (out of scope this week, tracked in EPIC #59): tyre-heatmap tile, coaching-summary tile reading from per-lap archive (schema v1, see [`pr-78-sidecar-autolaunch-lap-archive`](../03_Investigations/pr-78-sidecar-autolaunch-lap-archive.md)), real-time `corner_advice` passthrough (see [`pr-75-ollama-corner-coaching-protocol`](../03_Investigations/pr-75-ollama-corner-coaching-protocol.md)).
 
 ## Key learnings carried over
 
@@ -100,7 +116,19 @@ From [`screen-debugging-journey-2026-04-21`](../03_Investigations/screen-debuggi
 6. **CSP API quirks**: `type(vec2/rgbm)` returns `"cdata"` not `"function"` (use nil-checks); `web.socket` is callback-based (`reconnect:true` mandatory); `ac.storage` table-form silently fails (use per-key form).
 7. **Sim-time not os.clock** for staleness — see `ac-storage-persistence.md` and the `corner_advice` TTL in PR #75.
 
-## What was delivered this session (2026-04-22)
+## What was delivered (2026-04-24)
+
+| Area | Artefact |
+|------|----------|
+| Template sync | PR [#87](https://github.com/agorokh/ac-copilot-trainer/pull/87) merged at `ab13a71` — 52 upstream commits incl. orchestrator hook-drift root-cause fix (template-repo PR #92). |
+| Hooks (deterministic flow) | New `scripts/hook_protect_main*.sh|.py`, `scripts/hook_sensitive_file_guard.sh`, `scripts/hook_bash_pre_tool.sh`. Old `PostToolUse:Bash "PASS"` prompt hook gone; only 2 advisory prompt hooks remain (LOAD reminder, SQL DDL guard). |
+| Skills delivered | `orchestrate`, `resolve-pr`, `post-merge`, `dependency-review`, `learner`, `ci-check`, `new-project-setup`, `release-notes`, `github-issue-creator` (Claude Code + Cursor). |
+| Steward automation | `.claude/agents/post-merge-steward.md` + `scripts/post_merge_sync.sh` (sync/vault phases) + `.github/workflows/vault-automerge.yml`. |
+| In-PR fixes | `tools/process_miner/github_client.py` `validate=True`; `.pre-commit-config.yaml` ruff bump to v0.15.12; steward path rewrite to `AcCopilotTrainer`. |
+| Upstream tracker | `agorokh/template-repo#97` filed (17+ deferred items, 3× P1, 2× P2). |
+| Post-merge handoff | This handoff updated (PR #87 → MERGED), `Current Focus.md` retired Stream T. |
+
+## What was delivered (2026-04-22)
 
 | Area | Artefact |
 |------|----------|

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/template-sync-pr87-2026-04-24.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/template-sync-pr87-2026-04-24.md
@@ -1,7 +1,7 @@
 ---
 type: investigation
-status: in_progress
-memory_tier: tier2
+status: active
+memory_tier: canonical
 last_updated: 2026-04-24
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -9,6 +9,9 @@ relates_to:
 ---
 
 # Template-sync PR #87 (2026-04-24)
+
+**Resolution:** PR #87 MERGED 2026-04-24T22:12Z as squash commit `ab13a71`. Upstream tracker [`agorokh/template-repo#97`](https://github.com/agorokh/template-repo/issues/97) carries 17+ deferred items (3× P1, 2× P2). See `Next Session Handoff.md` for follow-up summary and post-merge classifier output.
+
 
 ## What
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #87.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).

## Summary by Sourcery

Update Vault documentation to reflect that template-sync PR #87 has been merged and incorporate its post-merge outcomes.

Documentation:
- Refresh next-session handoff notes with post-merge status of PR #87, summarize upstream tracker items, local fixes, and new template-driven tooling and workflows.
- Clarify that active focus remains on rig screen Phase-2 LVGL work while template-sync changes are meta/infra, and adjust concrete next steps accordingly.
- Promote the template-sync investigation for PR #87 to canonical status with a resolution note and cross-links to follow-up materials.
- Update current-focus log to retire the template-sync stream, record PR #87 as recently landed, and align handoff guidance for upcoming work.