### PR TITLE
ci: allow vault post-merge branches (#179)

### DIFF
--- a/scripts/ci_policy.py
+++ b/scripts/ci_policy.py
@@ -36,6 +36,7 @@ ALLOWED_BRANCH_PREFIXES: tuple[str, ...] = (
     "cursor/",
     "renovate/",
     "sanitize/",  # urgent privacy/metadata scrub branches (e.g. PR #113)
+    "vault/",  # vault-only post-merge handoff branches
 )
 
 # Conventional commit style for PR titles (type, optional scope, optional !, colon, message).

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -33,6 +33,7 @@ def ci_policy_mod():
         "dependabot/pip/foo",
         "cursor/feat_issue-1_x",
         "renovate/configure",
+        "vault/post-merge-pr176",
     ],
 )
 def test_validate_branch_accepts_allowed(ci_policy_mod, branch: str) -> None:
@@ -154,6 +155,22 @@ def test_main_pull_request_valid(
         "pull_request": {
             "title": "chore: do something",
             "head": {"ref": "chore/issue-99-x"},
+        }
+    }
+    p = tmp_path / "event.json"
+    p.write_text(json.dumps(ev), encoding="utf-8")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(p))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    assert ci_policy_mod.main() == 0
+
+
+def test_main_pull_request_vault_branch_valid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, ci_policy_mod
+) -> None:
+    ev = {
+        "pull_request": {
+            "title": "docs(vault): post-merge handoff for PR #176",
+            "head": {"ref": "vault/post-merge-pr176"},
         }
     }
     p = tmp_path / "event.json"

--- a/tests/test_repo_knowledge/test_mcp_server_import.py
+++ b/tests/test_repo_knowledge/test_mcp_server_import.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
+
 import pytest
 
-pytest.importorskip("mcp")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_MCP_NAMESPACE = (REPO_ROOT / "scripts" / "mcp").resolve()
+
+
+def _installed_mcp_available() -> bool:
+    spec = importlib.util.find_spec("mcp")
+    if spec is None:
+        return False
+    locations = [Path(p).resolve() for p in spec.submodule_search_locations or []]
+    if spec.origin is None and locations and all(p == REPO_MCP_NAMESPACE for p in locations):
+        return False
+    return True
+
+
+if not _installed_mcp_available():
+    pytest.skip("requires installed mcp package from [knowledge]", allow_module_level=True)
 
 
 def test_mcp_server_module_imports() -> None:


### PR DESCRIPTION
## Summary
- allow documented vault-only post-merge branches via the vault/ prefix in ci_policy.py
- add regression coverage for vault/post-merge-pr<N> branch validation and PR event handling
- harden optional MCP import smoke so scripts/mcp namespace pollution does not make dev-only ci-test fail without the [knowledge] extra

## Verification
- git diff --check
- uv run --extra dev python -m pytest tests/test_ci_policy.py tests/test_repo_knowledge/test_mcp_server_import.py -q
- make ci-fast PYTHON=.venv/bin/python

Closes #179