### PR TITLE
chore(post-merge): unify /post-merge across Claude/Cursor/Codex/Antigravity

### DIFF
--- a/.claude/agents/post-merge-steward.md
+++ b/.claude/agents/post-merge-steward.md
@@ -3,7 +3,9 @@ name: post-merge-steward
 description: |
   After a PR merges: sync local main, clean the merged branch, classify the diff for migrations/env/deps/scripts,
   and ship vault handoff updates via a labeled `vault/post-merge-pr<N>` branch + auto-merge workflow (never push to main).
-  Triggers on "post-merge", "land PR", "PR merged", or SessionStart when local main is behind origin/main.
+  Triggers on "post-merge", "land PR", "PR merged", or SessionStart when local main is behind origin/main
+  (the SessionStart hook `scripts/hook_session_start_post_merge_steward.py` writes a deterministic block marker;
+   see invariant `session-boundary-hygiene.md` and issue #246).
 model: inherit
 color: green
 memory: project
@@ -43,12 +45,14 @@ mcp__agentic-memory__query_knowledge_graph(
 ### Phase A — `sync` (deterministic; no LLM)
 
 1. Run `scripts/post_merge_sync.sh sync <P>`. The script:
-   - Auto-stashes any WIP under label `post-merge-pr<P>-wip` (recovery instructions printed on failure).
+   - Auto-stashes any WIP under label `post-merge-pr<P>-wip` (audited internal use — `POST_MERGE_SYNC_INTERNAL=1` allowance to the `hook_block_git_stash.py` gate; recovery instructions printed on failure).
    - Merges PR if still OPEN (`gh pr merge --squash --delete-branch`).
    - `git checkout main && git pull --ff-only origin main`.
    - Deletes local PR head branch when safe; prunes stale tracking branches.
    - Reports linked-issue states.
    - Restores stash best-effort on success.
+   - On success: clears `.scratch/session_stale.marker` so the
+     `hook_stale_main_gate.py` PreToolUse gate unblocks Edit/Write (issue #246).
 
 2. **Never** auto-run migrations, DB commands, or destructive scripts. Detect and print only.
 
@@ -59,8 +63,8 @@ mcp__agentic-memory__query_knowledge_graph(
 ### Phase C — vault SAVE (LLM judgment, then deterministic ship)
 
 4. **SAVE** per `docs/00_Core/SESSION_LIFECYCLE.md`, editing **only** files under `docs/01_Vault/`:
-   - Update `docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md`: move merged work to “What was delivered” (PR link, merge SHA, date); refresh “Resume here” / “What remains” (include Phase B follow-ups).
-   - Update `docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md` if this PR closed the active focus.
+   - Update `docs/01_Vault/AgentFactory/00_System/Next Session Handoff.md`: move merged work to “What was delivered” (PR link, merge SHA, date); refresh “Resume here” / “What remains” (include Phase B follow-ups).
+   - Update `docs/01_Vault/AgentFactory/00_System/Current Focus.md` if this PR closed the active focus.
 
 5. Ship the vault edits via `scripts/post_merge_sync.sh vault <P>`. The script:
    - Refuses to commit if any **non-vault** tracked changes exist (exit 30) — keep the working tree scoped.

--- a/.codex/skills/post-merge/SKILL.md
+++ b/.codex/skills/post-merge/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: post-merge
+description: After a PR merges — sync main, clean branch, classify diff, update vault handoff. Use after merging a PR or when local main is behind origin.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent
+---
+
+# Post-Merge Steward (Codex)
+
+Delegates to the `post-merge-steward` agent. Load and follow `.claude/agents/post-merge-steward.md`.
+
+This is the Codex mirror of `.claude/skills/post-merge/SKILL.md`. Behaviour
+is identical across Claude Code, Cursor, Codex, and Antigravity surfaces.
+The canonical source is `.claude/agents/post-merge-steward.md` — edit there,
+not in any mirror.
+
+In Codex, where the dedicated `post-merge-steward` agent type may not be
+available, execute the procedure from the canonical agent doc inline using
+the `Task` tool with whatever subagent type is supported.

--- a/scripts/check_agent_forbidden.py
+++ b/scripts/check_agent_forbidden.py
@@ -30,6 +30,10 @@ ALLOWED_TOPLEVEL_DIRS = {
     # Common additions when you specialize (uncomment as needed):
     # "apps",
     # "archive",
+    # /post-merge unification (agorokh/agent-factory#246 follow-up): each repo
+    # mirrors the canonical agent doc into .codex/skills/post-merge/SKILL.md
+    # for Codex parity.
+    ".codex",
 }
 
 # Tracked files at repository root (single path segment). Warnings only if not listed.


### PR DESCRIPTION
## Summary

One canonical `/post-merge` behaviour across Claude Code, Cursor, Codex, and Antigravity. Follow-up to [agorokh/agent-factory#246](https://github.com/agorokh/agent-factory/issues/246).

All four surfaces now delegate to the same source of truth: `.claude/agents/post-merge-steward.md` (149 lines, identical to agent-factory's canonical).

| Surface | File |
|---------|------|
| canonical source | `.claude/agents/post-merge-steward.md` |
| Claude Code | `.claude/skills/post-merge/SKILL.md` |
| Cursor | `.cursor/skills/post-merge/SKILL.md` |
| Codex | `.codex/skills/post-merge/SKILL.md` |
| Antigravity | `.agents/skills/post-merge/SKILL.md` (only if `.agents/` already present) |

The old Codex format `.codex/agents/post-merge-steward.toml` is replaced by `.codex/skills/post-merge/SKILL.md` matching the convention established by `.codex/skills/account-intake-overview/` in agent-factory.

## Test plan

- [ ] CI green
- [x] `/post-merge` invocation flows through identical procedure on every surface (verified by content equality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
