### PR TITLE
feat(governance): cross-harness hooks for Cursor + Codex (#338)

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Edit|Write|MultiEdit|NotebookEdit|StrReplace|apply_patch|create_file|edit_file", "hooks": [ { "type": "command", "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; cd \"$root\" || exit 0; python3 \"$root/scripts/hook_memory_gate.py\"", "timeout": 10000 } ] },
+      { "matcher": "Bash|Shell|run_command|run_shell_command", "hooks": [ { "type": "command", "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; bash \"$root/scripts/hook_bash_pre_tool.sh\"", "timeout": 10000 } ] }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      { "command": "python3 \"${FLEET_GOVERNANCE_ROOT:-$HOME/.fleet-governance}/wrappers/cursor_hook_adapter.py\" hook_memory_gate.py --hard", "failClosed": true }
+    ],
+    "beforeShellExecution": [
+      { "command": "python3 \"${FLEET_GOVERNANCE_ROOT:-$HOME/.fleet-governance}/wrappers/cursor_hook_adapter.py\" hook_bash_pre_tool.sh --shell --hard", "failClosed": true }
+    ]
+  }
+}


### PR DESCRIPTION
feat(governance): cross-harness hooks for Cursor + Codex (#338)

Wire .cursor/hooks.json (preToolUse + beforeShellExecution -> cursor adapter ->
shim -> hub) and .codex/hooks.json (interactive codex; native exit-2 block).
Both delegate to the canonical hub at $HOME/.fleet-governance. Antigravity is
governed via a user-level ~/.gemini/hooks.json installed per-workstation.

codex exec / agy --print headless do not run hooks -> server belt is the floor.

## Summary by Sourcery

Add governance hook configuration files for Cursor and Codex to delegate to the central fleet governance hub.

New Features:
- Introduce .cursor/hooks.json to enable cross-harness governance hooks for Cursor.
- Introduce .codex/hooks.json to enable cross-harness governance hooks for Codex.