### PR TITLE
feat(trainer): wire connection/session/lap lifecycle WS producers (#180)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -36,6 +36,7 @@ local hudSettings = require("hud_settings")
 local realtimeCoaching = require("realtime_coaching")
 -- Issue #86 Part C/D: rig-screen-driven features.
 local coachingPublisher = require("coaching_publisher")
+local lifecyclePublisher = require("lifecycle_publisher")
 local setupLibrary = require("setup_library")
 
 --- Pixel sizes per window title; must match ``manifest.ini`` WINDOW_* ``SIZE=``.
@@ -1623,6 +1624,20 @@ function script.update(dt)
       })
     end)
 
+    -- Issue #180 Part D step 2: lifecycle topics. `session` fires only on
+    -- track/car/session change; `connection` is a ~1 Hz heartbeat. Both no-op
+    -- when the WS isn't open. (`lap` is published at the lap boundary below.)
+    pcall(function()
+      lifecyclePublisher.publishSessionIfChanged({ car = car, sim = sim, wsBridge = wsBridge })
+      lifecyclePublisher.publishConnectionIfDue({
+        dt = dt,
+        car = car,
+        sim = sim,
+        wsBridge = wsBridge,
+        appVersion = APP_VERSION_UI,
+      })
+    end)
+
     -- Periodic [RT-DIAG] log (every 3 sec) to verify what the engine sees
     -- live. Issue #75 round 3: prove the in-corner / brake-distance pipeline.
     state._rtDiagT = (state._rtDiagT or 0) + (dt or 0)
@@ -1805,6 +1820,19 @@ function script.update(dt)
       segBrakes = state.brakingPoints.best
     end
     state.lapsCompleted = (state.lapsCompleted or 0) + 1
+    -- Issue #180 Part D step 2: publish the `lap` topic once at the boundary.
+    -- No-op when the WS isn't open. `lastMs` is car.previousLapTimeMs (read above);
+    -- validity reflects whether this just-completed lap was invalidated.
+    pcall(function()
+      lifecyclePublisher.publishLap({
+        lap = lc,
+        lastLapMs = lastMs,
+        bestLapMs = state.bestLapMs,
+        lapsCompleted = state.lapsCompleted,
+        valid = not state.lapInvalidatedThisLap,
+        wsBridge = wsBridge,
+      })
+    end)
     local spanForAnalytics = 0
     if #completedTrace >= 2 then
       spanForAnalytics = completedTrace[#completedTrace].eMs - completedTrace[1].eMs

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1101,6 +1101,7 @@ local function resetRuntimeAfterLeavingTrack()
   wsBridge.reset()
   renderDiag.reset()
   realtimeCoaching.reset()
+  lifecyclePublisher.reset()  -- #180: re-emit `session` after a reset (else stale key suppresses it)
   state.realtimeActiveHint = nil
   state._cachedRealtimeView = nil
   hud.reset()
@@ -1133,6 +1134,7 @@ local function resetRollingDrivingState()
   )
   hud.reset()
   realtimeCoaching.reset()
+  lifecyclePublisher.reset()  -- #180: same-session/stint restart must re-emit `session`
   tel = newTelemetry()
   brakes = newBrakes()
   td:resetLapAggregates()
@@ -1820,16 +1822,24 @@ function script.update(dt)
       segBrakes = state.brakingPoints.best
     end
     state.lapsCompleted = (state.lapsCompleted or 0) + 1
-    -- Issue #180 Part D step 2: publish the `lap` topic once at the boundary.
-    -- No-op when the WS isn't open. `lastMs` is car.previousLapTimeMs (read above);
-    -- validity reflects whether this just-completed lap was invalidated.
+    -- Issue #180 Part D step 2: publish the `lap` topic once at the boundary. No-op when
+    -- the WS isn't open. Review-fixes: `lap`/`laps_completed` both use the app's completed
+    -- counter (not car.lapCount) so they agree; `best_lap_ms` folds in THIS lap so a new PB
+    -- / the first lap isn't reported stale; an untimed boundary (out-lap,
+    -- previousLapTimeMs == 0) sends `last_lap_ms = nil` rather than a misleading 0.
     pcall(function()
+      local lapValid = not state.lapInvalidatedThisLap
+      local timedMs = (lastMs and lastMs > 0) and lastMs or nil
+      local bestSoFar = state.bestLapMs
+      if lapValid and timedMs and (not bestSoFar or timedMs < bestSoFar) then
+        bestSoFar = timedMs
+      end
       lifecyclePublisher.publishLap({
-        lap = lc,
-        lastLapMs = lastMs,
-        bestLapMs = state.bestLapMs,
+        lap = state.lapsCompleted,
+        lastLapMs = timedMs,
+        bestLapMs = bestSoFar,
         lapsCompleted = state.lapsCompleted,
-        valid = not state.lapInvalidatedThisLap,
+        valid = lapValid,
         wsBridge = wsBridge,
       })
     end)

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1626,29 +1626,6 @@ function script.update(dt)
       })
     end)
 
-    -- Issue #180 Part D step 2: lifecycle topics. `session` fires only on
-    -- track/car/session change; `connection` is a ~1 Hz heartbeat. Both no-op
-    -- when the WS isn't open. (`lap` is published at the lap boundary below.)
-    pcall(function()
-      -- Per-frame WS-reconnect detection: on a sidecar (re)connect, re-arm `session` so it
-      -- re-emits THIS frame — before any subsequent `lap` — without waiting on the heartbeat
-      -- and without resetting the stint best (#180 review: avoids the duplicate / 1 s-delay
-      -- edges of coupling reconnect detection to the heartbeat).
-      local wsConn = type(wsBridge.sidecarConnected) == "function" and wsBridge.sidecarConnected()
-      if wsConn and not state._wsPrevConnected then
-        lifecyclePublisher.rearmSession()
-      end
-      state._wsPrevConnected = wsConn
-      lifecyclePublisher.publishConnectionIfDue({
-        dt = dt,
-        car = car,
-        sim = sim,
-        wsBridge = wsBridge,
-        appVersion = APP_VERSION_UI,
-      })
-      lifecyclePublisher.publishSessionIfChanged({ car = car, sim = sim, wsBridge = wsBridge })
-    end)
-
     -- Periodic [RT-DIAG] log (every 3 sec) to verify what the engine sees
     -- live. Issue #75 round 3: prove the in-corner / brake-distance pipeline.
     state._rtDiagT = (state._rtDiagT or 0) + (dt or 0)
@@ -1736,6 +1713,30 @@ function script.update(dt)
     wsBridge.configure(pendingWsSidecarUrl)
     pendingWsSidecarUrl = nil
   end
+
+  -- Issue #180 Part D step 2: lifecycle topics, published AFTER wsBridge.tick()/pollInbound()
+  -- so they observe the CURRENT-frame WS state and always precede the `lap` boundary below
+  -- (Cursor HIGH on #182: publishing before the tick let a mid-frame-ready WS send `lap`
+  -- without a preceding `session`). `session` fires only on track/car/session change;
+  -- `connection` is a ~1 Hz heartbeat; both no-op when the WS isn't open. (`car` is non-nil
+  -- here — guaranteed by the `if not car then return end` guard above.)
+  pcall(function()
+    -- Per-frame WS-reconnect detection: on a sidecar (re)connect, re-arm `session` so it
+    -- re-emits THIS frame — before any subsequent `lap` — without resetting the stint best.
+    local wsConn = type(wsBridge.sidecarConnected) == "function" and wsBridge.sidecarConnected()
+    if wsConn and not state._wsPrevConnected then
+      lifecyclePublisher.rearmSession()
+    end
+    state._wsPrevConnected = wsConn
+    lifecyclePublisher.publishConnectionIfDue({
+      dt = dt,
+      car = car,
+      sim = sim,
+      wsBridge = wsBridge,
+      appVersion = APP_VERSION_UI,
+    })
+    lifecyclePublisher.publishSessionIfChanged({ car = car, sim = sim, wsBridge = wsBridge })
+  end)
   -- Round 10: drain any corner_advice replies into state.cornerAdvisories.
   -- The takeCornerAdvisory API returns the cached text for a label without
   -- consuming it — we walk known corner labels from trackSegments and copy.

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1630,7 +1630,8 @@ function script.update(dt)
     -- track/car/session change; `connection` is a ~1 Hz heartbeat. Both no-op
     -- when the WS isn't open. (`lap` is published at the lap boundary below.)
     pcall(function()
-      lifecyclePublisher.publishSessionIfChanged({ car = car, sim = sim, wsBridge = wsBridge })
+      -- Connection first: its heartbeat detects a WS reconnect and re-arms `session`
+      -- re-emission, so `session` re-publishes in this same frame after a reconnect.
       lifecyclePublisher.publishConnectionIfDue({
         dt = dt,
         car = car,
@@ -1638,6 +1639,7 @@ function script.update(dt)
         wsBridge = wsBridge,
         appVersion = APP_VERSION_UI,
       })
+      lifecyclePublisher.publishSessionIfChanged({ car = car, sim = sim, wsBridge = wsBridge })
     end)
 
     -- Periodic [RT-DIAG] log (every 3 sec) to verify what the engine sees
@@ -1828,18 +1830,11 @@ function script.update(dt)
     -- / the first lap isn't reported stale; an untimed boundary (out-lap,
     -- previousLapTimeMs == 0) sends `last_lap_ms = nil` rather than a misleading 0.
     pcall(function()
-      local lapValid = not state.lapInvalidatedThisLap
-      local timedMs = (lastMs and lastMs > 0) and lastMs or nil
-      local bestSoFar = state.bestLapMs
-      if lapValid and timedMs and (not bestSoFar or timedMs < bestSoFar) then
-        bestSoFar = timedMs
-      end
       lifecyclePublisher.publishLap({
         lap = state.lapsCompleted,
-        lastLapMs = timedMs,
-        bestLapMs = bestSoFar,
+        lastLapMs = lastMs,  -- raw; the producer treats <=0 as untimed and tracks the stint best
         lapsCompleted = state.lapsCompleted,
-        valid = lapValid,
+        valid = not state.lapInvalidatedThisLap,
         wsBridge = wsBridge,
       })
     end)

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1630,8 +1630,15 @@ function script.update(dt)
     -- track/car/session change; `connection` is a ~1 Hz heartbeat. Both no-op
     -- when the WS isn't open. (`lap` is published at the lap boundary below.)
     pcall(function()
-      -- Connection first: its heartbeat detects a WS reconnect and re-arms `session`
-      -- re-emission, so `session` re-publishes in this same frame after a reconnect.
+      -- Per-frame WS-reconnect detection: on a sidecar (re)connect, re-arm `session` so it
+      -- re-emits THIS frame — before any subsequent `lap` — without waiting on the heartbeat
+      -- and without resetting the stint best (#180 review: avoids the duplicate / 1 s-delay
+      -- edges of coupling reconnect detection to the heartbeat).
+      local wsConn = type(wsBridge.sidecarConnected) == "function" and wsBridge.sidecarConnected()
+      if wsConn and not state._wsPrevConnected then
+        lifecyclePublisher.rearmSession()
+      end
+      state._wsPrevConnected = wsConn
       lifecyclePublisher.publishConnectionIfDue({
         dt = dt,
         car = car,

--- a/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
+++ b/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
@@ -24,14 +24,14 @@ local TOPIC_CONNECTION = "connection"
 local TOPIC_SESSION = "session"
 local TOPIC_LAP = "lap"
 
--- Module-level rate-limiter / change-detector state. Reset via M.reset() on
--- session change so a new session re-emits `session` and the heartbeat re-aligns.
+-- Module-level rate-limiter / change-detector state.
+-- `session` is a pure CHANGE event: published when track/car/session-index changes, and
+-- re-armed by M.rearmSession() (WS reconnect) / M.reset() (stint reset). It is deliberately
+-- NOT coupled to the connection heartbeat — doing so spawned reconnect edge cases (duplicate
+-- on reset; ~1s re-emit delay). Reconnect re-arm is driven per-frame by the entry script via
+-- ws_bridge.sidecarConnected(), so `session` re-emits immediately (before any `lap`).
 local _connAccum = 0.0
 local _lastSessionKey = nil
--- Result of the last connection-heartbeat publish — a down->up transition means a fresh /
--- reconnected WS, on which `session` must re-emit (else a tap that joined after the original
--- `session` sees `lap` with no preceding `session`).
-local _lastConnOk = false
 -- Best timed lap of THIS stint. Tracked here (reset by M.reset) so `best_lap_ms` stays
 -- consistent with `laps_completed`, which also resets per stint — instead of seeding from
 -- the trainer's session-persistent `state.bestLapMs`.
@@ -125,20 +125,12 @@ function M.publishConnectionIfDue(opts)
   if _connAccum < 0 then
     _connAccum = 0.0
   end
-  local ok = wsBridge.publishTopic(TOPIC_CONNECTION, {
+  return wsBridge.publishTopic(TOPIC_CONNECTION, {
     car_id = _carId(opts.car),
     track_id = _trackId(),
     session_index = _sessionIndex(opts.sim),
     app_version = (opts.appVersion ~= nil) and tostring(opts.appVersion) or nil,
   }) == true
-  -- Reconnect detection: a fresh/reconnected WS (down->up) re-arms `session` so a tap that
-  -- joined after the original `session` still gets one before any `lap`. The 1 Hz heartbeat
-  -- is the reliable observation point (it always calls publishTopic when due).
-  if ok and not _lastConnOk then
-    _lastSessionKey = nil
-  end
-  _lastConnOk = ok
-  return ok
 end
 
 
@@ -208,12 +200,18 @@ function M.publishLap(opts)
 end
 
 
---- Reset rate-limiter + change-detector + stint-best (call on session/stint reset).
---- Deliberately does NOT touch `_lastConnOk`: that tracks the WS connection (owned by the
---- connection heartbeat), and a stint reset does not drop the WS. Resetting it here made the
---- next heartbeat falsely detect a reconnect, clear the key again, and emit a DUPLICATE
---- `session` ~1s after the intended one (Cursor on #182). `_lastSessionKey = nil` already
---- re-emits `session` exactly once, which is the intent.
+--- Re-arm ONLY the `session` change-detector so the next call re-emits `session` for the
+--- current identity. Driven per-frame by the entry script on a WS reconnect (via
+--- ws_bridge.sidecarConnected() false->true) so a reconnected tap gets `session` immediately
+--- — before any subsequent `lap` — without disturbing the stint best or the heartbeat.
+function M.rearmSession()
+  _lastSessionKey = nil
+end
+
+
+--- Reset rate-limiter + change-detector + stint-best (call on session/STINT reset, not on a
+--- mere WS reconnect — use M.rearmSession() for that). `_lastSessionKey = nil` re-emits
+--- `session` once for the new stint; `_stintBest = nil` rescopes `best_lap_ms` to the stint.
 function M.reset()
   _connAccum = 0.0
   _lastSessionKey = nil

--- a/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
+++ b/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
@@ -1,0 +1,182 @@
+-- Lifecycle WS topic publishers (issue #180, EPIC #154 Part D step 2).
+--
+-- Owns the three *lifecycle* topics the autonomous self-test harness's sequence
+-- assertions need (session -> lap boundary -> ...):
+--   * `connection`  — ~1 Hz heartbeat (car/track/session identity + app version).
+--   * `session`     — event-driven; published only when track/car/session changes.
+--   * `lap`         — published once per `car.lapCount` boundary (lap time + validity).
+--
+-- Model mirrors `coaching_publisher.lua`: each publish is a no-op when the WS
+-- isn't open (`wsBridge.publishTopic` returns false until the v1 hello handshake
+-- completes, see ws_bridge.lua / the #170 fix), so these are safe to call every
+-- frame at any frame rate. The topic strings are declared as `local` constants so
+-- the `test_ws_topic_allowlist` drift-guard can statically resolve them against
+-- `external_protocol.KNOWN_TOPICS`.
+--
+-- The richer telemetry topics (`delta`, `tire_temps`) are intentionally NOT here —
+-- they need current-elapsed-ms / per-wheel-temp data-source wiring and ship as a
+-- follow-up (see #180), keeping this module to the low-risk lifecycle set.
+
+local M = {}
+
+local CONNECTION_INTERVAL_SEC = 1.0
+local TOPIC_CONNECTION = "connection"
+local TOPIC_SESSION = "session"
+local TOPIC_LAP = "lap"
+
+-- Module-level rate-limiter / change-detector state. Reset via M.reset() on
+-- session change so a new session re-emits `session` and the heartbeat re-aligns.
+local _connAccum = 0.0
+local _lastSessionKey = nil
+
+
+local function _wsReady(opts)
+  local wsBridge = opts.wsBridge
+  if not wsBridge or type(wsBridge.publishTopic) ~= "function" then
+    return nil
+  end
+  return wsBridge
+end
+
+
+local function _carId(car)
+  -- ac.getCarID(0) is the stable content id; fall back to car.id if present.
+  if ac and type(ac.getCarID) == "function" then
+    local ok, v = pcall(ac.getCarID, 0)
+    if ok and type(v) == "string" and v ~= "" then
+      return v
+    end
+  end
+  if car then
+    local ok, v = pcall(function()
+      return car.id
+    end)
+    if ok and type(v) == "string" and v ~= "" then
+      return v
+    end
+  end
+  return nil
+end
+
+
+local function _trackId()
+  if ac and type(ac.getTrackID) == "function" then
+    local ok, v = pcall(ac.getTrackID)
+    if ok and type(v) == "string" and v ~= "" then
+      return v
+    end
+  end
+  return nil
+end
+
+
+local function _sessionIndex(sim)
+  if sim then
+    local ok, v = pcall(function()
+      return sim.currentSessionIndex
+    end)
+    if ok and type(v) == "number" then
+      return v
+    end
+  end
+  return nil
+end
+
+
+--- ~1 Hz connection heartbeat.
+---@param opts table  {dt:number, car?, sim?, wsBridge, appVersion?}
+---@return boolean  true if a frame was actually published this call
+function M.publishConnectionIfDue(opts)
+  if type(opts) ~= "table" then
+    return false
+  end
+  local wsBridge = _wsReady(opts)
+  if not wsBridge then
+    return false
+  end
+  local dt = tonumber(opts.dt) or 0
+  -- Cap a single frame's contribution so a long pause/resume doesn't burst, but
+  -- still wakes on the next call (same shape as coaching_publisher's accumulator).
+  if dt > 0 then
+    _connAccum = _connAccum + math.min(dt, CONNECTION_INTERVAL_SEC)
+  end
+  if _connAccum < CONNECTION_INTERVAL_SEC then
+    return false
+  end
+  _connAccum = _connAccum - CONNECTION_INTERVAL_SEC
+  if _connAccum < 0 then
+    _connAccum = 0.0
+  end
+  return wsBridge.publishTopic(TOPIC_CONNECTION, {
+    car_id = _carId(opts.car),
+    track_id = _trackId(),
+    session_index = _sessionIndex(opts.sim),
+    app_version = (opts.appVersion ~= nil) and tostring(opts.appVersion) or nil,
+  }) == true
+end
+
+
+--- Publish `session` only when track/car/session-index changes since the last call.
+---@param opts table  {car?, sim?, wsBridge}
+---@return boolean  true if a frame was actually published this call
+function M.publishSessionIfChanged(opts)
+  if type(opts) ~= "table" then
+    return false
+  end
+  local wsBridge = _wsReady(opts)
+  if not wsBridge then
+    return false
+  end
+  local trackId = _trackId()
+  local carId = _carId(opts.car)
+  local sessIdx = _sessionIndex(opts.sim)
+  local key = tostring(trackId) .. "|" .. tostring(carId) .. "|" .. tostring(sessIdx)
+  if key == _lastSessionKey then
+    return false
+  end
+  -- Only record the key once the publish actually SUCCEEDS: if the WS is down
+  -- when the session first changes, publishTopic returns false (no-op) and we
+  -- must retry on the next call rather than swallow the initial `session` frame
+  -- the harness's session->lap sequence assertion depends on.
+  local ok = wsBridge.publishTopic(TOPIC_SESSION, {
+    track_id = trackId,
+    car_id = carId,
+    session_index = sessIdx,
+  }) == true
+  if ok then
+    _lastSessionKey = key
+  end
+  return ok
+end
+
+
+--- Publish `lap` once, at a `car.lapCount` boundary (caller detects the boundary).
+---@param opts table  {lap?, lastLapMs?, bestLapMs?, lapsCompleted?, valid?:boolean, wsBridge}
+---@return boolean  true if a frame was actually published this call
+function M.publishLap(opts)
+  if type(opts) ~= "table" then
+    return false
+  end
+  local wsBridge = _wsReady(opts)
+  if not wsBridge then
+    return false
+  end
+  return wsBridge.publishTopic(TOPIC_LAP, {
+    lap = tonumber(opts.lap),
+    last_lap_ms = tonumber(opts.lastLapMs),
+    best_lap_ms = tonumber(opts.bestLapMs),
+    laps_completed = tonumber(opts.lapsCompleted),
+    -- Treat missing as valid; only an explicit false marks an invalidated lap.
+    valid = opts.valid ~= false,
+  }) == true
+end
+
+
+--- Reset rate-limiter + change-detector (call on session change).
+function M.reset()
+  _connAccum = 0.0
+  _lastSessionKey = nil
+end
+
+
+return M

--- a/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
+++ b/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
@@ -186,17 +186,25 @@ function M.publishLap(opts)
   if timedMs and timedMs <= 0 then
     timedMs = nil  -- untimed boundary (e.g. out-lap): no valid lap time, don't send a fake 0
   end
-  if valid and timedMs and (not _stintBest or timedMs < _stintBest) then
-    _stintBest = timedMs
+  -- Compute the candidate stint best INCLUDING this lap for the payload, but COMMIT it only
+  -- after a successful publish — mirrors `session`'s publish-then-record, so `best_lap_ms`
+  -- never reflects a lap whose frame was not delivered (WS down/not acked) (Cursor on #182).
+  local candidateBest = _stintBest
+  if valid and timedMs and (not candidateBest or timedMs < candidateBest) then
+    candidateBest = timedMs
   end
-  return wsBridge.publishTopic(TOPIC_LAP, {
+  local ok = wsBridge.publishTopic(TOPIC_LAP, {
     lap = tonumber(opts.lap),
     last_lap_ms = timedMs,
-    best_lap_ms = _stintBest,
+    best_lap_ms = candidateBest,
     laps_completed = tonumber(opts.lapsCompleted),
     -- Treat missing as valid; only an explicit false marks an invalidated lap.
     valid = valid,
   }) == true
+  if ok then
+    _stintBest = candidateBest
+  end
+  return ok
 end
 
 

--- a/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
+++ b/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
@@ -60,10 +60,20 @@ end
 
 
 local function _trackId()
-  if ac and type(ac.getTrackID) == "function" then
-    local ok, v = pcall(ac.getTrackID)
-    if ok and type(v) == "string" and v ~= "" then
-      return v
+  if ac then
+    -- Prefer the full id (track/layout) so multi-layout tracks (e.g. a GP vs national
+    -- layout) are distinguished; fall back to the bare track id.
+    if type(ac.getTrackFullID) == "function" then
+      local ok, v = pcall(ac.getTrackFullID, "/")
+      if ok and type(v) == "string" and v ~= "" then
+        return v
+      end
+    end
+    if type(ac.getTrackID) == "function" then
+      local ok, v = pcall(ac.getTrackID)
+      if ok and type(v) == "string" and v ~= "" then
+        return v
+      end
     end
   end
   return nil

--- a/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
+++ b/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
@@ -209,10 +209,14 @@ end
 
 
 --- Reset rate-limiter + change-detector + stint-best (call on session/stint reset).
+--- Deliberately does NOT touch `_lastConnOk`: that tracks the WS connection (owned by the
+--- connection heartbeat), and a stint reset does not drop the WS. Resetting it here made the
+--- next heartbeat falsely detect a reconnect, clear the key again, and emit a DUPLICATE
+--- `session` ~1s after the intended one (Cursor on #182). `_lastSessionKey = nil` already
+--- re-emits `session` exactly once, which is the intent.
 function M.reset()
   _connAccum = 0.0
   _lastSessionKey = nil
-  _lastConnOk = false
   _stintBest = nil
 end
 

--- a/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
+++ b/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
@@ -28,6 +28,14 @@ local TOPIC_LAP = "lap"
 -- session change so a new session re-emits `session` and the heartbeat re-aligns.
 local _connAccum = 0.0
 local _lastSessionKey = nil
+-- Result of the last connection-heartbeat publish — a down->up transition means a fresh /
+-- reconnected WS, on which `session` must re-emit (else a tap that joined after the original
+-- `session` sees `lap` with no preceding `session`).
+local _lastConnOk = false
+-- Best timed lap of THIS stint. Tracked here (reset by M.reset) so `best_lap_ms` stays
+-- consistent with `laps_completed`, which also resets per stint — instead of seeding from
+-- the trainer's session-persistent `state.bestLapMs`.
+local _stintBest = nil
 
 
 local function _wsReady(opts)
@@ -117,12 +125,20 @@ function M.publishConnectionIfDue(opts)
   if _connAccum < 0 then
     _connAccum = 0.0
   end
-  return wsBridge.publishTopic(TOPIC_CONNECTION, {
+  local ok = wsBridge.publishTopic(TOPIC_CONNECTION, {
     car_id = _carId(opts.car),
     track_id = _trackId(),
     session_index = _sessionIndex(opts.sim),
     app_version = (opts.appVersion ~= nil) and tostring(opts.appVersion) or nil,
   }) == true
+  -- Reconnect detection: a fresh/reconnected WS (down->up) re-arms `session` so a tap that
+  -- joined after the original `session` still gets one before any `lap`. The 1 Hz heartbeat
+  -- is the reliable observation point (it always calls publishTopic when due).
+  if ok and not _lastConnOk then
+    _lastSessionKey = nil
+  end
+  _lastConnOk = ok
+  return ok
 end
 
 
@@ -161,7 +177,9 @@ end
 
 
 --- Publish `lap` once, at a `car.lapCount` boundary (caller detects the boundary).
----@param opts table  {lap?, lastLapMs?, bestLapMs?, lapsCompleted?, valid?:boolean, wsBridge}
+--- `best_lap_ms` is derived here as the best timed lap of the current stint (see `_stintBest`),
+--- not taken from the caller, so it resets with the stint alongside `laps_completed`.
+---@param opts table  {lap?, lastLapMs?, lapsCompleted?, valid?:boolean, wsBridge}
 ---@return boolean  true if a frame was actually published this call
 function M.publishLap(opts)
   if type(opts) ~= "table" then
@@ -171,21 +189,31 @@ function M.publishLap(opts)
   if not wsBridge then
     return false
   end
+  local valid = opts.valid ~= false
+  local timedMs = tonumber(opts.lastLapMs)
+  if timedMs and timedMs <= 0 then
+    timedMs = nil  -- untimed boundary (e.g. out-lap): no valid lap time, don't send a fake 0
+  end
+  if valid and timedMs and (not _stintBest or timedMs < _stintBest) then
+    _stintBest = timedMs
+  end
   return wsBridge.publishTopic(TOPIC_LAP, {
     lap = tonumber(opts.lap),
-    last_lap_ms = tonumber(opts.lastLapMs),
-    best_lap_ms = tonumber(opts.bestLapMs),
+    last_lap_ms = timedMs,
+    best_lap_ms = _stintBest,
     laps_completed = tonumber(opts.lapsCompleted),
     -- Treat missing as valid; only an explicit false marks an invalidated lap.
-    valid = opts.valid ~= false,
+    valid = valid,
   }) == true
 end
 
 
---- Reset rate-limiter + change-detector (call on session change).
+--- Reset rate-limiter + change-detector + stint-best (call on session/stint reset).
 function M.reset()
   _connAccum = 0.0
   _lastSessionKey = nil
+  _lastConnOk = false
+  _stintBest = nil
 end
 
 

--- a/tests/test_lifecycle_publisher.py
+++ b/tests/test_lifecycle_publisher.py
@@ -1,0 +1,216 @@
+"""Lupa L0 regression for the #180 Part D step 2 lifecycle producers.
+
+`modules/lifecycle_publisher.lua` owns the three lifecycle WS topics the autonomous
+self-test harness's sequence assertions need: `connection` (~1 Hz heartbeat),
+`session` (on track/car/session change), and `lap` (on the lap boundary). These tests
+exercise it under lupa with NO Assetto Corsa and NO sidecar — a Lua-side capturing
+`wsBridge` records every `publishTopic(topic, payload)` so we assert topic names,
+payload shape, rate-limiting, change-detection, and the no-op-when-WS-down contract.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
+
+# `ac` content-id mocks + two capturing wsBridge factories: one whose publishTopic
+# succeeds (returns true, like a hello-acked sidecar) and one that returns false
+# (WS not open). Both record their calls so tests can assert on the payloads.
+_STUB = r"""
+ac = {
+  getCarID = function(_i) return "bmw_m3_gt2" end,
+  getTrackID = function() return "ks_laguna_seca" end,
+}
+function make_ws()
+  local calls = {}
+  return {
+    _calls = calls,
+    publishTopic = function(topic, payload)
+      calls[#calls + 1] = { topic = topic, payload = payload }
+      return true
+    end,
+  }
+end
+function make_ws_closed()
+  local calls = {}
+  return {
+    _calls = calls,
+    publishTopic = function(topic, payload)
+      calls[#calls + 1] = { topic = topic, payload = payload }
+      return false  -- WS not hello-acked yet
+    end,
+  }
+end
+"""
+
+
+def _runtime():
+    rt = lupa.LuaRuntime(unpack_returned_tuples=False)
+    rt.execute(_STUB)
+    p = str(MODULES_DIR).replace("\\", "/")
+    rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
+    return rt
+
+
+def test_connection_heartbeat_is_rate_limited_to_1hz():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local s1 = { currentSessionIndex = 1 }
+          local r1 = M.publishConnectionIfDue({ dt = 0.5, sim = s1, wsBridge = ws })
+          local r2 = M.publishConnectionIfDue({ dt = 0.6, sim = s1, wsBridge = ws })
+          local c = ws._calls[1]
+          return { r1 = r1, r2 = r2, n = #ws._calls, topic = c and c.topic,
+                   car = c and c.payload.car_id, track = c and c.payload.track_id,
+                   sess = c and c.payload.session_index }
+        end)()
+        """
+    )
+    assert out["r1"] is False  # 0.5s < 1.0s -> not due
+    assert out["r2"] is True  # 1.1s accumulated -> publish
+    assert out["n"] == 1
+    assert out["topic"] == "connection"
+    assert out["car"] == "bmw_m3_gt2"
+    assert out["track"] == "ks_laguna_seca"
+    assert out["sess"] == 1
+
+
+def test_session_published_once_then_suppressed_until_change():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local opts0 = { sim = { currentSessionIndex = 0 }, wsBridge = ws }
+          local r1 = M.publishSessionIfChanged(opts0)  -- first -> publish
+          local r2 = M.publishSessionIfChanged(opts0)  -- same key -> suppress
+          -- changed session index -> publish again
+          local r3 = M.publishSessionIfChanged({ sim = { currentSessionIndex = 1 }, wsBridge = ws })
+          local c = ws._calls[1]
+          return { r1 = r1, r2 = r2, r3 = r3, n = #ws._calls, topic = c and c.topic,
+                   sess = c and c.payload.session_index }
+        end)()
+        """
+    )
+    assert out["r1"] is True
+    assert out["r2"] is False
+    assert out["r3"] is True
+    assert out["n"] == 2
+    assert out["topic"] == "session"
+    assert out["sess"] == 0
+
+
+def test_session_retries_after_ws_recovers():
+    # Regression: a session change while the WS is down must NOT mark the key as
+    # sent, so the initial `session` frame is re-published once the WS comes up.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local sim0 = { currentSessionIndex = 0 }
+          local down = make_ws_closed()
+          local r_down = M.publishSessionIfChanged({ sim = sim0, wsBridge = down })
+          local up = make_ws()
+          local r_up = M.publishSessionIfChanged({ sim = sim0, wsBridge = up })
+          local c = up._calls[1]
+          return { r_down = r_down, r_up = r_up, n_up = #up._calls, topic = c and c.topic }
+        end)()
+        """
+    )
+    assert out["r_down"] is False  # WS down -> no-op
+    assert out["r_up"] is True  # same session re-published once WS is up
+    assert out["n_up"] == 1
+    assert out["topic"] == "session"
+
+
+def test_lap_publishes_payload_with_validity():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishLap({ lap = 3, lastLapMs = 91234, bestLapMs = 90000,
+                                   lapsCompleted = 2, valid = false, wsBridge = ws })
+          local p = ws._calls[1] and ws._calls[1].payload
+          return { r = r, n = #ws._calls, topic = ws._calls[1] and ws._calls[1].topic,
+                   lap = p and p.lap, last = p and p.last_lap_ms, best = p and p.best_lap_ms,
+                   done = p and p.laps_completed, valid = p and p.valid }
+        end)()
+        """
+    )
+    assert out["r"] is True
+    assert out["n"] == 1
+    assert out["topic"] == "lap"
+    assert out["lap"] == 3
+    assert out["last"] == 91234
+    assert out["best"] == 90000
+    assert out["done"] == 2
+    assert out["valid"] is False
+
+
+def test_lap_defaults_to_valid_when_unspecified():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          M.publishLap({ lap = 1, wsBridge = ws })
+          return { valid = ws._calls[1].payload.valid }
+        end)()
+        """
+    )
+    assert out["valid"] is True  # missing `valid` -> treated as a valid lap
+
+
+def test_all_producers_noop_when_ws_down():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws_closed()
+          local sim0 = { currentSessionIndex = 0 }
+          local c = M.publishConnectionIfDue({ dt = 2.0, sim = sim0, wsBridge = ws })
+          local s = M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })
+          local l = M.publishLap({ lap = 1, wsBridge = ws })
+          return { c = c, s = s, l = l }
+        end)()
+        """
+    )
+    assert out["c"] is False
+    assert out["s"] is False
+    assert out["l"] is False
+
+
+def test_producers_return_false_without_wsbridge():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          return {
+            c = M.publishConnectionIfDue({ dt = 2.0 }),
+            s = M.publishSessionIfChanged({}),
+            l = M.publishLap({ lap = 1 }),
+            bad = M.publishLap("not a table"),
+          }
+        end)()
+        """
+    )
+    assert out["c"] is False
+    assert out["s"] is False
+    assert out["l"] is False
+    assert out["bad"] is False

--- a/tests/test_lifecycle_publisher.py
+++ b/tests/test_lifecycle_publisher.py
@@ -284,6 +284,35 @@ def test_session_reemits_on_ws_reconnect():
     assert out["r3"] is True  # reconnect re-armed -> session re-emitted
 
 
+def test_stint_reset_emits_session_once_not_duplicate():
+    # Regression (Cursor on #182 r2-fix): a stint reset with the WS still up must re-emit
+    # `session` exactly once. The earlier code reset _lastConnOk=false, so the next heartbeat
+    # falsely detected a reconnect and emitted a SECOND (duplicate) session ~1s later.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local sim0 = { currentSessionIndex = 0 }
+          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })  -- initial connect
+          M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- session #1
+          M.reset()  -- stint reset (WS still up)
+          M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- session #2 (intended re-emit)
+          -- a due heartbeat (WS still up, not a reconnect) must NOT clear the key:
+          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })
+          M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- must be SUPPRESSED (no dup)
+          local sessions = 0
+          for _, c in ipairs(ws._calls) do
+            if c.topic == "session" then sessions = sessions + 1 end
+          end
+          return { sessions = sessions }
+        end)()
+        """
+    )
+    assert out["sessions"] == 2  # one initial + one post-reset; NOT a third spurious duplicate
+
+
 def test_all_producers_noop_when_ws_down():
     rt = _runtime()
     out = rt.eval(

--- a/tests/test_lifecycle_publisher.py
+++ b/tests/test_lifecycle_publisher.py
@@ -255,39 +255,59 @@ def test_lap_stint_best_resets_on_reset():
     assert out["b2"] == 112000  # stint best reset -> the new (slower) lap is the new best
 
 
-def test_session_reemits_on_ws_reconnect():
-    # Regression (codex P2): after a WS down->up reconnect (same identity), the connection
-    # heartbeat re-arms `session` so a reconnected tap sees `session` before any `lap`.
+def test_rearm_session_reemits_for_unchanged_identity():
+    # The entry script calls M.rearmSession() on a WS reconnect; the next publishSessionIfChanged
+    # must re-emit `session` even though the identity is unchanged (so a reconnected tap sees
+    # `session` before any `lap`). Reconnect detection lives in the entry script (per-frame via
+    # ws_bridge.sidecarConnected()), not in this producer.
     rt = _runtime()
     out = rt.eval(
         r"""
         (function()
-          local up = { v = true }
-          local ws = { _calls = {} }
-          ws.publishTopic = function(t, _p) ws._calls[#ws._calls + 1] = t; return up.v end
           local M = require("lifecycle_publisher"); M.reset()
-          local sim0 = { currentSessionIndex = 0 }
-          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })  -- initial up
-          local r1 = M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- publishes
-          local r2 = M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- suppressed
-          up.v = false
-          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })  -- WS down
-          up.v = true
-          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })  -- reconnect -> re-arm
-          local r3 = M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- re-emits
-          return { r1 = r1, r2 = r2, r3 = r3 }
+          local ws = make_ws()
+          local opts = { sim = { currentSessionIndex = 0 }, wsBridge = ws }
+          local r1 = M.publishSessionIfChanged(opts)  -- publishes
+          local r2 = M.publishSessionIfChanged(opts)  -- same key -> suppressed
+          M.rearmSession()                            -- WS reconnect re-arm
+          local r3 = M.publishSessionIfChanged(opts)  -- re-emits, identity unchanged
+          return { r1 = r1, r2 = r2, r3 = r3, n = #ws._calls }
         end)()
         """
     )
     assert out["r1"] is True
-    assert out["r2"] is False  # same identity, still connected -> suppressed
-    assert out["r3"] is True  # reconnect re-armed -> session re-emitted
+    assert out["r2"] is False
+    assert out["r3"] is True
+    assert out["n"] == 2
+
+
+def test_rearm_session_does_not_reset_stint_best():
+    # rearmSession() (WS reconnect) must NOT clear the stint best — only M.reset() (stint) does.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local function lap(n, ms)
+            M.publishLap({
+              lap = n, lastLapMs = ms, lapsCompleted = n, valid = true, wsBridge = ws,
+            })
+          end
+          lap(1, 104000)
+          M.rearmSession()  -- reconnect: stint best must survive
+          lap(2, 109000)
+          return { b2 = ws._calls[2].payload.best_lap_ms }
+        end)()
+        """
+    )
+    assert out["b2"] == 104000  # stint best preserved across a reconnect re-arm
 
 
 def test_stint_reset_emits_session_once_not_duplicate():
-    # Regression (Cursor on #182 r2-fix): a stint reset with the WS still up must re-emit
-    # `session` exactly once. The earlier code reset _lastConnOk=false, so the next heartbeat
-    # falsely detected a reconnect and emitted a SECOND (duplicate) session ~1s later.
+    # The connection heartbeat must NOT touch the session change-detector key: after a stint
+    # reset (WS still up) `session` re-emits exactly once, and a subsequent due heartbeat does
+    # not produce a duplicate. (Reconnect re-arm is the entry script's job, not the heartbeat's.)
     rt = _runtime()
     out = rt.eval(
         r"""

--- a/tests/test_lifecycle_publisher.py
+++ b/tests/test_lifecycle_publisher.py
@@ -177,45 +177,111 @@ def test_trackid_prefers_full_id_for_layout():
     assert out["track"] == "ks_brands_hatch/gp"
 
 
-def test_lap_publishes_payload_with_validity():
+def test_lap_payload_and_stint_best_tracking():
+    # best_lap_ms is the producer-tracked min of valid timed laps THIS stint (not the
+    # caller's value), and an invalid lap does not update it.
     rt = _runtime()
     out = rt.eval(
         r"""
         (function()
           local M = require("lifecycle_publisher"); M.reset()
           local ws = make_ws()
-          local r = M.publishLap({ lap = 3, lastLapMs = 91234, bestLapMs = 90000,
-                                   lapsCompleted = 2, valid = false, wsBridge = ws })
-          local p = ws._calls[1] and ws._calls[1].payload
-          return { r = r, n = #ws._calls, topic = ws._calls[1] and ws._calls[1].topic,
-                   lap = p and p.lap, last = p and p.last_lap_ms, best = p and p.best_lap_ms,
-                   done = p and p.laps_completed, valid = p and p.valid }
+          local function lap(n, ms, valid)
+            M.publishLap({
+              lap = n, lastLapMs = ms, lapsCompleted = n, valid = valid, wsBridge = ws,
+            })
+          end
+          lap(1, 110000, true)   -- best -> 110000
+          lap(2, 105000, true)   -- faster -> best 105000
+          lap(3, 108000, true)   -- slower -> best stays 105000
+          lap(4, 100000, false)  -- invalid -> best stays 105000, last=100000
+          local function best(i) return ws._calls[i].payload.best_lap_ms end
+          local p4 = ws._calls[4].payload
+          return { topic = ws._calls[1].topic, b1 = best(1), b2 = best(2), b3 = best(3),
+                   b4 = best(4), last4 = p4.last_lap_ms, valid4 = p4.valid,
+                   lap4 = p4.lap, done4 = p4.laps_completed }
         end)()
         """
     )
-    assert out["r"] is True
-    assert out["n"] == 1
     assert out["topic"] == "lap"
-    assert out["lap"] == 3
-    assert out["last"] == 91234
-    assert out["best"] == 90000
-    assert out["done"] == 2
-    assert out["valid"] is False
+    assert out["b1"] == 110000
+    assert out["b2"] == 105000
+    assert out["b3"] == 105000
+    assert out["b4"] == 105000  # invalid lap didn't lower the stint best
+    assert out["last4"] == 100000
+    assert out["valid4"] is False
+    assert out["lap4"] == 4
+    assert out["done4"] == 4
 
 
-def test_lap_defaults_to_valid_when_unspecified():
+def test_lap_untimed_boundary_sends_nil_last_lap():
     rt = _runtime()
     out = rt.eval(
         r"""
         (function()
           local M = require("lifecycle_publisher"); M.reset()
           local ws = make_ws()
-          M.publishLap({ lap = 1, wsBridge = ws })
-          return { valid = ws._calls[1].payload.valid }
+          M.publishLap({ lap = 1, lastLapMs = 0, lapsCompleted = 1, wsBridge = ws })  -- out-lap
+          local p = ws._calls[1].payload
+          return { last = p.last_lap_ms, best = p.best_lap_ms, valid = p.valid }
         end)()
         """
     )
-    assert out["valid"] is True  # missing `valid` -> treated as a valid lap
+    assert out["last"] is None  # untimed -> nil, not a fake 0
+    assert out["best"] is None  # no valid timed lap yet
+    assert out["valid"] is True
+
+
+def test_lap_stint_best_resets_on_reset():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local function lap(ms)
+            M.publishLap({
+              lap = 1, lastLapMs = ms, lapsCompleted = 1, valid = true, wsBridge = ws,
+            })
+          end
+          lap(105000)
+          M.reset()  -- new stint
+          lap(112000)
+          return { b1 = ws._calls[1].payload.best_lap_ms, b2 = ws._calls[2].payload.best_lap_ms }
+        end)()
+        """
+    )
+    assert out["b1"] == 105000
+    assert out["b2"] == 112000  # stint best reset -> the new (slower) lap is the new best
+
+
+def test_session_reemits_on_ws_reconnect():
+    # Regression (codex P2): after a WS down->up reconnect (same identity), the connection
+    # heartbeat re-arms `session` so a reconnected tap sees `session` before any `lap`.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local up = { v = true }
+          local ws = { _calls = {} }
+          ws.publishTopic = function(t, _p) ws._calls[#ws._calls + 1] = t; return up.v end
+          local M = require("lifecycle_publisher"); M.reset()
+          local sim0 = { currentSessionIndex = 0 }
+          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })  -- initial up
+          local r1 = M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- publishes
+          local r2 = M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- suppressed
+          up.v = false
+          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })  -- WS down
+          up.v = true
+          M.publishConnectionIfDue({ dt = 1.0, sim = sim0, wsBridge = ws })  -- reconnect -> re-arm
+          local r3 = M.publishSessionIfChanged({ sim = sim0, wsBridge = ws })  -- re-emits
+          return { r1 = r1, r2 = r2, r3 = r3 }
+        end)()
+        """
+    )
+    assert out["r1"] is True
+    assert out["r2"] is False  # same identity, still connected -> suppressed
+    assert out["r3"] is True  # reconnect re-armed -> session re-emitted
 
 
 def test_all_producers_noop_when_ws_down():

--- a/tests/test_lifecycle_publisher.py
+++ b/tests/test_lifecycle_publisher.py
@@ -134,6 +134,49 @@ def test_session_retries_after_ws_recovers():
     assert out["topic"] == "session"
 
 
+def test_session_reemits_after_reset():
+    # Regression (Cursor/CodeRabbit/codex P1): a same-session/stint restart calls
+    # M.reset(), after which the unchanged session identity must be re-published
+    # (else the harness's session->lap sequence misses the restart's session frame).
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local opts = { sim = { currentSessionIndex = 0 }, wsBridge = ws }
+          local r1 = M.publishSessionIfChanged(opts)  -- publish
+          local r2 = M.publishSessionIfChanged(opts)  -- same key -> suppressed
+          M.reset()
+          local r3 = M.publishSessionIfChanged(opts)  -- re-published after reset
+          return { r1 = r1, r2 = r2, r3 = r3, n = #ws._calls }
+        end)()
+        """
+    )
+    assert out["r1"] is True
+    assert out["r2"] is False
+    assert out["r3"] is True
+    assert out["n"] == 2
+
+
+def test_trackid_prefers_full_id_for_layout():
+    # codex P2: multi-layout tracks must be distinguished -> prefer ac.getTrackFullID
+    # (track/layout) over the bare ac.getTrackID.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          ac.getTrackFullID = function(_sep) return "ks_brands_hatch/gp" end
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          M.publishSessionIfChanged({ sim = { currentSessionIndex = 0 }, wsBridge = ws })
+          return { track = ws._calls[1] and ws._calls[1].payload.track_id }
+        end)()
+        """
+    )
+    assert out["track"] == "ks_brands_hatch/gp"
+
+
 def test_lap_publishes_payload_with_validity():
     rt = _runtime()
     out = rt.eval(

--- a/tests/test_lifecycle_publisher.py
+++ b/tests/test_lifecycle_publisher.py
@@ -255,6 +255,29 @@ def test_lap_stint_best_resets_on_reset():
     assert out["b2"] == 112000  # stint best reset -> the new (slower) lap is the new best
 
 
+def test_lap_best_not_committed_on_failed_publish():
+    # Mirrors session's publish-then-record: a lap whose frame fails to send (WS down) must NOT
+    # advance the stint best, so a later DELIVERED lap reports a best among delivered laps only.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local down = make_ws_closed()
+          M.publishLap({
+            lap = 1, lastLapMs = 104000, lapsCompleted = 1, valid = true, wsBridge = down,
+          })
+          local up = make_ws()
+          M.publishLap({
+            lap = 2, lastLapMs = 110000, lapsCompleted = 2, valid = true, wsBridge = up,
+          })
+          return { best = up._calls[1].payload.best_lap_ms }
+        end)()
+        """
+    )
+    assert out["best"] == 110000  # the dropped faster lap (104000) was not committed
+
+
 def test_rearm_session_reemits_for_unchanged_identity():
     # The entry script calls M.rearmSession() on a WS reconnect; the next publishSessionIfChanged
     # must re-emit `session` even though the identity is unchanged (so a reconnected tap sees


### PR DESCRIPTION
Part of #180 / EPIC #154 Part D step 2 — the **lifecycle subset** (`connection`, `session`, `lap`). `delta` + `tire_temps` are a tracked follow-up (need current-elapsed-ms / per-wheel-temp wiring).

## What
`modules/lifecycle_publisher.lua` (modeled on `coaching_publisher.lua`): `connection` (~1 Hz heartbeat), `session` (event-driven on track/car/session change), `lap` (at the `car.lapCount` boundary). Wired into `ac_copilot_trainer.lua` `script.update` (connection+session) and the lap boundary (lap). All no-op when the WS isn't open (`publishTopic` returns false pre-handshake).

These are the lifecycle topics the **L1.5 sequence assertions** need (session → lap boundary). A live WS tap during a real drive confirmed they were **silent** before this (only `coaching.snapshot` flowed — the declared-but-unproduced gap #180 targets).

## Correctness note
`session` records its change-detection key **only on a successful publish**, so a session-change while the WS is down isn't swallowed — it re-publishes once connected (regression-tested).

## Verification
- **Headless:** 7 lupa tests (`tests/test_lifecycle_publisher.py`); `test_ws_topic_allowlist` drift-guard still green; both Lua files lupa-compile-check.
- **In-game (gate before ready/merge):** tap a live drive, confirm `connection`/`session`/`lap` flow. Held DRAFT until observed (anti-false-green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)