### PR TITLE
fix(trainer): defer wrap-shaped teleport resets (#188)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -951,6 +951,9 @@ state = {
   -- any mid-track clock seed (app load/reload mid-lap, post-reset re-arm) — Cursor + codex on #185.
   -- Defaults true: no delta until the first clean lap is started (an out-lap clock is mid-track).
   deltaRefStale = true,
+  -- One-frame confirmation for wrap-shaped same-lap spline jumps on CSP builds without
+  -- resetCounter: if lapCount does not catch up on the next frame, reset rolling state (#188).
+  pendingWrapResetLapCount = nil,
   bestLapTrace = {},
   -- Local in-game PB/reference snapshot. When an imported reference is active,
   -- realtime code still reads `bestLapTrace`, but persistence saves these local fields.
@@ -1280,6 +1283,7 @@ local function resetRuntimeAfterLeavingTrack()
   state.lastSplinePos = nil
   state.lastResetCounter = nil  -- re-prime teleport detection on next track entry
   state.deltaRefStale = true  -- re-entry: no boundary-aligned clock yet, delta silent until first lap
+  state.pendingWrapResetLapCount = nil
   state.bestLapTrace = {}
   state.localBestLapTrace = {}
   state.localBestBrakePoints = {}
@@ -1379,6 +1383,7 @@ local function resetRollingDrivingState()
   lifecyclePublisher.reset()  -- #180: same-session/stint restart must re-emit `session`
   telemetryPublisher.reset()  -- #180: reset delta/tire_temps rate-limiters
   state.deltaRefStale = true  -- #180/#185: clock reset; delta silent until the next clean lap boundary
+  state.pendingWrapResetLapCount = nil
   tel = newTelemetry()
   brakes = newBrakes()
   td:resetLapAggregates()
@@ -2481,18 +2486,19 @@ function script.update(dt)
     state.focusPracticeHudSummarySig = nil
   end
 
-  if teleported or (state.lastLapCount >= 0 and lc < state.lastLapCount) then
-    -- Teleport/return-to-garage/pit reset (guarded resetCounter bumped, computed above) OR a
-    -- lap-counter rollback: the prior stint's rolling state (lap clock, coaching, aggregates) is
-    -- stale. The teleport case also covers a wrap-shaped same-lap rewind the spline heuristic
-    -- below cannot (codex on #185).
+  local resetDecision = delta.rollingResetDecision({
+    pendingWrapLapCount = state.pendingWrapResetLapCount,
+    lastLapCount = state.lastLapCount,
+    lapCount = lc,
+    prevSpline = state.lastSplinePos,
+    spline = sp,
+    teleported = teleported,
+  })
+  state.pendingWrapResetLapCount = resetDecision.pendingWrapLapCount
+  if resetDecision.reset then
+    -- Teleport/resetCounter, lap rollback, non-wrap same-lap spline rewind, or a deferred
+    -- wrap-shaped same-lap jump whose lapCount did not catch up on the following frame (#188).
     resetRollingDrivingState()
-  elseif state.lastLapCount >= 0 and lc == state.lastLapCount and state.lastSplinePos then
-    -- Same-lap backward spline jump = pit/session reset (shared with the `delta` producer's skip
-    -- guard via delta.isBackwardSplineReset so the discontinuity threshold can't drift — #185).
-    if delta.isBackwardSplineReset(state.lastSplinePos, sp) then
-      resetRollingDrivingState()
-    end
   end
 
   state.lastLapCount = lc

--- a/src/ac_copilot_trainer/modules/delta.lua
+++ b/src/ac_copilot_trainer/modules/delta.lua
@@ -120,6 +120,18 @@ function M.isBackwardSplineJump(prevSpline, spline)
   return ((spline or 0) - prevSpline) < SPLINE_REWIND_THRESHOLD
 end
 
+local function isLikelyLapWrap(prevSpline, spline)
+  return prevSpline ~= nil and prevSpline > 0.8 and (spline or 0) < 0.25
+end
+
+--- True when a backward jump has the same shape as a normal lap wrap.
+---@param prevSpline number|nil
+---@param spline number
+---@return boolean
+function M.isWrapShapedBackwardSplineJump(prevSpline, spline)
+  return M.isBackwardSplineJump(prevSpline, spline) and isLikelyLapWrap(prevSpline, spline)
+end
+
 --- True when the spline jumped backward in a way that should CLEAR rolling driving state (lap
 --- clock, coaching, aggregates) via resetRollingDrivingState. CONSERVATIVE: excludes a lap *wrap*
 --- (prev near 1.0 -> now near 0.0), because over-triggering here is NOT harmless — a false positive
@@ -134,8 +146,55 @@ function M.isBackwardSplineReset(prevSpline, spline)
   if not M.isBackwardSplineJump(prevSpline, spline) then
     return false
   end
-  local likelyWrap = prevSpline > 0.8 and (spline or 0) < 0.25
-  return not likelyWrap
+  return not isLikelyLapWrap(prevSpline, spline)
+end
+
+--- Decide whether the end-of-update rolling state should reset.
+---
+--- Wrap-shaped same-lap jumps are ambiguous on CSP builds without `car.resetCounter`: they might
+--- be a real lap wrap exposed one frame before `lapCount`, or a return-to-pits teleport landing
+--- near the start line. Defer exactly one frame; if `lapCount` advances, it was a lap wrap; if it
+--- does not, clear rolling state for the abandoned stint (#188).
+---@param opts table
+---@return table { reset: boolean, pendingWrapLapCount: number|nil }
+function M.rollingResetDecision(opts)
+  opts = opts or {}
+  local pendingWrapLapCount = opts.pendingWrapLapCount
+  local lastLapCount = opts.lastLapCount
+  local lapCount = opts.lapCount
+
+  if opts.teleported then
+    return { reset = true, pendingWrapLapCount = nil }
+  end
+
+  if type(lastLapCount) == "number"
+      and type(lapCount) == "number"
+      and lastLapCount >= 0
+      and lapCount < lastLapCount then
+    return { reset = true, pendingWrapLapCount = nil }
+  end
+
+  if pendingWrapLapCount ~= nil then
+    if type(lapCount) == "number" and lapCount > pendingWrapLapCount then
+      return { reset = false, pendingWrapLapCount = nil }
+    end
+    return { reset = true, pendingWrapLapCount = nil }
+  end
+
+  if type(lastLapCount) == "number"
+      and type(lapCount) == "number"
+      and lastLapCount >= 0
+      and lapCount == lastLapCount
+      and opts.prevSpline ~= nil then
+    if M.isBackwardSplineReset(opts.prevSpline, opts.spline) then
+      return { reset = true, pendingWrapLapCount = nil }
+    end
+    if M.isWrapShapedBackwardSplineJump(opts.prevSpline, opts.spline) then
+      return { reset = false, pendingWrapLapCount = lapCount }
+    end
+  end
+
+  return { reset = false, pendingWrapLapCount = nil }
 end
 
 --- Sector durations (ms) for three spline thirds: [0,1/3), [1/3,2/3), [2/3,1).

--- a/src/ac_copilot_trainer/modules/delta.lua
+++ b/src/ac_copilot_trainer/modules/delta.lua
@@ -175,7 +175,10 @@ function M.rollingResetDecision(opts)
   end
 
   if pendingWrapLapCount ~= nil then
-    if type(lapCount) == "number" and lapCount > pendingWrapLapCount then
+    if type(lapCount) ~= "number" then
+      return { reset = false, pendingWrapLapCount = pendingWrapLapCount }
+    end
+    if lapCount > pendingWrapLapCount then
       return { reset = false, pendingWrapLapCount = nil }
     end
     return { reset = true, pendingWrapLapCount = nil }

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -145,6 +145,12 @@ def test_rolling_reset_decision_resets_deferred_wrap_when_lap_count_stays_same()
     assert out["pending"] is None
 
 
+def test_rolling_reset_decision_keeps_deferred_wrap_when_lap_count_unavailable():
+    out = _decision(pending="5", prev="0.05", cur="0.08", last_lap="5", lap="nil")
+    assert out["reset"] is False
+    assert out["pending"] == 5
+
+
 def test_rolling_reset_decision_immediate_for_non_wrap_same_lap_rewind():
     out = _decision(prev="0.62", cur="0.05", last_lap="5", lap="5")
     assert out["reset"] is True

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,10 +1,9 @@
-"""Lupa L0 regression for `delta.lua` predicates used by the #180 `delta` WS producer.
+"""Lupa L0 regression for `delta.lua` predicates used by the #180/#188 reset guards.
 
-`delta.isBackwardSplineReset(prevSpline, spline)` is the shared discontinuity test that BOTH the
-live `delta` producer's skip guard (in `ac_copilot_trainer.lua` `script.update`) and the
-end-of-update `resetRollingDrivingState` detection consume, so the pit/session-reset threshold
-cannot drift between them (Cursor + codex on #185: a same-lap spline rewind would otherwise leak
-one bogus delta against the prior stint's lap clock + reference trace before the reset fires).
+`delta.isBackwardSplineJump(prevSpline, spline)` is the liberal skip guard for the live `delta`
+producer; `delta.isBackwardSplineReset(prevSpline, spline)` is the conservative immediate reset
+predicate for rolling state. The one-frame `rollingResetDecision` covers #188's ambiguous
+wrap-shaped same-lap jump on CSP builds where `car.resetCounter` is unavailable.
 
 A *lap wrap* (prev spline near 1.0, now near 0.0) is forward lap completion, NOT a reset, and must
 return False. The backward threshold is strict (`d < -0.2`).
@@ -23,10 +22,14 @@ MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
 
 
 def _call(fn: str, prev: str, cur: str):
+    return _eval(f"return D.{fn}({prev}, {cur})")
+
+
+def _eval(body: str):
     rt = lupa.LuaRuntime(unpack_returned_tuples=False)
     p = str(MODULES_DIR).replace("\\", "/")
     rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
-    return rt.eval(f"(function() local D = require('delta') return D.{fn}({prev}, {cur}) end)()")
+    return rt.eval(f"(function() local D = require('delta') {body} end)()")
 
 
 def _is_reset(prev: str, cur: str):
@@ -35,6 +38,31 @@ def _is_reset(prev: str, cur: str):
 
 def _is_jump(prev: str, cur: str):
     return _call("isBackwardSplineJump", prev, cur)
+
+
+def _is_wrap_jump(prev: str, cur: str):
+    return _call("isWrapShapedBackwardSplineJump", prev, cur)
+
+
+def _decision(
+    *,
+    pending: str = "nil",
+    last_lap: str = "5",
+    lap: str = "5",
+    prev: str = "0.40",
+    cur: str = "0.45",
+    teleported: str = "false",
+):
+    return _eval(
+        "local r = D.rollingResetDecision({"
+        f"pendingWrapLapCount = {pending}, "
+        f"lastLapCount = {last_lap}, "
+        f"lapCount = {lap}, "
+        f"prevSpline = {prev}, "
+        f"spline = {cur}, "
+        f"teleported = {teleported}"
+        "}) return { reset = r.reset, pending = r.pendingWrapLapCount }"
+    )
 
 
 def test_backward_spline_reset_detects_mid_lap_rewind():
@@ -74,6 +102,11 @@ def test_backward_spline_jump_includes_wrap_shaped():
     # and skipping a delta frame on it is harmless even when resetCounter is unavailable (#185).
     assert _is_jump("0.95", "0.05") is True  # wrap-shaped -> reset excludes, jump includes
     assert _is_reset("0.95", "0.05") is False  # the conservative variant still excludes it
+    assert _is_wrap_jump("0.95", "0.05") is True
+
+
+def test_wrap_shaped_helper_ignores_non_wrap_mid_lap_rewind():
+    assert _is_wrap_jump("0.62", "0.05") is False
 
 
 def test_backward_spline_jump_detects_mid_lap_rewind():
@@ -92,3 +125,36 @@ def test_backward_spline_jump_nil_prev_is_false():
 def test_backward_spline_jump_threshold_is_strict():
     assert _is_jump("0.50", "0.30") is False  # d = -0.20
     assert _is_jump("0.50", "0.29") is True  # d = -0.21
+
+
+def test_rolling_reset_decision_defer_wrap_shaped_same_lap_jump():
+    out = _decision(prev="0.95", cur="0.05", last_lap="5", lap="5")
+    assert out["reset"] is False
+    assert out["pending"] == 5
+
+
+def test_rolling_reset_decision_clears_deferred_wrap_when_lap_count_catches_up():
+    out = _decision(pending="5", prev="0.05", cur="0.08", last_lap="5", lap="6")
+    assert out["reset"] is False
+    assert out["pending"] is None
+
+
+def test_rolling_reset_decision_resets_deferred_wrap_when_lap_count_stays_same():
+    out = _decision(pending="5", prev="0.05", cur="0.08", last_lap="5", lap="5")
+    assert out["reset"] is True
+    assert out["pending"] is None
+
+
+def test_rolling_reset_decision_immediate_for_non_wrap_same_lap_rewind():
+    out = _decision(prev="0.62", cur="0.05", last_lap="5", lap="5")
+    assert out["reset"] is True
+    assert out["pending"] is None
+
+
+def test_rolling_reset_decision_immediate_for_reset_counter_and_lap_rollback():
+    by_counter = _decision(teleported="true", prev="0.40", cur="0.41", last_lap="5", lap="5")
+    by_rollback = _decision(prev="0.40", cur="0.41", last_lap="5", lap="4")
+    assert by_counter["reset"] is True
+    assert by_counter["pending"] is None
+    assert by_rollback["reset"] is True
+    assert by_rollback["pending"] is None

--- a/tests/test_repo_knowledge/test_mcp_server_import.py
+++ b/tests/test_repo_knowledge/test_mcp_server_import.py
@@ -11,18 +11,21 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_MCP_NAMESPACE = (REPO_ROOT / "scripts" / "mcp").resolve()
 
 
-def _installed_mcp_available() -> bool:
+def _fastmcp_available() -> bool:
     spec = importlib.util.find_spec("mcp")
     if spec is None:
         return False
     locations = [Path(p).resolve() for p in spec.submodule_search_locations or []]
     if spec.origin is None and locations and all(p == REPO_MCP_NAMESPACE for p in locations):
         return False
-    return True
+    try:
+        return importlib.util.find_spec("mcp.server.fastmcp") is not None
+    except ModuleNotFoundError:
+        return False
 
 
-if not _installed_mcp_available():
-    pytest.skip("requires installed mcp package from [knowledge]", allow_module_level=True)
+if not _fastmcp_available():
+    pytest.skip("requires installed mcp.server.fastmcp from [knowledge]", allow_module_level=True)
 
 
 def test_mcp_server_module_imports() -> None:


### PR DESCRIPTION
## Summary
- add a one-frame deferred rolling-reset decision for wrap-shaped same-lap spline jumps when `car.resetCounter` is unavailable
- wire the trainer reset path to clear stale pending state on runtime/stint resets
- harden the optional repo-knowledge MCP import smoke so `ci-fast` passes without the `[knowledge]` extra

## Verification
- `.venv/bin/python -m pytest -q tests/test_delta.py tests/test_csp_helpers.py` -> 21 passed
- `PYTHON=.venv/bin/python make ci-fast` -> OK (885 passed, 75 skipped, coverage 80.10%)
- Lua decision matrix observed:
  - wrap same-lap first frame: reset=False pending=5
  - next frame lapCount catches up: reset=False pending=None
  - next frame lapCount still same: reset=True pending=None

## Live-rig note
This session ran on macOS, with no local AC/Content Manager process and no fresh Chronicle route to the rig. Rather than closing #188 as moot without observing `car.resetCounter` on the rig, this PR implements the conservative branch from the issue: defer ambiguous wrap-shaped same-lap jumps for one frame and reset only if `lapCount` does not catch up.