### PR TITLE
feat(harness): L1.5 WS-sequence probe (EPIC #154 Part E) — #190

### DIFF
--- a/tests/test_sequence_probe.py
+++ b/tests/test_sequence_probe.py
@@ -1,8 +1,12 @@
 """L0 regression for the #190 L1.5 WS-sequence probe (`tools/ac_harness/sequence_probe.py`).
 
-`evaluate_sequence` is a pure function over a frame stream, so the declared-topic presence + the
-session-before-lap ordering contract are exercised here with synthetic streams — no AC, no sidecar.
-The live tap is gated (in-sim on a real drive) and not covered in CI.
+`evaluate_sequence` is a pure function over a frame stream, so the continuous-stream presence, the
+conditional-lifecycle handling, and the session-before-lap ordering contract are exercised here with
+synthetic streams — no AC, no sidecar. The live tap is gated (in-sim on a real drive), not in CI.
+
+Two modes: the default "window" mode (ad-hoc / mid-session tap) requires only the continuous streams
+and treats session/lap/delta as conditional notes; `strict_lifecycle=True` (controlled tap from
+session start) also requires those and strictly enforces session→lap ordering.
 """
 
 from __future__ import annotations
@@ -10,7 +14,8 @@ from __future__ import annotations
 import json
 
 from tools.ac_harness.sequence_probe import (
-    DEFAULT_REQUIRED_TOPICS,
+    DEFAULT_CONTINUOUS_TOPICS,
+    LIFECYCLE_TOPICS,
     evaluate_sequence,
     frames_from_jsonl,
 )
@@ -35,6 +40,7 @@ def _good_stream() -> list[dict]:
     ]
 
 
+# --------------------------------------------------------------------------- default "window" mode
 def test_good_stream_passes():
     r = evaluate_sequence(_good_stream())
     assert r.ok is True
@@ -43,20 +49,47 @@ def test_good_stream_passes():
     assert r.counts["tire_temps"] == 2
 
 
-def test_all_required_topics_present_in_good_stream():
+def test_continuous_topics_are_required_checks():
     r = evaluate_sequence(_good_stream())
-    present = {c.name for c in r.checks if c.ok and c.name.startswith("present:")}
-    for topic in DEFAULT_REQUIRED_TOPICS:
-        assert f"present:{topic}" in present
+    check_names = {c.name for c in r.checks}
+    for topic in DEFAULT_CONTINUOUS_TOPICS:
+        assert f"present:{topic}" in check_names
 
 
-def test_lap_before_session_fails_ordering():
-    # lap emitted before any session violates the #182 lifecycle contract.
+def test_missing_continuous_topic_fails():
+    # No tire_temps at all (e.g. the rr=0-class data-source failure) -> continuous presence fails.
+    frames = [_f("connection"), _f("session"), _f("lap"), _f("delta"), _f("coaching.snapshot")]
+    r = evaluate_sequence(frames)
+    assert r.ok is False
+    tt = next(c for c in r.checks if c.name == "present:tire_temps")
+    assert tt.ok is False
+    assert tt.detail == "never seen"
+
+
+def test_lap_without_session_is_ok_in_window_mode():
+    # Mid-session tap: a `lap` with no `session` is the session-event-preceded-the-tap case, NOT a
+    # violation. Continuous streams present -> PASS, with an informational note (this is the exact
+    # situation the live operator drive surfaced).
+    frames = [_f("connection"), _f("lap"), _f("delta"), _f("tire_temps"), _f("coaching.snapshot")]
+    r = evaluate_sequence(frames)
+    assert r.ok is True
+    assert not any(c.name == "order:session-before-lap" for c in r.checks)
+    assert any("mid-session" in n for n in r.notes)
+
+
+def test_lifecycle_topics_reported_as_notes_in_window_mode():
+    r = evaluate_sequence(_good_stream())
+    note_text = " ".join(r.notes)
+    for topic in LIFECYCLE_TOPICS:
+        assert topic in note_text  # each conditional topic is reported informationally
+
+
+def test_session_after_lap_fails_ordering():
+    # If BOTH are observed and session comes AFTER lap, that IS a real ordering violation.
     frames = [
         _f("connection"),
         _f("lap"),
         _f("session"),
-        _f("delta"),
         _f("tire_temps"),
         _f("coaching.snapshot"),
     ]
@@ -66,29 +99,9 @@ def test_lap_before_session_fails_ordering():
     assert order.ok is False
 
 
-def test_lap_without_session_fails():
-    frames = [_f("connection"), _f("lap"), _f("delta"), _f("tire_temps"), _f("coaching.snapshot")]
-    r = evaluate_sequence(frames)
-    assert r.ok is False
-    order = next(c for c in r.checks if c.name == "order:session-before-lap")
-    assert order.ok is False
-    assert "no session" in order.detail
-
-
-def test_missing_continuous_topic_fails_presence():
-    # No tire_temps at all (e.g. the rr=0-class data-source failure) -> presence check fails.
-    frames = [_f("connection"), _f("session"), _f("lap"), _f("delta"), _f("coaching.snapshot")]
-    r = evaluate_sequence(frames)
-    assert r.ok is False
-    tt = next(c for c in r.checks if c.name == "present:tire_temps")
-    assert tt.ok is False
-    assert tt.detail == "never seen"
-
-
-def test_empty_stream_fails_all_presence():
+def test_empty_stream_fails_continuous_presence():
     r = evaluate_sequence([])
     assert r.ok is False
-    # all required-topic presence checks fail; no ordering check (no lap)
     assert all(not c.ok for c in r.checks if c.name.startswith("present:"))
     assert not any(c.name == "order:session-before-lap" for c in r.checks)
 
@@ -98,25 +111,42 @@ def test_non_topic_and_malformed_frames_ignored():
     frames = [
         {"v": 1, "type": "hello-ack"},  # no topic
         "garbage",  # non-dict
-        _f("connection"),
-        _f("session"),
-        _f("lap"),
-        _f("delta"),
-        _f("tire_temps"),
-        _f("coaching.snapshot"),
+        *_good_stream(),
     ]
     r = evaluate_sequence(frames)
     assert r.ok is True
     assert r.counts["connection"] == 1
 
 
-def test_setup_active_not_required():
-    # setup.active is event-driven (only on a setup change), so a clean lap without it still passes.
-    r = evaluate_sequence(_good_stream())
+def test_setup_active_not_continuous():
+    # setup.active is event-driven (only on a setup change); never a required continuous stream.
+    assert "setup.active" not in DEFAULT_CONTINUOUS_TOPICS
+    assert "setup.active" not in LIFECYCLE_TOPICS
+
+
+# --------------------------------------------------------------------------- strict_lifecycle mode
+def test_strict_lifecycle_requires_session_lap_delta():
+    # The controlled L1.5 run (tap from session start) must capture the full lifecycle.
+    r = evaluate_sequence(_good_stream(), strict_lifecycle=True)
     assert r.ok is True
-    assert "setup.active" not in DEFAULT_REQUIRED_TOPICS
+    names = {c.name for c in r.checks}
+    for topic in LIFECYCLE_TOPICS:
+        assert f"present:{topic}" in names
+    assert "order:session-before-lap" in names
 
 
+def test_strict_lifecycle_fails_on_missing_session():
+    # Mid-session-shaped stream under strict mode -> session required -> FAIL (+ ordering fail).
+    frames = [_f("connection"), _f("lap"), _f("delta"), _f("tire_temps"), _f("coaching.snapshot")]
+    r = evaluate_sequence(frames, strict_lifecycle=True)
+    assert r.ok is False
+    sess = next(c for c in r.checks if c.name == "present:session")
+    assert sess.ok is False
+    order = next(c for c in r.checks if c.name == "order:session-before-lap")
+    assert order.ok is False
+
+
+# --------------------------------------------------------------------------- jsonl loader
 def test_frames_from_jsonl_round_trip(tmp_path):
     p = tmp_path / "frames.jsonl"
     lines = [json.dumps(_f(t)) for t in ("connection", "session", "lap")]

--- a/tests/test_sequence_probe.py
+++ b/tests/test_sequence_probe.py
@@ -162,6 +162,23 @@ def test_strict_does_not_require_delta():
     assert any(n.startswith("delta:") for n in r.notes)
 
 
+# ------------------------------------------------------------------- require_lap (--wait-lap)
+def test_require_lap_fails_when_lap_absent():
+    # --wait-lap waited for a lap; if it timed out (lap absent) the probe must FAIL, not pass with
+    # lap as a note — otherwise --wait-lap could false-green the lap producer (codex on #191).
+    frames = [_f("connection"), _f("tire_temps"), _f("coaching.snapshot")]
+    r = evaluate_sequence(frames, require_lap=True)
+    assert r.ok is False
+    lap = next(c for c in r.checks if c.name == "present:lap")
+    assert lap.ok is False
+
+
+def test_require_lap_passes_when_lap_present():
+    r = evaluate_sequence(_good_stream(), require_lap=True)
+    assert r.ok is True
+    assert any(c.name == "present:lap" and c.ok for c in r.checks)
+
+
 # --------------------------------------------------------------------------- jsonl loader
 def test_frames_from_jsonl_round_trip(tmp_path):
     p = tmp_path / "frames.jsonl"

--- a/tests/test_sequence_probe.py
+++ b/tests/test_sequence_probe.py
@@ -1,12 +1,14 @@
-"""L0 regression for the #190 L1.5 WS-sequence probe (`tools/ac_harness/sequence_probe.py`).
+"""L0 regression for the L1.5 WS-sequence probe (`tools/ac_harness/sequence_probe.py`).
 
-`evaluate_sequence` is a pure function over a frame stream, so the continuous-stream presence, the
-conditional-lifecycle handling, and the session-before-lap ordering contract are exercised here with
-synthetic streams — no AC, no sidecar. The live tap is gated (in-sim on a real drive), not in CI.
+The probe is Part E of EPIC #154, verifying the #180 producer pipeline. `evaluate_sequence` is a
+pure function over a frame stream, so the continuous-stream presence, the state.snapshot-only
+filter, the conditional-lifecycle handling, and the session-before-lap ordering are exercised here
+with synthetic streams — no AC, no sidecar. The live tap is gated (in-sim on a real drive), not CI.
 
-Two modes: the default "window" mode (ad-hoc / mid-session tap) requires only the continuous streams
-and treats session/lap/delta as conditional notes; `strict_lifecycle=True` (controlled tap from
-session start) also requires those and strictly enforces session→lap ordering.
+Two modes: default "window" (ad-hoc / mid-session tap) requires only the continuous streams and
+treats session/lap/delta as conditional notes; `strict_lifecycle=True` (controlled tap from session
+start) also requires session + lap and strictly enforces session→lap ordering. `delta` is never
+required (it depends on a reference lap), only ever a note.
 """
 
 from __future__ import annotations
@@ -15,7 +17,7 @@ import json
 
 from tools.ac_harness.sequence_probe import (
     DEFAULT_CONTINUOUS_TOPICS,
-    LIFECYCLE_TOPICS,
+    STRICT_LIFECYCLE_TOPICS,
     evaluate_sequence,
     frames_from_jsonl,
 )
@@ -24,6 +26,11 @@ from tools.ac_harness.sequence_probe import (
 def _f(topic: str) -> dict:
     """A published topic frame as the tap receives it (ws_bridge.publishTopic envelope)."""
     return {"v": 1, "type": "state.snapshot", "topic": topic, "payload": {}}
+
+
+def _other(topic: str) -> dict:
+    """A non-snapshot frame that merely carries a topic key (must NOT count)."""
+    return {"v": 1, "type": "diagnostic", "topic": topic}
 
 
 def _good_stream() -> list[dict]:
@@ -66,10 +73,23 @@ def test_missing_continuous_topic_fails():
     assert tt.detail == "never seen"
 
 
+def test_non_snapshot_frames_do_not_count():
+    # A diagnostic/client frame carrying topic="lap"/"tire_temps" must NOT satisfy the contract.
+    frames = [
+        _f("connection"),
+        _f("coaching.snapshot"),
+        _other("tire_temps"),  # not a snapshot -> tire_temps still missing
+        _other("lap"),  # not a snapshot -> lap not counted
+    ]
+    r = evaluate_sequence(frames)
+    assert r.ok is False
+    assert "tire_temps" not in r.counts  # the diagnostic frame did not inflate the count
+    assert "lap" not in r.counts
+
+
 def test_lap_without_session_is_ok_in_window_mode():
     # Mid-session tap: a `lap` with no `session` is the session-event-preceded-the-tap case, NOT a
-    # violation. Continuous streams present -> PASS, with an informational note (this is the exact
-    # situation the live operator drive surfaced).
+    # violation (the exact situation the live operator drive surfaced). Continuous present -> PASS.
     frames = [_f("connection"), _f("lap"), _f("delta"), _f("tire_temps"), _f("coaching.snapshot")]
     r = evaluate_sequence(frames)
     assert r.ok is True
@@ -77,22 +97,16 @@ def test_lap_without_session_is_ok_in_window_mode():
     assert any("mid-session" in n for n in r.notes)
 
 
-def test_lifecycle_topics_reported_as_notes_in_window_mode():
+def test_session_lap_delta_reported_as_notes_in_window_mode():
     r = evaluate_sequence(_good_stream())
     note_text = " ".join(r.notes)
-    for topic in LIFECYCLE_TOPICS:
-        assert topic in note_text  # each conditional topic is reported informationally
+    for topic in ("session", "lap", "delta"):
+        assert topic in note_text
 
 
 def test_session_after_lap_fails_ordering():
     # If BOTH are observed and session comes AFTER lap, that IS a real ordering violation.
-    frames = [
-        _f("connection"),
-        _f("lap"),
-        _f("session"),
-        _f("tire_temps"),
-        _f("coaching.snapshot"),
-    ]
+    frames = [_f("connection"), _f("lap"), _f("session"), _f("tire_temps"), _f("coaching.snapshot")]
     r = evaluate_sequence(frames)
     assert r.ok is False
     order = next(c for c in r.checks if c.name == "order:session-before-lap")
@@ -107,36 +121,28 @@ def test_empty_stream_fails_continuous_presence():
 
 
 def test_non_topic_and_malformed_frames_ignored():
-    # Control frames (no topic) and non-dicts must not break evaluation or inflate counts.
-    frames = [
-        {"v": 1, "type": "hello-ack"},  # no topic
-        "garbage",  # non-dict
-        *_good_stream(),
-    ]
+    frames = [{"v": 1, "type": "hello-ack"}, "garbage", *_good_stream()]
     r = evaluate_sequence(frames)
     assert r.ok is True
     assert r.counts["connection"] == 1
 
 
-def test_setup_active_not_continuous():
-    # setup.active is event-driven (only on a setup change); never a required continuous stream.
+def test_setup_active_not_required():
     assert "setup.active" not in DEFAULT_CONTINUOUS_TOPICS
-    assert "setup.active" not in LIFECYCLE_TOPICS
+    assert "setup.active" not in STRICT_LIFECYCLE_TOPICS
 
 
 # --------------------------------------------------------------------------- strict_lifecycle mode
-def test_strict_lifecycle_requires_session_lap_delta():
-    # The controlled L1.5 run (tap from session start) must capture the full lifecycle.
+def test_strict_requires_session_and_lap():
     r = evaluate_sequence(_good_stream(), strict_lifecycle=True)
     assert r.ok is True
     names = {c.name for c in r.checks}
-    for topic in LIFECYCLE_TOPICS:
+    for topic in STRICT_LIFECYCLE_TOPICS:
         assert f"present:{topic}" in names
     assert "order:session-before-lap" in names
 
 
-def test_strict_lifecycle_fails_on_missing_session():
-    # Mid-session-shaped stream under strict mode -> session required -> FAIL (+ ordering fail).
+def test_strict_fails_on_missing_session():
     frames = [_f("connection"), _f("lap"), _f("delta"), _f("tire_temps"), _f("coaching.snapshot")]
     r = evaluate_sequence(frames, strict_lifecycle=True)
     assert r.ok is False
@@ -144,6 +150,16 @@ def test_strict_lifecycle_fails_on_missing_session():
     assert sess.ok is False
     order = next(c for c in r.checks if c.name == "order:session-before-lap")
     assert order.ok is False
+
+
+def test_strict_does_not_require_delta():
+    # delta needs a reference lap; requiring it would false-fail a healthy no-reference session.
+    # A full session→lap with NO delta must still PASS in strict mode (delta stays a note).
+    frames = [_f("connection"), _f("session"), _f("lap"), _f("tire_temps"), _f("coaching.snapshot")]
+    r = evaluate_sequence(frames, strict_lifecycle=True)
+    assert r.ok is True
+    assert not any(c.name == "present:delta" for c in r.checks)
+    assert any(n.startswith("delta:") for n in r.notes)
 
 
 # --------------------------------------------------------------------------- jsonl loader

--- a/tests/test_sequence_probe.py
+++ b/tests/test_sequence_probe.py
@@ -1,0 +1,127 @@
+"""L0 regression for the #190 L1.5 WS-sequence probe (`tools/ac_harness/sequence_probe.py`).
+
+`evaluate_sequence` is a pure function over a frame stream, so the declared-topic presence + the
+session-before-lap ordering contract are exercised here with synthetic streams — no AC, no sidecar.
+The live tap is gated (in-sim on a real drive) and not covered in CI.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tools.ac_harness.sequence_probe import (
+    DEFAULT_REQUIRED_TOPICS,
+    evaluate_sequence,
+    frames_from_jsonl,
+)
+
+
+def _f(topic: str) -> dict:
+    """A published topic frame as the tap receives it (ws_bridge.publishTopic envelope)."""
+    return {"v": 1, "type": "state.snapshot", "topic": topic, "payload": {}}
+
+
+def _good_stream() -> list[dict]:
+    # connection heartbeat, session before lap, then continuous streams — a normal drive.
+    return [
+        _f("connection"),
+        _f("session"),
+        _f("delta"),
+        _f("tire_temps"),
+        _f("coaching.snapshot"),
+        _f("lap"),
+        _f("delta"),
+        _f("tire_temps"),
+    ]
+
+
+def test_good_stream_passes():
+    r = evaluate_sequence(_good_stream())
+    assert r.ok is True
+    assert all(c.ok for c in r.checks)
+    assert r.counts["delta"] == 2
+    assert r.counts["tire_temps"] == 2
+
+
+def test_all_required_topics_present_in_good_stream():
+    r = evaluate_sequence(_good_stream())
+    present = {c.name for c in r.checks if c.ok and c.name.startswith("present:")}
+    for topic in DEFAULT_REQUIRED_TOPICS:
+        assert f"present:{topic}" in present
+
+
+def test_lap_before_session_fails_ordering():
+    # lap emitted before any session violates the #182 lifecycle contract.
+    frames = [
+        _f("connection"),
+        _f("lap"),
+        _f("session"),
+        _f("delta"),
+        _f("tire_temps"),
+        _f("coaching.snapshot"),
+    ]
+    r = evaluate_sequence(frames)
+    assert r.ok is False
+    order = next(c for c in r.checks if c.name == "order:session-before-lap")
+    assert order.ok is False
+
+
+def test_lap_without_session_fails():
+    frames = [_f("connection"), _f("lap"), _f("delta"), _f("tire_temps"), _f("coaching.snapshot")]
+    r = evaluate_sequence(frames)
+    assert r.ok is False
+    order = next(c for c in r.checks if c.name == "order:session-before-lap")
+    assert order.ok is False
+    assert "no session" in order.detail
+
+
+def test_missing_continuous_topic_fails_presence():
+    # No tire_temps at all (e.g. the rr=0-class data-source failure) -> presence check fails.
+    frames = [_f("connection"), _f("session"), _f("lap"), _f("delta"), _f("coaching.snapshot")]
+    r = evaluate_sequence(frames)
+    assert r.ok is False
+    tt = next(c for c in r.checks if c.name == "present:tire_temps")
+    assert tt.ok is False
+    assert tt.detail == "never seen"
+
+
+def test_empty_stream_fails_all_presence():
+    r = evaluate_sequence([])
+    assert r.ok is False
+    # all required-topic presence checks fail; no ordering check (no lap)
+    assert all(not c.ok for c in r.checks if c.name.startswith("present:"))
+    assert not any(c.name == "order:session-before-lap" for c in r.checks)
+
+
+def test_non_topic_and_malformed_frames_ignored():
+    # Control frames (no topic) and non-dicts must not break evaluation or inflate counts.
+    frames = [
+        {"v": 1, "type": "hello-ack"},  # no topic
+        "garbage",  # non-dict
+        _f("connection"),
+        _f("session"),
+        _f("lap"),
+        _f("delta"),
+        _f("tire_temps"),
+        _f("coaching.snapshot"),
+    ]
+    r = evaluate_sequence(frames)
+    assert r.ok is True
+    assert r.counts["connection"] == 1
+
+
+def test_setup_active_not_required():
+    # setup.active is event-driven (only on a setup change), so a clean lap without it still passes.
+    r = evaluate_sequence(_good_stream())
+    assert r.ok is True
+    assert "setup.active" not in DEFAULT_REQUIRED_TOPICS
+
+
+def test_frames_from_jsonl_round_trip(tmp_path):
+    p = tmp_path / "frames.jsonl"
+    lines = [json.dumps(_f(t)) for t in ("connection", "session", "lap")]
+    lines.insert(2, "")  # blank line -> skipped
+    lines.append("{not valid json")  # invalid -> skipped
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    frames = frames_from_jsonl(str(p))
+    assert [f["topic"] for f in frames] == ["connection", "session", "lap"]

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -1,24 +1,32 @@
-"""L1.5 in-sim WS-sequence probe (EPIC #154 Part E, issue #190).
+"""L1.5 in-sim WS-sequence probe (EPIC #154 Part E — verifies the #180 producer pipeline).
 
 The L1.5 layer asserts on the **message sequence** the trainer emits during a drive — not pixels.
 It consumes the trainer's published WS frames (live tap via `ai_sidecar.harness_client`, or a
 recorded JSONL file) and checks the declared-topic contract:
 
   * the CONTINUOUS streams (connection / tire_temps / coaching.snapshot) are present — the
-    "pipeline is alive" check, required in any driving window; and
+    "pipeline alive" check, required in any driving window; and
   * the lifecycle ordering invariant holds: the first ``session`` precedes the first ``lap``
     (the #182 contract — no ``lap`` frame may precede a ``session``), asserted whenever a
     ``session`` is observed.
 
-CONDITIONAL topics (``session`` / ``lap`` / ``delta``) are only present under specific
-circumstances — ``session`` is an event that fires at session start (a mid-session tap misses it),
-``lap`` needs a lap boundary in the window, and ``delta`` needs a reference lap + an s/f-aligned
-clock. By default these are reported as informational notes, NOT failures, so an ad-hoc mid-session
-tap doesn't spuriously fail. Pass ``strict_lifecycle=True`` for the controlled L1.5 run that taps
-from session start, where their presence + strict session→lap ordering ARE required.
+Only ``type == "state.snapshot"`` frames (the `ws_bridge.publishTopic` envelope) are counted, so a
+diagnostic/client frame that merely carries a ``topic`` key cannot satisfy the contract.
 
-Published topic frames are shaped ``{v, type="state.snapshot", topic, payload}`` (see
-`ws_bridge.publishTopic`), so frames are filtered by their top-level ``topic`` key.
+CONDITIONAL topics are present only under specific circumstances, so a short or mid-session tap may
+legitimately miss them — this is NOT a producer fault:
+  * ``session`` — an EVENT (session start / track-car change / reconnect). A tap that connects
+    mid-session misses it: sidecar fan-out is topic-agnostic and `publishSessionIfChanged`
+    suppresses the same key until a reconnect/change, so subscribing does not replay it. To assert
+    ``session`` / session-before-lap, tap from session start (``--strict --wait-lap``) or, as a
+    future enhancement, have the trainer re-emit ``session`` to late-attaching subscribers.
+  * ``lap``   — needs a lap boundary in the window (use ``--wait-lap``).
+  * ``delta`` — needs a reference lap (``state.bestSortedTrace``) AND an s/f-aligned clock, so it is
+    ALWAYS reported as a note (never required) — requiring it would false-fail a healthy
+    no-reference session.
+
+By default session/lap are informational notes; ``strict_lifecycle=True`` (the controlled tap from
+session start) requires session + lap present and strictly enforces session-before-lap.
 
 `evaluate_sequence()` is a **pure function**, unit-tested off-sim with synthetic frame streams.
 The live tap (`tap_frames` / ``__main__``) is **gated**: it needs AC running and a car on track,
@@ -27,9 +35,13 @@ so it is exercised in-sim on a real (operator-launched) drive, not in CI.
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 from dataclasses import dataclass, field
+
+# Producer-snapshot envelope type (ws_bridge.publishTopic). Only these frames count.
+STATE_SNAPSHOT_TYPE = "state.snapshot"
 
 # Topics that stream CONTINUOUSLY whenever a car is on track — required presence in any driving
 # window (the "pipeline alive" check).
@@ -39,16 +51,22 @@ DEFAULT_CONTINUOUS_TOPICS: tuple[str, ...] = (
     "coaching.snapshot",  # continuous coaching stream
 )
 
-# CONDITIONAL topics — present only under specific circumstances, so a short or mid-session tap may
-# legitimately miss them (NOT a producer fault): `session` is an EVENT (session start / track-car
-# change / reconnect — a tap connecting mid-session misses it); `lap` needs a lap boundary in the
-# window; `delta` needs a reference lap to exist AND an s/f-aligned clock (see deltaRefStale).
-# Reported as informational notes by default; promoted to required checks under strict_lifecycle.
-LIFECYCLE_TOPICS: tuple[str, ...] = ("session", "lap", "delta")
+# Lifecycle topics carrying the ordering contract — informational notes by default, required under
+# strict_lifecycle. `delta` is deliberately EXCLUDED: it needs a reference lap + an s/f-aligned
+# clock, so it is always a note (requiring it would false-fail a healthy no-reference session).
+STRICT_LIFECYCLE_TOPICS: tuple[str, ...] = ("session", "lap")
 
-# `setup.active` is event-driven (only on a setup change) and never required for a baseline lap.
-# Everything the live tap subscribes to:
-ALL_TAP_TOPICS: tuple[str, ...] = DEFAULT_CONTINUOUS_TOPICS + LIFECYCLE_TOPICS
+# Everything the live tap subscribes to (`setup.active` is event-driven and never required).
+ALL_TAP_TOPICS: tuple[str, ...] = (
+    "connection",
+    "session",
+    "lap",
+    "delta",
+    "tire_temps",
+    "coaching.snapshot",
+)
+
+_CONTINUOUS_SET = frozenset(DEFAULT_CONTINUOUS_TOPICS)
 
 
 @dataclass
@@ -80,15 +98,21 @@ class SequenceResult:
 
 
 def _ordered_topics(frames: list[dict]) -> list[tuple[int, str]]:
-    """Return ``(index, topic)`` for each frame with a string ``topic`` key, in arrival order."""
+    """Return ``(index, topic)`` for each ``state.snapshot`` frame with a string ``topic`` key."""
     out: list[tuple[int, str]] = []
     for i, f in enumerate(frames):
-        if not isinstance(f, dict):
+        if not isinstance(f, dict) or f.get("type") != STATE_SNAPSHOT_TYPE:
             continue
         topic = f.get("topic")
         if isinstance(topic, str):
             out.append((i, topic))
     return out
+
+
+def _conditional_note(topic: str, first_index: dict[str, int], counts: dict[str, int]) -> str:
+    if topic in first_index:
+        return f"{topic}: count={counts[topic]}"
+    return f"{topic}: not in window (conditional: event / boundary / reference-lap)"
 
 
 def evaluate_sequence(
@@ -100,11 +124,11 @@ def evaluate_sequence(
     """Evaluate a frame stream against the L1.5 contract (pure).
 
     Default "window" mode: require the continuous streams, and assert session-before-lap only
-    when a ``session`` is observed. Lifecycle topics are reported as notes — a mid-session tap
+    when a ``session`` is observed. session/lap/delta are reported as notes — a mid-session tap
     legitimately misses the ``session`` event, a lap boundary, or a reference lap for ``delta``.
 
-    ``strict_lifecycle=True`` (controlled tap from session start): also require ``session``,
-    ``lap``, ``delta`` present and strictly enforce session-before-lap.
+    ``strict_lifecycle=True`` (controlled tap from session start): also require ``session`` and
+    ``lap`` present and strictly enforce session-before-lap. ``delta`` stays a note in both modes.
     """
     ordered = _ordered_topics(frames)
     first_index: dict[str, int] = {}
@@ -128,16 +152,17 @@ def evaluate_sequence(
     for topic in continuous_topics:
         checks.append(_presence(topic))
 
-    # 2) lifecycle topics: required only under strict_lifecycle; otherwise informational.
-    for topic in LIFECYCLE_TOPICS:
+    # 2) session / lap: required under strict_lifecycle; otherwise informational notes.
+    for topic in STRICT_LIFECYCLE_TOPICS:
         if strict_lifecycle:
             checks.append(_presence(topic))
-        elif topic in first_index:
-            notes.append(f"{topic}: count={counts[topic]}")
         else:
-            notes.append(f"{topic}: not in window (conditional: event / boundary / reference-lap)")
+            notes.append(_conditional_note(topic, first_index, counts))
 
-    # 3) ordering: the first `session` precedes the first `lap` (#182 lifecycle contract).
+    # 3) delta: always a note (needs a reference lap + an s/f-aligned clock) — never required.
+    notes.append(_conditional_note("delta", first_index, counts))
+
+    # 4) ordering: the first `session` precedes the first `lap` (#182 lifecycle contract).
     if "session" in first_index and "lap" in first_index:
         ok = first_index["session"] < first_index["lap"]
         checks.append(
@@ -155,7 +180,7 @@ def evaluate_sequence(
         else:
             notes.append(
                 "lap seen without session — tap likely started mid-session (session is an "
-                "event that fired before connect); use strict_lifecycle from session start to "
+                "event that fired before connect); use --strict --wait-lap from session start to "
                 "assert session→lap ordering"
             )
 
@@ -179,30 +204,87 @@ def frames_from_jsonl(path: str) -> list[dict]:
     return frames
 
 
-async def tap_frames(url: str = "ws://127.0.0.1:8765", *, seconds: float = 20.0) -> list[dict]:
-    """Tap the sidecar for ``seconds`` and return the frames received (live; needs AC driving).
+def _is_snapshot(frame: dict, topic: str) -> bool:
+    return (
+        isinstance(frame, dict)
+        and frame.get("type") == STATE_SNAPSHOT_TYPE
+        and frame.get("topic") == topic
+    )
 
-    Imported lazily so the pure evaluator has no hard dependency on the sidecar client.
+
+async def tap_frames(
+    url: str = "ws://127.0.0.1:8765",
+    *,
+    seconds: float = 20.0,
+    wait_for_lap: bool = False,
+    settle_timeout: float = 120.0,
+    lap_timeout: float = 180.0,
+) -> list[dict]:
+    """Tap the sidecar and return the frames received (live; needs AC driving).
+
+    Default: a fixed ``seconds`` window. With ``wait_for_lap=True`` the tap first waits (up to
+    ``settle_timeout``) for the car to be on track, then waits (up to ``lap_timeout``) for a ``lap``
+    frame — so a slow real lap is captured rather than false-failing a fixed 20 s window.
+
+    Always closes the client (try/finally) and fails fast on a missing hello handshake. Imported
+    lazily so the pure evaluator has no hard dependency on the sidecar client.
     """
     from tools.ai_sidecar.harness_client import HarnessClient
 
     hc = HarnessClient(url)
-    await hc.connect(retries=40, retry_delay=0.25)
-    await hc.hello(timeout=10)
-    await hc.subscribe(list(ALL_TAP_TOPICS))
-    # Frames accumulate in hc.frames via the client's background recv task; wait the window out.
-    await asyncio.sleep(seconds)
-    frames = list(hc.frames)
-    await hc.close()
-    return frames
+    try:
+        await hc.connect(retries=40, retry_delay=0.25)
+        if await hc.hello(timeout=10) is None:
+            raise RuntimeError("sidecar hello handshake timed out (no hello_ack)")
+        await hc.subscribe(list(ALL_TAP_TOPICS))
+        if wait_for_lap:
+            # Wait for the car to be on track (any continuous topic), then for a lap boundary.
+            # `wait_for` consumes from a separate queue; `hc.frames` still accrues the full stream.
+            await hc.wait_for(
+                lambda f: any(_is_snapshot(f, t) for t in _CONTINUOUS_SET),
+                timeout=settle_timeout,
+            )
+            await hc.wait_for(lambda f: _is_snapshot(f, "lap"), timeout=lap_timeout)
+        else:
+            await asyncio.sleep(seconds)
+        return list(hc.frames)
+    finally:
+        await hc.close()
 
 
-async def _main() -> int:
-    frames = await tap_frames(seconds=20.0)
-    result = evaluate_sequence(frames)
+async def _amain(args: argparse.Namespace) -> int:
+    frames = await tap_frames(seconds=args.seconds, wait_for_lap=args.wait_lap)
+    result = evaluate_sequence(frames, strict_lifecycle=args.strict)
     print(result.summary())
     return 0 if result.ok else 1
 
 
+def _main() -> int:
+    parser = argparse.ArgumentParser(description="L1.5 in-sim WS-sequence probe")
+    parser.add_argument(
+        "--seconds", type=float, default=20.0, help="fixed tap window (window mode)"
+    )
+    parser.add_argument(
+        "--wait-lap",
+        action="store_true",
+        help="wait for the car on track, then for a lap boundary (slow laps), not a fixed window",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="require session + lap and enforce session→lap ordering (tap from session start)",
+    )
+    return asyncio.run(_amain(parser.parse_args()))
+
+
 if __name__ == "__main__":
-    raise SystemExit(asyncio.run(_main()))
+    import sys
+    from pathlib import Path
+
+    # Direct invocation (`python tools/ac_harness/sequence_probe.py`) puts tools/ac_harness on
+    # sys.path, not the repo root — so the lazy `from tools...` import would fail on a fresh clone.
+    # Put the repo root first so both `python <file>` and `python -m ...` work.
+    _repo_root = str(Path(__file__).resolve().parents[2])
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
+    raise SystemExit(_main())

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -4,9 +4,18 @@ The L1.5 layer asserts on the **message sequence** the trainer emits during a dr
 It consumes the trainer's published WS frames (live tap via `ai_sidecar.harness_client`, or a
 recorded JSONL file) and checks the declared-topic contract:
 
-  * every declared producer topic appears at least once during the drive, and
+  * the CONTINUOUS streams (connection / tire_temps / coaching.snapshot) are present — the
+    "pipeline is alive" check, required in any driving window; and
   * the lifecycle ordering invariant holds: the first ``session`` precedes the first ``lap``
-    (the #182 contract — no ``lap`` frame may precede a ``session``).
+    (the #182 contract — no ``lap`` frame may precede a ``session``), asserted whenever a
+    ``session`` is observed.
+
+CONDITIONAL topics (``session`` / ``lap`` / ``delta``) are only present under specific
+circumstances — ``session`` is an event that fires at session start (a mid-session tap misses it),
+``lap`` needs a lap boundary in the window, and ``delta`` needs a reference lap + an s/f-aligned
+clock. By default these are reported as informational notes, NOT failures, so an ad-hoc mid-session
+tap doesn't spuriously fail. Pass ``strict_lifecycle=True`` for the controlled L1.5 run that taps
+from session start, where their presence + strict session→lap ordering ARE required.
 
 Published topic frames are shaped ``{v, type="state.snapshot", topic, payload}`` (see
 `ws_bridge.publishTopic`), so frames are filtered by their top-level ``topic`` key.
@@ -22,17 +31,24 @@ import asyncio
 import json
 from dataclasses import dataclass, field
 
-# The declared producer topics whose presence we assert during a drive. `setup.active` is
-# event-driven (only on a setup change) so it is NOT required for a baseline lap; the other six
-# should all appear on any normal driving session.
-DEFAULT_REQUIRED_TOPICS: tuple[str, ...] = (
-    "connection",
-    "session",
-    "lap",
-    "delta",
-    "tire_temps",
-    "coaching.snapshot",
+# Topics that stream CONTINUOUSLY whenever a car is on track — required presence in any driving
+# window (the "pipeline alive" check).
+DEFAULT_CONTINUOUS_TOPICS: tuple[str, ...] = (
+    "connection",  # ~1 Hz heartbeat
+    "tire_temps",  # ~5 Hz per-wheel temps
+    "coaching.snapshot",  # continuous coaching stream
 )
+
+# CONDITIONAL topics — present only under specific circumstances, so a short or mid-session tap may
+# legitimately miss them (NOT a producer fault): `session` is an EVENT (session start / track-car
+# change / reconnect — a tap connecting mid-session misses it); `lap` needs a lap boundary in the
+# window; `delta` needs a reference lap to exist AND an s/f-aligned clock (see deltaRefStale).
+# Reported as informational notes by default; promoted to required checks under strict_lifecycle.
+LIFECYCLE_TOPICS: tuple[str, ...] = ("session", "lap", "delta")
+
+# `setup.active` is event-driven (only on a setup change) and never required for a baseline lap.
+# Everything the live tap subscribes to:
+ALL_TAP_TOPICS: tuple[str, ...] = DEFAULT_CONTINUOUS_TOPICS + LIFECYCLE_TOPICS
 
 
 @dataclass
@@ -50,6 +66,7 @@ class SequenceResult:
 
     ok: bool
     checks: list[Check] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
     counts: dict[str, int] = field(default_factory=dict)
 
     def summary(self) -> str:
@@ -57,6 +74,8 @@ class SequenceResult:
         lines = [f"{head}: L1.5 sequence probe ({len(self.checks)} checks)"]
         for c in self.checks:
             lines.append(f"  [{'ok' if c.ok else 'XX'}] {c.name} — {c.detail}")
+        for n in self.notes:
+            lines.append(f"  (i) {n}")
         return "\n".join(lines)
 
 
@@ -75,9 +94,18 @@ def _ordered_topics(frames: list[dict]) -> list[tuple[int, str]]:
 def evaluate_sequence(
     frames: list[dict],
     *,
-    required_topics: tuple[str, ...] = DEFAULT_REQUIRED_TOPICS,
+    continuous_topics: tuple[str, ...] = DEFAULT_CONTINUOUS_TOPICS,
+    strict_lifecycle: bool = False,
 ) -> SequenceResult:
-    """Evaluate a frame stream against the L1.5 declared-topic + ordering contract (pure)."""
+    """Evaluate a frame stream against the L1.5 contract (pure).
+
+    Default "window" mode: require the continuous streams, and assert session-before-lap only
+    when a ``session`` is observed. Lifecycle topics are reported as notes — a mid-session tap
+    legitimately misses the ``session`` event, a lap boundary, or a reference lap for ``delta``.
+
+    ``strict_lifecycle=True`` (controlled tap from session start): also require ``session``,
+    ``lap``, ``delta`` present and strictly enforce session-before-lap.
+    """
     ordered = _ordered_topics(frames)
     first_index: dict[str, int] = {}
     counts: dict[str, int] = {}
@@ -86,35 +114,52 @@ def evaluate_sequence(
         first_index.setdefault(topic, i)
 
     checks: list[Check] = []
+    notes: list[str] = []
 
-    # 1) presence: each required producer topic appears at least once.
-    for topic in required_topics:
+    def _presence(topic: str) -> Check:
         present = topic in first_index
-        checks.append(
-            Check(
-                f"present:{topic}",
-                present,
-                f"count={counts.get(topic, 0)}" if present else "never seen",
-            )
+        return Check(
+            f"present:{topic}",
+            present,
+            f"count={counts.get(topic, 0)}" if present else "never seen",
         )
 
-    # 2) ordering: the first `session` precedes the first `lap` (no lap without a preceding
-    #    session — the #182 lifecycle contract). Only assertable when a `lap` was emitted; absence
-    #    of `lap` is already flagged by the presence check above.
-    if "lap" in first_index:
-        if "session" not in first_index:
+    # 1) continuous streams must be present (pipeline alive).
+    for topic in continuous_topics:
+        checks.append(_presence(topic))
+
+    # 2) lifecycle topics: required only under strict_lifecycle; otherwise informational.
+    for topic in LIFECYCLE_TOPICS:
+        if strict_lifecycle:
+            checks.append(_presence(topic))
+        elif topic in first_index:
+            notes.append(f"{topic}: count={counts[topic]}")
+        else:
+            notes.append(f"{topic}: not in window (conditional: event / boundary / reference-lap)")
+
+    # 3) ordering: the first `session` precedes the first `lap` (#182 lifecycle contract).
+    if "session" in first_index and "lap" in first_index:
+        ok = first_index["session"] < first_index["lap"]
+        checks.append(
+            Check(
+                "order:session-before-lap",
+                ok,
+                f"session@{first_index['session']} lap@{first_index['lap']}",
+            )
+        )
+    elif "lap" in first_index and "session" not in first_index:
+        # A lap with no session in the window is almost always a mid-session tap (the session event
+        # fired before we connected), NOT a contract violation — so it fails only in strict mode.
+        if strict_lifecycle:
             checks.append(Check("order:session-before-lap", False, "lap emitted with no session"))
         else:
-            ok = first_index["session"] < first_index["lap"]
-            checks.append(
-                Check(
-                    "order:session-before-lap",
-                    ok,
-                    f"session@{first_index['session']} lap@{first_index['lap']}",
-                )
+            notes.append(
+                "lap seen without session — tap likely started mid-session (session is an "
+                "event that fired before connect); use strict_lifecycle from session start to "
+                "assert session→lap ordering"
             )
 
-    return SequenceResult(ok=all(c.ok for c in checks), checks=checks, counts=counts)
+    return SequenceResult(ok=all(c.ok for c in checks), checks=checks, notes=notes, counts=counts)
 
 
 def frames_from_jsonl(path: str) -> list[dict]:
@@ -144,7 +189,7 @@ async def tap_frames(url: str = "ws://127.0.0.1:8765", *, seconds: float = 20.0)
     hc = HarnessClient(url)
     await hc.connect(retries=40, retry_delay=0.25)
     await hc.hello(timeout=10)
-    await hc.subscribe(list(DEFAULT_REQUIRED_TOPICS))
+    await hc.subscribe(list(ALL_TAP_TOPICS))
     # Frames accumulate in hc.frames via the client's background recv task; wait the window out.
     await asyncio.sleep(seconds)
     frames = list(hc.frames)

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -120,6 +120,7 @@ def evaluate_sequence(
     *,
     continuous_topics: tuple[str, ...] = DEFAULT_CONTINUOUS_TOPICS,
     strict_lifecycle: bool = False,
+    require_lap: bool = False,
 ) -> SequenceResult:
     """Evaluate a frame stream against the L1.5 contract (pure).
 
@@ -129,6 +130,10 @@ def evaluate_sequence(
 
     ``strict_lifecycle=True`` (controlled tap from session start): also require ``session`` and
     ``lap`` present and strictly enforce session-before-lap. ``delta`` stays a note in both modes.
+
+    ``require_lap=True``: require a ``lap`` even outside strict mode — used with ``--wait-lap``,
+    where the caller explicitly waited for a lap, so a timed-out/absent lap must FAIL rather than
+    silently pass as a note (codex on #191).
     """
     ordered = _ordered_topics(frames)
     first_index: dict[str, int] = {}
@@ -152,14 +157,21 @@ def evaluate_sequence(
     for topic in continuous_topics:
         checks.append(_presence(topic))
 
-    # 2) session / lap: required under strict_lifecycle; otherwise informational notes.
-    for topic in STRICT_LIFECYCLE_TOPICS:
-        if strict_lifecycle:
-            checks.append(_presence(topic))
-        else:
-            notes.append(_conditional_note(topic, first_index, counts))
+    # 2) session: required under strict_lifecycle; otherwise an informational note.
+    if strict_lifecycle:
+        checks.append(_presence("session"))
+    else:
+        notes.append(_conditional_note("session", first_index, counts))
 
-    # 3) delta: always a note (needs a reference lap + an s/f-aligned clock) — never required.
+    # 3) lap: required under strict_lifecycle OR require_lap. With --wait-lap the caller explicitly
+    #    waited for a lap, so a timed-out/absent lap must FAIL the check rather than pass as a note
+    #    (codex on #191); otherwise it is an informational note.
+    if strict_lifecycle or require_lap:
+        checks.append(_presence("lap"))
+    else:
+        notes.append(_conditional_note("lap", first_index, counts))
+
+    # 4) delta: always a note (needs a reference lap + an s/f-aligned clock) — never required.
     notes.append(_conditional_note("delta", first_index, counts))
 
     # 4) ordering: the first `session` precedes the first `lap` (#182 lifecycle contract).
@@ -254,7 +266,8 @@ async def tap_frames(
 
 async def _amain(args: argparse.Namespace) -> int:
     frames = await tap_frames(seconds=args.seconds, wait_for_lap=args.wait_lap)
-    result = evaluate_sequence(frames, strict_lifecycle=args.strict)
+    # --wait-lap explicitly waited for a lap, so require it: a timed-out wait must FAIL, not pass.
+    result = evaluate_sequence(frames, strict_lifecycle=args.strict, require_lap=args.wait_lap)
     print(result.summary())
     return 0 if result.ok else 1
 

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -1,0 +1,163 @@
+"""L1.5 in-sim WS-sequence probe (EPIC #154 Part E, issue #190).
+
+The L1.5 layer asserts on the **message sequence** the trainer emits during a drive — not pixels.
+It consumes the trainer's published WS frames (live tap via `ai_sidecar.harness_client`, or a
+recorded JSONL file) and checks the declared-topic contract:
+
+  * every declared producer topic appears at least once during the drive, and
+  * the lifecycle ordering invariant holds: the first ``session`` precedes the first ``lap``
+    (the #182 contract — no ``lap`` frame may precede a ``session``).
+
+Published topic frames are shaped ``{v, type="state.snapshot", topic, payload}`` (see
+`ws_bridge.publishTopic`), so frames are filtered by their top-level ``topic`` key.
+
+`evaluate_sequence()` is a **pure function**, unit-tested off-sim with synthetic frame streams.
+The live tap (`tap_frames` / ``__main__``) is **gated**: it needs AC running and a car on track,
+so it is exercised in-sim on a real (operator-launched) drive, not in CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+
+# The declared producer topics whose presence we assert during a drive. `setup.active` is
+# event-driven (only on a setup change) so it is NOT required for a baseline lap; the other six
+# should all appear on any normal driving session.
+DEFAULT_REQUIRED_TOPICS: tuple[str, ...] = (
+    "connection",
+    "session",
+    "lap",
+    "delta",
+    "tire_temps",
+    "coaching.snapshot",
+)
+
+
+@dataclass
+class Check:
+    """One assertion in the sequence contract."""
+
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass
+class SequenceResult:
+    """Outcome of evaluating a frame stream against the L1.5 contract."""
+
+    ok: bool
+    checks: list[Check] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        head = "PASS" if self.ok else "FAIL"
+        lines = [f"{head}: L1.5 sequence probe ({len(self.checks)} checks)"]
+        for c in self.checks:
+            lines.append(f"  [{'ok' if c.ok else 'XX'}] {c.name} — {c.detail}")
+        return "\n".join(lines)
+
+
+def _ordered_topics(frames: list[dict]) -> list[tuple[int, str]]:
+    """Return ``(index, topic)`` for each frame with a string ``topic`` key, in arrival order."""
+    out: list[tuple[int, str]] = []
+    for i, f in enumerate(frames):
+        if not isinstance(f, dict):
+            continue
+        topic = f.get("topic")
+        if isinstance(topic, str):
+            out.append((i, topic))
+    return out
+
+
+def evaluate_sequence(
+    frames: list[dict],
+    *,
+    required_topics: tuple[str, ...] = DEFAULT_REQUIRED_TOPICS,
+) -> SequenceResult:
+    """Evaluate a frame stream against the L1.5 declared-topic + ordering contract (pure)."""
+    ordered = _ordered_topics(frames)
+    first_index: dict[str, int] = {}
+    counts: dict[str, int] = {}
+    for i, topic in ordered:
+        counts[topic] = counts.get(topic, 0) + 1
+        first_index.setdefault(topic, i)
+
+    checks: list[Check] = []
+
+    # 1) presence: each required producer topic appears at least once.
+    for topic in required_topics:
+        present = topic in first_index
+        checks.append(
+            Check(
+                f"present:{topic}",
+                present,
+                f"count={counts.get(topic, 0)}" if present else "never seen",
+            )
+        )
+
+    # 2) ordering: the first `session` precedes the first `lap` (no lap without a preceding
+    #    session — the #182 lifecycle contract). Only assertable when a `lap` was emitted; absence
+    #    of `lap` is already flagged by the presence check above.
+    if "lap" in first_index:
+        if "session" not in first_index:
+            checks.append(Check("order:session-before-lap", False, "lap emitted with no session"))
+        else:
+            ok = first_index["session"] < first_index["lap"]
+            checks.append(
+                Check(
+                    "order:session-before-lap",
+                    ok,
+                    f"session@{first_index['session']} lap@{first_index['lap']}",
+                )
+            )
+
+    return SequenceResult(ok=all(c.ok for c in checks), checks=checks, counts=counts)
+
+
+def frames_from_jsonl(path: str) -> list[dict]:
+    """Load a recorded frame stream (one JSON object per line). Blank/invalid lines are skipped."""
+    frames: list[dict] = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                frames.append(obj)
+    return frames
+
+
+async def tap_frames(url: str = "ws://127.0.0.1:8765", *, seconds: float = 20.0) -> list[dict]:
+    """Tap the sidecar for ``seconds`` and return the frames received (live; needs AC driving).
+
+    Imported lazily so the pure evaluator has no hard dependency on the sidecar client.
+    """
+    from tools.ai_sidecar.harness_client import HarnessClient
+
+    hc = HarnessClient(url)
+    await hc.connect(retries=40, retry_delay=0.25)
+    await hc.hello(timeout=10)
+    await hc.subscribe(list(DEFAULT_REQUIRED_TOPICS))
+    # Frames accumulate in hc.frames via the client's background recv task; wait the window out.
+    await asyncio.sleep(seconds)
+    frames = list(hc.frames)
+    await hc.close()
+    return frames
+
+
+async def _main() -> int:
+    frames = await tap_frames(seconds=20.0)
+    result = evaluate_sequence(frames)
+    print(result.summary())
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))


### PR DESCRIPTION
Part E (L1.5) of EPIC #154. The verification harness for the now-complete #180 producer pipeline.

`tools/ac_harness/sequence_probe.py` — `evaluate_sequence()` (pure) asserts the in-sim message-sequence contract over a frame stream (live tap or recorded JSONL):
- **presence**: connection / session / lap / delta / tire_temps / coaching.snapshot each appear ≥1× during a drive (`setup.active` is event-driven → not required).
- **ordering**: first `session` precedes first `lap` (the #182 lifecycle contract).

**Tests (9, off-sim):** good stream, lap-before-session, lap-without-session, missing continuous topic, empty, malformed/non-topic frames ignored, setup.active-not-required, JSONL round-trip. ruff clean.

**DRAFT — gated on in-sim observation (anti-false-green).** `tap_frames`/`__main__` need AC running + a car on track. On the next operator-launched drive this runs alongside `.scratch/diag_wheels.py` (tire_temps.rr vs the physics oracle) to verify all five #180 producers end-to-end. Ready-for-review once observed against a real drive.

Remaining Part E work (separate, larger): the `carcsw` Custom AI mmap driver (so the agent drives car 0 itself, no operator lap) — see #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)