### PR TITLE
fix(hooks): resolve Windows venv python in .claude hook commands (#160)

### DIFF
--- a/.claude/settings.base.json
+++ b/.claude/settings.base.json
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/knowledge_session_summary.py\" 2>/dev/null || true"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/knowledge_session_summary.py\" 2>/dev/null || true"
           },
           {
             "type": "command",
@@ -22,11 +22,11 @@
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/bin/python3\"; [ -x \"$PY\" ] || PY=python3; \"$PY\" \"$root/scripts/hook_session_start_memory_prefetch.py\" || true"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_session_start_memory_prefetch.py\" || true"
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_session_start_memory_redirect.py\" 2>/dev/null || true"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_session_start_memory_redirect.py\" 2>/dev/null || true"
           }
         ]
       }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "input=$(cat); file_path=$(echo \"$input\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; input=$(cat); file_path=$(echo \"$input\" | \"$PY\" -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
             "timeout": 5000
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_post_bash_failure_hint.py\"",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_post_bash_failure_hint.py\"",
             "timeout": 5000
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/bin/python3\"; [ -x \"$PY\" ] || PY=python3; \"$PY\" \"$root/scripts/hook_memory_query_stamp.py\" || true",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_memory_query_stamp.py\" || true",
             "timeout": 5000
           }
         ]
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_sql_ddl_guard.py\"",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_sql_ddl_guard.py\"",
             "timeout": 5000
           }
         ]
@@ -99,7 +99,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_memory_gate.py\"",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_memory_gate.py\"",
             "timeout": 5000
           }
         ]
@@ -110,7 +110,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/session_debrief.py\" 2>/dev/null || true",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/session_debrief.py\" 2>/dev/null || true",
             "timeout": 15000
           }
         ]

--- a/.claude/settings.base.json
+++ b/.claude/settings.base.json
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; input=$(cat); file_path=$(echo \"$input\" | \"$PY\" -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; input=$(cat); file_path=$(printf '%s' \"$input\" | \"$PY\" -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
             "timeout": 5000
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/knowledge_session_summary.py\" 2>/dev/null || true"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/knowledge_session_summary.py\" 2>/dev/null || true"
           },
           {
             "type": "command",
@@ -22,11 +22,11 @@
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/bin/python3\"; [ -x \"$PY\" ] || PY=python3; \"$PY\" \"$root/scripts/hook_session_start_memory_prefetch.py\" || true"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_session_start_memory_prefetch.py\" || true"
           },
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_session_start_memory_redirect.py\" 2>/dev/null || true"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_session_start_memory_redirect.py\" 2>/dev/null || true"
           }
         ]
       }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "input=$(cat); file_path=$(echo \"$input\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; input=$(cat); file_path=$(echo \"$input\" | \"$PY\" -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
             "timeout": 5000
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_post_bash_failure_hint.py\"",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_post_bash_failure_hint.py\"",
             "timeout": 5000
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/bin/python3\"; [ -x \"$PY\" ] || PY=python3; \"$PY\" \"$root/scripts/hook_memory_query_stamp.py\" || true",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_memory_query_stamp.py\" || true",
             "timeout": 5000
           }
         ]
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_sql_ddl_guard.py\"",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_sql_ddl_guard.py\"",
             "timeout": 5000
           }
         ]
@@ -99,7 +99,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/hook_memory_gate.py\"",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/hook_memory_gate.py\"",
             "timeout": 5000
           }
         ]
@@ -110,7 +110,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; python3 \"$root/scripts/session_debrief.py\" 2>/dev/null || true",
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}\"; PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; \"$PY\" \"$root/scripts/session_debrief.py\" 2>/dev/null || true",
             "timeout": 15000
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; input=$(cat); file_path=$(echo \"$input\" | \"$PY\" -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); PY=\"$root/.venv/Scripts/python.exe\"; [ -x \"$PY\" ] || PY=\"$root/.venv/bin/python\"; [ -x \"$PY\" ] || PY=\"$(command -v python3 || command -v python)\"; input=$(cat); file_path=$(printf '%s' \"$input\" | \"$PY\" -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null); [ -z \"$file_path\" ] && exit 0; case \"$file_path\" in *docs/01_Vault/*) mkdir -p \"$root/.scratch\" && touch \"$root/.scratch/vault-dirty\";; esac; exit 0",
             "timeout": 5000
           }
         ]


### PR DESCRIPTION
Closes #160.

On Windows the venv interpreter is `.venv/Scripts/python.exe` and there is no `python3`, but every `.claude` hook resolved `$root/.venv/bin/python3` then bare `python3`. Result on this PC: the SessionStart **prefetch** + PostToolUse **query-stamp** silently no-op, and the Edit/Write **memory gate** fails to execute (fail-open) — governed development is broken in both Claude Code and Cursor.

Resolve the interpreter uniformly across all hooks:
```
.venv/Scripts/python.exe -> .venv/bin/python -> python3 -> python
```
`settings.json` regenerated via `scripts/merge_settings.py --no-local`.

Verified on Windows 11: both JSON valid, 0 bare `python3` left; the resolver picks `.venv/Scripts/python.exe` (3.13.12) and the query-stamp hook stamps the gate from a live Tier-3 query (proven in mcp-servers #167).

Source-level fix landed in agorokh/template-repo #305; this brings the child into line so the PC is a first-class dev host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify Python interpreter resolution for .claude hooks to work consistently across platforms, including Windows virtual environments.

Bug Fixes:
- Fix .claude hook commands failing or no-op on Windows due to hardcoded python3 interpreter paths.

Enhancements:
- Standardize hook interpreter resolution order to prefer project virtualenv Python before falling back to system interpreters.
- Regenerate .claude settings to remove bare python3 references and ensure consistent configuration across environments.