### PR TITLE
feat(test-harness): L1 sidecar WS-tap harness client + ci-drive (#154)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean ci-fast ci-conventional ci-format ci-lint ci-test ci-security ci-secrets ci-policy ci-agent-proof ci-csp-api ci-csp-ui-safety doppler-doctor memory-contract memory-contract-check init-knowledge bootstrap-knowledge merge-settings format lint test hooks-install hooks-run
+.PHONY: all clean ci-fast ci-conventional ci-format ci-lint ci-test ci-security ci-secrets ci-policy ci-agent-proof ci-csp-api ci-csp-ui-safety ci-drive doppler-doctor memory-contract memory-contract-check init-knowledge bootstrap-knowledge merge-settings format lint test hooks-install hooks-run
 
 PYTHON ?= python3
 
@@ -64,6 +64,13 @@ lint:
 	$(PYTHON) -m ruff check --fix src tests tools scripts
 
 test: ci-test
+
+# Layer-1 autonomous self-test (issue #154): boot a loopback sidecar and drive it with
+# the headless harness client; asserts the deterministic coaching rubric. Integration
+# smoke — kept OUT of ci-fast (which stays game-free and millisecond-fast); the same
+# logic is gated deterministically by tests/test_harness_client.py inside ci-test.
+ci-drive:
+	bash scripts/baseline_copilot_check.sh
 
 hooks-install:
 	pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,13 @@ line-ending = "lf"
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "ASYNC", "DTZ"]
 
+[tool.ruff.lint.per-file-ignores]
+# ASYNC109: the headless test-harness client (issue #154 Part C) deliberately exposes a
+# `timeout=` kwarg — `expect_coaching_response(timeout=...)` is the ergonomic API a test
+# wants; the rule's suggested asyncio.timeout wrapper would force every caller to wrap
+# each call for no real benefit. Internals still use asyncio.wait_for for the deadline.
+"tools/ai_sidecar/harness_client.py" = ["ASYNC109"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra"

--- a/scripts/baseline_copilot_check.sh
+++ b/scripts/baseline_copilot_check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Baseline copilot harness smoke (issue #154 Part C) — the council-grade "baseline" check.
+#
+# Boots a loopback ai_sidecar, drives it with the headless harness client, and asserts the
+# deterministic coaching rubric (reference lap -> no improvementRanking; slower lap ->
+# ordered improvementRanking). Cleans up the sidecar on exit. Exit 0 = PASS.
+#
+# No Assetto Corsa, no Windows box, no human: this is the agent's L1 self-test of the
+# sidecar coaching contract. Run via `make ci-drive`.
+set -euo pipefail
+
+PYTHON="${PYTHON:-python3}"
+PORT="${AC_HARNESS_PORT:-8771}"
+URL="ws://127.0.0.1:${PORT}"
+
+# Deterministic coaching: keep the Ollama debrief OFF so the wire payload is stable.
+unset AC_COPILOT_OLLAMA_ENABLE 2>/dev/null || true
+
+echo "[baseline] starting sidecar on ${URL}"
+"${PYTHON}" -m tools.ai_sidecar --host 127.0.0.1 --port "${PORT}" &
+SIDECAR_PID=$!
+
+cleanup() {
+  kill "${SIDECAR_PID}" 2>/dev/null || true
+  wait "${SIDECAR_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# The harness client retries the initial connect, so no explicit readiness probe is
+# needed; a brief head start just keeps the logs tidy.
+sleep 0.5
+
+echo "[baseline] injecting scenario via harness client"
+if "${PYTHON}" -m tools.ai_sidecar.harness_client --url "${URL}" --inject baseline; then
+  echo "[baseline] PASS"
+  exit 0
+fi
+echo "[baseline] FAIL"
+exit 1

--- a/scripts/baseline_copilot_check.sh
+++ b/scripts/baseline_copilot_check.sh
@@ -26,9 +26,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# The harness client retries the initial connect, so no explicit readiness probe is
-# needed; a brief head start just keeps the logs tidy.
+# run_inject retries the initial connect, so no explicit readiness probe is needed for the
+# *timing* race; a brief head start just keeps the logs tidy.
 sleep 0.5
+
+# Fail fast if the sidecar we spawned already died — e.g. the port was occupied by a stale
+# process, in which case our process exits and the harness could otherwise connect to that
+# pre-existing listener and report a misleading PASS without testing this process (Codex).
+if ! kill -0 "${SIDECAR_PID}" 2>/dev/null; then
+  echo "[baseline] FAIL: sidecar (pid ${SIDECAR_PID}) is not running — is port ${PORT} already in use?"
+  exit 1
+fi
 
 echo "[baseline] injecting scenario via harness client"
 if "${PYTHON}" -m tools.ai_sidecar.harness_client --url "${URL}" --inject baseline; then

--- a/scripts/baseline_copilot_check.sh
+++ b/scripts/baseline_copilot_check.sh
@@ -10,7 +10,12 @@
 set -euo pipefail
 
 PYTHON="${PYTHON:-python3}"
-PORT="${AC_HARNESS_PORT:-8771}"
+# Pick a free ephemeral port unless the operator pins one. A guaranteed-free port makes a
+# stale-listener collision impossible — otherwise, if a pre-existing sidecar held the port,
+# our spawned process would exit and the harness could connect to that stale listener and
+# report a misleading PASS (ChatGPT Codex). The kill -0 check below still catches a sidecar
+# that failed to start for any other reason.
+PORT="${AC_HARNESS_PORT:-$("${PYTHON}" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')}"
 URL="ws://127.0.0.1:${PORT}"
 
 # Deterministic coaching: keep the Ollama debrief OFF so the wire payload is stable.
@@ -30,11 +35,10 @@ trap cleanup EXIT
 # *timing* race; a brief head start just keeps the logs tidy.
 sleep 0.5
 
-# Fail fast if the sidecar we spawned already died — e.g. the port was occupied by a stale
-# process, in which case our process exits and the harness could otherwise connect to that
-# pre-existing listener and report a misleading PASS without testing this process (Codex).
+# Fail fast if the sidecar we spawned already died (failed import, bad args, etc.) so we
+# never inject against a dead/wrong listener and report a misleading PASS (ChatGPT Codex).
 if ! kill -0 "${SIDECAR_PID}" 2>/dev/null; then
-  echo "[baseline] FAIL: sidecar (pid ${SIDECAR_PID}) is not running — is port ${PORT} already in use?"
+  echo "[baseline] FAIL: sidecar (pid ${SIDECAR_PID}) did not stay up on port ${PORT}"
   exit 1
 fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest fixtures for the AC Copilot Trainer test suite (issue #154 Part C)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "llm_live: exercises a live Ollama endpoint (nondeterministic); deselected by default.",
+    )
+
+
+@pytest.fixture
+def disable_ollama(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the deterministic coaching path: no Ollama ``debrief`` on coaching_response.
+
+    The sidecar attaches a ``debrief`` field only when ``AC_COPILOT_OLLAMA_ENABLE`` is
+    truthy (``tools/ai_sidecar/coaching/llm_coach.py:debrief_feature_enabled``). Golden
+    coaching_response tests must run with it unset so the wire payload is deterministic.
+    """
+    monkeypatch.delenv("AC_COPILOT_OLLAMA_ENABLE", raising=False)

--- a/tests/fixtures/golden/coaching_response_ref_then_slower.json
+++ b/tests/fixtures/golden/coaching_response_ref_then_slower.json
@@ -1,0 +1,45 @@
+{
+  "protocol": 1,
+  "event": "coaching_response",
+  "lap": 2,
+  "hints": [
+    {
+      "kind": "general",
+      "text": "Sidecar v1: ack lap 2"
+    }
+  ],
+  "improvementRanking": [
+    {
+      "corner": 1,
+      "metric": "min_speed_kmh",
+      "last": 48.0,
+      "reference": 55.0,
+      "priority": 0.1273,
+      "suggestion": "Corner 1: carry more minimum speed (last 48.0 km/h vs reference 55.0 km/h)."
+    },
+    {
+      "corner": 1,
+      "metric": "apex_speed_kmh",
+      "last": 88.0,
+      "reference": 95.0,
+      "priority": 0.0737,
+      "suggestion": "Corner 1: raise apex speed (last 88.0 km/h vs reference 95.0 km/h)."
+    },
+    {
+      "corner": 2,
+      "metric": "min_speed_kmh",
+      "last": 58.0,
+      "reference": 60.0,
+      "priority": 0.0333,
+      "suggestion": "Corner 2: carry more minimum speed (last 58.0 km/h vs reference 60.0 km/h)."
+    },
+    {
+      "corner": 2,
+      "metric": "apex_speed_kmh",
+      "last": 99.0,
+      "reference": 102.0,
+      "priority": 0.0294,
+      "suggestion": "Corner 2: raise apex speed (last 99.0 km/h vs reference 102.0 km/h)."
+    }
+  ]
+}

--- a/tests/test_harness_client.py
+++ b/tests/test_harness_client.py
@@ -1,0 +1,216 @@
+"""L1 sidecar WS-tap harness client tests (issue #154 Part C).
+
+Drives a real in-process ``ai_sidecar`` over a loopback WebSocket with the headless
+``HarnessClient`` and asserts the deterministic coaching surface — the agent's no-human
+self-test of the sidecar contract. Plain ``asyncio.run`` (repo has no pytest-asyncio).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+websockets = pytest.importorskip("websockets")
+from websockets.asyncio.server import serve as ws_serve  # noqa: E402
+
+from tools.ai_sidecar.harness_client import (  # noqa: E402
+    BASELINE_LAP_FRAMES,
+    HarnessClient,
+    evaluate_baseline_rubric,
+    main,
+    run_inject,
+)
+from tools.ai_sidecar.protocol import prepare_outbound_message  # noqa: E402
+from tools.ai_sidecar.server import _external_peers, _handler, make_token_check  # noqa: E402
+from tools.ai_sidecar.session import LapComparisonState  # noqa: E402
+
+_GOLDEN = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "golden"
+    / "coaching_response_ref_then_slower.json"
+)
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+@asynccontextmanager
+async def _running_sidecar(token: str | None = None) -> AsyncIterator[int]:
+    port = _free_port()
+    process_request = make_token_check(token)
+    _external_peers.clear()
+    try:
+        async with ws_serve(
+            lambda ws: _handler(ws, reply_coaching=True),
+            "127.0.0.1",
+            port,
+            process_request=process_request,
+        ):
+            yield port
+    finally:
+        _external_peers.clear()
+
+
+def _ws_url(port: int) -> str:
+    return f"ws://127.0.0.1:{port}/"
+
+
+def test_hello_handshake() -> None:
+    async def _run() -> dict[str, Any] | None:
+        async with _running_sidecar() as port:
+            async with HarnessClient(_ws_url(port)) as hc:
+                return await hc.hello(timeout=2.0)
+
+    ack = asyncio.run(_run())
+    assert ack is not None
+    assert ack["type"] == "hello_ack"
+    assert "config.set" in ack["capabilities"]
+
+
+def test_baseline_scenario_matches_golden(disable_ollama: None) -> None:
+    """The slower lap's coaching_response on the wire must equal the committed golden
+    AND the in-process deterministic generator — wire == golden == pure function."""
+
+    async def _run() -> list[dict[str, Any]]:
+        captured: list[dict[str, Any]] = []
+        async with _running_sidecar() as port:
+            async with HarnessClient(_ws_url(port)) as hc:
+                assert await hc.hello(timeout=2.0) is not None
+                for frame in BASELINE_LAP_FRAMES:
+                    await hc.send(frame)
+                    resp = await hc.expect_coaching_response(lap=frame["lap"], timeout=3.0)
+                    assert resp is not None, f"no coaching_response for lap {frame['lap']}"
+                    captured.append(resp)
+        return captured
+
+    captured = asyncio.run(_run())
+    assert len(captured) == 2
+    first, second = captured
+
+    # Reference lap: ack only, no ranking yet.
+    assert "improvementRanking" not in first
+
+    # Cross-check the in-process deterministic generator (ref primes state, then slower).
+    state = LapComparisonState()
+    prepare_outbound_message(BASELINE_LAP_FRAMES[0], reply_coaching=True, lap_state=state)
+    expected = prepare_outbound_message(
+        BASELINE_LAP_FRAMES[1], reply_coaching=True, lap_state=state
+    )
+
+    golden = json.loads(_GOLDEN.read_text(encoding="utf-8"))
+    assert expected == golden, "committed golden drifted from prepare_outbound_message"
+    assert second == golden, "wire coaching_response drifted from golden"
+
+    # Spot-check the ordering contract: biggest-regret corner first.
+    ranking = second["improvementRanking"]
+    assert ranking[0]["corner"] == 1
+    assert ranking[0]["metric"] == "min_speed_kmh"
+    assert [r["priority"] for r in ranking] == sorted(
+        (r["priority"] for r in ranking), reverse=True
+    )
+
+
+def test_run_inject_baseline_passes(disable_ollama: None) -> None:
+    async def _run() -> tuple[int, dict[str, Any]]:
+        async with _running_sidecar() as port:
+            return await run_inject(_ws_url(port), scenario="baseline", timeout=3.0)
+
+    code, detail = asyncio.run(_run())
+    assert code == 0, detail
+    assert detail["responses"] == 2
+    assert detail["ranking_len"] >= 1
+
+
+def test_run_inject_unknown_scenario_returns_2() -> None:
+    code, detail = asyncio.run(run_inject("ws://127.0.0.1:1/", scenario="nope"))
+    assert code == 2
+    assert "unknown scenario" in detail["reason"]
+
+
+def test_main_baseline_exit_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def _fake_inject(*_a: Any, **_k: Any) -> tuple[int, dict[str, Any]]:
+        return 0, {"responses": 2, "ranking_len": 4}
+
+    monkeypatch.setattr("tools.ai_sidecar.harness_client.run_inject", _fake_inject)
+    rc = main(["--url", "ws://127.0.0.1:9/", "--inject", "baseline"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["pass"] is True
+
+
+def test_evaluate_baseline_rubric_pass() -> None:
+    responses = [
+        {"event": "coaching_response", "lap": 1, "hints": []},
+        {
+            "event": "coaching_response",
+            "lap": 2,
+            "improvementRanking": [
+                {"corner": 1, "priority": 0.12},
+                {"corner": 2, "priority": 0.03},
+            ],
+        },
+    ]
+    ok, detail = evaluate_baseline_rubric(responses)
+    assert ok, detail
+    assert detail["top"]["corner"] == 1
+
+
+def test_evaluate_baseline_rubric_failures() -> None:
+    # Too few responses.
+    ok, _ = evaluate_baseline_rubric([{"event": "coaching_response", "lap": 1}])
+    assert not ok
+    # Missing lap 2.
+    ok, _ = evaluate_baseline_rubric(
+        [{"lap": 1}, {"lap": 1, "improvementRanking": [{"priority": 1}]}]
+    )
+    assert not ok
+    # Reference lap wrongly carries a ranking.
+    ok, _ = evaluate_baseline_rubric(
+        [
+            {"lap": 1, "improvementRanking": [{"priority": 1}]},
+            {"lap": 2, "improvementRanking": [{"priority": 1}]},
+        ]
+    )
+    assert not ok
+    # Slower lap has empty ranking.
+    ok, _ = evaluate_baseline_rubric([{"lap": 1}, {"lap": 2, "improvementRanking": []}])
+    assert not ok
+    # Ranking not ordered by descending priority.
+    ok, _ = evaluate_baseline_rubric(
+        [{"lap": 1}, {"lap": 2, "improvementRanking": [{"priority": 0.1}, {"priority": 0.9}]}]
+    )
+    assert not ok
+
+
+def test_harness_send_without_connect_raises() -> None:
+    async def _run() -> None:
+        hc = HarnessClient("ws://127.0.0.1:1/")
+        with pytest.raises(RuntimeError, match="not connected"):
+            await hc.send({"v": 1, "type": "hello", "client": "x"})
+
+    asyncio.run(_run())
+
+
+def test_connect_retries_then_raises_on_dead_port() -> None:
+    async def _run() -> None:
+        hc = HarnessClient("ws://127.0.0.1:1/")
+        with pytest.raises(OSError):
+            await hc.connect(retries=2, retry_delay=0.01)
+
+    asyncio.run(_run())

--- a/tests/test_harness_client.py
+++ b/tests/test_harness_client.py
@@ -170,8 +170,8 @@ def test_evaluate_baseline_rubric_pass() -> None:
             "event": "coaching_response",
             "lap": 2,
             "improvementRanking": [
-                {"corner": 1, "priority": 0.12},
-                {"corner": 2, "priority": 0.03},
+                {"corner": 1, "metric": "min_speed_kmh", "priority": 0.12},
+                {"corner": 2, "metric": "apex_speed_kmh", "priority": 0.03},
             ],
         },
     ]
@@ -205,6 +205,35 @@ def test_evaluate_baseline_rubric_failures() -> None:
         [{"lap": 1}, {"lap": 2, "improvementRanking": [{"priority": 0.1}, {"priority": 0.9}]}]
     )
     assert not ok
+    # Non-empty + sorted but the WRONG corner/metric ranked first must fail (Codex): a
+    # single {corner: 99} item would otherwise pass and hide a ranking regression.
+    ok, _ = evaluate_baseline_rubric(
+        [
+            {"lap": 1},
+            {
+                "lap": 2,
+                "improvementRanking": [{"corner": 99, "metric": "min_speed_kmh", "priority": 0.9}],
+            },
+        ]
+    )
+    assert not ok
+
+
+def test_wait_for_preserves_out_of_order_frames() -> None:
+    """A frame that arrives before the one we're waiting for is buffered, not discarded."""
+
+    async def _run() -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        hc = HarnessClient("ws://127.0.0.1:1/")
+        await hc._queue.put({"event": "B", "n": 1})  # arrives first
+        await hc._queue.put({"event": "A", "n": 2})  # arrives second
+        # Ask for A first: B must be buffered so the later wait still finds it.
+        a = await hc.wait_for(lambda f: f.get("event") == "A", timeout=1.0)
+        b = await hc.wait_for(lambda f: f.get("event") == "B", timeout=1.0)
+        return a, b
+
+    a, b = asyncio.run(_run())
+    assert a is not None and a["n"] == 2
+    assert b is not None and b["n"] == 1
 
 
 def test_harness_send_without_connect_raises() -> None:

--- a/tests/test_harness_client.py
+++ b/tests/test_harness_client.py
@@ -141,6 +141,15 @@ def test_run_inject_unknown_scenario_returns_2() -> None:
     assert "unknown scenario" in detail["reason"]
 
 
+def test_run_inject_connect_failure_returns_1() -> None:
+    """A still-dead sidecar exhausts the retry budget and reports a clean failure (Cursor)."""
+    code, detail = asyncio.run(
+        run_inject("ws://127.0.0.1:1/", connect_retries=2, connect_retry_delay=0.01)
+    )
+    assert code == 1
+    assert "could not connect" in detail["reason"]
+
+
 def test_main_baseline_exit_zero(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tools/ai_sidecar/harness_client.py
+++ b/tools/ai_sidecar/harness_client.py
@@ -97,6 +97,9 @@ class HarnessClient:
             self._headers[AUTH_HEADER] = token
         self.frames: list[dict[str, Any]] = []
         self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        # Frames pulled from the queue that an earlier wait_for() did not match are kept
+        # here so a later expect_*() can still find them (out-of-order arrival robustness).
+        self._pending: list[dict[str, Any]] = []
         self._ws: Any = None
         self._recv_task: asyncio.Task[None] | None = None
 
@@ -182,7 +185,15 @@ class HarnessClient:
     async def wait_for(
         self, predicate: Callable[[dict[str, Any]], bool], *, timeout: float = 5.0
     ) -> dict[str, Any] | None:
-        """Return the next received frame matching ``predicate``, or ``None`` on timeout."""
+        """Return the next frame matching ``predicate``, or ``None`` on timeout.
+
+        Frames already received but not matched by an earlier wait are searched first and
+        consumed on match; new non-matching frames are buffered (not discarded) so a later
+        ``expect_*`` can still find a response that arrived out of order (ChatGPT Codex).
+        """
+        for i, frame in enumerate(self._pending):
+            if predicate(frame):
+                return self._pending.pop(i)
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         while True:
@@ -195,6 +206,7 @@ class HarnessClient:
                 return None
             if predicate(frame):
                 return frame
+            self._pending.append(frame)
 
     async def expect_coaching_response(
         self, *, lap: int | None = None, timeout: float = 5.0
@@ -244,7 +256,15 @@ def evaluate_baseline_rubric(
     if priorities != sorted(priorities, reverse=True):
         detail["reason"] = "improvementRanking not ordered by descending priority"
         return False, detail
-    detail["top"] = ranking[0]
+    # The baseline frames are deterministic: corner 1 loses the most min-speed, so it must
+    # rank first. Asserting the exact top item makes ci-drive catch ranking regressions —
+    # a non-empty-but-wrong ranking (e.g. corner 99 first) otherwise passes (ChatGPT Codex).
+    top = ranking[0]
+    if top.get("corner") != 1 or top.get("metric") != "min_speed_kmh":
+        detail["reason"] = f"top-ranked item is not the expected corner-1 min_speed_kmh: {top}"
+        detail["top"] = top
+        return False, detail
+    detail["top"] = top
     detail["ranking_len"] = len(ranking)
     return True, detail
 

--- a/tools/ai_sidecar/harness_client.py
+++ b/tools/ai_sidecar/harness_client.py
@@ -110,9 +110,12 @@ class HarnessClient:
     async def connect(self, *, retries: int = 1, retry_delay: float = 0.25) -> None:
         """Open the socket and start the background receive loop.
 
-        Retries the initial connect on a refused/unreachable socket so a harness launched
-        immediately after the sidecar process does not race the listen() (see
-        scripts/baseline_copilot_check.sh).
+        Pass ``retries > 1`` to tolerate a refused/unreachable socket (e.g. a sidecar still
+        booting): the connect is re-attempted ``retries`` times, ``retry_delay`` seconds
+        apart. The default (``retries=1``) is a single attempt, suited to tests that connect
+        to an already-listening sidecar; ``run_inject`` — the CLI / ``ci-drive`` path that
+        races a just-spawned sidecar — passes a generous budget so the script's fixed sleep
+        is only a head start, not the correctness guard.
         """
         from websockets.asyncio.client import connect as ws_connect
 
@@ -247,12 +250,28 @@ def evaluate_baseline_rubric(
 
 
 async def run_inject(
-    url: str, *, token: str | None = None, scenario: str = "baseline", timeout: float = 8.0
+    url: str,
+    *,
+    token: str | None = None,
+    scenario: str = "baseline",
+    timeout: float = 8.0,
+    connect_retries: int = 40,
+    connect_retry_delay: float = 0.25,
 ) -> tuple[int, dict[str, Any]]:
-    """Connect, inject ``scenario``, evaluate the rubric. Returns ``(exit_code, detail)``."""
+    """Connect, inject ``scenario``, evaluate the rubric. Returns ``(exit_code, detail)``.
+
+    Uses a generous connect-retry budget (default ~10s) so the CLI / ``ci-drive`` path is
+    robust against a sidecar that is still booting — the fixed sleep in
+    ``baseline_copilot_check.sh`` is only a head start, not the correctness guard.
+    """
     if scenario != "baseline":
         return 2, {"reason": f"unknown scenario: {scenario!r}"}
-    async with HarnessClient(url, token=token) as hc:
+    hc = HarnessClient(url, token=token)
+    try:
+        await hc.connect(retries=connect_retries, retry_delay=connect_retry_delay)
+    except OSError as exc:
+        return 1, {"reason": f"could not connect to sidecar: {exc}"}
+    try:
         ack = await hc.hello(timeout=timeout)
         if ack is None:
             return 1, {"reason": "no hello_ack from sidecar"}
@@ -264,6 +283,8 @@ async def run_inject(
                 responses.append(resp)
         ok, detail = evaluate_baseline_rubric(responses)
         return (0 if ok else 1), detail
+    finally:
+        await hc.close()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -275,9 +296,21 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--token", default=None, help="X-AC-Copilot-Token for non-loopback binds")
     p.add_argument("--inject", default="baseline", choices=["baseline"], help="scenario to inject")
     p.add_argument("--timeout", type=float, default=8.0, help="per-step timeout seconds")
+    p.add_argument(
+        "--connect-retries",
+        type=int,
+        default=40,
+        help="initial-connect attempts (~0.25s apart) to tolerate a still-booting sidecar",
+    )
     args = p.parse_args(argv)
     code, detail = asyncio.run(
-        run_inject(args.url, token=args.token, scenario=args.inject, timeout=args.timeout)
+        run_inject(
+            args.url,
+            token=args.token,
+            scenario=args.inject,
+            timeout=args.timeout,
+            connect_retries=args.connect_retries,
+        )
     )
     print(json.dumps({"pass": code == 0, "detail": detail}, indent=2))
     return code

--- a/tools/ai_sidecar/harness_client.py
+++ b/tools/ai_sidecar/harness_client.py
@@ -1,0 +1,287 @@
+"""Headless WebSocket harness client for agent-driven trainer tests (issue #154 Part C).
+
+This is the **Layer-1 (L1) tap** of the autonomous self-test harness: a headless v1
+WebSocket peer that drives a running ``ai_sidecar`` the same way the in-game Lua app
+does — injecting ``lap_complete`` / ``corner_query`` frames and capturing the sidecar's
+``coaching_response`` / ``corner_advice`` / ``state.snapshot`` replies — so a test (or a
+CLI rubric) can assert on them with **no Assetto Corsa, no Windows box, and no human**.
+
+The sidecar's legacy coaching flow (``{"protocol":1,"event":"lap_complete"}`` ->
+``coaching_response``) is per-connection and needs no second peer, so this client drives
+and asserts the deterministic rules-engine surface (hints + ``improvementRanking``) on a
+developer machine. The v1 ``{"v":1,"type":...}`` envelope (hello / state.subscribe) is
+also spoken for the observation surface.
+
+CLI rubric (used by ``scripts/baseline_copilot_check.sh`` / ``make ci-drive``)::
+
+    python -m tools.ai_sidecar.harness_client --url ws://127.0.0.1:8765 --inject baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from tools.ai_sidecar.external_protocol import (
+    AUTH_HEADER,
+    CLIENT_HEADER,
+    ENVELOPE_KEY,
+    ENVELOPE_VERSION,
+    TYPE_HELLO,
+    TYPE_HELLO_ACK,
+    TYPE_KEY,
+)
+from tools.ai_sidecar.protocol import (
+    EVENT_COACHING_RESPONSE,
+    EVENT_CORNER_ADVICE,
+    PROTOCOL_VERSION,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default deterministic scenario: a fast reference lap followed by a slower lap on the
+# same two corners. Mirrors tests/fixtures/lap_sidecar_{ref,last}.json so the sidecar
+# emits a coaching_response with NO improvementRanking for the reference lap and an
+# ordered improvementRanking for the slower lap. Inlined (not loaded from tests/) so the
+# CLI works from an installed package without the test tree.
+BASELINE_LAP_FRAMES: tuple[dict[str, Any], ...] = (
+    {
+        "protocol": PROTOCOL_VERSION,
+        "event": "lap_complete",
+        "lap": 1,
+        "lapTimeMs": 90000,
+        "telemetry": {
+            "corners": [
+                {"id": 1, "minSpeedKmh": 55, "apexSpeedKmh": 95},
+                {"id": 2, "minSpeedKmh": 60, "apexSpeedKmh": 102},
+            ]
+        },
+    },
+    {
+        "protocol": PROTOCOL_VERSION,
+        "event": "lap_complete",
+        "lap": 2,
+        "lapTimeMs": 94000,
+        "telemetry": {
+            "corners": [
+                {"id": 1, "minSpeedKmh": 48, "apexSpeedKmh": 88},
+                {"id": 2, "minSpeedKmh": 58, "apexSpeedKmh": 99},
+            ]
+        },
+    },
+)
+
+
+class HarnessClient:
+    """A headless WS peer that injects frames and captures the sidecar's replies.
+
+    Use as an async context manager::
+
+        async with HarnessClient(url, token=tok) as hc:
+            await hc.hello()
+            await hc.send(frame)
+            resp = await hc.expect_coaching_response(lap=2)
+    """
+
+    def __init__(
+        self, url: str, *, token: str | None = None, client_id: str = "ac-harness"
+    ) -> None:
+        self.url = url
+        self.client_id = client_id
+        self._headers: dict[str, str] = {CLIENT_HEADER: client_id}
+        if token:
+            self._headers[AUTH_HEADER] = token
+        self.frames: list[dict[str, Any]] = []
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._ws: Any = None
+        self._recv_task: asyncio.Task[None] | None = None
+
+    async def __aenter__(self) -> HarnessClient:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.close()
+
+    async def connect(self, *, retries: int = 1, retry_delay: float = 0.25) -> None:
+        """Open the socket and start the background receive loop.
+
+        Retries the initial connect on a refused/unreachable socket so a harness launched
+        immediately after the sidecar process does not race the listen() (see
+        scripts/baseline_copilot_check.sh).
+        """
+        from websockets.asyncio.client import connect as ws_connect
+
+        last_exc: Exception | None = None
+        for _ in range(max(1, retries)):
+            try:
+                self._ws = await ws_connect(self.url, additional_headers=self._headers)
+            except OSError as exc:  # ConnectionRefused / DNS / unreachable
+                last_exc = exc
+                await asyncio.sleep(retry_delay)
+                continue
+            self._recv_task = asyncio.create_task(self._recv_loop())
+            return
+        assert last_exc is not None
+        raise last_exc
+
+    async def close(self) -> None:
+        if self._recv_task is not None:
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except asyncio.CancelledError:
+                pass
+            self._recv_task = None
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def _recv_loop(self) -> None:
+        try:
+            async for raw in self._ws:
+                if not isinstance(raw, str):
+                    continue
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning("harness: non-JSON frame ignored: %s", raw[:120])
+                    continue
+                if isinstance(data, dict):
+                    self.frames.append(data)
+                    await self._queue.put(data)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # connection closed / reset — end the loop quietly
+            logger.info("harness recv loop ended: %s", exc)
+
+    async def send(self, frame: dict[str, Any]) -> None:
+        if self._ws is None:
+            raise RuntimeError("harness client is not connected")
+        await self._ws.send(json.dumps(frame, separators=(",", ":")))
+
+    async def hello(self, *, timeout: float = 5.0) -> dict[str, Any] | None:
+        """Send the v1 hello and wait for the sidecar's hello_ack."""
+        await self.send(
+            {ENVELOPE_KEY: ENVELOPE_VERSION, TYPE_KEY: TYPE_HELLO, "client": self.client_id}
+        )
+        return await self.wait_for(lambda f: f.get(TYPE_KEY) == TYPE_HELLO_ACK, timeout=timeout)
+
+    async def subscribe(self, topics: list[str], *, timeout: float = 2.0) -> None:
+        await self.send(
+            {ENVELOPE_KEY: ENVELOPE_VERSION, TYPE_KEY: "state.subscribe", "topics": topics}
+        )
+
+    async def wait_for(
+        self, predicate: Callable[[dict[str, Any]], bool], *, timeout: float = 5.0
+    ) -> dict[str, Any] | None:
+        """Return the next received frame matching ``predicate``, or ``None`` on timeout."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return None
+            try:
+                frame = await asyncio.wait_for(self._queue.get(), timeout=remaining)
+            except TimeoutError:
+                return None
+            if predicate(frame):
+                return frame
+
+    async def expect_coaching_response(
+        self, *, lap: int | None = None, timeout: float = 5.0
+    ) -> dict[str, Any] | None:
+        def _pred(f: dict[str, Any]) -> bool:
+            if f.get("event") != EVENT_COACHING_RESPONSE:
+                return False
+            return lap is None or f.get("lap") == lap
+
+        return await self.wait_for(_pred, timeout=timeout)
+
+    async def expect_corner_advice(
+        self, *, corner: str, timeout: float = 5.0
+    ) -> dict[str, Any] | None:
+        return await self.wait_for(
+            lambda f: f.get("event") == EVENT_CORNER_ADVICE and f.get("corner") == corner,
+            timeout=timeout,
+        )
+
+
+def evaluate_baseline_rubric(
+    responses: list[dict[str, Any]],
+) -> tuple[bool, dict[str, Any]]:
+    """Pure rubric for the baseline scenario — testable without a socket.
+
+    PASS iff: two coaching_response frames were captured; the reference lap (lap 1) has
+    NO improvementRanking; the slower lap (lap 2) has a non-empty improvementRanking that
+    is ordered by descending priority and whose top item is the biggest-regret corner.
+    """
+    detail: dict[str, Any] = {"responses": len(responses)}
+    if len(responses) < 2:
+        detail["reason"] = "expected 2 coaching_response frames"
+        return False, detail
+    ref = next((r for r in responses if r.get("lap") == 1), None)
+    slow = next((r for r in responses if r.get("lap") == 2), None)
+    if ref is None or slow is None:
+        detail["reason"] = "missing reference (lap 1) or slower (lap 2) response"
+        return False, detail
+    if "improvementRanking" in ref:
+        detail["reason"] = "reference lap must not carry improvementRanking"
+        return False, detail
+    ranking = slow.get("improvementRanking")
+    if not isinstance(ranking, list) or not ranking:
+        detail["reason"] = "slower lap must carry a non-empty improvementRanking"
+        return False, detail
+    priorities = [r.get("priority", 0.0) for r in ranking]
+    if priorities != sorted(priorities, reverse=True):
+        detail["reason"] = "improvementRanking not ordered by descending priority"
+        return False, detail
+    detail["top"] = ranking[0]
+    detail["ranking_len"] = len(ranking)
+    return True, detail
+
+
+async def run_inject(
+    url: str, *, token: str | None = None, scenario: str = "baseline", timeout: float = 8.0
+) -> tuple[int, dict[str, Any]]:
+    """Connect, inject ``scenario``, evaluate the rubric. Returns ``(exit_code, detail)``."""
+    if scenario != "baseline":
+        return 2, {"reason": f"unknown scenario: {scenario!r}"}
+    async with HarnessClient(url, token=token) as hc:
+        ack = await hc.hello(timeout=timeout)
+        if ack is None:
+            return 1, {"reason": "no hello_ack from sidecar"}
+        responses: list[dict[str, Any]] = []
+        for frame in BASELINE_LAP_FRAMES:
+            await hc.send(frame)
+            resp = await hc.expect_coaching_response(lap=frame["lap"], timeout=timeout)
+            if resp is not None:
+                responses.append(resp)
+        ok, detail = evaluate_baseline_rubric(responses)
+        return (0 if ok else 1), detail
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    p = argparse.ArgumentParser(
+        description="Headless AC Copilot Trainer harness client (issue #154)"
+    )
+    p.add_argument("--url", default="ws://127.0.0.1:8765", help="sidecar WebSocket URL")
+    p.add_argument("--token", default=None, help="X-AC-Copilot-Token for non-loopback binds")
+    p.add_argument("--inject", default="baseline", choices=["baseline"], help="scenario to inject")
+    p.add_argument("--timeout", type=float, default=8.0, help="per-step timeout seconds")
+    args = p.parse_args(argv)
+    code, detail = asyncio.run(
+        run_inject(args.url, token=args.token, scenario=args.inject, timeout=args.timeout)
+    )
+    print(json.dumps({"pass": code == 0, "detail": detail}, indent=2))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## EPIC #154 Part C — Layer-1 sidecar WS-tap harness

The L1 tap of the autonomous self-test harness: a **headless WebSocket peer** that drives a running `ai_sidecar` exactly like the in-game Lua app does — injecting `lap_complete` frames and capturing `coaching_response` — so the agent can assert the deterministic coaching surface with **no Assetto Corsa, no Windows box, no human**. This is the reusable observation tap that the later in-sim layers (L1.5/L2) build on. ADR: `docs/01_Vault/AcCopilotTrainer/01_Decisions/autonomous-self-test-harness.md` (vault PR #155).

### What's here
- **`tools/ai_sidecar/harness_client.py`** — `HarnessClient` (`connect`/`hello`/`send`/`expect_coaching_response`/`expect_corner_advice`) with a connect-retry, a pure `evaluate_baseline_rubric`, an async `run_inject`, and a CLI: `python -m tools.ai_sidecar.harness_client --url ws://… --inject baseline`.
- **`tests/test_harness_client.py`** — drives a real in-process sidecar over loopback; the slower lap's `coaching_response` **on the wire == committed golden == `prepare_outbound_message` output** (wire == golden == pure function). 9 tests; also covers the rubric branches, connect-retry, and CLI.
- **`tests/conftest.py`** — `disable_ollama` fixture (forces the deterministic, Ollama-off path) + `llm_live` marker registration.
- **`tests/fixtures/golden/coaching_response_ref_then_slower.json`** — the deterministic golden.
- **`scripts/baseline_copilot_check.sh` + `make ci-drive`** — boot-a-sidecar-and-assert integration smoke (the council-grade "baseline" check). Kept **out of `ci-fast`** so the gate stays game-free and fast; the same logic is gated deterministically inside `ci-test`.
- **`pyproject.toml`** — documented per-file `ASYNC109` ignore for the harness client's intentional `timeout=` kwarg API.

### Verification (operator-grade, observed not inferred)
- `make ci-format` clean · `make ci-lint` clean · `make ci-test` → **742 passed** (the one local red, `test_repo_knowledge/test_mcp_server_import.py`, is a **pre-existing, unrelated** test-isolation bug that only triggers without the `[knowledge]` extra — confirmed on clean `main`, green in CI which installs `mcp`; filed separately).
- `make ci-drive` → **`[baseline] PASS`**: the harness boots a real sidecar, connects (`external hello accepted client=ac-harness`), injects two laps, and the slower lap yields the correct ordered `improvementRanking` (corner 1 `min_speed_kmh` first, priority `0.1273`).

Refs #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
