### PR TITLE
feat(test-harness): L0 off-sim Lua trace-replay layer + schema reflection (#154)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,11 @@ omit = [
   "tools/process_miner/run.py",
   "tools/repo_knowledge/mcp_server.py",
   "tools/ai_sidecar/__main__.py",
+  # Opt-in semantic-clustering module: imports sentence-transformers / sklearn
+  # (the ".[mining-semantic]" extra, NOT in ".[dev]"). Its entire test file is
+  # importorskip-gated on sklearn, so in the default ci-test venv it is
+  # structurally 0%-coverable -- same class as mcp_server.py above. Omit so the
+  # deps-gated module does not drag the aggregate floor below 80% when the
+  # optional ML stack is absent (it was already pulling ci-test under 80 on main).
+  "tools/process_miner/semantic_cluster.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,11 +111,4 @@ omit = [
   "tools/process_miner/run.py",
   "tools/repo_knowledge/mcp_server.py",
   "tools/ai_sidecar/__main__.py",
-  # Opt-in semantic-clustering module: imports sentence-transformers / sklearn
-  # (the ".[mining-semantic]" extra, NOT in ".[dev]"). Its entire test file is
-  # importorskip-gated on sklearn, so in the default ci-test venv it is
-  # structurally 0%-coverable -- same class as mcp_server.py above. Omit so the
-  # deps-gated module does not drag the aggregate floor below 80% when the
-  # optional ML stack is absent (it was already pulling ci-test under 80 on main).
-  "tools/process_miner/semantic_cluster.py",
 ]

--- a/tests/fixtures/csp_luajit_parity.lua
+++ b/tests/fixtures/csp_luajit_parity.lua
@@ -1,0 +1,51 @@
+-- LuaJIT (Lua 5.1) <-> lupa (Lua 5.5) parity shim for the L0 trace-replay harness.
+--
+-- WHY THIS EXISTS
+-- ---------------
+-- CSP runs the coaching modules under LuaJIT, which implements the Lua 5.1 API.
+-- The off-sim trace-replay harness runs the SAME modules under lupa, which (as of
+-- lupa 2.8) binds Lua 5.5. A handful of stdlib functions present in 5.1/LuaJIT
+-- were removed in later Lua versions; calling them throws under lupa even though
+-- they work fine in production. The runtime smoke test never caught this because
+-- it only `require()`s the modules -- it never calls `:update`/`tick`, which is
+-- where the missing functions are actually invoked.
+--
+-- This file installs the minimal set of 5.1-parity globals so the unmodified
+-- modules behave identically under lupa as under CSP/LuaJIT. Keep it MINIMAL and
+-- commented: every entry must correspond to a real call site in the modules.
+--
+-- VERIFIED GAPS (lupa 2.8 / Lua 5.5)
+-- ----------------------------------
+--   * math.atan2 -- removed in Lua 5.3+. brake_detection.lua:flatHeading() calls
+--     math.atan2(y, x) for heading. Lua 5.5's two-arg math.atan(y, x) is the
+--     direct equivalent (and is exactly what LuaJIT's math.atan2 computes).
+--     Confirmed empirically: `math.atan2 ~= nil` is false under this lupa build,
+--     and brake_detection:update() raised
+--     "attempt to call a nil value (field 'atan2')" without this shim.
+--
+-- If you discover a module needs another 5.1-only function when you actually call
+-- :update/tick under lupa, add it here (with a comment naming the call site) so
+-- the harness and CSP stay in lockstep.
+
+if not math.atan2 then
+  -- LuaJIT/Lua 5.1: math.atan2(y, x). Lua 5.5: math.atan(y, x) is identical.
+  math.atan2 = function(y, x)
+    return math.atan(y, x)
+  end
+end
+
+-- math.pow was removed in Lua 5.3 (use the ^ operator). The coaching modules do
+-- not currently use it, but it is a common LuaJIT-ism; provide it defensively so
+-- a future module edit that uses math.pow does not silently diverge between the
+-- harness and CSP.
+if not math.pow then
+  math.pow = function(base, exp)
+    return base ^ exp
+  end
+end
+
+-- `unpack` was moved to table.unpack in Lua 5.2+. LuaJIT keeps the global
+-- `unpack`. Alias it so any module that uses the bare global matches CSP.
+if not unpack and table and table.unpack then
+  unpack = table.unpack
+end

--- a/tests/test_lua_trace_replay.py
+++ b/tests/test_lua_trace_replay.py
@@ -1,0 +1,430 @@
+"""L0 off-sim Lua trace-replay tests (EPIC #154 Part A + Part B bootstrap).
+
+These run the REAL CSP coaching modules under ``lupa`` against synthetic
+telemetry traces -- no Assetto Corsa, no Windows, no WebSocket, no human. Unlike
+``tests/test_lua_runtime_smoke.py`` (which only ``require()``s the modules and so
+never exercised the ``math.atan2`` LuaJIT-parity gap), every test here actually
+CALLS ``:update`` / ``tick`` and asserts the coaching OUTPUTS.
+
+The module contracts asserted on were verified against the real source:
+
+* ``brake_detection.lua`` -- ``M.new(cfg)`` -> ``:update(car, dt)`` emits a brake
+  event ``{spline, px, py, pz, entrySpeed, heading}`` on brake RELEASE after the
+  hold qualifies (``brakeDurationMin`` 0.5 s). Uses ``math.atan2`` for heading.
+* ``realtime_coaching.lua`` -- ``M.tick(opts)`` returns a viewmodel with
+  ``primaryLine`` in {"DRIVE A LAP","BRAKE NOW","PREPARE TO BRAKE",
+  "CARRY MORE SPEED","EASE OFF","APPROACHING","ON PACE"} plus ``kind`` /
+  ``subState`` / ``cornerLabel`` / ``targetSpeedKmh`` / ``distToBrakeM``.
+* ``corner_analysis.lua`` -- ``M.buildSegments(trace, brakePoints)`` /
+  ``M.cornerFeaturesForLap(trace, segments)``.
+* ``delta.lua`` -- ``M.prepareTrace`` / ``M.bestElapsedMsAtSpline`` /
+  ``M.deltaSecondsAtSpline``.
+* ``telemetry.lua`` -- ``:update(dt, car, sim)`` (note arg order) -> per-lap
+  trace via ``finalizeLapTrace``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+from tools.ac_harness.trace_replay import (  # noqa: E402 - after importorskip
+    BRAKE_ENTRY_SPEED_KMH,
+    BRAKE_SPLINE,
+    SchemaViolationError,
+    TraceReplayHarness,
+    available_scenarios,
+    load_schema,
+    synthesize_trace,
+)
+
+
+@pytest.fixture
+def harness() -> TraceReplayHarness:
+    """A fresh lupa harness per test (modules carry module-level state)."""
+    return TraceReplayHarness()
+
+
+def _replay_brake_detection(
+    harness: TraceReplayHarness, frames: list[dict[str, float]]
+) -> list[dict[str, float]]:
+    """Drive brake_detection:update over a trace; return emitted brake events."""
+    bd = harness.require("brake_detection")
+    det = bd.new(harness.lua.table())
+    events: list[dict[str, float]] = []
+    for f in frames:
+        car = harness.make_car(
+            brake=f["brake"],
+            speedKmh=f["speed"],
+            splinePosition=f["spline"],
+            position={"x": f["px"], "y": f["py"], "z": f["pz"]},
+            look={"x": 1.0, "y": 0.0, "z": 0.0},
+        )
+        ev = harness.call_guarding_schema(det.update, det, car, 0.05)
+        if ev is not None:
+            events.append(
+                {
+                    "spline": float(ev["spline"]),
+                    "entrySpeed": float(ev["entrySpeed"]),
+                    "heading": float(ev["heading"]),
+                }
+            )
+    return events
+
+
+# ---------------------------------------------------------------------------
+# brake_detection :update -- the test that would have caught the atan2 gap
+# ---------------------------------------------------------------------------
+
+
+def test_brake_detection_emits_event_for_braking_scenario(harness: TraceReplayHarness) -> None:
+    """L0-01: the 'brake_too_late' trace produces exactly one brake event with the
+    expected entrySpeed and spline. This CALLS :update (exercising math.atan2 via
+    flatHeading), which the require()-only smoke test never did."""
+    frames = synthesize_trace("brake_too_late")
+    events = _replay_brake_detection(harness, frames)
+
+    assert len(events) == 1, f"expected exactly one brake event, got {len(events)}: {events}"
+    ev = events[0]
+    assert ev["entrySpeed"] == pytest.approx(BRAKE_ENTRY_SPEED_KMH, abs=0.01), (
+        f"entrySpeed must be the speed at first brake frame ({BRAKE_ENTRY_SPEED_KMH}), "
+        f"got {ev['entrySpeed']}"
+    )
+    assert ev["spline"] == pytest.approx(BRAKE_SPLINE, abs=1e-6), (
+        f"brake event spline must be the braking-zone start ({BRAKE_SPLINE}), got {ev['spline']}"
+    )
+    # heading came back as a real number => math.atan2 parity shim worked.
+    assert isinstance(ev["heading"], float)
+
+
+def test_brake_detection_clean_lap_emits_no_event(harness: TraceReplayHarness) -> None:
+    """L0-02 (FALSE-POSITIVE GUARD): a clean lap with zero braking must produce NO
+    brake events. A detector that fired here would generate phantom brake points."""
+    frames = synthesize_trace("clean_lap")
+    events = _replay_brake_detection(harness, frames)
+    assert events == [], f"clean lap must emit no brake events, got {events}"
+
+
+def test_brake_detection_short_tap_does_not_qualify(harness: TraceReplayHarness) -> None:
+    """L0-03: a sub-threshold-duration brake tap (< brakeDurationMin 0.5 s) must
+    NOT qualify as a brake point -- guards against twitch-braking false events."""
+    bd = harness.require("brake_detection")
+    det = bd.new(harness.lua.table())
+    # 3 frames * 0.05 s = 0.15 s of braking, then release => below the 0.5 s floor.
+    seq = [
+        (0.10, 0.0, 150.0),
+        (0.11, 0.9, 150.0),
+        (0.12, 0.9, 140.0),
+        (0.13, 0.9, 130.0),
+        (0.14, 0.0, 120.0),
+    ]
+    fired = False
+    for spline, brake, speed in seq:
+        car = harness.make_car(
+            brake=brake,
+            speedKmh=speed,
+            splinePosition=spline,
+            position={"x": 0.0, "y": 0.0, "z": 0.0},
+            look={"x": 1.0, "y": 0.0, "z": 0.0},
+        )
+        if harness.call_guarding_schema(det.update, det, car, 0.05) is not None:
+            fired = True
+    assert not fired, "a 0.15 s brake tap must not qualify (brakeDurationMin = 0.5 s)"
+
+
+# ---------------------------------------------------------------------------
+# realtime_coaching tick -- should-brake vs on-pace
+# ---------------------------------------------------------------------------
+
+
+def _brake_points_and_segments(harness: TraceReplayHarness) -> tuple:
+    """A single low-entry-speed brake point at T1 plus matching segments."""
+    brakes = harness.lua.execute(
+        """return {
+            { spline = 0.20, px = 0, py = 0, pz = 0, entrySpeed = 95, label = "T1" },
+        }"""
+    )
+    segs = harness.lua.execute(
+        """return {
+            { kind = "brake",    s0 = 0.18, s1 = 0.20, label = "B1" },
+            { kind = "corner",   s0 = 0.20, s1 = 0.26, label = "T1", brakeSpline = 0.18 },
+            { kind = "straight", s0 = 0.26, s1 = 1.00, label = "S1" },
+        }"""
+    )
+    return brakes, segs
+
+
+def test_realtime_coaching_should_brake_says_brake_now(harness: TraceReplayHarness) -> None:
+    """L0-04: ~31 m before T1 (target 95) at 142 km/h must say 'BRAKE NOW' with
+    kind='brake', a 'TARGET 95 KM/H' secondary, and cornerLabel 'T1'."""
+    rtc = harness.require("realtime_coaching")
+    rtc.reset()
+    brakes, segs = _brake_points_and_segments(harness)
+    # 31 m / 4500 m = 0.0069 ahead of 0.20 => splinePos 0.193.
+    opts = harness.lua.table()
+    opts["splinePos"] = 0.193
+    opts["currentSpeedKmh"] = 142
+    opts["brakingPoints"] = brakes
+    opts["segments"] = segs
+    opts["trackLengthM"] = 4500
+    view = rtc.tick(opts)
+
+    assert view is not None
+    assert view["primaryLine"] == "BRAKE NOW", (
+        f"~31 m before T1 (target 95) at 142 km/h must say 'BRAKE NOW', got {view['primaryLine']!r}"
+    )
+    assert view["kind"] == "brake", f"kind must be 'brake', got {view['kind']!r}"
+    assert view["subState"] == "braking", f"subState must be 'braking', got {view['subState']!r}"
+    assert "TARGET" in (view["secondaryLine"] or ""), (
+        f"secondary must show the target speed, got {view['secondaryLine']!r}"
+    )
+    assert view["cornerLabel"] == "T1", f"cornerLabel must be 'T1', got {view['cornerLabel']!r}"
+    assert view["targetSpeedKmh"] == 95, f"targetSpeedKmh must be 95, got {view['targetSpeedKmh']}"
+
+
+def test_realtime_coaching_on_pace_clean(harness: TraceReplayHarness) -> None:
+    """L0-05 (FALSE-POSITIVE GUARD): on a straight far from the next brake point and
+    not over-speed, the viewmodel must be informational ('ON PACE' / 'APPROACHING'),
+    NEVER an urgent brake/line hint. No false coaching on a clean stretch."""
+    rtc = harness.require("realtime_coaching")
+    rtc.reset()
+    brakes, segs = _brake_points_and_segments(harness)
+    opts = harness.lua.table()
+    opts["splinePos"] = 0.50  # far past T1, on the long straight
+    opts["currentSpeedKmh"] = 200
+    opts["brakingPoints"] = brakes
+    opts["segments"] = segs
+    opts["trackLengthM"] = 4500
+    view = rtc.tick(opts)
+
+    assert view is not None
+    primary = (view["primaryLine"] or "").upper()
+    assert view["kind"] == "info", (
+        f"a clean straight must yield kind='info', got {view['kind']!r} ({primary!r})"
+    )
+    assert "BRAKE" not in primary, f"clean straight must NOT raise a brake hint, got {primary!r}"
+    assert any(word in primary for word in ("ON PACE", "APPROACHING", "FREE", "NEXT")), (
+        f"clean straight viewmodel must be informational, got {primary!r}"
+    )
+
+
+def test_realtime_coaching_empty_state_is_placeholder(harness: TraceReplayHarness) -> None:
+    """L0-06: with NO reference data at all, tick returns the placeholder viewmodel
+    ('DRIVE A LAP' / subState 'no_reference') and never nil."""
+    rtc = harness.require("realtime_coaching")
+    rtc.reset()
+    opts = harness.lua.table()
+    opts["splinePos"] = 0.5
+    opts["currentSpeedKmh"] = 90
+    opts["brakingPoints"] = harness.lua.table()
+    opts["segments"] = harness.lua.table()
+    opts["trackLengthM"] = 4500
+    view = rtc.tick(opts)
+
+    assert view is not None, "tick must never return nil"
+    assert view["primaryLine"] == "DRIVE A LAP", (
+        f"empty state must say 'DRIVE A LAP', got {view['primaryLine']!r}"
+    )
+    assert view["subState"] == "no_reference", (
+        f"empty state subState must be 'no_reference', got {view['subState']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# corner_analysis + delta end-to-end on a synthesized + telemetry-ingested trace
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_ingest_then_corner_and_delta_pipeline(harness: TraceReplayHarness) -> None:
+    """L0-07: feed a synthesized lap through telemetry:update(dt, car, sim), finalize
+    the lap trace, then run corner_analysis.buildSegments + cornerFeaturesForLap and
+    delta.prepareTrace + bestElapsedMsAtSpline + deltaSecondsAtSpline end-to-end."""
+    tel = harness.require("telemetry")
+    ca = harness.require("corner_analysis")
+    dl = harness.require("delta")
+
+    frames = synthesize_trace("brake_too_late")
+
+    # Ingest via the real telemetry buffer. NOTE arg order: update(dt, car, sim).
+    t = tel.new(harness.lua.table())
+    t.beginLapClock(t, 0.0)
+    game_time = 0.0
+    for f in frames:
+        car = harness.make_car(
+            brake=f["brake"],
+            gas=f["throttle"],
+            steer=f["steer"],
+            gear=int(f["gear"]),
+            speedKmh=f["speed"],
+            splinePosition=f["spline"],
+            position={"x": f["px"], "y": f["py"], "z": f["pz"]},
+        )
+        sim = harness.make_sim(isInMainMenu=False, gameTime=game_time)
+        harness.call_guarding_schema(t.update, t, 0.05, car, sim)
+        game_time += 0.05
+
+    lap_trace = t.finalizeLapTrace(t)
+    rows = harness.lua.eval("function(tr) return #tr end")(lap_trace)
+    assert rows > 0, "telemetry must produce a non-empty lap trace"
+
+    # corner_analysis: with an explicit brake point we get a real 'corner' segment.
+    brakes = harness.lua.execute(
+        f"""return {{
+            {{ spline = {BRAKE_SPLINE}, px = 0, py = 0, pz = 0, entrySpeed = 95, label = "T1" }},
+        }}"""
+    )
+    segs = ca.buildSegments(lap_trace, brakes)
+    nseg = harness.lua.eval("function(s) return #s end")(segs)
+    assert nseg >= 2, f"buildSegments must produce a brake+corner pair, got {nseg} segments"
+    kinds = harness.lua.eval(
+        "function(s) local o = {} for i = 1, #s do o[i] = s[i].kind end "
+        'return table.concat(o, ",") end'
+    )(segs)
+    assert "corner" in kinds, f"buildSegments must classify a corner, got kinds: {kinds!r}"
+
+    feats = ca.cornerFeaturesForLap(lap_trace, segs)
+    nfeat = harness.lua.eval("function(s) return #s end")(feats)
+    assert nfeat >= 1, "cornerFeaturesForLap must extract at least one corner feature"
+
+    # delta: sorted view + interpolation must return finite numbers.
+    sorted_tr = dl.prepareTrace(lap_trace)
+    assert sorted_tr is not None, "prepareTrace must return a sorted trace"
+    elapsed = dl.bestElapsedMsAtSpline(sorted_tr, 0.5)
+    assert elapsed is not None and elapsed > 0, "bestElapsedMsAtSpline(0.5) must be positive"
+    dsec = dl.deltaSecondsAtSpline(sorted_tr, 0.5, elapsed + 1000.0)
+    assert dsec == pytest.approx(1.0, abs=1e-6), (
+        f"deltaSecondsAtSpline with +1000 ms current must be +1.0 s, got {dsec}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema gate -- the anti-hallucination guard fires
+# ---------------------------------------------------------------------------
+
+
+def test_schema_gate_blocks_unknown_car_field(harness: TraceReplayHarness) -> None:
+    """L0-08: reading a car field NOT in ac_schema.json must raise loudly. This is
+    the guard that makes a test which drifts onto a hallucinated CSP API FAIL
+    instead of silently passing on a field that does not exist in production."""
+    car = harness.make_car(speedKmh=100.0)
+    reader = harness.lua.eval("function(c) return c.totallyMadeUpField end")
+    with pytest.raises(SchemaViolationError, match="SCHEMA-VIOLATION: car.totallyMadeUpField"):
+        harness.call_guarding_schema(reader, car)
+
+
+def test_schema_gate_blocks_unknown_sim_field(harness: TraceReplayHarness) -> None:
+    """L0-09: same guard on the sim table."""
+    sim = harness.make_sim(gameTime=1.0)
+    reader = harness.lua.eval("function(s) return s.notARealSimField end")
+    with pytest.raises(SchemaViolationError, match="SCHEMA-VIOLATION: sim.notARealSimField"):
+        harness.call_guarding_schema(reader, sim)
+
+
+def test_schema_gate_blocks_unknown_vec3_subfield(harness: TraceReplayHarness) -> None:
+    """L0-10: vec3 sub-fields are gated too (car.position.w is not x/y/z)."""
+    car = harness.make_car(position={"x": 1.0, "y": 2.0, "z": 3.0}, speedKmh=100.0)
+    reader = harness.lua.eval("function(c) return c.position.w end")
+    with pytest.raises(SchemaViolationError, match="SCHEMA-VIOLATION: car.position.w"):
+        harness.call_guarding_schema(reader, car)
+
+
+def test_schema_gate_allows_declared_fields(harness: TraceReplayHarness) -> None:
+    """L0-11: declared fields read back; an unset-but-declared field returns nil so
+    the modules' ``car.x or 0`` pattern keeps working (the gate must not over-block)."""
+    car = harness.make_car(speedKmh=123.0, position={"x": 4.0, "y": 5.0, "z": 6.0})
+    assert harness.lua.eval("function(c) return c.speedKmh end")(car) == pytest.approx(123.0)
+    assert harness.lua.eval("function(c) return c.position.y end")(car) == pytest.approx(5.0)
+    # brake is declared but unset on this car => nil, NOT a schema violation.
+    assert harness.lua.eval("function(c) return c.brake end")(car) is None
+
+
+# ---------------------------------------------------------------------------
+# Harness / schema metadata sanity
+# ---------------------------------------------------------------------------
+
+
+def test_schema_marks_itself_a_bootstrap() -> None:
+    """L0-12: ac_schema.json must declare itself a code-derived bootstrap pending an
+    on-box dump_schema.lua refresh (so nobody mistakes it for the full CSP API)."""
+    schema = load_schema()
+    assert "bootstrap" in schema.note.lower(), "schema _note must say it is a bootstrap"
+    assert "dump_schema.lua" in schema.note, "schema _note must point at dump_schema.lua"
+    # The fields the modules actually read must be present.
+    assert {"speedKmh", "brake", "splinePosition", "position", "look"} <= schema.car_fields
+    assert {"isInMainMenu", "gameTime"} <= schema.sim_fields
+
+
+def test_synthesize_trace_scenarios_have_expected_shape(harness: TraceReplayHarness) -> None:
+    """L0-13: both scenarios emit frames with the full column set the modules read."""
+    assert set(available_scenarios()) == {"clean_lap", "brake_too_late"}
+    expected_cols = {
+        "spline",
+        "speed",
+        "eMs",
+        "throttle",
+        "brake",
+        "steer",
+        "gear",
+        "px",
+        "py",
+        "pz",
+    }
+    for scenario in available_scenarios():
+        frames = synthesize_trace(scenario)
+        assert len(frames) > 0
+        assert set(frames[0].keys()) == expected_cols, (
+            f"{scenario} frame columns drifted: {set(frames[0].keys()) ^ expected_cols}"
+        )
+
+
+def test_synthesize_trace_rejects_unknown_scenario() -> None:
+    """L0-14: an unknown scenario name fails fast with a helpful message."""
+    with pytest.raises(ValueError, match="unknown scenario"):
+        synthesize_trace("does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# Harness Lua-interop helpers (to_lua_trace, vec3 coercion variants)
+# ---------------------------------------------------------------------------
+
+
+def test_to_lua_trace_builds_indexed_array(harness: TraceReplayHarness) -> None:
+    """L0-15: to_lua_trace converts a Python frame list into a 1-indexed Lua array
+    whose rows carry every column, so it can feed corner_analysis/delta directly."""
+    frames = synthesize_trace("brake_too_late")
+    arr = harness.to_lua_trace(frames)
+    n = harness.lua.eval("function(tr) return #tr end")(arr)
+    assert n == len(frames), f"Lua array length must match frame count, got {n} vs {len(frames)}"
+    # Row 1 must be readable and carry the spline/speed columns.
+    first_spline = harness.lua.eval("function(tr) return tr[1].spline end")(arr)
+    assert first_spline == pytest.approx(frames[0]["spline"])
+    # A converted trace flows through the real corner pipeline.
+    ca = harness.require("corner_analysis")
+    brakes = harness.lua.execute(
+        f'return {{ {{ spline = {BRAKE_SPLINE}, entrySpeed = 95, label = "T1" }} }}'
+    )
+    segs = ca.buildSegments(arr, brakes)
+    assert harness.lua.eval("function(s) return #s end")(segs) >= 2
+
+
+def test_make_car_accepts_vec3_as_tuple(harness: TraceReplayHarness) -> None:
+    """L0-16: vec3 fields may be passed as an (x, y, z) tuple/list, not only a dict.
+    Both coercion paths must produce a gated, readable vec3."""
+    car = harness.make_car(speedKmh=80.0, position=(7.0, 8.0, 9.0))
+    assert harness.lua.eval("function(c) return c.position.x end")(car) == pytest.approx(7.0)
+    assert harness.lua.eval("function(c) return c.position.z end")(car) == pytest.approx(9.0)
+    # Still gated on sub-fields.
+    with pytest.raises(SchemaViolationError, match="SCHEMA-VIOLATION: car.position"):
+        harness.call_guarding_schema(
+            harness.lua.eval("function(c) return c.position.bogus end"), car
+        )
+
+
+def test_make_car_vec3_scalar_passthrough(harness: TraceReplayHarness) -> None:
+    """L0-17: a non-dict/non-sequence vec3 value (e.g. an already-built Lua vec3 or a
+    scalar) is passed through unchanged -- the harness must not try to coerce it."""
+    lua_vec = harness.lua.eval("function() return { x = 1.0, y = 2.0, z = 3.0 } end")()
+    car = harness.make_car(speedKmh=50.0, look=lua_vec)
+    # look is the same passthrough table; reading x works (ungated passthrough).
+    assert harness.lua.eval("function(c) return c.look.x end")(car) == pytest.approx(1.0)

--- a/tests/test_lua_trace_replay.py
+++ b/tests/test_lua_trace_replay.py
@@ -428,3 +428,10 @@ def test_make_car_vec3_scalar_passthrough(harness: TraceReplayHarness) -> None:
     car = harness.make_car(speedKmh=50.0, look=lua_vec)
     # look is the same passthrough table; reading x works (ungated passthrough).
     assert harness.lua.eval("function(c) return c.look.x end")(car) == pytest.approx(1.0)
+
+
+def test_clean_lap_rejects_degenerate_n() -> None:
+    """synthesize_trace('clean_lap', n=1) raises a clear ValueError, not ZeroDivisionError
+    (Cursor): a single-frame trace cannot span the spline so i/(n-1) would divide by zero."""
+    with pytest.raises(ValueError, match="n >= 2"):
+        synthesize_trace("clean_lap", n=1)

--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -1,0 +1,28 @@
+"""Off-sim (L0) Lua trace-replay harness for the AC Copilot Trainer coaching brain.
+
+This package lets the agent regression-test the real CSP Lua coaching modules
+under ``lupa`` against synthetic/recorded telemetry traces -- with NO Assetto
+Corsa, NO Windows, NO WebSocket, and NO human. It is the cheapest, most
+deterministic layer (L0) of the autonomous self-test harness for EPIC #154.
+
+See :mod:`tools.ac_harness.trace_replay` for the runtime builder, the trace
+synthesizer, and the schema-gated mock ``ac``/``car``/``sim`` tables.
+"""
+
+from __future__ import annotations
+
+from tools.ac_harness.trace_replay import (
+    AcSchema,
+    SchemaViolationError,
+    TraceReplayHarness,
+    load_schema,
+    synthesize_trace,
+)
+
+__all__ = [
+    "AcSchema",
+    "SchemaViolationError",
+    "TraceReplayHarness",
+    "load_schema",
+    "synthesize_trace",
+]

--- a/tools/ac_harness/ac_schema.json
+++ b/tools/ac_harness/ac_schema.json
@@ -1,0 +1,105 @@
+{
+  "_note": "CODE-DERIVED BOOTSTRAP schema, pending an on-box dump_schema.lua refresh. The car.* / sim.* field sets below were collected by grepping src/ac_copilot_trainer/modules/*.lua (and the entry script) for the fields the trainer ACTUALLY reads off ac.getCar(0) / ac.getSim(). It is intentionally a SUBSET of the full CSP ac.StateCar / ac.StateSim API: only fields the coaching brain consumes. The mock car/sim in tools/ac_harness/trace_replay.py is gated against this set so a test that drifts onto a hallucinated field fails loudly. To refresh against the real CSP API, run tools/ac_harness/dump_schema.lua in a live AC session (requires the Windows AC PC) and let it overwrite this file.",
+  "_source": "grep of src/ac_copilot_trainer/modules/*.lua and src/ac_copilot_trainer/ac_copilot_trainer.lua",
+  "_generated_by": "manual code-derivation (bootstrap); refresh via tools/ac_harness/dump_schema.lua on the AC PC",
+  "lua_runtime_note": "CSP runs LuaJIT (Lua 5.1); the harness runs lupa (Lua 5.5). See tests/fixtures/csp_luajit_parity.lua.",
+  "car": {
+    "speedKmh": {
+      "type": "number",
+      "read_by": ["telemetry.lua", "brake_detection.lua", "entry"],
+      "note": "Current speed in km/h."
+    },
+    "brake": {
+      "type": "number",
+      "read_by": ["telemetry.lua", "brake_detection.lua", "corner_analysis(via trace)"],
+      "note": "Brake pedal 0..1."
+    },
+    "gas": {
+      "type": "number",
+      "read_by": ["telemetry.lua"],
+      "note": "Throttle pedal 0..1 (stored as 'throttle' in the trace)."
+    },
+    "steer": {
+      "type": "number",
+      "read_by": ["telemetry.lua"],
+      "note": "Steering input. NOTE: car.steering does NOT exist on the C-struct and throws -- telemetry.lua uses car.steer."
+    },
+    "gear": {
+      "type": "number",
+      "read_by": ["telemetry.lua"],
+      "note": "Current gear (floored to integer)."
+    },
+    "splinePosition": {
+      "type": "number",
+      "read_by": ["telemetry.lua", "brake_detection.lua", "entry"],
+      "note": "Normalized track position 0..1."
+    },
+    "look": {
+      "type": "vec3",
+      "fields": {
+        "x": "number",
+        "y": "number",
+        "z": "number"
+      },
+      "read_by": ["brake_detection.lua"],
+      "note": "Heading vector; brake_detection uses look.x/look.z for math.atan2 heading."
+    },
+    "velocity": {
+      "type": "vec3",
+      "fields": {
+        "x": "number",
+        "y": "number",
+        "z": "number"
+      },
+      "read_by": ["brake_detection.lua"],
+      "note": "Fallback heading source (may throw on the C-struct -- read under pcall)."
+    },
+    "position": {
+      "type": "vec3",
+      "fields": {
+        "x": "number",
+        "y": "number",
+        "z": "number"
+      },
+      "read_by": ["telemetry.lua", "brake_detection.lua"],
+      "note": "World position; px/py/pz columns of the trace."
+    }
+  },
+  "sim": {
+    "isInMainMenu": {
+      "type": "boolean",
+      "read_by": ["telemetry.lua"],
+      "note": "When true, telemetry:update is a no-op."
+    },
+    "gameTime": {
+      "type": "number",
+      "read_by": ["csp_helpers.lua (simSeconds)"],
+      "note": "Preferred sim clock (seconds). simSeconds reads it under pcall."
+    },
+    "time": {
+      "type": "number",
+      "read_by": ["csp_helpers.lua (simSeconds)"],
+      "note": "Fallback sim clock if gameTime is absent."
+    },
+    "trackLengthM": {
+      "type": "number",
+      "read_by": ["lap_archive.lua", "entry"],
+      "note": "Track length in meters; used to convert spline deltas to meters."
+    },
+    "trackGripLevel": {
+      "type": "number",
+      "read_by": ["lap_archive.lua"],
+      "note": "Grip 0..1 (session metadata)."
+    },
+    "ambientTemperature": {
+      "type": "number",
+      "read_by": ["lap_archive.lua"],
+      "note": "Ambient temp (session metadata)."
+    },
+    "trackTemperature": {
+      "type": "number",
+      "read_by": ["lap_archive.lua"],
+      "note": "Track temp (session metadata)."
+    }
+  }
+}

--- a/tools/ac_harness/dump_schema.lua
+++ b/tools/ac_harness/dump_schema.lua
@@ -125,6 +125,11 @@ local function encode(tbl, indent)
 end
 
 local _done = false
+-- Bounded retry on write failure: retry a few frames (the app-data folder may not be ready
+-- on the very first frame) then give up, so a permanently-bad path neither marks done with
+-- no file nor spams ac.log every frame forever (Cursor).
+local MAX_WRITE_ATTEMPTS = 30
+local _writeAttempts = 0
 
 local function dumpSchema()
   local car = ac.getCar(0)
@@ -174,13 +179,22 @@ local function dumpSchema()
   if fh then
     fh:write(encode(schema))
     fh:close()
+    _done = true
     if ac and ac.log then
       ac.log("[ac_harness] wrote schema to " .. out)
     end
-  elseif ac and ac.log then
-    ac.log("[ac_harness] FAILED to open " .. out .. " for writing")
+    return
   end
-  _done = true
+  -- Write failed: leave _done false so script.update retries on later frames, but stop after
+  -- MAX_WRITE_ATTEMPTS so a permanently-bad path gives up cleanly instead of looping (Cursor).
+  _writeAttempts = _writeAttempts + 1
+  if _writeAttempts >= MAX_WRITE_ATTEMPTS then
+    _done = true
+    if ac and ac.log then
+      ac.log(string.format(
+        "[ac_harness] FAILED to open %s for writing after %d attempts", out, _writeAttempts))
+    end
+  end
 end
 
 -- CSP app entry points. update() is called each frame; we run once.

--- a/tools/ac_harness/dump_schema.lua
+++ b/tools/ac_harness/dump_schema.lua
@@ -1,0 +1,166 @@
+-- tools/ac_harness/dump_schema.lua
+--
+-- SCHEMA REFLECTION (EPIC #154 Part B) -- source-of-truth refresh for ac_schema.json.
+--
+-- REQUIRES THE ASSETTO CORSA PC. This is a tiny CSP app, NOT run in CI and NOT
+-- run by the off-sim harness. It must execute inside a live Assetto Corsa + CSP
+-- session, where `ac.getCar(0)` and `ac.getSim()` return the real C-struct
+-- StateCar / StateSim. It dumps the field names and value-types those structs
+-- actually expose to tools/ac_harness/ac_schema.json, which the off-sim mock in
+-- trace_replay.py is gated against.
+--
+-- The bootstrap ac_schema.json shipped in this repo is CODE-DERIVED (grep of the
+-- modules for the fields the trainer reads). It is a SUBSET of the real API. Run
+-- this on the AC box when you want to widen/validate the schema against the
+-- genuine CSP surface, or after a CSP update that may have changed field names.
+--
+-- HOW TO USE (on the AC PC)
+-- -------------------------
+--   1. Drop this folder where CSP can load it as a Lua app (or paste the body
+--      into an existing app's update()), enter a session, and put a car on track.
+--   2. The script writes ac_schema.json next to itself on the first frame that
+--      both ac.getCar(0) and ac.getSim() are non-nil, then logs and stops.
+--   3. Copy the produced ac_schema.json back into tools/ac_harness/ in the repo
+--      (review the diff -- it should ADD fields, rarely remove them).
+--
+-- The list of fields we probe is intentionally the union of what the trainer
+-- reads today (see ac_schema.json) plus a few neighbors, because the CSP
+-- StateCar/StateSim C-structs do not support generic key iteration with pairs()
+-- -- you can only read named fields, and reading a non-existent field can THROW
+-- rather than return nil. So we pcall each candidate name and record only the
+-- ones that resolve to a value.
+
+local CAR_CANDIDATES = {
+  -- fields the trainer reads today
+  "speedKmh", "brake", "gas", "steer", "gear", "splinePosition",
+  "look", "velocity", "position",
+  -- neighbors worth recording if present (do not add to the gated set without
+  -- a corresponding module read; recording is harmless, gating is not)
+  "rpm", "drivetrainSpeed", "acceleration", "angularVelocity",
+}
+
+local SIM_CANDIDATES = {
+  "isInMainMenu", "gameTime", "time",
+  "trackLengthM", "trackGripLevel", "ambientTemperature", "trackTemperature",
+  "isReplayActive", "isPaused", "carsCount",
+}
+
+local VEC3_SUBFIELDS = { "x", "y", "z" }
+
+local function luaType(v)
+  local t = type(v)
+  if t == "userdata" or t == "cdata" then
+    -- Probe for a vec3-shaped value (CSP returns vec3 userdata for look/pos/vel).
+    local ok = pcall(function()
+      return v.x + v.y + v.z
+    end)
+    if ok then
+      return "vec3"
+    end
+  end
+  return t
+end
+
+--- Probe one named field on a CSP C-struct. Returns (present, typeString).
+local function probeField(struct, name)
+  local ok, val = pcall(function()
+    return struct[name]
+  end)
+  if not ok or val == nil then
+    return false, nil
+  end
+  return true, luaType(val)
+end
+
+--- Minimal JSON-ish serializer (CSP has no json.encode guarantee across builds).
+local function encode(tbl, indent)
+  indent = indent or ""
+  local nextIndent = indent .. "  "
+  local parts = {}
+  -- Stable key order for a clean diff.
+  local keys = {}
+  for k in pairs(tbl) do
+    keys[#keys + 1] = k
+  end
+  table.sort(keys)
+  for _, k in ipairs(keys) do
+    local v = tbl[k]
+    local encoded
+    if type(v) == "table" then
+      encoded = encode(v, nextIndent)
+    else
+      encoded = '"' .. tostring(v) .. '"'
+    end
+    parts[#parts + 1] = nextIndent .. '"' .. tostring(k) .. '": ' .. encoded
+  end
+  return "{\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "}"
+end
+
+local _done = false
+
+local function dumpSchema()
+  local car = ac.getCar(0)
+  local sim = ac.getSim()
+  if not car or not sim then
+    return
+  end
+
+  local schema = {
+    _note = "ON-BOX DUMP from a live AC session via tools/ac_harness/dump_schema.lua. "
+      .. "Overwrites the code-derived bootstrap. Review the diff before committing.",
+    car = {},
+    sim = {},
+  }
+
+  for _, name in ipairs(CAR_CANDIDATES) do
+    local present, t = probeField(car, name)
+    if present then
+      local entry = { type = t }
+      if t == "vec3" then
+        local subs = {}
+        for _, s in ipairs(VEC3_SUBFIELDS) do
+          subs[s] = "number"
+        end
+        entry.fields = subs
+      end
+      schema.car[name] = entry
+    end
+  end
+
+  for _, name in ipairs(SIM_CANDIDATES) do
+    local present, t = probeField(sim, name)
+    if present then
+      schema.sim[name] = { type = t }
+    end
+  end
+
+  -- Write next to this script. ac.getFolder(ac.FolderID.AppLuaRoot) resolves the
+  -- app's own directory in CSP.
+  local out
+  if ac and type(ac.getFolder) == "function" and ac.FolderID then
+    out = ac.getFolder(ac.FolderID.AppLuaRoot) .. "/ac_schema.json"
+  else
+    out = "ac_schema.json"
+  end
+  local fh = io.open(out, "w")
+  if fh then
+    fh:write(encode(schema))
+    fh:close()
+    if ac and ac.log then
+      ac.log("[ac_harness] wrote schema to " .. out)
+    end
+  elseif ac and ac.log then
+    ac.log("[ac_harness] FAILED to open " .. out .. " for writing")
+  end
+  _done = true
+end
+
+-- CSP app entry points. update() is called each frame; we run once.
+function script.update(_dt)
+  if not _done then
+    dumpSchema()
+  end
+end
+
+-- Allow manual one-shot invocation from a console/REPL too.
+return { dump = dumpSchema }

--- a/tools/ac_harness/dump_schema.lua
+++ b/tools/ac_harness/dump_schema.lua
@@ -72,7 +72,35 @@ local function probeField(struct, name)
   return true, luaType(val)
 end
 
---- Minimal JSON-ish serializer (CSP has no json.encode guarantee across builds).
+--- Escape a string for JSON: backslash first, then quote and the common control chars,
+--- so a description/path containing `"` or `\` cannot produce malformed JSON (gemini).
+local function escapeStr(s)
+  s = tostring(s)
+  s = s:gsub("\\", "\\\\")
+  s = s:gsub('"', '\\"')
+  s = s:gsub("\n", "\\n")
+  s = s:gsub("\r", "\\r")
+  s = s:gsub("\t", "\\t")
+  return s
+end
+
+--- Encode a scalar (non-table) value with the correct JSON type — numbers, booleans, and
+--- nil are NOT quoted (quoting them would emit `"true"` / `"123"`, which is wrong JSON).
+local function encodeScalar(v)
+  local tv = type(v)
+  if tv == "number" then
+    return tostring(v)
+  elseif tv == "boolean" then
+    return v and "true" or "false"
+  elseif v == nil then
+    return "null"
+  end
+  return '"' .. escapeStr(v) .. '"'
+end
+
+--- Minimal pretty-printing JSON serializer (CSP has no json.encode guarantee across
+--- builds). Type-aware scalars + escaped string keys/values; stable key order for a
+--- clean diff.
 local function encode(tbl, indent)
   indent = indent or ""
   local nextIndent = indent .. "  "
@@ -89,9 +117,9 @@ local function encode(tbl, indent)
     if type(v) == "table" then
       encoded = encode(v, nextIndent)
     else
-      encoded = '"' .. tostring(v) .. '"'
+      encoded = encodeScalar(v)
     end
-    parts[#parts + 1] = nextIndent .. '"' .. tostring(k) .. '": ' .. encoded
+    parts[#parts + 1] = nextIndent .. '"' .. escapeStr(k) .. '": ' .. encoded
   end
   return "{\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "}"
 end

--- a/tools/ac_harness/trace_replay.py
+++ b/tools/ac_harness/trace_replay.py
@@ -307,6 +307,8 @@ def _clean_lap(n: int = CLEAN_LAP_FRAMES) -> list[TraceFrame]:
     and realtime_coaching has nothing urgent to say (the false-positive guard).
     Speed is a gentle sinusoid well above the in-corner thresholds.
     """
+    if n < 2:
+        raise ValueError(f"_clean_lap needs n >= 2 to span the spline, got {n}")
     frames: list[TraceFrame] = []
     for i in range(n):
         sp = i / (n - 1)

--- a/tools/ac_harness/trace_replay.py
+++ b/tools/ac_harness/trace_replay.py
@@ -1,0 +1,424 @@
+"""L0 off-sim Lua trace-replay harness (EPIC #154 Part A + Part B bootstrap).
+
+Runs the REAL CSP coaching modules under ``lupa`` against synthetic telemetry
+traces, with a LuaJIT<->lupa parity shim and a *schema-gated* mock ``car``/``sim``
+so a test that drifts onto a hallucinated CSP field fails loudly instead of
+silently passing.
+
+Public surface:
+
+* :func:`load_schema` / :class:`AcSchema` -- the code-derived ``ac_schema.json``.
+* :class:`TraceReplayHarness` -- builds the runtime, loads modules, mints gated
+  ``car``/``sim`` tables and converts traces to Lua.
+* :func:`synthesize_trace` -- emits named telemetry scenarios as plain frames.
+* :class:`SchemaViolationError` -- raised (from Lua) when a non-schema field is read.
+
+Nothing here imports Assetto Corsa, Windows, or a WebSocket. The only heavy dep
+is ``lupa`` (already a dev dependency).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Sequence
+
+# Repo + module layout. trace_replay.py lives at tools/ac_harness/; the modules
+# are at src/ac_copilot_trainer/modules/ and the parity shim at tests/fixtures/.
+_HARNESS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = _HARNESS_DIR.parent.parent
+MODULES_DIR = REPO_ROOT / "src" / "ac_copilot_trainer" / "modules"
+PARITY_SHIM = REPO_ROOT / "tests" / "fixtures" / "csp_luajit_parity.lua"
+SCHEMA_PATH = _HARNESS_DIR / "ac_schema.json"
+
+# A telemetry frame the modules consume. Field names match exactly what
+# telemetry.lua / brake_detection.lua / corner_analysis.lua read off the trace
+# rows and the live car table (see ac_schema.json / the module sources):
+#   spline, speed, eMs, throttle, brake, steer, gear, px, py, pz
+TraceFrame = dict[str, float]
+
+
+class SchemaViolationError(RuntimeError):
+    """Raised when Lua code reads a ``car``/``sim`` field absent from the schema.
+
+    The mock tables installed by :class:`TraceReplayHarness` raise a Lua error
+    whose message is prefixed with ``SCHEMA-VIOLATION:``; lupa surfaces that as a
+    ``LuaError`` which the harness re-raises as this type so tests can assert on
+    it without importing lupa internals.
+    """
+
+
+@dataclass(frozen=True)
+class AcSchema:
+    """The set of ``car.*`` / ``sim.*`` fields the trainer is allowed to read.
+
+    Built from ``ac_schema.json`` (code-derived bootstrap). ``car_vec3`` maps a
+    vec3-typed car field (``look``/``position``/``velocity``) to its allowed
+    sub-fields, so the mock can gate ``car.position.x`` too.
+    """
+
+    car_fields: frozenset[str]
+    sim_fields: frozenset[str]
+    car_vec3: dict[str, frozenset[str]] = field(default_factory=dict)
+    note: str = ""
+
+
+def load_schema(path: Path | str = SCHEMA_PATH) -> AcSchema:
+    """Load and parse ``ac_schema.json`` into an :class:`AcSchema`."""
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    car_spec = raw.get("car", {})
+    sim_spec = raw.get("sim", {})
+    car_vec3: dict[str, frozenset[str]] = {}
+    for name, spec in car_spec.items():
+        if isinstance(spec, dict) and spec.get("type") == "vec3":
+            sub = spec.get("fields", {})
+            car_vec3[name] = frozenset(sub.keys()) if sub else frozenset({"x", "y", "z"})
+    return AcSchema(
+        car_fields=frozenset(car_spec.keys()),
+        sim_fields=frozenset(sim_spec.keys()),
+        car_vec3=car_vec3,
+        note=str(raw.get("_note", "")),
+    )
+
+
+# Lua factory that wraps a backing table in a schema gate: reads of a key NOT in
+# the allowlist raise a Lua error. vec3 sub-tables are themselves gated. This is
+# defined once and `require`-free so it works under a bare LuaRuntime.
+_SCHEMA_GATE_LUA = r"""
+-- _make_gated(backing, allowed, kind) returns a proxy table that:
+--   * returns backing[k] when k is in `allowed` (a set: allowed[k] == true)
+--   * raises "SCHEMA-VIOLATION: <kind>.<k> ..." otherwise
+-- Reads that are present-but-nil are allowed (the modules use `car.x or 0`),
+-- but reads of a key the schema never declared are hard errors.
+function _make_gated(backing, allowed, kind)
+  local proxy = {}
+  return setmetatable(proxy, {
+    __index = function(_, k)
+      if allowed[k] then
+        return backing[k]
+      end
+      error("SCHEMA-VIOLATION: " .. tostring(kind) .. "." .. tostring(k)
+        .. " is not a declared CSP field in ac_schema.json"
+        .. " (the trainer must not read it, or refresh the schema via dump_schema.lua)", 2)
+    end,
+    __newindex = function(_, k, v)
+      rawset(backing, k, v)
+    end,
+    -- Expose the backing length / pairs for completeness (not gated).
+    __len = function() return #backing end,
+  })
+end
+"""
+
+# Minimal mock of the CSP globals the modules touch when NOT going through the
+# schema-gated car/sim. telemetry.lua requires csp_helpers which references the
+# `ac` global only inside functions we do not call on the hot path; brake/tick do
+# not need ac/ui/web/physics at all. We still install thin stubs so a module that
+# touches them at require-time does not explode, mirroring the established
+# test_lua_runtime_smoke.py / test_phase5_rebuild_ete.py pattern.
+_MOCK_GLOBALS_LUA = r"""
+ac = ac or {
+  log = function() end,
+  getFolder = function() return "" end,
+  FolderID = { Root = 0, AppLuaRoot = 1, ScriptConfig = 2 },
+}
+ui = ui or {}
+-- web.socket is callback-based in CSP; the harness never opens one, but provide a
+-- no-op so a require of ws_bridge (if ever pulled in) does not throw.
+web = web or {
+  socket = function() return { close = function() end } end,
+}
+physics = physics or {}
+function _vec3(x, y, z) return { x = x or 0, y = y or 0, z = z or 0 } end
+vec3 = vec3 or _vec3
+function _vec2(x, y) return { x = x or 0, y = y or 0 } end
+vec2 = vec2 or _vec2
+"""
+
+
+class TraceReplayHarness:
+    """A lupa runtime preloaded for off-sim coaching-module replay.
+
+    Usage::
+
+        h = TraceReplayHarness()
+        bd = h.require("brake_detection")
+        det = bd.new(h.lua.table())
+        car = h.make_car(brake=0.0, speedKmh=180.0, splinePosition=0.2)
+        ev = det.update(det, car, 0.016)
+    """
+
+    def __init__(self, schema: AcSchema | None = None) -> None:
+        import lupa
+
+        self._lupa = lupa
+        self.schema = schema if schema is not None else load_schema()
+        self.lua = lupa.LuaRuntime(unpack_returned_tuples=False)
+        # package.path -> modules dir (mirrors the established smoke-test setup).
+        modules_path = str(MODULES_DIR).replace("\\", "/")
+        self.lua.execute(f'package.path = package.path .. ";{modules_path}/?.lua"')
+        # Parity shim FIRST so any module that uses math.atan2 etc. works on call.
+        self.lua.execute(PARITY_SHIM.read_text(encoding="utf-8"))
+        # Mock globals + the schema-gate factory.
+        self.lua.execute(_MOCK_GLOBALS_LUA)
+        self.lua.execute(_SCHEMA_GATE_LUA)
+        # Pre-build the allowed-field sets as Lua sets once.
+        self._car_allowed = self._as_lua_set(self.schema.car_fields)
+        self._sim_allowed = self._as_lua_set(self.schema.sim_fields)
+        self._vec3_allowed = {
+            name: self._as_lua_set(subs) for name, subs in self.schema.car_vec3.items()
+        }
+
+    # -- module loading -----------------------------------------------------
+
+    def require(self, module_name: str) -> Any:  # noqa: ANN401 - lupa table
+        """``require()`` a coaching module by name and return its table.
+
+        ``require`` returns two values (module, loader-path); execute() with an
+        explicit single return so lupa hands back only the module table.
+        """
+        return self.lua.execute(f'local m = require("{module_name}"); return m')
+
+    # -- Lua interop helpers -------------------------------------------------
+
+    def _as_lua_set(self, names: frozenset[str] | set[str]) -> Any:  # noqa: ANN401
+        """Build a Lua table used as a set: ``{name = true, ...}``."""
+        tbl = self.lua.table()
+        for n in names:
+            tbl[n] = True
+        return tbl
+
+    def to_lua_trace(self, frames: Sequence[TraceFrame]) -> Any:  # noqa: ANN401
+        """Convert a Python list of frame dicts into a 1-indexed Lua array."""
+        arr = self.lua.table()
+        for i, frame in enumerate(frames, start=1):
+            row = self.lua.table()
+            for k, v in frame.items():
+                row[k] = v
+            arr[i] = row
+        return arr
+
+    # -- schema-gated mock car/sim ------------------------------------------
+
+    def make_car(self, **fields: Any) -> Any:  # noqa: ANN401 - returns Lua table
+        """Build a schema-gated mock ``car`` table.
+
+        Only keys present in ``schema.car_fields`` may be read back; reading any
+        other key raises a Lua ``SCHEMA-VIOLATION`` error. vec3 fields
+        (``position``/``look``/``velocity``) are passed as ``(x, y, z)`` tuples
+        or dicts and are themselves gated on their sub-fields.
+        """
+        backing = self.lua.table()
+        for name, value in fields.items():
+            if name in self._vec3_allowed:
+                backing[name] = self._make_vec3(name, value)
+            else:
+                backing[name] = value
+        gate = self.lua.globals()._make_gated
+        return gate(backing, self._car_allowed, "car")
+
+    def make_sim(self, **fields: Any) -> Any:  # noqa: ANN401 - returns Lua table
+        """Build a schema-gated mock ``sim`` table (same gating as ``make_car``)."""
+        backing = self.lua.table()
+        for name, value in fields.items():
+            backing[name] = value
+        gate = self.lua.globals()._make_gated
+        return gate(backing, self._sim_allowed, "sim")
+
+    def _make_vec3(self, field_name: str, value: Any) -> Any:  # noqa: ANN401
+        """Gate a vec3 sub-table on its allowed sub-fields (x/y/z)."""
+        if isinstance(value, dict):
+            x, y, z = value.get("x", 0.0), value.get("y", 0.0), value.get("z", 0.0)
+        elif isinstance(value, (tuple, list)):
+            x, y, z = (list(value) + [0.0, 0.0, 0.0])[:3]
+        else:  # already a Lua table or scalar -- pass through ungated
+            return value
+        backing = self.lua.table()
+        backing["x"], backing["y"], backing["z"] = x, y, z
+        allowed = self._vec3_allowed[field_name]
+        gate = self.lua.globals()._make_gated
+        return gate(backing, allowed, f"car.{field_name}")
+
+    # -- error translation ---------------------------------------------------
+
+    def call_guarding_schema(self, fn: Any, *args: Any) -> Any:  # noqa: ANN401
+        """Call a Lua function, translating SCHEMA-VIOLATION Lua errors.
+
+        Re-raises as :class:`SchemaViolationError` so tests do not depend on
+        ``lupa``'s exception type.
+        """
+        try:
+            return fn(*args)
+        except self._lupa.LuaError as exc:  # pragma: no cover - exercised in tests
+            if "SCHEMA-VIOLATION" in str(exc):
+                raise SchemaViolationError(str(exc)) from exc
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Trace synthesis
+# ---------------------------------------------------------------------------
+
+# Scenario knobs kept module-level so tests can reference the same constants the
+# generator uses (e.g. the braking spline / entry speed they assert on).
+SCENARIO_TRACK_LENGTH_M = 4500.0
+BRAKE_SPLINE = 0.20  # where the "brake too late" scenario starts braking
+BRAKE_ENTRY_SPEED_KMH = 180.0  # speed at the moment brake is first applied
+CLEAN_LAP_FRAMES = 240
+DT_S = 0.05  # 20 Hz synthetic sampling
+
+
+def _base_frame(
+    *,
+    spline: float,
+    speed: float,
+    e_ms: float,
+    throttle: float = 1.0,
+    brake: float = 0.0,
+    steer: float = 0.0,
+    gear: int = 4,
+    px: float = 0.0,
+    py: float = 0.0,
+    pz: float = 0.0,
+) -> TraceFrame:
+    return {
+        "spline": spline,
+        "speed": speed,
+        "eMs": e_ms,
+        "throttle": throttle,
+        "brake": brake,
+        "steer": steer,
+        "gear": float(gear),
+        "px": px,
+        "py": py,
+        "pz": pz,
+    }
+
+
+def _clean_lap(n: int = CLEAN_LAP_FRAMES) -> list[TraceFrame]:
+    """A smooth lap: speed never spikes-then-drops sharply, light steering.
+
+    Designed so corner_analysis does NOT detect spurious speed-minima corners
+    and realtime_coaching has nothing urgent to say (the false-positive guard).
+    Speed is a gentle sinusoid well above the in-corner thresholds.
+    """
+    frames: list[TraceFrame] = []
+    for i in range(n):
+        sp = i / (n - 1)
+        # Gentle speed undulation 150..210 km/h; amplitude < the 8 km/h corner
+        # dead band per local window, so no false "minima" corners.
+        speed = 180.0 + 30.0 * math.sin(sp * 2.0 * math.pi)
+        steer = 0.03 * math.sin(sp * 4.0 * math.pi)  # mild, below 0.12 corner gate
+        frames.append(
+            _base_frame(
+                spline=sp,
+                speed=speed,
+                e_ms=sp * 90000.0,
+                throttle=0.95,
+                brake=0.0,
+                steer=steer,
+                gear=5,
+                px=sp * 100.0,
+            )
+        )
+    return frames
+
+
+def _brake_too_late_lap(
+    *,
+    brake_spline: float = BRAKE_SPLINE,
+    entry_speed: float = BRAKE_ENTRY_SPEED_KMH,
+) -> list[TraceFrame]:
+    """A lap with one hard, sustained braking zone at ``brake_spline``.
+
+    Built so brake_detection emits exactly one qualified brake event with
+    ``entrySpeed == entry_speed`` and ``spline == brake_spline``:
+      * full throttle up to brake_spline,
+      * brake held > 0.3 for well over brakeDurationMin (0.5 s) across several
+        frames (the modeled corner), speed bleeding down,
+      * brake released after the corner -> event fires on release.
+    """
+    frames: list[TraceFrame] = []
+    n_pre = 60
+    n_brake = 24  # 24 * 0.05 s = 1.2 s of braking >> 0.5 s minimum
+    n_post = 80
+    total = n_pre + n_brake + n_post
+    idx = 0
+
+    def push(sp: float, speed: float, brake: float, steer: float, e_ms: float) -> None:
+        frames.append(
+            _base_frame(
+                spline=sp,
+                speed=speed,
+                e_ms=e_ms,
+                throttle=0.0 if brake > 0 else 0.95,
+                brake=brake,
+                steer=steer,
+                gear=4 if brake > 0 else 5,
+                px=sp * 100.0,
+            )
+        )
+
+    # Pre-brake straight: accelerate up to entry_speed, arriving AT brake_spline.
+    for i in range(n_pre):
+        sp = (i / n_pre) * brake_spline
+        speed = 120.0 + (entry_speed - 120.0) * (i / max(1, n_pre - 1))
+        push(sp, speed, 0.0, 0.0, idx * DT_S * 1000.0)
+        idx += 1
+
+    # Braking zone: spline advances slowly through the corner, speed drops, brake
+    # firmly above threshold so it QUALIFIES; entrySpeed is captured on the FIRST
+    # braking frame -> equals entry_speed exactly.
+    for i in range(n_brake):
+        sp = brake_spline + (i / n_brake) * 0.04
+        speed = entry_speed - (entry_speed - 90.0) * (i / max(1, n_brake - 1))
+        push(sp, speed, 0.9, 0.25 * math.sin(i / n_brake * math.pi), idx * DT_S * 1000.0)
+        idx += 1
+
+    # Post-corner: brake released (event fires here), accelerate away.
+    for i in range(n_post):
+        sp = (brake_spline + 0.04) + (i / n_post) * (1.0 - (brake_spline + 0.04))
+        speed = 90.0 + 100.0 * (i / max(1, n_post - 1))
+        push(sp, speed, 0.0, 0.0, idx * DT_S * 1000.0)
+        idx += 1
+
+    assert len(frames) == total
+    return frames
+
+
+_SCENARIOS = {
+    "clean_lap": _clean_lap,
+    "brake_too_late": _brake_too_late_lap,
+}
+
+
+def synthesize_trace(scenario: str, **kwargs: Any) -> list[TraceFrame]:
+    """Return a list of telemetry frames for a named scenario.
+
+    Supported scenarios:
+
+    * ``"clean_lap"`` -- a smooth lap with no hard braking and no spurious
+      corners (the false-positive guard input).
+    * ``"brake_too_late"`` -- a lap with one sustained braking zone at
+      ``BRAKE_SPLINE`` entering at ``BRAKE_ENTRY_SPEED_KMH``; produces exactly
+      one brake event.
+
+    Frame fields match what the modules read:
+    ``spline, speed, eMs, throttle, brake, steer, gear, px, py, pz``.
+    """
+    try:
+        builder = _SCENARIOS[scenario]
+    except KeyError as exc:
+        valid = ", ".join(sorted(_SCENARIOS))
+        raise ValueError(f"unknown scenario {scenario!r}; valid: {valid}") from exc
+    return builder(**kwargs)
+
+
+def available_scenarios() -> list[str]:
+    """Names accepted by :func:`synthesize_trace`."""
+    return sorted(_SCENARIOS)


### PR DESCRIPTION
## EPIC #154 Part A — L0 off-sim Lua trace-replay layer (+ Part B schema-reflection bootstrap)

The cheapest, most deterministic layer of the autonomous self-test harness: it runs the **real CSP Lua coaching modules under `lupa`** against synthetic/recorded telemetry traces and asserts the coaching outputs — **no Assetto Corsa, no Windows, no human**. This regression-tests the coaching *brain* (brake detection, realtime coaching cascade, corner analysis, delta) on every `ci-fast`.

### What's here
- **`tests/fixtures/csp_luajit_parity.lua`** — minimal LuaJIT-5.1 ↔ lupa-5.5 parity shim (`math.atan2`, defensively `math.pow`/`unpack`). Documents each entry's real call site.
- **`tools/ac_harness/trace_replay.py`** — a `lupa` harness: sets `package.path` to the modules dir, loads the parity shim, installs a **schema-gated** mock `ac`/`car`/`sim` (accessing a field not in `ac_schema.json` raises `SchemaViolationError`), and synthesizes telemetry traces for named scenarios. 100% covered.
- **`tests/test_lua_trace_replay.py`** — 17 tests asserting on the **real** module contracts (verified at `file:line`): brake_detection emits exactly one event (`entrySpeed≈180`, `spline≈0.20`) on the braking lap and **zero on the clean lap** (false-positive guard); `realtime_coaching.tick` → `"BRAKE NOW"`/`TARGET 95 KM/H` vs the clean/on-pace case; `telemetry:update(dt,car,sim)` → corner_analysis → delta end-to-end; the schema gate fires on bogus fields.
- **Schema Reflection (Part B bootstrap):** `tools/ac_harness/dump_schema.lua` (documented; requires the AC PC to refresh) + `tools/ac_harness/ac_schema.json` (code-derived bootstrap, self-marked pending an on-box refresh). The gate validates *our* reads against this subset so a test that drifts from the real API fails loudly instead of passing on a hallucinated field.

### Verification (observed against reality)
- **`make ci-fast: OK`** with CI's extras installed (`.[dev,mining,knowledge]`): ci-format/ci-lint clean, **774 passed, coverage ≥80**, bandit 0/0/0, ci-csp-api 0 warnings, ci-csp-ui-safety 0 violations.
- **Independently reproduced the anti-false-green proof:** disabling the atan2 shim makes the braking tests fail with the exact `brake_detection.lua:22: attempt to call a nil value (field 'atan2')` in `flatHeading` — proving the tests reach real module code (the old require-only smoke never did). Reverted; green.
- **Coverage hygiene:** dropped an unnecessary `semantic_cluster.py` coverage `omit` that a worktree draft added — it's covered in CI (sklearn present) and the floor was already met without it; the omit only masked a dev-only-venv shortfall and would weaken the gate. Confirmed 774 passed + ≥80 without it.

### Gaps (honest)
- `dump_schema.lua` needs the Windows AC+CSP PC to run; `ac_schema.json` is a code-derived subset until that on-box refresh. The schema gate validates our reads, not the full live `StateCar`/`StateSim`.
- The pre-existing `tests/test_repo_knowledge/test_mcp_server_import.py` local-only failure (no `mcp` in a dev-only venv) is tracked in #156 and passes in CI.

Refs #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
