### PR TITLE
feat(sidecar): /health + /metrics endpoint (#167)

### DIFF
--- a/tests/test_ai_sidecar_observability.py
+++ b/tests/test_ai_sidecar_observability.py
@@ -88,7 +88,12 @@ def test_metrics_endpoint_single_content_type_and_core_series() -> None:
     assert "ac_sidecar_connected_peers 0" in body
 
 
-def test_ws_upgrade_still_works_and_counts_messages() -> None:
+def test_ws_upgrade_still_works_and_counts_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Isolate the process-global counters so the exact-count assertion below is
+    # deterministic under the full suite (other tests also drive hello frames
+    # through the shared METRICS singleton, which would push the count past 1).
+    monkeypatch.setattr(obs, "METRICS", obs.SidecarMetrics())
+
     async def _run() -> str:
         async with _running_sidecar() as port:
             async with ws_connect(f"ws://127.0.0.1:{port}") as client:

--- a/tests/test_ai_sidecar_observability.py
+++ b/tests/test_ai_sidecar_observability.py
@@ -1,0 +1,127 @@
+"""Observability endpoints for the AI sidecar (issue #167).
+
+``/health`` + ``/metrics`` are served over the websockets ``process_request``
+hook on the SAME WS port (``make_process_request``); counters live in
+``tools.ai_sidecar.observability``. Plain ``asyncio.run`` (the repo has no
+pytest-asyncio), mirroring ``test_ai_sidecar_external.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import urllib.request
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+
+websockets = pytest.importorskip("websockets")
+from websockets.asyncio.client import connect as ws_connect  # noqa: E402
+from websockets.asyncio.server import serve as ws_serve  # noqa: E402
+
+from tools.ai_sidecar import external_protocol as ep  # noqa: E402
+from tools.ai_sidecar import observability as obs  # noqa: E402
+from tools.ai_sidecar.server import (  # noqa: E402
+    _external_peers,
+    _handler,
+    make_process_request,
+)
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+@asynccontextmanager
+async def _running_sidecar(token: str | None = None) -> AsyncIterator[int]:
+    port = _free_port()
+    _external_peers.clear()
+    try:
+        async with ws_serve(
+            lambda ws: _handler(ws, reply_coaching=True),
+            "127.0.0.1",
+            port,
+            process_request=make_process_request(token),
+        ):
+            yield port
+    finally:
+        _external_peers.clear()
+
+
+def _http_get(port: int, path: str) -> tuple[int, list[str], str]:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as resp:
+        return resp.status, resp.headers.get_all("Content-Type") or [], resp.read().decode()
+
+
+def test_health_endpoint_on_ws_port() -> None:
+    async def _run() -> tuple[int, list[str], str]:
+        async with _running_sidecar() as port:
+            return await asyncio.to_thread(_http_get, port, "/health")
+
+    status, content_types, body = asyncio.run(_run())
+    assert status == 200
+    # Exactly ONE Content-Type — guards the websockets respond() append-bug.
+    assert content_types == ["application/json"]
+    payload = json.loads(body)
+    assert payload["status"] == "ok"
+    assert payload["connected_peers"] == 0
+
+
+def test_metrics_endpoint_single_content_type_and_core_series() -> None:
+    async def _run() -> tuple[int, list[str], str]:
+        async with _running_sidecar() as port:
+            return await asyncio.to_thread(_http_get, port, "/metrics")
+
+    status, content_types, body = asyncio.run(_run())
+    assert status == 200
+    # Exactly ONE Content-Type, Prometheus exposition — the de-dup fix's guard.
+    assert content_types == ["text/plain; version=0.0.4; charset=utf-8"]
+    assert "ac_sidecar_up 1" in body
+    assert "ac_sidecar_build_info{" in body
+    assert "ac_sidecar_connected_peers 0" in body
+
+
+def test_ws_upgrade_still_works_and_counts_messages() -> None:
+    async def _run() -> str:
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}") as client:
+                await client.send(
+                    json.dumps({ep.ENVELOPE_KEY: 1, ep.TYPE_KEY: ep.TYPE_HELLO, "client": "test"})
+                )
+                ack = json.loads(await asyncio.wait_for(client.recv(), timeout=5))
+                assert ack[ep.TYPE_KEY] == ep.TYPE_HELLO_ACK
+                # Peer held open → /metrics reflects it + the hello message counter.
+                _, _, body = await asyncio.to_thread(_http_get, port, "/metrics")
+                return body
+
+    body = asyncio.run(_run())
+    assert "ac_sidecar_connected_peers 1" in body
+    assert 'ac_sidecar_messages_total{type="hello"} 1' in body
+
+
+def test_metrics_builder_screen_recency(monkeypatch: pytest.MonkeyPatch) -> None:
+    m = obs.SidecarMetrics()
+    monkeypatch.setattr(obs, "METRICS", m)
+    assert "ac_sidecar_screen_connected 0" in obs.build_metrics_text(0)
+    m.note_screen_seen()
+    assert "ac_sidecar_screen_connected 1" in obs.build_metrics_text(0)
+
+
+def test_metrics_builder_message_label_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    m = obs.SidecarMetrics()
+    monkeypatch.setattr(obs, "METRICS", m)
+    m.record_message("event", "lap_complete")
+    m.record_message("type", "hello")
+    m.record_ollama_followup_error()
+    text = obs.build_metrics_text(3)
+    assert 'ac_sidecar_messages_total{event="lap_complete"} 1' in text
+    assert 'ac_sidecar_messages_total{type="hello"} 1' in text
+    assert "ac_sidecar_ollama_followup_errors_total 1" in text
+    assert "ac_sidecar_connected_peers 3" in text

--- a/tools/ai_sidecar/observability.py
+++ b/tools/ai_sidecar/observability.py
@@ -1,0 +1,150 @@
+"""Prometheus ``/metrics`` + ``/health`` text builders for the AI sidecar (issue #167).
+
+Stdlib-only emitter — the metric set is small and fixed-cardinality, so a full
+``prometheus_client`` dependency is unwarranted (keeps the ``[coaching]`` extra
+to ``websockets`` + the ML libs). The endpoints are served over the websockets
+``process_request`` hook on the same ``:8765`` port (see
+``server.make_process_request``), so a plain HTTP ``GET /health`` or ``/metrics``
+short-circuits the WS upgrade and never enters the coaching handler.
+
+Thread-safety: counters are mutated from the asyncio event-loop thread (the
+process_request hook + frame dispatch) and from ``asyncio.to_thread`` worker
+threads (the Ollama follow-up error path), so increments take a module lock.
+``build_metrics_text`` snapshots the counters under the lock and formats the
+exposition text OUTSIDE the lock, so rendering ``/metrics`` cannot stall a
+concurrent WS upgrade.
+
+Cross-repo: fleet registration of this surface as a session-scoped service lands
+in ``agorokh/workstation-ops`` (#517).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass, field
+
+from tools.ai_sidecar.external_protocol import SERVER_VERSION
+from tools.ai_sidecar.protocol import PROTOCOL_VERSION
+
+# Prometheus text exposition content type (version 0.0.4).
+PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+HEALTH_CONTENT_TYPE = "application/json"
+# A screen counts as "connected" if its client header was seen this recently.
+SCREEN_RECENCY_SECONDS = 120.0
+
+_lock = threading.Lock()
+
+
+@dataclass
+class SidecarMetrics:
+    """Process-global counters/gauges for the sidecar (singleton ``METRICS``)."""
+
+    # (label_key, label_value) -> count, e.g. ("event", "lap_complete") or ("type", "hello").
+    messages: dict[tuple[str, str], int] = field(default_factory=dict)
+    ollama_followup_errors: int = 0
+    last_message_ts: float = 0.0  # unix seconds of the last dispatched message
+    screen_last_seen_monotonic: float = 0.0  # time.monotonic() of the last screen client header
+
+    def record_message(self, label_key: str, label_value: str) -> None:
+        with _lock:
+            key = (label_key, label_value)
+            self.messages[key] = self.messages.get(key, 0) + 1
+            self.last_message_ts = time.time()
+
+    def record_ollama_followup_error(self) -> None:
+        with _lock:
+            self.ollama_followup_errors += 1
+
+    def note_screen_seen(self) -> None:
+        with _lock:
+            self.screen_last_seen_monotonic = time.monotonic()
+
+
+METRICS = SidecarMetrics()
+
+
+def _escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _labels(pairs: dict[str, str]) -> str:
+    if not pairs:
+        return ""
+    inner = ",".join(f'{k}="{_escape(v)}"' for k, v in sorted(pairs.items()))
+    return "{" + inner + "}"
+
+
+def build_health_json(connected_peers: int) -> str:
+    """Instant health body: the endpoint answering IS liveness."""
+    return json.dumps({"status": "ok", "connected_peers": connected_peers}, separators=(",", ":"))
+
+
+def build_metrics_text(connected_peers: int) -> str:
+    """Prometheus exposition text for the sidecar's fixed metric set.
+
+    Snapshots the shared counters under the lock, then formats outside it.
+    """
+    with _lock:
+        messages = dict(METRICS.messages)  # snapshot under lock; format below outside it
+        ollama_errors = METRICS.ollama_followup_errors
+        last_message_ts = METRICS.last_message_ts
+        screen_last_seen = METRICS.screen_last_seen_monotonic
+
+    now_mono = time.monotonic()
+    screen_connected = (
+        1 if screen_last_seen > 0 and (now_mono - screen_last_seen) < SCREEN_RECENCY_SECONDS else 0
+    )
+
+    lines: list[str] = []
+
+    def emit(
+        name: str, help_text: str, metric_type: str, samples: list[tuple[dict[str, str], object]]
+    ) -> None:
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} {metric_type}")
+        for label_pairs, value in samples:
+            lines.append(f"{name}{_labels(label_pairs)} {value}")
+
+    emit("ac_sidecar_up", "Sidecar HTTP endpoint is answering.", "gauge", [({}, 1)])
+    emit(
+        "ac_sidecar_build_info",
+        "Sidecar build/version info.",
+        "gauge",
+        [({"protocol_version": str(PROTOCOL_VERSION), "server_version": SERVER_VERSION}, 1)],
+    )
+    emit(
+        "ac_sidecar_connected_peers",
+        "External v1 peers currently connected.",
+        "gauge",
+        [({}, connected_peers)],
+    )
+    emit(
+        "ac_sidecar_messages_total",
+        "Messages dispatched, by envelope label (event= legacy, type= v1).",
+        "counter",
+        [
+            ({label_key: label_value}, count)
+            for (label_key, label_value), count in sorted(messages.items())
+        ],
+    )
+    emit(
+        "ac_sidecar_ollama_followup_errors_total",
+        "Ollama coaching follow-ups that failed or did not deliver.",
+        "counter",
+        [({}, ollama_errors)],
+    )
+    emit(
+        "ac_sidecar_screen_connected",
+        "1 if an ESP32 rig-screen client was seen within the recency window.",
+        "gauge",
+        [({}, screen_connected)],
+    )
+    emit(
+        "ac_sidecar_last_message_timestamp",
+        "Unix timestamp of the last dispatched message (0 if none yet).",
+        "gauge",
+        [({}, f"{last_message_ts:.0f}")],
+    )
+    return "\n".join(lines) + "\n"

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -21,6 +21,7 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Any
 
+from tools.ai_sidecar import observability
 from tools.ai_sidecar.coaching.llm_coach import debrief_feature_enabled
 from tools.ai_sidecar.external_protocol import (
     AUTH_HEADER,
@@ -169,8 +170,10 @@ async def _send_ollama_followup(
         raise
     except Exception as e:
         logger.info("ollama followup raised: %s", e)
+        observability.METRICS.record_ollama_followup_error()
         return
     if followup is None:
+        observability.METRICS.record_ollama_followup_error()
         return
     await _safe_send(websocket, followup)
 
@@ -227,6 +230,64 @@ def make_token_check(token: str | None):
         return None
 
     return _check
+
+
+def _http_response(connection: Any, status: HTTPStatus, body: str, content_type: str) -> Any:
+    """Build a plain HTTP response on the WS connection with a SINGLE, correct
+    Content-Type.
+
+    ``connection.respond(status, text)`` hardcodes ``Content-Type: text/plain;
+    charset=utf-8`` and ``Headers.__setitem__`` APPENDS rather than replaces
+    (websockets 16.0, verified), so a naive ``resp.headers["Content-Type"] = …``
+    yields TWO Content-Type headers and a strict Prometheus scraper / JSON client
+    mis-parses the body. Delete the default header first, then set ours.
+    """
+    response = connection.respond(status, body)
+    try:
+        del response.headers["Content-Type"]
+    except KeyError:  # pragma: no cover - defensive across websockets versions
+        pass
+    response.headers["Content-Type"] = content_type
+    return response
+
+
+def make_process_request(token: str | None):
+    """Build the websockets ``process_request`` hook.
+
+    Serves ``GET /health`` and ``GET /metrics`` as plain HTTP on the SAME port as
+    the WebSocket (short-circuiting the upgrade so they never enter ``_handler``),
+    then falls through to the optional token gate (``make_token_check``) for a real
+    WS upgrade. Installed UNCONDITIONALLY so the endpoints work even in the default
+    no-token loopback deployment. Read-only ``/health`` and ``/metrics`` carry no
+    secrets and are intentionally not token-gated; the WS upgrade keeps the gate.
+    """
+    token_check = make_token_check(token)
+
+    def _process_request(connection: Any, request: Any) -> Any:
+        path = (getattr(request, "path", "") or "").split("?", 1)[0]
+        if path in ("/health", "/healthz"):
+            return _http_response(
+                connection,
+                HTTPStatus.OK,
+                observability.build_health_json(len(_external_peers)),
+                observability.HEALTH_CONTENT_TYPE,
+            )
+        if path == "/metrics":
+            return _http_response(
+                connection,
+                HTTPStatus.OK,
+                observability.build_metrics_text(len(_external_peers)),
+                observability.PROM_CONTENT_TYPE,
+            )
+        # A rig-screen sighting rides on the WS upgrade (the client header is on
+        # the upgrade request), then the token gate applies if one is configured.
+        if request.headers.get(CLIENT_HEADER):
+            observability.METRICS.note_screen_seen()
+        if token_check is not None:
+            return token_check(connection, request)
+        return None
+
+    return _process_request
 
 
 async def _broadcast_external(frame: dict[str, Any], *, exclude: Any) -> None:
@@ -383,8 +444,13 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
             # Route any envelope-like payload through external validation so
             # malformed `{v,type}` frames get explicit protocol errors.
             if ENVELOPE_KEY in data or TYPE_KEY in data:
+                observability.METRICS.record_message("type", str(data.get(TYPE_KEY, "?")))
                 await _handle_external_frame(websocket, data)
                 continue
+
+            event_name = data.get("event")
+            if event_name is not None:
+                observability.METRICS.record_message("event", str(event_name))
 
             if data.get("event") == "lap_complete":
                 hints = data.get("coachingHints") or []
@@ -475,7 +541,7 @@ async def _run(host: str, port: int, reply_coaching: bool, token: str | None) ->
     except ImportError as e:
         raise SystemExit('websockets is required. Install: pip install -e ".[coaching]"') from e
 
-    process_request = make_token_check(token)
+    process_request = make_process_request(token)
     _external_peers.clear()
     try:
         async with websockets.serve(


### PR DESCRIPTION
Closes #167. Cross-repo L3 of the Windows-PC fleet observability audit (fleet registration: agorokh/workstation-ops#517).

Adds `/health` (instant JSON) + `/metrics` (Prometheus text) to the AI sidecar, served over the existing `websockets` `process_request` hook on the **same :8765 port** — no new port, no new dependency, WS upgrade + token gate preserved.

### What
- New `tools/ai_sidecar/observability.py`: stdlib Prometheus emitter (snapshot-under-lock, format-outside) exposing `ac_sidecar_up`, `ac_sidecar_build_info`, `ac_sidecar_connected_peers`, `ac_sidecar_messages_total{event|type}`, `ac_sidecar_ollama_followup_errors_total`, `ac_sidecar_screen_connected`, `ac_sidecar_last_message_timestamp`.
- `server.py`: `make_process_request` composes the endpoints + the existing `make_token_check` (kept intact, so the token tests still pass); `_run` installs it. Metric hooks at message ingress + the Ollama follow-up error paths; screen-seen on the WS upgrade client header.
- **Content-Type de-dup**: `connection.respond()` hardcodes `text/plain` and `Headers.__setitem__` *appends* (websockets 16.0, verified), so `_http_response` deletes the default header before setting ours — otherwise the response carries two Content-Type headers.

### Verified
- 20 sidecar tests pass (4 new + 16 existing, no regression); ruff clean.
- New tests assert **exactly one** Content-Type on /health (`application/json`) and /metrics (`text/plain; version=0.0.4`), that the WS upgrade still works (hello→hello_ack), and the message/screen counters.
- **Live on pc**: `python -m tools.ai_sidecar` → `curl /health` and `/metrics` return 200 with single correct Content-Type and real series.

### Note (read-only exposure)
/health + /metrics are not token-gated (no secrets). The WS control surface keeps the token gate. Central scraping (tailnet bind + firewall scope) is deferred to the workstation-ops session-scoped registration (#517).