### PR TITLE
fix(mcp): resolve Windows venv python in repo-knowledge + agentic-memory launchers (#162)

### DIFF
--- a/scripts/mcp/agentic-memory.sh
+++ b/scripts/mcp/agentic-memory.sh
@@ -127,11 +127,17 @@ _resolve_python() {
     _resolve_command_executable "${candidate}"
     return $?
   fi
+  if [[ -n "${MCP_ROOT:-}" && -x "${MCP_ROOT}/.venv/Scripts/python.exe" ]]; then
+    # Windows venv layout (git-bash): interpreter lives under Scripts/, not bin/.
+    printf '%s' "${MCP_ROOT}/.venv/Scripts/python.exe"
+    return 0
+  fi
   if [[ -n "${MCP_ROOT:-}" && -x "${MCP_ROOT}/.venv/bin/python" ]]; then
     printf '%s' "${MCP_ROOT}/.venv/bin/python"
     return 0
   fi
-  _resolve_command_executable python3
+  # Windows has `python`, not `python3`; prefer whichever resolves.
+  _resolve_command_executable python3 || _resolve_command_executable python
 }
 
 MCP_ROOT="$(_resolve_root "AGENTIC_MEMORY_MCP_SERVERS_ROOT" "${AGENTIC_MEMORY_MCP_SERVERS_ROOT:-}" "${CHILD_REPO_ROOT}/../mcp-servers")" || exit 1

--- a/scripts/mcp/repo-knowledge.sh
+++ b/scripts/mcp/repo-knowledge.sh
@@ -51,12 +51,16 @@ _validate_python_path() {
 if [[ -n "${REPO_KNOWLEDGE_PYTHON:-}" ]]; then
   PYTHON="$(_expand_home "${REPO_KNOWLEDGE_PYTHON}")"
   _validate_python_path "${PYTHON}" 1
+elif [[ -x "${ROOT_DIR}/.venv/Scripts/python.exe" ]]; then
+  # Windows venv layout (git-bash): interpreter lives under Scripts/, not bin/.
+  PYTHON="${ROOT_DIR}/.venv/Scripts/python.exe"
 elif [[ -x "${ROOT_DIR}/.venv/bin/python" ]]; then
   PYTHON="${ROOT_DIR}/.venv/bin/python"
 else
-  PYTHON="python3"
-  if [[ ! -x "$(command -v "${PYTHON}" 2>/dev/null)" ]]; then
-    echo "repo-knowledge.sh: Neither .venv python nor system python3 is executable" >&2
+  # Windows has `python`, not `python3`; prefer whichever resolves.
+  PYTHON="$(command -v python3 || command -v python || true)"
+  if [[ -z "${PYTHON}" ]]; then
+    echo "repo-knowledge.sh: Neither .venv python nor system python/python3 is executable" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
Closes #162.

After #160/#161 the `.claude` hooks resolve Python on Windows, but the **MCP launchers** still didn't. `.mcp.json` runs `bash scripts/mcp/repo-knowledge.sh` and `bash scripts/mcp/agentic-memory.sh`; both resolved `.venv/bin/python` then bare `python3` — neither exists on Windows (venv is `.venv/Scripts/python.exe`; no `python3`).

- `repo-knowledge.sh`: prefer `.venv/Scripts/python.exe`, then `.venv/bin/python`, then `python3`/`python`.
- `agentic-memory.sh` `_resolve_python`: same, applied to the `MCP_ROOT` (mcp-servers) venv it bridges through.

Mirrors agorokh/mcp-servers #165. Verified on Windows 11 (with `.[knowledge]` installed): repo-knowledge + agentic-memory launchers start.