### PR TITLE
fix(sidecar): trainer v1 hello handshake — register before publish, survive error frames, frame-paced retry (#170)

### DIFF
--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -87,14 +87,22 @@ local sidecarProtocolReady = false
 --- Hello-retry state for the v1 external surface: some CSP builds don't fire
 --- params.onOpen reliably on the first connect. Without a hello we never
 --- register as a v1 peer with the sidecar, and `state.snapshot` frames are
---- silently dropped (no loopback target). Track per-socket whether we've
---- successfully sent hello and the last attempt time so we can retry from
---- M.tick at most once a second.
+--- silently dropped (no loopback target). The retry MUST be paced on real
+--- frames (a tick counter), NOT sim-time: in the pre-drive pit menu the sim
+--- clock is frozen while the render loop (M.tick) keeps running, so a sim-time
+--- gate fired the retry exactly once and never recovered from a first send that
+--- lost the CSP `web.socket` writable race — stranding us connected-but-
+--- unregistered so coaching.snapshot never fans out. Found in-sim on AG_PC
+--- (#170 / EPIC #154).
 local externalHelloPending = false
-local externalHelloLastTryT = -1e9
-local externalHelloLogLastT = -1e9
-local EXTERNAL_HELLO_LOG_MIN_SEC = 10.0
-local EXTERNAL_HELLO_RETRY_SEC = 1.0
+local helloRetryFrames = 0
+local helloSendCount = 0
+--- Resend hello every N M.tick frames (~0.2 s at 60 Hz) until hello_ack flips
+--- `sidecarProtocolReady`. Frame-paced so a frozen sim clock cannot stall it.
+local EXTERNAL_HELLO_RETRY_FRAMES = 12
+--- Emit at most one hello-retry diagnostic per this many actual sends so a
+--- (briefly) unresponsive sidecar cannot spam the CSP console (Qodo on PR #91).
+local EXTERNAL_HELLO_LOG_EVERY_SENDS = 10
 --- Forward declaration — assigned where `tryOpen` is defined (used before spawn).
 local tryOpen
 
@@ -449,7 +457,8 @@ tryOpen = function()
   -- sidecar's v1 hello_ack arrives) — this is the only reliable signal that
   -- our hello landed and we're registered as an external peer.
   externalHelloPending = true
-  externalHelloLastTryT = -1e9
+  helloRetryFrames = 0
+  helloSendCount = 0
   local function announceExternalHello()
     M.sendJson({
       v = PROTOCOL_VERSION,
@@ -602,9 +611,24 @@ function M.pollInbound(maxPerTick)
         -- Issue #81: external-client envelope. The sidecar fans `config.set`,
         -- `action`, and `state.subscribe` here so we can apply them locally
         -- and emit acks/values that the sidecar broadcasts back to the screen.
-        sidecarProtocolReady = true
         local t = data.type
-        if t == "action" then
+        -- A non-error v1 frame (hello_ack, or a fanned action/config/state/
+        -- request) proves the sidecar registered us as a peer. An `error`
+        -- frame must NOT flip readiness: the sidecar emits {v=1,type="error"}
+        -- to REJECT a frame (e.g. a state.snapshot sent before our hello
+        -- landed), and treating that as "registered" cancels the hello retry
+        -- below — stranding us connected-but-unregistered so coaching.snapshot
+        -- never fans out to the rig screen / harness tap. Found in-sim on
+        -- AG_PC delivering #170 / EPIC #154 (off-sim L0/L1 can't see this).
+        if t ~= "error" then
+          sidecarProtocolReady = true
+        end
+        if t == "error" then
+          if ac and type(ac.log) == "function" then
+            pcall(ac.log, "[COPILOT][WS-DIAG] sidecar rejected frame: "
+              .. tostring(data.message) .. " ref=" .. tostring(data.ref_type))
+          end
+        elseif t == "action" then
           local name = type(data.name) == "string" and data.name or ""
           local handler = actionHandlers[name]
           if not handler then
@@ -837,20 +861,24 @@ function M.tick(simTime)
     -- `sidecarProtocolReady`), at which point we stop retrying. The sidecar's
     -- `_external_peers.add()` is idempotent so duplicate hellos are no-ops.
     if externalHelloPending and not sidecarProtocolReady then
-      if currentSimT - externalHelloLastTryT >= EXTERNAL_HELLO_RETRY_SEC then
-        externalHelloLastTryT = currentSimT
+      -- Frame-paced retry (see EXTERNAL_HELLO_RETRY_FRAMES note above): immune to
+      -- the frozen pit-menu sim clock that previously let the hello be attempted
+      -- only once.
+      helloRetryFrames = helloRetryFrames + 1
+      if helloRetryFrames >= EXTERNAL_HELLO_RETRY_FRAMES then
+        helloRetryFrames = 0
         local sent = M.sendJson({
           v = PROTOCOL_VERSION,
           type = "hello",
           client = "ac-copilot-trainer-lua",
         })
-        if ac and type(ac.log) == "function" then
-          -- Retries stay at 1 Hz for correctness; log line is rate-limited so a
-          -- dead sidecar cannot spam the CSP console (Qodo on PR #91).
-          if currentSimT - externalHelloLogLastT >= EXTERNAL_HELLO_LOG_MIN_SEC then
-            externalHelloLogLastT = currentSimT
-            ac.log("[COPILOT][WS-DIAG] hello retry sent=" .. tostring(sent))
-          end
+        helloSendCount = helloSendCount + 1
+        -- Log the first send and then every EXTERNAL_HELLO_LOG_EVERY_SENDS so a
+        -- (briefly) unresponsive sidecar cannot spam the CSP console.
+        if ac and type(ac.log) == "function"
+            and (helloSendCount % EXTERNAL_HELLO_LOG_EVERY_SENDS) == 1 then
+          ac.log("[COPILOT][WS-DIAG] hello retry sent=" .. tostring(sent)
+            .. " try=" .. tostring(helloSendCount))
         end
       end
     elseif sidecarProtocolReady then
@@ -922,7 +950,11 @@ end
 ---@return boolean
 function M.publishTopic(topic, payload)
   if type(topic) ~= "string" or topic == "" then return false end
-  if not sock then return false end
+  -- Only publish after the v1 hello handshake completes (hello_ack seen, so we
+  -- are a registered peer). Sending a state.snapshot before registration makes
+  -- the sidecar reject it ("peer must send hello before other frame types") and
+  -- never fan it out — the in-sim failure mode found on AG_PC (#170 / #154).
+  if not M.sidecarConnected() then return false end
   return M.sendJson({
     v = PROTOCOL_VERSION,
     type = "state.snapshot",

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -84,6 +84,13 @@ local lastCornerQueryAt = {}  ---@type table<string, number>
 local _recvQueue = {}
 --- True after first inbound JSON with matching `protocol` (CodeRabbit #78).
 local sidecarProtocolReady = false
+-- v1-registration flag: true ONLY once a non-error v1 frame (hello_ack, or a
+-- fanned action/config/state) arrives, proving the sidecar added us to its v1
+-- `_external_peers`. Deliberately SEPARATE from `sidecarProtocolReady`, which the
+-- legacy `protocol=1` recv path also sets — a legacy reply (e.g. corner_advice)
+-- must NOT unblock the v1 `state.snapshot` publish path or stop the hello retry
+-- before the v1 handshake actually completes (chatgpt-codex P1 on PR #171).
+local externalHelloAcked = false
 --- Hello-retry state for the v1 external surface: some CSP builds don't fire
 --- params.onOpen reliably on the first connect. Without a hello we never
 --- register as a v1 peer with the sidecar, and `state.snapshot` frames are
@@ -457,6 +464,7 @@ tryOpen = function()
   -- sidecar's v1 hello_ack arrives) — this is the only reliable signal that
   -- our hello landed and we're registered as an external peer.
   externalHelloPending = true
+  externalHelloAcked = false
   helloRetryFrames = 0
   helloSendCount = 0
   local function announceExternalHello()
@@ -622,6 +630,11 @@ function M.pollInbound(maxPerTick)
         -- AG_PC delivering #170 / EPIC #154 (off-sim L0/L1 can't see this).
         if t ~= "error" then
           sidecarProtocolReady = true
+          -- A non-error v1 frame proves the sidecar registered us as a v1 peer
+          -- (hello_ack, or a fanned action/config/state). This — not the
+          -- legacy-inclusive `sidecarProtocolReady` — gates the v1 publish path
+          -- and the hello-retry stop (chatgpt-codex P1 on PR #171).
+          externalHelloAcked = true
         end
         if t == "error" then
           if ac and type(ac.log) == "function" then
@@ -860,7 +873,7 @@ function M.tick(simTime)
     -- hello until we observe a v1 frame back from the sidecar (which sets
     -- `sidecarProtocolReady`), at which point we stop retrying. The sidecar's
     -- `_external_peers.add()` is idempotent so duplicate hellos are no-ops.
-    if externalHelloPending and not sidecarProtocolReady then
+    if externalHelloPending and not externalHelloAcked then
       -- Frame-paced retry (see EXTERNAL_HELLO_RETRY_FRAMES note above): immune to
       -- the frozen pit-menu sim clock that previously let the hello be attempted
       -- only once.
@@ -881,7 +894,7 @@ function M.tick(simTime)
             .. " try=" .. tostring(helloSendCount))
         end
       end
-    elseif sidecarProtocolReady then
+    elseif externalHelloAcked then
       externalHelloPending = false
     end
     return
@@ -950,11 +963,14 @@ end
 ---@return boolean
 function M.publishTopic(topic, payload)
   if type(topic) ~= "string" or topic == "" then return false end
-  -- Only publish after the v1 hello handshake completes (hello_ack seen, so we
-  -- are a registered peer). Sending a state.snapshot before registration makes
-  -- the sidecar reject it ("peer must send hello before other frame types") and
-  -- never fan it out — the in-sim failure mode found on AG_PC (#170 / #154).
-  if not M.sidecarConnected() then return false end
+  -- Only publish after the v1 hello handshake completes (a non-error v1 frame
+  -- seen, so we are in the sidecar's v1 `_external_peers`). Gate on the
+  -- v1-specific `externalHelloAcked`, NOT `sidecarConnected()`/`sidecarProtocolReady`
+  -- — the latter is also set by the legacy `protocol=1` flow, and a legacy reply
+  -- arriving before hello_ack would otherwise unblock this v1 publish path while
+  -- we are still unregistered, so the sidecar would reject the snapshot
+  -- ("peer must send hello before other frame types") (chatgpt-codex P1, PR #171).
+  if not (sock and externalHelloAcked) then return false end
   return M.sendJson({
     v = PROTOCOL_VERSION,
     type = "state.snapshot",

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -477,6 +477,17 @@ tryOpen = function()
   local opened = nil
   local params = {
     onOpen = function()
+      -- Re-arm v1 (and legacy) registration gating on every transport open. With
+      -- `reconnect = true` CSP auto-reconnects on a transient drop by firing this
+      -- callback WITHOUT going through `tryOpen`, so the tryOpen resets are skipped;
+      -- a stale `externalHelloAcked = true` would then suppress the hello retry on
+      -- the new socket and leave us unregistered with the sidecar's new connection
+      -- (CodeRabbit Major on PR #171).
+      sidecarProtocolReady = false
+      externalHelloAcked = false
+      externalHelloPending = true
+      helloRetryFrames = 0
+      helloSendCount = 0
       -- Always announce hello on onOpen. The previous "inline hello + dedup"
       -- pattern silently dropped the registration when the inline send fired
       -- before the socket was actually open: sendJson returned false, and

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -38,9 +38,11 @@ ac = { log = function() end, getFolder = function() return "" end, FolderID = { 
 os = os or {}
 web = {}
 _ws_on_recv = nil
+_ws_on_open = nil
 _ws_sent = 0
 function web.socket(_u, cb, _p)
   _ws_on_recv = cb
+  _ws_on_open = _p and _p.onOpen or nil
   local s = { close = function() end }
   setmetatable(s, { __call = function(_, _data) _ws_sent = _ws_sent + 1 end })
   return s
@@ -144,5 +146,28 @@ def test_legacy_protocol_frame_does_not_unblock_v1_publish():
     )
     assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is False
     # Only a v1 hello_ack opens the v1 publish path.
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True
+
+
+def test_reconnect_via_onopen_rearms_handshake():
+    # CodeRabbit Major on PR #171: with reconnect=true, CSP auto-reconnects by
+    # firing onOpen WITHOUT calling tryOpen. The handshake gating must re-arm on
+    # that new transport session, or a stale externalHelloAcked would suppress the
+    # hello retry and leave us unregistered with the sidecar's new connection.
+    rt = _runtime()
+    _open(rt)
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True
+
+    # Simulate a CSP auto-reconnect: onOpen fires on the new socket, no tryOpen.
+    assert rt.eval("_ws_on_open ~= nil"), "ws_bridge must register an onOpen callback"
+    sent_before = int(rt.eval("_ws_sent"))
+    rt.execute("_ws_on_open()")
+    # Re-armed: publishing is gated again until a fresh hello_ack...
+    assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is False
+    # ...and a hello was re-announced on the new session.
+    assert int(rt.eval("_ws_sent")) > sent_before
+    # A fresh hello_ack re-registers us.
     _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
     assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -128,3 +128,21 @@ def test_hello_ack_registers_and_unblocks_publish():
     assert _connected(rt) is True
     # With the handshake complete, coaching.snapshot publishing resumes.
     assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True
+
+
+def test_legacy_protocol_frame_does_not_unblock_v1_publish():
+    # chatgpt-codex P1 on PR #171: the v1 publish path must require the v1 hello
+    # handshake, not just any-protocol readiness. A legacy protocol=1 reply (e.g.
+    # corner_advice) sets the legacy `sidecarProtocolReady` but NOT v1 registration
+    # — publishTopic must stay blocked until the real v1 hello_ack arrives, else
+    # the sidecar (which only fans to v1 _external_peers) rejects the snapshot.
+    rt = _runtime()
+    _open(rt)
+    _inject(
+        rt,
+        {"protocol": 1, "event": "corner_advice", "corner": "T1", "text": "lift", "lap": 0},
+    )
+    assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is False
+    # Only a v1 hello_ack opens the v1 publish path.
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -1,0 +1,130 @@
+"""Regression test for #170 — the trainer's v1 hello handshake with the sidecar.
+
+Found in-sim on AG_PC: the trainer connected at the WS layer but never registered
+as a v1 peer, so ``coaching.snapshot`` was rejected and never fanned out (to the
+rig screen or a harness tap). Three coupled defects, all asserted here under lupa
+with NO Assetto Corsa and NO sidecar:
+
+1. ``publishTopic`` published a ``state.snapshot`` before the hello handshake
+   completed (guarded only on ``sock``) -> the sidecar rejected it.
+2. The sidecar's ``{v:1,type:"error"}`` rejection is itself a v1 frame, and the
+   recv path marked ``sidecarProtocolReady`` true for *any* v1 frame -> the hello
+   retry was cancelled and the peer stranded unregistered forever.
+3. The hello retry was paced on sim-time, which is frozen in the pre-drive pit
+   menu, so it fired only once and never recovered from a first send that lost
+   the CSP ``web.socket`` writable race.
+
+These tests exercise the Lua recv/tick path directly so the regression cannot
+recur unnoticed (off-sim L0 — the EPIC #154 layer that should have caught it).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
+
+# Minimal CSP-ish globals ws_bridge touches. `web.socket` captures the recv
+# callback and counts sends; the returned socket is a callable table (CSP
+# sockets are callables — `sock(json)` sends), matching `M.sendJson`.
+_STUB = r"""
+ac = { log = function() end, getFolder = function() return "" end, FolderID = { Root = 0 } }
+os = os or {}
+web = {}
+_ws_on_recv = nil
+_ws_sent = 0
+function web.socket(_u, cb, _p)
+  _ws_on_recv = cb
+  local s = { close = function() end }
+  setmetatable(s, { __call = function(_, _data) _ws_sent = _ws_sent + 1 end })
+  return s
+end
+"""
+
+
+def _runtime() -> lupa.LuaRuntime:
+    rt = lupa.LuaRuntime(unpack_returned_tuples=False)
+    rt.execute(_STUB)
+    p = str(MODULES_DIR).replace("\\", "/")
+    rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
+    g = rt.globals()
+
+    def _parse(s):
+        if not isinstance(s, str):
+            s = str(s)
+        return rt.table_from(json.loads(s))
+
+    def _stringify(t, pretty=False):
+        # Content is irrelevant to these tests (we assert on state + return
+        # values, not wire bytes); just hand sendJson a non-empty string.
+        return "{}"
+
+    g["JSON"] = rt.table_from({"parse": _parse, "stringify": _stringify})
+    return rt
+
+
+def _open(rt) -> None:
+    rt.execute('local wb = require("ws_bridge"); wb.configure("ws://127.0.0.1:8765"); wb.tick(0)')
+    assert rt.eval("_ws_on_recv ~= nil"), "socket should have opened on first tick"
+
+
+def _inject(rt, frame: dict) -> None:
+    rt.globals()["_inject_payload"] = json.dumps(frame)
+    rt.execute("_ws_on_recv(_inject_payload)")
+    rt.execute('local wb = require("ws_bridge"); wb.tick(0); wb.pollInbound(8)')
+
+
+def _connected(rt) -> bool:
+    return bool(rt.eval('require("ws_bridge").sidecarConnected()'))
+
+
+def test_publish_is_gated_until_hello_ack():
+    rt = _runtime()
+    _open(rt)
+    # Before hello_ack we are not a registered peer...
+    assert _connected(rt) is False
+    # ...so publishTopic must NOT emit a state.snapshot (fix #1).
+    assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is False
+
+
+def test_error_frame_does_not_register_peer():
+    rt = _runtime()
+    _open(rt)
+    _inject(
+        rt,
+        {
+            "v": 1,
+            "type": "error",
+            "message": "peer must send hello before other frame types",
+            "ref_type": "state.snapshot",
+        },
+    )
+    # An error frame is a v1 frame but must NOT flip readiness (fix #2), or the
+    # hello retry below would be cancelled and we'd never register.
+    assert _connected(rt) is False
+
+
+def test_hello_retry_is_frame_paced_under_frozen_sim_clock():
+    rt = _runtime()
+    _open(rt)
+    sent_before = int(rt.eval("_ws_sent"))
+    # All ticks pass simTime=0 (frozen pit-menu clock). A sim-time gate would
+    # fire once; the frame-paced retry (fix #3) fires repeatedly.
+    rt.execute('local wb = require("ws_bridge"); for _ = 1, 30 do wb.tick(0) end')
+    assert int(rt.eval("_ws_sent")) > sent_before
+
+
+def test_hello_ack_registers_and_unblocks_publish():
+    rt = _runtime()
+    _open(rt)
+    assert _connected(rt) is False
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert _connected(rt) is True
+    # With the handshake complete, coaching.snapshot publishing resumes.
+    assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True


### PR DESCRIPTION
## What

Fixes #170 — in a **live Assetto Corsa session on the rig (AG_PC)** the trainer's Lua
`ws_bridge` connects to the `ai_sidecar` at the WS layer but **never registers as a v1 peer**,
so every `coaching.snapshot` it publishes is rejected and **never fans out** — to the rig
screen (PR #91 AC-Copilot mirror) *or* to a headless harness tap. Found while delivering the
in-sim half of EPIC #154 directly on the rig. Pure off-sim L0/L1 (Parts A–C) cannot observe
this — it is a live CSP `web.socket` timing interaction.

## Root cause (three coupled defects in `modules/ws_bridge.lua`)

1. **Publish raced the handshake.** `publishTopic` emitted a v1 `state.snapshot` guarded only
   on `sock`. `coachingPublisher.publishIfDue` runs *before* `wsBridge.tick` in
   `script.update`, so the snapshot hit the sidecar before any hello → rejected with
   `peer must send hello before other frame types`.
2. **The error reply falsely satisfied "registered".** The rejection is `{v:1,type:"error"}`
   — itself a v1 frame — and the recv path set `sidecarProtocolReady=true` for *any* v1 frame,
   cancelling the hello retry and stranding the peer unregistered forever.
3. **The retry was sim-time-paced.** `wsBridge.tick` first runs in the pre-drive pit menu where
   `sim.gameTime` is frozen; the sim-time-gated retry fired **once** and never recovered from a
   first send that lost CSP's `web.socket` writable race (`onOpen` is unreliable on first connect).

## Fix

- `publishTopic` now gates on `M.sidecarConnected()` (sock **and** `sidecarProtocolReady`), so no
  v1 frame is sent before the hello handshake completes.
- `error` frames never flip `sidecarProtocolReady` (logged instead) → the hello retry persists
  until a real `hello_ack`.
- Hello retry is now **frame-paced** (`EXTERNAL_HELLO_RETRY_FRAMES`, ~0.2 s at 60 Hz) so a frozen
  sim clock cannot stall it.

## Verification

- **Deterministic L0 (new):** `tests/test_ws_bridge_hello_handshake.py` — 4 lupa tests covering
  all three behaviors (publish gated until `hello_ack`; error frame doesn't register; frame-paced
  retry under a frozen sim clock; `hello_ack` registers + unblocks publish). Green; existing
  `test_lua_runtime_smoke.py` still green.
- **In-game (AG_PC):** observed the exact pre-fix rejection storm at the WS layer and confirmed it
  is suppressed post-fix; confirmed AC launches and the trainer reads live car-0 state
  (`[COPILOT][RT-DIAG] sp=… trackLen=3559`). The on-track **positive** confirmation
  (`coaching.snapshot` fanning to a tap) requires the player car on track — `wsBridge.tick` is
  gated behind `if sim.isInMainMenu then return`. OS-level input injection into AC's menu does
  **not** work (raw input + no background-process focus), so autonomous "go on track" must come
  from the CSP Custom AI driver (EPIC #154 Part E), tracked there.

## Notes

- No protocol bump; sidecar contract unchanged.
- 8 unrelated tests fail locally on this minimal public spoke (agentic-memory wrapper,
  governance-hub shims, memory-contract links, session-debrief) — **confirmed pre-existing on
  `main`**, not touched by this change.

Relates to #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
