### PR TITLE
fix(memory): prefetch naive mode + 30s timeout [fleet probe contract]

### DIFF
--- a/scripts/hook_session_start_memory_prefetch.py
+++ b/scripts/hook_session_start_memory_prefetch.py
@@ -46,7 +46,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
-DEFAULT_TIMEOUT_S = 6.0
+# Fleet probe contract (ws-ops#128/template#159): measured naive ~14-18s,
+# hybrid ~40s; prefetch needs a relevance stamp, so naive + 30s.
+DEFAULT_TIMEOUT_S = 30.0
 SUMMARY_TRUNCATE = 1200  # chars of summary stdout we surface to the agent
 
 
@@ -216,7 +218,7 @@ def _resolve_vault_root(vr: str, root: Path) -> Path:
 def _http_query_lightrag(endpoint: str, prompt: str, timeout: float) -> str:
     """POST /query → response text. Empty on failure."""
     url = endpoint.rstrip("/") + "/query"
-    payload = json.dumps({"query": prompt, "mode": "hybrid"}).encode("utf-8")
+    payload = json.dumps({"query": prompt, "mode": "naive"}).encode("utf-8")
     req = urllib.request.Request(
         url,
         data=payload,


### PR DESCRIPTION
Force-propagated from template-repo#159 (merged). Fixes the 6s+hybrid false-DOWN that hard-blocks edits. Measured on host: naive ~14-18s, hybrid ~40s. Refs ws-ops#128, agent-factory#291. Generated with Claude Code

## Summary by Sourcery

Adjust session start memory prefetch behavior to align with fleet probe performance constraints and avoid false negative DOWN states.

Bug Fixes:
- Increase the memory prefetch HTTP timeout to accommodate slower but acceptable naive and hybrid query latencies.
- Switch memory prefetch queries from hybrid to naive mode to ensure a relevance stamp is obtained within the allowed timeout.