### PR TITLE
docs(vault): post-merge handoff for PR #89

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-04-24T22:30:00Z
+last_updated: 2026-04-25T05:15:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -25,11 +25,13 @@ relates_to:
 
 # Next session handoff
 
-## Resume here (2026-04-24, post-merge of PR #87)
+## Resume here (2026-04-25, post-merge of PR #89)
+
+**Same-day follow-up PR [#89](https://github.com/agorokh/ac-copilot-trainer/pull/89) MERGED 2026-04-25T05:08:27Z** as squash commit `a55a0ed` on `main`. Two-line `.gitattributes` patch pinning `*.sh` and `*.bash` to `eol=lf` — fixes the Windows-checkout regression introduced by PR #87 where Git checked out shell hooks with CRLF and Bash failed `bash: root=...: No such file or directory` on `PreToolUse:Bash`. The hook fix is now live at the repo level. Same item is queued upstream as part of [`agorokh/template-repo#97`](https://github.com/agorokh/template-repo/issues/97) so the next downstream sync inherits the fix.
 
 **Template-sync PR [#87](https://github.com/agorokh/ac-copilot-trainer/pull/87) MERGED 2026-04-24T22:12:09Z** as squash commit `ab13a71` on `main`. Synced canonical template from `template-repo@76e62d2` to `template-repo@061d9ab` (template-2026.04, 52 upstream commits) and unblocked the `issue-driven-coding-orchestrator` hook-drift bug (template-repo PR #92). The merge bundled three template-sync commits plus two unrelated vault-SAVE commits (`8353a0c`, `325983b`) that landed on the same branch in the resolution loop — those are now on `main` as well.
 
-**Active focus has not moved.** The hot path remains rig screen Phase-2 LVGL bring-up (Stream A, EPIC #59). Template-sync is meta/infra, not a new feature stream — see `Current Focus.md` Stream A for the next concrete moves.
+**Active focus has not moved.** The hot path remains rig screen Phase-2 LVGL bring-up (Stream A, EPIC #59). PR #87 was meta/infra and PR #89 is its hotfix; neither shifts the feature stream — see `Current Focus.md` Stream A for the next concrete moves.
 
 ### Upstream tracker (READ THIS BEFORE NEXT TEMPLATE SYNC)
 
@@ -115,6 +117,12 @@ From [`screen-debugging-journey-2026-04-21`](../03_Investigations/screen-debuggi
 5. **Factory backup restore** is the proof-of-life test when display looks dead. Binary at `firmware/screen/_factory-backup/jc3248w535_v0.9.1_factory.bin`.
 6. **CSP API quirks**: `type(vec2/rgbm)` returns `"cdata"` not `"function"` (use nil-checks); `web.socket` is callback-based (`reconnect:true` mandatory); `ac.storage` table-form silently fails (use per-key form).
 7. **Sim-time not os.clock** for staleness — see `ac-storage-persistence.md` and the `corner_advice` TTL in PR #75.
+
+## What was delivered (2026-04-25)
+
+| Area | Artefact |
+|------|----------|
+| Hook hotfix | PR [#89](https://github.com/agorokh/ac-copilot-trainer/pull/89) merged at `a55a0ed` — `.gitattributes` pins `*.sh` / `*.bash` to `eol=lf`, fixing the Windows CRLF hook misfire from PR #87. Same item tracked upstream in [`agorokh/template-repo#97`](https://github.com/agorokh/template-repo/issues/97). |
 
 ## What was delivered (2026-04-24)
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #89.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).

## Summary by Sourcery

Document the post-merge handoff context and outcomes for PR #89 in the Vault handoff notes.

Documentation:
- Update the next-session handoff document with details of PR #89, including its purpose as a hook hotfix and its merge metadata.
- Add a 2026-04-25 delivery summary section capturing the hook hotfix from PR #89 and its upstream tracking, and refresh timestamps and focus notes accordingly.