### PR TITLE
fix(ci): route PR-creating workflows through GH_PAT, fail-closed (#186)

### DIFF
--- a/.github/workflows/cross-repo-mining.yml
+++ b/.github/workflows/cross-repo-mining.yml
@@ -91,10 +91,19 @@ jobs:
           MINING_EMIT_LEARNED: "1"
         run: python scripts/cross_repo_aggregate.py
 
+      - name: Verify GH_PAT is configured
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -z "${GH_PAT:-}" ]; then
+            echo "::error::GH_PAT is not configured — cannot open a PR with the default token (blocked by repo policy)."
+            exit 1
+          fi
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           commit-message: "chore(mining): cross-repo learned rules (process-miner)"
           branch: process-miner/learned-rules-${{ github.run_id }}
           delete-branch: true

--- a/.github/workflows/process-miner.yml
+++ b/.github/workflows/process-miner.yml
@@ -62,8 +62,13 @@ jobs:
 
       - name: Open PR with learned rules
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::GH_PAT is not configured for this repo — cannot open a PR (default GITHUB_TOKEN is blocked by policy)."
+            exit 1
+          fi
           BRANCH="miner/weekly-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
           git checkout -b "$BRANCH"
           git add .claude/rules/learned .cursor/rules/learned reports/process_miner AGENTS.md || true
@@ -73,8 +78,14 @@ jobs:
           fi
           git commit -m "chore: weekly process miner — learned rules"
           git push --set-upstream origin "$BRANCH"
-          gh pr create \
+          if gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore: weekly miner rules" \
-            --body "Auto-generated from process miner. Refs #14. Review learned rules before merging."
+            --body "Auto-generated from process miner. Refs #14. Review learned rules before merging."; then
+            echo "Opened PR for $BRANCH."
+          else
+            echo "::error::Could not open a PR for $BRANCH; deleting the orphan branch so it does not accumulate."
+            git push origin --delete "$BRANCH" || true
+            exit 1
+          fi

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
       - uses: actions/setup-python@v6
         with:
@@ -71,11 +72,15 @@ jobs:
 
       - name: Create sync PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           VCS_REF: ${{ steps.ref.outputs.ref }}
         shell: bash
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::GH_PAT is not configured for this repo — cannot open a PR (default GITHUB_TOKEN is blocked by policy)."
+            exit 1
+          fi
           # Include untracked files (git diff alone misses new files from the template).
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes after copier update."

--- a/docs/01_Vault/AcCopilotTrainer/02_Investigations/2026-06-15-pr-workflows-gh-pat.md
+++ b/docs/01_Vault/AcCopilotTrainer/02_Investigations/2026-06-15-pr-workflows-gh-pat.md
@@ -1,0 +1,52 @@
+---
+type: investigation
+status: active
+created: 2026-06-15
+updated: 2026-06-15
+relates_to:
+  - AcCopilotTrainer/02_Investigations/_index.md
+---
+
+# PR-creating workflows routed through GH_PAT (fail-closed)
+
+## Summary
+
+Repo policy blocks the default `GITHUB_TOKEN` from `createPullRequest` and from
+pushing changes under `.github/workflows/`. Three scheduled workflows that open
+pull requests were therefore failing (or would fail) when run with the default
+token. This investigation records the fix: route every PR-creating step through
+the fine-grained PAT `secrets.GH_PAT` (already provisioned in this repo from
+Doppler) and fail closed when that secret is absent.
+
+## Affected workflows
+
+- `.github/workflows/process-miner.yml` — "Open PR with learned rules" step.
+- `.github/workflows/template-sync.yml` — `actions/checkout` (so pushes can
+  include `.github/workflows` changes) and the "Create sync PR" step.
+- `.github/workflows/cross-repo-mining.yml` — `learned-rules-pr` job's
+  `peter-evans/create-pull-request` action.
+
+## Fix
+
+1. **process-miner.yml** — `GH_TOKEN` now reads `secrets.GH_PAT`; the run block
+   starts with `set -euo pipefail`, a guard aborts with a clear `::error::` if
+   `GH_PAT` is empty, and the `gh pr create` invocation is wrapped so a failed
+   creation deletes the orphan branch instead of leaving it to accumulate.
+2. **template-sync.yml** — `actions/checkout` now passes `token: secrets.GH_PAT`
+   (needed so pushes can include `.github/workflows` changes and the PR can be
+   created); the "Create sync PR" step switches `GH_TOKEN` to `secrets.GH_PAT`
+   and adds the same fail-closed guard. The label-creation step that uses
+   `GITHUB_TOKEN` purely for `gh label create` is intentionally left unchanged.
+3. **cross-repo-mining.yml** — the `learned-rules-pr` job's create-pull-request
+   action token switches to `secrets.GH_PAT`, and a "Verify GH_PAT is configured"
+   guard step runs before it. The read-only `aggregate` job and its
+   `GITHUB_TOKEN` (API reads only) are left unchanged.
+
+## Provenance
+
+This is the proven fleet fix, already merged and verified in
+`agorokh/workstation-ops` and `agorokh/template-repo`. See
+agorokh/workstation-ops#624.
+
+`GH_PAT` was already provisioned (fine-grained PAT projected from Doppler); no
+secret was created or modified by this change.


### PR DESCRIPTION
## What

Route every PR-creating step through the already-provisioned fine-grained PAT `secrets.GH_PAT` (projected from Doppler), and fail closed when that secret is absent.

## Why

Repo policy blocks the default `GITHUB_TOKEN` from `createPullRequest` and from pushing `.github/workflows` changes, so the scheduled PR-opening workflows fail under the default token. This is the proven fleet fix, already merged and verified in `agorokh/workstation-ops` and `agorokh/template-repo`.

## Changes

- **process-miner.yml** — "Open PR with learned rules": `GH_TOKEN` → `secrets.GH_PAT`; `set -euo pipefail` + fail-closed guard at the top of the run block; `gh pr create` wrapped so a failed creation deletes the orphan branch.
- **template-sync.yml** — `actions/checkout` now passes `token: secrets.GH_PAT` (so pushes can include `.github/workflows` changes); "Create sync PR" step switches `GH_TOKEN` to `secrets.GH_PAT` with the same guard. The `gh label create` step (read/label-only `GITHUB_TOKEN`) is unchanged.
- **cross-repo-mining.yml** — `learned-rules-pr` job's `peter-evans/create-pull-request` token → `secrets.GH_PAT`, with a "Verify GH_PAT is configured" guard step before it. The read-only `aggregate` job and its `GITHUB_TOKEN` (API reads only) are unchanged.

No secret was created or modified — `GH_PAT` is already provisioned in this repo.

YAML validated with `yaml.safe_load` for all three edited files.

Closes #186
Refs agorokh/workstation-ops#624

🤖 Generated with [Claude Code](https://claude.com/claude-code)