### PR TITLE
fix(skills): scrub remaining defunct-agent name refs (#350)

### DIFF
--- a/.claude/rules/orchestration.md
+++ b/.claude/rules/orchestration.md
@@ -13,7 +13,7 @@ paths:
 |------|------------|
 | Issue → branch → Draft PR → implement → `make ci-fast` | `.claude/skills/orchestrate/SKILL.md` |
 | Green CI + GraphQL `reviewThreads` + `sleep 600` | `.claude/skills/resolve-pr/SKILL.md` |
-| Dependabot / workflows / `.mcp.json` risk + merge order | `.claude/skills/dependency-review/SKILL.md` → then **pr-resolution-follow-up** for the bot loop |
+| Dependabot / workflows / `.mcp.json` risk + merge order | `.claude/skills/dependency-review/SKILL.md` → then **resolve-pr** for the bot loop |
 | Post-merge pattern extraction (optional) | `.claude/skills/learner/SKILL.md` |
 | After merge: sync main, classify diff, vault handoff | `.claude/skills/post-merge/SKILL.md` |
 

--- a/.claude/settings.base.json
+++ b/.claude/settings.base.json
@@ -18,7 +18,7 @@
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; cd \"$root\" || exit 0; if [ \"${CLAUDE_SKIP_NETWORK:-}\" = \"1\" ]; then exit 0; fi; ( git fetch origin main --quiet 2>/dev/null & _pmf=$!; ( sleep 8; kill $_pmf 2>/dev/null ) & wait $_pmf 2>/dev/null ) || true; BEHIND=$(git rev-list --count main..origin/main 2>/dev/null || echo 0); case \"$BEHIND\" in ''|*[!0-9]*) BEHIND=0;; esac; if [ \"$BEHIND\" -gt 0 ] 2>/dev/null; then echo \"WARNING: local main is $BEHIND commit(s) behind origin/main. Run post-merge-steward (see .claude/agents/post-merge-steward.md) or: git checkout main && git pull --ff-only origin main\"; fi"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; cd \"$root\" || exit 0; if [ \"${CLAUDE_SKIP_NETWORK:-}\" = \"1\" ]; then exit 0; fi; ( git fetch origin main --quiet 2>/dev/null & _pmf=$!; ( sleep 8; kill $_pmf 2>/dev/null ) & wait $_pmf 2>/dev/null ) || true; BEHIND=$(git rev-list --count main..origin/main 2>/dev/null || echo 0); case \"$BEHIND\" in ''|*[!0-9]*) BEHIND=0;; esac; if [ \"$BEHIND\" -gt 0 ] 2>/dev/null; then echo \"WARNING: local main is $BEHIND commit(s) behind origin/main. Run post-merge-steward (see .claude/skills/post-merge/SKILL.md) or: git checkout main && git pull --ff-only origin main\"; fi"
           },
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; cd \"$root\" || exit 0; if [ \"${CLAUDE_SKIP_NETWORK:-}\" = \"1\" ]; then exit 0; fi; ( git fetch origin main --quiet 2>/dev/null & _pmf=$!; ( sleep 8; kill $_pmf 2>/dev/null ) & wait $_pmf 2>/dev/null ) || true; BEHIND=$(git rev-list --count main..origin/main 2>/dev/null || echo 0); case \"$BEHIND\" in ''|*[!0-9]*) BEHIND=0;; esac; if [ \"$BEHIND\" -gt 0 ] 2>/dev/null; then echo \"WARNING: local main is $BEHIND commit(s) behind origin/main. Run post-merge-steward (see .claude/agents/post-merge-steward.md) or: git checkout main && git pull --ff-only origin main\"; fi"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; cd \"$root\" || exit 0; if [ \"${CLAUDE_SKIP_NETWORK:-}\" = \"1\" ]; then exit 0; fi; ( git fetch origin main --quiet 2>/dev/null & _pmf=$!; ( sleep 8; kill $_pmf 2>/dev/null ) & wait $_pmf 2>/dev/null ) || true; BEHIND=$(git rev-list --count main..origin/main 2>/dev/null || echo 0); case \"$BEHIND\" in ''|*[!0-9]*) BEHIND=0;; esac; if [ \"$BEHIND\" -gt 0 ] 2>/dev/null; then echo \"WARNING: local main is $BEHIND commit(s) behind origin/main. Run post-merge-steward (see .claude/skills/post-merge/SKILL.md) or: git checkout main && git pull --ff-only origin main\"; fi"
           },
           {
             "type": "command",


### PR DESCRIPTION
Final scrub of bare defunct-agent name refs in .claude/rules + the SessionStart settings message (-> successor skills). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Align the dependency review orchestration table with the current resolve-pr follow-up skill name.