### PR TITLE
feat(trainer): wire delta + tire_temps WS producers (#180 — completes Part D step 2)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1746,14 +1746,15 @@ function script.update(dt)
   -- same delta.deltaSecondsAtSpline computation the HUD uses; `tire_temps` streams current
   -- per-wheel core temps. Both rate-limited internally and no-op when the WS isn't open.
   pcall(function()
-    -- Skip `delta` on the lap-boundary frame: there `tel:lapStartTime()` still belongs to the
-    -- finished lap (it's reset by beginLapClock in the boundary handler BELOW) while
-    -- car.splinePosition has already wrapped to ~0, so deltaSecondsAtSpline would emit a bogus
-    -- ~full-lap delta once per crossing (Cursor on #185). Use the same boundary condition the
-    -- handler uses; `state.lastLapCount` here still holds the pre-boundary value.
+    -- Skip `delta` on ANY lap-count change frame (forward boundary OR a session/pit-restart
+    -- rollback). On such a frame `tel:lapStartTime()` and the reference trace still belong to
+    -- the prior lap/stint while car state has moved on (spline wrapped, or car reset), so
+    -- deltaSecondsAtSpline would emit a bogus cross-lap/cross-stint delta (Cursor + codex on
+    -- #185). `state.lastLapCount` here still holds the pre-handler value; `~=` covers both the
+    -- forward crossing (reset by beginLapClock below) and the rollback (reset later this frame).
     local lcNow = car.lapCount or 0
-    local atLapBoundary = (state.lastLapCount or -1) >= 0 and lcNow > state.lastLapCount
-    if state.bestSortedTrace and tel:lapStartTime() and not atLapBoundary then
+    local atLapCountChange = (state.lastLapCount or -1) >= 0 and lcNow ~= state.lastLapCount
+    if state.bestSortedTrace and tel:lapStartTime() and not atLapCountChange then
       local eMs = (ch.simSeconds(sim) - tel:lapStartTime()) * 1000
       local spNow = car.splinePosition or 0
       local rawDelta = delta.deltaSecondsAtSpline(state.bestSortedTrace, spNow, eMs)

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -818,6 +818,9 @@ state = {
   },
   recording = true,
   lastSplinePos = nil,
+  -- car.resetCounter from the previous frame; a change = teleport/return-to-garage/pit reset (a
+  -- wrap-shaped rewind the spline heuristic can't classify). Drives delta-skip + rolling reset (#185).
+  lastResetCounter = nil,
   bestLapTrace = {},
   --- Lap time (ms) for the lap that produced `bestLapTrace`; used to omit stale trace from saves when PB improves without a new reference trace.
   bestReferenceLapMs = nil,
@@ -1049,6 +1052,7 @@ local function resetRuntimeAfterLeavingTrack()
   lastDriveCar = nil
   lastDriveSim = nil
   state.lastSplinePos = nil
+  state.lastResetCounter = nil  -- re-prime teleport detection on next track entry
   state.bestLapTrace = {}
   state.bestReferenceLapMs = nil
   state.bestSortedTrace = nil
@@ -1760,7 +1764,18 @@ function script.update(dt)
     local spNow = car.splinePosition or 0
     local atLapCountChange = (state.lastLapCount or -1) >= 0 and lcNow ~= state.lastLapCount
     local splineReset = delta.isBackwardSplineReset(state.lastSplinePos, spNow)
-    if state.bestSortedTrace and tel:lapStartTime() and not atLapCountChange and not splineReset then
+    -- A teleport/return-to-garage/pit reset bumps car.resetCounter and can land the car back near
+    -- the start line with lapCount unchanged — a wrap-shaped rewind the spline heuristic above
+    -- excludes (likelyWrap). resetCounter is the unambiguous teleport signal, so skip delta on it
+    -- too; the end-of-update reset uses the same signal to clear rolling state (codex on #185).
+    local teleported = state.lastResetCounter ~= nil and (car.resetCounter or 0) ~= state.lastResetCounter
+    if
+      state.bestSortedTrace
+      and tel:lapStartTime()
+      and not atLapCountChange
+      and not splineReset
+      and not teleported
+    then
       local eMs = (ch.simSeconds(sim) - tel:lapStartTime()) * 1000
       local rawDelta = delta.deltaSecondsAtSpline(state.bestSortedTrace, spNow, eMs)
       telemetryPublisher.publishDeltaIfDue({
@@ -2154,7 +2169,12 @@ function script.update(dt)
     state.focusPracticeHudSummarySig = nil
   end
 
-  if state.lastLapCount >= 0 and lc < state.lastLapCount then
+  local resetCounterNow = car.resetCounter or 0
+  local teleported = state.lastResetCounter ~= nil and resetCounterNow ~= state.lastResetCounter
+  if teleported or (state.lastLapCount >= 0 and lc < state.lastLapCount) then
+    -- Teleport/return-to-garage/pit reset (resetCounter bumped) OR a lap-counter rollback: the
+    -- prior stint's rolling state (lap clock, coaching, aggregates) is stale. The teleport case
+    -- also covers a wrap-shaped same-lap rewind the spline heuristic below cannot (codex on #185).
     resetRollingDrivingState()
   elseif state.lastLapCount >= 0 and lc == state.lastLapCount and state.lastSplinePos then
     -- Same-lap backward spline jump = pit/session reset (shared with the `delta` producer's skip
@@ -2167,6 +2187,7 @@ function script.update(dt)
   state.lastLapCount = lc
   state.lastSplinePos = sp
   state.lastSplineSector = sp
+  state.lastResetCounter = resetCounterNow
 end
 
 function script.onWindowHide()

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1708,6 +1708,16 @@ function script.update(dt)
   lastDriveSim = sim
   state.wasDriving = true
 
+  -- car.resetCounter is NOT a confirmed-safe StateCar field (csp-api-field-safety decision /
+  -- issue #24: unknown StateCar fields THROW, and this read runs outside the pcall blocks below
+  -- as well). Read it ONCE through the guarded helper and reuse `teleported` for both the
+  -- delta-skip and the end-of-update rolling reset. nil on builds lacking the field => teleport
+  -- detection is gracefully off (the spline heuristic + lap-count rollback still apply). (#185)
+  local resetCounterNow = ch.safeCarField(car, "resetCounter")
+  local teleported = state.lastResetCounter ~= nil
+    and resetCounterNow ~= nil
+    and resetCounterNow ~= state.lastResetCounter
+
   if not state.initialized then
     tryLoadDisk()
   end
@@ -1764,11 +1774,10 @@ function script.update(dt)
     local spNow = car.splinePosition or 0
     local atLapCountChange = (state.lastLapCount or -1) >= 0 and lcNow ~= state.lastLapCount
     local splineReset = delta.isBackwardSplineReset(state.lastSplinePos, spNow)
-    -- A teleport/return-to-garage/pit reset bumps car.resetCounter and can land the car back near
-    -- the start line with lapCount unchanged — a wrap-shaped rewind the spline heuristic above
-    -- excludes (likelyWrap). resetCounter is the unambiguous teleport signal, so skip delta on it
-    -- too; the end-of-update reset uses the same signal to clear rolling state (codex on #185).
-    local teleported = state.lastResetCounter ~= nil and (car.resetCounter or 0) ~= state.lastResetCounter
+    -- `teleported` (computed once above via the guarded resetCounter read) covers a wrap-shaped
+    -- rewind the spline heuristic excludes (likelyWrap) — a teleport/return-to-garage/pit reset
+    -- that lands near the start with lapCount unchanged. Skip delta on it; the end-of-update reset
+    -- reuses the same signal to clear rolling state (codex on #185).
     if
       state.bestSortedTrace
       and tel:lapStartTime()
@@ -2169,12 +2178,11 @@ function script.update(dt)
     state.focusPracticeHudSummarySig = nil
   end
 
-  local resetCounterNow = car.resetCounter or 0
-  local teleported = state.lastResetCounter ~= nil and resetCounterNow ~= state.lastResetCounter
   if teleported or (state.lastLapCount >= 0 and lc < state.lastLapCount) then
-    -- Teleport/return-to-garage/pit reset (resetCounter bumped) OR a lap-counter rollback: the
-    -- prior stint's rolling state (lap clock, coaching, aggregates) is stale. The teleport case
-    -- also covers a wrap-shaped same-lap rewind the spline heuristic below cannot (codex on #185).
+    -- Teleport/return-to-garage/pit reset (guarded resetCounter bumped, computed above) OR a
+    -- lap-counter rollback: the prior stint's rolling state (lap clock, coaching, aggregates) is
+    -- stale. The teleport case also covers a wrap-shaped same-lap rewind the spline heuristic
+    -- below cannot (codex on #185).
     resetRollingDrivingState()
   elseif state.lastLapCount >= 0 and lc == state.lastLapCount and state.lastSplinePos then
     -- Same-lap backward spline jump = pit/session reset (shared with the `delta` producer's skip

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1746,7 +1746,14 @@ function script.update(dt)
   -- same delta.deltaSecondsAtSpline computation the HUD uses; `tire_temps` streams current
   -- per-wheel core temps. Both rate-limited internally and no-op when the WS isn't open.
   pcall(function()
-    if state.bestSortedTrace and tel:lapStartTime() then
+    -- Skip `delta` on the lap-boundary frame: there `tel:lapStartTime()` still belongs to the
+    -- finished lap (it's reset by beginLapClock in the boundary handler BELOW) while
+    -- car.splinePosition has already wrapped to ~0, so deltaSecondsAtSpline would emit a bogus
+    -- ~full-lap delta once per crossing (Cursor on #185). Use the same boundary condition the
+    -- handler uses; `state.lastLapCount` here still holds the pre-boundary value.
+    local lcNow = car.lapCount or 0
+    local atLapBoundary = (state.lastLapCount or -1) >= 0 and lcNow > state.lastLapCount
+    if state.bestSortedTrace and tel:lapStartTime() and not atLapBoundary then
       local eMs = (ch.simSeconds(sim) - tel:lapStartTime()) * 1000
       local spNow = car.splinePosition or 0
       local rawDelta = delta.deltaSecondsAtSpline(state.bestSortedTrace, spNow, eMs)

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1773,16 +1773,17 @@ function script.update(dt)
     local lcNow = car.lapCount or 0
     local spNow = car.splinePosition or 0
     local atLapCountChange = (state.lastLapCount or -1) >= 0 and lcNow ~= state.lastLapCount
-    local splineReset = delta.isBackwardSplineReset(state.lastSplinePos, spNow)
-    -- `teleported` (computed once above via the guarded resetCounter read) covers a wrap-shaped
-    -- rewind the spline heuristic excludes (likelyWrap) — a teleport/return-to-garage/pit reset
-    -- that lands near the start with lapCount unchanged. Skip delta on it; the end-of-update reset
-    -- reuses the same signal to clear rolling state (codex on #185).
+    -- For the delta SKIP we use the LIBERAL isBackwardSplineJump (includes wrap-shaped jumps):
+    -- skipping a delta frame is harmless, and since this only runs with lapCount unchanged
+    -- (`not atLapCountChange`), any backward jump here is a reset/teleport, not a lap wrap. This
+    -- also covers builds where resetCounter is unavailable, so a wrap-shaped same-lap teleport
+    -- never leaks a bogus delta even when `teleported` can't be determined (codex on #185).
+    local splineJump = delta.isBackwardSplineJump(state.lastSplinePos, spNow)
     if
       state.bestSortedTrace
       and tel:lapStartTime()
       and not atLapCountChange
-      and not splineReset
+      and not splineJump
       and not teleported
     then
       local eMs = (ch.simSeconds(sim) - tel:lapStartTime()) * 1000
@@ -1853,8 +1854,11 @@ function script.update(dt)
     state.lastLapCount = lc
   end
 
-  -- Lap boundary: finalize trace before appending this frame's sample.
-  if state.lastLapCount >= 0 and lc > state.lastLapCount then
+  -- Lap boundary: finalize trace before appending this frame's sample. Skip on a teleport frame
+  -- (`teleported`, the guarded resetCounter signal computed above): a return-to-garage/pit reset
+  -- can coincide with a lapCount increase, and finalizing/publishing/archiving here would record a
+  -- bogus lap from the abandoned stint before the end-of-update rolling reset runs (codex on #185).
+  if state.lastLapCount >= 0 and lc > state.lastLapCount and not teleported then
     -- Last frame of the completed lap may still carry invalidation (CSP `ac.StateCar`).
     if carLapInvalidatedFlag(car) then
       state.lapInvalidatedThisLap = true

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -37,6 +37,7 @@ local realtimeCoaching = require("realtime_coaching")
 -- Issue #86 Part C/D: rig-screen-driven features.
 local coachingPublisher = require("coaching_publisher")
 local lifecyclePublisher = require("lifecycle_publisher")
+local telemetryPublisher = require("telemetry_publisher")
 local setupLibrary = require("setup_library")
 
 --- Pixel sizes per window title; must match ``manifest.ini`` WINDOW_* ``SIZE=``.
@@ -1102,6 +1103,7 @@ local function resetRuntimeAfterLeavingTrack()
   renderDiag.reset()
   realtimeCoaching.reset()
   lifecyclePublisher.reset()  -- #180: re-emit `session` after a reset (else stale key suppresses it)
+  telemetryPublisher.reset()  -- #180: reset delta/tire_temps rate-limiters
   state.realtimeActiveHint = nil
   state._cachedRealtimeView = nil
   hud.reset()
@@ -1135,6 +1137,7 @@ local function resetRollingDrivingState()
   hud.reset()
   realtimeCoaching.reset()
   lifecyclePublisher.reset()  -- #180: same-session/stint restart must re-emit `session`
+  telemetryPublisher.reset()  -- #180: reset delta/tire_temps rate-limiters
   tel = newTelemetry()
   brakes = newBrakes()
   td:resetLapAggregates()
@@ -1736,6 +1739,29 @@ function script.update(dt)
       appVersion = APP_VERSION_UI,
     })
     lifecyclePublisher.publishSessionIfChanged({ car = car, sim = sim, wsBridge = wsBridge })
+  end)
+
+  -- Issue #180 Part D step 2: telemetry topics (continuous streams, no ordering contract).
+  -- `delta` is published only once a reference lap exists (state.bestSortedTrace) using the
+  -- same delta.deltaSecondsAtSpline computation the HUD uses; `tire_temps` streams current
+  -- per-wheel core temps. Both rate-limited internally and no-op when the WS isn't open.
+  pcall(function()
+    if state.bestSortedTrace and tel:lapStartTime() then
+      local eMs = (ch.simSeconds(sim) - tel:lapStartTime()) * 1000
+      local spNow = car.splinePosition or 0
+      local rawDelta = delta.deltaSecondsAtSpline(state.bestSortedTrace, spNow, eMs)
+      telemetryPublisher.publishDeltaIfDue({
+        dt = dt,
+        deltaS = rawDelta,
+        spline = spNow,
+        wsBridge = wsBridge,
+      })
+    end
+    telemetryPublisher.publishTireTempsIfDue({
+      dt = dt,
+      temps = tires:currentTemps(car),
+      wsBridge = wsBridge,
+    })
   end)
   -- Round 10: drain any corner_advice replies into state.cornerAdvisories.
   -- The takeCornerAdvisory API returns the cached text for a label without

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -821,11 +821,13 @@ state = {
   -- car.resetCounter from the previous frame; a change = teleport/return-to-garage/pit reset (a
   -- wrap-shaped rewind the spline heuristic can't classify). Drives delta-skip + rolling reset (#185).
   lastResetCounter = nil,
-  -- True after a backward spline discontinuity (teleport/reset) until the next clean lap boundary
-  -- re-arms the lap clock. While set, the `delta` producer stays silent: a one-frame skip is not
-  -- enough because tel:lapStartTime() stays stale on CSP builds lacking resetCounter, so delta would
-  -- otherwise leak bogus values against the abandoned stint's clock all stint (codex on #185).
-  deltaRefStale = false,
+  -- True while the lap clock is NOT aligned to a clean start/finish boundary, so `delta` (elapsed
+  -- vs the reference lap's elapsed-at-spline, both measured from s/f) would be misaligned. The
+  -- `delta` producer stays SILENT while set. Cleared ONLY when beginLapClock fires at a real lap
+  -- boundary (lapCount increment at the s/f line); SET on init, reset/teleport, backward jump, and
+  -- any mid-track clock seed (app load/reload mid-lap, post-reset re-arm) — Cursor + codex on #185.
+  -- Defaults true: no delta until the first clean lap is started (an out-lap clock is mid-track).
+  deltaRefStale = true,
   bestLapTrace = {},
   --- Lap time (ms) for the lap that produced `bestLapTrace`; used to omit stale trace from saves when PB improves without a new reference trace.
   bestReferenceLapMs = nil,
@@ -1058,7 +1060,7 @@ local function resetRuntimeAfterLeavingTrack()
   lastDriveSim = nil
   state.lastSplinePos = nil
   state.lastResetCounter = nil  -- re-prime teleport detection on next track entry
-  state.deltaRefStale = false  -- clean slate on re-entry; first lap boundary keeps it armed
+  state.deltaRefStale = true  -- re-entry: no boundary-aligned clock yet, delta silent until first lap
   state.bestLapTrace = {}
   state.bestReferenceLapMs = nil
   state.bestSortedTrace = nil
@@ -1148,6 +1150,7 @@ local function resetRollingDrivingState()
   realtimeCoaching.reset()
   lifecyclePublisher.reset()  -- #180: same-session/stint restart must re-emit `session`
   telemetryPublisher.reset()  -- #180: reset delta/tire_temps rate-limiters
+  state.deltaRefStale = true  -- #180/#185: clock reset; delta silent until the next clean lap boundary
   tel = newTelemetry()
   brakes = newBrakes()
   td:resetLapAggregates()
@@ -2129,6 +2132,10 @@ function script.update(dt)
   if tel:lapStartTime() == nil and not sim.isInMainMenu and state.lastLapCount >= 0 then
     tel:beginLapClock(ch.simSeconds(sim))
     resetDeltaSmoother()
+    -- This is a MID-TRACK seed (app load/reload or post-reset re-arm), NOT a start/finish boundary,
+    -- so the clock is not aligned to s/f: keep delta silent until the next real lap boundary clears
+    -- this. Publishing now would give subscribers elapsed-from-reload vs reference-from-s/f (codex on #185).
+    state.deltaRefStale = true
     state.sectorStartSimT = ch.simSeconds(sim)
     state.sectorIndex = 1
     state.lastSplineSector = sp

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1752,11 +1752,16 @@ function script.update(dt)
     -- deltaSecondsAtSpline would emit a bogus cross-lap/cross-stint delta (Cursor + codex on
     -- #185). `state.lastLapCount` here still holds the pre-handler value; `~=` covers both the
     -- forward crossing (reset by beginLapClock below) and the rollback (reset later this frame).
+    -- Also skip a SAME-LAP pit/session reset: the spline jumps backward without a lap-count
+    -- change, and the end-of-update reset guard detects it AFTER this block runs. Mirror that
+    -- discontinuity test via the shared delta.isBackwardSplineReset so producer and reset guard
+    -- cannot drift; otherwise one bogus delta leaks out against the rewound spline (codex on #185).
     local lcNow = car.lapCount or 0
+    local spNow = car.splinePosition or 0
     local atLapCountChange = (state.lastLapCount or -1) >= 0 and lcNow ~= state.lastLapCount
-    if state.bestSortedTrace and tel:lapStartTime() and not atLapCountChange then
+    local splineReset = delta.isBackwardSplineReset(state.lastSplinePos, spNow)
+    if state.bestSortedTrace and tel:lapStartTime() and not atLapCountChange and not splineReset then
       local eMs = (ch.simSeconds(sim) - tel:lapStartTime()) * 1000
-      local spNow = car.splinePosition or 0
       local rawDelta = delta.deltaSecondsAtSpline(state.bestSortedTrace, spNow, eMs)
       telemetryPublisher.publishDeltaIfDue({
         dt = dt,
@@ -2152,10 +2157,9 @@ function script.update(dt)
   if state.lastLapCount >= 0 and lc < state.lastLapCount then
     resetRollingDrivingState()
   elseif state.lastLapCount >= 0 and lc == state.lastLapCount and state.lastSplinePos then
-    local lastSp = state.lastSplinePos
-    local d = sp - lastSp
-    local likelyWrap = lastSp > 0.8 and sp < 0.25
-    if d < -0.2 and not likelyWrap then
+    -- Same-lap backward spline jump = pit/session reset (shared with the `delta` producer's skip
+    -- guard via delta.isBackwardSplineReset so the discontinuity threshold can't drift — #185).
+    if delta.isBackwardSplineReset(state.lastSplinePos, sp) then
       resetRollingDrivingState()
     end
   end

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -821,6 +821,11 @@ state = {
   -- car.resetCounter from the previous frame; a change = teleport/return-to-garage/pit reset (a
   -- wrap-shaped rewind the spline heuristic can't classify). Drives delta-skip + rolling reset (#185).
   lastResetCounter = nil,
+  -- True after a backward spline discontinuity (teleport/reset) until the next clean lap boundary
+  -- re-arms the lap clock. While set, the `delta` producer stays silent: a one-frame skip is not
+  -- enough because tel:lapStartTime() stays stale on CSP builds lacking resetCounter, so delta would
+  -- otherwise leak bogus values against the abandoned stint's clock all stint (codex on #185).
+  deltaRefStale = false,
   bestLapTrace = {},
   --- Lap time (ms) for the lap that produced `bestLapTrace`; used to omit stale trace from saves when PB improves without a new reference trace.
   bestReferenceLapMs = nil,
@@ -1053,6 +1058,7 @@ local function resetRuntimeAfterLeavingTrack()
   lastDriveSim = nil
   state.lastSplinePos = nil
   state.lastResetCounter = nil  -- re-prime teleport detection on next track entry
+  state.deltaRefStale = false  -- clean slate on re-entry; first lap boundary keeps it armed
   state.bestLapTrace = {}
   state.bestReferenceLapMs = nil
   state.bestSortedTrace = nil
@@ -1779,12 +1785,19 @@ function script.update(dt)
     -- also covers builds where resetCounter is unavailable, so a wrap-shaped same-lap teleport
     -- never leaks a bogus delta even when `teleported` can't be determined (codex on #185).
     local splineJump = delta.isBackwardSplineJump(state.lastSplinePos, spNow)
+    if splineJump or teleported then
+      -- Mark the reference clock stale until a clean lap boundary re-arms it (cleared at
+      -- beginLapClock). Without this, delta resumes the very next frame against the abandoned
+      -- stint's lap clock — the leak codex flagged on resetCounter-less builds (#185 / #188).
+      state.deltaRefStale = true
+    end
     if
       state.bestSortedTrace
       and tel:lapStartTime()
       and not atLapCountChange
       and not splineJump
       and not teleported
+      and not state.deltaRefStale
     then
       local eMs = (ch.simSeconds(sim) - tel:lapStartTime()) * 1000
       local rawDelta = delta.deltaSecondsAtSpline(state.bestSortedTrace, spNow, eMs)
@@ -1866,6 +1879,7 @@ function script.update(dt)
     local completedTrace = tel:finalizeLapTrace()
     tel:beginLapClock(ch.simSeconds(sim))
     resetDeltaSmoother()
+    state.deltaRefStale = false  -- clean lap clock re-armed at the s/f line: delta valid again (#185)
     -- car.previousLapTimeMs is valid; car.lastLapTimeMs may not exist on the C-struct (throws, not nil).
     local lastMs = car.previousLapTimeMs or 0
     state.lastLapMs = lastMs > 0 and lastMs or state.lastLapMs

--- a/src/ac_copilot_trainer/modules/csp_helpers.lua
+++ b/src/ac_copilot_trainer/modules/csp_helpers.lua
@@ -70,6 +70,28 @@ function M.sanitizeId(s, fallback)
   return s
 end
 
+--- pcall-guarded read of a possibly-unconfirmed `ac.StateCar` field. CSP StateCar throws on
+--- unknown fields (csp-api-field-safety decision / issue #24), so risky fields not on the
+--- confirmed-valid list (e.g. `resetCounter`) MUST be read through this rather than directly.
+--- Returns the field value, or `default` (nil if omitted) when `car` is nil, the field is absent,
+--- or the read throws — so callers degrade gracefully on builds lacking the field.
+---@param car any
+---@param key string
+---@param default any
+---@return any
+function M.safeCarField(car, key, default)
+  if car == nil then
+    return default
+  end
+  local ok, v = pcall(function()
+    return car[key]
+  end)
+  if ok and v ~= nil then
+    return v
+  end
+  return default
+end
+
 function M.safeCarIdRaw()
   if not ac or type(ac.getCarID) ~= "function" then
     return nil

--- a/src/ac_copilot_trainer/modules/delta.lua
+++ b/src/ac_copilot_trainer/modules/delta.lua
@@ -102,23 +102,40 @@ function M.deltaSecondsAtSpline(sortedTrace, splinePos, currentElapsedMs)
   return (currentElapsedMs - bestE) / 1000
 end
 
---- True when the spline jumped backward far enough to indicate a pit/session reset rather than a
---- normal lap wrap. Shared by the live `delta` producer's skip guard and the end-of-update
---- `resetRollingDrivingState` detection so the two cannot drift on the discontinuity threshold
---- (Cursor + codex on #185: a same-lap spline rewind would otherwise emit one bogus delta against
---- the prior stint's lap clock + reference trace before the reset fires). A lap *wrap* (prev spline
---- near 1.0, now near 0.0) is excluded — that is a forward lap completion, not a reset.
+local SPLINE_REWIND_THRESHOLD = -0.2  -- a backward spline delta past this = discontinuity, not jitter
+
+--- True when the spline jumped backward past the rewind threshold — ANY shape, INCLUDING a
+--- wrap-shaped jump (prev near 1.0 -> now near 0.0). Use this where over-triggering is HARMLESS:
+--- the `delta` producer's skip guard. Both producer callers run only with lapCount unchanged
+--- (atLapCountChange already excludes real lap wraps), so a wrap-shaped backward jump there is a
+--- teleport/return-to-garage/pit reset, not a lap completion — and skipping a delta frame on it is
+--- always safe even on CSP builds where resetCounter is unavailable (codex on #185).
 ---@param prevSpline number|nil  previous frame's car.splinePosition (nil before the first frame)
 ---@param spline number          this frame's car.splinePosition
 ---@return boolean
-function M.isBackwardSplineReset(prevSpline, spline)
+function M.isBackwardSplineJump(prevSpline, spline)
   if prevSpline == nil then
     return false
   end
-  spline = spline or 0
-  local d = spline - prevSpline
-  local likelyWrap = prevSpline > 0.8 and spline < 0.25
-  return d < -0.2 and not likelyWrap
+  return ((spline or 0) - prevSpline) < SPLINE_REWIND_THRESHOLD
+end
+
+--- True when the spline jumped backward in a way that should CLEAR rolling driving state (lap
+--- clock, coaching, aggregates) via resetRollingDrivingState. CONSERVATIVE: excludes a lap *wrap*
+--- (prev near 1.0 -> now near 0.0), because over-triggering here is NOT harmless — a false positive
+--- at the start/finish line would wipe coaching/session every lap if CSP ever exposes spline before
+--- the matching lapCount increment. Use this where the cost of a false reset is high (the
+--- end-of-update reset). Teleports are caught unambiguously by car.resetCounter; this is the
+--- spline-only fallback for genuine backward driving (Cursor + codex on #185).
+---@param prevSpline number|nil
+---@param spline number
+---@return boolean
+function M.isBackwardSplineReset(prevSpline, spline)
+  if not M.isBackwardSplineJump(prevSpline, spline) then
+    return false
+  end
+  local likelyWrap = prevSpline > 0.8 and (spline or 0) < 0.25
+  return not likelyWrap
 end
 
 --- Sector durations (ms) for three spline thirds: [0,1/3), [1/3,2/3), [2/3,1).

--- a/src/ac_copilot_trainer/modules/delta.lua
+++ b/src/ac_copilot_trainer/modules/delta.lua
@@ -102,6 +102,25 @@ function M.deltaSecondsAtSpline(sortedTrace, splinePos, currentElapsedMs)
   return (currentElapsedMs - bestE) / 1000
 end
 
+--- True when the spline jumped backward far enough to indicate a pit/session reset rather than a
+--- normal lap wrap. Shared by the live `delta` producer's skip guard and the end-of-update
+--- `resetRollingDrivingState` detection so the two cannot drift on the discontinuity threshold
+--- (Cursor + codex on #185: a same-lap spline rewind would otherwise emit one bogus delta against
+--- the prior stint's lap clock + reference trace before the reset fires). A lap *wrap* (prev spline
+--- near 1.0, now near 0.0) is excluded — that is a forward lap completion, not a reset.
+---@param prevSpline number|nil  previous frame's car.splinePosition (nil before the first frame)
+---@param spline number          this frame's car.splinePosition
+---@return boolean
+function M.isBackwardSplineReset(prevSpline, spline)
+  if prevSpline == nil then
+    return false
+  end
+  spline = spline or 0
+  local d = spline - prevSpline
+  local likelyWrap = prevSpline > 0.8 and spline < 0.25
+  return d < -0.2 and not likelyWrap
+end
+
 --- Sector durations (ms) for three spline thirds: [0,1/3), [1/3,2/3), [2/3,1).
 ---@param sortedTrace LapTraceSample[]|nil
 ---@return number[]|nil three cumulative boundaries ms at 1/3 and 2/3, and lap end

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -35,6 +35,18 @@ local function _wsReady(opts)
 end
 
 
+--- Coerce to a FINITE number, or nil. Rejects NaN and ±inf so a non-finite value never reaches
+--- the wire (JSON cannot represent them). Defense-in-depth at the publish boundary: the wheel
+--- reader already filters non-finite temps, but the publisher must not trust its caller (#185).
+local function _finite(v)
+  v = tonumber(v)
+  if v == nil or v ~= v or v == math.huge or v == -math.huge then
+    return nil
+  end
+  return v
+end
+
+
 --- Advance an accumulator by dt (capped at one interval so a long pause/resume doesn't burst),
 --- returning true + the carried-over remainder when a publish is due. Mirrors coaching_publisher.
 local function _due(accum, dt, interval)
@@ -64,9 +76,9 @@ function M.publishDeltaIfDue(opts)
   if not wsBridge then
     return false
   end
-  local deltaS = tonumber(opts.deltaS)
+  local deltaS = _finite(opts.deltaS)
   if deltaS == nil then
-    return false  -- no reference lap yet / delta unavailable: nothing meaningful to send
+    return false  -- no reference lap yet / delta unavailable / non-finite: nothing to send
   end
   local due, accum = _due(_deltaAccum, tonumber(opts.dt) or 0, DELTA_INTERVAL_SEC)
   _deltaAccum = accum
@@ -96,10 +108,10 @@ function M.publishTireTempsIfDue(opts)
   if type(temps) ~= "table" then
     return false
   end
-  local fl = tonumber(temps.fl)
-  local fr = tonumber(temps.fr)
-  local rl = tonumber(temps.rl)
-  local rr = tonumber(temps.rr)
+  local fl = _finite(temps.fl)
+  local fr = _finite(temps.fr)
+  local rl = _finite(temps.rl)
+  local rr = _finite(temps.rr)
   if fl == nil and fr == nil and rl == nil and rr == nil then
     -- No wheel temp resolvable on this CSP build/car: treat the sample as UNAVAILABLE rather
     -- than publishing an empty {} every interval (Lua drops nil-valued keys), which would

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -87,7 +87,7 @@ function M.publishDeltaIfDue(opts)
   end
   return wsBridge.publishTopic(TOPIC_DELTA, {
     delta_s = deltaS,
-    spline = tonumber(opts.spline),
+    spline = _finite(opts.spline),  -- omit a non-finite spline rather than emit unserializable JSON (#185)
   }) == true
 end
 

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -96,16 +96,26 @@ function M.publishTireTempsIfDue(opts)
   if type(temps) ~= "table" then
     return false
   end
+  local fl = tonumber(temps.fl)
+  local fr = tonumber(temps.fr)
+  local rl = tonumber(temps.rl)
+  local rr = tonumber(temps.rr)
+  if fl == nil and fr == nil and rl == nil and rr == nil then
+    -- No wheel temp resolvable on this CSP build/car: treat the sample as UNAVAILABLE rather
+    -- than publishing an empty {} every interval (Lua drops nil-valued keys), which would
+    -- mask the data-source failure as apparently-live-but-empty samples (codex on #185).
+    return false
+  end
   local due, accum = _due(_tireAccum, tonumber(opts.dt) or 0, TIRE_INTERVAL_SEC)
   _tireAccum = accum
   if not due then
     return false
   end
   return wsBridge.publishTopic(TOPIC_TIRE_TEMPS, {
-    fl = tonumber(temps.fl),
-    fr = tonumber(temps.fr),
-    rl = tonumber(temps.rl),
-    rr = tonumber(temps.rr),
+    fl = fl,
+    fr = fr,
+    rl = rl,
+    rr = rr,
   }) == true
 end
 

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -1,0 +1,120 @@
+-- Telemetry WS topic publishers (issue #180, EPIC #154 Part D step 2 — telemetry subset).
+--
+-- The two high-rate, continuous telemetry topics declared in `external_protocol.KNOWN_TOPICS`:
+--   * `delta`       — live time delta vs the reference lap (reuses delta.deltaSecondsAtSpline).
+--   * `tire_temps`  — current per-wheel core temps {fl, fr, rl, rr}.
+--
+-- Unlike the lifecycle topics (`lifecycle_publisher.lua`) these carry NO ordering contract and
+-- need no reconnect machinery — they are continuous streams like `coaching.snapshot`, so a
+-- (re)connected consumer simply gets the next sample within the publish interval. Both are
+-- thin, STATELESS rate-limited publishers (no publish-then-record): the caller computes the
+-- value, this module rate-limits and forwards via `wsBridge.publishTopic`, and is a no-op when
+-- the WS isn't open (`publishTopic` returns false until the v1 hello handshake completes).
+--
+-- Wired into `ac_copilot_trainer.lua` `script.update` AFTER `wsBridge.tick()`/`pollInbound()`
+-- (current-frame WS state), alongside the lifecycle block. Topic strings are `local` consts so
+-- the `test_ws_topic_allowlist` drift-guard can resolve them against KNOWN_TOPICS.
+
+local M = {}
+
+local DELTA_INTERVAL_SEC = 0.1  -- ~10 Hz, matches the HUD delta refresh
+local TIRE_INTERVAL_SEC = 0.2  -- ~5 Hz; temps move slowly, no need for 10 Hz
+local TOPIC_DELTA = "delta"
+local TOPIC_TIRE_TEMPS = "tire_temps"
+
+local _deltaAccum = 0.0
+local _tireAccum = 0.0
+
+
+local function _wsReady(opts)
+  local wsBridge = opts.wsBridge
+  if not wsBridge or type(wsBridge.publishTopic) ~= "function" then
+    return nil
+  end
+  return wsBridge
+end
+
+
+--- Advance an accumulator by dt (capped at one interval so a long pause/resume doesn't burst),
+--- returning true + the carried-over remainder when a publish is due. Mirrors coaching_publisher.
+local function _due(accum, dt, interval)
+  if dt > 0 then
+    accum = accum + math.min(dt, interval)
+  end
+  if accum < interval then
+    return false, accum
+  end
+  accum = accum - interval
+  if accum < 0 then
+    accum = 0.0
+  end
+  return true, accum
+end
+
+
+--- Publish `delta` at ~10 Hz. The caller passes the already-computed delta seconds (from
+--- delta.deltaSecondsAtSpline) so this module never duplicates the delta math.
+---@param opts table  {dt:number, deltaS:number, spline?:number, wsBridge}
+---@return boolean  true if a frame was actually published this call
+function M.publishDeltaIfDue(opts)
+  if type(opts) ~= "table" then
+    return false
+  end
+  local wsBridge = _wsReady(opts)
+  if not wsBridge then
+    return false
+  end
+  local deltaS = tonumber(opts.deltaS)
+  if deltaS == nil then
+    return false  -- no reference lap yet / delta unavailable: nothing meaningful to send
+  end
+  local due, accum = _due(_deltaAccum, tonumber(opts.dt) or 0, DELTA_INTERVAL_SEC)
+  _deltaAccum = accum
+  if not due then
+    return false
+  end
+  return wsBridge.publishTopic(TOPIC_DELTA, {
+    delta_s = deltaS,
+    spline = tonumber(opts.spline),
+  }) == true
+end
+
+
+--- Publish `tire_temps` at ~5 Hz. `opts.temps` is {fl, fr, rl, rr} (numbers or nil), e.g. from
+--- `tire_monitor`'s :currentTemps(car).
+---@param opts table  {dt:number, temps:table, wsBridge}
+---@return boolean  true if a frame was actually published this call
+function M.publishTireTempsIfDue(opts)
+  if type(opts) ~= "table" then
+    return false
+  end
+  local wsBridge = _wsReady(opts)
+  if not wsBridge then
+    return false
+  end
+  local temps = opts.temps
+  if type(temps) ~= "table" then
+    return false
+  end
+  local due, accum = _due(_tireAccum, tonumber(opts.dt) or 0, TIRE_INTERVAL_SEC)
+  _tireAccum = accum
+  if not due then
+    return false
+  end
+  return wsBridge.publishTopic(TOPIC_TIRE_TEMPS, {
+    fl = tonumber(temps.fl),
+    fr = tonumber(temps.fr),
+    rl = tonumber(temps.rl),
+    rr = tonumber(temps.rr),
+  }) == true
+end
+
+
+--- Reset the rate-limiters (e.g. on session/stint reset).
+function M.reset()
+  _deltaAccum = 0.0
+  _tireAccum = 0.0
+end
+
+
+return M

--- a/src/ac_copilot_trainer/modules/tire_monitor.lua
+++ b/src/ac_copilot_trainer/modules/tire_monitor.lua
@@ -156,6 +156,35 @@ function Mon:update(car, dt, spline)
   end
 end
 
+--- Current per-wheel core temps {fl, fr, rl, rr}, read live from `car.wheels` (issue #180
+--- `tire_temps` producer). Read-only; each value is a number or nil if unavailable. Reuses the
+--- same `readWheelTemp` fallback chain and wheel order (1=fl,2=fr,3=rl,4=rr) as :update, so the
+--- streamed temps agree with the lap aggregates. pcall-guards every `car.wheels` access.
+---@param car any
+---@return table  {fl, fr, rl, rr}
+function Mon:currentTemps(car)
+  local out = { fl = nil, fr = nil, rl = nil, rr = nil }
+  if not car then
+    return out
+  end
+  local okW, wheels = pcall(function()
+    return car.wheels
+  end)
+  if not okW or wheels == nil then
+    return out
+  end
+  local keys = { "fl", "fr", "rl", "rr" }
+  for i = 1, 4 do
+    local oki, one = pcall(function()
+      return wheels[i]
+    end)
+    if oki and one ~= nil then
+      out[keys[i]] = readWheelTemp(one)
+    end
+  end
+  return out
+end
+
 ---@return string|nil
 function Mon:lapSummaryLine()
   local a, amin, amax = summarizeTemps(self.lapTemps.fl)

--- a/src/ac_copilot_trainer/modules/tire_monitor.lua
+++ b/src/ac_copilot_trainer/modules/tire_monitor.lua
@@ -68,7 +68,15 @@ local function readWheelTemp(one)
   if type(temp) == "table" and temp.average ~= nil then
     temp = temp.average
   end
-  return tonumber(temp)
+  local n = tonumber(temp)
+  -- Reject non-finite reads (NaN / ±inf): a CSP field can be present but non-finite, and a NaN
+  -- would survive the `== nil` guards downstream and serialize as invalid JSON in `tire_temps`
+  -- (codex on #185). The lap aggregator's pushTemp already rejects NaN; mirror that at the source
+  -- so the live `currentTemps` path is finite-only too. (NaN ~= itself; ±inf == math.huge.)
+  if n == nil or n ~= n or n == math.huge or n == -math.huge then
+    return nil
+  end
+  return n
 end
 
 local function readWheelSlip(one)

--- a/src/ac_copilot_trainer/modules/tire_monitor.lua
+++ b/src/ac_copilot_trainer/modules/tire_monitor.lua
@@ -91,48 +91,38 @@ function Mon:update(car, dt, spline)
     return
   end
   wheels = wobj
-  local n = 4
-  local okN, nn = pcall(function()
-    return #wheels
-  end)
-  if okN and type(nn) == "number" and nn > 0 then
-    n = math.min(nn, 4)
-  end
   local anySlip = false
   local maxHold = 0
   local hold = self.slipHoldPerWheel
-  for i = 1, n do
+  -- CSP `car.wheels` is 0-indexed per `ac.Wheel` (0=FL,1=FR,2=RL,3=RR); shipped CSP apps iterate
+  -- `for i=0,3`. Read at the 0-based wheel index `wi`, map to the 1-based internal state slot
+  -- (lapTemps/lapPeakSlip/hold) so the lap aggregates stay labeled FL/FR/RL/RR correctly. A car
+  -- always has exactly 4 wheels, so we cover all four slots (no `#wheels` probe — unreliable on a
+  -- 0-indexed CSP array) and reset a slot's lockup hold when its wheel is unreadable this frame.
+  local lapBuckets = { self.lapTemps.fl, self.lapTemps.fr, self.lapTemps.rl, self.lapTemps.rr }
+  for wi = 0, 3 do
+    local slot = wi + 1
     local oki, one = pcall(function()
-      return wheels[i]
+      return wheels[wi]
     end)
     if oki and one ~= nil then
-      local temp = readWheelTemp(one)
-      if i == 1 then
-        pushTemp(self.lapTemps.fl, temp)
-      elseif i == 2 then
-        pushTemp(self.lapTemps.fr, temp)
-      elseif i == 3 then
-        pushTemp(self.lapTemps.rl, temp)
-      else
-        pushTemp(self.lapTemps.rr, temp)
-      end
+      pushTemp(lapBuckets[slot], readWheelTemp(one))
       local slip = readWheelSlip(one)
-      if math.abs(slip) > math.abs(self.lapPeakSlip[i] or 0) then
-        self.lapPeakSlip[i] = slip
+      if math.abs(slip) > math.abs(self.lapPeakSlip[slot] or 0) then
+        self.lapPeakSlip[slot] = slip
       end
       if math.abs(slip) >= LOCKUP_SLIP then
         anySlip = true
-        hold[i] = hold[i] + d
-        if hold[i] > maxHold then
-          maxHold = hold[i]
+        hold[slot] = hold[slot] + d
+        if hold[slot] > maxHold then
+          maxHold = hold[slot]
         end
       else
-        hold[i] = 0
+        hold[slot] = 0
       end
+    else
+      hold[slot] = 0
     end
-  end
-  for i = n + 1, 4 do
-    hold[i] = 0
   end
   if not anySlip then
     self.lockupRearm = true
@@ -158,8 +148,13 @@ end
 
 --- Current per-wheel core temps {fl, fr, rl, rr}, read live from `car.wheels` (issue #180
 --- `tire_temps` producer). Read-only; each value is a number or nil if unavailable. Reuses the
---- same `readWheelTemp` fallback chain and wheel order (1=fl,2=fr,3=rl,4=rr) as :update, so the
+--- same `readWheelTemp` fallback chain and wheel order (0=fl,1=fr,2=rl,3=rr) as :update, so the
 --- streamed temps agree with the lap aggregates. pcall-guards every `car.wheels` access.
+---
+--- CSP `car.wheels` is **0-indexed** per `ac.Wheel` (FrontLeft=0, FrontRight=1, RearLeft=2,
+--- RearRight=3). Shipped CSP apps iterate `for i=0,3` (e.g. CMRT-Essential-HUD). The earlier
+--- 1-based read (`wheels[1..4]`) shifted every corner by one and read an out-of-bounds zero-
+--- struct for RR — the live `tire_temps.rr=0` regression confirmed against the AC physics oracle.
 ---@param car any
 ---@return table  {fl, fr, rl, rr}
 function Mon:currentTemps(car)
@@ -173,8 +168,8 @@ function Mon:currentTemps(car)
   if not okW or wheels == nil then
     return out
   end
-  local keys = { "fl", "fr", "rl", "rr" }
-  for i = 1, 4 do
+  local keys = { [0] = "fl", [1] = "fr", [2] = "rl", [3] = "rr" }
+  for i = 0, 3 do
     local oki, one = pcall(function()
       return wheels[i]
     end)

--- a/tests/test_csp_helpers.py
+++ b/tests/test_csp_helpers.py
@@ -1,0 +1,87 @@
+"""Lupa L0 regression for `csp_helpers.safeCarField` — guarded reads of risky `ac.StateCar` fields.
+
+CSP `ac.StateCar` is a C-struct that THROWS on unknown fields (csp-api-field-safety decision /
+issue #24). `safeCarField` is the pcall-guarded reader required for fields not on the confirmed
+list (e.g. `resetCounter`, used for teleport detection in #185): it must return the value when the
+field exists and a default (nil) — without propagating the error — when the read throws, so the
+caller degrades gracefully on builds lacking the field instead of aborting `script.update`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
+
+
+def _runtime():
+    rt = lupa.LuaRuntime(unpack_returned_tuples=False)
+    p = str(MODULES_DIR).replace("\\", "/")
+    rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
+    return rt
+
+
+def test_safe_car_field_returns_value_when_present():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local ch = require("csp_helpers")
+          local car = { resetCounter = 7 }
+          return ch.safeCarField(car, "resetCounter")
+        end)()
+        """
+    )
+    assert out == 7
+
+
+def test_safe_car_field_nil_car_returns_default():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local ch = require("csp_helpers")
+          return { d = ch.safeCarField(nil, "resetCounter", -1),
+                   n = ch.safeCarField(nil, "resetCounter") }
+        end)()
+        """
+    )
+    assert out["d"] == -1
+    assert out["n"] is None  # no default -> nil
+
+
+def test_safe_car_field_absent_field_returns_default():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local ch = require("csp_helpers")
+          local car = { lapCount = 3 }
+          return ch.safeCarField(car, "resetCounter") == nil
+        end)()
+        """
+    )
+    assert out is True
+
+
+def test_safe_car_field_throwing_field_does_not_propagate():
+    # Mimic CSP StateCar: a metatable __index that errors on unknown fields. safeCarField must
+    # swallow the throw and return the default (the exact P1 scenario from #185).
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local ch = require("csp_helpers")
+          local car = setmetatable({}, { __index = function() error("unknown field") end })
+          local ok, res = pcall(function() return ch.safeCarField(car, "resetCounter", 99) end)
+          return { ok = ok, res = res }
+        end)()
+        """
+    )
+    assert out["ok"] is True  # safeCarField did NOT propagate the error
+    assert out["res"] == 99  # fell back to the default

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,0 +1,62 @@
+"""Lupa L0 regression for `delta.lua` predicates used by the #180 `delta` WS producer.
+
+`delta.isBackwardSplineReset(prevSpline, spline)` is the shared discontinuity test that BOTH the
+live `delta` producer's skip guard (in `ac_copilot_trainer.lua` `script.update`) and the
+end-of-update `resetRollingDrivingState` detection consume, so the pit/session-reset threshold
+cannot drift between them (Cursor + codex on #185: a same-lap spline rewind would otherwise leak
+one bogus delta against the prior stint's lap clock + reference trace before the reset fires).
+
+A *lap wrap* (prev spline near 1.0, now near 0.0) is forward lap completion, NOT a reset, and must
+return False. The backward threshold is strict (`d < -0.2`).
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
+
+
+def _is_reset(prev: str, cur: str):
+    rt = lupa.LuaRuntime(unpack_returned_tuples=False)
+    p = str(MODULES_DIR).replace("\\", "/")
+    rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
+    return rt.eval(
+        "(function() local D = require('delta')"
+        f" return D.isBackwardSplineReset({prev}, {cur}) end)()"
+    )
+
+
+def test_backward_spline_reset_detects_mid_lap_rewind():
+    # Pit/session reset mid-lap: spline jumps 0.62 -> 0.05 (d = -0.57), prev not near 1.0 -> reset.
+    assert _is_reset("0.62", "0.05") is True
+
+
+def test_backward_spline_reset_ignores_lap_wrap():
+    # Normal lap completion: prev 0.95 (>0.8), now 0.05 (<0.25) -> likelyWrap -> NOT a reset.
+    assert _is_reset("0.95", "0.05") is False
+
+
+def test_backward_spline_reset_ignores_forward_progress():
+    assert _is_reset("0.40", "0.45") is False
+
+
+def test_backward_spline_reset_ignores_small_backward_noise():
+    # -0.05 is within the -0.2 tolerance (GPS/spline jitter), not a reset.
+    assert _is_reset("0.50", "0.45") is False
+
+
+def test_backward_spline_reset_nil_prev_is_false():
+    # First frame after entry: no prior spline -> cannot be a reset.
+    assert _is_reset("nil", "0.5") is False
+
+
+def test_backward_spline_reset_threshold_is_strict():
+    # Exactly -0.2 is NOT < -0.2; just past it is. Pins the threshold both consumers rely on.
+    assert _is_reset("0.50", "0.30") is False  # d = -0.20
+    assert _is_reset("0.50", "0.29") is True  # d = -0.21

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -22,14 +22,19 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
 
 
-def _is_reset(prev: str, cur: str):
+def _call(fn: str, prev: str, cur: str):
     rt = lupa.LuaRuntime(unpack_returned_tuples=False)
     p = str(MODULES_DIR).replace("\\", "/")
     rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
-    return rt.eval(
-        "(function() local D = require('delta')"
-        f" return D.isBackwardSplineReset({prev}, {cur}) end)()"
-    )
+    return rt.eval(f"(function() local D = require('delta') return D.{fn}({prev}, {cur}) end)()")
+
+
+def _is_reset(prev: str, cur: str):
+    return _call("isBackwardSplineReset", prev, cur)
+
+
+def _is_jump(prev: str, cur: str):
+    return _call("isBackwardSplineJump", prev, cur)
 
 
 def test_backward_spline_reset_detects_mid_lap_rewind():
@@ -60,3 +65,30 @@ def test_backward_spline_reset_threshold_is_strict():
     # Exactly -0.2 is NOT < -0.2; just past it is. Pins the threshold both consumers rely on.
     assert _is_reset("0.50", "0.30") is False  # d = -0.20
     assert _is_reset("0.50", "0.29") is True  # d = -0.21
+
+
+# --- isBackwardSplineJump: LIBERAL variant for the harmless delta-skip (INCLUDES wrap-shaped) ----
+def test_backward_spline_jump_includes_wrap_shaped():
+    # Unlike isBackwardSplineReset, the jump variant does NOT exclude wrap-shaped rewinds — the
+    # delta producer only calls it with lapCount unchanged, where a wrap-shaped jump is a teleport,
+    # and skipping a delta frame on it is harmless even when resetCounter is unavailable (#185).
+    assert _is_jump("0.95", "0.05") is True  # wrap-shaped -> reset excludes, jump includes
+    assert _is_reset("0.95", "0.05") is False  # the conservative variant still excludes it
+
+
+def test_backward_spline_jump_detects_mid_lap_rewind():
+    assert _is_jump("0.62", "0.05") is True
+
+
+def test_backward_spline_jump_ignores_forward_and_noise():
+    assert _is_jump("0.40", "0.45") is False  # forward
+    assert _is_jump("0.50", "0.45") is False  # -0.05 within tolerance
+
+
+def test_backward_spline_jump_nil_prev_is_false():
+    assert _is_jump("nil", "0.5") is False
+
+
+def test_backward_spline_jump_threshold_is_strict():
+    assert _is_jump("0.50", "0.30") is False  # d = -0.20
+    assert _is_jump("0.50", "0.29") is True  # d = -0.21

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -211,6 +211,9 @@ def test_producers_return_false_without_wsbridge():
 
 # --------------------------------------------------------------------------- tire_monitor accessor
 def test_mon_current_temps_reads_four_wheels():
+    # CSP `car.wheels` is 0-indexed per `ac.Wheel` (FrontLeft=0 .. RearRight=3) — the table is
+    # keyed [0..3], NOT a 1-based list. A 1-based read (`wheels[1..4]`) would shift every corner
+    # by one and return rr=0 from the out-of-bounds slot (the live regression this fix closes).
     rt = _runtime()
     out = rt.eval(
         r"""
@@ -218,18 +221,70 @@ def test_mon_current_temps_reads_four_wheels():
           local TM = require("tire_monitor")
           local mon = TM.new()
           local car = { wheels = {
-            { temperature = 85 },
-            { temperature = 86 },
-            { temperature = 83 },
-            { temperature = { average = 84 } },
+            [0] = { temperature = 85 },
+            [1] = { temperature = 86 },
+            [2] = { temperature = 83 },
+            [3] = { temperature = { average = 84 } },
           } }
           local t = mon:currentTemps(car)
           return { fl = t.fl, fr = t.fr, rl = t.rl, rr = t.rr }
         end)()
         """
     )
-    # order fl,fr,rl,rr; the rr wheel uses the {average=...} table form (readWheelTemp unwraps it)
+    # order fl,fr,rl,rr; the rr wheel (index 3) uses the {average=...} form (readWheelTemp unwraps)
     assert (out["fl"], out["fr"], out["rl"], out["rr"]) == (85, 86, 83, 84)
+
+
+def test_mon_current_temps_fl_read_from_index_zero():
+    # Pin the fix directly: FL must come from wheel index 0 (a 1-based read would miss [0] and
+    # instead pull [1..4], shifting every corner and reading rr from an out-of-bounds slot).
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local TM = require("tire_monitor")
+          local mon = TM.new()
+          local car = { wheels = {
+            [0] = { temperature = 60 },
+            [1] = { temperature = 61 },
+            [2] = { temperature = 62 },
+            [3] = { temperature = 63 },
+          } }
+          local t = mon:currentTemps(car)
+          return { fl = t.fl, rr = t.rr }
+        end)()
+        """
+    )
+    assert out["fl"] == 60  # index 0 -> fl (the corner a 1-based read would drop)
+    assert out["rr"] == 63  # index 3 -> rr (was reading the out-of-bounds 0 before the fix)
+
+
+def test_mon_update_lap_summary_uses_zero_indexed_wheels():
+    # Mon:update shares the wheel-order contract with currentTemps; its lap aggregates must be
+    # labeled from the same 0-based read so the summary line's FL/FR/RL/RR match reality.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local TM = require("tire_monitor")
+          local mon = TM.new()
+          local car = { wheels = {
+            [0] = { temperature = 70, slipRatio = 0 },
+            [1] = { temperature = 71, slipRatio = 0 },
+            [2] = { temperature = 80, slipRatio = 0 },
+            [3] = { temperature = 81, slipRatio = 0 },
+          } }
+          mon:update(car, 0.1, 0.5)
+          return mon:lapSummaryLine()
+        end)()
+        """
+    )
+    assert out is not None
+    # FL=70 (idx0), FR=71 (idx1), RL=80 (idx2), RR=81 (idx3) — corner labels follow the enum order.
+    assert "FL 70" in out
+    assert "FR 71" in out
+    assert "RL 80" in out
+    assert "RR 81" in out
 
 
 def test_mon_current_temps_nil_car_is_all_nil():

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -134,6 +134,44 @@ def test_tire_temps_noop_without_temps_table():
     assert out["n"] == 0
 
 
+def test_tire_temps_noop_when_all_temps_nil():
+    # No wheel temp resolvable (CSP build/car) -> empty {} payload would mask the failure;
+    # treat the sample as unavailable and don't publish (codex on #185).
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishTireTempsIfDue({ dt = 1.0, temps = {}, wsBridge = ws })
+          return { r = r, n = #ws._calls }
+        end)()
+        """
+    )
+    assert out["r"] is False
+    assert out["n"] == 0
+
+
+def test_tire_temps_publishes_with_partial_temps():
+    # At least one resolvable temp -> still a meaningful sample, publish it.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishTireTempsIfDue({ dt = 1.0, temps = { fl = 80 }, wsBridge = ws })
+          local p = ws._calls[1] and ws._calls[1].payload
+          return { r = r, n = #ws._calls, fl = p and p.fl, fr = p and p.fr }
+        end)()
+        """
+    )
+    assert out["r"] is True
+    assert out["n"] == 1
+    assert out["fl"] == 80
+    assert out["fr"] is None  # unresolved wheels stay absent
+
+
 # --------------------------------------------------------------------------- contracts
 def test_both_noop_when_ws_down():
     rt = _runtime()

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -152,6 +152,91 @@ def test_tire_temps_noop_when_all_temps_nil():
     assert out["n"] == 0
 
 
+def test_tire_temps_drops_non_finite_values():
+    # A non-finite wheel temp (NaN / ±inf) must never reach the wire — JSON can't represent it.
+    # The finite wheels still publish; the bad ones are omitted (codex on #185).
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishTireTempsIfDue({
+            dt = 1.0, temps = { fl = 80, fr = 0/0, rl = 1/0, rr = 84 }, wsBridge = ws,
+          })
+          local p = ws._calls[1] and ws._calls[1].payload
+          return { r = r, n = #ws._calls, fl = p and p.fl,
+                   has_fr = p and p.fr ~= nil, has_rl = p and p.rl ~= nil, rr = p and p.rr }
+        end)()
+        """
+    )
+    assert out["r"] is True
+    assert out["n"] == 1
+    assert out["fl"] == 80
+    assert out["has_fr"] is False  # NaN dropped
+    assert out["has_rl"] is False  # +inf dropped
+    assert out["rr"] == 84
+
+
+def test_tire_temps_noop_when_all_non_finite():
+    # Every wheel non-finite -> treat the sample as unavailable, don't publish an empty frame.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishTireTempsIfDue({
+            dt = 1.0, temps = { fl = 0/0, fr = 1/0, rl = -1/0 }, wsBridge = ws,
+          })
+          return { r = r, n = #ws._calls }
+        end)()
+        """
+    )
+    assert out["r"] is False
+    assert out["n"] == 0
+
+
+def test_delta_noop_on_non_finite():
+    # A non-finite delta_s (e.g. degenerate reference trace) is unserializable -> skip the frame.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishDeltaIfDue({ dt = 1.0, deltaS = 0/0, spline = 0.5, wsBridge = ws })
+          return { r = r, n = #ws._calls }
+        end)()
+        """
+    )
+    assert out["r"] is False
+    assert out["n"] == 0
+
+
+def test_mon_current_temps_drops_nan_wheel():
+    # readWheelTemp must reject a non-finite field at the source so currentTemps is finite-only.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local TM = require("tire_monitor")
+          local mon = TM.new()
+          local car = { wheels = {
+            [0] = { temperature = 0/0 },
+            [1] = { temperature = 70 },
+            [2] = { temperature = 71 },
+            [3] = { temperature = 72 },
+          } }
+          local t = mon:currentTemps(car)
+          return { has_fl = t.fl ~= nil, fr = t.fr, rl = t.rl, rr = t.rr }
+        end)()
+        """
+    )
+    assert out["has_fl"] is False  # NaN at index 0 -> fl unavailable
+    assert (out["fr"], out["rl"], out["rr"]) == (70, 71, 72)
+
+
 def test_tire_temps_publishes_with_partial_temps():
     # At least one resolvable temp -> still a meaningful sample, publish it.
     rt = _runtime()

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -197,6 +197,27 @@ def test_tire_temps_noop_when_all_non_finite():
     assert out["n"] == 0
 
 
+def test_delta_omits_non_finite_spline():
+    # delta_s finite but spline non-finite (corrupt/reset frame): the spline field must be omitted,
+    # not emitted as unserializable JSON (codex on #185). The frame still publishes.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishDeltaIfDue({ dt = 1.0, deltaS = -0.3, spline = 1/0, wsBridge = ws })
+          local p = ws._calls[1] and ws._calls[1].payload
+          return { r = r, n = #ws._calls, ds = p and p.delta_s, has_spline = p and p.spline ~= nil }
+        end)()
+        """
+    )
+    assert out["r"] is True
+    assert out["n"] == 1
+    assert out["ds"] == -0.3
+    assert out["has_spline"] is False  # +inf spline omitted
+
+
 def test_delta_noop_on_non_finite():
     # A non-finite delta_s (e.g. degenerate reference trace) is unserializable -> skip the frame.
     rt = _runtime()

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -1,0 +1,215 @@
+"""Lupa L0 regression for the #180 Part D step 2 telemetry producers.
+
+`modules/telemetry_publisher.lua` owns the two continuous telemetry WS topics: `delta` (live
+time delta vs the reference lap) and `tire_temps` (current per-wheel core temps). These are
+thin, stateless, rate-limited publishers — no ordering contract, no reconnect machinery. Also
+covers `tire_monitor.Mon:currentTemps()`, the live per-wheel read the `tire_temps` producer
+consumes. Exercised under lupa with a capturing `wsBridge` (publishTopic returns true) or a
+closed one (returns false) so the no-op-when-WS-down contract is asserted.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
+
+_STUB = r"""
+function make_ws()
+  local calls = {}
+  return {
+    _calls = calls,
+    publishTopic = function(topic, payload)
+      calls[#calls + 1] = { topic = topic, payload = payload }
+      return true
+    end,
+  }
+end
+function make_ws_closed()
+  local calls = {}
+  return {
+    _calls = calls,
+    publishTopic = function(topic, payload)
+      calls[#calls + 1] = { topic = topic, payload = payload }
+      return false
+    end,
+  }
+end
+"""
+
+
+def _runtime():
+    rt = lupa.LuaRuntime(unpack_returned_tuples=False)
+    rt.execute(_STUB)
+    p = str(MODULES_DIR).replace("\\", "/")
+    rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
+    return rt
+
+
+# --------------------------------------------------------------------------- delta
+def test_delta_rate_limited_to_10hz():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r1 = M.publishDeltaIfDue({ dt = 0.05, deltaS = -0.30, spline = 0.5, wsBridge = ws })
+          local r2 = M.publishDeltaIfDue({
+            dt = 0.06, deltaS = -0.25, spline = 0.52, wsBridge = ws,
+          })
+          local p = ws._calls[1] and ws._calls[1].payload
+          return { r1 = r1, r2 = r2, n = #ws._calls, topic = ws._calls[1] and ws._calls[1].topic,
+                   ds = p and p.delta_s, sp = p and p.spline }
+        end)()
+        """
+    )
+    assert out["r1"] is False  # 0.05 < 0.1 -> not due
+    assert out["r2"] is True  # 0.11 accumulated -> publish
+    assert out["n"] == 1
+    assert out["topic"] == "delta"
+    assert out["ds"] == -0.25
+    assert out["sp"] == 0.52
+
+
+def test_delta_noop_without_reference_delta():
+    # No reference lap yet -> caller passes deltaS=nil -> nothing to publish.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishDeltaIfDue({ dt = 1.0, deltaS = nil, spline = 0.5, wsBridge = ws })
+          return { r = r, n = #ws._calls }
+        end)()
+        """
+    )
+    assert out["r"] is False
+    assert out["n"] == 0
+
+
+# --------------------------------------------------------------------------- tire_temps
+def test_tire_temps_rate_limited_and_payload():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local temps = { fl = 85, fr = 86, rl = 83, rr = 84 }
+          local r1 = M.publishTireTempsIfDue({ dt = 0.1, temps = temps, wsBridge = ws })
+          local r2 = M.publishTireTempsIfDue({ dt = 0.15, temps = temps, wsBridge = ws })
+          local p = ws._calls[1] and ws._calls[1].payload
+          return { r1 = r1, r2 = r2, n = #ws._calls, topic = ws._calls[1] and ws._calls[1].topic,
+                   fl = p and p.fl, fr = p and p.fr, rl = p and p.rl, rr = p and p.rr }
+        end)()
+        """
+    )
+    assert out["r1"] is False  # 0.1 < 0.2 -> not due
+    assert out["r2"] is True  # 0.25 accumulated -> publish
+    assert out["n"] == 1
+    assert out["topic"] == "tire_temps"
+    assert (out["fl"], out["fr"], out["rl"], out["rr"]) == (85, 86, 83, 84)
+
+
+def test_tire_temps_noop_without_temps_table():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local r = M.publishTireTempsIfDue({ dt = 1.0, temps = nil, wsBridge = ws })
+          return { r = r, n = #ws._calls }
+        end)()
+        """
+    )
+    assert out["r"] is False
+    assert out["n"] == 0
+
+
+# --------------------------------------------------------------------------- contracts
+def test_both_noop_when_ws_down():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws_closed()
+          local d = M.publishDeltaIfDue({ dt = 1.0, deltaS = -0.2, spline = 0.5, wsBridge = ws })
+          local t = M.publishTireTempsIfDue({ dt = 1.0, temps = { fl = 80 }, wsBridge = ws })
+          return { d = d, t = t }
+        end)()
+        """
+    )
+    assert out["d"] is False
+    assert out["t"] is False
+
+
+def test_producers_return_false_without_wsbridge():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          return {
+            d = M.publishDeltaIfDue({ dt = 1.0, deltaS = -0.2 }),
+            t = M.publishTireTempsIfDue({ dt = 1.0, temps = { fl = 80 } }),
+            bad = M.publishDeltaIfDue("not a table"),
+          }
+        end)()
+        """
+    )
+    assert out["d"] is False
+    assert out["t"] is False
+    assert out["bad"] is False
+
+
+# --------------------------------------------------------------------------- tire_monitor accessor
+def test_mon_current_temps_reads_four_wheels():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local TM = require("tire_monitor")
+          local mon = TM.new()
+          local car = { wheels = {
+            { temperature = 85 },
+            { temperature = 86 },
+            { temperature = 83 },
+            { temperature = { average = 84 } },
+          } }
+          local t = mon:currentTemps(car)
+          return { fl = t.fl, fr = t.fr, rl = t.rl, rr = t.rr }
+        end)()
+        """
+    )
+    # order fl,fr,rl,rr; the rr wheel uses the {average=...} table form (readWheelTemp unwraps it)
+    assert (out["fl"], out["fr"], out["rl"], out["rr"]) == (85, 86, 83, 84)
+
+
+def test_mon_current_temps_nil_car_is_all_nil():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local TM = require("tire_monitor")
+          local mon = TM.new()
+          local t = mon:currentTemps(nil)
+          return {
+            has_fl = t.fl ~= nil, has_fr = t.fr ~= nil,
+            has_rl = t.rl ~= nil, has_rr = t.rr ~= nil,
+          }
+        end)()
+        """
+    )
+    assert out["has_fl"] is False
+    assert out["has_fr"] is False
+    assert out["has_rl"] is False
+    assert out["has_rr"] is False


### PR DESCRIPTION
Completes #180 Part D step 2 — the **telemetry subset** (`delta`, `tire_temps`), following the lifecycle producers in #182. With this, **all 5 declared `KNOWN_TOPICS` have producers**, closing the declared-but-unproduced false-green gap the #173 drift-guard was built to expose.

## What
- `modules/telemetry_publisher.lua`: `delta` (~10 Hz; reuses `delta.deltaSecondsAtSpline` — the caller passes the computed delta, so no duplicated math; published only once a reference lap exists) and `tire_temps` (~5 Hz; current per-wheel core temps). Stateless rate-limited publishers, no-op when the WS isn't open, **no reconnect machinery** (continuous streams, no ordering contract — unlike the lifecycle topics).
- `tire_monitor.Mon:currentTemps(car)`: live per-wheel core temps `{fl,fr,rl,rr}` reusing the existing `readWheelTemp` fallback + wheel order.
- Wired into `ac_copilot_trainer.lua` `script.update` **after `wsBridge.tick()`/`pollInbound()`** (current-frame WS state), with `reset()` in both reset paths.

## Verification
- **Headless:** 8 lupa tests (`tests/test_telemetry_publisher.py`) — rate-limit, payload shape, no-op-when-WS-down, `Mon:currentTemps`. `test_ws_topic_allowlist` drift-guard green; all three Lua files lupa-compile.
- **In-game (gate before ready/merge):** tap a **≥2-lap** drive (so a reference exists and `delta` flows) and confirm `delta`/`tire_temps` stream with advancing values. Held DRAFT until observed (anti-false-green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)