### PR TITLE
fix(governance): public checker asserts harness-config PRESENCE (closes deletion blind spot)

### DIFF
--- a/tests/test_public_governance_conformance.py
+++ b/tests/test_public_governance_conformance.py
@@ -70,9 +70,14 @@ def test_claude_settings_wire_memory_gate() -> None:
     assert "hook_memory_gate" in blob, "PreToolUse must wire hook_memory_gate (first-try gate)"
 
 
-def test_tracked_harness_configs_wire_gate() -> None:
-    """Each harness config present in the tree must wire the memory gate (fresh-clone coverage)."""
+def test_tracked_harness_configs_present_and_wire_gate() -> None:
+    """Required harness configs must be TRACKED (present) AND wire the memory gate, so a fresh clone
+    in that harness gets the first-try gate. Asserting presence (not `if present`) means DELETING a
+    harness config is caught — not just mutation (agent-factory#350 falsification: closes the
+    deletion blind spot)."""
     for rel in (".cursor/hooks.json", ".codex/hooks.json"):
         p = REPO_ROOT / rel
-        if p.is_file():
-            assert _wires_gate(p), f"{rel} present but does not wire hook_memory_gate"
+        assert p.is_file(), (
+            f"{rel} missing — fresh-clone agents in that harness would build blind (first-try gap)"
+        )
+        assert _wires_gate(p), f"{rel} present but does not wire hook_memory_gate"


### PR DESCRIPTION
agorokh/agent-factory#350 falsification audit (Council-decided). The public conformance checker used `if path.is_file()`, so **deleting** `.cursor/.codex/hooks.json` passed silently (only mutation was caught). Now it **asserts presence**. Negative-controlled: `rm .cursor/hooks.json` now FAILS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)