### PR TITLE
docs(vault): add cross-repo scope clause to secrets-from-doppler

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/invariants/secrets-from-doppler.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/invariants/secrets-from-doppler.md
@@ -2,7 +2,7 @@
 type: invariant
 status: active
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-06-13
 relates_to:
   - AcCopilotTrainer/00_System/invariants/_index.md
   - AcCopilotTrainer/00_System/invariants/no-secrets.md
@@ -24,6 +24,12 @@ LLM-extraction substrates (Graphiti, LightRAG) consume DIAL via the three-tier f
 3. `OPENROUTER_API_KEY` (last-resort diversification when DIAL unreachable)
 
 A raw `OPENAI_API_KEY` sourced from a real OpenAI key **must never** appear in any substrate config, `.env`, ADR, or deploy bundle in this org.
+
+## Scope (cross-repo boundary)
+
+This invariant governs **this project's own deployed services** (its `launchd` units and recurring scripts, wrapped with `doppler run --`). The threat it prevents is a **rogue, uncontrolled `.env`** that *silently overrides* a correct Doppler substitution (the originating postmortem) — not a controlled projection.
+
+A **co-located foreign-repo container** on a shared host — another project's compose service running on the same machine — that consumes a **Doppler-*projected*, operator-managed `.env`** follows **that repo's own sanctioned secret-consumption model**, *provided* **Doppler remains the canonical upstream** and the projection is **verifiable** against it (e.g. the on-disk value's hash matches Doppler). That controlled projection is a different posture from the rogue-override threat above. Do **not** hand-edit a foreign repo's host `.env` to repair such a secret — re-project via that repo's sanctioned path, and record the cross-repo reconciliation as an ADR in the owning project's vault.
 
 ## Rationale
 


### PR DESCRIPTION
Zero-drift fleet propagation of the canonical Scope (cross-repo boundary) clause merged in template-repo#307 (issue template-repo#306). Generic clause, docs-only, ruled reconciliation (Council of agents) — not a new decision or functional change. Pilot precedent: agorokh/hermescraft#214.