### PR TITLE
fix(memory): propagate canonical host-aware agentic-memory wrapper

### DIFF
--- a/scripts/mcp/agentic-memory.sh
+++ b/scripts/mcp/agentic-memory.sh
@@ -19,6 +19,15 @@
 #   AGENTIC_MEMORY_SOURCE_REGISTRY    default: $AGENTIC_MEMORY_AGENT_FACTORY_ROOT/tools/hermes_adapter/fleet_registry.toml
 #   AGENTIC_MEMORY_MCP_PYTHON         default: $AGENTIC_MEMORY_MCP_SERVERS_ROOT/.venv/bin/python OR python3
 #
+# Materialization (MCP runtime cache — not a memory tier):
+#   The materializer runs from agent-factory and anchors --repo-root there, so
+#   relative vault_root paths in the central registry resolve against the
+#   registry-owning checkout rather than whichever child repo launched the MCP.
+#   It writes a derived bridge TOML under .cache/agentic_memory/ (gitignored, same
+#   class as .cache/repo_knowledge/). This is ephemeral MCP wiring regenerated from
+#   agent-factory's fleet_registry.toml — not Tier-1/2/3 memory; agents must not treat
+#   it as durable knowledge or add it to ops/memory_manifest.yml workspaces.
+#
 # Output:
 #   Exports AGENTIC_MEMORY_REGISTRY_PATH to the materialized registry file,
 #   then execs the agentic-memory MCP server over stdio.
@@ -32,7 +41,6 @@
 
 set -uo pipefail
 
-# Disable -e for the validation phase so we can emit a clean error message.
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 CHILD_REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 
@@ -44,20 +52,67 @@ _die() {
 
 _expand_home() {
   local p="${1:-}"
+  local home="${HOME:-}"
+  if [[ "${p}" == "~" || "${p}" == "~/"* ]]; then
+    if [[ -z "${home}" ]]; then
+      if ! home="$(cd ~ 2>/dev/null && pwd -P)"; then
+        _die "HOME is unset and shell could not resolve ~; set HOME or use absolute AGENTIC_MEMORY_* paths."
+      fi
+    fi
+  fi
   if [[ "${p}" == "~" ]]; then
-    printf '%s' "${HOME}"
+    printf '%s' "${home}"
     return
   fi
   if [[ "${p}" == "~/"* ]]; then
-    printf '%s' "${HOME}/${p:2}"
+    printf '%s' "${home}/${p:2}"
     return
   fi
   printf '%s' "${p}"
 }
 
+_to_abs_path() {
+  local p="$(_expand_home "${1:-}")"
+  if [[ "${p}" != /* ]]; then
+    p="${CHILD_REPO_ROOT}/${p}"
+  fi
+  printf '%s' "${p}"
+}
+
+_resolve_python() {
+  local candidate="${1:-}"
+  if [[ -n "${candidate}" ]]; then
+    candidate="$(_expand_home "${candidate}")"
+    if [[ "${candidate}" == */* || "${candidate}" == ./* ]]; then
+      if [[ "${candidate}" != /* ]]; then
+        candidate="${CHILD_REPO_ROOT}/${candidate}"
+      fi
+      if [[ ! -x "${candidate}" ]]; then
+        return 1
+      fi
+      printf '%s' "${candidate}"
+      return 0
+    fi
+    if ! command -v "${candidate}" >/dev/null 2>&1; then
+      return 1
+    fi
+    command -v "${candidate}"
+    return 0
+  fi
+  if [[ -x "${MCP_ROOT}/.venv/bin/python" ]]; then
+    printf '%s' "${MCP_ROOT}/.venv/bin/python"
+    return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  return 1
+}
+
 # Resolve AGENTIC_MEMORY_MCP_SERVERS_ROOT.
 if [[ -n "${AGENTIC_MEMORY_MCP_SERVERS_ROOT:-}" ]]; then
-  MCP_ROOT="$(_expand_home "${AGENTIC_MEMORY_MCP_SERVERS_ROOT}")"
+  MCP_ROOT="$(_to_abs_path "${AGENTIC_MEMORY_MCP_SERVERS_ROOT}")"
 else
   MCP_ROOT="${CHILD_REPO_ROOT}/../mcp-servers"
 fi
@@ -73,7 +128,7 @@ fi
 
 # Resolve AGENTIC_MEMORY_AGENT_FACTORY_ROOT.
 if [[ -n "${AGENTIC_MEMORY_AGENT_FACTORY_ROOT:-}" ]]; then
-  AF_ROOT="$(_expand_home "${AGENTIC_MEMORY_AGENT_FACTORY_ROOT}")"
+  AF_ROOT="$(_to_abs_path "${AGENTIC_MEMORY_AGENT_FACTORY_ROOT}")"
 else
   AF_ROOT="${CHILD_REPO_ROOT}/../agent-factory"
 fi
@@ -82,9 +137,12 @@ if [[ ! -d "${AF_ROOT}" ]]; then
   _die "AGENTIC_MEMORY_AGENT_FACTORY_ROOT not found at ${AF_ROOT}; clone agorokh/agent-factory as a sibling of this repo or set the env var."
 fi
 
-# Resolve source registry path.
+# Resolve source registry path (relative overrides are under agent-factory root).
 if [[ -n "${AGENTIC_MEMORY_SOURCE_REGISTRY:-}" ]]; then
   SRC_REGISTRY="$(_expand_home "${AGENTIC_MEMORY_SOURCE_REGISTRY}")"
+  if [[ "${SRC_REGISTRY}" != /* ]]; then
+    SRC_REGISTRY="${AF_ROOT}/${SRC_REGISTRY}"
+  fi
 else
   SRC_REGISTRY="${AF_ROOT}/tools/hermes_adapter/fleet_registry.toml"
 fi
@@ -94,36 +152,68 @@ if [[ ! -f "${SRC_REGISTRY}" ]]; then
 fi
 
 # Resolve python interpreter for the bridge (materialize + server).
-BRIDGE_PYTHON="${AGENTIC_MEMORY_MCP_PYTHON:-}"
-if [[ -n "${BRIDGE_PYTHON}" ]]; then
-  BRIDGE_PYTHON="$(_expand_home "${BRIDGE_PYTHON}")"
-  if [[ ! -x "${BRIDGE_PYTHON}" ]]; then
-    _die "AGENTIC_MEMORY_MCP_PYTHON is set but not executable: ${BRIDGE_PYTHON}"
+if ! BRIDGE_PYTHON="$(_resolve_python "${AGENTIC_MEMORY_MCP_PYTHON:-}")"; then
+  if [[ -n "${AGENTIC_MEMORY_MCP_PYTHON:-}" ]]; then
+    _die "AGENTIC_MEMORY_MCP_PYTHON is set but not found or not executable: ${AGENTIC_MEMORY_MCP_PYTHON}"
   fi
-elif [[ -x "${MCP_ROOT}/.venv/bin/python" ]]; then
-  BRIDGE_PYTHON="${MCP_ROOT}/.venv/bin/python"
-elif command -v python3 >/dev/null 2>&1; then
-  BRIDGE_PYTHON="$(command -v python3)"
-else
   _die "no python3 interpreter found; install python3 or set AGENTIC_MEMORY_MCP_PYTHON."
 fi
+
+if ! (
+  cd -- "${AF_ROOT}" && \
+  "${BRIDGE_PYTHON}" -c "import tools.hermes_adapter.agentic_memory_registry_materialize" >/dev/null 2>&1
+); then
+  _die "tools.hermes_adapter.agentic_memory_registry_materialize not importable from ${AF_ROOT}; verify AGENTIC_MEMORY_AGENT_FACTORY_ROOT."
+fi
+
+# Host-aware bridge resolution: when this wrapper runs on a non-central host
+# (HERMES_HOST_ID != the host marked is_memory_central in the manifest), the
+# helper emits the central host's tailnet name (or Tailscale-resolved IP if
+# system DNS doesn't know it). The materializer then rewrites loopback
+# endpoints to ``http://<central>:<port>/`` automatically. Operator-set
+# AGENTIC_MEMORY_BRIDGE_HOST always wins (helper emits nothing in that case).
+_bridge_host_override_check="${AGENTIC_MEMORY_BRIDGE_HOST:-}"
+_bridge_host_override_check="${_bridge_host_override_check//[[:space:]]/}"
+if [[ -z "${_bridge_host_override_check}" ]]; then
+  _detected_bridge_host="$(
+    cd -- "${AF_ROOT}" && \
+    "${BRIDGE_PYTHON}" -m tools.hermes_adapter.agentic_memory_host_aware_bridge \
+      --manifest "${AF_ROOT}/ops/memory_manifest.yml"
+  )" || _detected_bridge_host=""
+  _detected_bridge_host="${_detected_bridge_host%%$'\n'*}"
+  if [[ -n "${_detected_bridge_host}" ]]; then
+    export AGENTIC_MEMORY_BRIDGE_HOST="${_detected_bridge_host}"
+  fi
+fi
+unset _bridge_host_override_check
 
 # Materialize the fleet registry. Run from the agent-factory root so the
 # tools.hermes_adapter package import resolves. Stdout is the absolute path to
 # the materialized registry; capture it into AGENTIC_MEMORY_REGISTRY_PATH.
-set -e
+_materialize_status=0
 MATERIALIZED="$(
   cd -- "${AF_ROOT}" && \
   "${BRIDGE_PYTHON}" -m tools.hermes_adapter.agentic_memory_registry_materialize \
     --source "${SRC_REGISTRY}" --repo-root "${AF_ROOT}"
-)"
-set +e
+)" || _materialize_status=$?
 
-if [[ -z "${MATERIALIZED}" || ! -f "${MATERIALIZED}" ]]; then
-  _die "agentic_memory_registry_materialize produced no output at ${MATERIALIZED:-<empty>}"
+# Materializer must emit a single filesystem path on stdout (logs belong on stderr).
+MATERIALIZED="${MATERIALIZED%%$'\n'*}"
+
+if [[ ${_materialize_status} -ne 0 || -z "${MATERIALIZED}" || ! -f "${MATERIALIZED}" ]]; then
+  _die "agentic_memory_registry_materialize failed or produced no output at ${MATERIALIZED:-<empty>}"
 fi
 
 export AGENTIC_MEMORY_REGISTRY_PATH="${MATERIALIZED}"
-export PYTHONPATH="${AGENTIC_PKG}${PYTHONPATH:+:${PYTHONPATH}}"
+# Prepend agentic-memory src so agentic_memory.server resolves before inherited PYTHONPATH.
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  export PYTHONPATH="${AGENTIC_PKG}:${PYTHONPATH}"
+else
+  export PYTHONPATH="${AGENTIC_PKG}"
+fi
 
-exec "${BRIDGE_PYTHON}" -m agentic_memory.server
+if ! "${BRIDGE_PYTHON}" -c "import agentic_memory.server" >/dev/null 2>&1; then
+  _die "agentic_memory.server not importable from ${MCP_ROOT}; verify AGENTIC_MEMORY_MCP_SERVERS_ROOT."
+fi
+
+exec "${BRIDGE_PYTHON}" -m agentic_memory.server "$@"


### PR DESCRIPTION
## What this fixes

The wrapper at `scripts/mcp/agentic-memory.sh` in this repo was a
pre-PR-#245 copy that did not invoke the host-aware bridge helper
before materializing the bridge registry. Agents spawned in this
repo on a non-central workstation (M1 Max / M5 Pro) had every
`mcp__agentic-memory__query_knowledge_graph` call go to a
localhost endpoint that did not exist — verified live from M1 Max
on 2026-05-25.

## What it ships

* `scripts/mcp/agentic-memory.sh` — replaced byte-for-byte with the
  canonical version from `agorokh/agent-factory` (post-#245 +
  post-#248). The wrapper itself is repo-agnostic.

## Verification

With `HERMES_HOST_ID=<this-host>` set on the consumer workstation,
the wrapper now auto-applies `AGENTIC_MEMORY_BRIDGE_HOST` to the
Tailscale CGNAT IP of `mac-mini-dev` and the materializer rewrites
loopback endpoints.

## Companions

* agorokh/agent-factory#245 (merged) — host-aware bridge module.
* agorokh/agent-factory#248 — disclosures→divorce marriage + agent-factory kickoff.

Generated with Claude Code.
