### PR TITLE
feat(session-journal): harden loader for malformed exports (#97)

### DIFF
--- a/tests/test_session_journal_loader.py
+++ b/tests/test_session_journal_loader.py
@@ -75,6 +75,37 @@ def test_non_utf8_raises_encoding_parse_error(tmp_path: Path) -> None:
     assert exc_info.value.reason == "encoding"
 
 
+def test_json_error_byte_offset_is_utf8_not_char_index(tmp_path: Path) -> None:
+    path = tmp_path / "unicode.json"
+    # Euro sign is one character but three UTF-8 bytes before the truncated tail.
+    text = '{"note": "\u20ac", "broken": '
+    path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(SessionJournalParseError) as exc_info:
+        load_export(path)
+
+    err = exc_info.value
+    char_pos = len(text)
+    assert err.byte_offset is not None
+    assert err.byte_offset == len(text[:char_pos].encode("utf-8"))
+    assert err.byte_offset > char_pos
+
+
+def test_ingest_loop_logs_oserror_and_continues(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(sample_valid_session_journal()), encoding="utf-8")
+    not_a_file = tmp_path / "subdir"
+    not_a_file.mkdir()
+
+    caplog.set_level(logging.ERROR)
+    loaded = ingest_exports([not_a_file, good])
+
+    assert len(loaded) == 1
+    assert any(r.exc_info is not None for r in caplog.records)
+
+
 def test_ingest_loop_logs_exception_and_continues(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_session_journal_loader.py
+++ b/tests/test_session_journal_loader.py
@@ -49,6 +49,28 @@ def test_schema_invalid_propagates_validation_error(tmp_path: Path) -> None:
     assert any("missing keys" in e for e in exc_info.value.errors)
 
 
+def test_json_array_raises_validation_error_at_trust_boundary(tmp_path: Path) -> None:
+    path = tmp_path / "array.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    with pytest.raises(ValidationError) as exc_info:
+        load_export(path)
+
+    assert exc_info.value.errors == ["root must be a JSON object"]
+
+
+def test_json_snippet_collapses_newlines(tmp_path: Path) -> None:
+    path = tmp_path / "multiline.json"
+    text = '{\n  "schema_version": 1,\n  "broken": '
+    path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(SessionJournalParseError) as exc_info:
+        load_export(path)
+
+    assert exc_info.value.snippet is not None
+    assert "\n" not in exc_info.value.snippet
+
+
 def test_missing_path_propagates_file_not_found(tmp_path: Path) -> None:
     missing = tmp_path / "does-not-exist.json"
     with pytest.raises(FileNotFoundError):
@@ -89,6 +111,20 @@ def test_json_error_byte_offset_is_utf8_not_char_index(tmp_path: Path) -> None:
     assert err.byte_offset is not None
     assert err.byte_offset == len(text[:char_pos].encode("utf-8"))
     assert err.byte_offset > char_pos
+
+
+def test_ingest_missing_file_logs_and_continues(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(sample_valid_session_journal()), encoding="utf-8")
+    missing = tmp_path / "missing.json"
+
+    caplog.set_level(logging.ERROR)
+    loaded = ingest_exports([missing, good])
+
+    assert len(loaded) == 1
+    assert any(r.exc_info is not None for r in caplog.records)
 
 
 def test_ingest_loop_logs_oserror_and_continues(

--- a/tests/test_session_journal_loader.py
+++ b/tests/test_session_journal_loader.py
@@ -1,0 +1,92 @@
+"""Session journal file loader (#97)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from tools.session_journal import (
+    SessionJournalParseError,
+    ValidationError,
+    ingest_exports,
+    load_export,
+    sample_valid_session_journal,
+)
+
+
+def test_load_export_valid_file(tmp_path: Path) -> None:
+    path = tmp_path / "ok.json"
+    path.write_text(json.dumps(sample_valid_session_journal()), encoding="utf-8")
+    loaded = load_export(path)
+    assert loaded["schema_version"] == 1
+
+
+def test_malformed_json_raises_parse_error_with_snippet(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    text = '{"schema_version": 1, "trailing": '
+    path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(SessionJournalParseError) as exc_info:
+        load_export(path)
+
+    err = exc_info.value
+    assert err.path == path
+    assert err.byte_offset is not None
+    assert err.snippet is not None
+    assert len(err.snippet) <= 200
+
+
+def test_schema_invalid_propagates_validation_error(tmp_path: Path) -> None:
+    path = tmp_path / "schema.json"
+    path.write_text('{"schema_version": 1}', encoding="utf-8")
+
+    with pytest.raises(ValidationError) as exc_info:
+        load_export(path)
+
+    assert any("missing keys" in e for e in exc_info.value.errors)
+
+
+def test_missing_path_propagates_file_not_found(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.json"
+    with pytest.raises(FileNotFoundError):
+        load_export(missing)
+
+
+def test_empty_file_raises_parse_error_with_reason(tmp_path: Path) -> None:
+    path = tmp_path / "empty.json"
+    path.write_bytes(b"")
+
+    with pytest.raises(SessionJournalParseError) as exc_info:
+        load_export(path)
+
+    assert exc_info.value.reason == "empty file"
+
+
+def test_non_utf8_raises_encoding_parse_error(tmp_path: Path) -> None:
+    path = tmp_path / "latin1.json"
+    path.write_bytes(b"\xff\xfe")
+
+    with pytest.raises(SessionJournalParseError) as exc_info:
+        load_export(path)
+
+    assert exc_info.value.reason == "encoding"
+
+
+def test_ingest_loop_logs_exception_and_continues(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(sample_valid_session_journal()), encoding="utf-8")
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+
+    caplog.set_level(logging.ERROR)
+    loaded = ingest_exports([bad, good])
+
+    assert len(loaded) == 1
+    assert loaded[0]["session_key"] == sample_valid_session_journal()["session_key"]
+    assert any("Failed to load session journal export" in r.message for r in caplog.records)
+    assert any(r.exc_info is not None for r in caplog.records)

--- a/tools/session_journal.py
+++ b/tools/session_journal.py
@@ -2,10 +2,64 @@
 
 from __future__ import annotations
 
+import json
+import logging
+from collections.abc import Iterable
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
+logger = logging.getLogger(__name__)
+
 JOURNAL_SCHEMA_VERSION = 1
+
+__all__ = [
+    "JOURNAL_SCHEMA_VERSION",
+    "SessionJournalParseError",
+    "ValidationError",
+    "ingest_exports",
+    "load_export",
+    "sample_valid_session_journal",
+    "validate_export",
+    "validate_session_journal",
+]
+
+
+class ValidationError(ValueError):
+    """Schema validation failed for a parsed session journal export."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+class SessionJournalParseError(Exception):
+    """Failed to read or parse a session journal export file."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        reason: str,
+        message: str,
+        byte_offset: int | None = None,
+        snippet: str | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.reason = reason
+        self.byte_offset = byte_offset
+        self.snippet = snippet
+        super().__init__(message)
+
+
+def _snippet_around(text: str, offset: int, width: int = 200) -> str:
+    if offset < 0:
+        offset = 0
+    half = max(1, width // 2)
+    start = max(0, offset - half)
+    end = min(len(text), offset + half)
+    return text[start:end]
+
 
 # Lua `JSON.stringify` omits keys with nil values; `llm_debrief` is reserved (milestone 3d).
 REQUIRED_TOP_LEVEL_KEYS = frozenset(
@@ -127,6 +181,61 @@ def validate_session_journal(obj: Any) -> list[str]:
                     errors.append(f"coaching_hints_last[{i}] must be object or string")
 
     return errors
+
+
+def validate_export(obj: Any) -> dict[str, Any]:
+    """Validate a parsed export object; raise ValidationError if invalid."""
+    errors = validate_session_journal(obj)
+    if errors:
+        raise ValidationError(errors)
+    return obj
+
+
+def load_export(path: str | Path) -> dict[str, Any]:
+    """Load, parse, and validate a session journal export from disk."""
+    export_path = Path(path)
+    raw = export_path.read_bytes()
+
+    if not raw:
+        raise SessionJournalParseError(
+            export_path,
+            reason="empty file",
+            message="empty file",
+        )
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise SessionJournalParseError(
+            export_path,
+            reason="encoding",
+            message=str(exc),
+            byte_offset=exc.start,
+        ) from exc
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SessionJournalParseError(
+            export_path,
+            reason="json",
+            message=str(exc),
+            byte_offset=exc.pos,
+            snippet=_snippet_around(text, exc.pos),
+        ) from exc
+
+    return validate_export(parsed)
+
+
+def ingest_exports(paths: Iterable[str | Path]) -> list[dict[str, Any]]:
+    """Load many exports; log failures and continue."""
+    loaded: list[dict[str, Any]] = []
+    for path in paths:
+        try:
+            loaded.append(load_export(path))
+        except (SessionJournalParseError, ValidationError, FileNotFoundError):
+            logger.exception("Failed to load session journal export: %s", path)
+    return loaded
 
 
 def sample_valid_session_journal() -> dict[str, Any]:

--- a/tools/session_journal.py
+++ b/tools/session_journal.py
@@ -34,7 +34,14 @@ class ValidationError(ValueError):
 
 
 class SessionJournalParseError(Exception):
-    """Failed to read or parse a session journal export file."""
+    """Failed to read or parse a session journal export file.
+
+    ``byte_offset`` is always a byte index into the on-disk UTF-8 file when set.
+    JSON syntax errors map ``JSONDecodeError.pos`` (a decoded-string character
+    index) through ``_utf8_byte_offset`` before storing. ``snippet`` is always
+    sliced from the decoded string at the character index (newlines collapsed
+    for log-friendly single-line output).
+    """
 
     def __init__(
         self,
@@ -58,7 +65,8 @@ def _snippet_around(text: str, offset: int, width: int = 200) -> str:
     half = max(1, width // 2)
     start = max(0, offset - half)
     end = min(len(text), offset + half)
-    return text[start:end]
+    snippet = text[start:end]
+    return snippet.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
 
 
 def _utf8_byte_offset(text: str, char_index: int) -> int:
@@ -230,6 +238,9 @@ def load_export(path: str | Path) -> dict[str, Any]:
             byte_offset=_utf8_byte_offset(text, exc.pos),
             snippet=_snippet_around(text, exc.pos),
         ) from exc
+
+    if not isinstance(parsed, dict):
+        raise ValidationError(["root must be a JSON object"])
 
     return validate_export(parsed)
 

--- a/tools/session_journal.py
+++ b/tools/session_journal.py
@@ -61,6 +61,13 @@ def _snippet_around(text: str, offset: int, width: int = 200) -> str:
     return text[start:end]
 
 
+def _utf8_byte_offset(text: str, char_index: int) -> int:
+    """Map a decoded-string index to a UTF-8 byte offset."""
+    if char_index <= 0:
+        return 0
+    return len(text[:char_index].encode("utf-8"))
+
+
 # Lua `JSON.stringify` omits keys with nil values; `llm_debrief` is reserved (milestone 3d).
 REQUIRED_TOP_LEVEL_KEYS = frozenset(
     {
@@ -220,7 +227,7 @@ def load_export(path: str | Path) -> dict[str, Any]:
             export_path,
             reason="json",
             message=str(exc),
-            byte_offset=exc.pos,
+            byte_offset=_utf8_byte_offset(text, exc.pos),
             snippet=_snippet_around(text, exc.pos),
         ) from exc
 
@@ -233,7 +240,7 @@ def ingest_exports(paths: Iterable[str | Path]) -> list[dict[str, Any]]:
     for path in paths:
         try:
             loaded.append(load_export(path))
-        except (SessionJournalParseError, ValidationError, FileNotFoundError):
+        except (SessionJournalParseError, ValidationError, OSError):
             logger.exception("Failed to load session journal export: %s", path)
     return loaded
 


### PR DESCRIPTION
## Summary

- Add `load_export`, `validate_export`, `SessionJournalParseError`, and `ValidationError` to `tools/session_journal.py` so malformed journal files fail with path, byte offset, and a snippet around JSON errors.
- Add `ingest_exports` for batch ingest loops that log full stack traces via `logger.exception()` and continue on failure.
- Add `tests/test_session_journal_loader.py` covering malformed JSON, schema errors, missing paths, empty files, encoding failures, and ingest-loop logging.

Fixes #97

## Test plan

- [x] `pytest tests/test_session_journal_loader.py tests/test_session_journal.py`
- [x] CI `ci-fast` on GitHub Actions

## Comment ledger (zero-sampling audit)

| # | Source | Status |
|---|--------|--------|
| 1-2 | Cursor Bugbot inline (UTF-8 offset, OSError ingest) | RESOLVED in `ab7dd16` |
| 3-26 | Issue comments (triggers, rate limits, bot summaries) | RESOLVED / no-action |
| 27-33 | Reviews + inline duplicates | RESOLVED |
| Qodo | Type guard at trust boundary | RESOLVED in `22f6b3c` |
| Qodo | Error context (byte_offset vs snippet docs, newline collapse) | RESOLVED in `22f6b3c` |

**Watermark (last push):** `22f6b3c`

## Issue #97 scope proof

| Criterion | Evidence |
|-----------|----------|
| Malformed JSON → `SessionJournalParseError` with path, byte offset, snippet | `test_malformed_json_*`, `test_json_error_byte_offset_*` |
| Schema-invalid → `ValidationError` propagates | `test_schema_invalid_*`, `test_json_array_*` |
| Missing path → `FileNotFoundError` propagates from `load_export` | `test_missing_path_*` |
| Empty file → `reason="empty file"` | `test_empty_file_*` |
| Ingest loop logs `logger.exception()` and continues | `test_ingest_loop_*`, `test_ingest_missing_*`, `test_ingest_loop_logs_oserror_*` |
| Existing schema tests unchanged | `test_session_journal.py` (16 tests) |

## Shift-left field test

First issue with curated Known pitfalls section; post-merge metrics go to template-repo per issue body.
