### PR TITLE
fix(gitattributes): pin *.sh and *.bash to eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.bat text eol=crlf
+*.sh text eol=lf
+*.bash text eol=lf


### PR DESCRIPTION
## Summary

- Pin `*.sh` and `*.bash` to `text eol=lf` in `.gitattributes` so Windows clones don't get CRLF-corrupted shell scripts via `core.autocrlf=true`.

## The bug

After PR #87 merged, every `PreToolUse:Bash` hook on Windows clones errored with:

\`\`\`
bash: root=/c/Users/arsen/Projects/ac-copilot-trainer: No such file or directory
\`\`\`

Cause: `core.autocrlf=true` (Git's Windows default) converted LF → CRLF on checkout for `scripts/hook_bash_pre_tool.sh` and the 7 other shell scripts. The repo stores LF correctly (verified via `git ls-files --eol`), but without an explicit `*.sh text eol=lf` rule the working tree got `\r\n` line endings. Bash can't parse a script where each line ends with a stray `\r`, so it treats variable-assignment lines as commands.

The error was non-blocking (hook exited non-zero with the harness in fail-open mode), but spammed every Bash tool call and effectively disabled the protect-main / vault-follow-up / sensitive-file guards.

## Fix

Two-line `.gitattributes` addition. After this lands, anyone who reclones (or runs `git rm --cached -r . && git reset --hard`) gets LF working copies. Existing clones can refresh manually:

\`\`\`bash
rm -f scripts/*.sh && git checkout HEAD -- scripts/*.sh
\`\`\`

## Upstream

`template-repo` only pins `*.bat text eol=crlf` and is missing the symmetric `*.sh` rule, so every spoke spawned from the template hits this on Windows. Adding to **agorokh/template-repo#97** so the next sync ships the rule and child repos can drop their override.

## Test plan

- [ ] CI green on Linux runners (no behavior change for them; gitattributes is a checkout-time concern).
- [ ] Re-checked out shell scripts on Windows are LF (`file scripts/hook_bash_pre_tool.sh` says no CRLF).
- [ ] All 8 shell scripts under `scripts/` pass `bash -n` syntax check.
- [ ] PreToolUse:Bash hook error no longer fires on subsequent Bash tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure shell scripts use LF line endings across platforms by updating Git attributes.

Bug Fixes:
- Prevent Windows checkouts from corrupting shell scripts with CRLF endings when core.autocrlf is enabled.

Build:
- Configure .gitattributes to pin *.sh and *.bash files to text eol=lf for consistent line endings in the working tree.