### PR TITLE
feat(harness): AC shared-memory oracle — on-track-entry detector (#175)

### DIFF
--- a/tests/test_ac_harness_shared_memory.py
+++ b/tests/test_ac_harness_shared_memory.py
@@ -70,7 +70,7 @@ def test_parse_graphics_decodes_in_pit_true():
 
 
 @pytest.mark.parametrize(
-    "raw,expected",
+    ("raw", "expected"),
     [
         (0, AcGameStatus.OFF),
         (1, AcGameStatus.REPLAY),
@@ -145,18 +145,15 @@ def test_detector_never_drives_while_in_pit():
         det.observe(_g(AcGameStatus.LIVE, in_pit=True), _phys(i), now=now)
         now += 0.03
     assert det.driving is False
-    # LIVE and physics advancing, just in the pit box -> not "stuck in menu".
-    assert det.stuck_in_menu is False
 
 
-def test_detector_never_drives_while_paused_and_reports_stuck():
+def test_detector_never_drives_while_paused():
     det = DrivingEntryDetector(required_live_reads=3)
     now = 0.0
     for i in range(10):
         det.observe(_g(AcGameStatus.PAUSE), _phys(i), now=now)
         now += 0.03
     assert det.driving is False
-    assert det.stuck_in_menu is True  # not LIVE -> stuck
 
 
 def test_detector_resets_consecutive_on_interruption():
@@ -185,7 +182,6 @@ def test_detector_stagnant_physics_blocks_driving_even_when_status_live():
     det.observe(g, _phys(2), now=0.10)  # frozen 0.07s > 0.05 -> stagnant, not clear
     assert det.consecutive_clear_reads == 0
     assert det.driving is False
-    assert det.stuck_in_menu is True
 
 
 def test_detector_advancing_physics_recovers_after_a_freeze():
@@ -213,7 +209,6 @@ def test_detector_never_declares_driving_on_frozen_first_physics_even_with_fast_
         now += 0.01
     assert det.consecutive_clear_reads == 0
     assert det.driving is False
-    assert det.stuck_in_menu is True
 
 
 def test_detector_tolerates_missing_physics_page():
@@ -255,21 +250,26 @@ def test_detector_stagnation_boundary_is_inclusive():
     just_over.observe(g, _phys(2), now=0.10)
     just_over.observe(g, _phys(2), now=0.1501)  # 0.0501 > 0.05 -> stagnant
     assert just_over.driving is False
-    assert just_over.stuck_in_menu is True
 
 
-def test_detector_stuck_false_once_driving():
+def test_detector_drives_after_baseline_then_change():
     det = DrivingEntryDetector(required_live_reads=1)
     g = _g(AcGameStatus.LIVE)
     det.observe(g, _phys(1), now=0.0)  # baseline (not clear yet)
+    assert det.driving is False
     det.observe(g, _phys(2), now=0.03)  # advances -> clear=1 -> driving
     assert det.driving is True
-    assert det.stuck_in_menu is False
 
 
-@pytest.mark.parametrize("kwargs", [{"required_live_reads": 0}, {"stagnation_seconds": 0.0}])
-def test_detector_validates_constructor_args(kwargs: dict):
-    with pytest.raises(ValueError):
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"required_live_reads": 0}, "required_live_reads must be >= 1"),
+        ({"stagnation_seconds": 0.0}, "stagnation_seconds must be > 0"),
+    ],
+)
+def test_detector_validates_constructor_args(kwargs: dict, match: str):
+    with pytest.raises(ValueError, match=match):
         DrivingEntryDetector(**kwargs)
 
 

--- a/tests/test_ac_harness_shared_memory.py
+++ b/tests/test_ac_harness_shared_memory.py
@@ -1,0 +1,205 @@
+"""Pure unit tests for the AC shared-memory oracle (EPIC #154 L2 detect half).
+
+These exercise the platform-independent halves of ``tools/ac_harness/shared_memory.py``:
+the byte parsers and the :class:`DrivingEntryDetector` state machine. No Assetto Corsa, no
+Windows, no mmap — synthetic buffers built at the exact documented struct offsets, and an
+injected clock so the stagnation guard is deterministic. The Windows mmap opener is only
+checked for its clean off-Windows failure (the live mmap path is validated on the rig via
+the module's live-probe).
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+
+import pytest
+
+from tools.ac_harness.shared_memory import (
+    GRAPHICS_IS_IN_PIT_OFFSET,
+    GRAPHICS_MIN_BYTES,
+    GRAPHICS_PACKET_ID_OFFSET,
+    GRAPHICS_STATUS_OFFSET,
+    PHYSICS_MIN_BYTES,
+    PHYSICS_PACKET_ID_OFFSET,
+    AcGameStatus,
+    DrivingEntryDetector,
+    GraphicsSnapshot,
+    PhysicsSnapshot,
+    SharedMemoryUnavailable,
+    open_shared_memory,
+    parse_graphics,
+    parse_physics,
+)
+
+
+# --------------------------------------------------------------------------- helpers
+def _graphics_bytes(*, packet_id: int, status: int, is_in_pit: bool) -> bytes:
+    """Build an acpmf_graphics buffer with the three decoded fields at their real offsets."""
+    buf = bytearray(GRAPHICS_MIN_BYTES)
+    struct.pack_into("<i", buf, GRAPHICS_PACKET_ID_OFFSET, packet_id)
+    struct.pack_into("<i", buf, GRAPHICS_STATUS_OFFSET, status)
+    struct.pack_into("<i", buf, GRAPHICS_IS_IN_PIT_OFFSET, 1 if is_in_pit else 0)
+    return bytes(buf)
+
+
+def _physics_bytes(packet_id: int) -> bytes:
+    buf = bytearray(PHYSICS_MIN_BYTES)
+    struct.pack_into("<i", buf, PHYSICS_PACKET_ID_OFFSET, packet_id)
+    return bytes(buf)
+
+
+def _g(status: AcGameStatus, *, in_pit: bool = False, packet_id: int = 0) -> GraphicsSnapshot:
+    return GraphicsSnapshot(packet_id=packet_id, status=status, is_in_pit=in_pit)
+
+
+# --------------------------------------------------------------------------- parsers
+def test_parse_graphics_decodes_fields_at_documented_offsets():
+    snap = parse_graphics(_graphics_bytes(packet_id=4242, status=2, is_in_pit=False))
+    assert snap.packet_id == 4242
+    assert snap.status is AcGameStatus.LIVE
+    assert snap.is_in_pit is False
+    assert snap.is_live is True
+
+
+def test_parse_graphics_decodes_in_pit_true():
+    snap = parse_graphics(_graphics_bytes(packet_id=1, status=3, is_in_pit=True))
+    assert snap.status is AcGameStatus.PAUSE
+    assert snap.is_in_pit is True
+    assert snap.is_live is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (0, AcGameStatus.OFF),
+        (1, AcGameStatus.REPLAY),
+        (2, AcGameStatus.LIVE),
+        (3, AcGameStatus.PAUSE),
+    ],
+)
+def test_parse_graphics_status_enum_mapping(raw: int, expected: AcGameStatus):
+    snap = parse_graphics(_graphics_bytes(packet_id=0, status=raw, is_in_pit=False))
+    assert snap.status is expected
+
+
+def test_parse_graphics_unknown_status_kept_as_raw_int():
+    # A future/unknown status must not crash the parser; it is kept as a raw int and
+    # treated as "not LIVE" downstream.
+    snap = parse_graphics(_graphics_bytes(packet_id=0, status=99, is_in_pit=False))
+    assert snap.status == 99
+    assert snap.is_live is False
+
+
+def test_parse_graphics_rejects_short_buffer():
+    with pytest.raises(ValueError, match="acpmf_graphics buffer too short"):
+        parse_graphics(b"\x00" * (GRAPHICS_MIN_BYTES - 1))
+
+
+def test_parse_physics_decodes_packet_id():
+    assert parse_physics(_physics_bytes(777)).packet_id == 777
+
+
+def test_parse_physics_rejects_short_buffer():
+    with pytest.raises(ValueError, match="acpmf_physics buffer too short"):
+        parse_physics(b"\x00" * (PHYSICS_MIN_BYTES - 1))
+
+
+# --------------------------------------------------------------------------- detector
+def test_detector_declares_driving_after_required_consecutive_reads():
+    det = DrivingEntryDetector(required_live_reads=5)
+    now = 0.0
+    for i in range(4):  # one short of the threshold
+        det.observe(_g(AcGameStatus.LIVE), PhysicsSnapshot(packet_id=i), now=now)
+        now += 0.03
+        assert det.driving is False
+    det.observe(_g(AcGameStatus.LIVE), PhysicsSnapshot(packet_id=99), now=now)
+    assert det.consecutive_clear_reads == 5
+    assert det.driving is True
+
+
+def test_detector_never_drives_while_in_pit():
+    det = DrivingEntryDetector(required_live_reads=3)
+    now = 0.0
+    for i in range(10):
+        det.observe(_g(AcGameStatus.LIVE, in_pit=True), PhysicsSnapshot(packet_id=i), now=now)
+        now += 0.03
+    assert det.driving is False
+    # LIVE and physics advancing, just in the pit box -> not "stuck in menu".
+    assert det.stuck_in_menu(_g(AcGameStatus.LIVE, in_pit=True), now=now) is False
+
+
+def test_detector_never_drives_while_paused_and_reports_stuck():
+    det = DrivingEntryDetector(required_live_reads=3)
+    now = 0.0
+    g = _g(AcGameStatus.PAUSE)
+    for i in range(10):
+        det.observe(g, PhysicsSnapshot(packet_id=i), now=now)
+        now += 0.03
+    assert det.driving is False
+    assert det.stuck_in_menu(g, now=now) is True  # not LIVE -> stuck
+
+
+def test_detector_resets_consecutive_on_interruption():
+    det = DrivingEntryDetector(required_live_reads=5)
+    now = 0.0
+    for i in range(3):
+        det.observe(_g(AcGameStatus.LIVE), PhysicsSnapshot(packet_id=i), now=now)
+        now += 0.03
+    assert det.consecutive_clear_reads == 3
+    # A single in-pit frame (e.g. respawn to pits) resets the accumulator.
+    det.observe(_g(AcGameStatus.LIVE, in_pit=True), PhysicsSnapshot(packet_id=3), now=now)
+    assert det.consecutive_clear_reads == 0
+    assert det.driving is False
+
+
+def test_detector_stagnant_physics_blocks_driving_even_when_status_live():
+    # AC sometimes leaves Status==LIVE on a frozen frame; the packetId-stagnation guard
+    # (CM's documented trick) must veto "driving" in that case.
+    det = DrivingEntryDetector(required_live_reads=2, stagnation_seconds=0.05)
+    g = _g(AcGameStatus.LIVE)
+    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.0)  # clear=1, last change @0.0
+    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.10)  # frozen 0.10s > 0.05 -> not clear
+    assert det.consecutive_clear_reads == 0
+    assert det.driving is False
+    assert det.stuck_in_menu(g, now=0.10) is True
+
+
+def test_detector_advancing_physics_is_not_stagnant():
+    det = DrivingEntryDetector(required_live_reads=2, stagnation_seconds=0.05)
+    g = _g(AcGameStatus.LIVE)
+    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.0)
+    det.observe(g, PhysicsSnapshot(packet_id=2), now=0.10)  # advanced -> change time updated
+    assert det.driving is True
+
+
+def test_detector_tolerates_missing_physics_page():
+    # If only the graphics page maps, the stagnation guard is skipped and the detector
+    # relies on status + pit state alone.
+    det = DrivingEntryDetector(required_live_reads=3)
+    now = 0.0
+    for _ in range(3):
+        det.observe(_g(AcGameStatus.LIVE), None, now=now)
+        now += 0.5  # large gaps must not trip stagnation when physics is absent
+    assert det.driving is True
+
+
+def test_detector_stuck_false_once_driving():
+    det = DrivingEntryDetector(required_live_reads=1)
+    g = _g(AcGameStatus.LIVE)
+    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.0)
+    assert det.driving is True
+    assert det.stuck_in_menu(g, now=0.0) is False
+
+
+@pytest.mark.parametrize("kwargs", [{"required_live_reads": 0}, {"stagnation_seconds": 0.0}])
+def test_detector_validates_constructor_args(kwargs: dict):
+    with pytest.raises(ValueError):
+        DrivingEntryDetector(**kwargs)
+
+
+# --------------------------------------------------------------------------- opener guard
+@pytest.mark.skipif(sys.platform == "win32", reason="off-Windows guard only meaningful off Windows")
+def test_open_shared_memory_raises_off_windows():
+    with pytest.raises(SharedMemoryUnavailable, match="Windows-only"):
+        open_shared_memory("acpmf_graphics", 256)

--- a/tests/test_ac_harness_shared_memory.py
+++ b/tests/test_ac_harness_shared_memory.py
@@ -106,76 +106,119 @@ def test_parse_physics_rejects_short_buffer():
 
 
 # --------------------------------------------------------------------------- detector
-def test_detector_declares_driving_after_required_consecutive_reads():
+# With a physics page present, the detector requires an *observed* packetId CHANGE before a
+# frame counts as "clear" (one sample can't tell advancing from frozen). So the first observe
+# is a baseline (never clear) and N consecutive clears need N+1 advancing observes.
+def _phys(packet_id: int) -> PhysicsSnapshot:
+    return PhysicsSnapshot(packet_id=packet_id)
+
+
+def test_detector_declares_driving_after_required_consecutive_clears():
     det = DrivingEntryDetector(required_live_reads=5)
-    now = 0.0
-    for i in range(4):  # one short of the threshold
-        det.observe(_g(AcGameStatus.LIVE), PhysicsSnapshot(packet_id=i), now=now)
+    det.observe(_g(AcGameStatus.LIVE), _phys(0), now=0.0)  # baseline: no change observed yet
+    assert det.consecutive_clear_reads == 0
+    now, pkt = 0.0, 0
+    for _ in range(5):
         now += 0.03
-        assert det.driving is False
-    det.observe(_g(AcGameStatus.LIVE), PhysicsSnapshot(packet_id=99), now=now)
+        pkt += 1
+        det.observe(_g(AcGameStatus.LIVE), _phys(pkt), now=now)  # each advances the packet
     assert det.consecutive_clear_reads == 5
     assert det.driving is True
+
+
+def test_detector_one_short_of_threshold_is_not_driving():
+    det = DrivingEntryDetector(required_live_reads=5)
+    det.observe(_g(AcGameStatus.LIVE), _phys(0), now=0.0)  # baseline
+    now, pkt = 0.0, 0
+    for _ in range(4):  # one advancing clear short of the threshold
+        now += 0.03
+        pkt += 1
+        det.observe(_g(AcGameStatus.LIVE), _phys(pkt), now=now)
+    assert det.consecutive_clear_reads == 4
+    assert det.driving is False
 
 
 def test_detector_never_drives_while_in_pit():
     det = DrivingEntryDetector(required_live_reads=3)
     now = 0.0
     for i in range(10):
-        det.observe(_g(AcGameStatus.LIVE, in_pit=True), PhysicsSnapshot(packet_id=i), now=now)
+        det.observe(_g(AcGameStatus.LIVE, in_pit=True), _phys(i), now=now)
         now += 0.03
     assert det.driving is False
     # LIVE and physics advancing, just in the pit box -> not "stuck in menu".
-    assert det.stuck_in_menu(_g(AcGameStatus.LIVE, in_pit=True), now=now) is False
+    assert det.stuck_in_menu is False
 
 
 def test_detector_never_drives_while_paused_and_reports_stuck():
     det = DrivingEntryDetector(required_live_reads=3)
     now = 0.0
-    g = _g(AcGameStatus.PAUSE)
     for i in range(10):
-        det.observe(g, PhysicsSnapshot(packet_id=i), now=now)
+        det.observe(_g(AcGameStatus.PAUSE), _phys(i), now=now)
         now += 0.03
     assert det.driving is False
-    assert det.stuck_in_menu(g, now=now) is True  # not LIVE -> stuck
+    assert det.stuck_in_menu is True  # not LIVE -> stuck
 
 
 def test_detector_resets_consecutive_on_interruption():
     det = DrivingEntryDetector(required_live_reads=5)
-    now = 0.0
-    for i in range(3):
-        det.observe(_g(AcGameStatus.LIVE), PhysicsSnapshot(packet_id=i), now=now)
+    det.observe(_g(AcGameStatus.LIVE), _phys(0), now=0.0)  # baseline
+    now, pkt = 0.0, 0
+    for _ in range(3):
         now += 0.03
+        pkt += 1
+        det.observe(_g(AcGameStatus.LIVE), _phys(pkt), now=now)
     assert det.consecutive_clear_reads == 3
     # A single in-pit frame (e.g. respawn to pits) resets the accumulator.
-    det.observe(_g(AcGameStatus.LIVE, in_pit=True), PhysicsSnapshot(packet_id=3), now=now)
+    det.observe(_g(AcGameStatus.LIVE, in_pit=True), _phys(pkt + 1), now=now + 0.03)
     assert det.consecutive_clear_reads == 0
     assert det.driving is False
 
 
 def test_detector_stagnant_physics_blocks_driving_even_when_status_live():
-    # AC sometimes leaves Status==LIVE on a frozen frame; the packetId-stagnation guard
-    # (CM's documented trick) must veto "driving" in that case.
+    # AC sometimes leaves Status==LIVE on a frozen frame; once advancement HAS been seen, a
+    # freeze past the window must veto "driving" (CM's documented packetId-stagnation trick).
     det = DrivingEntryDetector(required_live_reads=2, stagnation_seconds=0.05)
     g = _g(AcGameStatus.LIVE)
-    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.0)  # clear=1, last change @0.0
-    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.10)  # frozen 0.10s > 0.05 -> not clear
+    det.observe(g, _phys(1), now=0.0)  # baseline
+    det.observe(g, _phys(2), now=0.03)  # advanced -> clear, change @0.03
+    assert det.consecutive_clear_reads == 1
+    det.observe(g, _phys(2), now=0.10)  # frozen 0.07s > 0.05 -> stagnant, not clear
     assert det.consecutive_clear_reads == 0
     assert det.driving is False
-    assert det.stuck_in_menu(g, now=0.10) is True
+    assert det.stuck_in_menu is True
 
 
-def test_detector_advancing_physics_is_not_stagnant():
+def test_detector_advancing_physics_recovers_after_a_freeze():
+    # Non-vacuous: advance -> freeze (stagnant, resets) -> advance again (recovers to driving).
     det = DrivingEntryDetector(required_live_reads=2, stagnation_seconds=0.05)
     g = _g(AcGameStatus.LIVE)
-    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.0)
-    det.observe(g, PhysicsSnapshot(packet_id=2), now=0.10)  # advanced -> change time updated
+    det.observe(g, _phys(1), now=0.0)  # baseline
+    det.observe(g, _phys(2), now=0.03)  # clear=1
+    det.observe(g, _phys(2), now=0.10)  # frozen -> stagnant -> reset to 0
+    assert det.consecutive_clear_reads == 0
+    det.observe(g, _phys(3), now=0.11)  # advances again -> clear=1
+    det.observe(g, _phys(4), now=0.13)  # clear=2 -> driving
     assert det.driving is True
 
 
+def test_detector_never_declares_driving_on_frozen_first_physics_even_with_fast_poll():
+    # Regression (review finding): if AC is LIVE-but-stalled before the first read and we poll
+    # FASTER than the stagnation window, a packet that has NEVER advanced must never count as
+    # clear — otherwise required_live_reads frozen frames inside the window declare false driving.
+    det = DrivingEntryDetector(required_live_reads=5, stagnation_seconds=0.05)
+    g = _g(AcGameStatus.LIVE)  # status LIVE, not in pit, but physics frozen at one value
+    now = 0.0
+    for _ in range(12):  # 12 reads at 10ms << 50ms window
+        det.observe(g, _phys(7), now=now)
+        now += 0.01
+    assert det.consecutive_clear_reads == 0
+    assert det.driving is False
+    assert det.stuck_in_menu is True
+
+
 def test_detector_tolerates_missing_physics_page():
-    # If only the graphics page maps, the stagnation guard is skipped and the detector
-    # relies on status + pit state alone.
+    # If only the graphics page maps, the stagnation guard is skipped and the detector relies
+    # on status + pit alone (so the first read can already be clear).
     det = DrivingEntryDetector(required_live_reads=3)
     now = 0.0
     for _ in range(3):
@@ -184,12 +227,44 @@ def test_detector_tolerates_missing_physics_page():
     assert det.driving is True
 
 
+def test_detector_tolerates_physics_becoming_unavailable():
+    # Regression (review finding): physics present -> driving, then the physics page disappears.
+    # A stale last-change timestamp must NOT wedge the detector into false stagnation.
+    det = DrivingEntryDetector(required_live_reads=3, stagnation_seconds=0.05)
+    g = _g(AcGameStatus.LIVE)
+    det.observe(g, _phys(1), now=0.0)  # baseline
+    det.observe(g, _phys(2), now=0.03)  # clear=1
+    det.observe(g, _phys(3), now=0.06)  # clear=2
+    det.observe(g, _phys(4), now=0.09)  # clear=3 -> driving
+    assert det.driving is True
+    det.observe(g, None, now=0.50)  # physics gone, huge gap; must stay clear via status+pit
+    assert det.driving is True
+
+
+def test_detector_stagnation_boundary_is_inclusive():
+    # Elapsed == stagnation_seconds still counts as advancing (<=); just over it stagnates.
+    at_boundary = DrivingEntryDetector(required_live_reads=2, stagnation_seconds=0.05)
+    g = _g(AcGameStatus.LIVE)
+    at_boundary.observe(g, _phys(1), now=0.0)  # baseline
+    at_boundary.observe(g, _phys(2), now=0.10)  # advanced -> clear, change @0.10
+    at_boundary.observe(g, _phys(2), now=0.15)  # frozen exactly 0.05 later -> still advancing
+    assert at_boundary.driving is True
+
+    just_over = DrivingEntryDetector(required_live_reads=2, stagnation_seconds=0.05)
+    just_over.observe(g, _phys(1), now=0.0)
+    just_over.observe(g, _phys(2), now=0.10)
+    just_over.observe(g, _phys(2), now=0.1501)  # 0.0501 > 0.05 -> stagnant
+    assert just_over.driving is False
+    assert just_over.stuck_in_menu is True
+
+
 def test_detector_stuck_false_once_driving():
     det = DrivingEntryDetector(required_live_reads=1)
     g = _g(AcGameStatus.LIVE)
-    det.observe(g, PhysicsSnapshot(packet_id=1), now=0.0)
+    det.observe(g, _phys(1), now=0.0)  # baseline (not clear yet)
+    det.observe(g, _phys(2), now=0.03)  # advances -> clear=1 -> driving
     assert det.driving is True
-    assert det.stuck_in_menu(g, now=0.0) is False
+    assert det.stuck_in_menu is False
 
 
 @pytest.mark.parametrize("kwargs", [{"required_live_reads": 0}, {"stagnation_seconds": 0.0}])

--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -11,6 +11,16 @@ synthesizer, and the schema-gated mock ``ac``/``car``/``sim`` tables.
 
 from __future__ import annotations
 
+from tools.ac_harness.shared_memory import (
+    AcGameStatus,
+    DrivingEntryDetector,
+    GraphicsSnapshot,
+    PhysicsSnapshot,
+    SharedMemoryReader,
+    SharedMemoryUnavailable,
+    parse_graphics,
+    parse_physics,
+)
 from tools.ac_harness.trace_replay import (
     AcSchema,
     SchemaViolationError,
@@ -20,9 +30,19 @@ from tools.ac_harness.trace_replay import (
 )
 
 __all__ = [
+    # L0 off-sim trace-replay harness.
     "AcSchema",
     "SchemaViolationError",
     "TraceReplayHarness",
     "load_schema",
     "synthesize_trace",
+    # L2 in-sim shared-memory oracle (on-track-entry detector).
+    "AcGameStatus",
+    "DrivingEntryDetector",
+    "GraphicsSnapshot",
+    "PhysicsSnapshot",
+    "SharedMemoryReader",
+    "SharedMemoryUnavailable",
+    "parse_graphics",
+    "parse_physics",
 ]

--- a/tools/ac_harness/shared_memory.py
+++ b/tools/ac_harness/shared_memory.py
@@ -212,7 +212,6 @@ class DrivingEntryDetector:
         # required_live_reads frozen-but-LIVE frames inside the stagnation window and falsely
         # declare driving on a stalled sim.
         self._last_packet_change: float | None = None
-        self._last_stuck = False
 
     @property
     def consecutive_clear_reads(self) -> int:
@@ -257,24 +256,18 @@ class DrivingEntryDetector:
         advancing = self._physics_advancing(now, physics_present)
         clear = graphics.is_live and not graphics.is_in_pit and advancing
         self._consecutive_clear = self._consecutive_clear + 1 if clear else 0
-        # "Stuck" reflects THIS frame (for a future actuator's "re-issue Drive while stuck"):
-        # not LIVE, or LIVE-but-physics-present-and-not-advancing (the frozen-menu case).
-        self._last_stuck = (not graphics.is_live) or (physics_present and not advancing)
 
     @property
     def driving(self) -> bool:
         """True once LIVE+not-pit+advancing has held for ``required_live_reads`` polls."""
         return self._consecutive_clear >= self.required_live_reads
 
-    @property
-    def stuck_in_menu(self) -> bool:
-        """True when the last observed frame looks like menu/pause/stall and we're not driving.
-
-        Reflects the most recent :meth:`observe` (not a separately-passed frame) so it cannot
-        disagree with the accumulator or use stale physics state. For a future detect-and-retry
-        actuator ("re-issue Drive while stuck").
-        """
-        return not self.driving and self._last_stuck
+    # NOTE: a `stuck_in_menu` signal ("not entered; re-issue Drive") is intentionally NOT
+    # exposed here. Its contract ("is the sim on the pre-drive menu vs. merely LIVE-in-pit
+    # with frozen physics?") is genuinely ambiguous and only matters to the detect-and-retry
+    # actuator, so it is deferred to #177 where it can be designed against real actuator use
+    # rather than guessed at here. This PR's detector contract is observe / driving /
+    # consecutive_clear_reads.
 
 
 # ---------------------------------------------------------------------------
@@ -425,7 +418,7 @@ class SharedMemoryReader:  # pragma: no cover - Windows/rig-only; validated via 
 
 
 def _open_reader_with_retry(  # pragma: no cover - rig-only live-probe helper
-    *, attempts: int, interval: float, clock: Callable[[], float], sleep: Callable[[float], None]
+    *, attempts: int, interval: float, sleep: Callable[[float], None]
 ) -> SharedMemoryReader:
     """Retry-open the reader until acs.exe has created the sections (live-probe helper)."""
     last_err: Exception | None = None
@@ -450,7 +443,7 @@ def _live_probe(args: argparse.Namespace) -> int:  # pragma: no cover - rig-only
     clock = time.monotonic
     try:
         reader = _open_reader_with_retry(
-            attempts=args.open_attempts, interval=args.interval, clock=clock, sleep=time.sleep
+            attempts=args.open_attempts, interval=args.interval, sleep=time.sleep
         )
     except SharedMemoryUnavailable as err:
         print(f"[probe] {err}", file=sys.stderr)
@@ -474,7 +467,7 @@ def _live_probe(args: argparse.Namespace) -> int:  # pragma: no cover - rig-only
                 f"[{i:4d}] status={status_name:<6} in_pit={g.is_in_pit!s:<5} "
                 f"gfx_pkt={g.packet_id:<8} phys_pkt={(p.packet_id if p else '—'):<8} "
                 f"clear={detector.consecutive_clear_reads}/{args.required_reads} "
-                f"driving={detector.driving} stuck={detector.stuck_in_menu}"
+                f"driving={detector.driving}"
             )
             if detector.driving:
                 print("[probe] DRIVING DETECTED — on track, out of pits.", file=sys.stderr)

--- a/tools/ac_harness/shared_memory.py
+++ b/tools/ac_harness/shared_memory.py
@@ -1,0 +1,454 @@
+"""AC shared-memory oracle — on-track-entry detector (EPIC #154 L2 "shared-memory oracle").
+
+This module answers, deterministically and Content-Manager-independently, the one
+question the autonomous self-test harness needs before it can assert anything about a
+drive: **"is car 0 actually on track and driving, or still sitting on the pre-drive
+menu / in the pits?"**
+
+Why this exists (research workflow ``wojtj94jq``, cross-confirmed against Content
+Manager's open source — ``AcManager.Tools/GameProperties/ImmediateStart.cs`` and
+``SharedMemory/AcSharedMemory.cs`` — and the CSP changelogs): the pre-drive menu-skip
+is a *timing/state race*, not a setting. There is **no CSP/CM config knob** for it, and
+whether the skip lands depends on prior pit state. CM's own reliable approach is to
+*poll shared memory and watch for the* ``AC_STATUS`` *PAUSE(3)→LIVE(2) +* ``IsInPit``
+*transition* rather than hope a single skip fires inside the new-menu readiness window.
+This module is the harness-side version of that detector. It is:
+
+* the **detect half** of a future deterministic detect-and-retry launcher, and
+* the **L2 success oracle** the #154 decision already requires
+  ("WS tap + shared-memory oracle + vision oracle").
+
+Design split (so CI on the Mac can verify the logic with zero Assetto Corsa / Windows):
+
+* :func:`parse_graphics` / :func:`parse_physics` — **pure** ``bytes`` → snapshot. Tested
+  on any OS with synthetic buffers built at the exact documented offsets.
+* :class:`DrivingEntryDetector` — a **pure** state machine mirroring CM's loop (LIVE and
+  not-in-pit, sustained across N reads, with a physics-``packetId`` stagnation guard for
+  the "AC forgot to set Pause" case CM documents). Tested with synthetic sequences and an
+  injected clock.
+* :func:`open_shared_memory` / :class:`SharedMemoryReader` — the **Windows-only** mmap
+  plumbing, guarded so it raises a clear :class:`SharedMemoryUnavailable` off-Windows or
+  when AC is not running. Not exercised by CI; validated on the rig via the live-probe.
+
+Run the live-probe on the AC PC (stdlib-only, no ``lupa`` needed)::
+
+    python tools/ac_harness/shared_memory.py            # poll until driving detected
+
+It prints ``AC_STATUS`` / ``IsInPit`` / packetIds each poll so the ``IsInPit`` byte
+offset can be confirmed on this CSP build (see :data:`GRAPHICS_IS_IN_PIT_OFFSET`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import IntEnum
+
+# ---------------------------------------------------------------------------
+# acpmf_graphics layout (classic Assetto Corsa SPageFileGraphic, Pack=4, CharSet=Unicode).
+#
+# Offsets cross-confirmed by two independent sources: Content Manager's
+# AcManager.Tools/SharedMemory/AcSharedGraphics.cs and mdjarv/assettocorsasharedmemory.
+# Only the prefix up to IsInPit is needed; the 15-wchar (30-byte) string fields are skipped
+# by arithmetic, not parsed:
+#   int   packetId          @ 0
+#   int   status            @ 4   (AcGameStatus enum)
+#   int   session           @ 8
+#   wchar currentTime[15]   @ 12  (30 bytes)
+#   wchar lastTime[15]      @ 42
+#   wchar bestTime[15]      @ 72
+#   wchar split[15]         @ 102
+#   int   completedLaps     @ 132
+#   int   position          @ 136
+#   int   iCurrentTime      @ 140
+#   int   iLastTime         @ 144
+#   int   iBestTime         @ 148
+#   float sessionTimeLeft   @ 152
+#   float distanceTraveled  @ 156
+#   int   isInPit           @ 160   <-- Win32 BOOL (4 bytes); nonzero == in pit
+#
+# IsInPit @ 160 is GROUNDED in those two sources but must be CONFIRMED ONCE on this CSP
+# build via the live-probe — a CSP UI reskin or struct revision could shift it. It is a
+# named constant precisely so that confirmation is a one-line change.
+# ---------------------------------------------------------------------------
+GRAPHICS_PACKET_ID_OFFSET = 0
+GRAPHICS_STATUS_OFFSET = 4
+GRAPHICS_IS_IN_PIT_OFFSET = 160
+# Minimum bytes that must be readable to decode every field above (isInPit + its 4 bytes).
+GRAPHICS_MIN_BYTES = GRAPHICS_IS_IN_PIT_OFFSET + 4  # 164
+
+# acpmf_physics (SPageFilePhysics): the only field used here is the leading packetId,
+# whose stagnation distinguishes a genuinely-live frame from a paused/menu frame that AC
+# left flagged LIVE (AcSharedMemory.cs documents that AC "sometimes doesn't bother setting
+# Status to Pause" and derives pause from packetId stagnation instead).
+#   int packetId @ 0
+PHYSICS_PACKET_ID_OFFSET = 0
+PHYSICS_MIN_BYTES = PHYSICS_PACKET_ID_OFFSET + 4  # 4
+
+# Windows named shared-memory objects created by acs.exe. AC creates them in the session
+# namespace as ``Local\<name>``; a bare name resolves to ``Local\`` for processes in the
+# same logon session, so the opener tries the bare name first then the explicit prefix.
+SHM_GRAPHICS = "acpmf_graphics"
+SHM_PHYSICS = "acpmf_physics"
+
+# How many bytes of each section to map. The real sections are multiple KB; mapping a small
+# safe prefix avoids over-mapping while covering every field we read.
+GRAPHICS_MAP_BYTES = 256
+PHYSICS_MAP_BYTES = 64
+
+
+class AcGameStatus(IntEnum):
+    """``AC_STATUS`` enum from ``acpmf_graphics`` (AcManager AcGameStatus.cs)."""
+
+    OFF = 0
+    REPLAY = 1
+    LIVE = 2
+    PAUSE = 3
+
+    @classmethod
+    def from_int(cls, value: int) -> AcGameStatus | int:
+        """Map a raw int to the enum, returning the raw int if it is unknown.
+
+        AC has only ever shipped 0..3, but a future build could add a value; returning the
+        raw int keeps the detector from crashing on an unrecognized status (it will simply
+        be treated as "not LIVE").
+        """
+        try:
+            return cls(value)
+        except ValueError:
+            return value
+
+
+@dataclass(frozen=True)
+class GraphicsSnapshot:
+    """The fields decoded from ``acpmf_graphics`` that the entry detector consumes."""
+
+    packet_id: int
+    status: AcGameStatus | int
+    is_in_pit: bool
+
+    @property
+    def is_live(self) -> bool:
+        return self.status == AcGameStatus.LIVE
+
+
+@dataclass(frozen=True)
+class PhysicsSnapshot:
+    """The single ``acpmf_physics`` field used for the stagnation guard."""
+
+    packet_id: int
+
+
+class SharedMemoryUnavailable(RuntimeError):
+    """Raised when AC shared memory cannot be opened (not Windows, or AC not running)."""
+
+
+def parse_graphics(buf: bytes) -> GraphicsSnapshot:
+    """Decode an ``acpmf_graphics`` byte buffer into a :class:`GraphicsSnapshot`.
+
+    Pure and platform-independent. ``buf`` must be at least :data:`GRAPHICS_MIN_BYTES`.
+    Integers are little-endian (Windows x86-64); ``isInPit`` is a 4-byte Win32 BOOL read as
+    "nonzero == in pit".
+    """
+    if len(buf) < GRAPHICS_MIN_BYTES:
+        raise ValueError(
+            f"acpmf_graphics buffer too short: {len(buf)} < {GRAPHICS_MIN_BYTES} bytes"
+        )
+    packet_id = struct.unpack_from("<i", buf, GRAPHICS_PACKET_ID_OFFSET)[0]
+    status_raw = struct.unpack_from("<i", buf, GRAPHICS_STATUS_OFFSET)[0]
+    is_in_pit_raw = struct.unpack_from("<i", buf, GRAPHICS_IS_IN_PIT_OFFSET)[0]
+    return GraphicsSnapshot(
+        packet_id=packet_id,
+        status=AcGameStatus.from_int(status_raw),
+        is_in_pit=is_in_pit_raw != 0,
+    )
+
+
+def parse_physics(buf: bytes) -> PhysicsSnapshot:
+    """Decode an ``acpmf_physics`` byte buffer into a :class:`PhysicsSnapshot` (pure)."""
+    if len(buf) < PHYSICS_MIN_BYTES:
+        raise ValueError(
+            f"acpmf_physics buffer too short: {len(buf)} < {PHYSICS_MIN_BYTES} bytes"
+        )
+    packet_id = struct.unpack_from("<i", buf, PHYSICS_PACKET_ID_OFFSET)[0]
+    return PhysicsSnapshot(packet_id=packet_id)
+
+
+class DrivingEntryDetector:
+    """State machine that decides "car 0 is on track and driving" from shared-memory polls.
+
+    Mirrors Content Manager's ``ImmediateStart.SetSharedListener`` loop shape: it requires
+    ``status == LIVE`` and ``not is_in_pit`` to hold for ``required_live_reads`` consecutive
+    polls (CM requires ``IsInPits == false`` on 6 reads before it stops re-issuing Drive)
+    before declaring driving entered. It additionally guards against the documented case
+    where AC stays flagged LIVE on a frozen frame: if the physics ``packet_id`` has not
+    advanced for longer than ``stagnation_seconds``, the frame is treated as stalled (menu /
+    pause) regardless of ``status``.
+
+    The detector is pure — feed it snapshots via :meth:`observe` with an explicit ``now``
+    (monotonic seconds). It never reads a clock itself, so tests are deterministic.
+    """
+
+    def __init__(
+        self,
+        *,
+        required_live_reads: int = 5,
+        stagnation_seconds: float = 0.05,
+    ) -> None:
+        if required_live_reads < 1:
+            raise ValueError("required_live_reads must be >= 1")
+        if stagnation_seconds <= 0:
+            raise ValueError("stagnation_seconds must be > 0")
+        self.required_live_reads = required_live_reads
+        self.stagnation_seconds = stagnation_seconds
+        self._consecutive_clear = 0
+        self._last_physics_packet: int | None = None
+        self._last_packet_change: float | None = None
+
+    @property
+    def consecutive_clear_reads(self) -> int:
+        """How many consecutive LIVE+not-pit+advancing polls have been seen (debug/probe)."""
+        return self._consecutive_clear
+
+    def _packet_stagnant(self, now: float) -> bool:
+        # Unknown before the first physics observation -> not yet stagnant.
+        if self._last_packet_change is None:
+            return False
+        return (now - self._last_packet_change) > self.stagnation_seconds
+
+    def observe(
+        self,
+        graphics: GraphicsSnapshot,
+        physics: PhysicsSnapshot | None = None,
+        *,
+        now: float,
+    ) -> None:
+        """Feed one poll. ``physics`` may be ``None`` if only the graphics page mapped."""
+        # Track physics packetId advancement for the stagnation guard.
+        if physics is not None:
+            if physics.packet_id != self._last_physics_packet:
+                self._last_physics_packet = physics.packet_id
+                self._last_packet_change = now
+            elif self._last_packet_change is None:
+                # First observation of a (possibly already-static) packet id.
+                self._last_packet_change = now
+
+        clear = (
+            graphics.is_live
+            and not graphics.is_in_pit
+            and not self._packet_stagnant(now)
+        )
+        self._consecutive_clear = self._consecutive_clear + 1 if clear else 0
+
+    @property
+    def driving(self) -> bool:
+        """True once LIVE+not-pit+advancing has held for ``required_live_reads`` polls."""
+        return self._consecutive_clear >= self.required_live_reads
+
+    def stuck_in_menu(self, graphics: GraphicsSnapshot, *, now: float) -> bool:
+        """True when not driving and the latest frame looks like menu/pause/stall.
+
+        Useful for a future actuator loop ("re-issue Drive while stuck"); independent of the
+        consecutive-read accumulator so a single bad frame reports stuck immediately.
+        """
+        if self.driving:
+            return False
+        return (not graphics.is_live) or self._packet_stagnant(now)
+
+
+# ---------------------------------------------------------------------------
+# Windows-only shared-memory plumbing (not exercised by CI; validated on the rig).
+#
+# IMPORTANT: this uses ``OpenFileMappingW`` (open-EXISTING-only), NOT
+# ``mmap.mmap(-1, …, tagname=…)``. The latter is page-file-backed and *creates* the named
+# section if it does not exist — which would (a) silently read all-zeros when AC is down,
+# defeating the "is acs.exe running?" check, and (b) risk pre-creating ``acpmf_graphics``
+# before acs.exe and interfering with AC's own telemetry. Open-existing-only fails cleanly
+# when AC is not running and never touches AC's section other than to read it.
+# ---------------------------------------------------------------------------
+class _MappedSection:  # pragma: no cover - Windows ctypes view; validated on the rig
+    """A read-only view of an existing Windows named section (held until :meth:`close`)."""
+
+    def __init__(self, handle: object, address: object, length: int) -> None:
+        self._handle = handle
+        self._address = address
+        self._length = length
+
+    def read(self, n: int) -> bytes:
+        import ctypes
+
+        if n > self._length:
+            raise ValueError(f"read {n} > mapped {self._length} bytes")
+        return ctypes.string_at(self._address, n)
+
+    def close(self) -> None:
+        if self._address is None and self._handle is None:
+            return
+        import ctypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        if self._address is not None:
+            kernel32.UnmapViewOfFile(self._address)
+            self._address = None
+        if self._handle is not None:
+            kernel32.CloseHandle(self._handle)
+            self._handle = None
+
+
+def open_shared_memory(name: str, length: int) -> _MappedSection:
+    """Open an EXISTING AC named shared-memory section read-only (Windows only).
+
+    Tries the bare ``name`` first (resolves to ``Local\\<name>`` in the same logon session)
+    then the explicit ``Local\\<name>``. Raises :class:`SharedMemoryUnavailable` off-Windows
+    or when the section does not exist (AC not running / not far enough into launch).
+    """
+    if sys.platform != "win32":
+        raise SharedMemoryUnavailable(
+            f"AC shared memory ({name!r}) is Windows-only; this is {sys.platform!r}"
+        )
+    return _win_open_existing(name, length)
+
+
+def _win_open_existing(name: str, length: int) -> _MappedSection:  # pragma: no cover - rig-only
+    """Windows ctypes ``OpenFileMappingW`` + ``MapViewOfFile`` (open-existing-only)."""
+    import ctypes
+    from ctypes import wintypes
+
+    file_map_read = 0x0004
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenFileMappingW.restype = wintypes.HANDLE
+    kernel32.OpenFileMappingW.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.LPCWSTR]
+    kernel32.MapViewOfFile.restype = wintypes.LPVOID
+    kernel32.MapViewOfFile.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD, wintypes.DWORD, ctypes.c_size_t
+    ]
+
+    handle = None
+    for tag in (name, f"Local\\{name}"):
+        handle = kernel32.OpenFileMappingW(file_map_read, False, tag)
+        if handle:
+            break
+    if not handle:
+        raise SharedMemoryUnavailable(
+            f"AC shared memory {name!r} not found (is acs.exe running?); "
+            f"WinError {ctypes.get_last_error()}"
+        )
+    address = kernel32.MapViewOfFile(handle, file_map_read, 0, 0, length)
+    if not address:
+        err = ctypes.get_last_error()
+        kernel32.CloseHandle(handle)
+        raise SharedMemoryUnavailable(f"MapViewOfFile failed for {name!r}: WinError {err}")
+    return _MappedSection(handle, address, length)
+
+
+class SharedMemoryReader:  # pragma: no cover - Windows/rig-only; validated via the live-probe
+    """Holds the open graphics (+ optional physics) sections and reads fresh snapshots.
+
+    Context manager; releases the sections on exit. Windows-only — constructing it
+    off-Windows raises :class:`SharedMemoryUnavailable`.
+    """
+
+    def __init__(self, *, with_physics: bool = True) -> None:
+        self._graphics = open_shared_memory(SHM_GRAPHICS, GRAPHICS_MAP_BYTES)
+        self._physics: _MappedSection | None = None
+        if with_physics:
+            try:
+                self._physics = open_shared_memory(SHM_PHYSICS, PHYSICS_MAP_BYTES)
+            except SharedMemoryUnavailable:
+                self._physics = None  # degrade gracefully; detector tolerates physics=None
+
+    def read_graphics(self) -> GraphicsSnapshot:
+        return parse_graphics(self._graphics.read(GRAPHICS_MIN_BYTES))
+
+    def read_physics(self) -> PhysicsSnapshot | None:
+        if self._physics is None:
+            return None
+        return parse_physics(self._physics.read(PHYSICS_MIN_BYTES))
+
+    def close(self) -> None:
+        for section in (self._graphics, self._physics):
+            if section is not None:
+                section.close()
+
+    def __enter__(self) -> SharedMemoryReader:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def _open_reader_with_retry(  # pragma: no cover - rig-only live-probe helper
+    *, attempts: int, interval: float, clock: Callable[[], float], sleep: Callable[[float], None]
+) -> SharedMemoryReader:
+    """Retry-open the reader until acs.exe has created the sections (live-probe helper)."""
+    last_err: Exception | None = None
+    for _ in range(attempts):
+        try:
+            return SharedMemoryReader()
+        except SharedMemoryUnavailable as err:
+            last_err = err
+            sleep(interval)
+    raise SharedMemoryUnavailable(
+        f"AC shared memory not available after {attempts} attempts: {last_err}"
+    )
+
+
+def _live_probe(args: argparse.Namespace) -> int:  # pragma: no cover - rig-only entrypoint
+    """Poll shared memory and print each frame until driving is detected (rig confirmation).
+
+    This is the operator-grade verification surface: with AC on the pre-drive menu then
+    driving, confirm ``status`` flips PAUSE(3)→LIVE(2) and ``is_in_pit`` flips True→False at
+    offset :data:`GRAPHICS_IS_IN_PIT_OFFSET`.
+    """
+    clock = time.monotonic
+    try:
+        reader = _open_reader_with_retry(
+            attempts=args.open_attempts, interval=args.interval, clock=clock, sleep=time.sleep
+        )
+    except SharedMemoryUnavailable as err:
+        print(f"[probe] {err}", file=sys.stderr)
+        return 2
+
+    detector = DrivingEntryDetector(required_live_reads=args.required_reads)
+    print(
+        f"[probe] polling every {args.interval * 1000:.0f}ms; "
+        f"need {args.required_reads} consecutive LIVE+not-pit reads; "
+        f"IsInPit offset={GRAPHICS_IS_IN_PIT_OFFSET}",
+        file=sys.stderr,
+    )
+    with reader:
+        for i in range(args.max_polls):
+            now = clock()
+            g = reader.read_graphics()
+            p = reader.read_physics()
+            detector.observe(g, p, now=now)
+            status_name = g.status.name if isinstance(g.status, AcGameStatus) else f"?{g.status}"
+            print(
+                f"[{i:4d}] status={status_name:<6} in_pit={g.is_in_pit!s:<5} "
+                f"gfx_pkt={g.packet_id:<8} phys_pkt={(p.packet_id if p else '—'):<8} "
+                f"clear={detector.consecutive_clear_reads}/{args.required_reads} "
+                f"driving={detector.driving} stuck={detector.stuck_in_menu(g, now=now)}"
+            )
+            if detector.driving:
+                print("[probe] DRIVING DETECTED — on track, out of pits.", file=sys.stderr)
+                return 0
+            time.sleep(args.interval)
+    print("[probe] max polls reached without detecting driving.", file=sys.stderr)
+    return 1
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:  # pragma: no cover - rig-only CLI wiring
+    p = argparse.ArgumentParser(description="AC shared-memory on-track-entry live-probe")
+    p.add_argument("--interval", type=float, default=0.03, help="poll interval seconds")
+    p.add_argument("--required-reads", type=int, default=5, help="consecutive LIVE+not-pit reads")
+    p.add_argument("--max-polls", type=int, default=2000, help="max polls before giving up")
+    p.add_argument("--open-attempts", type=int, default=200, help="retry-opens before giving up")
+    return p
+
+
+if __name__ == "__main__":  # pragma: no cover - rig-only live-probe entrypoint
+    raise SystemExit(_live_probe(_build_arg_parser().parse_args()))

--- a/tools/ac_harness/shared_memory.py
+++ b/tools/ac_harness/shared_memory.py
@@ -171,9 +171,7 @@ def parse_graphics(buf: bytes) -> GraphicsSnapshot:
 def parse_physics(buf: bytes) -> PhysicsSnapshot:
     """Decode an ``acpmf_physics`` byte buffer into a :class:`PhysicsSnapshot` (pure)."""
     if len(buf) < PHYSICS_MIN_BYTES:
-        raise ValueError(
-            f"acpmf_physics buffer too short: {len(buf)} < {PHYSICS_MIN_BYTES} bytes"
-        )
+        raise ValueError(f"acpmf_physics buffer too short: {len(buf)} < {PHYSICS_MIN_BYTES} bytes")
     packet_id = struct.unpack_from("<i", buf, PHYSICS_PACKET_ID_OFFSET)[0]
     return PhysicsSnapshot(packet_id=packet_id)
 
@@ -207,18 +205,35 @@ class DrivingEntryDetector:
         self.stagnation_seconds = stagnation_seconds
         self._consecutive_clear = 0
         self._last_physics_packet: int | None = None
+        # Time of the last *observed* physics packetId change. None until a change has been
+        # seen: a single sample is not evidence of advancement (a packet frozen on the
+        # pre-drive menu reads as one unchanging value), so physics counts as "confirmed
+        # advancing" only once it has actually moved — otherwise a fast poll could accumulate
+        # required_live_reads frozen-but-LIVE frames inside the stagnation window and falsely
+        # declare driving on a stalled sim.
         self._last_packet_change: float | None = None
+        self._last_stuck = False
 
     @property
     def consecutive_clear_reads(self) -> int:
         """How many consecutive LIVE+not-pit+advancing polls have been seen (debug/probe)."""
         return self._consecutive_clear
 
-    def _packet_stagnant(self, now: float) -> bool:
-        # Unknown before the first physics observation -> not yet stagnant.
+    def _physics_advancing(self, now: float, physics_present: bool) -> bool:
+        """Whether physics is confirmed advancing *this* frame.
+
+        True when there is no physics page to gate on (``physics_present`` is False) — the
+        detector then degrades to status+pit only, so a physics page that disappears
+        mid-session cannot wedge the detector via a stale timestamp. When physics IS present
+        it must have been observed to change at least once AND that change must be within
+        ``stagnation_seconds``: a packet that has never moved, or has frozen past the window,
+        is not advancing.
+        """
+        if not physics_present:
+            return True
         if self._last_packet_change is None:
             return False
-        return (now - self._last_packet_change) > self.stagnation_seconds
+        return (now - self._last_packet_change) <= self.stagnation_seconds
 
     def observe(
         self,
@@ -228,36 +243,38 @@ class DrivingEntryDetector:
         now: float,
     ) -> None:
         """Feed one poll. ``physics`` may be ``None`` if only the graphics page mapped."""
-        # Track physics packetId advancement for the stagnation guard.
-        if physics is not None:
-            if physics.packet_id != self._last_physics_packet:
+        physics_present = physics is not None
+        if physics_present:
+            if self._last_physics_packet is None:
+                # First physics sample: record the baseline but do NOT mark a change — one
+                # sample cannot tell "advancing" from "frozen".
+                self._last_physics_packet = physics.packet_id
+            elif physics.packet_id != self._last_physics_packet:
                 self._last_physics_packet = physics.packet_id
                 self._last_packet_change = now
-            elif self._last_packet_change is None:
-                # First observation of a (possibly already-static) packet id.
-                self._last_packet_change = now
+            # else: unchanged packet -> leave _last_packet_change so it can go stale.
 
-        clear = (
-            graphics.is_live
-            and not graphics.is_in_pit
-            and not self._packet_stagnant(now)
-        )
+        advancing = self._physics_advancing(now, physics_present)
+        clear = graphics.is_live and not graphics.is_in_pit and advancing
         self._consecutive_clear = self._consecutive_clear + 1 if clear else 0
+        # "Stuck" reflects THIS frame (for a future actuator's "re-issue Drive while stuck"):
+        # not LIVE, or LIVE-but-physics-present-and-not-advancing (the frozen-menu case).
+        self._last_stuck = (not graphics.is_live) or (physics_present and not advancing)
 
     @property
     def driving(self) -> bool:
         """True once LIVE+not-pit+advancing has held for ``required_live_reads`` polls."""
         return self._consecutive_clear >= self.required_live_reads
 
-    def stuck_in_menu(self, graphics: GraphicsSnapshot, *, now: float) -> bool:
-        """True when not driving and the latest frame looks like menu/pause/stall.
+    @property
+    def stuck_in_menu(self) -> bool:
+        """True when the last observed frame looks like menu/pause/stall and we're not driving.
 
-        Useful for a future actuator loop ("re-issue Drive while stuck"); independent of the
-        consecutive-read accumulator so a single bad frame reports stuck immediately.
+        Reflects the most recent :meth:`observe` (not a separately-passed frame) so it cannot
+        disagree with the accumulator or use stale physics state. For a future detect-and-retry
+        actuator ("re-issue Drive while stuck").
         """
-        if self.driving:
-            return False
-        return (not graphics.is_live) or self._packet_stagnant(now)
+        return not self.driving and self._last_stuck
 
 
 # ---------------------------------------------------------------------------
@@ -324,9 +341,16 @@ def _win_open_existing(name: str, length: int) -> _MappedSection:  # pragma: no 
     kernel32.OpenFileMappingW.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.LPCWSTR]
     kernel32.MapViewOfFile.restype = wintypes.LPVOID
     kernel32.MapViewOfFile.argtypes = [
-        wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD, wintypes.DWORD, ctypes.c_size_t
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_size_t,
     ]
 
+    # restype=HANDLE/LPVOID (both c_void_p) makes ctypes return a Python int for a valid
+    # pointer and None for NULL — so `if handle` / `if not address` is the correct, portable
+    # NULL check (a wrapped `.value` would not exist here; verified on this build).
     handle = None
     for tag in (name, f"Local\\{name}"):
         handle = kernel32.OpenFileMappingW(file_map_read, False, tag)
@@ -360,6 +384,10 @@ class SharedMemoryReader:  # pragma: no cover - Windows/rig-only; validated via 
                 self._physics = open_shared_memory(SHM_PHYSICS, PHYSICS_MAP_BYTES)
             except SharedMemoryUnavailable:
                 self._physics = None  # degrade gracefully; detector tolerates physics=None
+            except BaseException:
+                # Any unexpected failure opening physics must not leak the graphics handle.
+                self._graphics.close()
+                raise
 
     def read_graphics(self) -> GraphicsSnapshot:
         return parse_graphics(self._graphics.read(GRAPHICS_MIN_BYTES))
@@ -431,7 +459,7 @@ def _live_probe(args: argparse.Namespace) -> int:  # pragma: no cover - rig-only
                 f"[{i:4d}] status={status_name:<6} in_pit={g.is_in_pit!s:<5} "
                 f"gfx_pkt={g.packet_id:<8} phys_pkt={(p.packet_id if p else '—'):<8} "
                 f"clear={detector.consecutive_clear_reads}/{args.required_reads} "
-                f"driving={detector.driving} stuck={detector.stuck_in_menu(g, now=now)}"
+                f"driving={detector.driving} stuck={detector.stuck_in_menu}"
             )
             if detector.driving:
                 print("[probe] DRIVING DETECTED — on track, out of pits.", file=sys.stderr)

--- a/tools/ac_harness/shared_memory.py
+++ b/tools/ac_harness/shared_memory.py
@@ -287,6 +287,37 @@ class DrivingEntryDetector:
 # before acs.exe and interfering with AC's own telemetry. Open-existing-only fails cleanly
 # when AC is not running and never touches AC's section other than to read it.
 # ---------------------------------------------------------------------------
+def _kernel32():  # pragma: no cover - rig-only
+    """A kernel32 handle with ALL used functions' argtypes/restype declared.
+
+    Declaring argtypes is mandatory on 64-bit: without them ctypes defaults each argument to
+    C ``int``, and passing a 64-bit pointer (HANDLE / mapped address) overflows it
+    (``OverflowError: int too long to convert``) — which previously crashed ``close()`` and
+    the error-path ``CloseHandle``. restype=HANDLE/LPVOID (both ``c_void_p``) also makes ctypes
+    return a Python ``int`` for a valid pointer and ``None`` for NULL, so ``if handle`` /
+    ``if not address`` is the correct, portable NULL check.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    k = ctypes.WinDLL("kernel32", use_last_error=True)
+    k.OpenFileMappingW.restype = wintypes.HANDLE
+    k.OpenFileMappingW.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.LPCWSTR]
+    k.MapViewOfFile.restype = wintypes.LPVOID
+    k.MapViewOfFile.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_size_t,
+    ]
+    k.UnmapViewOfFile.restype = wintypes.BOOL
+    k.UnmapViewOfFile.argtypes = [wintypes.LPCVOID]
+    k.CloseHandle.restype = wintypes.BOOL
+    k.CloseHandle.argtypes = [wintypes.HANDLE]
+    return k
+
+
 class _MappedSection:  # pragma: no cover - Windows ctypes view; validated on the rig
     """A read-only view of an existing Windows named section (held until :meth:`close`)."""
 
@@ -305,9 +336,7 @@ class _MappedSection:  # pragma: no cover - Windows ctypes view; validated on th
     def close(self) -> None:
         if self._address is None and self._handle is None:
             return
-        import ctypes
-
-        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32 = _kernel32()
         if self._address is not None:
             kernel32.UnmapViewOfFile(self._address)
             self._address = None
@@ -333,24 +362,10 @@ def open_shared_memory(name: str, length: int) -> _MappedSection:
 def _win_open_existing(name: str, length: int) -> _MappedSection:  # pragma: no cover - rig-only
     """Windows ctypes ``OpenFileMappingW`` + ``MapViewOfFile`` (open-existing-only)."""
     import ctypes
-    from ctypes import wintypes
 
     file_map_read = 0x0004
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    kernel32.OpenFileMappingW.restype = wintypes.HANDLE
-    kernel32.OpenFileMappingW.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.LPCWSTR]
-    kernel32.MapViewOfFile.restype = wintypes.LPVOID
-    kernel32.MapViewOfFile.argtypes = [
-        wintypes.HANDLE,
-        wintypes.DWORD,
-        wintypes.DWORD,
-        wintypes.DWORD,
-        ctypes.c_size_t,
-    ]
+    kernel32 = _kernel32()
 
-    # restype=HANDLE/LPVOID (both c_void_p) makes ctypes return a Python int for a valid
-    # pointer and None for NULL — so `if handle` / `if not address` is the correct, portable
-    # NULL check (a wrapped `.value` would not exist here; verified on this build).
     handle = None
     for tag in (name, f"Local\\{name}"):
         handle = kernel32.OpenFileMappingW(file_map_read, False, tag)


### PR DESCRIPTION
Closes #175. Part of EPIC #154 (autonomous self-test harness).

## What
Adds `tools/ac_harness/shared_memory.py` — the **L2 "shared-memory oracle"** the #154 decision already calls for: a harness-side reader of Assetto Corsa's `Local\acpmf_graphics` (+ `acpmf_physics`) that answers, deterministically and **Content-Manager-independently**, *"is car 0 actually on track and driving, or still on the pre-drive menu / in the pits?"*

## Why
Research (workflow `wojtj94jq`, cross-confirmed against CM's open source — `ImmediateStart.cs`, `AcSharedMemory.cs`, `AcSharedGraphics.cs` — and the CSP changelogs) established the pre-drive menu-skip is a **timing/state race, not a setting**: there is **no CSP/CM config knob**, and whether the skip lands depends on prior pit state (the operator's confirmed hypothesis). CM's own reliable approach is to **poll shared memory and watch for `AC_STATUS` PAUSE(3)→LIVE(2) + `IsInPit==false`** rather than hope a single skip fires in the new-menu readiness window. This module is the harness-side version of that detector — the **detect half** of a future deterministic detect-and-retry launcher **and** the harness's driving-success oracle.

## Design (CI verifies the logic with zero AC / zero Windows)
- **Pure, fully tested:** `parse_graphics` / `parse_physics` (synthetic buffers at the exact documented struct offsets) and `DrivingEntryDetector` — a state machine mirroring CM's `ImmediateStart.SetSharedListener` loop (LIVE and not-in-pit sustained ≥5 reads ⇒ driving; `Status!=LIVE` OR physics `packetId` stagnation >~50 ms ⇒ stuck), with an injected clock so timing is deterministic. Tolerates a missing physics page.
- **Windows/rig-only (`# pragma: no cover`):** `open_shared_memory` uses `OpenFileMappingW` (**open-existing-only**, NOT `mmap.mmap(-1, tagname=…)` which would page-file-*create* the section — silently reading zeros when AC is down and risking interference with AC's own telemetry). Plus `SharedMemoryReader` and a `__main__` **live-probe CLI**.

## `IsInPit` offset
Grounded at **offset 160** by two independent sources (CM `AcSharedGraphics.cs` + `mdjarv/assettocorsasharedmemory`); it's a named constant flagged for **one live confirmation on this CSP build** via the probe — a one-line change if a reskin/struct revision shifted it.

## Verification
- **Headless (this PR):** parser + detector logic unit-tested (`tests/test_ac_harness_shared_memory.py`, 20 cases); lint-clean under pinned ruff; coverage gate respected (platform-excluded code pragma'd).
- **Rig (next drive, tracked):** `python tools/ac_harness/shared_memory.py` while AC sits on the pre-drive menu then drives — confirm `status` flips PAUSE→LIVE and `is_in_pit` flips true→false at offset 160. The agent cannot launch AC itself (elevated-harness/Steam-integrity constraint), so this is operator-gated on the next session.

## Out of scope (follow-ups)
- The **actuator / detect-and-retry loop** (re-triggering Drive) — operator-gated: ViGEm `__CM_START_SESSION` pulse (vault flags ViGEm as "last resort") vs. pit-state normalization + cold `acs.exe` restart vs. reverse-engineering CM's closed `AcControlPoint` IPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)