### PR TITLE
fix(memory): adopt shared endpoint resolver + reachable-endpoint prefetch (#180)

### DIFF
--- a/ops/memory_manifest.yml
+++ b/ops/memory_manifest.yml
@@ -1,3 +1,20 @@
+# ----------------------------------------------------------------------------
+# repo: per-repo classification data for hook_memory_gate.py (PR #194).
+# Template propagation copies the gate code but NEVER overwrites this
+# block. Adjust code_dirs to enumerate THIS repo's actual code directories
+# so the gate gates real production code (not just template defaults).
+# ----------------------------------------------------------------------------
+repo:
+  code_dirs:
+    - "src"
+    - "scripts"
+    - "tests"
+    - "ops"
+    - "tools"
+    - ".github/workflows"
+    - ".github/actions"
+    - "firmware"
+
 manifest_version: 1
 updated_at: "2026-04-23T18:00:00Z"
 owner: "template-repo"

--- a/scripts/hook_memory_gate.py
+++ b/scripts/hook_memory_gate.py
@@ -21,6 +21,9 @@ Behavior:
   * **Degraded mode:** when the SessionStart prefetch wrote
     ``.scratch/.last_memory_query.missing`` (no Tier-3 workspace registered
     for this repo), the gate warns once on stderr and allows.
+  * **Bridge mismatch:** when that missing marker says ``gate_policy=block``
+    (for example manifest workspace disabled or not visible in the active
+    agentic-memory bridge provenance), the gate blocks code-path edits.
 
 Fail-open contract (same shape as the other deterministic hooks):
   * Malformed JSON → exit 0.
@@ -45,6 +48,10 @@ import shlex
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
 
 # ---------------------------------------------------------------------------
 # Path policy
@@ -190,7 +197,7 @@ _BASH_INDIRECT_EXEC_RE = re.compile(
     """,
     re.VERBOSE | re.IGNORECASE,
 )
-_BASH_SYNTHETIC_CODE_PATH = "scripts/bash_memory_gate_edit"
+_BASH_SYNTHETIC_CODE_PATH = "scripts/.bash_memory_gate_edit"
 
 _DEFAULT_TTL_SECONDS = 1800  # 30 minutes
 _LOCK_NAME = ".last_memory_query"
@@ -198,17 +205,33 @@ _LOCK_MISSING_NAME = ".last_memory_query.missing"
 
 
 def _repo_root() -> Path:
+    """Resolve to the main working directory, even from a git worktree.
+
+    In a worktree, ``.git`` is a *file*, and ``Path.cwd()`` walks to the worktree
+    path whose basename is a random slug — never matching manifest
+    ``match_repo_basenames``. After locating any ``.git`` (or ``CLAUDE_PROJECT_DIR``),
+    ask git for ``--git-common-dir`` so the workspace match in
+    ``ops/memory_manifest.yml`` succeeds for both main and worktree sessions.
+    Both ``hook_session_start_memory_prefetch.py`` and this gate must agree on
+    the same root, since prefetch stamps and gate reads
+    ``.scratch/.last_memory_query``.
+    """
+    from hook_repo_root import normalize_to_main_worktree_dir
+
     env_root = os.environ.get("CLAUDE_PROJECT_DIR")
     if env_root:
-        candidate = Path(env_root)
-        if candidate.is_dir():
-            return candidate.resolve()
-    # Fall back to git rev-parse equivalent.
+        candidate_env = Path(env_root)
+        if candidate_env.is_dir():
+            return normalize_to_main_worktree_dir(candidate_env)
     here = Path.cwd().resolve()
+    candidate: Path | None = None
     for parent in (here, *here.parents):
         if (parent / ".git").exists():
-            return parent
-    return here
+            candidate = parent
+            break
+    if candidate is None:
+        return here
+    return normalize_to_main_worktree_dir(candidate)
 
 
 def _gate_enabled() -> bool:
@@ -337,11 +360,8 @@ def _file_tokens(rel_path: str) -> list[str]:
     # like `.github/` since they are semantically substantive.
     parts = rel_path.split("/")
     if parts and "." in parts[-1]:
-        base = parts[-1]
-        # Leading-dot basenames (``.bash_edit``) are not ``name.ext``.
-        if not (base.startswith(".") and base.count(".") == 1):
-            # Drop the file extension: `gate.py` → `gate`.
-            parts[-1] = base.rsplit(".", 1)[0]
+        # Drop the file extension: `gate.py` → `gate`.
+        parts[-1] = parts[-1].rsplit(".", 1)[0]
     out: list[str] = []
     for segment in parts:
         for tok in _TOKEN_SPLIT_RE.split(segment):
@@ -534,19 +554,61 @@ def main() -> int:
 
     lock_path, missing_path = _lock_paths(root)
     lock = _read_lock(lock_path)
-    missing_marker_present = missing_path.is_file()
-    missing = _read_lock(missing_path) if missing_marker_present else None
+    missing = _read_lock(missing_path)
 
-    # Degraded mode: SessionStart prefetch said no workspace registered for this
-    # repo. Warn once on stderr and allow — the right fix is to register the
-    # workspace via PR C, not to break developer flow.
-    if missing_marker_present:
-        sys.stderr.write(
-            "WARN  hook_memory_gate.py: degraded — Tier-3 prefetch unavailable "
-            f"for {root} (see ops/memory_manifest.yml). "
-            "Code-path edits allowed; register or provision the workspace.\n"
-        )
-        return 0
+    # Degraded mode: no manifest workspace is a bootstrap warning, but a
+    # registered workspace that failed prefetch is a hard memory-gate failure.
+    if missing:
+        ws = missing.get("workspace") if isinstance(missing, dict) else None
+        registered_ws = ws.strip() if isinstance(ws, str) else ""
+        gate_policy = missing.get("gate_policy") if isinstance(missing, dict) else None
+        # A timeout-origin marker (gate_policy == "warn") means the substrate is healthy
+        # but slow — never hard-block on a mere prefetch timeout, even for a registered
+        # workspace (agorokh/workstation-ops#128 rec 2). A genuine outage (registered_ws
+        # with no warn policy) or a bridge mismatch (gate_policy == "block") still blocks.
+        if gate_policy != "warn" and (registered_ws or gate_policy == "block"):
+            return _emit_block(
+                root=root,
+                paths=code_paths,
+                workspace_hint=registered_ws or _maybe_workspace_hint(lock, missing),
+                reason=(
+                    str(missing.get("reason") or "registered Tier-3 workspace is unavailable")
+                    + ". Fix the active agentic-memory registry/allowlist before code-path edits."
+                ),
+            )
+        if gate_policy == "warn":
+            # Stale warn marker can coexist if unlink failed after a later successful
+            # prefetch — honor a fresh lock instead of skipping relevance checks.
+            # But if the warn marker is newer than the lock, the most recent prefetch
+            # timed out, so we degrade to warn-only even if the leftover lock is within TTL.
+            warn_is_newer = lock and str(missing.get("timestamp_utc", "")) > str(
+                lock.get("timestamp_utc", "")
+            )
+            if not lock or not _lock_is_fresh(lock, _ttl_seconds()) or warn_is_newer:
+                sys.stderr.write(
+                    "WARN  hook_memory_gate.py: degraded (warn-only) — Tier-3 prefetch "
+                    f"timed out for {root}: {missing.get('reason') or 'substrate slow'}. "
+                    "Code-path edits allowed; query Tier-3 manually to ground this session.\n"
+                )
+                return 0
+        elif str(missing.get("reason") or "") == "accepted_gap":
+            # A recorded resolution_exceptions gap is known and accepted — the
+            # SessionStart NOTE already surfaced the tracking issue. Degrade
+            # *quietly* (no "register or provision" nudge) per the manifest
+            # contract, so it does not become recurring noise (Qodo review,
+            # PR #175). Code-path edits allowed.
+            sys.stderr.write(
+                "WARN  hook_memory_gate.py: accepted Tier-3 gap (see SessionStart "
+                f"NOTE) for {root}; code-path edits allowed.\n"
+            )
+            return 0
+        else:
+            sys.stderr.write(
+                "WARN  hook_memory_gate.py: degraded — Tier-3 prefetch unavailable "
+                f"for {root} (see ops/memory_manifest.yml). "
+                "Code-path edits allowed; register or provision the workspace.\n"
+            )
+            return 0
 
     workspace_hint = _maybe_workspace_hint(lock, missing)
 

--- a/scripts/hook_memory_gate.py
+++ b/scripts/hook_memory_gate.py
@@ -57,28 +57,42 @@ if str(_SCRIPT_DIR) not in sys.path:
 # Path policy
 # ---------------------------------------------------------------------------
 
-_CODE_PATH_PREFIXES: tuple[str, ...] = (
-    "src/",
-    "scripts/",
-    "tests/",
-    "ops/",
-    ".github/workflows/",
-    ".github/actions/",
-    "tools/",
+# Canonical default code-dir classification lives in hook_memory_manifest.py
+# (single source of truth, shared with the prefetch). The gate reads per-repo
+# overrides from the ``repo:`` block in ``ops/memory_manifest.yml`` — moved out
+# of code so propagation can't clobber each child's project-specific dirs
+# (council #180 fix; closes the wave-introduced enforcement regression).
+# These module-level constants remain as ULTIMATE FALLBACK if manifest load
+# fails entirely. ``noqa: E402`` — the import must follow the sys.path tweak
+# above so hook_memory_manifest can be imported when this script is invoked
+# directly by Claude Code's PreToolUse hook (not via ``python -m``).
+from hook_memory_manifest import (  # noqa: E402
+    DEFAULT_CODE_DIR_TOP_LEVEL,
+    DEFAULT_CODE_PATH_PREFIXES,
+    DEFAULT_CODE_PATH_TOP_LEVEL,
 )
-_CODE_PATH_TOP_LEVEL: frozenset[str] = frozenset(
+
+_CODE_PATH_PREFIXES: tuple[str, ...] = DEFAULT_CODE_PATH_PREFIXES
+_CODE_PATH_TOP_LEVEL: frozenset[str] = DEFAULT_CODE_PATH_TOP_LEVEL
+_CODE_DIR_TOP_LEVEL: frozenset[str] = DEFAULT_CODE_DIR_TOP_LEVEL
+
+# NON-OVERRIDABLE gated paths — these always classify as "code" regardless of
+# per-repo `repo.code_dirs` overrides. Qodo PR #194 security HIGH: an attacker
+# (or careless override) could otherwise set `code_dirs: ["src"]` (omitting
+# `ops/`) and editing `ops/memory_manifest.yml` (the gate's own config) would
+# become ungated → exact Mistral bypass, reintroduced via overrides. Always-
+# gating these closes that hole: the gate's own configuration files and CI
+# workflows stay protected even if every other override is hostile.
+_ALWAYS_GATED_PATHS: frozenset[str] = frozenset(
     {
-        "pyproject.toml",
-        "Makefile",
-        "setup.py",
-        "setup.cfg",
-        "requirements.txt",
-        "requirements-dev.txt",
+        "ops/memory_manifest.yml",
+        "ops/memory_manifest.local.yml",
         ".pre-commit-config.yaml",
     }
 )
-_CODE_DIR_TOP_LEVEL: frozenset[str] = frozenset(
-    {"src", "scripts", "tests", "ops", "tools", ".github"}
+_ALWAYS_GATED_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",  # CI config controls what runs on PRs
+    ".github/actions/",
 )
 
 # Anything under these matches "documentation / prompt" and is allowed.
@@ -126,19 +140,94 @@ _BASH_FILE_EDIT_RE = re.compile(
     | >\s*(?:{_CODE_TOP_FOR_REDIRECT})\b
     | >>\s*["'](?:{_CODE_TOP_FOR_REDIRECT})["']
     | >\s*["'](?:{_CODE_TOP_FOR_REDIRECT})["']
-    | \b(?:cp|mv)\s+\S+\s+\S+
     )
     """,
     re.VERBOSE | re.IGNORECASE,
 )
-_BASH_COPY_MOVE_VERB_RE = re.compile(r"\b(?:cp|mv)\b", re.IGNORECASE)
+# Top-level shell operators that separate commands in a compound line.
+# Used by ``_bash_copy_move_destinations_any`` so a ``cp``/``mv`` that's not the
+# very first token still gets caught (e.g. ``cd /tmp && cp foo scripts/bar``).
+# Imperfect on operators inside quoted strings — false negatives there only mean
+# the gate misses the segment, never over-blocks (issue #180 follow-up: the
+# previous over-broad ``\bcp\b`` substring regex matched at quote boundaries
+# inside ``--jq '"cp ..."'`` and false-blocked read-only commands).
+_BASH_SEGMENT_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||;|\||\bthen\b|\bdo\b|\bfi\b|\bdone\b)\s*")
+
+
+# Common command-launcher wrappers that PREFIX the real command. We need to
+# skip them so ``sudo cp foo bar`` / ``env cp foo bar`` / ``/bin/cp foo bar``
+# still parse as cp (Qodo PR #194 HIGH + Cursor LOW — closing the wrapper
+# bypass). Each wrapper may take its own flags before the real command.
+_BASH_LEADING_WRAPPERS: frozenset[str] = frozenset(
+    {
+        "sudo",
+        "env",
+        "command",
+        "exec",
+        "nice",
+        "ionice",
+        "nohup",
+        "time",
+        "stdbuf",
+        "doas",
+        "xargs",  # `xargs cp ...` (with -I) — over-detect is OK, only triggers a stamp check
+    }
+)
+
+
+def _bash_command_basename(token: str) -> str:
+    """Return the basename of a command token, lowercased.
+
+    ``/bin/cp`` → ``cp``; ``cp`` → ``cp``; ``/usr/bin/env`` → ``env``. Empty
+    token → ``""``. Used so wrapper-skipping + cp/mv detection work on absolute
+    paths as well as bare names (Qodo PR #194 HIGH).
+    """
+    if not token:
+        return ""
+    # Handle both / and \ for cross-platform robustness.
+    return token.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
 
 
 def _bash_copy_move_destinations(cmd: str) -> list[str]:
-    """Return destination operand(s) for ``cp``/``mv`` (flags-aware, including ``-t``)."""
+    """Return destination operand(s) for ``cp``/``mv`` (flags-aware, including ``-t``).
+
+    Operates on a single segment. Strips leading wrappers (``sudo``, ``env``,
+    ``command``, ``/usr/bin/env``, …) and matches on the BASENAME of the first
+    real command token, so ``sudo cp …``, ``/bin/cp …``, and ``env -i cp …`` all
+    resolve to ``cp`` (Qodo PR #194 / Cursor LOW). For compound commands
+    (``cd /tmp && cp foo bar``), see ``_bash_copy_move_destinations_any`` which
+    splits on top-level operators.
+    """
     try:
         parts = shlex.split(cmd, posix=True)
     except ValueError:
+        return []
+    if not parts:
+        return []
+    # Strip leading wrappers (sudo, env, …) and their own flags until we find
+    # the real command name.
+    i = 0
+    while i < len(parts):
+        basename = _bash_command_basename(parts[i])
+        if basename in ("cp", "mv"):
+            # Normalize: rewrite the first token to the bare basename so the
+            # downstream logic doesn't need to re-strip wrappers/paths.
+            parts = [basename] + parts[i + 1 :]
+            break
+        if basename in _BASH_LEADING_WRAPPERS:
+            i += 1
+            # Skip wrapper-level flags (e.g. ``sudo -E -u user``,
+            # ``env -i FOO=bar``). Stop at first non-flag token (which is the
+            # next loop iteration's command-name candidate).
+            while i < len(parts) and parts[i].startswith("-"):
+                i += 1
+            # ``env`` accepts ``VAR=value`` before the command name — skip too.
+            if basename == "env":
+                while i < len(parts) and "=" in parts[i] and not parts[i].startswith("-"):
+                    i += 1
+            continue
+        # Not a wrapper, not cp/mv — give up (this segment doesn't begin with
+        # a cp/mv invocation we can analyze).
         return []
     if not parts or parts[0].lower() not in ("cp", "mv"):
         return []
@@ -174,6 +263,24 @@ def _bash_copy_move_destinations(cmd: str) -> list[str]:
     return [dest] if dest else []
 
 
+def _bash_copy_move_destinations_any(cmd: str) -> list[str]:
+    """Collect ``cp``/``mv`` destinations from EVERY segment of a compound command.
+
+    Splits on top-level shell operators (``;``, ``&&``, ``||``, ``|``) and runs the
+    leading-token ``cp``/``mv`` parser on each segment. Replaces the prior
+    ``_BASH_COPY_MOVE_VERB_RE = r"\\b(?:cp|mv)\\b"`` substring matcher whose
+    word boundaries matched at quote characters and over-blocked benign reads
+    like ``gh api --jq '... "cp" ...'`` (#180 / #188 hardening).
+    """
+    out: list[str] = []
+    for segment in _BASH_SEGMENT_SPLIT_RE.split(cmd):
+        seg = segment.strip()
+        if not seg:
+            continue
+        out.extend(_bash_copy_move_destinations(seg))
+    return out
+
+
 # Issue #115 council review (Mistral bypass #2, #4): indirect-execution write
 # paths the agent can use to mutate code without triggering Edit/Write tools.
 # Conservative: treat ANY interpreter eval (-c / -e) and any `<scheme> | sh`
@@ -198,6 +305,170 @@ _BASH_INDIRECT_EXEC_RE = re.compile(
     re.VERBOSE | re.IGNORECASE,
 )
 _BASH_SYNTHETIC_CODE_PATH = "scripts/.bash_memory_gate_edit"
+
+# ---------------------------------------------------------------------------
+# Indirect-exec MUTATION detection (#180 / #188 council fix — only gate
+# indirect-exec that actually MUTATES, so read-only one-liners like
+# ``python -c "import json; print(json.load(open('x.json')))"`` don't brick
+# agents on every repo. The prior "block all indirect-exec" policy was
+# operationally too aggressive; the gate's purpose is forcing memory-grounding
+# before *file mutations*, not arbitrary read computation.
+# ---------------------------------------------------------------------------
+_BASH_INDIRECT_EXEC_PIPE_TO_SHELL_RE = re.compile(
+    r"(?:curl|wget|fetch)\s+[^|]*\|\s*(?:bash|sh|zsh|python3?)\b",
+    re.IGNORECASE,
+)
+# Shell-context indirect-exec — the -c arg / heredoc body IS shell, so the
+# shell-mutation regex applies (`>` redirects, `rm`, `mkdir`, etc. are mutations).
+_BASH_INDIRECT_EXEC_SHELL_CONTEXT_RE = re.compile(
+    r"""
+    (?:
+      \bbash\s+-c\b
+    | \bzsh\s+-c\b
+    | \bsh\s+-c\b
+    | \beval\s+["'$]
+    | <<\s*['"]?(?:EOF|PY|SH|BASH|HEREDOC)\b
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+# Language-context mutation patterns (Python/Node/Deno/Perl/Ruby API surface).
+# Applies to ANY indirect-exec. Distinct from shell patterns so the Python
+# expression ``print(1 > 0)`` doesn't trigger the `>` redirect pattern (Cursor
+# PR #194 HIGH) and the string method ``"x".replace("a","b")`` doesn't trigger
+# the Path.replace pattern (Cursor PR #194 MEDIUM).
+_INDIRECT_EXEC_LANG_MUTATION_RE = re.compile(
+    r"""(?ix)
+    (?:
+      # ---- File-open in write/append/exclusive mode.
+      # Positional: ``open(filename, 'w')`` / ``open('x', 'a+')``. REQUIRE the
+      # comma so ``open("x")`` (read-only default) doesn't match — without the
+      # comma, ``"x"`` looks like a single-char mode under the char class.
+      \bopen\s*\([^,)]+,\s*['"][awx][+]?b?t?['"]
+      # Keyword: ``open(filename, mode='w')`` / ``open(path, mode="a+")``.
+    | \bopen\s*\([^)]*\bmode\s*=\s*['"][awx]
+      # Perl-specific: ``open(F, ">file")`` / ``open(F, ">>file")`` — perl
+      # encodes write mode with a leading ``>`` in the second arg. Distinct
+      # from Python's ``print(1 > 0)`` because the perl form requires
+      # ``open(`` first.
+    | \bopen\s*\([^,)]+,\s*['"]>>?
+      # ---- Python pathlib / file mutators.
+      # NOTE: ``\.replace\s*\(`` is intentionally NOT here — it would match
+      # ``str.replace()`` (extremely common). ``Path.replace()`` users should
+      # use ``os.replace(...)`` (covered below by the os.* alternation).
+    | \.write_text\s*\(
+    | \.write_bytes\s*\(
+    | \.writelines\s*\(
+    | \.write\s*\(
+    | \.touch\s*\(
+    | \.mkdir\s*\(
+    | \.unlink\s*\(
+    | \.rename\s*\(
+    | \.rmdir\s*\(
+    | \.chmod\s*\(
+    | \.symlink_to\s*\(
+    | \.hardlink_to\s*\(
+      # ---- os / shutil / tempfile mutators
+    | \bos\.(?:remove|unlink|rename|replace|mkdir|makedirs|rmdir|chmod
+            |symlink|link|truncate|fdopen|write)\s*\(
+    | \bshutil\.(?:copy(?:[2y]|file|tree)?|move|rmtree|chown|copyfileobj)\s*\(
+    | \btempfile\.(?:NamedTemporaryFile|mkstemp|mkdtemp)\s*\(
+    | \bjson\.dump\s*\(
+    | \bpickle\.dump\s*\(
+    | \byaml\.dump\s*\(
+      # ---- Dynamic-exec / evasion (we can't analyze further → conservative block).
+      # Use negative lookbehind ``(?<!\.)`` on ``compile``/``eval``/``exec`` so
+      # method calls (``re.compile(...)``, ``engine.execute(...)``, ``.eval(...)``
+      # on numpy/pandas/sqlalchemy objects) DON'T false-match. Cursor PR #194
+      # MEDIUM: ``re.compile(r"\\d+")`` was being blocked because ``\b`` fires
+      # between ``.`` and ``c``. The Python builtins are bare (no leading dot);
+      # the negative lookbehind preserves their detection without the false
+      # positives on ubiquitous module-method calls.
+    | \bsubprocess\.(?:run|call|Popen|check_call|check_output)\s*\(
+    | \bos\.system\s*\(
+    | \bos\.popen\s*\(
+    | \b__import__\s*\(
+    | (?<!\.)\bcompile\s*\(
+    | (?<!\.)\beval\s*\(
+    | (?<!\.)\bexec\s*\(
+      # ---- Node.js fs writers. Match the METHOD name (without ``fs.`` prefix)
+      # so ``require("fs").writeFileSync(...)`` is caught — ``fs.`` is not
+      # contiguous when fs is imported inline.
+    | \b(?:writeFile|writeFileSync|appendFile|appendFileSync
+          |unlinkSync|rmSync|rmdirSync|mkdirSync|mkdirpSync
+          |renameSync|copyFile|copyFileSync|symlinkSync|truncateSync
+          |chmodSync|chownSync)\s*\(
+    | \bDeno\.write(?:Text)?File(?:Sync)?\s*\(
+    | \bDeno\.remove(?:Sync)?\s*\(
+    )
+    """,
+)
+# Shell-context mutation primitives — ONLY applied when the indirect-exec is in
+# shell context (bash/zsh/sh -c, heredoc, or eval). Not applied to language
+# -c/-e content because e.g. ``perl -e 'print 1 if $x > 5'`` is a comparison.
+_INDIRECT_EXEC_SHELL_MUTATION_RE = re.compile(
+    r"""(?ix)
+    (?:
+      # Redirection target must be PATH-LIKE — starts with /, ., or word char,
+      # AND contains at least one path separator or extension dot. Excludes
+      # bare numeric/word comparisons like ``> 0`` or ``> 5``.
+      >[>]?\s*(?:["']?(?:/|\./|\.{1,2}/|[\w-]+\.[\w/.-]+|[\w/-]+/[\w/.-]+)|/dev/)
+    | \brm\s+(?:-[a-zA-Z]+\s+)*\S+
+    | \bmkdir\b\s+\S+
+    | \btouch\b\s+\S+
+    | \btee\b\s+
+    | \bcp\b\s+\S+\s+\S+
+    | \bmv\b\s+\S+\s+\S+
+    | \bln\b\s+(?:-\S+\s+)?\S+\s+\S+
+    | \bchmod\b\s+
+    | \bchown\b\s+
+    | \bsed\s+-i
+    )
+    """,
+)
+
+
+def _indirect_exec_is_mutation(cmd: str) -> bool:
+    """Heuristic: True if the indirect-exec command appears to MUTATE state.
+
+    The gate's purpose is forcing memory-grounding before file *mutations*;
+    pure read-only one-liners (``python -c "import json; print(...)"``,
+    ``node -e "1+1"``, ``perl -e 'print 1'``) shouldn't brick agents.
+    Council #180/#188 / Mistral + Cursor PR #194 reviews: only gate indirect-
+    exec that actually mutates, and distinguish SHELL context from LANGUAGE
+    context so ``python -c "print(1 > 0)"`` isn't false-blocked by the shell
+    redirect regex.
+
+    Three paths to ``True``:
+
+    * Pipe-to-shell (``curl … | bash``, ``wget … | sh``): remote content can
+      do anything, so it is treated as mutation by default — bias toward
+      blocking ambient remote-exec.
+    * The command matches a LANGUAGE-API mutation primitive (file-open in
+      write/append mode, ``.write_*``, ``os.remove``, ``shutil.copy``,
+      Node ``fs.writeFile*``, dynamic-exec like ``eval`` / ``exec`` /
+      ``__import__`` / ``subprocess.*`` / ``os.system``).
+    * The command is in SHELL context (``bash -c``, ``zsh -c``, ``sh -c``,
+      ``eval "…"``, or a heredoc) AND its content contains a shell mutation
+      pattern (``>`` redirect to a path-like target, ``rm``, ``mkdir``, etc.).
+
+    Shell-context detection is what lets ``python -c "print(1 > 0)"`` pass
+    (no SHELL context → shell `>` regex never runs against it) while
+    ``bash -c "rm scripts/x.py"`` still blocks.
+
+    Bias: when in doubt about a dynamic-exec form, block — these are the routes
+    a coding agent under pressure would use to bypass Edit/Write tools.
+    """
+    if _BASH_INDIRECT_EXEC_PIPE_TO_SHELL_RE.search(cmd):
+        return True
+    if _INDIRECT_EXEC_LANG_MUTATION_RE.search(cmd):
+        return True
+    if _BASH_INDIRECT_EXEC_SHELL_CONTEXT_RE.search(cmd) and (
+        _INDIRECT_EXEC_SHELL_MUTATION_RE.search(cmd)
+    ):
+        return True
+    return False
+
 
 _DEFAULT_TTL_SECONDS = 1800  # 30 minutes
 _LOCK_NAME = ".last_memory_query"
@@ -271,23 +542,46 @@ def _normalize_rel_path(path: str, *, root: Path | None = None) -> str:
         return norm
 
 
-def _classify(path: str, *, root: Path | None = None) -> str:
-    """Return ``"doc"``, ``"code"``, or ``"other"`` for a repo-relative path."""
+def _classify(
+    path: str,
+    *,
+    root: Path | None = None,
+    code_prefixes: tuple[str, ...] | None = None,
+    code_top_level: frozenset[str] | None = None,
+    code_dir_top_level: frozenset[str] | None = None,
+) -> str:
+    """Return ``"doc"``, ``"code"``, or ``"other"`` for a repo-relative path.
+
+    The three ``code_*`` arguments override the module defaults — used by
+    ``main()`` to pass per-repo overrides from the ``repo:`` block in
+    ``ops/memory_manifest.yml``. ``None`` (the default) means "use module
+    defaults" so callers/tests can keep the simple signature.
+    """
+    cp_prefixes = code_prefixes if code_prefixes is not None else _CODE_PATH_PREFIXES
+    cp_top = code_top_level if code_top_level is not None else _CODE_PATH_TOP_LEVEL
+    cd_top = code_dir_top_level if code_dir_top_level is not None else _CODE_DIR_TOP_LEVEL
     norm = _normalize_rel_path(path, root=root)
     if not norm:
         return "other"
+    # Non-overridable gated paths take precedence over per-repo overrides
+    # (Qodo PR #194 security HIGH — close the "shrink the allowlist" bypass).
+    if norm in _ALWAYS_GATED_PATHS:
+        return "code"
+    for prefix in _ALWAYS_GATED_PREFIXES:
+        if norm.startswith(prefix):
+            return "code"
     # Top-level exact matches take precedence.
     if "/" not in norm:
         if norm in _DOC_PATH_TOP_LEVEL:
             return "doc"
-        if norm in _CODE_PATH_TOP_LEVEL or norm in _CODE_DIR_TOP_LEVEL:
+        if norm in cp_top or norm in cd_top:
             return "code"
         # Other top-level files (e.g. ad-hoc scripts) — be conservative and treat as doc.
         return "doc"
     for prefix in _DOC_PATH_PREFIXES:
         if norm.startswith(prefix):
             return "doc"
-    for prefix in _CODE_PATH_PREFIXES:
+    for prefix in cp_prefixes:
         if norm.startswith(prefix):
             return "code"
     return "other"
@@ -301,6 +595,36 @@ def _to_repo_relative(path: str, root: Path) -> str:
     except (ValueError, OSError):
         pass
     return path
+
+
+def _classify_root_for(touched_path: str, *, main_root: Path) -> Path:
+    """Resolve the classification root for a single touched path.
+
+    The memory gate normalizes its **lockfile** path to the main worktree (so
+    SessionStart and the gate agree on one ``.scratch/.last_memory_query``).
+    But path **classification** must happen against the file's OWN worktree
+    root — an absolute path inside a linked git worktree (e.g. Claude Code's
+    ``.claude/worktrees/<name>/scripts/foo.py``) cannot relativize to the main
+    root, so ``_to_repo_relative`` falls back to the absolute string and
+    ``_classify`` returns ``"other"`` → the gate skips a real code edit
+    (Codex P1 finding from the #180 wave bot review; agent-factory
+    ``worktree-memory-prefetch-bug-2026-05-19``).
+
+    Relative paths and paths with no ``.git`` ancestor fall back to
+    ``main_root``.
+    """
+    try:
+        from hook_repo_root import worktree_root_for
+    except ImportError:
+        return main_root
+    try:
+        p = Path(touched_path)
+    except (ValueError, OSError):
+        return main_root
+    if not p.is_absolute():
+        return main_root
+    wt = worktree_root_for(p)
+    return wt if wt is not None else main_root
 
 
 def _lock_paths(root: Path) -> tuple[Path, Path]:
@@ -436,9 +760,17 @@ def _extract_touched_paths(tool_name: str, tool_input: dict) -> list[str]:
         if not isinstance(cmd, str):
             return out
         direct_edit = bool(_BASH_FILE_EDIT_RE.search(cmd))
-        indirect_exec = bool(_BASH_INDIRECT_EXEC_RE.search(cmd))
-        copy_dests = _bash_copy_move_destinations(cmd)
-        copy_move = bool(copy_dests) or bool(_BASH_COPY_MOVE_VERB_RE.search(cmd))
+        # Council #180/#188: only gate indirect-exec that actually MUTATES.
+        # Allow read-only one-liners (``python -c "import json; print(...)"``);
+        # block when the command has mutation primitives or pipes remote content
+        # to a shell.
+        indirect_exec_detected = bool(_BASH_INDIRECT_EXEC_RE.search(cmd))
+        indirect_exec = indirect_exec_detected and _indirect_exec_is_mutation(cmd)
+        # Compound-aware cp/mv detection — replaces the prior loose substring
+        # regex that matched ``cp``/``mv`` inside quoted arguments and falsely
+        # blocked benign read commands like ``gh api --jq '... "cp" ...'``.
+        copy_dests = _bash_copy_move_destinations_any(cmd)
+        copy_move = bool(copy_dests)
         if direct_edit or indirect_exec or copy_move:
             for dest in copy_dests:
                 out.append(dest)
@@ -546,9 +878,57 @@ def main() -> int:
     if not paths:
         return 0  # no file/path → nothing to gate (e.g. `gh pr view`)
 
-    root = _repo_root()
-    rel_paths = [_to_repo_relative(p, root) for p in paths]
-    code_paths = [p for p in rel_paths if _classify(p, root=root) == "code"]
+    root = _repo_root()  # main worktree — drives lockfile path
+    # Classify each touched path against its OWN worktree root so an absolute
+    # path inside a linked git worktree (Claude Code's
+    # ``.claude/worktrees/<name>/scripts/foo.py``) is correctly classified as
+    # ``"code"`` instead of falling back to ``"other"`` (Codex P1 from #180 wave).
+    # Per-repo manifest data drives the code_dirs allowlist (council #180 fix)
+    # so propagation can't clobber each child's project-specific dirs. Cache
+    # the classifier overrides per worktree root within this single invocation.
+    classifier_cache: dict[Path, tuple[tuple[str, ...], frozenset[str], frozenset[str]]] = {}
+
+    def _classifier_for(
+        classify_root: Path,
+    ) -> tuple[tuple[str, ...], frozenset[str], frozenset[str]]:
+        cached = classifier_cache.get(classify_root)
+        if cached is not None:
+            return cached
+        try:
+            from hook_memory_manifest import (
+                load_manifest,
+                repo_code_dir_top_level,
+                repo_code_path_prefixes,
+                repo_code_path_top_level,
+            )
+
+            manifest = load_manifest(classify_root)
+            triple = (
+                repo_code_path_prefixes(manifest),
+                repo_code_path_top_level(manifest),
+                repo_code_dir_top_level(manifest),
+            )
+        except Exception:  # noqa: BLE001 — fall back to hardcoded defaults
+            triple = (_CODE_PATH_PREFIXES, _CODE_PATH_TOP_LEVEL, _CODE_DIR_TOP_LEVEL)
+        classifier_cache[classify_root] = triple
+        return triple
+
+    code_paths: list[str] = []
+    for raw_path in paths:
+        classify_root = _classify_root_for(raw_path, main_root=root)
+        rel = _to_repo_relative(raw_path, classify_root)
+        cp_prefixes, cp_top, cd_top = _classifier_for(classify_root)
+        if (
+            _classify(
+                rel,
+                root=classify_root,
+                code_prefixes=cp_prefixes,
+                code_top_level=cp_top,
+                code_dir_top_level=cd_top,
+            )
+            == "code"
+        ):
+            code_paths.append(rel)
     if not code_paths:
         return 0  # all touches are doc/other — allowed
 

--- a/scripts/hook_memory_manifest.py
+++ b/scripts/hook_memory_manifest.py
@@ -1,4 +1,17 @@
-"""Shared manifest loading for deterministic memory hook scripts."""
+"""Shared manifest loading for deterministic memory hook scripts.
+
+Owns the canonical default code-dir allowlist (``DEFAULT_CODE_PATH_PREFIXES`` /
+``DEFAULT_CODE_PATH_TOP_LEVEL`` / ``DEFAULT_CODE_DIR_TOP_LEVEL``) so the gate and
+the prefetch can't drift on what counts as a code path, and exposes
+``repo_code_path_prefixes`` / ``repo_code_path_top_level`` /
+``repo_code_dir_top_level`` / ``repo_tier3_workspace_id`` for the per-repo
+``repo:`` block in ``ops/memory_manifest.yml``. Council #180 fix: hardcoding the
+allowlist in the gate let propagation copy template's defaults over each child's
+project-specific code dirs (regression — child production edits bypassed the
+gate). Per-repo manifest data is gated by being under ``ops/``, so editing it
+still requires a fresh substrate stamp (closes Mistral's "shrink the allowlist"
+bypass).
+"""
 
 from __future__ import annotations
 
@@ -8,6 +21,35 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+# ---------------------------------------------------------------------------
+# Canonical default code-path classification — single source of truth.
+# Both the gate and the contract docs reference these. Children override via
+# the per-repo ``repo:`` block in ``ops/memory_manifest.yml``.
+# ---------------------------------------------------------------------------
+DEFAULT_CODE_PATH_PREFIXES: tuple[str, ...] = (
+    "src/",
+    "scripts/",
+    "tests/",
+    "ops/",
+    ".github/workflows/",
+    ".github/actions/",
+    "tools/",
+)
+DEFAULT_CODE_PATH_TOP_LEVEL: frozenset[str] = frozenset(
+    {
+        "pyproject.toml",
+        "Makefile",
+        "setup.py",
+        "setup.cfg",
+        "requirements.txt",
+        "requirements-dev.txt",
+        ".pre-commit-config.yaml",
+    }
+)
+DEFAULT_CODE_DIR_TOP_LEVEL: frozenset[str] = frozenset(
+    {"src", "scripts", "tests", "ops", "tools", ".github"}
+)
 
 
 def _yaml_scalar(value: str) -> str:
@@ -41,11 +83,24 @@ def _apply_field(row: dict[str, Any], text: str) -> str | None:
 
 
 def _fallback_manifest_from_text(text: str) -> dict[str, Any]:
-    """Parse the manifest subset needed by hooks when PyYAML is unavailable."""
+    """Parse the manifest subset needed by hooks when PyYAML is unavailable.
 
+    Covers:
+    * ``hosts: [- workspaces: [- name/backend/endpoint/vault_root/match_repo_basenames]]``
+    * Top-level ``repo:`` block with ``code_dirs`` / ``code_top_level`` lists
+      and ``tier3_workspace_id`` scalar (Qodo PR #194 HIGH: without this, the
+      per-repo override silently drops in PyYAML-missing hook runtimes and the
+      gate falls back to template defaults — re-introducing the wave-introduced
+      clobber regression for repos relying on the override).
+    """
     hosts: list[dict[str, Any]] = []
+    repo_block: dict[str, Any] = {}
     in_hosts = False
     hosts_indent = -1
+    in_repo = False
+    repo_indent = -1
+    repo_list_key: str | None = None
+    repo_list_indent = -1
     current_host: dict[str, Any] | None = None
     host_indent: int | None = None
     in_workspaces = False
@@ -61,11 +116,54 @@ def _fallback_manifest_from_text(text: str) -> dict[str, Any]:
         current = None
         current_list_key = None
 
+    def exit_repo() -> None:
+        nonlocal in_repo, repo_indent, repo_list_key, repo_list_indent
+        in_repo = False
+        repo_indent = -1
+        repo_list_key = None
+        repo_list_indent = -1
+
     for raw_line in text.splitlines():
         if not raw_line.strip() or raw_line.lstrip().startswith("#"):
             continue
         indent = len(raw_line) - len(raw_line.lstrip())
         stripped = raw_line.strip()
+
+        # Exit repo: block when we hit another top-level (indent <= repo_indent).
+        if in_repo and indent <= repo_indent:
+            exit_repo()
+
+        # Top-level `repo:` block.
+        if re.match(r"repo:\s*(?:#.*)?$", stripped):
+            finish_current()
+            in_hosts = False
+            in_workspaces = False
+            in_repo = True
+            repo_indent = indent
+            repo_list_key = None
+            continue
+
+        if in_repo and indent > repo_indent:
+            # A scalar key or the start of a list (`code_dirs:`, `code_top_level:`,
+            # `tier3_workspace_id: "..."`).
+            scalar_m = re.match(r"(code_dirs|code_top_level|tier3_workspace_id):\s*(.*)$", stripped)
+            if scalar_m:
+                key = scalar_m.group(1)
+                raw_value = scalar_m.group(2).strip()
+                if not raw_value or raw_value.startswith("#"):
+                    # Block scalar with list to follow.
+                    repo_block[key] = []
+                    repo_list_key = key
+                    repo_list_indent = indent
+                else:
+                    repo_block[key] = _yaml_scalar(raw_value)
+                    repo_list_key = None
+                continue
+            if repo_list_key and stripped.startswith("- ") and indent > repo_list_indent:
+                repo_block.setdefault(repo_list_key, []).append(_yaml_scalar(stripped[2:].strip()))
+                continue
+            # Unrecognized line inside repo: — ignore (forward-compat with new keys).
+            continue
 
         if re.match(r"hosts:\s*(?:#.*)?$", stripped):
             finish_current()
@@ -128,7 +226,10 @@ def _fallback_manifest_from_text(text: str) -> dict[str, Any]:
             current_list_key = _apply_field(current, stripped)
 
     finish_current()
-    return {"hosts": hosts}
+    out: dict[str, Any] = {"hosts": hosts}
+    if repo_block:
+        out["repo"] = repo_block
+    return out
 
 
 def load_manifest(root: Path, *, warn_missing_pyyaml: bool = False) -> dict[str, Any] | None:
@@ -212,6 +313,23 @@ def resolve_workspace(root: Path, manifest: dict[str, Any] | None) -> dict[str, 
     if not candidates:
         return None
 
+    # Kimi #180 council: workspace resolution is template-relative — must live
+    # in per-repo data, not copied logic. If the manifest declares
+    # `repo.tier3_workspace_id`, that's THIS repo's canonical workspace name
+    # (e.g. template-repo → "agent_factory_steward", verified live via
+    # mcp__agentic-memory 2026-06-01). Wins over name/vault_root/basename match.
+    tier3_id = repo_tier3_workspace_id(manifest)
+    if tier3_id:
+        id_keys = name_match_keys(tier3_id)
+        for workspace in candidates:
+            name = workspace_name(workspace)
+            if name and name_match_keys(name) & id_keys:
+                return workspace
+        # tier3_id declared but no matching workspace row → return None and let
+        # SessionStart surface the standard "no workspace registered" warning
+        # rather than silently degrade to a wrong workspace.
+        return None
+
     vault_matches: list[dict[str, Any]] = []
     for workspace in candidates:
         vault_root = workspace.get("vault_root")
@@ -253,6 +371,187 @@ def online_workspace_name_for_failure(root: Path) -> str | None:
     if not workspace or workspace_backend(workspace) == "graphiti":
         return None
     return workspace_name(workspace) or None
+
+
+# ---------------------------------------------------------------------------
+# Per-repo classification & workspace-resolution data (council #180 fix).
+#
+# A top-level ``repo:`` block in ``ops/memory_manifest.yml`` holds per-repo
+# configuration the gate consumes. Schema:
+#
+#     repo:
+#       # Optional. Overrides DEFAULT_CODE_PATH_PREFIXES — when present,
+#       # REPLACES the defaults (each entry normalized to trailing "/").
+#       code_dirs:
+#         - "src"
+#         - "scripts"
+#         - "agent"         # child override: this repo's runtime code lives here
+#         - "core"
+#
+#       # Optional. Overrides DEFAULT_CODE_PATH_TOP_LEVEL (exact filenames).
+#       code_top_level:
+#         - "pyproject.toml"
+#         - "Justfile"      # child override
+#
+#       # Optional. The Tier-3 workspace this repo's memory canonically lives in,
+#       # when it differs from the repo basename. E.g. template-repo's memory
+#       # lives in "agent_factory_steward" (fleet/template governance workspace).
+#       tier3_workspace_id: "agent_factory_steward"
+#
+# Why: hardcoding these in scripts/ meant the propagation wave copied template's
+# code_dirs onto every child and clobbered each child's project-specific dirs —
+# child production code then bypassed the gate (the regression we shipped).
+# Putting them in per-repo manifest data means propagation updates LOGIC
+# (scripts/hook_memory_gate.py) but never the per-repo classification surface.
+# Mistral's adversarial review: editing this config to shrink the allowlist
+# would re-introduce the bypass — but ``ops/`` is itself a code path, so
+# editing ``ops/memory_manifest.yml`` requires a fresh substrate stamp
+# (verified in tests/test_hook_memory_gate.py).
+# ---------------------------------------------------------------------------
+
+
+def load_repo_section(manifest: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the top-level ``repo:`` block, or an empty dict."""
+    if not isinstance(manifest, dict):
+        return {}
+    repo = manifest.get("repo")
+    return repo if isinstance(repo, dict) else {}
+
+
+def repo_code_path_prefixes(manifest: dict[str, Any] | None) -> tuple[str, ...]:
+    """Per-repo code-dir prefixes; absent block/key → ``DEFAULT_CODE_PATH_PREFIXES``.
+
+    Each entry is normalized to a trailing-slash POSIX prefix
+    (``"agent"`` → ``"agent/"``).
+    """
+    repo = load_repo_section(manifest)
+    raw = repo.get("code_dirs")
+    if not isinstance(raw, list) or not raw:
+        return DEFAULT_CODE_PATH_PREFIXES
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        s = item.strip().replace("\\", "/").lstrip("/")
+        if not s:
+            continue
+        if not s.endswith("/"):
+            s = s + "/"
+        out.append(s)
+    return tuple(out) if out else DEFAULT_CODE_PATH_PREFIXES
+
+
+def repo_code_path_top_level(manifest: dict[str, Any] | None) -> frozenset[str]:
+    """Per-repo top-level code filenames; absent → ``DEFAULT_CODE_PATH_TOP_LEVEL``."""
+    repo = load_repo_section(manifest)
+    raw = repo.get("code_top_level")
+    if not isinstance(raw, list) or not raw:
+        return DEFAULT_CODE_PATH_TOP_LEVEL
+    out = {s.strip() for s in raw if isinstance(s, str) and s.strip()}
+    return frozenset(out) if out else DEFAULT_CODE_PATH_TOP_LEVEL
+
+
+def repo_code_dir_top_level(manifest: dict[str, Any] | None) -> frozenset[str]:
+    """Per-repo top-level code DIR names; derived from ``code_dirs`` first segments.
+
+    Absent → ``DEFAULT_CODE_DIR_TOP_LEVEL``. Used to classify bare top-level
+    references like ``Edit("scripts")`` (the directory itself) as code.
+    """
+    repo = load_repo_section(manifest)
+    raw = repo.get("code_dirs")
+    if isinstance(raw, list) and raw:
+        out: set[str] = set()
+        for item in raw:
+            if not isinstance(item, str):
+                continue
+            first = item.strip().replace("\\", "/").lstrip("/").split("/", 1)[0]
+            if first:
+                out.add(first)
+        if out:
+            return frozenset(out)
+    return DEFAULT_CODE_DIR_TOP_LEVEL
+
+
+def repo_tier3_workspace_id(manifest: dict[str, Any] | None) -> str | None:
+    """The Tier-3 workspace this repo's memory canonically lives in (per-repo data).
+
+    Returns ``None`` when the ``repo:`` block omits ``tier3_workspace_id`` — in
+    that case the prefetch's existing name/vault-root resolver fires. Set this
+    when the canonical workspace name differs from the repo basename — e.g.
+    template-repo's memory lives in ``agent_factory_steward`` (the fleet
+    governance workspace, verified live via mcp__agentic-memory queries
+    2026-06-01); the bare ``template_repo`` workspace row is a dead placeholder.
+    """
+    repo = load_repo_section(manifest)
+    val = repo.get("tier3_workspace_id")
+    if isinstance(val, str) and val.strip():
+        return val.strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Oracle / consumer-contract checker (Kimi #180 council — walk-back loop cure)
+#
+# Asserts that the gate's CLASSIFIER (the proposed code change) is consistent
+# with the manifest's DECLARED code_dirs/code_top_level (the per-repo data).
+# Catches: a propagation that changes gate logic in a way that breaks a
+# child's declared dirs — surfaced at CI/merge, not by human review after.
+# ---------------------------------------------------------------------------
+
+
+def oracle_classification_failures(
+    manifest: dict[str, Any] | None,
+    # callable signature:
+    #   (path, *, root, code_prefixes, code_top_level, code_dir_top_level) -> str
+    classify_fn: Any,
+    root: Path | None = None,
+) -> list[str]:
+    """Run the consumer-contract oracle for the manifest+classifier pair.
+
+    For every declared ``code_dir`` and ``code_top_level``, synthesize a sample
+    path and assert ``classify_fn(sample) == "code"``. Returns a list of
+    failure strings (empty list == oracle PASS). Callers should assert
+    ``len(failures) == 0`` and surface failures in the assertion message so
+    the operator sees exactly which declaration the gate broke.
+
+    Intra-repo use: load this repo's manifest, pass the gate's ``_classify``,
+    fail at pytest time if classification drifts from declaration.
+
+    Cross-repo (CI) use: a workflow can fetch each child's manifest, run this
+    against the proposed gate code, fail the wave PR if any child's
+    declarations are no longer honored — this is the walk-back loop cure
+    (Kimi #180: catch the regression at CI/merge, not in human review).
+    """
+    prefixes = repo_code_path_prefixes(manifest)
+    top_level = repo_code_path_top_level(manifest)
+    dir_top = repo_code_dir_top_level(manifest)
+
+    def _check(path: str) -> str:
+        return classify_fn(
+            path,
+            root=root,
+            code_prefixes=prefixes,
+            code_top_level=top_level,
+            code_dir_top_level=dir_top,
+        )
+
+    failures: list[str] = []
+    for prefix in prefixes:
+        sample = prefix + "oracle_sample_file.py"
+        kind = _check(sample)
+        if kind != "code":
+            failures.append(
+                f"code_dir '{prefix}' declared in ops/memory_manifest.yml "
+                f"but '{sample}' classifies as '{kind}' (expected 'code')"
+            )
+    for top in sorted(top_level):
+        kind = _check(top)
+        if kind != "code":
+            failures.append(
+                f"code_top_level '{top}' declared in ops/memory_manifest.yml "
+                f"but classifies as '{kind}' (expected 'code')"
+            )
+    return failures
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/hook_memory_manifest.py
+++ b/scripts/hook_memory_manifest.py
@@ -1,0 +1,585 @@
+"""Shared manifest loading for deterministic memory hook scripts."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+def _yaml_scalar(value: str) -> str:
+    cleaned = value.split("#", 1)[0].strip()
+    if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {'"', "'"}:
+        return cleaned[1:-1]
+    return cleaned
+
+
+def _apply_field(row: dict[str, Any], text: str) -> str | None:
+    match = re.match(r"([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", text)
+    if not match:
+        return None
+    key = match.group(1)
+    if key not in {
+        "name",
+        "workspace",
+        "id",
+        "backend",
+        "endpoint",
+        "vault_root",
+        "match_repo_basenames",
+    }:
+        return None
+    raw_value = match.group(2)
+    if key == "match_repo_basenames" and not raw_value.strip():
+        row[key] = []
+    else:
+        row[key] = _yaml_scalar(raw_value)
+    return key
+
+
+def _fallback_manifest_from_text(text: str) -> dict[str, Any]:
+    """Parse the manifest subset needed by hooks when PyYAML is unavailable."""
+
+    hosts: list[dict[str, Any]] = []
+    in_hosts = False
+    hosts_indent = -1
+    current_host: dict[str, Any] | None = None
+    host_indent: int | None = None
+    in_workspaces = False
+    workspaces_indent = -1
+    row_indent: int | None = None
+    current: dict[str, Any] | None = None
+    current_list_key: str | None = None
+
+    def finish_current() -> None:
+        nonlocal current, current_list_key
+        if current and current_host is not None:
+            current_host.setdefault("workspaces", []).append(current)
+        current = None
+        current_list_key = None
+
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip())
+        stripped = raw_line.strip()
+
+        if re.match(r"hosts:\s*(?:#.*)?$", stripped):
+            finish_current()
+            in_hosts = True
+            hosts_indent = indent
+            current_host = None
+            host_indent = None
+            in_workspaces = False
+            row_indent = None
+            continue
+
+        if in_workspaces and indent <= workspaces_indent:
+            finish_current()
+            in_workspaces = False
+            row_indent = None
+
+        if (
+            in_hosts
+            and not in_workspaces
+            and stripped.startswith("- ")
+            and indent > hosts_indent
+            and (host_indent is None or indent <= host_indent)
+        ):
+            current_host = {"workspaces": []}
+            hosts.append(current_host)
+            host_indent = indent
+            _apply_field(current_host, stripped[2:].strip())
+            continue
+
+        if re.match(r"workspaces:\s*(?:#.*)?$", stripped):
+            finish_current()
+            if current_host is None:
+                current_host = {"workspaces": []}
+                hosts.append(current_host)
+            in_workspaces = True
+            workspaces_indent = indent
+            row_indent = None
+            continue
+
+        if not in_workspaces:
+            if current_host is not None and host_indent is not None and indent > host_indent:
+                _apply_field(current_host, stripped)
+            continue
+
+        if stripped.startswith("- ") and (row_indent is None or indent == row_indent):
+            finish_current()
+            row_indent = indent
+            current = {}
+            current_list_key = _apply_field(current, stripped[2:].strip())
+            continue
+
+        if current is not None and row_indent is not None and indent > row_indent:
+            if (
+                current_list_key == "match_repo_basenames"
+                and isinstance(current.get(current_list_key), list)
+                and stripped.startswith("- ")
+            ):
+                current[current_list_key].append(_yaml_scalar(stripped[2:].strip()))
+                continue
+            current_list_key = _apply_field(current, stripped)
+
+    finish_current()
+    return {"hosts": hosts}
+
+
+def load_manifest(root: Path, *, warn_missing_pyyaml: bool = False) -> dict[str, Any] | None:
+    path = root / "ops" / "memory_manifest.yml"
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        if warn_missing_pyyaml:
+            print(
+                "WARNING: hook_session_start_memory_prefetch.py needs PyYAML; "
+                "using limited manifest parser fallback. Run `pip install -e '.[dev]'` "
+                "or use the repo .venv python in SessionStart hooks "
+                "(see .claude/settings.base.json).",
+                file=sys.stderr,
+            )
+        return _fallback_manifest_from_text(text)
+    try:
+        payload = yaml.safe_load(text)
+    except Exception:  # noqa: BLE001
+        return _fallback_manifest_from_text(text)
+    return payload if isinstance(payload, dict) else _fallback_manifest_from_text(text)
+
+
+def name_match_keys(name: str) -> set[str]:
+    lowered = name.lower()
+    return {lowered, lowered.replace("-", "_"), lowered.replace("_", "-")}
+
+
+def resolve_vault_root(vault_root: str, root: Path) -> Path:
+    expanded = Path(os.path.expanduser(vault_root))
+    if expanded.is_absolute():
+        return expanded.resolve()
+    return (root / expanded).resolve()
+
+
+def workspace_name(workspace: dict[str, Any]) -> str:
+    name = workspace.get("name", workspace.get("workspace", workspace.get("id", "")))
+    return name.strip() if isinstance(name, str) else ""
+
+
+def workspace_backend(workspace: dict[str, Any]) -> str:
+    backend = workspace.get("backend", "lightrag")
+    if backend is None:
+        return "lightrag"
+    if isinstance(backend, str):
+        return backend.strip().lower() or "lightrag"
+    return "lightrag"
+
+
+def workspace_match_repo_basenames(workspace: dict[str, Any]) -> set[str]:
+    raw = workspace.get("match_repo_basenames") or []
+    if not isinstance(raw, list):
+        return set()
+    names: set[str] = set()
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            names.update(name_match_keys(item.strip()))
+    return names
+
+
+def resolve_workspace(root: Path, manifest: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(manifest, dict):
+        return None
+    hosts = manifest.get("hosts") or []
+    if not isinstance(hosts, list):
+        return None
+    candidates: list[dict[str, Any]] = []
+    for host in hosts:
+        if not isinstance(host, dict):
+            continue
+        rows = host.get("workspaces") or []
+        if not isinstance(rows, list):
+            continue
+        candidates.extend(row for row in rows if isinstance(row, dict))
+    if not candidates:
+        return None
+
+    vault_matches: list[dict[str, Any]] = []
+    for workspace in candidates:
+        vault_root = workspace.get("vault_root")
+        if not isinstance(vault_root, str):
+            continue
+        try:
+            if resolve_vault_root(vault_root, root).is_relative_to(root):
+                vault_matches.append(workspace)
+        except (OSError, ValueError):
+            pass
+    if len(vault_matches) == 1:
+        return vault_matches[0]
+
+    basename_keys = name_match_keys(root.name)
+    for workspace in candidates:
+        name = workspace_name(workspace)
+        if name and name_match_keys(name) & basename_keys:
+            return workspace
+    for workspace in candidates:
+        if workspace_match_repo_basenames(workspace) & basename_keys:
+            return workspace
+    return None
+
+
+def active_workspace_backend(root: Path, workspace: str) -> str | None:
+    manifest = load_manifest(root)
+    active = resolve_workspace(root, manifest)
+    if not active:
+        return None
+    active_name = workspace_name(active)
+    if active_name != workspace and not (name_match_keys(active_name) & name_match_keys(workspace)):
+        return None
+    return workspace_backend(active)
+
+
+def online_workspace_name_for_failure(root: Path) -> str | None:
+    manifest = load_manifest(root)
+    workspace = resolve_workspace(root, manifest)
+    if not workspace or workspace_backend(workspace) == "graphiti":
+        return None
+    return workspace_name(workspace) or None
+
+
+# ---------------------------------------------------------------------------
+# Shared substrate endpoint resolution (template-repo#180 / workstation-ops#170)
+#
+# Single source of truth for "how do I reach workspace X from THIS host",
+# imported by BOTH the SessionStart prefetch hook and the memory gate so they
+# cannot drift to different endpoint logic again. The prior bug: the prefetch
+# hard-coded ``http://localhost:8020`` + a loopback-only SSRF guard, so it could
+# never reach the substrate from a remote tailnet host even though the MCP read
+# path (consumer fleet registry + Tailscale Serve) could. Result: the gate
+# hard-blocked all code edits on every non-central host.
+#
+# This resolver is PURE (no network I/O — callers probe the returned
+# candidates). Precedence: env bridge override -> consumer registry -> legacy
+# registry -> manifest endpoint -> loopback. Security (council-reconciled,
+# Mistral + Perplexity): the non-loopback allowlist is the set of hosts the
+# trusted registries name, plus an explicitly-configured bridge host that is
+# itself Tailscale-shaped (``*.ts.net`` or the 100.64.0.0/10 CGNAT range) — NOT
+# a blanket wildcard. Non-loopback endpoints must be HTTPS: Tailscale Serve
+# terminates TLS with a real ``*.ts.net`` cert, so callers connect via the
+# ts.net hostname for SNI; raw-IP-over-HTTP across the tailnet is rejected.
+# ---------------------------------------------------------------------------
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+_REGISTRY_ENV_VARS = (
+    "AGENTIC_MEMORY_REGISTRY_PATH",
+    "AGENTIC_MEMORY_CONSUMER_REGISTRY_PATH",
+    "LIGHTRAG_FLEET_REGISTRY",
+)
+# (dir, glob, source-label) — consumer registries first (host-local tailnet
+# view), then the legacy registry. Mirrors the exporter/drift-probe precedence
+# documented in docs/grafana.md.
+_DEFAULT_REGISTRY_DIRS = (
+    ("~/.config/mcp-servers", "*fleet-registry.toml", "consumer_registry"),
+    ("~/.config/agentic-memory", "fleet_registry.toml", "legacy_registry"),
+)
+_DEFAULT_SUBSTRATE_PORT = 8020
+# Closed-loopback placeholder ports (e.g. http://127.0.0.1:1 used by
+# not-yet-provisioned manifest rows): never reachable, never a probe target.
+_PLACEHOLDER_PORTS = frozenset({0, 1})
+
+
+@dataclass(frozen=True)
+class EndpointCandidate:
+    """One ordered, allowlist-validated way to reach a workspace substrate."""
+
+    url: str
+    scheme: str
+    host: str
+    port: int
+    source: str  # env_bridge|consumer_registry|legacy_registry|env_registry|manifest|loopback
+    priority: int
+
+
+def _is_loopback_host(host: str) -> bool:
+    return host.strip("[]").strip().lower() in _LOOPBACK_HOSTS
+
+
+def _is_tailnet_shaped(host: str) -> bool:
+    """True for a ``*.ts.net`` hostname or an IP in Tailscale's 100.64.0.0/10."""
+    import ipaddress
+
+    cleaned = host.strip("[]").strip().lower()
+    if not cleaned:
+        return False
+    if cleaned.endswith(".ts.net"):
+        return True
+    try:
+        addr = ipaddress.ip_address(cleaned)
+    except ValueError:
+        return False
+    return addr in ipaddress.ip_network("100.64.0.0/10")
+
+
+def _split_endpoint(endpoint: str) -> tuple[str, str, int] | None:
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(endpoint.strip())
+    except (ValueError, AttributeError):
+        return None
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        return None
+    return parsed.scheme, parsed.hostname.lower(), int(port)
+
+
+def _registry_sources(env: dict[str, str]) -> list[tuple[Path, str]]:
+    """Ordered (path, source-label) registry files to consult.
+
+    Honors the explicit override env vars in precedence order; otherwise globs
+    the default consumer registry dir first, then the legacy registry.
+    """
+    explicit: list[tuple[Path, str]] = []
+    for var in _REGISTRY_ENV_VARS:
+        raw = (env.get(var) or "").strip()
+        if not raw:
+            continue
+        candidate = Path(os.path.expanduser(raw))
+        # Drift runtime ignores non-absolute override paths; match it so the
+        # resolver can't follow a cwd-relative file the MCP layer won't load.
+        if candidate.is_absolute():
+            explicit.append((candidate, "env_registry"))
+    if explicit:
+        return explicit
+    out: list[tuple[Path, str]] = []
+    for dir_str, pattern, label in _DEFAULT_REGISTRY_DIRS:
+        base = Path(os.path.expanduser(dir_str))
+        if not base.is_dir():
+            continue
+        for path in sorted(base.glob(pattern)):
+            out.append((path, label))
+    return out
+
+
+def _parse_registry(path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Return ``(rows, default_enabled)`` for a registry TOML file.
+
+    ``default_enabled`` comes from a ``[defaults] enabled`` key when present
+    (legacy registry shape); rows without their own ``enabled`` inherit it.
+    """
+    try:
+        import tomllib
+    except ImportError:  # pragma: no cover - Python < 3.11
+        return [], True
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, tomllib.TOMLDecodeError):
+        return [], True
+    defaults_raw = data.get("defaults", {})
+    if "defaults" in data and not isinstance(defaults_raw, dict):
+        # Drift runtime discards the whole file when [defaults] is malformed.
+        return [], {}
+    defaults: dict[str, Any] = defaults_raw if isinstance(defaults_raw, dict) else {}
+    # Match the drift runtime: only the `vaults` array defines substrate rows.
+    value = data.get("vaults")
+    rows = [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+    return rows, defaults
+
+
+def _row_workspace_id(row: dict[str, Any]) -> str | None:
+    # Precedence matches the fleet registry loaders (exporter / drift runtime):
+    # canonical `id`, then `workspace`, then human-facing `name` last.
+    for key in ("id", "workspace", "name"):
+        val = row.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def _row_enabled(row: dict[str, Any], defaults: dict[str, Any]) -> bool:
+    value = row.get("enabled", defaults.get("enabled", True))
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes", "on")
+    return bool(value)
+
+
+def _row_backend(row: dict[str, Any], defaults: dict[str, Any]) -> str:
+    # Per-row backend wins; otherwise inherit the file-level [defaults].backend
+    # (drift-runtime semantics); absent everywhere → LightRAG (consumer shape).
+    backend = row.get("backend", defaults.get("backend"))
+    if isinstance(backend, str) and backend.strip():
+        return backend.strip().lower()
+    return "lightrag"
+
+
+def _row_is_lightrag(row: dict[str, Any], defaults: dict[str, Any]) -> bool:
+    # Offline/graphiti rows are never on the agent read path.
+    return _row_backend(row, defaults) == "lightrag"
+
+
+def _row_endpoint(row: dict[str, Any], defaults: dict[str, Any]) -> str | None:
+    # Consumer registries use `endpoint`; the legacy/source shape uses `api_url`,
+    # and may carry a file-level [defaults] URL that per-row entries inherit.
+    for source in (row, defaults):
+        for key in ("endpoint", "api_url"):
+            val = source.get(key)
+            if isinstance(val, str) and val.strip():
+                return val
+    return None
+
+
+def resolve_memory_endpoints(
+    workspace: str,
+    manifest_workspace: dict[str, Any] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+    registry_sources: list[tuple[Path, str]] | None = None,
+) -> list[EndpointCandidate]:
+    """Resolve ordered, allowlist-validated substrate endpoints for THIS host.
+
+    Shared by the SessionStart prefetch hook and the memory gate so the two
+    cannot drift. Pure: no network I/O. Returns candidates ordered by priority
+    (lower first); callers probe in order and use the first that answers.
+    """
+    env = dict(os.environ) if env is None else env
+    keys = name_match_keys(workspace) if workspace else set()
+    # (priority, source, scheme, host, port)
+    raw: list[tuple[int, str, str, str, int]] = []
+    registry_hosts: set[str] = set()
+
+    sources = _registry_sources(env) if registry_sources is None else registry_sources
+    for index, (path, label) in enumerate(sources):
+        if not path.is_file():
+            continue
+        rows, defaults = _parse_registry(path)
+        for row in rows:
+            if not _row_enabled(row, defaults):
+                continue  # a disabled vault is not a reachable probe target
+            if not _row_is_lightrag(row, defaults):
+                continue  # offline/graphiti rows are never on the agent read path
+            rid = _row_workspace_id(row)
+            if not rid:
+                continue
+            # An empty workspace must not match every registry row.
+            if not keys or not (name_match_keys(rid) & keys):
+                continue
+            endpoint = _row_endpoint(row, defaults)
+            if endpoint is None:
+                continue
+            parsed = _split_endpoint(endpoint)
+            if parsed and parsed[2] not in _PLACEHOLDER_PORTS:
+                # Collect from ALL sources; precedence is enforced by the
+                # priority ordering (consumer registries rank above legacy),
+                # and callers probe in order. We intentionally do NOT stop at
+                # the first matching source: if a higher-precedence row is later
+                # rejected by the allowlist (e.g. plain-HTTP to a tailnet IP), a
+                # valid HTTPS endpoint from a lower-precedence registry must
+                # still survive as a fallback.
+                raw.append((20 + index, label, *parsed))
+                if not _is_loopback_host(parsed[1]):
+                    registry_hosts.add(parsed[1])
+
+    if isinstance(manifest_workspace, dict):
+        # Only attach the manifest endpoint when the row is actually THIS
+        # workspace and is an online (lightrag) substrate — never a mismatched
+        # snippet, an offline graphiti row, or (with an empty workspace arg) any
+        # manifest row at all.
+        mf_name = workspace_name(manifest_workspace)
+        mf_matches = bool(mf_name) and bool(keys) and bool(name_match_keys(mf_name) & keys)
+        endpoint = manifest_workspace.get("endpoint")
+        if (
+            mf_matches
+            and workspace_backend(manifest_workspace) == "lightrag"
+            and isinstance(endpoint, str)
+        ):
+            parsed = _split_endpoint(endpoint)
+            # Skip closed-loopback placeholder rows (e.g. http://127.0.0.1:1):
+            # they are never reachable and must not seed base_port or candidates.
+            if parsed and parsed[2] not in _PLACEHOLDER_PORTS:
+                raw.append((40, "manifest", *parsed))
+
+    bridge = (env.get("AGENTIC_MEMORY_BRIDGE_HOST") or "").strip().lower()
+    bridge_allowed = (
+        bool(bridge)
+        and not _is_loopback_host(bridge)
+        and (bridge in registry_hosts or _is_tailnet_shaped(bridge))
+    )
+    # Non-loopback allowlist: registry-named hosts + an explicitly-configured,
+    # Tailscale-shaped bridge host. A manifest/registry host that merely *looks*
+    # Tailscale-shaped but is neither registry-named nor the configured bridge is
+    # NOT trusted (a repo-controlled manifest must not inject probe targets).
+    allowed_nonloop = set(registry_hosts)
+    if bridge_allowed:
+        allowed_nonloop.add(bridge)
+
+    def _accepted(scheme: str, host: str) -> bool:
+        if _is_loopback_host(host):
+            return True
+        return host in allowed_nonloop and scheme == "https"
+
+    # base_port and the "is there a real substrate?" decision come ONLY from
+    # endpoints that survive the allowlist — a to-be-rejected host's port must
+    # never set the loopback/bridge fallback port. Ignore placeholder ports and
+    # the bare HTTPS-443 default (Serve fronts 443; the substrate listens on 8020+).
+    # base_port: lowest-priority accepted port, excluding the bare HTTPS-443
+    # default (Serve fronts 443; the substrate listens on 8020+). A 443-only
+    # endpoint still counts as a real substrate (below) — it just doesn't set the
+    # loopback port.
+    port_seeds = sorted(
+        (pri, port)
+        for (pri, _src, scheme, host, port) in raw
+        if _accepted(scheme, host) and port not in _PLACEHOLDER_PORTS and port != 443
+    )
+    base_port = port_seeds[0][1] if port_seeds else _DEFAULT_SUBSTRATE_PORT
+    # A "real substrate" is any accepted, non-placeholder endpoint (443 included).
+    have_real_substrate = any(
+        _accepted(scheme, host) and port not in _PLACEHOLDER_PORTS
+        for (_pri, _src, scheme, host, port) in raw
+    )
+    # A loopback fallback is only meaningful when the workspace config actually
+    # points at loopback (central host). Synthesizing 127.0.0.1:<port> for a
+    # remote-only substrate can hit an unrelated local service reusing the port
+    # and stamp success for the wrong workspace (#187 review, Codex P2).
+    have_loopback_signal = any(
+        _is_loopback_host(host) and port not in _PLACEHOLDER_PORTS
+        for (_pri, _src, _scheme, host, port) in raw
+    )
+
+    # The bridge reaches a real substrate — never synthesize it for a
+    # placeholder/unprovisioned workspace that has no real endpoint of its own
+    # (a global AGENTIC_MEMORY_BRIDGE_HOST must not fabricate a probe target for
+    # an unprovisioned workspace; #187 review, Codex P1).
+    if bridge_allowed and have_real_substrate:
+        raw.append((10, "env_bridge", "https", bridge, base_port))
+
+    # Loopback fallback only when the config actually points at loopback.
+    if have_loopback_signal:
+        raw.append((90, "loopback", "http", "127.0.0.1", base_port))
+
+    seen: set[str] = set()
+    out: list[EndpointCandidate] = []
+    for priority, source, scheme, host, port in sorted(raw, key=lambda item: item[0]):
+        if not _is_loopback_host(host):
+            if host not in allowed_nonloop:
+                continue  # not registry-named or the configured bridge
+            if scheme != "https":
+                continue  # non-loopback substrate must use Tailscale Serve TLS
+        url = f"{scheme}://{host}:{port}"
+        if url in seen:
+            continue
+        seen.add(url)
+        out.append(EndpointCandidate(url, scheme, host, port, source, priority))
+    return out

--- a/scripts/hook_repo_root.py
+++ b/scripts/hook_repo_root.py
@@ -1,0 +1,112 @@
+# OWNER: @agorokh
+"""Shared repo-root resolution for Claude Code memory hooks.
+
+Git worktrees expose `.git` as a file and use a random slug as the worktree
+directory name. Hooks that stamp or read ``.scratch/.last_memory_query`` must
+normalize to the **main** checkout via ``git rev-parse --git-common-dir`` so
+manifest ``match_repo_basenames`` and lockfile paths stay consistent.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def session_toplevel_dir() -> Path:
+    """Checkout directory for the active session (main clone or worktree).
+
+    Canonical implementation for all memory hooks. SessionStart stamps
+    ``.scratch/.last_memory_query`` here; gate/drift/Stop hooks read it from
+    the same path (Stop hooks may pass ``argv[1]`` via ``memory_hook_candidates``).
+    """
+    env_root = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p.resolve()
+    here = Path.cwd().resolve()
+    for parent in (here, *here.parents):
+        if (parent / ".git").exists():
+            return parent
+    return here
+
+
+def memory_hook_candidates() -> list[Path]:
+    """Session checkout path(s) before worktree normalization (Stop hooks)."""
+    candidates: list[Path] = []
+    if len(sys.argv) > 1:
+        arg = sys.argv[1].strip()
+        if arg:
+            candidates.append(Path(arg).expanduser().resolve())
+    env = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env:
+        candidates.append(Path(env).expanduser().resolve())
+    candidates.append(Path.cwd().resolve())
+    return candidates
+
+
+def resolve_memory_roots() -> tuple[Path, Path]:
+    """Return ``(main_repo_root, session_toplevel)`` for memory hooks."""
+    session = memory_hook_candidates()[0]
+    return normalize_to_main_worktree_dir(session), session
+
+
+def normalize_to_main_worktree_dir(base: Path) -> Path:
+    """Return the main repo working directory when *base* is a git worktree."""
+    resolved = base.expanduser().resolve()
+    try:
+        out = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(resolved),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=4,
+        )
+        if out.returncode == 0:
+            common = Path(out.stdout.strip())
+            if common.is_dir() and common.name == ".git":
+                return common.parent.resolve()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return resolved
+
+
+def worktree_root_for(path: Path) -> Path | None:
+    """Nearest ancestor of *path* containing a ``.git`` entry — its OWN worktree root.
+
+    A linked git worktree carries a ``.git`` **file** (a ``gitdir:`` pointer); the
+    main repo has a ``.git`` **directory** — either satisfies ``.exists()``.
+    Resolving against the file's own worktree means a file inside a **nested**
+    worktree (e.g. Claude Code's ``.claude/worktrees/<name>/``) or an **external**
+    worktree is classified by its position *within that worktree* (``docs/`` vs
+    code), not as ``.claude/worktrees/<name>/...`` relative to the main repo —
+    which matched no doc prefix and blocked every worktree edit under a marker
+    (agent-factory#308 / template-repo#182).
+
+    Use this for **per-file classifying** hooks (e.g. the stale-main gate's
+    docs-vs-code check). For **session/identity** root (memory hooks) use
+    ``session_toplevel_dir`` / ``normalize_to_main_worktree_dir`` instead — these
+    are the "two distinct needs" reconciled in agent-factory#310.
+
+    Returns ``None`` when no ``.git`` ancestor exists (file outside any repo); the
+    caller then falls back to its own ``_REPO_ROOT`` and ultimately fails closed.
+    """
+    try:
+        real = path.resolve()
+    except OSError:
+        real = path
+    base = real if real.is_dir() else real.parent
+    for parent in (base, *base.parents):
+        if (parent / ".git").exists():
+            return parent
+    return None

--- a/scripts/hook_session_start_memory_prefetch.py
+++ b/scripts/hook_session_start_memory_prefetch.py
@@ -299,21 +299,52 @@ def _resolve_workspace(
 ) -> dict | None:
     """Return the workspace dict that matches this repo, or None.
 
+    Resolution order (Kimi #180 council — template-relative config must live
+    in per-repo data, not copied logic):
+      1. ``repo.tier3_workspace_id`` — explicit per-repo redirect when the
+         canonical workspace name differs from the repo basename
+         (e.g. template-repo → ``agent_factory_steward``). Local manifest
+         wins over tracked, mirroring the ``resolution_exceptions`` precedence
+         decided in PR #175 (Qodo review).
+      2. Workspace name matches repo basename (hyphen/underscore tolerant).
+      3. ``vault_root`` prefix matches this repo's root.
+
     Candidates are the tracked manifest's workspaces first, then the
-    operator-owned ``memory_manifest.local.yml`` extension — so a tracked
-    name-match wins, and operator child-repo rows registered locally are
-    visible to SessionStart prefetch (previously only the agent-facing ladder
-    consulted the local manifest; the deterministic hook ignored it).
+    operator-owned ``memory_manifest.local.yml`` extension — so operator
+    child-repo rows registered locally are visible to SessionStart prefetch.
     """
     candidates = _gather_workspaces(manifest) + _gather_workspaces(local_manifest)
     if not candidates:
         return None
-    # Prefer workspace name (repo basename) over vault_root path heuristics.
+    # 1. Explicit per-repo redirect via repo.tier3_workspace_id.
+    tier3_id: str | None = None
+    for man in (local_manifest, manifest):  # local wins
+        if not isinstance(man, dict):
+            continue
+        repo_block = man.get("repo")
+        if isinstance(repo_block, dict):
+            val = repo_block.get("tier3_workspace_id")
+            if isinstance(val, str) and val.strip():
+                tier3_id = val.strip()
+                break
+    if tier3_id:
+        id_keys = _name_match_keys(tier3_id)
+        for ws in candidates:
+            ws_name = ws.get("name")
+            if isinstance(ws_name, str) and _name_match_keys(ws_name) & id_keys:
+                return ws
+        # tier3_id declared but unknown to the manifest → return None so the
+        # standard "no workspace registered" warning surfaces. Better than
+        # silently falling back to basename match and resolving to a wrong
+        # workspace.
+        return None
+    # 2. Workspace name matches repo basename.
     basename_keys = _name_match_keys(root.name)
     for ws in candidates:
         ws_name = ws.get("name")
         if isinstance(ws_name, str) and _name_match_keys(ws_name) & basename_keys:
             return ws
+    # 3. vault_root prefix match (only if unambiguous).
     vault_matches: list[dict] = []
     for ws in candidates:
         vr = ws.get("vault_root")
@@ -494,11 +525,20 @@ def _load_bridge_provenance() -> dict | None:
         data = json.loads(raw)
     except (json.JSONDecodeError, ValueError):
         return None
-    if isinstance(data, dict) and isinstance(data.get("result"), str):
-        try:
-            data = json.loads(data["result"])
-        except (json.JSONDecodeError, ValueError):
-            return None
+    # The MCP envelope wraps the payload in a ``result`` field. Earlier servers
+    # returned a JSON string; newer ones return the decoded object directly.
+    # Qodo PR #194 / #192 Part 6: both must be unwrapped — otherwise the
+    # dict-form envelope leaks through with no ``visible_workspace_ids`` and
+    # ``_bridge_workspace_problem`` silently skips the mismatch check.
+    if isinstance(data, dict) and "result" in data:
+        inner = data["result"]
+        if isinstance(inner, str):
+            try:
+                data = json.loads(inner)
+            except (json.JSONDecodeError, ValueError):
+                return None
+        elif isinstance(inner, dict):
+            data = inner
     return data if isinstance(data, dict) else None
 
 
@@ -783,12 +823,13 @@ def main() -> int:
     workspace_name = ws.get("name") or ""
     raw_backend = ws.get("backend")
     if raw_backend is None or str(raw_backend).strip() == "":
-        sys.stderr.write(
-            f"WARN  hook_session_start_memory_prefetch: workspace {workspace_name!r} "
-            "omits backend; skipping Tier-3 HTTP prefetch (set backend explicitly in "
-            "ops/memory_manifest.yml — see MEMORY_SUBSTRATE.md).\n"
-        )
-        backend = ""
+        # Per manifest contract (ops/memory_manifest.yml schema v2 notes): a row
+        # that omits ``backend`` MUST be treated as ``lightrag`` (the canonical
+        # online substrate). The old "skip prefetch, treat as empty" behavior
+        # hard-blocked any registered v1-manifest workspace (Qodo PR #194 / #192
+        # Part 5). Default to lightrag and continue — explicit unknown values
+        # still warn + skip below.
+        backend = "lightrag"
     else:
         backend = str(raw_backend).lower()
         if backend not in ("lightrag", "graphiti"):

--- a/scripts/hook_session_start_memory_prefetch.py
+++ b/scripts/hook_session_start_memory_prefetch.py
@@ -5,9 +5,10 @@ This is the LOAD half of the memory contract
 (``docs/00_Core/MEMORY_CONTRACT.md``):
 
 1. Resolve the **active workspace** for this repo from
-   ``ops/memory_manifest.yml`` (matched by repo path under ``vault_root`` when
-   name matching fails, else the workspace whose name matches the repo
-   directory).
+   ``ops/memory_manifest.yml`` (matched by ``vault_root`` containing the repo
+   path, falling back to the workspace whose name matches the parent
+   directory). The operator-owned ``ops/memory_manifest.local.yml`` extension is
+   merged in too, so child-repo workspaces registered locally resolve here.
 2. Issue an HTTP query against the workspace endpoint with a prompt derived
    from the current branch name (and optional ``CLAUDE_LOAD_PROMPT`` env).
 3. Print a short, deterministic summary to stdout so Claude Code injects it
@@ -18,7 +19,10 @@ This is the LOAD half of the memory contract
 
 If no workspace is registered for this repo, the hook writes
 ``.scratch/.last_memory_query.missing`` instead so the gate degrades to
-warn-only and the human sees the gap.
+warn-only and the human sees the gap. If a top-level ``resolution_exceptions``
+block (tracked or local manifest) lists this repo as a *known, accepted* gap,
+the hook surfaces the tracking issue and degrades quietly so the agent does not
+re-file a duplicate ``architectural-invariant-gap`` issue every session.
 
 The script is **deterministic** (no LLM in the hook hot path; the upstream
 MCP server may use one for extraction, but its call is a network request from
@@ -28,8 +32,19 @@ this script's perspective). Fail-open contract: any error → degrade to
 Environment knobs (rare):
 
 * ``CLAUDE_MEMORY_PREFETCH=0`` — skip the entire hook (treated as "missing").
-* ``CLAUDE_MEMORY_PREFETCH_TIMEOUT_S`` — HTTP timeout (default 6s).
+* ``CLAUDE_MEMORY_PREFETCH_TIMEOUT_S`` — HTTP timeout (default 30s; ~2× measured
+  naive p100 headroom on the fleet — see ``DEFAULT_TIMEOUT_S``).
+* ``CLAUDE_MEMORY_PREFETCH_MODE`` — LightRAG query mode for the prefetch
+  (default ``naive``, ~14–18s measured on the fleet; ``local`` adds graph
+  relevance but is ~34–40s — no faster than ``hybrid``/``mix`` — so it is not
+  the prefetch default).
 * ``CLAUDE_LOAD_PROMPT`` — override the auto-derived prompt.
+* ``AGENTIC_MEMORY_BRIDGE_PROVENANCE_JSON`` / ``..._FILE`` — optional
+  sanitized output from ``mcp__agentic-memory__get_bridge_provenance``. When
+  present, a manifest LightRAG workspace must be visible and not disabled in
+  the active bridge; otherwise the hook writes a blocking missing marker so
+  ``hook_memory_gate.py`` fails fast instead of letting the agent silently query
+  the wrong workspace universe.
 """
 
 from __future__ import annotations
@@ -40,29 +55,71 @@ import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
-# Fleet probe contract (ws-ops#128/template#159): measured naive ~14-18s,
-# hybrid ~40s; prefetch needs a relevance stamp, so naive + 30s.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+# Fleet probe contract (agorokh/workstation-ops#128, agorokh/template-repo#159,
+# agorokh/agent-factory#291). The old 6s default falsely reported the substrate
+# "unreachable" and hard-blocked edits fleet-wide, because real query latency is far
+# higher. MEASURED on the fleet (M2PRO, 2026-05-30, two live workspaces):
+#     naive  ~14–18s   |   local  ~34–40s   |   mix/hybrid  ~38–41s
+# So ``local`` is NOT "a few seconds" — it is ~40s, no better than hybrid for a prefetch.
+# Only ``naive`` returns materially faster, and the SessionStart prefetch only needs a
+# relevance *stamp* (vector/keyword retrieval that mentions the work's tokens), not graph
+# synthesis. Three-part fix: (1) prefetch uses ``naive``; (2) timeout raised to 30s
+# (≈2× the measured naive p100 for headroom); (3) a *timeout* is warn-only (substrate
+# slow, not down) — see main() / hook_memory_gate.py — never a hard block.
 DEFAULT_TIMEOUT_S = 30.0
+DEFAULT_QUERY_MODE = "naive"
+ERR_TIMEOUT = "timeout"
+ERR_UNREACHABLE = "unreachable"
 SUMMARY_TRUNCATE = 1200  # chars of summary stdout we surface to the agent
+BRIDGE_PROVENANCE_LIMIT = 16_384  # bytes/chars; provenance should be small sanitized JSON
+# Optional opt-in staleness guard for a file-sourced capture, in seconds. The
+# default is **0 (disabled)**: an mtime TTL is the wrong validity signal because
+# the capture is written once per *server launch*, not per Claude session, so a
+# long-running bridge would have a still-accurate file that a TTL would wrongly
+# drop — silently disabling the drift check (cursor-bot #172 review). Freshness
+# is instead guaranteed at the source: the wrapper rewrites the file on every
+# launch, and ``capture_bridge_provenance.py`` removes it when it cannot produce
+# fresh provenance in a real launch. Operators who still want a backstop set
+# ``AGENTIC_MEMORY_BRIDGE_PROVENANCE_MAX_AGE_S`` to a positive value.
+DEFAULT_BRIDGE_PROVENANCE_MAX_AGE_S = 0  # disabled by default; opt-in only
 
 
 def _repo_root() -> Path:
+    """Resolve to the **main** working directory, even from a git worktree.
+
+    Worktree layout: `.git` is a *file* containing `gitdir: .../worktrees/<slug>`.
+    Walking up looking for `.git` stops at the worktree path, whose basename is
+    a random slug that never matches manifest `match_repo_basenames`. The fix:
+    once we find the `.git` marker (or ``CLAUDE_PROJECT_DIR``), ask git for
+    ``--git-common-dir`` (the shared main ``.git``) and return its parent.
+    """
+    from hook_repo_root import normalize_to_main_worktree_dir
+
     env_root = os.environ.get("CLAUDE_PROJECT_DIR")
     if env_root:
         p = Path(env_root)
         if p.is_dir():
-            return p.resolve()
+            return normalize_to_main_worktree_dir(p)
     here = Path.cwd().resolve()
+    candidate: Path | None = None
     for parent in (here, *here.parents):
         if (parent / ".git").exists():
-            return parent
-    return here
+            candidate = parent
+            break
+    if candidate is None:
+        return here
+    return normalize_to_main_worktree_dir(candidate)
 
 
 def _enabled() -> bool:
@@ -81,6 +138,28 @@ def _timeout_s() -> float:
     except (TypeError, ValueError):
         pass
     return DEFAULT_TIMEOUT_S
+
+
+def _query_mode() -> str:
+    """LightRAG mode for the SessionStart prefetch.
+
+    Defaults to ``naive`` (~14–18s measured on the fleet — the prefetch only needs a
+    relevance stamp, not graph synthesis). Overridable via ``CLAUDE_MEMORY_PREFETCH_MODE``
+    for operators who want ``local`` (slower, ~34–40s, more graph-local relevance) or,
+    rarely, ``hybrid``/``mix``.
+    """
+    raw = os.environ.get("CLAUDE_MEMORY_PREFETCH_MODE", "").strip().lower()
+    if not raw:
+        return DEFAULT_QUERY_MODE
+    valid_modes = ("local", "naive", "hybrid", "mix", "global")
+    if raw in valid_modes:
+        return raw
+    sys.stderr.write(
+        "WARN  hook_session_start_memory_prefetch: unrecognized "
+        f"CLAUDE_MEMORY_PREFETCH_MODE {raw!r}; falling back to default "
+        f"{DEFAULT_QUERY_MODE!r}. Accepted values: {valid_modes}\n"
+    )
+    return DEFAULT_QUERY_MODE
 
 
 def _ttl_seconds() -> int:
@@ -128,24 +207,85 @@ def _derive_prompt(root: Path) -> str:
     return root.name
 
 
-def _load_manifest(root: Path) -> dict | None:
-    path = root / "ops" / "memory_manifest.yml"
+def _safe_load_yaml(path: Path, *, warn_on_problems: bool) -> dict | None:
+    """Load a YAML mapping from ``path``; return ``None`` on any failure.
+
+    ``warn_on_problems`` makes setup/parse defects **loud** on stderr — missing
+    PyYAML, an unparseable file, or a non-mapping top level. Only the *tracked*
+    manifest sets this: a malformed tracked manifest is operator misconfiguration
+    that would otherwise silently route into the degraded "no workspace" /
+    "accepted gap" paths and mask the real problem (Qodo review, PR #175). A
+    missing or malformed *local* manifest is routine and stays quiet.
+    """
     if not path.is_file():
         return None
     try:
         import yaml  # type: ignore
     except ImportError:
-        print(
-            "WARNING: hook_session_start_memory_prefetch.py needs PyYAML — "
-            "run `pip install -e '.[dev]'` or use the repo .venv python in "
-            "SessionStart hooks (see .claude/settings.base.json).",
-            file=sys.stderr,
-        )
+        if warn_on_problems:
+            print(
+                "WARNING: hook_session_start_memory_prefetch.py needs PyYAML — "
+                "run `pip install -e '.[dev]'` or use the repo .venv python in "
+                "SessionStart hooks (see .claude/settings.base.json).",
+                file=sys.stderr,
+            )
         return None
     try:
-        return yaml.safe_load(path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        if warn_on_problems:
+            print(
+                f"WARNING: hook_session_start_memory_prefetch.py could not parse "
+                f"{path.name} ({exc.__class__.__name__}); treating as no manifest. "
+                "Fix the YAML to restore Tier-3 workspace resolution.",
+                file=sys.stderr,
+            )
         return None
+    if data is not None and not isinstance(data, dict):
+        if warn_on_problems:
+            print(
+                f"WARNING: hook_session_start_memory_prefetch.py: {path.name} top "
+                f"level is {type(data).__name__}, not a mapping; treating as no "
+                "manifest.",
+                file=sys.stderr,
+            )
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _load_manifest(root: Path) -> dict | None:
+    return _safe_load_yaml(root / "ops" / "memory_manifest.yml", warn_on_problems=True)
+
+
+def _load_local_manifest(root: Path) -> dict | None:
+    """Operator-owned, gitignored manifest extension (``memory_manifest.local.yml``).
+
+    The committed manifest ships only a generic skeleton; child-repo workspaces
+    and resolution exceptions this operator owns live here. The local example
+    file (``ops/memory_manifest.local.example.yml``) has long documented that "a
+    merge step at boot can concatenate the workspaces" — this is that merge.
+    """
+    return _safe_load_yaml(root / "ops" / "memory_manifest.local.yml", warn_on_problems=False)
+
+
+def _gather_workspaces(manifest: dict | None) -> list[dict]:
+    """Flatten ``hosts[].workspaces`` from a manifest dict."""
+    if not isinstance(manifest, dict):
+        return []
+    hosts = manifest.get("hosts") or []
+    if not isinstance(hosts, list):
+        return []
+    out: list[dict] = []
+    for host in hosts:
+        if not isinstance(host, dict):
+            continue
+        workspaces = host.get("workspaces")
+        if not isinstance(workspaces, list):
+            continue
+        for ws in workspaces:
+            if isinstance(ws, dict):
+                out.append(ws)
+    return out
 
 
 def _name_match_keys(name: str) -> set[str]:
@@ -154,20 +294,18 @@ def _name_match_keys(name: str) -> set[str]:
     return {lowered, lowered.replace("-", "_"), lowered.replace("_", "-")}
 
 
-def _resolve_workspace(root: Path, manifest: dict | None) -> dict | None:
-    """Return the workspace dict that matches this repo, or None."""
-    if not isinstance(manifest, dict):
-        return None
-    hosts = manifest.get("hosts") or []
-    if not isinstance(hosts, list):
-        return None
-    candidates: list[dict] = []
-    for host in hosts:
-        if not isinstance(host, dict):
-            continue
-        for ws in host.get("workspaces") or []:
-            if isinstance(ws, dict):
-                candidates.append(ws)
+def _resolve_workspace(
+    root: Path, manifest: dict | None, local_manifest: dict | None
+) -> dict | None:
+    """Return the workspace dict that matches this repo, or None.
+
+    Candidates are the tracked manifest's workspaces first, then the
+    operator-owned ``memory_manifest.local.yml`` extension — so a tracked
+    name-match wins, and operator child-repo rows registered locally are
+    visible to SessionStart prefetch (previously only the agent-facing ladder
+    consulted the local manifest; the deterministic hook ignored it).
+    """
+    candidates = _gather_workspaces(manifest) + _gather_workspaces(local_manifest)
     if not candidates:
         return None
     # Prefer workspace name (repo basename) over vault_root path heuristics.
@@ -182,12 +320,47 @@ def _resolve_workspace(root: Path, manifest: dict | None) -> dict | None:
         if isinstance(vr, str):
             try:
                 vr_resolved = _resolve_vault_root(vr, root)
-                if root.is_relative_to(vr_resolved):
+                if vr_resolved.is_relative_to(root):
                     vault_matches.append(ws)
             except (OSError, ValueError):
                 pass
     if len(vault_matches) == 1:
         return vault_matches[0]
+    return None
+
+
+def _resolve_exception(
+    root: Path, manifest: dict | None, local_manifest: dict | None
+) -> dict | None:
+    """Return a recorded ``resolution_exceptions`` entry for this repo, or None.
+
+    A ``resolution_exceptions`` block (top-level, in the tracked manifest or the
+    local extension) maps a repo basename to ``{reason, tracking_issue}`` and
+    declares the missing Tier-3 workspace a *known, accepted gap*. The prefetch
+    surfaces it and degrades to warn-only so the agent does NOT file yet another
+    duplicate ``architectural-invariant-gap`` issue each session (the recurring
+    pain behind template-repo#145 / #167 / #169 / #172).
+
+    **Local entries win** — checked source-by-source (local first, then tracked)
+    rather than via a merged dict. A merged ``dict.update()`` only overwrites on
+    *identical* keys, so a local ``foo_bar`` and a tracked ``foo-bar`` (both
+    valid under the documented hyphen/underscore tolerance) would BOTH survive
+    and tracked-first iteration would wrongly win (Qodo review, PR #175).
+    """
+    basename_keys = _name_match_keys(root.name)
+    for man in (local_manifest, manifest):  # local precedence
+        if not isinstance(man, dict):
+            continue
+        block = man.get("resolution_exceptions")
+        if not isinstance(block, dict):
+            continue
+        for key, val in block.items():
+            if (
+                isinstance(key, str)
+                and isinstance(val, dict)
+                and _name_match_keys(key) & basename_keys
+            ):
+                return val
     return None
 
 
@@ -215,10 +388,19 @@ def _resolve_vault_root(vr: str, root: Path) -> Path:
     return (root / expanded).resolve()
 
 
-def _http_query_lightrag(endpoint: str, prompt: str, timeout: float) -> str:
-    """POST /query → response text. Empty on failure."""
+def _http_query_lightrag(
+    endpoint: str, prompt: str, timeout: float, mode: str
+) -> tuple[str, str | None]:
+    """POST /query → ``(response_text, error_kind)``.
+
+    ``error_kind`` is ``None`` on success, ``ERR_TIMEOUT`` when the substrate did not
+    answer within ``timeout`` (healthy but slow — a cold hybrid query is ~40s), or
+    ``ERR_UNREACHABLE`` for connection refused / DNS / other transport errors. The caller
+    treats ``ERR_TIMEOUT`` as warn-only and ``ERR_UNREACHABLE`` as a genuine outage
+    (agorokh/workstation-ops#128).
+    """
     url = endpoint.rstrip("/") + "/query"
-    payload = json.dumps({"query": prompt, "mode": "naive"}).encode("utf-8")
+    payload = json.dumps({"query": prompt, "mode": mode}).encode("utf-8")
     req = urllib.request.Request(
         url,
         data=payload,
@@ -228,16 +410,133 @@ def _http_query_lightrag(endpoint: str, prompt: str, timeout: float) -> str:
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed scheme
             body = resp.read().decode("utf-8", errors="replace")
-    except (urllib.error.URLError, OSError, TimeoutError):
-        return ""
+    except TimeoutError:  # socket.timeout is an alias of TimeoutError (py3.10+)
+        return "", ERR_TIMEOUT
+    except urllib.error.URLError as exc:
+        # urlopen wraps a read/connect timeout in URLError(reason=TimeoutError).
+        if isinstance(getattr(exc, "reason", None), TimeoutError):
+            return "", ERR_TIMEOUT
+        return "", ERR_UNREACHABLE
+    except OSError:
+        return "", ERR_UNREACHABLE
     # LightRAG returns {"response": "...prose..."} or plain text; surface the field if present.
     try:
         data = json.loads(body)
         if isinstance(data, dict) and isinstance(data.get("response"), str):
-            return data["response"]
+            return data["response"], None
     except (json.JSONDecodeError, ValueError):
         pass
-    return body
+    return body, None
+
+
+def _default_bridge_provenance_file() -> Path:
+    """Canonical capture path written by ``scripts/mcp/capture_bridge_provenance.py``.
+
+    Kept identical to that script's ``default_provenance_path`` (sans the env
+    override, which ``_load_bridge_provenance`` handles separately) so the
+    wrapper-side writer and this reader agree without an env handshake. Parity is
+    pinned by ``tests/test_capture_bridge_provenance.py``.
+    """
+    cache_home = os.environ.get("XDG_CACHE_HOME", "").strip() or str(Path.home() / ".cache")
+    return Path(cache_home) / "agentic-memory" / "bridge_provenance.json"
+
+
+def _bridge_provenance_max_age_s() -> float:
+    raw = os.environ.get("AGENTIC_MEMORY_BRIDGE_PROVENANCE_MAX_AGE_S", "")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return float(DEFAULT_BRIDGE_PROVENANCE_MAX_AGE_S)
+
+
+def _read_bridge_provenance_file(path: Path) -> str:
+    """Read a provenance capture, honouring the staleness + size bounds.
+
+    Returns "" (treated as "no assertion") when the file is absent, too large,
+    or older than the max-age guard. A non-positive max age disables the guard.
+    """
+    max_age = _bridge_provenance_max_age_s()
+    try:
+        if max_age > 0:
+            age = time.time() - path.stat().st_mtime
+            if age > max_age:
+                return ""
+        with path.open("r", encoding="utf-8") as f:
+            raw = f.read(BRIDGE_PROVENANCE_LIMIT + 1)
+    except OSError:
+        return ""
+    if len(raw) > BRIDGE_PROVENANCE_LIMIT:
+        return ""
+    return raw
+
+
+def _load_bridge_provenance() -> dict | None:
+    """Return optional agentic-memory bridge provenance supplied by the host.
+
+    The MCP tool itself is not callable from this deterministic SessionStart
+    hook, but ``scripts/mcp/agentic-memory.sh`` captures the sanitized
+    ``get_bridge_provenance`` payload to a well-known file before launching the
+    server (issue #172). Resolution order: inline ``..._JSON`` env →
+    ``..._FILE`` env → the canonical capture file. Absence means "no assertion
+    available" rather than failure; malformed payloads fail open so a bad shell
+    export does not wedge startup.
+    """
+    raw = os.environ.get("AGENTIC_MEMORY_BRIDGE_PROVENANCE_JSON", "").strip()
+    if len(raw) > BRIDGE_PROVENANCE_LIMIT:
+        return None
+    if not raw:
+        fp = os.environ.get("AGENTIC_MEMORY_BRIDGE_PROVENANCE_FILE", "").strip()
+        path = Path(os.path.expanduser(fp)) if fp else _default_bridge_provenance_file()
+        raw = _read_bridge_provenance_file(path)
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if isinstance(data, dict) and isinstance(data.get("result"), str):
+        try:
+            data = json.loads(data["result"])
+        except (json.JSONDecodeError, ValueError):
+            return None
+    return data if isinstance(data, dict) else None
+
+
+def _bridge_workspace_problem(ws: dict, provenance: dict | None) -> tuple[str | None, str | None]:
+    """Return ``(code, message)`` when bridge provenance contradicts manifest.
+
+    Only live LightRAG rows are checked. Graphiti rows are offline-only or
+    placeholders per ``MEMORY_SUBSTRATE.md`` and intentionally do not appear on
+    the agent read path.
+    """
+    if not provenance:
+        return None, None
+    workspace = ws.get("name")
+    if not isinstance(workspace, str) or not workspace:
+        return None, None
+    backend = str(ws.get("backend") or "").lower()
+    if backend != "lightrag":
+        return None, None
+
+    visible_raw = provenance.get("visible_workspace_ids")
+    disabled_raw = provenance.get("disabled_workspace_ids")
+    visible = [str(x) for x in visible_raw] if isinstance(visible_raw, list) else []
+    disabled = [str(x) for x in disabled_raw] if isinstance(disabled_raw, list) else []
+    registry = provenance.get("registry_path") or "<unknown registry>"
+
+    if workspace in disabled:
+        return (
+            "bridge_workspace_disabled",
+            f"manifest workspace {workspace!r} is disabled in active agentic-memory "
+            f"bridge registry {registry}; visible_workspace_ids={visible}",
+        )
+    if visible and workspace not in visible:
+        return (
+            "bridge_workspace_not_visible",
+            f"manifest workspace {workspace!r} is not visible in active agentic-memory "
+            f"bridge registry {registry}; visible_workspace_ids={visible}",
+        )
+    return None, None
 
 
 # Maximum chars of substrate response body persisted into the lockfile.
@@ -253,7 +552,8 @@ def _stamp_lock(
     prompt: str,
     ok: bool,
     response_body: str = "",
-    provisioned: bool,
+    reason: str | None = None,
+    gate_policy: str = "allow",
 ) -> Path:
     """Write the gate lockfile.
 
@@ -287,13 +587,11 @@ def _stamp_lock(
         "response_body": safe_body if ok else "",
         "response_body_len": len(safe_body) if ok else 0,
     }
-    if provisioned:
+    if reason:
+        payload["reason"] = reason
+    if ok:
         out = scratch / ".last_memory_query"
-        if not ok:
-            payload["hint"] = (
-                "Tier-3 prefetch did not return a response body — issue an "
-                "mcp__agentic-memory__query_knowledge_graph call before code edits"
-            )
+        # Best-effort delete of any stale "missing" marker
         try:
             (scratch / ".last_memory_query.missing").unlink()
         except FileNotFoundError:
@@ -303,6 +601,7 @@ def _stamp_lock(
     else:
         out = scratch / ".last_memory_query.missing"
         payload["hint"] = workspace or "no workspace registered for this repo"
+        payload["gate_policy"] = gate_policy
         try:
             (scratch / ".last_memory_query").unlink()
         except FileNotFoundError:
@@ -325,10 +624,16 @@ def _print_summary(*, workspace: str | None, prompt: str, body: str) -> None:
             snippet = snippet[:SUMMARY_TRUNCATE] + "…(truncated)"
         sys.stdout.write(f"  result:\n{snippet}\n")
     else:
-        sys.stdout.write(
-            "  result: (substrate unreachable or empty; gate will allow "
-            "code-path edits in degraded mode)\n"
-        )
+        if workspace:
+            sys.stdout.write(
+                "  result: (substrate unreachable or empty; gate will block "
+                "code-path edits until Tier-3 prefetch succeeds)\n"
+            )
+        else:
+            sys.stdout.write(
+                "  result: (substrate unreachable or empty; gate will allow "
+                "code-path edits in degraded mode)\n"
+            )
     sys.stdout.write("---\n")
 
 
@@ -430,26 +735,45 @@ def main() -> int:
         _print_super_ego_prefix(root)
     prompt = _derive_prompt(root)
     if not _enabled():
-        _stamp_lock(
-            root,
-            workspace=None,
-            prompt=prompt,
-            ok=False,
-            response_body="",
-            provisioned=False,
-        )
+        _stamp_lock(root, workspace=None, prompt=prompt, ok=False, response_body="")
         return 0
     manifest = _load_manifest(root)
-    ws = _resolve_workspace(root, manifest)
+    local_manifest = _load_local_manifest(root)
+    ws = _resolve_workspace(root, manifest, local_manifest)
     if ws is None:
-        _stamp_lock(
-            root,
-            workspace=None,
-            prompt=prompt,
-            ok=False,
-            response_body="",
-            provisioned=False,
-        )
+        exception = _resolve_exception(root, manifest, local_manifest)
+        if exception is not None:
+            why = str(exception.get("reason") or "accepted Tier-3 gap").strip()
+            tracking = str(exception.get("tracking_issue") or "").strip()
+            # An accepted gap is semantically "no workspace registered, but known"
+            # — it must behave like the generic no-workspace path: gate_policy
+            # defaults to "allow" (workspace=None), so hook_memory_gate.py's
+            # no-workspace branch allows code edits UNCONDITIONALLY, independent of
+            # any leftover .last_memory_query lock. Do NOT use gate_policy="warn"
+            # here: that policy is for the timeout case (a *registered* workspace
+            # whose leftover fresh lock should still enforce relevance), and a
+            # coexisting fresh lock (best-effort unlink failed, or timestamp tie)
+            # would then fall through to relevance checks and wrongly block edits
+            # despite a recorded resolution_exceptions gap (Cursor Bugbot, PR #175).
+            _stamp_lock(
+                root,
+                workspace=None,
+                prompt=prompt,
+                ok=False,
+                response_body="",
+                reason="accepted_gap",
+            )
+            msg = f"NOTE: accepted Tier-3 gap for this repo ({why})"
+            if tracking:
+                msg += f"; tracked in {tracking}"
+            msg += (
+                ". Gate allows code-path edits (degraded, like an unregistered "
+                "workspace); do NOT file a new architectural-invariant-gap issue "
+                "(recorded in resolution_exceptions).\n"
+            )
+            sys.stdout.write(msg)
+            return 0
+        _stamp_lock(root, workspace=None, prompt=prompt, ok=False, response_body="")
         sys.stdout.write(
             "WARNING: no Tier-3 workspace registered for this repo in "
             "ops/memory_manifest.yml; gate degrades to warn-only on code paths "
@@ -457,33 +781,99 @@ def main() -> int:
         )
         return 0
     workspace_name = ws.get("name") or ""
-    endpoint = ws.get("endpoint") or ""
-    backend = (ws.get("backend") or "lightrag").lower()
-    body = ""
-    prefetch_ok = bool(endpoint and backend == "lightrag")
-    if prefetch_ok:
-        allowed, reason = _endpoint_allowed(endpoint)
-        if not allowed:
-            prefetch_ok = False
+    raw_backend = ws.get("backend")
+    if raw_backend is None or str(raw_backend).strip() == "":
+        sys.stderr.write(
+            f"WARN  hook_session_start_memory_prefetch: workspace {workspace_name!r} "
+            "omits backend; skipping Tier-3 HTTP prefetch (set backend explicitly in "
+            "ops/memory_manifest.yml — see MEMORY_SUBSTRATE.md).\n"
+        )
+        backend = ""
+    else:
+        backend = str(raw_backend).lower()
+        if backend not in ("lightrag", "graphiti"):
             sys.stderr.write(
-                f"WARN  hook_session_start_memory_prefetch: blocked endpoint "
-                f"({reason}): {endpoint}\n"
+                f"WARN  hook_session_start_memory_prefetch: workspace {workspace_name!r} "
+                f"has unknown backend={raw_backend!r}; skipping Tier-3 HTTP prefetch.\n"
             )
-        else:
-            body = _http_query_lightrag(endpoint, prompt, _timeout_s())
-            if not body.strip():
-                prefetch_ok = False
-    # Graphiti has no SessionStart HTTP prefetch yet. Stamping a provisioned lock
-    # with an empty response_body hard-blocks the gate with no recovery path
-    # (MCP queries do not refresh `.last_memory_query` today).
-    provisioned = backend != "graphiti"
+    bridge_problem, bridge_message = _bridge_workspace_problem(ws, _load_bridge_provenance())
+    if bridge_problem:
+        _stamp_lock(
+            root,
+            workspace=workspace_name,
+            prompt=prompt,
+            ok=False,
+            response_body="",
+            reason=bridge_problem,
+            gate_policy="block",
+        )
+        sys.stdout.write(
+            "ERROR: Tier-3 workspace mismatch: "
+            f"{bridge_message}. Do not query a different workspace; run "
+            "mcp__agentic-memory__get_bridge_provenance and fix the bridge "
+            "registry/allowlist before code-path edits.\n"
+        )
+        return 0
+    body = ""
     if backend == "graphiti":
         sys.stdout.write(
-            "WARNING: graphiti workspace — SessionStart HTTP prefetch is not "
-            "implemented yet; gate degrades to warn-only. Call "
-            "mcp__agentic-memory__query_knowledge_graph for context until "
-            "graphiti HTTP prefetch or MCP lockfile refresh lands.\n"
+            "NOTE: workspace declares backend=graphiti (offline-only per sunset ADR); "
+            "SessionStart prefetch does not query Graphiti on the agent read path. "
+            "Registered-workspace code edits stay blocked until backend is lightrag "
+            "and the endpoint is live.\n"
         )
+    prefetch_ok = backend == "lightrag"
+    if prefetch_ok:
+        from hook_memory_manifest import resolve_memory_endpoints
+
+        timeout_s = _timeout_s()
+        mode = _query_mode()
+        # Probe reachable endpoints in priority order (env-bridge ts.net →
+        # consumer-registry HTTPS → loopback) instead of the old loopback-only
+        # SSRF guard + single manifest endpoint, so a non-central tailnet host can
+        # reach the same substrate the MCP read path uses rather than dead
+        # loopback (template-repo#180 / workstation-ops#170). The resolver applies
+        # its own allowlist (registry-named or Tailscale-shaped host; HTTPS for
+        # non-loopback), so the loopback-only _endpoint_allowed guard is retired.
+        candidates = resolve_memory_endpoints(workspace_name, ws, env=dict(os.environ))
+        saw_timeout = False
+        for candidate in candidates:
+            body, err = _http_query_lightrag(candidate.url, prompt, timeout_s, mode)
+            if err is None and body.strip():
+                break
+            if err == ERR_TIMEOUT:
+                # A timeout on ONE candidate doesn't prove the substrate is merely
+                # slow — it may be a stale bridge/blackholed registry host while a
+                # later candidate (e.g. manifest loopback) answers. Keep probing;
+                # only treat it as slow-not-down if nothing answers (#187 review).
+                saw_timeout = True
+            body = ""
+        if not body.strip() and saw_timeout:
+            # Substrate is healthy but slow (a cold LightRAG query can take ~40s).
+            # A mere timeout must NEVER hard-block edits (ws-ops#128 rec 2): write a
+            # warn-only missing marker so the gate degrades instead of bricking the
+            # session, even though the workspace is registered.
+            _stamp_lock(
+                root,
+                workspace=workspace_name,
+                prompt=prompt,
+                ok=False,
+                response_body="",
+                reason=(
+                    f"prefetch timed out after {timeout_s:g}s (substrate slow, not down); "
+                    "warn-only — raise CLAUDE_MEMORY_PREFETCH_TIMEOUT_S or query manually"
+                ),
+                gate_policy="warn",
+            )
+            sys.stdout.write(
+                f"WARNING: Tier-3 prefetch timed out after {timeout_s:g}s for workspace "
+                f"{workspace_name!r} (mode={mode}); substrate is slow, not down. "
+                "Gate degrades to warn-only this session; run "
+                "mcp__agentic-memory__query_knowledge_graph manually to ground edits.\n"
+            )
+            return 0
+        if not body.strip():
+            prefetch_ok = False
     # TODO(PR-D+): handle backend == "graphiti" via its HTTP API once finalized.
     _stamp_lock(
         root,
@@ -491,27 +881,40 @@ def main() -> int:
         prompt=prompt,
         ok=prefetch_ok,
         response_body=body,
-        provisioned=provisioned,
     )
     _print_summary(workspace=workspace_name, prompt=prompt, body=body)
     return 0
+
+
+def _workspace_name_for_failure(root: Path) -> str | None:
+    """Best-effort registered workspace id for fail-open missing markers."""
+    try:
+        manifest = _load_manifest(root)
+        local_manifest = _load_local_manifest(root)
+        ws = _resolve_workspace(root, manifest, local_manifest)
+        if not ws:
+            return None
+        name = str(ws.get("name") or "").strip()
+        return name or None
+    except Exception:  # noqa: BLE001
+        return None
 
 
 if __name__ == "__main__":
     try:
         sys.exit(main())
     except Exception as exc:  # noqa: BLE001 — fail-open
-        # On total failure, still stamp the missing marker so the gate degrades
-        # to warn-only and the session can proceed.
+        # On total failure, still stamp the missing marker. If a registered
+        # workspace can be resolved, the gate blocks code edits; otherwise this
+        # remains the no-workspace bootstrap warning path.
         try:
             root = _repo_root()
             _stamp_lock(
                 root,
-                workspace=None,
+                workspace=_workspace_name_for_failure(root),
                 prompt="(prefetch error)",
                 ok=False,
                 response_body="",
-                provisioned=False,
             )
         except Exception:  # noqa: BLE001
             pass

--- a/tests/test_gate_classifier_oracle.py
+++ b/tests/test_gate_classifier_oracle.py
@@ -1,0 +1,92 @@
+"""Oracle / consumer-contract test for the gate classifier.
+
+Kimi #180 council: the recurring design→propagate→walk-back loop happens
+because a change to the gate's classifier (in scripts/) can silently break a
+child repo's declared code_dirs (in ops/memory_manifest.yml). Bot review
+catches it AFTER propagation. This oracle catches it BEFORE — at CI/merge.
+
+How it works:
+  * Load THIS repo's ops/memory_manifest.yml.
+  * Extract declared `repo.code_dirs` / `repo.code_top_level` (or template
+    defaults when absent).
+  * Synthesize a sample path under each declared entry.
+  * Assert the gate's `_classify` returns "code" for every sample.
+
+If a future PR alters _classify in a way that breaks a declared dir, this
+test fails with the specific declaration that no longer holds — the operator
+sees exactly which contract was broken, immediately, not after bot review.
+
+Cross-repo extension (Wave-2): a CI workflow can fetch each child's
+manifest via gh and run the same oracle with the proposed gate code.
+That closes the loop fleet-wide; this intra-repo version pins it for
+THIS repo on every PR.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from hook_memory_gate import _classify  # noqa: E402
+from hook_memory_manifest import (  # noqa: E402
+    DEFAULT_CODE_PATH_PREFIXES,
+    DEFAULT_CODE_PATH_TOP_LEVEL,
+    load_manifest,
+    oracle_classification_failures,
+    repo_code_path_prefixes,
+)
+
+
+def test_oracle_repo_manifest_classifies_declared_dirs_as_code() -> None:
+    """THIS repo's gate classifier must honor every dir/file declared in
+    ops/memory_manifest.yml. The walk-back loop cure (Kimi #180)."""
+    manifest = load_manifest(REPO_ROOT)
+    failures = oracle_classification_failures(manifest, _classify, root=REPO_ROOT)
+    assert failures == [], (
+        "Gate classifier broke the manifest contract — "
+        "either fix _classify or update ops/memory_manifest.yml.\n"
+        + "\n".join(f"  * {f}" for f in failures)
+    )
+
+
+def test_oracle_failures_reported_when_classifier_drifts(tmp_path: Path) -> None:
+    """Sanity-check the oracle itself: synthesize a divergence and confirm
+    the oracle reports it (so a real regression actually fires)."""
+    manifest = {"repo": {"code_dirs": ["completely_made_up_dir_name"]}}
+
+    def _broken_classify(
+        path: str, *, root, code_prefixes, code_top_level, code_dir_top_level
+    ) -> str:
+        # Deliberately doesn't honor the override → returns "other" always.
+        return "other"
+
+    failures = oracle_classification_failures(manifest, _broken_classify, root=tmp_path)
+    assert failures, "oracle did not surface a broken classifier"
+    assert any("completely_made_up_dir_name" in f for f in failures)
+
+
+def test_template_defaults_classify_as_code() -> None:
+    """Defensive: the gate's hardcoded fallback defaults must themselves all
+    classify as code (a divergence here would mean defaults are unreachable
+    via the classifier — silent gate-coverage gap)."""
+    for prefix in DEFAULT_CODE_PATH_PREFIXES:
+        sample = prefix + "x.py"
+        assert _classify(sample) == "code", f"default prefix '{prefix}' not code"
+    for top in DEFAULT_CODE_PATH_TOP_LEVEL:
+        assert _classify(top) == "code", f"default top-level '{top}' not code"
+
+
+def test_oracle_uses_manifest_overrides_not_module_defaults() -> None:
+    """Pass an override manifest with a non-default dir; oracle must use that
+    dir (not the module defaults). Ensures the oracle exercises the per-repo
+    override path, not the fallback."""
+    manifest = {"repo": {"code_dirs": ["my_runtime_pkg"]}}
+    failures = oracle_classification_failures(manifest, _classify)
+    # When override is honored, _classify('my_runtime_pkg/x.py', code_prefixes=('my_runtime_pkg/',))
+    # returns 'code' → no failure.
+    assert failures == [], failures
+    # Also assert this actually changed the prefix set (not just same as defaults).
+    assert repo_code_path_prefixes(manifest) == ("my_runtime_pkg/",)

--- a/tests/test_hook_memory_gate.py
+++ b/tests/test_hook_memory_gate.py
@@ -609,45 +609,338 @@ def test_bash_non_file_edit_allowed(fake_repo: Path) -> None:
 # -------------------------------------------------------------------------
 
 
-def test_bash_python_dash_c_blocked(fake_repo: Path) -> None:
-    """`python -c "..."` is an arbitrary code-write surface → gate fires."""
+def test_bash_python_dash_c_mutating_blocked(fake_repo: Path) -> None:
+    """`python -c "open('x','w').write(...)"` mutates a file → gate fires."""
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'python -c \'open("x.py","w").write("y")\''},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"mutating python -c not blocked: {stderr}"
+
+
+def test_bash_python3_dash_c_pathlib_mutation_blocked(fake_repo: Path) -> None:
+    """`Path(...).write_text(...)` is a mutation primitive."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": 'python3 -c \'from pathlib import Path; Path("x.py").write_text("y")\''
+            },
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_python_dash_c_readonly_allowed(fake_repo: Path) -> None:
+    """`python -c "import json; print(json.load(open('x.json')))"` is read-only.
+
+    Council #180/#188: don't brick agents on read-only one-liners — the gate's
+    purpose is forcing memory-grounding before *mutations*, not pure reads.
+    """
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "python -c 'import json; print(json.load(open(\"x.json\")))'"
+            },
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"read-only python -c was blocked: {stderr}"
+
+
+def test_bash_python_dash_c_bare_open_readonly_allowed(fake_repo: Path) -> None:
+    """`open('x')` defaults to read mode 'r' → not a mutation."""
     rc, _, stderr = _run(
         {"tool_name": "Bash", "tool_input": {"command": "python -c 'open(\"x\")'"}},
         cwd=fake_repo,
     )
-    assert rc == 2, f"stderr: {stderr}"
+    assert rc == 0, f"read-only open() was blocked: {stderr}"
 
 
-def test_bash_python3_dash_c_blocked(fake_repo: Path) -> None:
+def test_bash_python_dash_c_dynamic_exec_blocked(fake_repo: Path) -> None:
+    """`python -c "eval(...)"` / `__import__(...)` are evasion patterns → block."""
     rc, _, _ = _run(
-        {"tool_name": "Bash", "tool_input": {"command": "python3 -c 'open(\"x\")'"}},
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -c 'eval(\"open(1)\")'"},
+        },
         cwd=fake_repo,
     )
     assert rc == 2
 
 
-def test_bash_node_eval_blocked(fake_repo: Path) -> None:
-    rc, _, _ = _run(
+def test_bash_node_eval_arithmetic_allowed(fake_repo: Path) -> None:
+    """`node -e "1+1"` has no mutation → allow."""
+    rc, _, stderr = _run(
         {"tool_name": "Bash", "tool_input": {"command": 'node -e "1+1"'}},
         cwd=fake_repo,
     )
+    assert rc == 0, f"arithmetic node -e was blocked: {stderr}"
+
+
+def test_bash_node_eval_fs_write_blocked(fake_repo: Path) -> None:
+    """`node -e "fs.writeFileSync(...)"` mutates → block."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'node -e "require(\\"fs\\").writeFileSync(\\"x\\",\\"y\\")"'},
+        },
+        cwd=fake_repo,
+    )
     assert rc == 2
 
 
-def test_bash_perl_e_blocked(fake_repo: Path) -> None:
-    rc, _, _ = _run(
+def test_bash_perl_e_print_allowed(fake_repo: Path) -> None:
+    """`perl -e 'print 1'` is read-only."""
+    rc, _, stderr = _run(
         {"tool_name": "Bash", "tool_input": {"command": "perl -e 'print 1'"}},
         cwd=fake_repo,
     )
-    assert rc == 2
+    assert rc == 0, f"perl print was blocked: {stderr}"
 
 
-def test_bash_ruby_e_blocked(fake_repo: Path) -> None:
-    rc, _, _ = _run(
+def test_bash_ruby_e_puts_allowed(fake_repo: Path) -> None:
+    """`ruby -e 'puts 1'` is read-only."""
+    rc, _, stderr = _run(
         {"tool_name": "Bash", "tool_input": {"command": "ruby -e 'puts 1'"}},
         cwd=fake_repo,
     )
+    assert rc == 0, f"ruby puts was blocked: {stderr}"
+
+
+def test_bash_perl_e_mutation_blocked(fake_repo: Path) -> None:
+    """`perl -e 'open(F,">x"); print F "y"'` mutates → block via `>` redirect."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'perl -e \'open(F,">x.py"); print F "y"\''},
+        },
+        cwd=fake_repo,
+    )
     assert rc == 2
+
+
+# -------------------------------------------------------------------------
+# Round-2 PR #194 review fixes:
+#   * Cursor HIGH (line 308) — `>` comparison in python -c must not block.
+#   * Cursor MEDIUM (line 276) — `str.replace()` must not block.
+#   * Qodo HIGH (line 652) — `sudo cp` / wrapped + absolute-path cp/mv MUST block.
+# -------------------------------------------------------------------------
+
+
+def test_bash_python_dash_c_with_greater_than_comparison_allowed(fake_repo: Path) -> None:
+    """`python -c "print(1 > 0)"` is a comparison, NOT a shell redirect.
+
+    Cursor PR #194 HIGH: the `>` redirect regex matched `> 0)` inside Python
+    code and false-blocked read-only one-liners that used `>` for comparison.
+    Fix splits shell context (bash -c) from language context (python -c) and
+    only applies the `>` regex to shell context.
+    """
+    rc, _, stderr = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "python -c 'print(1 > 0)'"}},
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"python -c comparison was wrongly blocked: {stderr}"
+
+
+def test_bash_perl_e_with_greater_than_comparison_allowed(fake_repo: Path) -> None:
+    """Cursor PR #194 HIGH also called out perl: `perl -e 'print 1 if $x > 5'`."""
+    rc, _, stderr = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "perl -e 'print 1 if $x > 5'"}},
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"perl -e comparison was wrongly blocked: {stderr}"
+
+
+def test_bash_python_dash_c_str_replace_allowed(fake_repo: Path) -> None:
+    """`python -c "print('hello'.replace('h','H'))"` is a string method, not a
+    file mutation. Cursor PR #194 MEDIUM: dropped `\\.replace\\s*\\(` from the
+    mutation regex; ``os.replace`` users still gated via the os.* alternation."""
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'python -c \'print("hello".replace("h","H"))\''},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"str.replace was wrongly blocked: {stderr}"
+
+
+def test_bash_python_dash_c_os_replace_blocked(fake_repo: Path) -> None:
+    """Companion: `os.replace()` IS a file mutation → still blocks."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'python -c \'import os; os.replace("a","b")\''},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_bash_dash_c_shell_redirect_still_blocks(fake_repo: Path) -> None:
+    """Companion: in SHELL context (`bash -c`), `>` redirect IS shell mutation."""
+    rc, _, _ = _run(
+        {"tool_name": "Bash", "tool_input": {"command": 'bash -c "echo x > /tmp/y.py"'}},
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_sudo_cp_into_scripts_blocked(fake_repo: Path) -> None:
+    """Qodo PR #194 HIGH/Security: `sudo cp` must be detected and blocked.
+
+    Prior gate only matched cp as the LEADING token, so `sudo cp foo
+    scripts/bar.py` slipped past — the gate's purpose is forcing memory-
+    grounding before mutations, regardless of which wrapper invokes them.
+    """
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "sudo cp /tmp/payload.py scripts/bar.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"sudo cp not detected: {stderr}"
+    assert "BLOCK" in stderr
+
+
+def test_bash_env_cp_into_scripts_blocked(fake_repo: Path) -> None:
+    """`env cp …` — same wrapper bypass class."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "env cp /tmp/payload.py scripts/bar.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_env_with_vars_then_cp_blocked(fake_repo: Path) -> None:
+    """`env FOO=bar cp …` — env accepts VAR=value before the command name."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "env FOO=bar BAZ=qux cp /tmp/x scripts/y.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_absolute_path_cp_into_scripts_blocked(fake_repo: Path) -> None:
+    """`/bin/cp …` — absolute-path invocation matches via basename."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "/bin/cp /tmp/payload.py scripts/bar.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_sudo_mv_into_scripts_blocked(fake_repo: Path) -> None:
+    """`sudo -E mv …` — wrapper with flags."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "sudo -E mv /tmp/x scripts/y.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_compound_sudo_cp_in_second_segment_blocked(fake_repo: Path) -> None:
+    """Compound: `cd /tmp && sudo cp foo scripts/bar` still caught."""
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "cd /tmp && sudo cp foo scripts/bar.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+# -------------------------------------------------------------------------
+# Round-3 PR #194 review fix: Cursor MEDIUM — `re.compile()` false-positive.
+# `\bcompile\s*\(` fires between `.` and `c` in `re.compile(`. Negative
+# lookbehind `(?<!\.)` distinguishes the builtin `compile()` (bare) from the
+# method form `re.compile()` (preceded by `.`).
+# -------------------------------------------------------------------------
+
+
+def test_bash_python_dash_c_re_compile_allowed(fake_repo: Path) -> None:
+    """`python -c "import re; re.compile(r'\\d+').match('123')"` is a read-only
+    Python idiom. Cursor PR #194 round-3 MEDIUM: must not false-block."""
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": 'python -c \'import re; print(re.compile(r"\\d+").match("123"))\''
+            },
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"re.compile was false-blocked: {stderr}"
+
+
+def test_bash_python_dash_c_bare_compile_blocked(fake_repo: Path) -> None:
+    """Companion: the BUILTIN `compile()` (bare, no leading `.`) still blocks.
+
+    `compile(source, file, mode)` is the dynamic-exec primitive — typically
+    chained with `exec(compile(...))` to evade Edit/Write tools.
+    """
+    rc, _, _ = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'python -c \'exec(compile("x=1","<s>","exec"))\''},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_bash_python_dash_c_bare_eval_blocked(fake_repo: Path) -> None:
+    """The BUILTIN `eval()` (bare) still blocks."""
+    rc, _, _ = _run(
+        {"tool_name": "Bash", "tool_input": {"command": "python -c 'eval(\"1+1\")'"}},
+        cwd=fake_repo,
+    )
+    assert rc == 2
+
+
+def test_lang_mutation_regex_lookbehind_distinguishes_method_from_builtin() -> None:
+    """Direct unit test of the lookbehind on `compile`/`eval`/`exec` —
+    distinguishes the builtin (bare, no `.`) from the method form (preceded by
+    `.`). Avoids subprocess + shell-quoting complexity that the integration
+    tests bring; pins the regex semantics directly for the Cursor PR #194
+    MEDIUM finding.
+    """
+    import sys
+    from pathlib import Path as _Path
+
+    sys.path.insert(0, str(_Path(__file__).resolve().parents[1] / "scripts"))
+    from hook_memory_gate import _indirect_exec_is_mutation
+
+    # Bare builtins → mutation (still gated).
+    assert _indirect_exec_is_mutation('python -c \'compile("x","<s>","exec")\'')
+    assert _indirect_exec_is_mutation("python -c 'eval(\"1+1\")'")
+    assert _indirect_exec_is_mutation("python -c 'exec(\"x=1\")'")
+    # Method form (preceded by `.`) → NOT mutation, lookbehind suppresses.
+    assert not _indirect_exec_is_mutation('python -c "re.compile(\\"x\\")"')
+    assert not _indirect_exec_is_mutation('python -c "df.eval(\\"a+1\\")"')
+    assert not _indirect_exec_is_mutation('python -c "engine.execute(\\"q\\")"')
+    # Also tolerate whitespace variants `re.compile (` and tab.
+    assert not _indirect_exec_is_mutation('python -c "re.compile (r\\"\\\\d+\\")"')
 
 
 def test_bash_curl_pipe_bash_blocked(fake_repo: Path) -> None:
@@ -708,9 +1001,17 @@ def test_bash_harmless_python_script_run_allowed(fake_repo: Path) -> None:
 
 
 def test_bash_indirect_exec_with_kill_switch(fake_repo: Path) -> None:
-    """CLAUDE_MEMORY_GATE=0 still bypasses indirect-exec patterns."""
+    """CLAUDE_MEMORY_GATE=0 still bypasses indirect-exec patterns even when MUTATING.
+
+    Uses a mutating command so the bypass is genuinely exercised (a read-only
+    one-liner is allowed without the kill switch under the council #180/#188
+    policy).
+    """
     rc, _, _ = _run(
-        {"tool_name": "Bash", "tool_input": {"command": "python -c 'open(\"x\")'"}},
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'python -c \'open("x.py","w").write("y")\''},
+        },
         cwd=fake_repo,
         env={"CLAUDE_MEMORY_GATE": "0"},
     )
@@ -801,3 +1102,272 @@ def test_bash_sed_inplace_on_doc_allowed(fake_repo: Path) -> None:
         cwd=fake_repo,
     )
     assert rc == 0
+
+
+# -------------------------------------------------------------------------
+# cp/mv false-positive coverage (#180 / #188 hardening — drop the loose
+# `\b(?:cp|mv)\b` substring regex; rely on the shlex-based segment parser).
+# -------------------------------------------------------------------------
+
+
+def test_bash_cp_substring_in_jq_filter_does_not_block(fake_repo: Path) -> None:
+    """`gh api --jq '... "cp" ...'` must NOT false-trigger the gate.
+
+    The previous `\\b(?:cp|mv)\\b` matched at quote boundaries inside argument
+    strings, blocking benign read commands. Compound-aware shlex parsing
+    distinguishes cp/mv as a leading command vs. cp/mv mentioned in args.
+    """
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    'gh api graphql -f q="x" --jq ".data | select(.body | test(\\"cp|mv\\"))"'
+                )
+            },
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"unexpected block (over-fire on cp/mv substring): {stderr}"
+
+
+def test_bash_cp_mentioned_in_quoted_arg_does_not_block(fake_repo: Path) -> None:
+    """`echo "cp foo bar"` is a read-only echo, not a copy."""
+    rc, _, stderr = _run(
+        {"tool_name": "Bash", "tool_input": {"command": 'echo "cp foo bar"'}},
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"unexpected block on echo of cp-string: {stderr}"
+
+
+def test_bash_compound_cp_after_cd_is_caught(fake_repo: Path) -> None:
+    """`cd /tmp && cp foo scripts/bar` MUST block (cp is in the second segment).
+
+    Regression guard: dropping the loose verb regex relies on segment-aware
+    parsing to keep catching cp/mv outside the leading-command slot.
+    """
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "cd /tmp && cp foo scripts/bar.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"compound cp not caught: {stderr}"
+    assert "BLOCK" in stderr
+
+
+def test_bash_compound_mv_with_pipe_is_caught(fake_repo: Path) -> None:
+    """A mv after a pipe is still gated."""
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls -la | head && mv /tmp/x scripts/y.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"compound mv not caught: {stderr}"
+
+
+# -------------------------------------------------------------------------
+# Worktree-aware classification (#180 / Codex P1 — absolute paths inside a
+# linked git worktree must be classified against THEIR OWN worktree root,
+# not the main checkout's root, or `_to_repo_relative` falls back to the
+# absolute string and `_classify` returns "other" → gate bypass.
+# -------------------------------------------------------------------------
+
+
+def test_absolute_path_in_linked_worktree_is_classified_as_code(tmp_path: Path) -> None:
+    """An Edit on ``<linked-worktree>/scripts/foo.py`` MUST block, even when
+    the gate's main root is a different directory.
+
+    Reproduces ``agent-factory#308 / template-repo#182`` for the memory gate:
+    Claude Code in a ``.claude/worktrees/<name>/`` checkout would send absolute
+    paths under that worktree; the gate normalized root to the main checkout
+    (correct for the shared lockfile), but then classified the absolute file
+    path against the main root — ``_to_repo_relative`` failed (not under main),
+    so ``_classify`` saw the absolute string and returned ``"other"``,
+    silently allowing a code edit without a stamp.
+    """
+    main = tmp_path / "main"
+    main.mkdir()
+    (main / ".git").mkdir()
+    (main / ".scratch").mkdir()
+    # Linked worktree — its .git is a FILE (gitdir pointer), which
+    # `worktree_root_for` walks ancestors to find via `.exists()`.
+    wt = tmp_path / "worktrees" / "feature-x"
+    wt.mkdir(parents=True)
+    (wt / ".git").write_text("gitdir: " + str(main / ".git" / "worktrees" / "feature-x"))
+    (wt / "scripts").mkdir()
+    target = wt / "scripts" / "foo.py"
+    target.write_text("# placeholder")
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": str(target)}},
+        cwd=main,
+    )
+    assert rc == 2, f"worktree code edit not classified as code: {stderr}"
+    assert "BLOCK" in stderr
+
+
+# -------------------------------------------------------------------------
+# Per-repo code-dir allowlist via ops/memory_manifest.yml (#180 council
+# fix — moves the allowlist out of code so propagation can't clobber each
+# child's project-specific code dirs).
+# -------------------------------------------------------------------------
+
+
+def _write_repo_block(root: Path, *, code_dirs: list[str] | None = None) -> None:
+    (root / "ops").mkdir(exist_ok=True)
+    lines = ["repo:"]
+    if code_dirs is not None:
+        lines.append("  code_dirs:")
+        for d in code_dirs:
+            lines.append(f'    - "{d}"')
+    lines.append("hosts: []\n")
+    (root / "ops" / "memory_manifest.yml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def test_per_repo_code_dirs_override_classifies_child_dir_as_code(
+    fake_repo: Path,
+) -> None:
+    """A child repo's ``agent/`` dir must classify as ``"code"`` when the manifest
+    declares it, even though it's NOT in template defaults.
+
+    Reproduces the #180 regression scenario: Alpaca, court-fillings, and
+    mcp-servers have project-specific runtime dirs (``agent/``, ``core/``,
+    ``court_filing_pipeline/``, ``packages/``) that template's hardcoded
+    allowlist excluded — the wave propagation then clobbered each child's
+    custom gate, so edits to those dirs bypassed memory enforcement entirely.
+    Moving the allowlist into manifest DATA fixes this: each repo declares
+    its own code_dirs in ops/memory_manifest.yml, and propagation never
+    touches that per-repo file.
+    """
+    _write_repo_block(fake_repo, code_dirs=["src", "scripts", "agent", "core"])
+    # No stamp; manifest declares agent/ as code → gate must BLOCK the edit.
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "agent/streaming/service.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"manifest-declared agent/ not classified as code: {stderr}"
+    assert "BLOCK" in stderr
+
+
+def test_per_repo_code_dirs_override_removes_default_when_replaced(
+    fake_repo: Path,
+) -> None:
+    """The override REPLACES defaults (not additive). If a repo's manifest
+    declares only ``["custom_pkg"]``, then ``scripts/foo.py`` is NOT classified
+    as code. Tests narrow the contract: child repos must enumerate everything
+    they want gated (no implicit template default inheritance to avoid the
+    silent-divergence trap Kimi flagged for shared-package model).
+    """
+    _write_repo_block(fake_repo, code_dirs=["custom_pkg"])
+    # scripts/ no longer in the per-repo allowlist → treated as "other" → allow.
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 0, f"narrowed allowlist failed: {stderr}"
+
+
+def test_per_repo_manifest_absent_falls_back_to_template_defaults(
+    fake_repo: Path,
+) -> None:
+    """No manifest at all → use template default allowlist. ``scripts/foo.py`` blocks."""
+    # No manifest file — use defaults.
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"defaults not used when manifest absent: {stderr}"
+
+
+def test_ops_memory_manifest_always_gated_even_when_overrides_exclude_ops(
+    fake_repo: Path,
+) -> None:
+    """Qodo PR #194 security HIGH: per-repo ``code_dirs`` REPLACES defaults, so
+    a child that sets e.g. ``code_dirs: ["src"]`` (omitting ``ops/``) could
+    make ``ops/memory_manifest.yml`` editable without a stamp — the EXACT
+    Mistral "shrink the allowlist" bypass, reintroduced via overrides.
+
+    The fix: ``_ALWAYS_GATED_PATHS`` overrides per-repo classification for the
+    gate's own config — `ops/memory_manifest.yml` always classifies as code
+    regardless of what `code_dirs` declares.
+    """
+    # Manifest deliberately excludes `ops/` from code_dirs.
+    _write_repo_block(fake_repo, code_dirs=["src", "scripts"])
+    # No stamp; editing ops/memory_manifest.yml MUST still block (the gate's
+    # own config is non-overridable).
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "ops/memory_manifest.yml"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"ops/memory_manifest.yml became editable via override: {stderr}"
+
+
+def test_github_workflows_always_gated_regardless_of_overrides(
+    fake_repo: Path,
+) -> None:
+    """CI workflow files (``.github/workflows/*``) are non-overridable — an
+    attacker can't shrink the allowlist to bypass review of CI changes."""
+    _write_repo_block(fake_repo, code_dirs=["src"])  # no .github/
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": ".github/workflows/ci.yml"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2, f".github/workflows/ became editable via override: {stderr}"
+
+
+def test_editing_manifest_itself_requires_stamp_gate_the_config(
+    fake_repo: Path,
+) -> None:
+    """Mistral's adversarial review (#180/#192): an agent must not be able to
+    shrink the allowlist by editing the manifest behind the gate's back.
+
+    Because the per-repo block lives in ``ops/memory_manifest.yml``, and
+    ``ops/`` is itself in the code-dir allowlist (template default), editing
+    the manifest requires a fresh substrate stamp — the gate gates its own
+    config. This test pins that property as a regression guard so any future
+    change that exempts ``ops/`` from the gate (e.g. moving it to docs) will
+    fail loudly.
+    """
+    # No stamp; editing the manifest must BLOCK.
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "ops/memory_manifest.yml"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 2, f"editing the gate's own config bypassed the gate: {stderr}"
+    assert "BLOCK" in stderr
+
+
+def test_absolute_path_in_linked_worktree_doc_is_allowed(tmp_path: Path) -> None:
+    """Companion: an Edit on ``<linked-worktree>/docs/foo.md`` must NOT block.
+
+    Worktree-aware classification routes ``docs/`` to the doc branch via the
+    worktree's own root, not as ``.claude/worktrees/.../docs/foo.md`` relative
+    to the main checkout (which matched no doc prefix in the buggy version).
+    """
+    main = tmp_path / "main"
+    main.mkdir()
+    (main / ".git").mkdir()
+    (main / ".scratch").mkdir()
+    wt = tmp_path / "worktrees" / "feature-x"
+    wt.mkdir(parents=True)
+    (wt / ".git").write_text("gitdir: " + str(main / ".git" / "worktrees" / "feature-x"))
+    (wt / "docs").mkdir()
+    target = wt / "docs" / "foo.md"
+    target.write_text("# doc")
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": str(target)}},
+        cwd=main,
+    )
+    assert rc == 0, f"worktree doc edit was wrongly blocked: {stderr}"

--- a/tests/test_hook_memory_gate.py
+++ b/tests/test_hook_memory_gate.py
@@ -7,7 +7,9 @@ Behaviors covered:
   * **Block (exit 2)** on code-path Edit when the stamp is stale or missing
     AND the missing marker is absent.
   * **Allow** on code-path Edit when ``.scratch/.last_memory_query.missing``
-    exists (degraded mode while PR C provisions workspaces).
+    records that no workspace is registered yet.
+  * **Block** when the missing marker names a registered workspace whose
+    prefetch failed.
   * **Allow** on doc-path Edit regardless of stamp state.
   * **Kill-switch** ``CLAUDE_MEMORY_GATE=0`` bypasses entirely.
   * **Fail-open** on malformed payload (exit 0).
@@ -79,7 +81,9 @@ def _write_lock(
     (scratch / ".last_memory_query").write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _write_missing(tmp_path: Path) -> None:
+def _write_missing(
+    tmp_path: Path, *, workspace: str | None = None, hint: str = "no workspace"
+) -> None:
     scratch = tmp_path / ".scratch"
     scratch.mkdir(exist_ok=True)
     (scratch / ".last_memory_query").unlink(missing_ok=True)
@@ -88,11 +92,11 @@ def _write_missing(tmp_path: Path) -> None:
             {
                 "token": "m",
                 "timestamp_utc": _now_minus(0),
-                "workspace": None,
+                "workspace": workspace,
                 "prompt": "test",
                 "ttl_seconds": 1800,
                 "prefetch_ok": False,
-                "hint": "no workspace",
+                "hint": hint,
             }
         ),
         encoding="utf-8",
@@ -105,6 +109,80 @@ def fake_repo(tmp_path: Path) -> Path:
     ``_repo_root`` walk anchors to ``tmp_path``."""
     (tmp_path / ".git").mkdir()
     return tmp_path
+
+
+def _write_accepted_gap_missing(scratch: Path) -> None:
+    scratch.mkdir(exist_ok=True)
+    (scratch / ".last_memory_query.missing").write_text(
+        json.dumps(
+            {
+                "token": "m",
+                "timestamp_utc": _now_minus(0),
+                "workspace": None,
+                "prompt": "test",
+                "ttl_seconds": 1800,
+                "prefetch_ok": False,
+                "reason": "accepted_gap",
+                "gate_policy": "allow",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_accepted_gap_marker_allows_code_path(fake_repo: Path) -> None:
+    """Qodo 'Output Contract' (PR #175): the prefetch's accepted-gap marker
+    (workspace=null, gate_policy=allow, reason=accepted_gap) must be consumed by
+    the gate as a no-workspace degrade — code-path edits allowed, not blocked."""
+    scratch = fake_repo / ".scratch"
+    scratch.mkdir(exist_ok=True)
+    (scratch / ".last_memory_query").unlink(missing_ok=True)
+    _write_accepted_gap_missing(scratch)
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 0, stderr
+    # Qodo "Accepted gap still warns": must degrade QUIETLY — a tailored
+    # accepted-gap line, NOT the generic "register or provision" nag.
+    assert "accepted Tier-3 gap" in stderr
+    assert "register or provision" not in stderr
+
+
+def test_accepted_gap_allows_even_with_coexisting_fresh_lock(fake_repo: Path) -> None:
+    """Cursor Bugbot regression (PR #175): an accepted-gap marker must allow
+    edits UNCONDITIONALLY, even if a fresh ``.last_memory_query`` lock with an
+    irrelevant body still exists (best-effort unlink failed or a timestamp tie).
+    Under the old gate_policy='warn' stamp this fell through to relevance checks
+    and blocked; with gate_policy='allow' the no-workspace branch returns 0."""
+    scratch = fake_repo / ".scratch"
+    scratch.mkdir(exist_ok=True)
+    # Fresh lock with a body that does NOT mention the edited file (would block
+    # under relevance checks if reached).
+    (scratch / ".last_memory_query").write_text(
+        json.dumps(
+            {
+                "token": "t",
+                "timestamp_utc": _now_minus(0),
+                "workspace": "some_ws",
+                "prompt": "test",
+                "ttl_seconds": 1800,
+                "prefetch_ok": True,
+                "response_body": "totally unrelated context about quux",
+                "response_body_len": 40,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_accepted_gap_missing(scratch)
+    rc, _, stderr = _run(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "scripts/hook_session_start_memory_prefetch.py"},
+        },
+        cwd=fake_repo,
+    )
+    assert rc == 0, stderr
 
 
 def test_fresh_stamp_allows_code_path(fake_repo: Path) -> None:
@@ -197,19 +275,6 @@ def test_no_stamp_blocks_code_path(fake_repo: Path) -> None:
     assert "BLOCK" in stderr
 
 
-def test_missing_marker_non_json_still_degrades(fake_repo: Path) -> None:
-    """Degraded mode is keyed on marker presence, not JSON parse success."""
-    scratch = fake_repo / ".scratch"
-    scratch.mkdir(exist_ok=True)
-    (scratch / ".last_memory_query.missing").write_text("unprovisioned\n", encoding="utf-8")
-    rc, _, stderr = _run(
-        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
-        cwd=fake_repo,
-    )
-    assert rc == 0
-    assert "degraded" in stderr.lower()
-
-
 def test_missing_marker_degrades_to_warn(fake_repo: Path) -> None:
     _write_missing(fake_repo)
     rc, _, stderr = _run(
@@ -220,8 +285,134 @@ def test_missing_marker_degrades_to_warn(fake_repo: Path) -> None:
     assert "degraded" in stderr.lower() or "prefetch unavailable" in stderr
 
 
-def test_missing_marker_wins_over_stale_lock(fake_repo: Path) -> None:
-    """Stale success stamp must not block when prefetch degraded."""
+def test_warn_missing_with_fresh_lock_enforces_relevance(fake_repo: Path) -> None:
+    """Stale warn marker + fresh lock must not skip token-overlap checks."""
+    scratch = fake_repo / ".scratch"
+    scratch.mkdir(exist_ok=True)
+    _write_lock(fake_repo, age_s=0, response_body="unrelated substrate prose only")
+    (scratch / ".last_memory_query.missing").write_text(
+        json.dumps(
+            {
+                "token": "m",
+                "timestamp_utc": _now_minus(60),
+                "workspace": "template_repo",
+                "prompt": "test",
+                "ttl_seconds": 1800,
+                "prefetch_ok": False,
+                "hint": "template_repo",
+                "gate_policy": "warn",
+                "reason": "prefetch timed out after 30s",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 2
+    assert "BLOCK" in stderr
+
+
+def test_recent_warn_missing_with_leftover_fresh_lock_degrades_to_warn(fake_repo: Path) -> None:
+    """If the warn marker is newer than the lock, we must degrade to warn-only."""
+    scratch = fake_repo / ".scratch"
+    scratch.mkdir(exist_ok=True)
+    _write_lock(fake_repo, age_s=60, response_body="unrelated substrate prose only")
+    (scratch / ".last_memory_query.missing").write_text(
+        json.dumps(
+            {
+                "token": "m",
+                "timestamp_utc": _now_minus(0),
+                "workspace": "template_repo",
+                "prompt": "test",
+                "ttl_seconds": 1800,
+                "prefetch_ok": False,
+                "hint": "template_repo",
+                "gate_policy": "warn",
+                "reason": "prefetch timed out after 30s",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 0
+    assert "degraded" in stderr.lower()
+
+
+def test_warn_missing_without_lock_allows_code_path(fake_repo: Path) -> None:
+    scratch = fake_repo / ".scratch"
+    scratch.mkdir(exist_ok=True)
+    (scratch / ".last_memory_query").unlink(missing_ok=True)
+    (scratch / ".last_memory_query.missing").write_text(
+        json.dumps(
+            {
+                "token": "m",
+                "timestamp_utc": _now_minus(0),
+                "workspace": "template_repo",
+                "prompt": "test",
+                "ttl_seconds": 1800,
+                "prefetch_ok": False,
+                "hint": "template_repo",
+                "gate_policy": "warn",
+                "reason": "prefetch timed out after 30s",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 0
+    assert "warn-only" in stderr.lower()
+
+
+def test_registered_missing_marker_blocks_code_path(fake_repo: Path) -> None:
+    _write_missing(fake_repo, workspace="template_repo", hint="template_repo")
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 2
+    assert "registered Tier-3 workspace is unavailable" in stderr
+    assert "template_repo" in stderr
+
+
+def test_blocking_missing_marker_blocks_code_path(fake_repo: Path) -> None:
+    scratch = fake_repo / ".scratch"
+    scratch.mkdir(exist_ok=True)
+    (scratch / ".last_memory_query").unlink(missing_ok=True)
+    (scratch / ".last_memory_query.missing").write_text(
+        json.dumps(
+            {
+                "token": "m",
+                "timestamp_utc": _now_minus(0),
+                "workspace": "alpaca_trading",
+                "prompt": "test",
+                "ttl_seconds": 1800,
+                "prefetch_ok": False,
+                "hint": "alpaca_trading",
+                "gate_policy": "block",
+                "reason": "bridge_workspace_not_visible",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 2
+    assert "bridge_workspace_not_visible" in stderr
+    assert "alpaca_trading" in stderr
+
+
+def test_registered_missing_marker_wins_over_stale_lock(fake_repo: Path) -> None:
+    """Stale success stamp must not bypass registered workspace prefetch failure."""
     scratch = fake_repo / ".scratch"
     scratch.mkdir(exist_ok=True)
     (scratch / ".last_memory_query").write_text(
@@ -251,11 +442,38 @@ def test_missing_marker_wins_over_stale_lock(fake_repo: Path) -> None:
         ),
         encoding="utf-8",
     )
-    rc, _, _ = _run(
+    rc, _, stderr = _run(
+        {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
+        cwd=fake_repo,
+    )
+    assert rc == 2
+    assert "registered Tier-3 workspace is unavailable" in stderr
+
+
+def test_unregistered_missing_marker_wins_over_stale_lock(fake_repo: Path) -> None:
+    """No-workspace bootstrap marker remains warn-only even with a stale lock."""
+    scratch = fake_repo / ".scratch"
+    scratch.mkdir(exist_ok=True)
+    (scratch / ".last_memory_query").write_text(
+        json.dumps(
+            {
+                "token": "t",
+                "timestamp_utc": _now_minus(3600),
+                "workspace": "stale_ws",
+                "prompt": "test",
+                "ttl_seconds": 1800,
+                "prefetch_ok": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_missing(fake_repo)
+    rc, _, stderr = _run(
         {"tool_name": "Edit", "tool_input": {"file_path": "scripts/foo.py"}},
         cwd=fake_repo,
     )
     assert rc == 0
+    assert "degraded" in stderr.lower()
 
 
 def test_doc_path_always_allowed(fake_repo: Path) -> None:
@@ -389,21 +607,6 @@ def test_bash_non_file_edit_allowed(fake_repo: Path) -> None:
 # code via interpreter eval or piped script execution rather than the
 # directly-gated Edit/Write tools.
 # -------------------------------------------------------------------------
-
-
-def test_bash_indirect_exec_irrelevant_body_still_blocked(fake_repo: Path) -> None:
-    """Indirect-exec synthetic path must not pass on generic ``scripts`` spam."""
-    _write_lock(
-        fake_repo,
-        age_s=60,
-        response_body="vault handoff and session lifecycle notes only",
-    )
-    rc, _, stderr = _run(
-        {"tool_name": "Bash", "tool_input": {"command": "python3 -c 'print(1)'"}},
-        cwd=fake_repo,
-    )
-    assert rc == 2
-    assert "token overlap" in stderr or "relevant" in stderr.lower()
 
 
 def test_bash_python_dash_c_blocked(fake_repo: Path) -> None:

--- a/tests/test_hook_memory_manifest.py
+++ b/tests/test_hook_memory_manifest.py
@@ -1,0 +1,289 @@
+"""Unit tests for the per-repo ``repo:`` block loaders in hook_memory_manifest.
+
+Covers the council #180 fix: code-dir classification moved out of code into
+per-repo manifest data so propagation can't clobber child code dirs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from hook_memory_manifest import (  # noqa: E402 — sys.path tweak above
+    DEFAULT_CODE_DIR_TOP_LEVEL,
+    DEFAULT_CODE_PATH_PREFIXES,
+    DEFAULT_CODE_PATH_TOP_LEVEL,
+    load_repo_section,
+    repo_code_dir_top_level,
+    repo_code_path_prefixes,
+    repo_code_path_top_level,
+    repo_tier3_workspace_id,
+)
+
+# ---------------------------------------------------------------------------
+# load_repo_section
+# ---------------------------------------------------------------------------
+
+
+def test_load_repo_section_none_manifest() -> None:
+    assert load_repo_section(None) == {}
+
+
+def test_load_repo_section_non_dict_manifest() -> None:
+    assert load_repo_section("hosts: []") == {}  # type: ignore[arg-type]
+
+
+def test_load_repo_section_missing_block() -> None:
+    assert load_repo_section({"hosts": []}) == {}
+
+
+def test_load_repo_section_block_is_not_dict() -> None:
+    assert load_repo_section({"repo": ["x"]}) == {}
+
+
+def test_load_repo_section_returns_block() -> None:
+    block = {"code_dirs": ["src"]}
+    assert load_repo_section({"repo": block}) == block
+
+
+# ---------------------------------------------------------------------------
+# repo_code_path_prefixes
+# ---------------------------------------------------------------------------
+
+
+def test_code_path_prefixes_default_when_none() -> None:
+    assert repo_code_path_prefixes(None) == DEFAULT_CODE_PATH_PREFIXES
+
+
+def test_code_path_prefixes_default_when_absent() -> None:
+    assert repo_code_path_prefixes({"hosts": []}) == DEFAULT_CODE_PATH_PREFIXES
+
+
+def test_code_path_prefixes_default_when_empty_list() -> None:
+    assert repo_code_path_prefixes({"repo": {"code_dirs": []}}) == DEFAULT_CODE_PATH_PREFIXES
+
+
+def test_code_path_prefixes_normalizes_to_trailing_slash() -> None:
+    out = repo_code_path_prefixes({"repo": {"code_dirs": ["src", "agent/", "core"]}})
+    assert out == ("src/", "agent/", "core/")
+
+
+def test_code_path_prefixes_strips_leading_slash() -> None:
+    out = repo_code_path_prefixes({"repo": {"code_dirs": ["/scripts", "tests"]}})
+    assert out == ("scripts/", "tests/")
+
+
+def test_code_path_prefixes_skips_non_strings_and_empties() -> None:
+    out = repo_code_path_prefixes({"repo": {"code_dirs": ["src", 42, None, "", "  ", "agent"]}})
+    assert out == ("src/", "agent/")
+
+
+# ---------------------------------------------------------------------------
+# repo_code_path_top_level
+# ---------------------------------------------------------------------------
+
+
+def test_code_path_top_level_default_when_none() -> None:
+    assert repo_code_path_top_level(None) == DEFAULT_CODE_PATH_TOP_LEVEL
+
+
+def test_code_path_top_level_default_when_absent() -> None:
+    assert repo_code_path_top_level({"repo": {}}) == DEFAULT_CODE_PATH_TOP_LEVEL
+
+
+def test_code_path_top_level_uses_override() -> None:
+    out = repo_code_path_top_level({"repo": {"code_top_level": ["Justfile", "Makefile"]}})
+    assert out == frozenset({"Justfile", "Makefile"})
+
+
+# ---------------------------------------------------------------------------
+# repo_code_dir_top_level (derived from code_dirs first segments)
+# ---------------------------------------------------------------------------
+
+
+def test_code_dir_top_level_default_when_no_code_dirs() -> None:
+    assert repo_code_dir_top_level(None) == DEFAULT_CODE_DIR_TOP_LEVEL
+
+
+def test_code_dir_top_level_derives_first_segments() -> None:
+    out = repo_code_dir_top_level(
+        {"repo": {"code_dirs": ["src/foo", "agent", ".github/workflows"]}}
+    )
+    assert out == frozenset({"src", "agent", ".github"})
+
+
+# ---------------------------------------------------------------------------
+# repo_tier3_workspace_id
+# ---------------------------------------------------------------------------
+
+
+def test_tier3_workspace_id_none_when_absent() -> None:
+    assert repo_tier3_workspace_id(None) is None
+    assert repo_tier3_workspace_id({"repo": {}}) is None
+
+
+def test_tier3_workspace_id_returns_value() -> None:
+    out = repo_tier3_workspace_id({"repo": {"tier3_workspace_id": "agent_factory_steward"}})
+    assert out == "agent_factory_steward"
+
+
+def test_tier3_workspace_id_strips_whitespace() -> None:
+    out = repo_tier3_workspace_id({"repo": {"tier3_workspace_id": "  ws  "}})
+    assert out == "ws"
+
+
+def test_tier3_workspace_id_ignores_empty_string() -> None:
+    assert repo_tier3_workspace_id({"repo": {"tier3_workspace_id": "   "}}) is None
+    assert repo_tier3_workspace_id({"repo": {"tier3_workspace_id": ""}}) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_workspace + repo.tier3_workspace_id integration
+# (Kimi #180 council: workspace resolution is template-relative — must live in
+# per-repo manifest data, not in copied gate logic.)
+# ---------------------------------------------------------------------------
+
+
+from hook_memory_manifest import resolve_workspace  # noqa: E402
+
+
+def _manifest_with_workspaces(*names: str) -> dict:
+    return {
+        "hosts": [
+            {
+                "id": "h",
+                "workspaces": [
+                    {"name": n, "backend": "lightrag", "endpoint": f"http://x:80{i}"}
+                    for i, n in enumerate(names)
+                ],
+            }
+        ]
+    }
+
+
+def test_resolve_workspace_uses_tier3_workspace_id_over_basename(tmp_path: Path) -> None:
+    """When ``repo.tier3_workspace_id`` is set, the resolver returns THAT
+    workspace regardless of the repo basename — this is how template-repo
+    routes to ``agent_factory_steward`` even though its directory is
+    ``template-repo``."""
+    root = tmp_path / "template-repo"
+    root.mkdir()
+    manifest = _manifest_with_workspaces("agent_factory_steward", "template_repo")
+    manifest["repo"] = {"tier3_workspace_id": "agent_factory_steward"}
+    out = resolve_workspace(root, manifest)
+    assert out is not None
+    assert out["name"] == "agent_factory_steward"
+
+
+def test_resolve_workspace_returns_none_when_tier3_id_unknown(tmp_path: Path) -> None:
+    """Declared but not in manifest → return None so SessionStart can surface
+    the standard 'no workspace registered' warning. Better than silently
+    falling back to a name match on a wrong workspace."""
+    root = tmp_path / "anything"
+    root.mkdir()
+    manifest = _manifest_with_workspaces("only_one_ws")
+    manifest["repo"] = {"tier3_workspace_id": "ghost_workspace_not_in_manifest"}
+    assert resolve_workspace(root, manifest) is None
+
+
+def test_resolve_workspace_falls_back_to_basename_when_no_tier3_id(tmp_path: Path) -> None:
+    """Absent ``repo.tier3_workspace_id`` → existing basename-match logic fires."""
+    root = tmp_path / "my_repo"
+    root.mkdir()
+    manifest = _manifest_with_workspaces("other_ws", "my_repo")
+    assert resolve_workspace(root, manifest) is not None
+    assert resolve_workspace(root, manifest)["name"] == "my_repo"
+
+
+def test_resolve_workspace_tier3_id_hyphen_underscore_tolerant(tmp_path: Path) -> None:
+    """``tier3_workspace_id: 'foo-bar'`` matches workspace ``foo_bar``."""
+    root = tmp_path / "anything"
+    root.mkdir()
+    manifest = _manifest_with_workspaces("foo_bar", "other")
+    manifest["repo"] = {"tier3_workspace_id": "foo-bar"}
+    out = resolve_workspace(root, manifest)
+    assert out is not None
+    assert out["name"] == "foo_bar"
+
+
+# ---------------------------------------------------------------------------
+# PyYAML-fallback parser preserves the repo: block (Qodo PR #194 HIGH —
+# without this, the per-repo override is silently dropped in hook runtimes
+# that lack PyYAML, re-introducing the wave-introduced clobber regression).
+# ---------------------------------------------------------------------------
+
+
+from hook_memory_manifest import _fallback_manifest_from_text  # noqa: E402
+
+
+def test_fallback_parser_preserves_repo_code_dirs_list() -> None:
+    text = """\
+repo:
+  code_dirs:
+    - "src"
+    - "scripts"
+    - "agent"
+hosts: []
+"""
+    parsed = _fallback_manifest_from_text(text)
+    assert parsed.get("repo", {}).get("code_dirs") == ["src", "scripts", "agent"]
+
+
+def test_fallback_parser_preserves_repo_tier3_workspace_id_scalar() -> None:
+    text = """\
+repo:
+  tier3_workspace_id: "agent_factory_steward"
+hosts: []
+"""
+    parsed = _fallback_manifest_from_text(text)
+    assert parsed.get("repo", {}).get("tier3_workspace_id") == "agent_factory_steward"
+
+
+def test_fallback_parser_preserves_repo_with_mixed_keys() -> None:
+    text = """\
+repo:
+  code_dirs:
+    - "src"
+    - "core"
+  code_top_level:
+    - "Justfile"
+    - "Makefile"
+  tier3_workspace_id: "my_workspace"
+hosts:
+  - id: h
+    workspaces:
+      - name: "my_workspace"
+        endpoint: "http://x:80"
+"""
+    parsed = _fallback_manifest_from_text(text)
+    assert parsed["repo"]["code_dirs"] == ["src", "core"]
+    assert parsed["repo"]["code_top_level"] == ["Justfile", "Makefile"]
+    assert parsed["repo"]["tier3_workspace_id"] == "my_workspace"
+    # hosts/workspaces still parsed correctly.
+    assert parsed["hosts"][0]["workspaces"][0]["name"] == "my_workspace"
+
+
+def test_fallback_parser_no_repo_block_returns_no_repo_key() -> None:
+    """Backward-compat: manifests without a repo: block don't grow one."""
+    text = "hosts:\n  - id: h\n    workspaces: []\n"
+    parsed = _fallback_manifest_from_text(text)
+    assert "repo" not in parsed
+
+
+def test_fallback_parser_repo_block_after_hosts() -> None:
+    """Repo block can come after hosts (YAML key order is free)."""
+    text = """\
+hosts:
+  - id: h
+    workspaces:
+      - name: "ws"
+        endpoint: "http://x:80"
+repo:
+  tier3_workspace_id: "ws"
+"""
+    parsed = _fallback_manifest_from_text(text)
+    assert parsed["repo"]["tier3_workspace_id"] == "ws"
+    assert parsed["hosts"][0]["workspaces"][0]["name"] == "ws"

--- a/tests/test_hook_repo_root.py
+++ b/tests/test_hook_repo_root.py
@@ -1,0 +1,97 @@
+"""CLI smoke + worktree-root regression matrix for ``scripts/hook_repo_root.py``."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from hook_repo_root import worktree_root_for  # noqa: E402
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@t")
+    _git(path, "config", "user.name", "t")
+    (path / "docs").mkdir(exist_ok=True)
+    (path / "README.md").write_text("x", encoding="utf-8")
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "init")
+
+
+def test_hook_repo_root_importable_via_python() -> None:
+    script = REPO_ROOT / "scripts" / "hook_repo_root.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import importlib.util, pathlib, sys; "
+            f"p=pathlib.Path({str(script)!r}); "
+            "spec=importlib.util.spec_from_file_location('hook_repo_root', p); "
+            "m=importlib.util.module_from_spec(spec); "
+            "spec.loader.exec_module(m); "
+            "assert callable(m.session_toplevel_dir)",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_worktree_root_for_main_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "main"
+    _init_repo(repo)
+    doc = repo / "docs" / "a.md"
+    doc.write_text("x", encoding="utf-8")
+    assert worktree_root_for(doc) == repo.resolve()
+    # directory argument resolves to itself
+    assert worktree_root_for(repo / "docs") == repo.resolve()
+
+
+def test_worktree_root_for_nested_worktree(tmp_path: Path) -> None:
+    # A nested worktree (Claude Code's .claude/worktrees/<name>/) must classify
+    # by its OWN root, not the main repo — the agent-factory#308 bug.
+    repo = tmp_path / "main"
+    _init_repo(repo)
+    wt = repo / ".claude" / "worktrees" / "slug"
+    _git(repo, "worktree", "add", "-q", str(wt))
+    (wt / "docs").mkdir(parents=True, exist_ok=True)
+    doc = wt / "docs" / "b.md"
+    doc.write_text("x", encoding="utf-8")
+    assert worktree_root_for(doc) == wt.resolve()
+
+
+def test_worktree_root_for_external_worktree(tmp_path: Path) -> None:
+    repo = tmp_path / "main"
+    _init_repo(repo)
+    wt = tmp_path / "external-wt"
+    _git(repo, "worktree", "add", "-q", str(wt))
+    doc = wt / "docs"
+    doc.mkdir(parents=True, exist_ok=True)
+    f = doc / "c.md"
+    f.write_text("x", encoding="utf-8")
+    assert worktree_root_for(f) == wt.resolve()
+
+
+def test_worktree_root_for_outside_any_repo(tmp_path: Path) -> None:
+    loose = tmp_path / "loose" / "file.md"
+    loose.parent.mkdir(parents=True, exist_ok=True)
+    loose.write_text("x", encoding="utf-8")
+    assert worktree_root_for(loose) is None

--- a/tests/test_hook_session_start_memory_prefetch.py
+++ b/tests/test_hook_session_start_memory_prefetch.py
@@ -142,6 +142,167 @@ def _load_prefetch_module():
     return mod
 
 
+def test_prefetch_resolves_via_tier3_workspace_id(tmp_path: Path) -> None:
+    """Kimi #180 council: ``repo.tier3_workspace_id`` is THIS repo's canonical
+    Tier-3 workspace and wins over basename / vault_root matching.
+
+    Template-repo's manifest declares ``tier3_workspace_id: agent_factory_steward``
+    — verified live 2026-06-01 that template-repo memory lives in that
+    workspace, not in a (never-provisioned) ``template_repo`` placeholder.
+    """
+    repo = _setup_repo(tmp_path / "template-repo", manifest=None)
+    prefetch = _load_prefetch_module()
+    tracked = {
+        "repo": {"tier3_workspace_id": "agent_factory_steward"},
+        "hosts": [
+            {
+                "workspaces": [
+                    {"name": "agent_factory_steward", "endpoint": "http://x/1"},
+                    {"name": "template_repo", "endpoint": "http://x/2"},
+                ]
+            }
+        ],
+    }
+    ws = prefetch._resolve_workspace(repo, tracked, None)
+    assert ws is not None
+    assert ws["name"] == "agent_factory_steward"
+
+
+def test_prefetch_tier3_workspace_id_local_wins(tmp_path: Path) -> None:
+    """Local manifest's ``repo.tier3_workspace_id`` wins over tracked, mirroring
+    the ``resolution_exceptions`` precedence settled in PR #175 (Qodo review)."""
+    repo = _setup_repo(tmp_path / "some-repo", manifest=None)
+    prefetch = _load_prefetch_module()
+    tracked = {
+        "repo": {"tier3_workspace_id": "tracked_ws"},
+        "hosts": [
+            {
+                "workspaces": [
+                    {"name": "tracked_ws", "endpoint": "http://x/t"},
+                    {"name": "local_ws", "endpoint": "http://x/l"},
+                ]
+            }
+        ],
+    }
+    local = {"repo": {"tier3_workspace_id": "local_ws"}}
+    ws = prefetch._resolve_workspace(repo, tracked, local)
+    assert ws is not None
+    assert ws["name"] == "local_ws"
+
+
+def test_prefetch_tier3_workspace_id_unknown_returns_none(tmp_path: Path) -> None:
+    """Declared but no matching workspace row → return None so SessionStart
+    surfaces the standard 'no workspace registered' warning rather than
+    silently falling through to basename match and resolving to a wrong row."""
+    repo = _setup_repo(tmp_path / "some-repo", manifest=None)
+    prefetch = _load_prefetch_module()
+    tracked = {
+        "repo": {"tier3_workspace_id": "ghost_not_in_manifest"},
+        "hosts": [{"workspaces": [{"name": "some_repo", "endpoint": "http://x/1"}]}],
+    }
+    ws = prefetch._resolve_workspace(repo, tracked, None)
+    assert ws is None
+
+
+def test_prefetch_missing_backend_defaults_to_lightrag(tmp_path: Path) -> None:
+    """Qodo PR #194 / #192 Part 5: per the manifest contract, a workspace row
+    that omits ``backend`` MUST be treated as ``lightrag`` (canonical online
+    substrate). The prior 'skip prefetch, treat as empty' bricked v1-manifest
+    workspaces that didn't yet have the field."""
+    manifest = textwrap.dedent("""\
+        manifest_version: 1
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "my_repo"
+                endpoint: "http://127.0.0.1:1"
+                vault_root: "/nowhere"
+        """)
+    repo = _setup_repo(tmp_path / "my_repo", manifest=manifest)
+    proc = _run(repo)
+    assert proc.returncode == 0
+    # No 'omits backend' warn on stderr — the default kicks in silently.
+    assert "omits backend" not in proc.stderr
+    # The workspace IS registered + treated as lightrag → prefetch runs and
+    # fails to reach loopback:1 → writes a registered-workspace missing marker
+    # (the gate then surfaces the unreachable substrate).
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file(), proc.stdout + proc.stderr
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["workspace"] == "my_repo"
+
+
+def test_prefetch_unwraps_dict_bridge_provenance_envelope(tmp_path: Path) -> None:
+    """Qodo PR #194 / #192 Part 6: when the MCP envelope's ``result`` is a
+    decoded dict (not a JSON string), it MUST be unwrapped — otherwise the
+    outer envelope leaks through with no ``visible_workspace_ids`` and the
+    bridge-mismatch check silently skips, allowing the prefetch to query the
+    wrong workspace.
+    """
+    prefetch = _load_prefetch_module()
+    # MCP envelope where `result` is already a dict (newer servers return this).
+    envelope = {
+        "result": {
+            "visible_workspace_ids": ["alpaca_trading"],
+            "disabled_workspace_ids": [],
+            "registry_path": "/tmp/test-registry.toml",
+        }
+    }
+    prov_file = tmp_path / "prov.json"
+    prov_file.write_text(json.dumps(envelope), encoding="utf-8")
+    import os as _os
+
+    _os.environ["AGENTIC_MEMORY_BRIDGE_PROVENANCE_FILE"] = str(prov_file)
+    try:
+        data = prefetch._load_bridge_provenance()
+    finally:
+        _os.environ.pop("AGENTIC_MEMORY_BRIDGE_PROVENANCE_FILE", None)
+    assert data is not None, "dict-form result envelope was not unwrapped"
+    assert data.get("visible_workspace_ids") == ["alpaca_trading"]
+
+
+def test_prefetch_unwraps_string_bridge_provenance_envelope(tmp_path: Path) -> None:
+    """Backward-compat: older servers return ``result`` as a JSON string; still
+    unwrapped correctly."""
+    prefetch = _load_prefetch_module()
+    inner = {
+        "visible_workspace_ids": ["foo_ws"],
+        "disabled_workspace_ids": [],
+        "registry_path": "/tmp/x.toml",
+    }
+    envelope = {"result": json.dumps(inner)}
+    prov_file = tmp_path / "prov.json"
+    prov_file.write_text(json.dumps(envelope), encoding="utf-8")
+    import os as _os
+
+    _os.environ["AGENTIC_MEMORY_BRIDGE_PROVENANCE_FILE"] = str(prov_file)
+    try:
+        data = prefetch._load_bridge_provenance()
+    finally:
+        _os.environ.pop("AGENTIC_MEMORY_BRIDGE_PROVENANCE_FILE", None)
+    assert data is not None
+    assert data.get("visible_workspace_ids") == ["foo_ws"]
+
+
+def test_prefetch_falls_back_to_name_match_without_tier3_id(tmp_path: Path) -> None:
+    """No ``tier3_workspace_id`` → existing basename-match logic fires."""
+    repo = _setup_repo(tmp_path / "alpaca_trading", manifest=None)
+    prefetch = _load_prefetch_module()
+    tracked = {
+        "hosts": [
+            {
+                "workspaces": [
+                    {"name": "other_ws", "endpoint": "http://x/o"},
+                    {"name": "alpaca_trading", "endpoint": "http://x/a"},
+                ]
+            }
+        ]
+    }
+    ws = prefetch._resolve_workspace(repo, tracked, None)
+    assert ws is not None
+    assert ws["name"] == "alpaca_trading"
+
+
 def test_tracked_workspace_wins_over_local_same_name(tmp_path: Path) -> None:
     # Qodo "Precedence Rules": when tracked and local both define the same
     # workspace name, the tracked row must win (no surprising local override).
@@ -391,7 +552,15 @@ def test_unknown_backend_writes_missing_marker(tmp_path: Path) -> None:
     assert missing.is_file()
 
 
-def test_missing_backend_skips_prefetch(tmp_path: Path) -> None:
+def test_missing_backend_defaults_to_lightrag_and_attempts_prefetch(
+    tmp_path: Path,
+) -> None:
+    """Qodo PR #194 / #192 Part 5 — updated from the prior 'skip prefetch +
+    warn' behavior. Per the manifest contract, omitted ``backend`` MUST default
+    to ``lightrag`` (canonical online substrate); the prefetch then attempts
+    the HTTP query like any other lightrag row. The unreachable endpoint here
+    fails → stamps the registered-workspace missing marker so the gate
+    surfaces the outage."""
     ws_name = tmp_path.name.lower().replace("-", "_")
     manifest = textwrap.dedent(f"""\
         manifest_version: 2
@@ -409,7 +578,8 @@ def test_missing_backend_skips_prefetch(tmp_path: Path) -> None:
     repo = _setup_repo(tmp_path, manifest=manifest)
     proc = _run(repo)
     assert proc.returncode == 0
-    assert "omits backend" in proc.stderr
+    # Per the new contract: no 'omits backend' warning — default kicks in.
+    assert "omits backend" not in proc.stderr
     missing = repo / ".scratch" / ".last_memory_query.missing"
     assert missing.is_file(), proc.stdout + proc.stderr
     assert not (repo / ".scratch" / ".last_memory_query").exists()

--- a/tests/test_hook_session_start_memory_prefetch.py
+++ b/tests/test_hook_session_start_memory_prefetch.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -31,16 +32,6 @@ def _run(cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedPr
         check=False,
         timeout=20,
     )
-
-
-def _read_stamp(repo: Path) -> tuple[Path, dict]:
-    """Return whichever stamp file exists (lock preferred over missing marker)."""
-    lock = repo / ".scratch" / ".last_memory_query"
-    missing = repo / ".scratch" / ".last_memory_query.missing"
-    if lock.is_file():
-        return lock, json.loads(lock.read_text(encoding="utf-8"))
-    assert missing.is_file()
-    return missing, json.loads(missing.read_text(encoding="utf-8"))
 
 
 def _setup_repo(tmp_path: Path, manifest: str | None) -> Path:
@@ -100,9 +91,9 @@ def test_workspace_match_manifest_hyphen_vs_dir_underscore(tmp_path: Path) -> No
     )
     proc = _run(repo)
     assert proc.returncode == 0
-    _path, data = _read_stamp(repo)
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
     assert data["workspace"] == "my-repo"
-    assert data["prefetch_ok"] is False
 
 
 def test_workspace_match_by_name(tmp_path: Path) -> None:
@@ -128,28 +119,209 @@ def test_workspace_match_by_name(tmp_path: Path) -> None:
     repo = _setup_repo(tmp_path, manifest=manifest)
     proc = _run(repo)
     assert proc.returncode == 0
-    stamp_path, data = _read_stamp(repo)
-    assert stamp_path.name == ".last_memory_query"
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file(), proc.stdout + proc.stderr
+    assert not (repo / ".scratch" / ".last_memory_query").exists()
+    data = json.loads(missing.read_text(encoding="utf-8"))
     assert data["workspace"] == ws_name
     assert data["prefetch_ok"] is False
+    assert "gate will block code-path edits" in proc.stdout
 
 
-def test_workspace_match_by_vault_root_containing_repo(tmp_path: Path) -> None:
-    """When the repo path lies under ``vault_root``, match even if names differ."""
-    vault_root = tmp_path / "vault"
-    repo = vault_root / "nested-repo"
-    repo.mkdir(parents=True)
-    (repo / ".git").mkdir()
-    (repo / "ops").mkdir()
+def _write_local_manifest(repo: Path, body: str) -> None:
+    (repo / "ops" / "memory_manifest.local.yml").write_text(body, encoding="utf-8")
+
+
+def _load_prefetch_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("prefetch", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_tracked_workspace_wins_over_local_same_name(tmp_path: Path) -> None:
+    # Qodo "Precedence Rules": when tracked and local both define the same
+    # workspace name, the tracked row must win (no surprising local override).
+    repo = _setup_repo(tmp_path, manifest=None)
+    ws_name = repo.name.lower().replace("-", "_")
+    _write_local_manifest(
+        repo,
+        textwrap.dedent(f"""\
+        hosts:
+          - workspaces:
+              - name: "{ws_name}"
+                endpoint: "http://127.0.0.1:1/local"
+        """),
+    )
+    prefetch = _load_prefetch_module()
+    tracked = {
+        "hosts": [{"workspaces": [{"name": ws_name, "endpoint": "http://127.0.0.1:1/tracked"}]}]
+    }
+    local = prefetch._load_local_manifest(repo)
+    ws = prefetch._resolve_workspace(repo, tracked, local)
+    assert ws is not None
+    assert ws.get("endpoint") == "http://127.0.0.1:1/tracked"
+
+
+def test_gather_workspaces_ignores_non_list_workspaces() -> None:
+    # Gemini Code Assist (PR #175): malformed truthy workspaces values must not
+    # raise while flattening manifest host rows.
+    prefetch = _load_prefetch_module()
+    assert prefetch._gather_workspaces({"hosts": [{"workspaces": True}]}) == []
+    assert prefetch._gather_workspaces({"hosts": [{"workspaces": 1}]}) == []
+
+
+def test_local_exception_wins_over_tracked_different_spelling(tmp_path: Path) -> None:
+    # Qodo "Exception precedence order-dependent": local must win even when the
+    # tracked manifest spells the same repo with the other separator. A merged
+    # dict would keep both keys and return tracked-first; local-precedence must
+    # be source-ordered, not iteration-ordered.
+    repo = _setup_repo(tmp_path / "repo_with_separator", manifest=None)
+    base = repo.name
+    hyphen = base.replace("_", "-")
+    under = base.replace("-", "_")
+    _write_local_manifest(
+        repo,
+        textwrap.dedent(f"""\
+        resolution_exceptions:
+          "{under}":
+            reason: "from local"
+            tracking_issue: "LOCAL"
+        """),
+    )
+    prefetch = _load_prefetch_module()
+    tracked = {
+        "resolution_exceptions": {hyphen: {"reason": "from tracked", "tracking_issue": "TRACKED"}}
+    }
+    local = prefetch._load_local_manifest(repo)
+    ex = prefetch._resolve_exception(repo, tracked, local)
+    assert ex is not None
+    assert hyphen != under
+    assert ex.get("tracking_issue") == "LOCAL", ex
+
+
+def test_malformed_tracked_manifest_warns_and_degrades(tmp_path: Path) -> None:
+    # Qodo "Silent Failure": a malformed *tracked* manifest must not silently
+    # route into the degraded path — it must warn so operator misconfig surfaces.
+    repo = _setup_repo(tmp_path, manifest="hosts: [unterminated\n  : : :\n")
+    proc = _run(repo)
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file(), proc.stdout + proc.stderr
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["workspace"] is None
+    assert "could not parse" in proc.stderr
+
+
+def test_local_manifest_workspace_is_merged(tmp_path: Path) -> None:
+    # Tracked manifest has no matching workspace; the operator-owned local
+    # extension does. The deterministic prefetch must resolve it (previously
+    # only the agent-facing ladder consulted the local manifest).
+    repo = _setup_repo(tmp_path, manifest="manifest_version: 2\n")
+    ws_name = repo.name.lower().replace("-", "_")
+    _write_local_manifest(
+        repo,
+        textwrap.dedent(f"""\
+        hosts:
+          - id: local-host
+            workspaces:
+              - name: "{ws_name}"
+                backend: lightrag
+                endpoint: "http://127.0.0.1:1"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries:
+                  - prompt: "test"
+                    mode: "hybrid"
+        """),
+    )
+    proc = _run(repo)
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file(), proc.stdout + proc.stderr
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["workspace"] == ws_name
+    assert data["prefetch_ok"] is False
+    # Registered (locally) but unreachable → block path, not the no-workspace warning.
+    assert "gate will block code-path edits" in proc.stdout
+
+
+def test_resolution_exception_degrades_quietly(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path, manifest=None)
+    basename = repo.name
+    tracking = "https://github.com/agorokh/template-repo/issues/167"
+    (repo / "ops" / "memory_manifest.yml").write_text(
+        textwrap.dedent(f"""\
+        manifest_version: 2
+        resolution_exceptions:
+          "{basename}":
+            reason: "Tier-3 workspace not yet provisioned on the fleet substrate"
+            tracking_issue: "{tracking}"
+        """),
+        encoding="utf-8",
+    )
+    proc = _run(repo)
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file(), proc.stdout + proc.stderr
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["reason"] == "accepted_gap"
+    # gate_policy must be the default "allow" (NOT "warn") so the gate's
+    # no-workspace branch allows edits unconditionally, independent of any
+    # leftover lock (Cursor Bugbot regression, PR #175).
+    assert data["gate_policy"] == "allow"
+    assert data["workspace"] is None
+    assert "accepted Tier-3 gap" in proc.stdout
+    assert tracking in proc.stdout
+    assert "do NOT file a new" in proc.stdout
+    # Must NOT emit the generic "register a workspace" warning for an accepted gap.
+    assert "no Tier-3 workspace registered" not in proc.stdout
+
+
+def test_resolution_exception_from_local_manifest(tmp_path: Path) -> None:
+    repo = _setup_repo(tmp_path, manifest="manifest_version: 2\n")
+    basename = repo.name
+    _write_local_manifest(
+        repo,
+        textwrap.dedent(f"""\
+        resolution_exceptions:
+          "{basename}":
+            reason: "known unprovisioned child repo"
+            tracking_issue: "https://github.com/agorokh/template-repo/issues/169"
+        """),
+    )
+    proc = _run(repo)
+    assert proc.returncode == 0
+    data = json.loads(
+        (repo / ".scratch" / ".last_memory_query.missing").read_text(encoding="utf-8")
+    )
+    assert data["reason"] == "accepted_gap"
+    assert "accepted Tier-3 gap" in proc.stdout
+    assert "issues/169" in proc.stdout
+
+
+def test_resolved_workspace_wins_over_exception(tmp_path: Path) -> None:
+    # A live (registered) workspace must take precedence over a stale exception
+    # entry for the same repo basename.
+    ws_name = tmp_path.name.lower().replace("-", "_")
     manifest = textwrap.dedent(f"""\
         manifest_version: 2
+        resolution_exceptions:
+          "{ws_name}":
+            reason: "should be ignored — workspace is registered"
+            tracking_issue: "https://example.com/stale"
         hosts:
           - id: test-host
             workspaces:
-              - name: unrelated-workspace
+              - name: "{ws_name}"
                 backend: lightrag
                 endpoint: "http://127.0.0.1:1"
-                vault_root: "{vault_root}"
+                vault_root: "/nowhere"
                 audit_log: "/nowhere"
                 launchd_label: null
                 stale_after_hours: 24
@@ -157,16 +329,18 @@ def test_workspace_match_by_vault_root_containing_repo(tmp_path: Path) -> None:
                   - prompt: "test"
                     mode: "hybrid"
         """)
-    (repo / "ops" / "memory_manifest.yml").write_text(manifest, encoding="utf-8")
+    repo = _setup_repo(tmp_path, manifest=manifest)
     proc = _run(repo)
     assert proc.returncode == 0
-    stamp_path, data = _read_stamp(repo)
-    assert stamp_path.name == ".last_memory_query"
-    assert data["workspace"] == "unrelated-workspace"
+    data = json.loads(
+        (repo / ".scratch" / ".last_memory_query.missing").read_text(encoding="utf-8")
+    )
+    assert data["workspace"] == ws_name
+    assert data.get("reason") != "accepted_gap"
+    assert "accepted Tier-3 gap" not in proc.stdout
 
 
-def test_graphiti_backend_degrades_via_missing_marker(tmp_path: Path) -> None:
-    """Graphiti without HTTP prefetch must not write an empty provisioned lock."""
+def test_graphiti_backend_writes_missing_marker(tmp_path: Path) -> None:
     ws_name = tmp_path.name.lower().replace("-", "_")
     manifest = textwrap.dedent(f"""\
         manifest_version: 2
@@ -191,7 +365,54 @@ def test_graphiti_backend_degrades_via_missing_marker(tmp_path: Path) -> None:
     data = json.loads(missing.read_text(encoding="utf-8"))
     assert data["prefetch_ok"] is False
     assert data["workspace"] == ws_name
-    assert "warn-only" in proc.stdout.lower()
+
+
+def test_unknown_backend_writes_missing_marker(tmp_path: Path) -> None:
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    manifest = textwrap.dedent(f"""\
+        manifest_version: 2
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "{ws_name}"
+                backend: neo4j_legacy
+                endpoint: "http://127.0.0.1:8060"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries: []
+        """)
+    repo = _setup_repo(tmp_path, manifest=manifest)
+    proc = _run(repo)
+    assert proc.returncode == 0
+    assert "unknown backend" in proc.stderr
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file()
+
+
+def test_missing_backend_skips_prefetch(tmp_path: Path) -> None:
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    manifest = textwrap.dedent(f"""\
+        manifest_version: 2
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "{ws_name}"
+                endpoint: "http://127.0.0.1:8060"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries: []
+        """)
+    repo = _setup_repo(tmp_path, manifest=manifest)
+    proc = _run(repo)
+    assert proc.returncode == 0
+    assert "omits backend" in proc.stderr
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file(), proc.stdout + proc.stderr
+    assert not (repo / ".scratch" / ".last_memory_query").exists()
 
 
 def test_disabled_via_env(tmp_path: Path) -> None:
@@ -233,10 +454,136 @@ def test_blocked_remote_http_endpoint_writes_missing_marker(tmp_path: Path) -> N
     repo = _setup_repo(tmp_path, manifest=manifest)
     proc = _run(repo)
     assert proc.returncode == 0
-    assert "blocked endpoint" in proc.stderr
-    stamp_path, data = _read_stamp(repo)
-    assert stamp_path.name == ".last_memory_query"
-    assert data["prefetch_ok"] is False
+    # The untrusted remote HTTP endpoint must never be contacted: the shared
+    # resolver's allowlist (non-loopback must be registry-named/Tailscale-shaped
+    # AND HTTPS) rejects it, so only the loopback fallback is probed — which is
+    # unreachable here — yielding a blocking missing marker and no fresh lock
+    # (template-repo#180 replaced the loopback-only _endpoint_allowed guard).
+    assert "evil.example" not in proc.stdout and "evil.example" not in proc.stderr
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    assert missing.is_file()
+    assert not (repo / ".scratch" / ".last_memory_query").exists()
+
+
+def test_bridge_provenance_not_visible_writes_blocking_marker(tmp_path: Path) -> None:
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    manifest = textwrap.dedent(f"""\
+        manifest_version: 2
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "{ws_name}"
+                backend: lightrag
+                endpoint: "http://127.0.0.1:1"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries: []
+        """)
+    repo = _setup_repo(tmp_path, manifest=manifest)
+    provenance = {
+        "registry_path": "/tmp/fleet-registry.toml",
+        "visible_workspace_ids": ["agent_factory_steward"],
+        "disabled_workspace_ids": [],
+    }
+    proc = _run(repo, env={"AGENTIC_MEMORY_BRIDGE_PROVENANCE_JSON": json.dumps(provenance)})
+    assert proc.returncode == 0
+    assert "Tier-3 workspace mismatch" in proc.stdout
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["workspace"] == ws_name
+    assert data["gate_policy"] == "block"
+    assert data["reason"] == "bridge_workspace_not_visible"
+
+
+def test_bridge_provenance_disabled_writes_blocking_marker(tmp_path: Path) -> None:
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    manifest = textwrap.dedent(f"""\
+        manifest_version: 2
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "{ws_name}"
+                backend: lightrag
+                endpoint: "http://127.0.0.1:1"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries: []
+        """)
+    repo = _setup_repo(tmp_path, manifest=manifest)
+    provenance = {
+        "registry_path": "/tmp/fleet-registry.toml",
+        "visible_workspace_ids": ["agent_factory_steward"],
+        "disabled_workspace_ids": [ws_name],
+    }
+    proc = _run(repo, env={"AGENTIC_MEMORY_BRIDGE_PROVENANCE_JSON": json.dumps(provenance)})
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["gate_policy"] == "block"
+    assert data["reason"] == "bridge_workspace_disabled"
+
+
+def test_bridge_provenance_ignored_for_graphiti_placeholder(tmp_path: Path) -> None:
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    manifest = textwrap.dedent(f"""\
+        manifest_version: 2
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "{ws_name}"
+                backend: graphiti
+                endpoint: "http://127.0.0.1:1"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries: []
+        """)
+    repo = _setup_repo(tmp_path, manifest=manifest)
+    provenance = {
+        "registry_path": "/tmp/fleet-registry.toml",
+        "visible_workspace_ids": ["agent_factory_steward"],
+        "disabled_workspace_ids": [ws_name],
+    }
+    proc = _run(repo, env={"AGENTIC_MEMORY_BRIDGE_PROVENANCE_JSON": json.dumps(provenance)})
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["workspace"] == ws_name
+    assert data["gate_policy"] == "allow"
+    assert data.get("reason") != "bridge_workspace_disabled"
+
+
+def test_bridge_provenance_file_size_limit_degrades(tmp_path: Path) -> None:
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    manifest = textwrap.dedent(f"""\
+        manifest_version: 2
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "{ws_name}"
+                backend: lightrag
+                endpoint: "http://127.0.0.1:1"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries: []
+        """)
+    repo = _setup_repo(tmp_path, manifest=manifest)
+    huge = tmp_path / "huge-provenance.json"
+    huge.write_text("{" + (" " * 20_000) + "}", encoding="utf-8")
+    proc = _run(repo, env={"AGENTIC_MEMORY_BRIDGE_PROVENANCE_FILE": str(huge)})
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["workspace"] == ws_name
+    assert data["gate_policy"] == "allow"
+    assert data.get("reason") != "bridge_workspace_not_visible"
 
 
 def test_pyyaml_missing_degrades(tmp_path: Path, monkeypatch) -> None:
@@ -248,6 +595,116 @@ def test_pyyaml_missing_degrades(tmp_path: Path, monkeypatch) -> None:
     """
     src = SCRIPT.read_text(encoding="utf-8")
     assert "import yaml" in src and "ImportError" in src
+
+
+# -------------------------------------------------------------------------
+# Bridge provenance auto-capture (issue #172). The wrapper writes the live
+# bridge's visible/disabled set to a well-known file; the prefetch reads it by
+# default so _bridge_workspace_problem fires without an env handshake.
+# -------------------------------------------------------------------------
+
+
+def _lightrag_ws_manifest(ws_name: str) -> str:
+    return textwrap.dedent(f"""\
+        manifest_version: 2
+        hosts:
+          - id: test-host
+            workspaces:
+              - name: "{ws_name}"
+                backend: lightrag
+                endpoint: "http://127.0.0.1:1"
+                vault_root: "/nowhere"
+                audit_log: "/nowhere"
+                launchd_label: null
+                stale_after_hours: 24
+                canary_queries: []
+        """)
+
+
+def _write_default_provenance(cache_home: Path, payload: dict) -> Path:
+    """Write a capture at the XDG default path the prefetch reads."""
+    prov = cache_home / "agentic-memory" / "bridge_provenance.json"
+    prov.parent.mkdir(parents=True, exist_ok=True)
+    prov.write_text(json.dumps(payload), encoding="utf-8")
+    return prov
+
+
+def test_bridge_provenance_default_path_blocks(tmp_path: Path) -> None:
+    """A not-visible workspace in the default capture file blocks — no env needed."""
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    repo = _setup_repo(tmp_path, manifest=_lightrag_ws_manifest(ws_name))
+    cache_home = tmp_path / "xdgcache"
+    _write_default_provenance(
+        cache_home,
+        {
+            "registry_path": "/tmp/fleet-registry.toml",
+            "visible_workspace_ids": ["agent_factory_steward"],
+            "disabled_workspace_ids": [],
+        },
+    )
+    # Note: only XDG_CACHE_HOME is set — no AGENTIC_MEMORY_BRIDGE_PROVENANCE_* env.
+    proc = _run(repo, env={"XDG_CACHE_HOME": str(cache_home)})
+    assert proc.returncode == 0
+    assert "Tier-3 workspace mismatch" in proc.stdout
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["workspace"] == ws_name
+    assert data["gate_policy"] == "block"
+    assert data["reason"] == "bridge_workspace_not_visible"
+
+
+def test_bridge_provenance_default_trusts_old_capture(tmp_path: Path) -> None:
+    """Default (no TTL): an old capture is still honoured, so a long-running
+    bridge does not silently disable the drift check (cursor-bot #172 review)."""
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    repo = _setup_repo(tmp_path, manifest=_lightrag_ws_manifest(ws_name))
+    cache_home = tmp_path / "xdgcache"
+    prov = _write_default_provenance(
+        cache_home,
+        {
+            "registry_path": "/tmp/fleet-registry.toml",
+            "visible_workspace_ids": ["agent_factory_steward"],
+            "disabled_workspace_ids": [],
+        },
+    )
+    old = time.time() - 30 * 24 * 3600  # 30 days old — no default TTL drops it
+    os.utime(prov, (old, old))
+    proc = _run(repo, env={"XDG_CACHE_HOME": str(cache_home)})
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    assert data["gate_policy"] == "block"
+    assert data["reason"] == "bridge_workspace_not_visible"
+
+
+def test_bridge_provenance_opt_in_staleness_ignores_old(tmp_path: Path) -> None:
+    """With a positive MAX_AGE_S backstop, a too-old capture is ignored."""
+    ws_name = tmp_path.name.lower().replace("-", "_")
+    repo = _setup_repo(tmp_path, manifest=_lightrag_ws_manifest(ws_name))
+    cache_home = tmp_path / "xdgcache"
+    prov = _write_default_provenance(
+        cache_home,
+        {
+            "registry_path": "/tmp/fleet-registry.toml",
+            "visible_workspace_ids": ["agent_factory_steward"],
+            "disabled_workspace_ids": [],
+        },
+    )
+    old = time.time() - 48 * 3600
+    os.utime(prov, (old, old))
+    proc = _run(
+        repo,
+        env={
+            "XDG_CACHE_HOME": str(cache_home),
+            "AGENTIC_MEMORY_BRIDGE_PROVENANCE_MAX_AGE_S": "3600",  # 1h backstop
+        },
+    )
+    assert proc.returncode == 0
+    missing = repo / ".scratch" / ".last_memory_query.missing"
+    data = json.loads(missing.read_text(encoding="utf-8"))
+    # Too-old capture ignored → falls back to the normal unreachable-placeholder path.
+    assert data.get("reason") != "bridge_workspace_not_visible"
+    assert data["gate_policy"] == "allow"
 
 
 # -------------------------------------------------------------------------
@@ -269,6 +726,81 @@ def _import_prefetch_module():
     return prefetch
 
 
+def _import_hook_repo_root_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "hook_repo_root", REPO_ROOT / "scripts" / "hook_repo_root.py"
+    )
+    assert spec and spec.loader
+    hook_repo_root = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hook_repo_root)
+    return hook_repo_root
+
+
+def _patch_git_common_dir(monkeypatch, hook_repo_root, main: Path) -> None:
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(cmd, list) and "--git-common-dir" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=str(main / ".git") + "\n", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(hook_repo_root.subprocess, "run", fake_run)
+
+
+def test_repo_root_normalizes_worktree_to_main(tmp_path: Path, monkeypatch) -> None:
+    """In a git worktree, _repo_root resolves to the main repo working dir.
+
+    A worktree's `.git` is a *file* (not a dir), `git rev-parse --show-toplevel`
+    returns the worktree path, and its basename is a random slug that never
+    matches manifest match_repo_basenames. The fix uses `--git-common-dir` to
+    find the shared `.git/`; its parent is the main repo. Without this fix,
+    sessions started inside .claude/worktrees/<slug>/ silently degrade the
+    Tier-3 memory gate to warn-only.
+    """
+    hook_repo_root = _import_hook_repo_root_module()
+    prefetch = _import_prefetch_module()
+    main = tmp_path / "template-repo"
+    main.mkdir()
+    (main / ".git").mkdir()
+    worktree = tmp_path / "wt-random-slug-abc123"
+    worktree.mkdir()
+    (worktree / ".git").write_text(
+        f"gitdir: {main / '.git' / 'worktrees' / 'wt-random-slug-abc123'}\n",
+        encoding="utf-8",
+    )
+
+    _patch_git_common_dir(monkeypatch, hook_repo_root, main)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(worktree)
+
+    resolved = prefetch._repo_root()
+    assert resolved == main.resolve(), f"expected main repo {main} but got {resolved}"
+
+
+def test_repo_root_normalizes_claude_project_dir_in_worktree(tmp_path: Path, monkeypatch) -> None:
+    """CLAUDE_PROJECT_DIR must not bypass worktree normalization."""
+    hook_repo_root = _import_hook_repo_root_module()
+    prefetch = _import_prefetch_module()
+    main = tmp_path / "template-repo"
+    main.mkdir()
+    (main / ".git").mkdir()
+    worktree = tmp_path / "wt-random-slug-abc123"
+    worktree.mkdir()
+    (worktree / ".git").write_text(
+        f"gitdir: {main / '.git' / 'worktrees' / 'wt-random-slug-abc123'}\n",
+        encoding="utf-8",
+    )
+
+    _patch_git_common_dir(monkeypatch, hook_repo_root, main)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(worktree))
+    monkeypatch.chdir(worktree)
+
+    resolved = prefetch._repo_root()
+    assert resolved == main.resolve(), f"expected main repo {main} but got {resolved}"
+
+
 def test_lockfile_carries_response_body(tmp_path: Path, monkeypatch) -> None:
     """The lockfile must persist the actual substrate response body."""
     prefetch = _import_prefetch_module()
@@ -280,7 +812,7 @@ def test_lockfile_carries_response_body(tmp_path: Path, monkeypatch) -> None:
             workspaces:
               - name: "{ws_name}"
                 backend: lightrag
-                endpoint: "http://example.invalid"
+                endpoint: "http://127.0.0.1:8020"
                 vault_root: "/nowhere"
                 audit_log: "/nowhere"
                 launchd_label: null
@@ -294,7 +826,7 @@ def test_lockfile_carries_response_body(tmp_path: Path, monkeypatch) -> None:
         "The hook_memory_gate.py enforces session-start prefetch stamps "
         "with response_body content for file relevance checks."
     )
-    monkeypatch.setattr(prefetch, "_http_query_lightrag", lambda *a, **k: fake_body)
+    monkeypatch.setattr(prefetch, "_http_query_lightrag", lambda *a, **k: (fake_body, None))
     monkeypatch.setattr(prefetch, "_endpoint_allowed", lambda e: (True, ""))
     monkeypatch.setattr(prefetch, "_repo_root", lambda: repo)
     monkeypatch.setattr(prefetch, "_derive_prompt", lambda root: "hook memory gate")
@@ -320,7 +852,7 @@ def test_response_body_truncated_to_limit(tmp_path: Path, monkeypatch) -> None:
             workspaces:
               - name: "{ws_name}"
                 backend: lightrag
-                endpoint: "http://example.invalid"
+                endpoint: "http://127.0.0.1:8020"
                 vault_root: "/nowhere"
                 audit_log: "/nowhere"
                 launchd_label: null
@@ -329,7 +861,7 @@ def test_response_body_truncated_to_limit(tmp_path: Path, monkeypatch) -> None:
         """)
     repo = _setup_repo(tmp_path, manifest=manifest)
     long_body = "x" * (prefetch.RESPONSE_BODY_LIMIT + 1000)
-    monkeypatch.setattr(prefetch, "_http_query_lightrag", lambda *a, **k: long_body)
+    monkeypatch.setattr(prefetch, "_http_query_lightrag", lambda *a, **k: (long_body, None))
     monkeypatch.setattr(prefetch, "_endpoint_allowed", lambda e: (True, ""))
     monkeypatch.setattr(prefetch, "_repo_root", lambda: repo)
     monkeypatch.setattr(prefetch, "_derive_prompt", lambda root: "test")

--- a/tests/test_memory_endpoint_resolver.py
+++ b/tests/test_memory_endpoint_resolver.py
@@ -1,0 +1,347 @@
+"""Tests for the shared substrate endpoint resolver.
+
+Covers the council-reconciled design for template-repo#180 / workstation-ops#170:
+one resolver shared by the SessionStart prefetch hook and the memory gate, so a
+remote tailnet host resolves the same reachable endpoint the MCP read path uses
+instead of dead loopback. Security: non-loopback endpoints must be HTTPS and
+within the Tailscale trust boundary (registry-named host or ``*.ts.net`` /
+100.64.0.0/10), never an arbitrary external host.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from hook_memory_manifest import (  # noqa: E402
+    EndpointCandidate,
+    _is_tailnet_shaped,
+    _split_endpoint,
+    resolve_memory_endpoints,
+)
+
+WORKSPACE = "agent_factory_steward"
+TSNET_HOST = "m2pro.tail31ce1b.ts.net"
+TAILNET_IP = "100.71.123.90"
+
+
+def _write_registry(
+    tmp_path: Path, name: str, endpoint: str, *, workspace: str = WORKSPACE
+) -> Path:
+    path = tmp_path / name
+    path.write_text(
+        f'[[vaults]]\nid = "{workspace}"\nendpoint = "{endpoint}"\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+def _urls(candidates: list[EndpointCandidate]) -> list[str]:
+    return [c.url for c in candidates]
+
+
+def test_tailnet_shaped_helper() -> None:
+    assert _is_tailnet_shaped(TSNET_HOST)
+    assert _is_tailnet_shaped(TAILNET_IP)  # 100.64.0.0/10
+    assert _is_tailnet_shaped("100.127.255.255")
+    assert not _is_tailnet_shaped("example.com")
+    assert not _is_tailnet_shaped("8.8.8.8")
+    assert not _is_tailnet_shaped("100.128.0.1")  # just outside CGNAT range
+    assert not _is_tailnet_shaped("")
+
+
+def test_split_endpoint() -> None:
+    assert _split_endpoint("https://m2pro.tail31ce1b.ts.net:8020") == ("https", TSNET_HOST, 8020)
+    assert _split_endpoint("http://localhost:8020") == ("http", "localhost", 8020)
+    assert _split_endpoint("https://host.ts.net") == ("https", "host.ts.net", 443)
+    assert _split_endpoint("ftp://x:1") is None
+    assert _split_endpoint("not a url") is None
+
+
+def test_remote_consumer_registry_https_resolves_before_loopback(tmp_path: Path) -> None:
+    reg = _write_registry(tmp_path, "m5-fleet-registry.toml", f"https://{TAILNET_IP}:8020")
+    manifest_ws = {"name": WORKSPACE, "endpoint": "http://localhost:8020"}
+    out = resolve_memory_endpoints(
+        WORKSPACE,
+        manifest_ws,
+        env={},
+        registry_sources=[(reg, "consumer_registry")],
+    )
+    urls = _urls(out)
+    assert f"https://{TAILNET_IP}:8020" in urls
+    # registry endpoint (priority 20) must come before the loopback fallback (90)
+    assert urls.index(f"https://{TAILNET_IP}:8020") < urls.index("http://127.0.0.1:8020")
+    assert out[0].source == "consumer_registry"
+
+
+def test_env_bridge_tsnet_takes_top_priority(tmp_path: Path) -> None:
+    # Only a loopback manifest is known (the exact remote-host bug); the bridge
+    # env var must still yield a reachable HTTPS ts.net candidate, ranked first.
+    manifest_ws = {"name": WORKSPACE, "endpoint": "http://localhost:8020"}
+    out = resolve_memory_endpoints(
+        WORKSPACE,
+        manifest_ws,
+        env={"AGENTIC_MEMORY_BRIDGE_HOST": TSNET_HOST},
+        registry_sources=[],
+    )
+    assert out[0].source == "env_bridge"
+    assert out[0].url == f"https://{TSNET_HOST}:8020"
+    assert out[0].scheme == "https"
+
+
+def test_non_loopback_http_is_rejected(tmp_path: Path) -> None:
+    # A non-loopback endpoint over plain HTTP must be dropped (Tailscale Serve TLS).
+    reg = _write_registry(tmp_path, "m5-fleet-registry.toml", f"http://{TAILNET_IP}:8020")
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "consumer_registry")]
+    )
+    assert all(not c.url.startswith(f"http://{TAILNET_IP}") for c in out)
+    # the rejected plain-HTTP endpoint was the only signal → no real substrate
+    assert _urls(out) == []  # no real substrate → no default-loopback probe (#180 P1/B)
+
+
+def test_poisoned_manifest_external_host_rejected() -> None:
+    manifest_ws = {"name": WORKSPACE, "endpoint": "https://evil.example.com:8020"}
+    out = resolve_memory_endpoints(WORKSPACE, manifest_ws, env={}, registry_sources=[])
+    assert all("evil.example.com" not in c.url for c in out)
+    assert _urls(out) == []  # no real substrate → no default-loopback probe (#180 P1/B)
+
+
+def test_bridge_external_host_rejected() -> None:
+    manifest_ws = {"name": WORKSPACE, "endpoint": "http://localhost:8020"}
+    out = resolve_memory_endpoints(
+        WORKSPACE,
+        manifest_ws,
+        env={"AGENTIC_MEMORY_BRIDGE_HOST": "evil.example.com"},
+        registry_sources=[],
+    )
+    assert all(c.source != "env_bridge" for c in out)
+    assert all("evil.example.com" not in c.url for c in out)
+
+
+def test_loopback_manifest_is_kept() -> None:
+    manifest_ws = {"name": WORKSPACE, "endpoint": "http://localhost:8020"}
+    out = resolve_memory_endpoints(WORKSPACE, manifest_ws, env={}, registry_sources=[])
+    assert "http://localhost:8020" in _urls(out)
+    assert "http://127.0.0.1:8020" in _urls(out)
+
+
+def test_workspace_id_mismatch_excluded(tmp_path: Path) -> None:
+    reg = _write_registry(
+        tmp_path, "m5-fleet-registry.toml", f"https://{TAILNET_IP}:8040", workspace="epam_dialx"
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "consumer_registry")]
+    )
+    # the epam_dialx row must not leak into agent_factory_steward resolution
+    assert all(":8040" not in c.url for c in out)
+
+
+def test_dedup_across_sources(tmp_path: Path) -> None:
+    reg1 = _write_registry(tmp_path, "m5-fleet-registry.toml", f"https://{TAILNET_IP}:8020")
+    reg2 = _write_registry(tmp_path, "other-fleet-registry.toml", f"https://{TAILNET_IP}:8020")
+    out = resolve_memory_endpoints(
+        WORKSPACE,
+        None,
+        env={},
+        registry_sources=[(reg1, "consumer_registry"), (reg2, "consumer_registry")],
+    )
+    assert _urls(out).count(f"https://{TAILNET_IP}:8020") == 1
+
+
+def test_candidates_ordered_by_priority(tmp_path: Path) -> None:
+    reg = _write_registry(tmp_path, "m5-fleet-registry.toml", f"https://{TAILNET_IP}:8020")
+    manifest_ws = {"name": WORKSPACE, "endpoint": "http://localhost:8020"}
+    out = resolve_memory_endpoints(
+        WORKSPACE,
+        manifest_ws,
+        env={"AGENTIC_MEMORY_BRIDGE_HOST": TSNET_HOST},
+        registry_sources=[(reg, "consumer_registry")],
+    )
+    priorities = [c.priority for c in out]
+    assert priorities == sorted(priorities)
+    assert out[0].source == "env_bridge"  # ts.net hostname (SNI/cert) tried first
+
+
+def test_disabled_registry_row_is_skipped(tmp_path: Path) -> None:
+    # enabled = false rows exist in the live consumer registry and must NOT
+    # become probe targets (workstation-ops#171 Cursor finding).
+    reg = tmp_path / "m5-fleet-registry.toml"
+    reg.write_text(
+        f'[[vaults]]\nid = "{WORKSPACE}"\n'
+        f'endpoint = "https://{TAILNET_IP}:8020"\nenabled = false\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "consumer_registry")]
+    )
+    assert all(":8020" not in c.url or c.source == "loopback" for c in out)
+    assert _urls(out) == []  # no real substrate → no default-loopback probe (#180 P1/B)
+
+
+def test_defaults_disabled_inherited_when_row_silent(tmp_path: Path) -> None:
+    reg = tmp_path / "m5-fleet-registry.toml"
+    reg.write_text(
+        f'[defaults]\nenabled = false\n\n[[vaults]]\nid = "{WORKSPACE}"\n'
+        f'endpoint = "https://{TAILNET_IP}:8020"\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "consumer_registry")]
+    )
+    assert all(c.source != "consumer_registry" for c in out)
+
+
+def test_non_lightrag_registry_row_is_skipped(tmp_path: Path) -> None:
+    reg = tmp_path / "fleet_registry.toml"
+    reg.write_text(
+        f'[[vaults]]\nworkspace = "{WORKSPACE}"\napi_url = "https://{TAILNET_IP}:8020"\n'
+        'backend = "graphiti"\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "legacy_registry")]
+    )
+    assert _urls(out) == []  # no real substrate → no default-loopback probe (#180 P1/B)
+
+
+def test_api_url_fallback_and_workspace_id(tmp_path: Path) -> None:
+    # Legacy/source registry shape: `workspace` id + `api_url` endpoint.
+    reg = tmp_path / "fleet_registry.toml"
+    reg.write_text(
+        f'[[vaults]]\nworkspace = "{WORKSPACE}"\napi_url = "https://{TAILNET_IP}:8020"\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "legacy_registry")]
+    )
+    assert f"https://{TAILNET_IP}:8020" in _urls(out)
+
+
+def test_placeholder_loopback_endpoint_is_skipped() -> None:
+    # The not-yet-provisioned manifest placeholder must not seed a port-1
+    # candidate or set base_port to 1.
+    manifest_ws = {"name": WORKSPACE, "endpoint": "http://127.0.0.1:1"}
+    out = resolve_memory_endpoints(WORKSPACE, manifest_ws, env={}, registry_sources=[])
+    assert all(":1" not in c.url for c in out)
+    # placeholder is unprovisioned → no real substrate → no default-loopback probe
+    assert _urls(out) == []
+
+
+def test_remote_https_443_endpoint_does_not_synthesize_loopback(tmp_path: Path) -> None:
+    # A portless HTTPS registry endpoint defaults to 443. It is a valid remote
+    # candidate, but since the config has no loopback signal NO loopback fallback
+    # is synthesized — and 443 must never leak into a loopback port.
+    reg = tmp_path / "m5-fleet-registry.toml"
+    reg.write_text(
+        f'[[vaults]]\nid = "{WORKSPACE}"\nendpoint = "https://{TSNET_HOST}"\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "consumer_registry")]
+    )
+    assert f"https://{TSNET_HOST}:443" in _urls(out)
+    assert not any(c.url.startswith("http://127.0.0.1") for c in out)
+
+
+def test_empty_workspace_does_not_match_all_rows(tmp_path: Path) -> None:
+    reg = _write_registry(
+        tmp_path, "m5-fleet-registry.toml", f"https://{TAILNET_IP}:8040", workspace="epam_dialx"
+    )
+    out = resolve_memory_endpoints("", None, env={}, registry_sources=[(reg, "consumer_registry")])
+    assert all(":8040" not in c.url for c in out)
+
+
+def test_higher_precedence_registry_ranks_first_but_fallback_kept(tmp_path: Path) -> None:
+    # Precedence is by ordering, not by dropping: the consumer registry endpoint
+    # ranks before the legacy one, but the legacy endpoint survives as a fallback
+    # (so a rejected higher-precedence endpoint never strands the resolver).
+    reg1 = _write_registry(tmp_path, "m5-fleet-registry.toml", f"https://{TAILNET_IP}:8020")
+    reg2 = _write_registry(tmp_path, "legacy.toml", f"https://{TAILNET_IP}:9999")
+    out = resolve_memory_endpoints(
+        WORKSPACE,
+        None,
+        env={},
+        registry_sources=[(reg1, "consumer_registry"), (reg2, "legacy_registry")],
+    )
+    urls = _urls(out)
+    assert f"https://{TAILNET_IP}:8020" in urls and f"https://{TAILNET_IP}:9999" in urls
+    assert urls.index(f"https://{TAILNET_IP}:8020") < urls.index(f"https://{TAILNET_IP}:9999")
+
+
+def test_break_does_not_strand_when_top_endpoint_rejected(tmp_path: Path) -> None:
+    # Higher-precedence row matches but its endpoint is plain-HTTP to a tailnet IP
+    # (rejected by the allowlist); the lower-precedence HTTPS endpoint must remain.
+    reg1 = _write_registry(tmp_path, "m5-fleet-registry.toml", f"http://{TAILNET_IP}:8020")
+    reg2 = _write_registry(tmp_path, "legacy.toml", f"https://{TAILNET_IP}:8040")
+    out = resolve_memory_endpoints(
+        WORKSPACE,
+        None,
+        env={},
+        registry_sources=[(reg1, "consumer_registry"), (reg2, "legacy_registry")],
+    )
+    assert f"https://{TAILNET_IP}:8040" in _urls(out)
+
+
+def test_defaults_backend_graphiti_skips_row(tmp_path: Path) -> None:
+    reg = tmp_path / "fleet_registry.toml"
+    reg.write_text(
+        f'[defaults]\nbackend = "graphiti"\n\n[[vaults]]\nworkspace = "{WORKSPACE}"\n'
+        f'api_url = "https://{TAILNET_IP}:8020"\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "legacy_registry")]
+    )
+    assert _urls(out) == []  # no real substrate → no default-loopback probe (#180 P1/B)
+
+
+def test_defaults_api_url_inherited(tmp_path: Path) -> None:
+    reg = tmp_path / "fleet_registry.toml"
+    reg.write_text(
+        f'[defaults]\napi_url = "https://{TAILNET_IP}:8020"\n\n'
+        f'[[vaults]]\nworkspace = "{WORKSPACE}"\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "legacy_registry")]
+    )
+    assert f"https://{TAILNET_IP}:8020" in _urls(out)
+
+
+def test_manifest_endpoint_workspace_mismatch_rejected() -> None:
+    # A manifest snippet for a DIFFERENT workspace must not attach its URL.
+    manifest_ws = {"name": "some_other_ws", "endpoint": f"https://{TAILNET_IP}:8020"}
+    out = resolve_memory_endpoints(WORKSPACE, manifest_ws, env={}, registry_sources=[])
+    assert all(c.source != "manifest" for c in out)
+
+
+def test_manifest_graphiti_row_skipped() -> None:
+    manifest_ws = {
+        "name": WORKSPACE,
+        "backend": "graphiti",
+        "endpoint": f"https://{TAILNET_IP}:8020",
+    }
+    out = resolve_memory_endpoints(WORKSPACE, manifest_ws, env={}, registry_sources=[])
+    assert all(c.source != "manifest" for c in out)
+
+
+def test_invalid_defaults_table_discards_file(tmp_path: Path) -> None:
+    reg = tmp_path / "m5-fleet-registry.toml"
+    reg.write_text(
+        f'defaults = "oops"\n[[vaults]]\nid = "{WORKSPACE}"\n'
+        f'endpoint = "https://{TAILNET_IP}:8020"\n',
+        encoding="utf-8",
+    )
+    out = resolve_memory_endpoints(
+        WORKSPACE, None, env={}, registry_sources=[(reg, "consumer_registry")]
+    )
+    assert all(c.source != "consumer_registry" for c in out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Fleet wave from template-repo#180 (validated via the health-vault canary #16).

## What
This repo's SessionStart prefetch used the **loopback-only** SSRF guard (ws-ops#170) and/or lacked the shared resolver, so on non-central tailnet hosts the substrate was unreachable and the memory gate hard-blocked code edits.

- Add `scripts/hook_memory_manifest.py` — shared resolver (ws-ops#171, hardened via template#187/#188): probes env-bridge `*.ts.net` → consumer-registry HTTPS → loopback, allowlist-validated.
- Replace `scripts/hook_session_start_memory_prefetch.py` with the template version that probes those candidates (timeout→warn / unreachable→block preserved).
- Bring `scripts/hook_repo_root.py` to canonical (adds `worktree_root_for` + session resolvers; additive).
- Add resolver + prefetch + repo-root tests.

Operational: non-central hosts set `AGENTIC_MEMORY_BRIDGE_HOST=<host>.ts.net`. Real Tier-3 memory for an unprovisioned workspace still needs the bridge to expose it (agent-factory#301); until then the gate degrades to **warn-only** (no false block).

## Verified
Self-contained resolver + prefetch tests pass locally + ruff clean; CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)