### PR TITLE
fix(memory): wave3 sunset-doctrine — adopt from template-repo@main

### DIFF
--- a/.cursor/rules/memory-contract.mdc
+++ b/.cursor/rules/memory-contract.mdc
@@ -4,9 +4,9 @@ alwaysApply: true
 
 # Memory contract (mandatory for every Cursor agent)
 
-Canonical contract: [`docs/00_Core/MEMORY_CONTRACT.md`](../../docs/00_Core/MEMORY_CONTRACT.md). Canonical invariant: [`memory-three-tiers.md`](../../docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md). Enforcement is by deterministic hooks (see `scripts/hook_memory_gate.py`), not by prompt-following.
+Canonical contract: [`docs/00_Core/MEMORY_CONTRACT.md`](../../docs/00_Core/MEMORY_CONTRACT.md). Canonical invariant: [`memory-three-tiers.md`](../../docs/01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md). Enforcement is by deterministic hooks (see `scripts/hook_memory_gate.py`), not by prompt-following.
 
-**Three tiers, one rule: read all three at LOAD, write to the right one at SAVE, no side channels.** Tier 1 = `AGENTS.md` (short operational facts, auto-loaded). Tier 2 = vault under `docs/01_Vault/<ProjectKey>/` (structured markdown graph, `@`-included). Tier 3 = semantic substrate via `mcp__agentic-memory__query_knowledge_graph` ([`ops/memory_manifest.yml`](../../ops/memory_manifest.yml); Graphiti canonical, LightRAG legacy). **Reading Tier 3 at LOAD is mandatory** for substantive sessions — it's the reason the substrate exists.
+**Three tiers, one rule: read all three at LOAD, write to the right one at SAVE, no side channels.** Tier 1 = `AGENTS.md` (short operational facts, auto-loaded). Tier 2 = vault under `docs/01_Vault/<ProjectKey>/` (structured markdown graph, `@`-included). Tier 3 = semantic substrate via `mcp__agentic-memory__query_knowledge_graph` ([`ops/memory_manifest.yml`](../../ops/memory_manifest.yml); **LightRAG canonical online**; Graphiti offline-only per the [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md)). **Reading Tier 3 at LOAD is mandatory** for substantive sessions — it's the reason the substrate exists.
 
 ## LOAD
 
@@ -18,7 +18,7 @@ At session start, the SessionStart command hook (`scripts/hook_session_start_mem
 
 ## SAVE
 
-Short operational facts go to **Tier 1** (`AGENTS.md`). Structured knowledge goes to **Tier 2** — small linked vault nodes per [`docs/01_Vault/00_Graph_Schema.md`](../../docs/01_Vault/00_Graph_Schema.md). Update `Next Session Handoff.md`. **Tier 3** (the semantic substrate) ingests Tier-2 automatically — do not double-write. **Never** write to `~/.claude/projects/.../memory/` — that auto-memory side channel is deprecated for this project (invariant: [`memory-three-tiers.md`](../../docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md)).
+Short operational facts go to **Tier 1** (`AGENTS.md`). Structured knowledge goes to **Tier 2** — small linked vault nodes per [`docs/01_Vault/00_Graph_Schema.md`](../../docs/01_Vault/00_Graph_Schema.md). Update `Next Session Handoff.md`. **Tier 3** (the semantic substrate) ingests Tier-2 automatically — do not double-write. **Never** write to `~/.claude/projects/.../memory/` — that auto-memory side channel is deprecated for this project (invariant: [`memory-three-tiers.md`](../../docs/01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md)).
 
 ## Cursor Task subagents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Guidance for **Claude Code** (claude.ai/code) in this repository.
 
-**Status:** AC Copilot Trainer
+**Status:** Template
 **Version:** 1.4
 **Category:** Core
 
@@ -29,27 +29,30 @@ Personal overrides: root **`.claude.local.md`** (gitignored) for preferences not
 
 ---
 
-## Persistent memory (three tiers, no side channels)
+## Persistent memory (two-tier)
 
-See `.claude/skills/vault-memory/SKILL.md` and **`docs/00_Core/SESSION_LIFECYCLE.md`** for LOAD/SAVE detail.
+See `.claude/skills/vault-memory/SKILL.md` and **`docs/00_Core/SESSION_LIFECYCLE.md`** for LOAD/SAVE.
 
-**Session start (LOAD):** `Next Session Handoff.md` → follow `relates_to` / `_index.md` for needed subgraph → `Current Focus.md` → `Project State.md` as needed; **Tier-3 substrate query is mandatory** before substantive code edits (enforced by `scripts/hook_memory_gate.py`).
+- **Tier 1** — `AGENTS.md` (quick facts, changelog block at bottom).
+- **Tier 2** — Obsidian vault graph: `docs/01_Vault/AcCopilotTrainer/` (rename on bootstrap); schema at `docs/01_Vault/00_Graph_Schema.md` (outside the renamed folder).
+
+**Session start (LOAD):** `Next Session Handoff.md` → follow `relates_to` / `_index.md` for needed subgraph → `Current Focus.md` → `Project State.md` as needed.
 
 **Session end (SAVE):** update `Next Session Handoff.md`; add or update **small linked nodes** (not only monolithic edits). See `SESSION_LIFECYCLE.md`.
 
-### Memory architecture
+### Memory architecture (three tiers, no side channels)
 
 Persistent memory in this project lives in **exactly one** of three tiers — write to the right one, **read all three**:
 
 | Tier | Substrate | Write | Read |
 |---|---|---|---|
 | **1** | `AGENTS.md` (operational facts + changelog) | Direct `Edit` for short facts (versions, ports, learned preferences) | Auto-loaded at session start |
-| **2** | Vault at `docs/01_Vault/AcCopilotTrainer/` — Obsidian markdown graph per [`docs/01_Vault/00_Graph_Schema.md`](docs/01_Vault/00_Graph_Schema.md) | Direct `Write` of small linked nodes (decisions, investigations, invariants, glossary, handoffs) | `@`-included by this `CLAUDE.md`; indirectly via Tier-3 query |
-| **3** | Per-workspace semantic substrate declared in [`ops/memory_manifest.yml`](ops/memory_manifest.yml). Canonical backend: Graphiti. See [`docs/00_Core/MEMORY_SUBSTRATE.md`](docs/00_Core/MEMORY_SUBSTRATE.md). | **Indirect** — built by re-ingesting Tier-2; agents do not write directly | `mcp__agentic-memory__query_knowledge_graph(prompt, workspace=…)`. **Read at LOAD is mandatory** for substantive sessions and is enforced by `scripts/hook_memory_gate.py`. |
+| **2** | Vault at `docs/01_Vault/AcCopilotTrainer/` (rename on bootstrap) — Obsidian markdown graph per [`docs/01_Vault/00_Graph_Schema.md`](docs/01_Vault/00_Graph_Schema.md) | Direct `Write` of small linked nodes (decisions, investigations, invariants, glossary, handoffs) | `@`-included by this `CLAUDE.md`; indirectly via Tier-3 query |
+| **3** | Per-workspace semantic substrate declared in [`ops/memory_manifest.yml`](ops/memory_manifest.yml). **Canonical backend: LightRAG (online).** Graphiti retained for offline entity-resolution + bi-temporal metadata only — see the [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md) maintained in agent-factory. Substrate detail: [`docs/00_Core/MEMORY_SUBSTRATE.md`](docs/00_Core/MEMORY_SUBSTRATE.md). | **Indirect** — built by re-ingesting Tier-2; agents do not write directly | `mcp__agentic-memory__query_knowledge_graph(prompt, workspace=…)`. **Read at LOAD is mandatory** for substantive sessions and is enforced by `scripts/hook_memory_gate.py`. |
 
 **Side channels are forbidden.** The Claude Code per-user auto-memory directory (`~/.claude/projects/.../memory/`) is **deprecated for this project** — `scripts/hook_session_start_memory_redirect.py` writes a deprecation marker there on every SessionStart so an agent that tries to write sees the warning. Scratch databases, per-user notes, ad-hoc files outside the three tiers — same: invisible to other agents, other sessions, teammates, and the Tier-3 ingest pipelines.
 
-Canonical invariant: [`docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md`](docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md). Full contract: [`docs/00_Core/MEMORY_CONTRACT.md`](docs/00_Core/MEMORY_CONTRACT.md). Postmortem driving this rule: [agorokh/template-repo#115](https://github.com/agorokh/template-repo/issues/115).
+Canonical invariant: [`docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md`](docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md). Full contract: [`docs/00_Core/MEMORY_CONTRACT.md`](docs/00_Core/MEMORY_CONTRACT.md). Postmortem driving this rule: [issue #115](https://github.com/agorokh/template-repo/issues/115).
 
 @docs/00_Core/MEMORY_CONTRACT.md
 @docs/00_Core/SESSION_LIFECYCLE.md

--- a/docs/00_Core/BOOTSTRAP_NEW_PROJECT.md
+++ b/docs/00_Core/BOOTSTRAP_NEW_PROJECT.md
@@ -14,7 +14,7 @@ cd path/to/new-repo
 make ci-fast
 ```
 
-Copier runs `scripts/copier_post_copy.py` after copy to rename `docs/01_Vault/AcCopilotTrainer` → `docs/01_Vault/<project_key>`, `src/ac_copilot_trainer` → `src/<package_name>`, patch `pyproject.toml`, and replace canonical path strings across text files. Files matching `_skip_if_exists` in `copier.yml` are not overwritten on **update**.
+Copier runs `scripts/copier_post_copy.py` after copy to rename `docs/01_Vault/ProjectTemplate` → `docs/01_Vault/<project_key>`, `src/project_template` → `src/<package_name>`, patch `pyproject.toml`, and replace canonical path strings across text files. Files matching `_skip_if_exists` in `copier.yml` are not overwritten on **update**.
 
 **Updates in an existing child repo** (after the first `copier copy`):
 
@@ -24,31 +24,31 @@ copier update --trust
 
 Use the reference workflow `.github/workflows/template-sync.yml` (optional) for scheduled or manual sync PRs; see [MAINTAINING_THE_TEMPLATE.md](MAINTAINING_THE_TEMPLATE.md).
 
-**Canonical template identity:** To work in **this** template repository unchanged, use default answers `project_key=AcCopilotTrainer`, `package_name=ac_copilot_trainer`, `project_name=ac-copilot-trainer`.
+**Canonical template identity:** To work in **this** template repository unchanged, use default answers `project_key=ProjectTemplate`, `package_name=project_template`, `project_name=project-template`.
 
 ## 1. Identity (manual bootstrap)
 
 If you did not use Copier, complete these manually:
 
 - [ ] Choose a **project key** (short, filesystem-safe, e.g. `AcmePlatform`). You will rename the vault folder to match.
-- [ ] Update `pyproject.toml`: `name`, `description`, and `[tool.setuptools.packages.find]` / package layout if you change `src/ac_copilot_trainer`.
-- [ ] Replace the Python package `src/ac_copilot_trainer/` with your package name (or keep and rename in one commit).
+- [ ] Update `pyproject.toml`: `name`, `description`, and `[tool.setuptools.packages.find]` / package layout if you change `src/project_template`.
+- [ ] Replace the Python package `src/project_template/` with your package name (or keep and rename in one commit).
 
 ## 2. Vault (Obsidian knowledge graph)
 
-- [ ] Rename `docs/01_Vault/AcCopilotTrainer` → `docs/01_Vault/<YourProjectKey>`.
+- [ ] Rename `docs/01_Vault/ProjectTemplate` → `docs/01_Vault/<YourProjectKey>`.
 - [ ] Keep **`docs/01_Vault/00_Graph_Schema.md`** at vault **parent** level (it is intentionally outside the renamed folder).
-- [ ] Global find-replace `AcCopilotTrainer` → `<YourProjectKey>` in:
+- [ ] Global find-replace `ProjectTemplate` → `<YourProjectKey>` in:
   - `CLAUDE.md`
-  - `docs/01_Vault/00_Graph_Schema.md` (especially `relates_to` entries such as `AcCopilotTrainer/00_System/...`)
+  - `docs/01_Vault/00_Graph_Schema.md` (especially `relates_to` entries such as `ProjectTemplate/00_System/...`)
   - `.claude/skills/vault-memory/SKILL.md` and `.cursor/skills/vault-memory/SKILL.md`
   - `.claude/rules/memory.md`, `.claude/rules/invariants.md`
   - `.claude/settings.json` (Stop / hook reminder paths)
   - `.cursor/rules/invariants.mdc`, `.cursor/BUGBOT.md`
   - `AGENTS.md`, `.cursorrules` (if they reference the old path)
-  - **GitHub custom agents:** `.github/agents/issue-refiner.agent.md` — replace `docs/01_Vault/AcCopilotTrainer/...` with `docs/01_Vault/<YourProjectKey>/...` (see HTML comment in that file).
+  - **GitHub custom agents:** `.github/agents/issue-refiner.agent.md` — replace `docs/01_Vault/ProjectTemplate/...` with `docs/01_Vault/<YourProjectKey>/...` (see HTML comment in that file).
 - [ ] **Restructure nodes** for your domain: add invariant nodes, glossary terms, and ADRs as small linked files; update `_index.md` files accordingly (see `00_Graph_Schema.md`).
-- [ ] Update **`relates_to` / `part_of`** in vault YAML: replace the `AcCopilotTrainer/` prefix with `<YourProjectKey>/` in every anchored path (paths are relative to `docs/01_Vault/`; no `..` segments — see `00_Graph_Schema.md`).
+- [ ] Update **`relates_to` / `part_of`** in vault YAML: replace the `ProjectTemplate/` prefix with `<YourProjectKey>/` in every anchored path (paths are relative to `docs/01_Vault/`; no `..` segments — see `00_Graph_Schema.md`).
 - [ ] Open the vault in Obsidian (optional: tune `.obsidian/` plugins — keep REST API off unless you intend to use it).
 
 ## 3. Agent docs
@@ -88,7 +88,7 @@ If you did not use Copier, complete these manually:
 Once bootstrapped, this repo should declare workstation services in `ops/service.yaml`, consumed by [workstation-ops](https://github.com/agorokh/workstation-ops) for cross-repo service inventory, port-collision detection, and drift auditing. The template ships only `ops/service.yaml.example`; the live `ops/service.yaml` is created by step 1 of the checklist below.
 
 - [ ] Copy `ops/service.yaml.example` → `ops/service.yaml`.
-- [ ] **Manual bootstrap only:** replace the canonical placeholder `repo_id: ac-copilot-trainer` with your project's actual repo name (must match the `repo_id` registered in `workstation-ops/ops/sources.yaml`). Copier-driven projects: `scripts/copier_post_copy.py` rewrites this automatically.
+- [ ] **Manual bootstrap only:** replace the canonical placeholder `repo_id: project-template` with your project's actual repo name (must match the `repo_id` registered in `workstation-ops/ops/sources.yaml`). Copier-driven projects: `scripts/copier_post_copy.py` rewrites this automatically.
 - [ ] Populate the `services:` list with any long-lived workstation services this repo exposes (launchd LaunchAgents, Docker containers, brew services, process-compose bundles). If this repo exposes none, keep `services: []` — the **explicit empty declaration** is intentional and tells workstation-ops this repo is catalog-aware with nothing to report. To add services, **delete the `[]`** and replace it with a YAML block list under `services:` (the commented examples in `ops/service.yaml.example` show the shape).
 - [ ] Register the repo in [`workstation-ops/ops/sources.yaml`](https://github.com/agorokh/workstation-ops/blob/main/ops/sources.yaml). The `path:` field below assumes the conventional layout where `workstation-ops` and your project repo are sibling directories under a common parent (e.g. `~/Projects/workstation-ops` and `~/Projects/<your-repo>`); adjust the relative path if your checkout differs:
 
@@ -104,7 +104,19 @@ Once bootstrapped, this repo should declare workstation services in `ops/service
 
 See [`ops/service.yaml.example`](../../ops/service.yaml.example) for the full schema reference and live-example links to agent-factory and Alpaca_trading.
 
-## 8. Verify
+## 8. Tier-3 semantic memory (optional)
+
+If your repo will use Tier-3 semantic memory (an entity-relation / bi-temporal graph that complements `AGENTS.md` and the Obsidian vault), declare a workspace for it.
+
+- [ ] Read [MEMORY_SUBSTRATE.md](MEMORY_SUBSTRATE.md) — substrate choice (`lightrag` canonical online; `graphiti` offline-only per the [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md)).
+- [ ] Read [VAULT_TAXONOMY.md](VAULT_TAXONOMY.md) — classify your vault as `repo-product` / `repo-embedded` / `human-curated`.
+- [ ] Add a workspace row to [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml) under the host that will own its ingest. Required fields: `name`, `backend`, `origin`, `endpoint`, `vault_root`, `audit_log`, `launchd_label`, `stale_after_hours`, and at least one `canary_queries[]` entry (each with `prompt` and `mode`). For `lightrag` workspaces (canonical), `launchd_label` typically follows `ai.lightrag.ingest-audit.<workspace_name>` (`null` if ingest is operator-managed externally). For offline-only `graphiti` workspaces, `launchd_label: null` (the shared offline MCP has no per-workspace plist).
+- [ ] Pin `MEMORY_MANIFEST_REF` in Doppler to an immutable tag (e.g. `memory-manifest-v2`), never to `main`.
+- [ ] For `lightrag` workspaces (canonical online), install the standard audit-ingest plist (`ai.lightrag.ingest-audit.<workspace_name>`) unless ingest is external — then set `launchd_label: null` and document why in workspace `notes`. For offline-only `graphiti` workspaces, no per-workspace launchd unit is needed (single shared MCP server, OFF the agent read path).
+
+If your repo does NOT use Tier-3, skip this section. `AGENTS.md` + vault (Tier 1+2) work standalone.
+
+## 9. Verify
 
 ```bash
 make hooks-install
@@ -129,11 +141,11 @@ It warns if the vault folder, package directory, or `pyproject.toml` name still 
 
 Use this checklist before you call the repo “bootstrapped”:
 
-- [ ] `docs/01_Vault/AcCopilotTrainer` renamed to your project key; `00_Graph_Schema.md` still at `docs/01_Vault/00_Graph_Schema.md`.
-- [ ] `src/ac_copilot_trainer/` renamed; imports and `pyproject.toml` package discovery updated.
-- [ ] `[project].name` in `pyproject.toml` is not `ac-copilot-trainer`.
+- [ ] `docs/01_Vault/ProjectTemplate` renamed to your project key; `00_Graph_Schema.md` still at `docs/01_Vault/00_Graph_Schema.md`.
+- [ ] `src/project_template/` renamed; imports and `pyproject.toml` package discovery updated.
+- [ ] `[project].name` in `pyproject.toml` is not `project-template`.
 - [ ] `python3 scripts/check_bootstrap_complete.py` prints no warnings.
-- [ ] `.github/agents/issue-refiner.agent.md` (and any copied agent prompts) point at `docs/01_Vault/<YourProjectKey>/...`, not `AcCopilotTrainer`.
+- [ ] `.github/agents/issue-refiner.agent.md` (and any copied agent prompts) point at `docs/01_Vault/<YourProjectKey>/...`, not `ProjectTemplate`.
 - [ ] `make ci-fast` passes; test PR confirms policy + CI workflows.
 - [ ] Invariants and glossary indexes reflect your domain; new knowledge uses small linked nodes per `00_Graph_Schema.md`.
 - [ ] `ops/service.yaml` exists with the correct `repo_id` and either a populated `services:` block or an explicit `services: []` (catalog-aware-no-services), and the repo is registered in `workstation-ops/ops/sources.yaml`.

--- a/docs/00_Core/MEMORY_CONTRACT.md
+++ b/docs/00_Core/MEMORY_CONTRACT.md
@@ -4,18 +4,18 @@
 **Category:** Core
 **Owns:** the LOAD/SAVE protocol across **all three memory tiers** for Claude Code, Cursor, and Task-spawned subagents.
 **Loaded by:** `@docs/00_Core/MEMORY_CONTRACT.md` in `CLAUDE.md` (Claude Code auto-inclusion); referenced by `.cursor/rules/memory-contract.mdc` (Cursor auto-apply); embedded in `.claude/agents/*.md` and `AGENTS.md` via marker-delimited sections re-rendered by `scripts/merge_memory_contract.py`.
-**Companion invariants:** [`memory-three-tiers.md`](../01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md), [`secrets-from-doppler.md`](../01_Vault/AcCopilotTrainer/00_System/invariants/secrets-from-doppler.md).
+**Companion invariants:** [`memory-three-tiers.md`](../01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md), [`secrets-from-doppler.md`](../01_Vault/ProjectTemplate/00_System/invariants/secrets-from-doppler.md).
 **Originating postmortem:** [issue #115](https://github.com/agorokh/template-repo/issues/115).
 
 ---
 
 ## The contract in one paragraph
 
-Memory in this project lives in **exactly three tiers** — `AGENTS.md` (Tier 1, short operational facts, auto-loaded), the vault (Tier 2, structured markdown graph), and a per-workspace semantic substrate (Tier 3, Graphiti / LightRAG, queryable via `mcp__agentic-memory__*`). Every agent — primary, Task-spawned subagent, Cursor coding agent, CLI invocation — **MUST**:
+Memory in this project lives in **exactly three tiers** — `AGENTS.md` (Tier 1, short operational facts, auto-loaded), the vault (Tier 2, structured markdown graph), and a per-workspace semantic substrate (Tier 3, LightRAG canonical online — Graphiti retained for offline entity-resolution + bi-temporal metadata only per the [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md) maintained in agent-factory — queryable via `mcp__agentic-memory__*`). Every agent — primary, Task-spawned subagent, Cursor coding agent, CLI invocation — **MUST**:
 
 1. **Read Tier 3 at LOAD** via `mcp__agentic-memory__query_knowledge_graph` for the active workspace before any substantive Edit/Write/Bash on code paths. The substrate is the reason we keep three tiers; skipping the read means re-discovering context every session.
 2. **Write to the right tier at SAVE.** Short operational facts → `AGENTS.md`. Structured knowledge (decisions, investigations, invariants, glossary, handoffs) → vault as small linked nodes. **Tier 3 is read-mostly from the agent surface** — it is rebuilt by re-ingesting Tier-2 on cadence; agents do not write to it directly.
-3. **Never write outside the three tiers.** The Claude Code per-user auto-memory directory (`~/.claude/projects/.../memory/`) is **deprecated for this project**. Scratch DBs and ad-hoc files outside the three tiers are side channels ([invariant](../01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md)). Tier-3 is normally populated by **vault → ingest**; direct substrate writes (`mcp__agentic-memory__add_episode`, etc.) are optional exceptions for material findings when the MCP is available — not a substitute for vault SAVE.
+3. **Never write outside the three tiers.** The Claude Code per-user auto-memory directory (`~/.claude/projects/.../memory/`) is **deprecated for this project**. Scratch DBs, ad-hoc files, and direct substrate-store writes that bypass the vault → ingest pipeline are all side channels ([invariant](../01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md)).
 
 These rules are enforced by deterministic hooks (`scripts/hook_session_start_memory_prefetch.py`, `scripts/hook_memory_gate.py`, `scripts/hook_stop_save_reminder.py`) — not by trust in the agent's prompt-following. Failure modes are explicit and surfaced to the human.
 
@@ -27,9 +27,9 @@ These rules are enforced by deterministic hooks (`scripts/hook_session_start_mem
 |---|---|---|---|
 | **1** | `AGENTS.md` bottom section + changelog | Direct `Edit` for short operational facts (commands, ports, learned preferences, policy updates) | Auto-loaded by Claude Code / Cursor at session start |
 | **2** | Obsidian vault at `docs/01_Vault/<ProjectKey>/` (markdown graph; `00_Graph_Schema.md`) | Direct `Write` / `Edit` of small linked nodes (decisions, investigations, invariants, glossary, handoffs) | `@`-included by `CLAUDE.md`; indirectly via Tier-3 query (the substrate is built by re-ingesting Tier-2) |
-| **3** | Per-workspace semantic substrate declared in [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml). Backend: `graphiti` (canonical) or `lightrag` (legacy). | **Indirect.** The substrate ingests Tier-2 vault notes on cadence (`stale_after_hours` per workspace). Agents do **not** write to the substrate directly. | `mcp__agentic-memory__query_knowledge_graph(prompt, workspace=…)` + `mcp__agentic-memory__search_*`. **Read at LOAD is mandatory.** |
+| **3** | Per-workspace semantic substrate declared in [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml). Backend: **`lightrag` (canonical online)** or `graphiti` (offline-only per [sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md); never on the agent read path). | **Indirect.** The substrate ingests Tier-2 vault notes on cadence (`stale_after_hours` per workspace). Agents do **not** write to the substrate directly — no MCP write tools are exposed by design. | For **`lightrag`** workspaces only: `mcp__agentic-memory__query_knowledge_graph(prompt, workspace=…)` + `mcp__agentic-memory__search_*`. Not used for `graphiti` rows (offline-only). **Read at LOAD is mandatory** when a matching LightRAG workspace is live. |
 
-Auto-memory (`~/.claude/projects/.../memory/`) is **not** a tier — it is a side channel actively deprecated for this project. See [`memory-three-tiers.md`](../01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md).
+Auto-memory (`~/.claude/projects/.../memory/`) is **not** a tier — it is a side channel actively deprecated for this project. See [`memory-three-tiers.md`](../01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md).
 
 ---
 
@@ -44,7 +44,7 @@ At session start, the `SessionStart` command hook (`.claude/settings.base.json`)
 
 **Agent obligation:** if you need to do meaningful work, **issue at least one `mcp__agentic-memory__query_knowledge_graph` call early in the session** with a prompt tied to the issue/branch/task. The SessionStart hook does an initial prefetch using branch name + issue title as the query; refine with a task-specific query once you understand scope.
 
-If you are a **Task-spawned subagent**, the orchestrator embeds the SessionStart memory prefetch output as a `## Pre-loaded memory context` block in your prompt. You inherit the same `.scratch/.last_memory_query` stamp on disk; further MCP queries supplement your context in the prompt but **do not** update the gate stamp today (only SessionStart prefetch writes/refreshes `.scratch/.last_memory_query`).
+If you are a **Task-spawned subagent**, the orchestrator embeds the SessionStart memory prefetch output as a `## Pre-loaded memory context` block in your prompt. You inherit the same lockfile on disk; further MCP queries supplement context but do not rewrite the gate stamp (only SessionStart prefetch updates `.scratch/.last_memory_query` today).
 
 ---
 
@@ -53,7 +53,7 @@ If you are a **Task-spawned subagent**, the orchestrator embeds the SessionStart
 At session end (Stop hook) or before a Phase-C vault commit:
 
 1. **Vault SAVE** — Update `Next Session Handoff.md`. Add or update small linked nodes for any new investigation, decision, or convention per [`00_Graph_Schema.md`](../01_Vault/00_Graph_Schema.md). Prefer **new small files** over appending to monoliths.
-2. **Tier-3 substrate write** — Material findings (new architectural decisions, recurring failure patterns, fleet-wide invariant violations) should be promoted to the substrate so future agents retrieve them at LOAD. For `graphiti` workspaces, add via `mcp__agentic-memory__add_episode` (when available) or rely on the vault → substrate ingest pipeline (Graphiti ingests new vault notes on its cadence). For `lightrag` workspaces, the ingest-audit launchd unit picks up new vault notes within `stale_after_hours`.
+2. **Tier-3 substrate write** — *agents never write to the substrate directly.* No MCP write tool is exposed; the substrate is rebuilt by re-ingesting Tier-2 vault notes on cadence. Material findings (architectural decisions, recurring failure patterns, fleet-wide invariant violations) become Tier-3-discoverable by being written as Tier-2 vault nodes (small linked markdown). For `lightrag` workspaces (canonical online), the ingest-audit launchd unit picks up new vault notes within `stale_after_hours`. Operational/audit events that don't merit a knowledge node go to JSONL audit logs alongside the vault (e.g. `docs/01_Vault/<ProjectKey>/_inbox/cycles/steward-events.jsonl`).
 3. **Stop audit** — `scripts/hook_stop_save_reminder.py` logs whether (a) the session touched code paths and (b) a vault or Tier-3 write occurred. Mismatches surface to the human as a one-line reminder; they are **not blocking** (template invariant: no LLM in hooks; the audit script is deterministic but advisory).
 
 ---
@@ -95,7 +95,7 @@ When the orchestrator (`issue-driven-coding-orchestrator`) or any agent invokes 
 
 - **Embed memory context.** The orchestrator MUST include a `## Pre-loaded memory context` section in the subagent's prompt with the SessionStart prefetch output (verbatim or summarized). Subagents do not auto-load `CLAUDE.md`; this is the explicit propagation channel.
 - **Embed the contract pointer.** Include the line `Memory contract: docs/00_Core/MEMORY_CONTRACT.md (loaded contract authoritative).` so the subagent treats memory as required, not optional.
-- **Inherit the lockfile.** Subagents in the same session share the parent's `.scratch/.last_memory_query` stamp; their own MCP queries supplement context but do not refresh the stamp (same rule as the primary agent until query-time stamp refresh lands).
+- **Inherit the lockfile.** Subagents in the same session share `.scratch/.last_memory_query`. They may refresh it with their own MCP queries but the parent's stamp counts.
 
 In **Cursor**, where Task only allows `subagent_type` in `{generalPurpose, explore, shell, best-of-n-runner}`, the same contract applies: use `generalPurpose` with the embedded memory context, per `.cursor/rules/cursor-task-delegation.mdc`.
 
@@ -169,9 +169,9 @@ Heuristic accuracy: the citation check is substring-match — an agent that happ
 ## See also
 
 - [`SESSION_LIFECYCLE.md`](SESSION_LIFECYCLE.md) — LOAD → OPERATE → SAVE that this contract slots into.
-- [`MEMORY_SUBSTRATE.md`](MEMORY_SUBSTRATE.md) — Tier-3 substrate detail (Graphiti vs LightRAG; workspace schema).
+- [`MEMORY_SUBSTRATE.md`](MEMORY_SUBSTRATE.md) — Tier-3 substrate detail (LightRAG canonical online; Graphiti offline-only per sunset ADR; workspace schema).
 - [`VAULT_TAXONOMY.md`](VAULT_TAXONOMY.md) — `origin` classification (`repo-product` / `repo-embedded` / `human-curated`).
 - [`HOOK_DESIGN.md`](HOOK_DESIGN.md) — why hooks are deterministic and never LLM-bearing.
-- [`memory-three-tiers.md`](../01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md), [`secrets-from-doppler.md`](../01_Vault/AcCopilotTrainer/00_System/invariants/secrets-from-doppler.md) — companion invariants.
+- [`memory-three-tiers.md`](../01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md), [`secrets-from-doppler.md`](../01_Vault/ProjectTemplate/00_System/invariants/secrets-from-doppler.md) — companion invariants.
 - [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml) — workspace registry.
 - [`ops/propagation_manifest.yml`](../../ops/propagation_manifest.yml) — fleet convergence tracking; PR C adds the `memory-enforcement-v1` invariant.

--- a/docs/00_Core/MEMORY_SUBSTRATE.md
+++ b/docs/00_Core/MEMORY_SUBSTRATE.md
@@ -1,9 +1,15 @@
 # Memory substrate (Tier-3)
 
 **Status:** Template
-**Version:** 1.0
+**Version:** 1.1
 **Category:** Core
 **Related:** [VAULT_TAXONOMY.md](VAULT_TAXONOMY.md), [SESSION_LIFECYCLE.md](SESSION_LIFECYCLE.md), [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml)
+
+> **2026-05-17 substrate-selection sunset** ([Graphiti sunset ADR in agent-factory](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md)):
+>
+> - **LightRAG = canonical online substrate.** All agent reads via `mcp__agentic-memory__*` (which wraps LightRAG). Default for new workspaces.
+> - **Graphiti = offline-only.** Retained for entity-resolution + bi-temporal metadata feeding LightRAG's chunk index. **Agents NEVER query Graphiti directly.**
+> - **Substrate writes are indirect.** No write tool is exposed on the agent surface; the substrate is rebuilt by re-ingesting Tier-2 vault notes on cadence.
 
 ---
 
@@ -11,45 +17,44 @@
 
 Tier-3 memory (the semantic graph that complements `AGENTS.md` and the Obsidian vault) is served by a **substrate**: a process or process-group that owns the graph store, the entity/relation extraction pipeline, and the retrieval surface that downstream agents call.
 
-This template supports two substrates today. Each workspace in `ops/memory_manifest.yml` declares its substrate via the per-workspace `backend` field.
+This template uses one canonical online substrate (LightRAG) plus an optional offline metadata layer (Graphiti). Each workspace in `ops/memory_manifest.yml` declares its substrate via the per-workspace `backend` field.
 
 | Backend | Purpose | Default for new workspaces? |
 |---|---|---|
-| `graphiti` ([getzep/graphiti](https://github.com/getzep/graphiti)) | Bi-temporal entity-relation graph with automatic contradiction detection. One MCP server hosts all workspaces by `group_id`. | **Yes — canonical going forward.** |
-| `lightrag` ([HKUDS/LightRAG](https://github.com/HKUDS/LightRAG)) | Dual-level (entity + relation) retrieval over a per-workspace HTTP server. Mature ingest path for narrative vaults. | No — workspaces that exist on this backend persist until each is migrated to `graphiti`. |
-
-There is **no perpetual sidecar**. The two-backend state is a migration window, not an end-state.
+| `lightrag` ([HKUDS/LightRAG](https://github.com/HKUDS/LightRAG)) | Dual-level (entity + relation) retrieval over a per-workspace HTTP server. **Canonical online substrate.** All agent reads via `mcp__agentic-memory__*`. | **Yes — canonical.** |
+| `graphiti` ([getzep/graphiti](https://github.com/getzep/graphiti)) | Bi-temporal entity-relation graph with automatic contradiction detection. **Offline-only after the 2026-05-17 sunset**: produces entity-resolution + bi-temporal metadata that feeds LightRAG's chunk index. Never on the agent read path. | No — offline use only. |
 
 ---
 
 ## Why the substrate choice matters
 
-The two backends differ in three semantic dimensions that propagate to every consumer:
+The two backends differ in three semantic dimensions:
 
 1. **Process topology**
-   - `graphiti`: **one** MCP server process, **one** Neo4j connection, workspaces partitioned by per-call `group_id`. Fewer ports, less per-workspace ops, single blast-radius.
-   - `lightrag`: **N** HTTP server processes (one per workspace) on distinct ports. Fault-isolated per workspace; more launchd plists.
+   - `lightrag`: **N** HTTP server processes (one per workspace) on distinct ports. Fault-isolated per workspace; one launchd plist per workspace.
+   - `graphiti`: **one** MCP server process, **one** Neo4j connection, workspaces partitioned by per-call `group_id`. For OFFLINE entity-resolution use only.
 
 2. **Temporal semantics**
-   - `graphiti`: bi-temporal edges (`valid_at` / `invalid_at` + `created_at` / `expired_at`). Contradictions detected on ingest and resolved by stamping `invalid_at` on the loser; nothing is hard-deleted. Supports "what was true at time T" queries natively.
-   - `lightrag`: append-mostly; no first-class temporal validity model. Time queries are not native.
+   - `lightrag`: append-mostly chunk index; time-aware retrieval comes from bi-temporal metadata that Graphiti feeds in offline.
+   - `graphiti`: bi-temporal edges (`valid_at` / `invalid_at` + `created_at` / `expired_at`). Used to produce metadata, **not** for online queries.
 
-3. **Retrieval shape**
-   - `graphiti`: structured entity/edge results from `search_nodes` / `search_memory_facts`. Caller composes prose.
-   - `lightrag`: prose RAG output with embedded reference lines. Mode parameter (`hybrid` / `mix` / `global` / `local` / `naive`) controls retrieval strategy.
+3. **Retrieval shape (agent-visible)**
+   - `lightrag` via `mcp__agentic-memory__query_knowledge_graph`: prose RAG output with embedded reference lines + `references` array. Mode parameter (`hybrid` / `mix` / `global` / `local` / `naive`) controls retrieval strategy.
+   - `graphiti`: **not exposed at the agent surface.** Its outputs land as metadata on LightRAG chunks via the ingest pipeline.
 
-These differences are why `ops/memory_manifest.yml` declares `canary_acceptance` per backend (the response shapes are not interchangeable) and why each workspace's `mode` field is backend-scoped vocabulary.
+These differences are why `ops/memory_manifest.yml` declares `canary_acceptance` per backend and why each workspace's `mode` field is backend-scoped vocabulary.
 
 ---
 
 ## When to use which
 
-- **`graphiti` is the default for any new workspace.** It is the canonical substrate going forward. Choose it unless you have a concrete reason not to.
-- **Choose `lightrag`** only when:
-  - You are operating an existing `lightrag` workspace that has not yet been migrated, OR
-  - You explicitly need LightRAG's mode vocabulary (`hybrid` / `mix` / `global` / `local` / `naive`) for a use case that has been validated against Graphiti's retrieval and demonstrably underperforms.
+- **`lightrag` is the canonical online substrate for every workspace.** All new workspaces are born onto LightRAG. All agent reads go through `mcp__agentic-memory__*`.
+- **`graphiti` is retained only for offline workflows** that LightRAG cannot replicate (per the sunset ADR):
+  - Bi-temporal entity resolution at ingest time
+  - Temporal drift detection
+  - Offline writeback validation
 
-The bias is: new workspaces are born onto `graphiti`. Existing `lightrag` workspaces migrate forward, they do not retroactively re-establish themselves as legacy.
+These offline outputs feed LightRAG's chunk metadata. Agents never see them as Graphiti queries; they see them as enriched LightRAG retrieval results.
 
 ---
 
@@ -61,21 +66,19 @@ Every workspace lives as a row under a host in `ops/memory_manifest.yml`. The mi
 
 ```yaml
 - name: "<workspace_id>"
-  backend: "graphiti"           # or "lightrag" if migrating an existing one
+  backend: "lightrag"           # canonical online; "graphiti" only for offline workspaces (per sunset ADR)
   origin: "repo-embedded"       # see VAULT_TAXONOMY.md
-  endpoint: "http://localhost:8100" # graphiti: shared MCP URL; lightrag: per-workspace port
+  endpoint: "http://localhost:8060" # per-workspace LightRAG port
   vault_root: "~/path/to/vault"
   audit_log: "~/path/to/vault/.turbovault/audit/operations.jsonl"
-  launchd_label: null           # graphiti: null; lightrag: ai.lightrag.ingest-audit.<name>
+  launchd_label: "ai.lightrag.ingest-audit.<name>" # null when ingest is operator-managed externally
   stale_after_hours: 24
   canary_queries:
     - prompt: "<short probe relevant to this vault>"
-      mode: "search_nodes"      # graphiti tool name OR lightrag mode
+      mode: "hybrid"            # lightrag retrieval mode
 ```
 
-For `graphiti` workspaces, `launchd_label` is `null` (single shared process). For `lightrag` workspaces, `launchd_label` typically follows `ai.lightrag.ingest-audit.<workspace_name>`; use `null` when ingest is operator-managed externally (see `divorce_proceedings` in the live manifest).
-
-For `graphiti` workspaces, the MCP `group_id` defaults to the workspace `name`. Override via manifest `graph_namespace` (consumers map that field to `group_id` on each Graphiti call).
+For `lightrag` workspaces, `launchd_label` typically follows `ai.lightrag.ingest-audit.<workspace_name>`; use `null` when ingest is operator-managed externally.
 
 ---
 
@@ -91,7 +94,7 @@ Tier-3 substrates (LightRAG, Graphiti, anything that runs programmatic LLM extra
 
 The base URL is `DIAL_BASE_URL` (verify exact var name in Doppler at use time).
 
-**Mapping to third-party tools:** upstream Graphiti / LightRAG images often demand env vars literally named `OPENAI_API_KEY` and `OPENAI_API_URL`. Those are *name slots* the tool's code looks for — the *values* MUST be sourced from DIAL. Compose / shell mapping pattern:
+**Mapping to third-party tools:** upstream LightRAG / Graphiti images often demand env vars literally named `OPENAI_API_KEY` and `OPENAI_API_URL`. Those are *name slots* the tool's code looks for — the *values* MUST be sourced from DIAL. Compose / shell mapping pattern:
 
 ```bash
 OPENAI_API_KEY=${DIAL_API_KEY_PROJECT:-${DIAL_API_KEY:?DIAL credential required}}
@@ -108,17 +111,18 @@ doppler run --project ag-dev-ecosystem --config dev_work -- docker compose up -d
 
 **Hard rule:** a raw `OPENAI_API_KEY` sourced from a real OpenAI key MUST NEVER appear in any substrate config, .env, ADR, or deploy bundle in this org.
 
-## Migration discipline
+---
 
-When migrating a workspace from `lightrag` to `graphiti`:
+## Sunset migration discipline
 
-1. Stand up the workspace in Graphiti (re-ingest via the file→episode reconciler — Graphiti has no LightRAG-graph importer).
-2. Verify recall quality against the existing canary queries (translated to Graphiti's tool vocabulary).
-3. Flip the `backend` value in `ops/memory_manifest.yml` in a single PR.
-4. Retire the LightRAG launchd plist for that workspace.
-5. Vault handoff: record the migration in the project's vault investigation log.
+Workspaces that were on `backend: graphiti` during the migration window are being reverted to `backend: lightrag` per the sunset ADR. Any new offline-use Graphiti deployments (entity-resolution, bi-temporal metadata pipelines) follow these rules:
 
-Do **not** leave a workspace ingesting into both substrates simultaneously — that creates the dual-write authority problem the substrate boundary is designed to avoid.
+1. Mark the workspace `backend: graphiti` ONLY for an offline use case justified by the sunset ADR's offline-workflow criteria.
+2. Add a `notes` field referencing the sunset ADR + the specific offline workflow.
+3. The agent-facing read path remains `mcp__agentic-memory__*` pointed at the LightRAG instance that consumes Graphiti's offline output.
+4. Verify the LightRAG canary still passes with the Graphiti-derived metadata in place.
+
+Do **not** add a Graphiti workspace to the agent's MCP connection list; it must remain off the read path. **Transitional exception:** rows in `ops/memory_manifest.yml` that still declare `backend: graphiti` as unprovisioned placeholders (see the manifest comment block) are not agent read targets—the SessionStart prefetch may probe them and records a `missing` marker until workstation-ops flips each row to `lightrag`.
 
 ---
 
@@ -126,11 +130,11 @@ Do **not** leave a workspace ingesting into both substrates simultaneously — t
 
 Consumers that parse `ops/memory_manifest.yml` MUST:
 
-- Treat a workspace with no `backend` field as `backend: "lightrag"` (the implicit v1 default).
-- Treat a flat (un-nested) `canary_acceptance` block as `canary_acceptance.lightrag` (the v1 shape).
+- Treat a workspace with no `backend` field as `backend: "lightrag"` (the canonical default).
+- Treat a flat (un-nested) `canary_acceptance` block as `canary_acceptance.lightrag` (the legacy v1 shape).
 - Default missing `origin` to `null` and treat as "unclassified" without erroring.
 
-This keeps v1 manifests parseable until every consumer adopts the v2 schema, and lets the migration roll out per-workspace rather than as a coordinated cut-over.
+**Strict mode (recommended for fleet health checks):** `scripts/check_memory_manifest.py` (wired into `ci_policy`) **fails** when a workspace row omits `backend`, uses an unknown value, or declares `graphiti` without `notes`. Manifest *parsers* may still default omitted `backend` to `lightrag` for backward compatibility when reading legacy files, but the SessionStart hook **does not** default at runtime — omitted `backend` skips HTTP prefetch and stamps `.scratch/.last_memory_query.missing`. The hook only issues HTTP reads when `backend == "lightrag"`; `graphiti` rows (including sunset placeholders) never hit the agent read path — see `tests/test_hook_session_start_memory_prefetch.py::test_graphiti_backend_writes_missing_marker` and `test_missing_backend_skips_prefetch`.
 
 ---
 
@@ -138,5 +142,6 @@ This keeps v1 manifests parseable until every consumer adopts the v2 schema, and
 
 - [VAULT_TAXONOMY.md](VAULT_TAXONOMY.md) — what `origin` means and how it shapes ingest cadence
 - [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml) — live manifest with the schema in use
-- [`.claude/rules/memory.md`](../../.claude/rules/memory.md) — rule pointer for agents
-- Graphiti MCP server: [getzep/graphiti/mcp_server](https://github.com/getzep/graphiti/tree/main/mcp_server)
+- [`.claude/rules/memory-substrate.md`](../../.claude/rules/memory-substrate.md) — rule pointer for agents
+- LightRAG: [HKUDS/LightRAG](https://github.com/HKUDS/LightRAG)
+- Graphiti (offline-only): [getzep/graphiti/mcp_server](https://github.com/getzep/graphiti/tree/main/mcp_server) — see [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md) in agent-factory

--- a/docs/00_Core/VAULT_TAXONOMY.md
+++ b/docs/00_Core/VAULT_TAXONOMY.md
@@ -1,0 +1,90 @@
+# Vault taxonomy (vault origin classification)
+
+**Status:** Template
+**Version:** 1.0
+**Category:** Core
+**Related:** [MEMORY_SUBSTRATE.md](MEMORY_SUBSTRATE.md), [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml)
+
+---
+
+## Why classify vault origin
+
+Vaults in this ecosystem have different *natures* depending on how they come into being. The same retrieval substrate (Tier-3) serves all of them, but the **ingest cadence, the value of bi-temporal modeling, and the conflict-resolution policy differ by origin**. Naming the three categories explicitly lets every consumer reason about each vault correctly.
+
+This is `origin` on the per-workspace row in [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml).
+
+---
+
+## The three origin types
+
+### `repo-product`
+
+The vault is a **build artifact** of another repository's content pipeline. Markdown is machine-generated from raw source (PDFs, scraped data, extracted entities, etc.). The source-of-truth is the input pipeline, not the vault itself.
+
+- **Update pattern:** bulk-rebuild when source changes; rare, atomic, large.
+- **Conflict semantics:** the rebuild replaces the prior vault snapshot wholesale; reconciliation happens at the pipeline boundary, not in the graph.
+- **Bi-temporal value:** mostly cosmetic — facts don't evolve incrementally within the vault, they get re-emitted by a deterministic pipeline.
+- **Examples:** `divorce_proceedings` (built from court-filing PDFs by the `court_fillings_processing` repo).
+
+### `repo-embedded`
+
+The vault **is** the repository's own documentation directory. Markdown lives in the same git history as the code; vault changes go through the same PR workflow as code changes.
+
+- **Update pattern:** continuous high-frequency edits, deletes, renames via PRs; small, atomic, frequent.
+- **Conflict semantics:** humans resolve via PR review; the vault is single-writer via the repo's branch protection.
+- **Bi-temporal value:** **high** — facts about an evolving system get superseded constantly; "what did we believe on date X" is a real query.
+- **Examples:** `agent_factory_steward` (this template's vault descendants), `alpaca_trading` (vault inside the trader repo).
+
+### `human-curated`
+
+The vault is an **operator-authored knowledge base** with mixed origins. Some entries are bulk-infused from external sources (papers, third-party knowledge dumps); others are manual notes; others are MCP-mediated structured imports. The operator (human) drives ingest cadence directly.
+
+- **Update pattern:** mixed — periodic bulk infusions plus continuous manual edits.
+- **Conflict semantics:** the operator is the single writer; conflicting facts resolved by hand (or by Tier-3's contradiction detection, surfaced for review).
+- **Bi-temporal value:** **useful** — particularly for tracking when external knowledge was infused vs. when manual edits happened.
+- **Examples:** `epam_dialx` (operator-curated EPAM knowledge base with Novartis-content infusions and structured MCP imports), `dial_sandbox_mnemos` (operator-curated demo subset of `epam_dialx`).
+
+---
+
+## Consequences for substrate choice
+
+The origin classification interacts with the substrate choice (see [MEMORY_SUBSTRATE.md](MEMORY_SUBSTRATE.md)):
+
+| Origin | Best substrate (online) | Rationale |
+|---|---|---|
+| `repo-product` | `lightrag` (canonical) | Bulk rebuild works cleanly; LightRAG dual-level retrieval matches `repo-product` query patterns |
+| `repo-embedded` | `lightrag` (canonical) — optionally backed by offline Graphiti metadata | Frequent edits + supersession benefit from bi-temporal metadata; under the [sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md), agents READ via LightRAG (`mcp__agentic-memory__*`); Graphiti runs OFFLINE to produce bi-temporal metadata that enriches LightRAG's chunk index |
+| `human-curated` | `lightrag` (canonical) | Mixed write patterns work well with LightRAG's hybrid retrieval mode |
+
+LightRAG is canonical online for every origin. Graphiti is offline-only — never on the agent read path — and is justified only when one of the sunset ADR's offline workflows (bi-temporal entity resolution, temporal drift detection, offline writeback validation) is required.
+
+---
+
+## Consequences for ingest cadence
+
+`origin` also informs `stale_after_hours` in the manifest:
+
+- `repo-product`: very generous (`168`+) — operator-driven bulk rebuilds, not continuous ingest.
+- `repo-embedded`: tight (`24` or less) — vault edits should propagate within a working day.
+- `human-curated`: medium (`24`–`72`) — operator drives cadence but ingest should keep up with bulk infusions.
+
+---
+
+## Adding a new vault
+
+When registering a new workspace in `ops/memory_manifest.yml`:
+
+1. Pick the `origin` that matches how the vault actually comes into being (not how you wish it did).
+2. Pick `backend: "lightrag"` (canonical online default; see the [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md) — `graphiti` only for offline use).
+3. Set `stale_after_hours` informed by `origin` per the table above.
+4. Add at least one canary query relevant to the vault's content.
+
+If unsure about origin, default to `human-curated` and revisit once the ingest pattern stabilizes.
+
+---
+
+## See also
+
+- [MEMORY_SUBSTRATE.md](MEMORY_SUBSTRATE.md) — substrate selection and per-workspace declaration
+- [BOOTSTRAP_NEW_PROJECT.md](BOOTSTRAP_NEW_PROJECT.md) §"8. Tier-3 semantic memory (optional)" — how to register a vault from scratch
+- [`ops/memory_manifest.yml`](../../ops/memory_manifest.yml) — the live schema

--- a/docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md
@@ -2,7 +2,7 @@
 type: invariant
 status: active
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-19
 relates_to:
   - AcCopilotTrainer/00_System/invariants/_index.md
   - AcCopilotTrainer/00_System/invariants/secrets-from-doppler.md
@@ -21,7 +21,7 @@ All persistent project memory lives in **exactly one** of three declared tiers. 
 |---|---|---|---|
 | **1** | [`AGENTS.md`](../../../../../AGENTS.md) + tier-1 changelog block | Direct `Edit` for short operational facts (commands, ports, learned preferences, policy updates) | Auto-loaded by Claude Code / Cursor at session start |
 | **2** | [Vault](../../) at `docs/01_Vault/<ProjectKey>/` (Obsidian markdown graph; see [`00_Graph_Schema.md`](../../../../00_Graph_Schema.md)) | Direct `Write` / `Edit` of small linked nodes (decisions, investigations, invariants, glossary, handoffs) | `@`-included by `CLAUDE.md`; also indirectly via Tier-3 query (the substrate is built by re-ingesting Tier-2) |
-| **3** | Per-workspace semantic substrate declared in [`ops/memory_manifest.yml`](../../../../../ops/memory_manifest.yml). Backend: `graphiti` (canonical) or `lightrag` (legacy). See [`MEMORY_SUBSTRATE.md`](../../../../00_Core/MEMORY_SUBSTRATE.md). | **Indirect.** The substrate ingests new vault notes on its cadence (`stale_after_hours` per workspace). Agents do **not** write to the substrate directly. | `mcp__agentic-memory__query_knowledge_graph(prompt, workspace=…)` + `mcp__agentic-memory__search_*`. **Read at LOAD is mandatory** for substantive sessions. |
+| **3** | Per-workspace semantic substrate declared in [`ops/memory_manifest.yml`](../../../../../ops/memory_manifest.yml). Backend: **`lightrag` (canonical online)** or `graphiti` (offline-only per [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md); never on the agent read path). See [`MEMORY_SUBSTRATE.md`](../../../../00_Core/MEMORY_SUBSTRATE.md). | **Indirect.** The substrate ingests new vault notes on its cadence (`stale_after_hours` per workspace). Agents do **not** write to the substrate directly — no MCP write tools are exposed by design. | For **`lightrag`** workspaces only: `mcp__agentic-memory__query_knowledge_graph(prompt, workspace=…)` + `mcp__agentic-memory__search_*`. Not used for `graphiti` rows (offline-only). **Read at LOAD is mandatory** when a matching LightRAG workspace is live. |
 
 ## What is forbidden (side channels)
 
@@ -52,7 +52,7 @@ Collapsing Tier 3 into "vault" misses the point. The vault is human-readable mar
 
 ## Rationale (postmortem)
 
-A 2026-05-16 postmortem ([template-repo issue #115](https://github.com/agorokh/template-repo/issues/115)) catalogued an agent that wrote 6 "memories" to the auto-memory directory and consequently re-derived a credential strategy that already existed in the vault — and got it wrong. The substrate (Graphiti) was reachable but never queried. Documentation alone did not prevent the drift; runtime enforcement is mandatory.
+A 2026-05-16 postmortem ([issue #115](https://github.com/agorokh/template-repo/issues/115); see also [`memory-enforcement-postmortem-2026-05-16.md`](../../02_Investigations/memory-enforcement-postmortem-2026-05-16.md)) catalogued an agent that wrote 6 "memories" to the auto-memory directory and consequently re-derived a credential strategy that already existed in the vault — and got it wrong. The substrate (Graphiti) was reachable but never queried. Documentation alone did not prevent the drift; runtime enforcement is mandatory.
 
 ## See also
 

--- a/ops/memory_manifest.yml
+++ b/ops/memory_manifest.yml
@@ -5,14 +5,30 @@ anchors:
   umbrella_issue: "https://github.com/agorokh/agent-factory/issues/62"
   umbrella_adr: "https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/memory-fleet-observability.md"
 
-# Canary-query acceptance contract (authoritative source; mirrors the ADR).
-# Consumers (``memory-health-scan`` skill + workstation-ops exporter):
-#   A workspace is "memory is working" iff
-#     (1) the response text does NOT contain "No relevant context found" (case-insensitive), AND
-#     (2) the response text contains at least one line matching ``^- \[\d+\]`` under a
-#         References section.
-# The top-level ``references: []`` envelope on the MCP result is bibliographic
-# metadata and MUST NOT be used as the acceptance signal.
+# ---------------------------------------------------------------------------
+# Schema v2 notes
+# ---------------------------------------------------------------------------
+# Two changes from v1, both backward-compatible for consumers that follow the
+# defaults documented below:
+#
+#  - Per-workspace `backend: "lightrag" | "graphiti"` discriminator.
+#    Consumers that encounter a workspace without `backend` MUST treat it as
+#    "lightrag" (the canonical default). **New workspaces SHOULD default to
+#    "lightrag" per docs/00_Core/MEMORY_SUBSTRATE.md** (the 2026-05-17 sunset
+#    ADR reversed an earlier "graphiti canonical" direction; `graphiti` is
+#    retained only for offline entity-resolution + bi-temporal metadata,
+#    never on the agent read path).
+#
+#  - Per-workspace `origin: "repo-product" | "repo-embedded" | "human-curated"`
+#    classification. Optional but recommended; see docs/00_Core/VAULT_TAXONOMY.md
+#    for definitions and ingest-cadence implications.
+#
+# Canary-acceptance contract is now keyed by backend (different substrates
+# return different response shapes). Consumers MUST look up
+# `canary_acceptance[workspace.backend]`. A flat (un-nested) v1 form, if seen,
+# is treated as `canary_acceptance.lightrag` for backward compatibility.
+# ---------------------------------------------------------------------------
+
 canary_acceptance:
   must_not_contain: "no relevant context found"
   must_match_regex: "^- \\[\\d+\\]"


### PR DESCRIPTION
Closes #104. See meta agorokh/agent-factory#178. Mechanical pull of the 8-file sunset doctrine from template-repo PR #124.

**Branch rename:** original PR opened on `wave3/sunset-doctrine`; renamed to `fix/` prefix to satisfy this repo's `scripts/ci_policy.py` branch-name policy (or template's equivalent). Old PR #105 auto-closed when head ref was renamed via GitHub branches/rename API.