### PR TITLE
feat(sidecar): reconcile WS topic allow-list + drift-guard (#154 Part D step 1)

### DIFF
--- a/tests/test_ws_topic_allowlist.py
+++ b/tests/test_ws_topic_allowlist.py
@@ -1,0 +1,112 @@
+"""WS topic allow-list integrity (EPIC #154 Part D, step 1).
+
+`external_protocol.KNOWN_TOPICS` is the allow-list `validate_inbound` consults for
+`state.subscribe`. Fan-out itself is topic-agnostic (`_broadcast_external`), so an
+omission here does NOT drop frames — it just makes a real, produced topic
+*unsubscribable*. That is the "produced-but-unsubscribable" sibling of the #170
+handshake bug: `coaching.snapshot` and `setup.active` were emitted by the trainer
+yet a client could never legitimately subscribe to them.
+
+These tests keep the allow-list honest:
+1. `validate_inbound` accepts a subscribe to every `KNOWN_TOPICS` entry and rejects
+   an unknown one.
+2. **Drift-guard** — every topic the Lua side actually publishes (via
+   `publishTopic`, whether an inline string literal or a `local TOPIC = "..."`
+   constant) MUST be in `KNOWN_TOPICS`. This fails CI the moment a new producer is
+   wired without its allow-list entry — the structural fix for the recurring
+   "forgot the allow-list" pitfall.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from tools.ai_sidecar.external_protocol import (
+    ENVELOPE_KEY,
+    ENVELOPE_VERSION,
+    KNOWN_TOPICS,
+    TYPE_KEY,
+    validate_inbound,
+)
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+LUA_SRC = REPO / "src" / "ac_copilot_trainer"
+
+# A call site: `<recv>.publishTopic(<first-arg>` — the leading dot excludes the
+# `function M.publishTopic(topic, payload)` definition (no dot) and the
+# `type(wsBridge.publishTopic)` guard (no `(` after the name).
+_CALL_RE = re.compile(r"\.publishTopic\s*\(\s*([^\s,)]+)")
+
+
+def _produced_topics() -> tuple[dict[str, str], list[str]]:
+    """Return ({topic: 'file'} , [unresolved-call descriptions]).
+
+    Resolves the first argument of each `.publishTopic(` CALL to a string literal:
+    direct ('"coaching.snapshot"') or via a `local NAME = "..."` / `NAME = "..."`
+    assignment in the same file (covers coaching_publisher's `TOPIC` constant).
+    A first-arg that cannot be resolved to a literal is reported as unresolved so
+    the guard fails loud rather than silently passing a producer it can't verify.
+    """
+    topics: dict[str, str] = {}
+    unresolved: list[str] = []
+    for f in sorted(LUA_SRC.rglob("*.lua")):
+        text = f.read_text(encoding="utf-8")
+        for m in _CALL_RE.finditer(text):
+            line_start = text.rfind("\n", 0, m.start()) + 1
+            line_end = text.find("\n", m.start())
+            line = text[line_start : line_end if line_end != -1 else len(text)]
+            if "function" in line:  # the definition, not a call
+                continue
+            arg = m.group(1)
+            if arg[:1] in ("'", '"'):
+                topics[arg.strip("'\"")] = f.name
+                continue
+            vm = re.search(rf"\b{re.escape(arg)}\s*=\s*['\"]([^'\"]+)['\"]", text)
+            if vm:
+                topics[vm.group(1)] = f.name
+            else:
+                unresolved.append(
+                    f"{f.name}: publishTopic({arg}) — first arg not a resolvable string literal"
+                )
+    return topics, unresolved
+
+
+@pytest.mark.parametrize("topic", sorted(KNOWN_TOPICS))
+def test_subscribe_accepts_every_known_topic(topic: str):
+    frame = {ENVELOPE_KEY: ENVELOPE_VERSION, TYPE_KEY: "state.subscribe", "topics": [topic]}
+    assert validate_inbound(frame) is None
+
+
+def test_subscribe_rejects_unknown_topic():
+    frame = {
+        ENVELOPE_KEY: ENVELOPE_VERSION,
+        TYPE_KEY: "state.subscribe",
+        "topics": ["definitely_not_a_real_topic"],
+    }
+    err = validate_inbound(frame)
+    assert err is not None and "unknown topic" in err
+
+
+def test_formerly_unsubscribable_produced_topics_are_now_allowed():
+    # The two topics the trainer already produced but a client could not subscribe to.
+    assert "coaching.snapshot" in KNOWN_TOPICS
+    assert "setup.active" in KNOWN_TOPICS
+
+
+def test_every_produced_topic_is_in_known_topics():
+    """Drift-guard: no producer may publish a topic that isn't subscribable."""
+    produced, unresolved = _produced_topics()
+    assert not unresolved, (
+        "publishTopic call(s) whose topic could not be statically resolved — "
+        f"extend the guard or use a literal/const: {unresolved}"
+    )
+    assert produced, "expected to find at least one publishTopic producer in the Lua sources"
+    missing = sorted(t for t in produced if t not in KNOWN_TOPICS)
+    assert not missing, (
+        "topic(s) produced by Lua but absent from KNOWN_TOPICS (forgot the allow-list — "
+        f"add to external_protocol.KNOWN_TOPICS): {missing} "
+        f"(produced set: {sorted(produced)})"
+    )

--- a/tests/test_ws_topic_allowlist.py
+++ b/tests/test_ws_topic_allowlist.py
@@ -60,6 +60,8 @@ def _produced_topics() -> tuple[dict[str, str], list[str]]:
             line = text[line_start : line_end if line_end != -1 else len(text)]
             if "function" in line:  # the definition, not a call
                 continue
+            if "--" in line[: m.start() - line_start]:  # commented-out call (Lua --)
+                continue
             arg = m.group(1)
             if arg[:1] in ("'", '"'):
                 topics[arg.strip("'\"")] = f.name

--- a/tests/test_ws_topic_allowlist.py
+++ b/tests/test_ws_topic_allowlist.py
@@ -44,42 +44,74 @@ _CALL_RE = re.compile(r"\.publishTopic\s*\(\s*([^\s,)]+)")
 # A definition's receiver is immediately preceded by `function ` (e.g.
 # `function M.publishTopic(`); a call's receiver is not.
 _DEF_RE = re.compile(r"\bfunction\s+[\w.]*\w$")
+# Lua string literals, stripped from a line prefix before the comment/definition
+# checks so a `--` or `function` INSIDE a string can't false-trigger them (cursor #173).
+_STR_RE = re.compile(r"\"[^\"]*\"|'[^']*'")
+
+
+def _resolve_calls(text: str) -> tuple[set[str], list[str]]:
+    """Return ({topics}, [unresolved]) for `.publishTopic(` CALLS in one Lua blob.
+
+    Resolves each call's first argument to a string literal: direct
+    ('"coaching.snapshot"') or via a `local NAME = "..."` / `NAME = "..."`
+    assignment in the same blob (covers coaching_publisher's `TOPIC` constant).
+    Skips the `function M.publishTopic(...)` definition and commented-out calls;
+    string literals are stripped from the line prefix first so a `--`/`function`
+    inside a string can't false-trigger those checks. A first-arg that cannot be
+    resolved to a literal is reported as unresolved so the guard fails loud rather
+    than silently passing a producer it can't verify.
+    """
+    topics: set[str] = set()
+    unresolved: list[str] = []
+    for m in _CALL_RE.finditer(text):
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        line_end = text.find("\n", m.start())
+        line = text[line_start : line_end if line_end != -1 else len(text)]
+        prefix = _STR_RE.sub("", line[: m.start() - line_start])
+        if "--" in prefix:  # commented-out call (Lua --)
+            continue
+        if _DEF_RE.search(prefix):  # the `function M.publishTopic(...)` definition, not a call
+            continue
+        arg = m.group(1)
+        if arg[:1] in ("'", '"'):
+            topics.add(arg.strip("'\""))
+            continue
+        vm = re.search(rf"\b{re.escape(arg)}\s*=\s*['\"]([^'\"]+)['\"]", text)
+        if vm:
+            topics.add(vm.group(1))
+        else:
+            unresolved.append(f"publishTopic({arg}) — first arg not a resolvable string literal")
+    return topics, unresolved
 
 
 def _produced_topics() -> tuple[dict[str, str], list[str]]:
-    """Return ({topic: 'file'} , [unresolved-call descriptions]).
-
-    Resolves the first argument of each `.publishTopic(` CALL to a string literal:
-    direct ('"coaching.snapshot"') or via a `local NAME = "..."` / `NAME = "..."`
-    assignment in the same file (covers coaching_publisher's `TOPIC` constant).
-    A first-arg that cannot be resolved to a literal is reported as unresolved so
-    the guard fails loud rather than silently passing a producer it can't verify.
-    """
+    """Aggregate `_resolve_calls` across every Lua source → ({topic: file}, [unresolved])."""
     topics: dict[str, str] = {}
     unresolved: list[str] = []
     for f in sorted(LUA_SRC.rglob("*.lua")):
-        text = f.read_text(encoding="utf-8")
-        for m in _CALL_RE.finditer(text):
-            line_start = text.rfind("\n", 0, m.start()) + 1
-            line_end = text.find("\n", m.start())
-            line = text[line_start : line_end if line_end != -1 else len(text)]
-            prefix = line[: m.start() - line_start]  # line text before this `.publishTopic(`
-            if "--" in prefix:  # commented-out call (Lua --)
-                continue
-            if _DEF_RE.search(prefix):  # the `function M.publishTopic(...)` definition, not a call
-                continue
-            arg = m.group(1)
-            if arg[:1] in ("'", '"'):
-                topics[arg.strip("'\"")] = f.name
-                continue
-            vm = re.search(rf"\b{re.escape(arg)}\s*=\s*['\"]([^'\"]+)['\"]", text)
-            if vm:
-                topics[vm.group(1)] = f.name
-            else:
-                unresolved.append(
-                    f"{f.name}: publishTopic({arg}) — first arg not a resolvable string literal"
-                )
+        found, unres = _resolve_calls(f.read_text(encoding="utf-8"))
+        for topic in found:
+            topics[topic] = f.name
+        unresolved += [f"{f.name}: {u}" for u in unres]
     return topics, unresolved
+
+
+def test_drift_guard_resolves_calls_and_skips_noise():
+    """Pin the static-analysis edge cases the guard must handle (gemini/cursor on #173)."""
+    text = "\n".join(
+        [
+            'local TOPIC = "coaching.snapshot"',
+            "wsBridge.publishTopic(TOPIC, {})",  # const-resolved
+            'wsBridge.publishTopic("setup.active", {})',  # inline literal
+            'pcall(function() wsBridge.publishTopic("delta", {}) end)',  # call on a function() line
+            'local s = "--"  wsBridge.publishTopic("session", {})',  # -- inside a string literal
+            '-- wsBridge.publishTopic("commented_out", {})',  # commented-out call
+            "function M.publishTopic(topic, payload) end",  # the definition
+        ]
+    )
+    topics, unresolved = _resolve_calls(text)
+    assert unresolved == []
+    assert topics == {"coaching.snapshot", "setup.active", "delta", "session"}
 
 
 @pytest.mark.parametrize("topic", sorted(KNOWN_TOPICS))

--- a/tests/test_ws_topic_allowlist.py
+++ b/tests/test_ws_topic_allowlist.py
@@ -49,18 +49,47 @@ _DEF_RE = re.compile(r"\bfunction\s+[\w.]*\w$")
 _STR_RE = re.compile(r"\"[^\"]*\"|'[^']*'")
 
 
+def _strip_lua_comments(text: str) -> str:
+    """Drop Lua `--` line comments, honoring string literals (a `--` inside a string
+    is not a comment, and an escaped quote doesn't end one). This is done ONCE up
+    front so neither a commented-out call nor a commented-out `NAME = "..."` decoy
+    assignment can be mistaken for live code. Block comments (`--[[ ]]`) are out of
+    scope — no producer wraps a publishTopic call in one.
+    """
+    out: list[str] = []
+    for line in text.splitlines():
+        i, in_str, cut = 0, None, None
+        while i < len(line):
+            c = line[i]
+            if in_str is not None:
+                if c == "\\":
+                    i += 1  # skip the escaped char
+                elif c == in_str:
+                    in_str = None
+            elif c in ("'", '"'):
+                in_str = c
+            elif c == "-" and line[i + 1 : i + 2] == "-":
+                cut = i
+                break
+            i += 1
+        out.append(line if cut is None else line[:cut])
+    return "\n".join(out)
+
+
 def _resolve_calls(text: str) -> tuple[set[str], list[str]]:
     """Return ({topics}, [unresolved]) for `.publishTopic(` CALLS in one Lua blob.
 
-    Resolves each call's first argument to a string literal: direct
-    ('"coaching.snapshot"') or via a `local NAME = "..."` / `NAME = "..."`
-    assignment in the same blob (covers coaching_publisher's `TOPIC` constant).
-    Skips the `function M.publishTopic(...)` definition and commented-out calls;
-    string literals are stripped from the line prefix first so a `--`/`function`
-    inside a string can't false-trigger those checks. A first-arg that cannot be
-    resolved to a literal is reported as unresolved so the guard fails loud rather
-    than silently passing a producer it can't verify.
+    Comments are stripped first (`_strip_lua_comments`), so commented calls and
+    commented decoy assignments are gone before parsing. Each call's first arg is
+    resolved to a string literal: direct ('"coaching.snapshot"') or via a
+    `local NAME = "..."` / `NAME = "..."` assignment in the same blob (covers
+    coaching_publisher's `TOPIC` constant). The `function M.publishTopic(...)`
+    definition is excluded via `_DEF_RE` (string literals stripped from the prefix
+    so a `function` inside a string can't false-trigger it). A first-arg that
+    cannot be resolved to a literal is reported as unresolved so the guard fails
+    loud rather than silently passing a producer it can't verify.
     """
+    text = _strip_lua_comments(text)
     topics: set[str] = set()
     unresolved: list[str] = []
     for m in _CALL_RE.finditer(text):
@@ -68,8 +97,6 @@ def _resolve_calls(text: str) -> tuple[set[str], list[str]]:
         line_end = text.find("\n", m.start())
         line = text[line_start : line_end if line_end != -1 else len(text)]
         prefix = _STR_RE.sub("", line[: m.start() - line_start])
-        if "--" in prefix:  # commented-out call (Lua --)
-            continue
         if _DEF_RE.search(prefix):  # the `function M.publishTopic(...)` definition, not a call
             continue
         arg = m.group(1)
@@ -100,8 +127,9 @@ def test_drift_guard_resolves_calls_and_skips_noise():
     """Pin the static-analysis edge cases the guard must handle (gemini/cursor on #173)."""
     text = "\n".join(
         [
+            '-- TOPIC = "decoy_wrong"',  # commented decoy assignment must NOT resolve
             'local TOPIC = "coaching.snapshot"',
-            "wsBridge.publishTopic(TOPIC, {})",  # const-resolved
+            "wsBridge.publishTopic(TOPIC, {})",  # const-resolved (to the real, non-decoy value)
             'wsBridge.publishTopic("setup.active", {})',  # inline literal
             'pcall(function() wsBridge.publishTopic("delta", {}) end)',  # call on a function() line
             'local s = "--"  wsBridge.publishTopic("session", {})',  # -- inside a string literal
@@ -112,6 +140,7 @@ def test_drift_guard_resolves_calls_and_skips_noise():
     topics, unresolved = _resolve_calls(text)
     assert unresolved == []
     assert topics == {"coaching.snapshot", "setup.active", "delta", "session"}
+    assert "decoy_wrong" not in topics and "commented_out" not in topics
 
 
 @pytest.mark.parametrize("topic", sorted(KNOWN_TOPICS))

--- a/tests/test_ws_topic_allowlist.py
+++ b/tests/test_ws_topic_allowlist.py
@@ -35,10 +35,15 @@ from tools.ai_sidecar.external_protocol import (
 REPO = pathlib.Path(__file__).resolve().parent.parent
 LUA_SRC = REPO / "src" / "ac_copilot_trainer"
 
-# A call site: `<recv>.publishTopic(<first-arg>` — the leading dot excludes the
-# `function M.publishTopic(topic, payload)` definition (no dot) and the
-# `type(wsBridge.publishTopic)` guard (no `(` after the name).
+# A call site: `<recv>.publishTopic(<first-arg>`. The leading dot + the required `(`
+# already exclude the `type(wsBridge.publishTopic)` guard (no `(` after the name). The
+# `function M.publishTopic(...)` DEFINITION is excluded separately via `_DEF_RE` — a
+# broad `"function" in line` test would wrongly skip a real call sharing a line with
+# `pcall(function() ... )` (cursor bugbot on #173).
 _CALL_RE = re.compile(r"\.publishTopic\s*\(\s*([^\s,)]+)")
+# A definition's receiver is immediately preceded by `function ` (e.g.
+# `function M.publishTopic(`); a call's receiver is not.
+_DEF_RE = re.compile(r"\bfunction\s+[\w.]*\w$")
 
 
 def _produced_topics() -> tuple[dict[str, str], list[str]]:
@@ -58,9 +63,10 @@ def _produced_topics() -> tuple[dict[str, str], list[str]]:
             line_start = text.rfind("\n", 0, m.start()) + 1
             line_end = text.find("\n", m.start())
             line = text[line_start : line_end if line_end != -1 else len(text)]
-            if "function" in line:  # the definition, not a call
+            prefix = line[: m.start() - line_start]  # line text before this `.publishTopic(`
+            if "--" in prefix:  # commented-out call (Lua --)
                 continue
-            if "--" in line[: m.start() - line_start]:  # commented-out call (Lua --)
+            if _DEF_RE.search(prefix):  # the `function M.publishTopic(...)` definition, not a call
                 continue
             arg = m.group(1)
             if arg[:1] in ("'", '"'):

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -67,14 +67,25 @@ KNOWN_ACTIONS: frozenset[str] = frozenset(
 )
 
 # Topics a client may `state.subscribe` to. Same rule as actions: the Lua side
-# is the producer; the sidecar fans out snapshots.
+# is the producer; the sidecar fans out snapshots. This allow-list must be the
+# single source of truth for EVERY topic the trainer publishes — fan-out itself
+# is topic-agnostic (`_broadcast_external`), so an omission here doesn't drop
+# frames, it only makes a real topic unsubscribable. `coaching.snapshot` and
+# `setup.active` were produced (coaching_publisher.lua / ac_copilot_trainer.lua)
+# but missing here, so a client could never legitimately subscribe to them — the
+# "produced-but-unsubscribable" sibling of the #170 handshake bug. The
+# `test_ws_topic_allowlist` drift-guard asserts every produced topic is listed.
 KNOWN_TOPICS: frozenset[str] = frozenset(
     {
+        # Declared topics (EPIC #154 Part D wires producers for these).
         "connection",
         "session",
         "lap",
         "delta",
         "tire_temps",
+        # Already-produced topics (made subscribable; were missing).
+        "coaching.snapshot",
+        "setup.active",
     }
 )
 


### PR DESCRIPTION
First step of EPIC #154 **Part D** (make the declared WS topics real), and a standalone correctness fix.

## Problem
`external_protocol.KNOWN_TOPICS` — the allow-list `validate_inbound` consults for `state.subscribe` — listed only the 5 *declared* topics (`connection/session/lap/delta/tire_temps`) and **omitted the two topics the trainer actually publishes**: `coaching.snapshot` (coaching_publisher.lua) and `setup.active` (ac_copilot_trainer.lua). Fan-out (`_broadcast_external`) is topic-agnostic so frames still reached peers, but a client could **never legitimately `state.subscribe`** to them — the "produced-but-unsubscribable" sibling of the #170 handshake bug found in-sim this session.

## Change
- Add `coaching.snapshot` + `setup.active` to `KNOWN_TOPICS` (honest 7-name set). No fan-out behaviour change — `state.subscribe` stays advisory.
- New `tests/test_ws_topic_allowlist.py`:
  - `validate_inbound` accepts a subscribe to every `KNOWN_TOPICS` entry, rejects unknown.
  - **Drift-guard** — statically resolves every `publishTopic` topic in the Lua sources (inline literal *and* `local TOPIC = "..."` constant, e.g. coaching_publisher's) and asserts each ∈ `KNOWN_TOPICS`. Fails CI the moment a producer is wired without its allow-list entry — the structural fix for the recurring "forgot the allow-list" pitfall.

## Verification
Pure-Python / no game: `pytest tests/test_ws_topic_allowlist.py` (10 passed). Prepares Part D's producer wiring (connection/session/lap/delta/tire_temps), tracked in the vault handoff.

Relates to #154.