### PR TITLE
fix(ws): rearm lifecycle on socket open epoch (#183)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1753,13 +1753,7 @@ function script.update(dt)
     -- that opens and drains hello_ack between two script.update samples, leaving the boolean
     -- true on both samples (#183).
     local wsConn = type(wsBridge.sidecarConnected) == "function" and wsBridge.sidecarConnected()
-    local wsEpoch = nil
-    if type(wsBridge.openEpoch) == "function" then
-      local okEpoch, gotEpoch = pcall(wsBridge.openEpoch)
-      if okEpoch then
-        wsEpoch = tonumber(gotEpoch)
-      end
-    end
+    local wsEpoch = type(wsBridge.openEpoch) == "function" and wsBridge.openEpoch() or nil
     local wsEpochChanged = wsEpoch ~= nil
       and state._wsPrevOpenEpoch ~= nil
       and wsEpoch ~= state._wsPrevOpenEpoch

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1749,11 +1749,27 @@ function script.update(dt)
   pcall(function()
     -- Per-frame WS-reconnect detection: on a sidecar (re)connect, re-arm `session` so it
     -- re-emits THIS frame — before any subsequent `lap` — without resetting the stint best.
+    -- The boolean catches normal false->true connects; openEpoch catches a CSP auto-reconnect
+    -- that opens and drains hello_ack between two script.update samples, leaving the boolean
+    -- true on both samples (#183).
     local wsConn = type(wsBridge.sidecarConnected) == "function" and wsBridge.sidecarConnected()
-    if wsConn and not state._wsPrevConnected then
+    local wsEpoch = nil
+    if type(wsBridge.openEpoch) == "function" then
+      local okEpoch, gotEpoch = pcall(wsBridge.openEpoch)
+      if okEpoch then
+        wsEpoch = tonumber(gotEpoch)
+      end
+    end
+    local wsEpochChanged = wsEpoch ~= nil
+      and state._wsPrevOpenEpoch ~= nil
+      and wsEpoch ~= state._wsPrevOpenEpoch
+    if wsConn and (not state._wsPrevConnected or wsEpochChanged) then
       lifecyclePublisher.rearmSession()
     end
     state._wsPrevConnected = wsConn
+    if wsEpoch ~= nil then
+      state._wsPrevOpenEpoch = wsEpoch
+    end
     lifecyclePublisher.publishConnectionIfDue({
       dt = dt,
       car = car,

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -487,6 +487,10 @@ tryOpen = function()
   local opened = nil
   local params = {
     onOpen = function()
+      -- Ignore stale onOpen from a socket handle replaced by configure/reset.
+      if opened ~= nil and sock ~= opened then
+        return
+      end
       socketOpenEpoch = socketOpenEpoch + 1
       -- Re-arm v1 (and legacy) registration gating on every transport open. With
       -- `reconnect = true` CSP auto-reconnects on a transient drop by firing this

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -104,6 +104,9 @@ local externalHelloAcked = false
 local externalHelloPending = false
 local helloRetryFrames = 0
 local helloSendCount = 0
+--- Monotonic transport-open counter. Incremented only from CSP's `onOpen`
+--- callback, including auto-reconnects that do not pass through `tryOpen`.
+local socketOpenEpoch = 0
 --- Resend hello every N M.tick frames (~0.2 s at 60 Hz) until hello_ack flips
 --- `sidecarProtocolReady`. Frame-paced so a frozen sim clock cannot stall it.
 local EXTERNAL_HELLO_RETRY_FRAMES = 12
@@ -301,6 +304,13 @@ function M.sidecarConnected()
   return sock ~= nil and sidecarProtocolReady
 end
 
+--- Public read-only transport-open epoch. The entry script uses this to detect
+--- reconnects that close/open/hello_ack between two per-frame boolean samples.
+---@return number
+function M.openEpoch()
+  return socketOpenEpoch
+end
+
 --- Clear socket state (e.g. leaving track / new session). URL unchanged.
 function M.reset()
   close_socket_if_any(sock)
@@ -477,6 +487,7 @@ tryOpen = function()
   local opened = nil
   local params = {
     onOpen = function()
+      socketOpenEpoch = socketOpenEpoch + 1
       -- Re-arm v1 (and legacy) registration gating on every transport open. With
       -- `reconnect = true` CSP auto-reconnects on a transient drop by firing this
       -- callback WITHOUT going through `tryOpen`, so the tryOpen resets are skipped;

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -39,10 +39,12 @@ os = os or {}
 web = {}
 _ws_on_recv = nil
 _ws_on_open = nil
+_ws_on_opens = {}
 _ws_sent = 0
 function web.socket(_u, cb, _p)
   _ws_on_recv = cb
   _ws_on_open = _p and _p.onOpen or nil
+  _ws_on_opens[#_ws_on_opens + 1] = _ws_on_open
   local s = { close = function() end }
   setmetatable(s, { __call = function(_, _data) _ws_sent = _ws_sent + 1 end })
   return s
@@ -201,3 +203,26 @@ def test_open_epoch_detects_subframe_reconnect_while_connected_boolean_stays_tru
     assert connected_before is True
     assert _connected(rt) is True
     assert _epoch(rt) == epoch_before + 1
+
+
+def test_stale_onopen_from_replaced_socket_is_ignored():
+    # CodeRabbit on #197: onClose already ignores stale callbacks from replaced
+    # handles. onOpen needs the same guard, or a late callback can bump the epoch
+    # and reset readiness for the active socket.
+    rt = _runtime()
+    _open(rt)
+    rt.execute("_ws_on_open()")
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert _connected(rt) is True
+    assert _epoch(rt) == 1
+
+    # Reconfigure onto a replacement socket, then invoke the original callback.
+    rt.execute('local wb = require("ws_bridge"); wb.configure("ws://127.0.0.1:9876"); wb.tick(0)')
+    assert int(rt.eval("#_ws_on_opens")) == 2
+    epoch_before = _epoch(rt)
+    sent_before = int(rt.eval("_ws_sent"))
+
+    rt.execute("_ws_on_opens[1]()")
+
+    assert _epoch(rt) == epoch_before
+    assert int(rt.eval("_ws_sent")) == sent_before

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -86,6 +86,10 @@ def _connected(rt) -> bool:
     return bool(rt.eval('require("ws_bridge").sidecarConnected()'))
 
 
+def _epoch(rt) -> int:
+    return int(rt.eval('require("ws_bridge").openEpoch()'))
+
+
 def test_publish_is_gated_until_hello_ack():
     rt = _runtime()
     _open(rt)
@@ -171,3 +175,29 @@ def test_reconnect_via_onopen_rearms_handshake():
     # A fresh hello_ack re-registers us.
     _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
     assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True
+
+
+def test_open_epoch_detects_subframe_reconnect_while_connected_boolean_stays_true():
+    # Issue #183: the entry script samples sidecarConnected() once per frame.
+    # A CSP auto-reconnect can fire onOpen and receive hello_ack between samples,
+    # leaving the boolean true before and after. openEpoch must still advance so
+    # script.update can re-arm lifecycle `session`.
+    rt = _runtime()
+    _open(rt)
+    assert _epoch(rt) == 0
+
+    assert rt.eval("_ws_on_open ~= nil"), "ws_bridge must register an onOpen callback"
+    rt.execute("_ws_on_open()")
+    assert _epoch(rt) == 1
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert _connected(rt) is True
+    connected_before = _connected(rt)
+    epoch_before = _epoch(rt)
+
+    # Entire reconnect + hello_ack sequence happens between two app update polls.
+    rt.execute("_ws_on_open()")
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+
+    assert connected_before is True
+    assert _connected(rt) is True
+    assert _epoch(rt) == epoch_before + 1


### PR DESCRIPTION
## Summary
- add a ws_bridge openEpoch counter incremented from CSP onOpen
- re-arm lifecycle session publishing when the open epoch changes, even if sidecarConnected stays true across frame samples
- guard stale onOpen callbacks from replaced socket handles
- add Lupa regressions for sub-frame reconnects and stale onOpen callbacks

## Verification
- /Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python -m pytest tests/test_ws_bridge_hello_handshake.py tests/test_lifecycle_publisher.py
- make ci-fast PYTHON=/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python

Closes #183