### PR TITLE
chore: document issue #108 closeout (keep memory-contract paths)

### DIFF
--- a/.cursor/rules/memory-contract.mdc
+++ b/.cursor/rules/memory-contract.mdc
@@ -4,7 +4,7 @@ alwaysApply: true
 
 # Memory contract (mandatory for every Cursor agent)
 
-Canonical contract: [`docs/00_Core/MEMORY_CONTRACT.md`](../../docs/00_Core/MEMORY_CONTRACT.md). Canonical invariant: [`memory-three-tiers.md`](../../docs/01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md). Enforcement is by deterministic hooks (see `scripts/hook_memory_gate.py`), not by prompt-following.
+Canonical contract: [`docs/00_Core/MEMORY_CONTRACT.md`](../../docs/00_Core/MEMORY_CONTRACT.md). Canonical invariant: [`memory-three-tiers.md`](../../docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md). Enforcement is by deterministic hooks (see `scripts/hook_memory_gate.py`), not by prompt-following.
 
 **Three tiers, one rule: read all three at LOAD, write to the right one at SAVE, no side channels.** Tier 1 = `AGENTS.md` (short operational facts, auto-loaded). Tier 2 = vault under `docs/01_Vault/<ProjectKey>/` (structured markdown graph, `@`-included). Tier 3 = semantic substrate via `mcp__agentic-memory__query_knowledge_graph` ([`ops/memory_manifest.yml`](../../ops/memory_manifest.yml); **LightRAG canonical online**; Graphiti offline-only per the [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md)). **Reading Tier 3 at LOAD is mandatory** for substantive sessions — it's the reason the substrate exists.
 
@@ -18,7 +18,7 @@ At session start, the SessionStart command hook (`scripts/hook_session_start_mem
 
 ## SAVE
 
-Short operational facts go to **Tier 1** (`AGENTS.md`). Structured knowledge goes to **Tier 2** — small linked vault nodes per [`docs/01_Vault/00_Graph_Schema.md`](../../docs/01_Vault/00_Graph_Schema.md). Update `Next Session Handoff.md`. **Tier 3** (the semantic substrate) ingests Tier-2 automatically — do not double-write. **Never** write to `~/.claude/projects/.../memory/` — that auto-memory side channel is deprecated for this project (invariant: [`memory-three-tiers.md`](../../docs/01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md)).
+Short operational facts go to **Tier 1** (`AGENTS.md`). Structured knowledge goes to **Tier 2** — small linked vault nodes per [`docs/01_Vault/00_Graph_Schema.md`](../../docs/01_Vault/00_Graph_Schema.md). Update `Next Session Handoff.md`. **Tier 3** (the semantic substrate) ingests Tier-2 automatically — do not double-write. **Never** write to `~/.claude/projects/.../memory/` — that auto-memory side channel is deprecated for this project (invariant: [`memory-three-tiers.md`](../../docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md)).
 
 ## Cursor Task subagents
 

--- a/.cursor/rules/memory-contract.mdc
+++ b/.cursor/rules/memory-contract.mdc
@@ -4,7 +4,7 @@ alwaysApply: true
 
 # Memory contract (mandatory for every Cursor agent)
 
-Canonical contract: [`docs/00_Core/MEMORY_CONTRACT.md`](../../docs/00_Core/MEMORY_CONTRACT.md). Canonical invariant: [`memory-three-tiers.md`](../../docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md). Enforcement is by deterministic hooks (see `scripts/hook_memory_gate.py`), not by prompt-following.
+Canonical contract: [`docs/00_Core/MEMORY_CONTRACT.md`](../../docs/00_Core/MEMORY_CONTRACT.md). Canonical invariant: [`memory-three-tiers.md`](../../docs/01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md). Enforcement is by deterministic hooks (see `scripts/hook_memory_gate.py`), not by prompt-following.
 
 **Three tiers, one rule: read all three at LOAD, write to the right one at SAVE, no side channels.** Tier 1 = `AGENTS.md` (short operational facts, auto-loaded). Tier 2 = vault under `docs/01_Vault/<ProjectKey>/` (structured markdown graph, `@`-included). Tier 3 = semantic substrate via `mcp__agentic-memory__query_knowledge_graph` ([`ops/memory_manifest.yml`](../../ops/memory_manifest.yml); **LightRAG canonical online**; Graphiti offline-only per the [Graphiti sunset ADR](https://github.com/agorokh/agent-factory/blob/main/docs/01_Vault/AgentFactory/01_Decisions/adr-2026-05-17-graphiti-sunset.md)). **Reading Tier 3 at LOAD is mandatory** for substantive sessions — it's the reason the substrate exists.
 
@@ -18,7 +18,7 @@ At session start, the SessionStart command hook (`scripts/hook_session_start_mem
 
 ## SAVE
 
-Short operational facts go to **Tier 1** (`AGENTS.md`). Structured knowledge goes to **Tier 2** — small linked vault nodes per [`docs/01_Vault/00_Graph_Schema.md`](../../docs/01_Vault/00_Graph_Schema.md). Update `Next Session Handoff.md`. **Tier 3** (the semantic substrate) ingests Tier-2 automatically — do not double-write. **Never** write to `~/.claude/projects/.../memory/` — that auto-memory side channel is deprecated for this project (invariant: [`memory-three-tiers.md`](../../docs/01_Vault/AcCopilotTrainer/00_System/invariants/memory-three-tiers.md)).
+Short operational facts go to **Tier 1** (`AGENTS.md`). Structured knowledge goes to **Tier 2** — small linked vault nodes per [`docs/01_Vault/00_Graph_Schema.md`](../../docs/01_Vault/00_Graph_Schema.md). Update `Next Session Handoff.md`. **Tier 3** (the semantic substrate) ingests Tier-2 automatically — do not double-write. **Never** write to `~/.claude/projects/.../memory/` — that auto-memory side channel is deprecated for this project (invariant: [`memory-three-tiers.md`](../../docs/01_Vault/ProjectTemplate/00_System/invariants/memory-three-tiers.md)).
 
 ## Cursor Task subagents
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-108-agent-alignment-closeout-2026-05.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-108-agent-alignment-closeout-2026-05.md
@@ -1,0 +1,29 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+last_updated: 2026-05-20
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+---
+
+# Issue #108 agent-surface alignment closeout (2026-05)
+
+## What
+
+Campaign issue [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) asked to align five drifted canonical agent bodies to `template-repo@main` with `ProjectTemplate` → `AcCopilotTrainer` substitutions.
+
+PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) merged with only `.cursor/rules/memory-contract.mdc` updated (vault invariant links corrected). The five agent files were not touched.
+
+PR [#110](https://github.com/agorokh/ac-copilot-trainer/pull/110) originally attempted a git revert of #109; that would have restored dead `ProjectTemplate` vault paths. This PR was retargeted to **document closeout** instead: issue #108 stays **closed**; remaining agent-body alignment is **deferred** (no follow-up issue opened unless Steward re-dispatches).
+
+## Decision
+
+- **Keep** PR #109’s `memory-contract.mdc` fix (`AcCopilotTrainer` invariant paths).
+- **Do not** revert to template placeholder paths in this repo.
+- Full SHA alignment of the five agent bodies is out of scope for the closeout PR.
+
+## Refs
+
+- [agent-factory#199](https://github.com/agorokh/agent-factory/issues/199) § 4 Step 2 (operator close-out plan)
+- [agent-factory PR #193](https://github.com/agorokh/agent-factory/pull/193) (campaign plan)


### PR DESCRIPTION
## Summary

Issue #108 (agent-surface alignment campaign) is **closed** without merging a harmful revert of PR #109.

- **Kept:** PR #109’s `.cursor/rules/memory-contract.mdc` fix (`AcCopilotTrainer` invariant paths — `ProjectTemplate` does not exist in this repo).
- **Deferred:** SHA alignment of the five drifted agent bodies until Steward re-dispatches.
- **Documented:** vault closeout note under `03_Investigations/issue-108-agent-alignment-closeout-2026-05.md`.

Replaces the original revert-only approach (invalid `revert/` branch for `ci_policy`; Codex P2 on dead vault paths).

Refs: agent-factory#199 § 4 Step 2.

## Test plan

- [x] `ci_policy` branch prefix `chore/`
- [ ] CI green on latest SHA

## Summary by Sourcery

Document the closeout of issue #108 while retaining the existing memory contract rule paths and avoiding the previously proposed revert of PR #109.