### PR TITLE
feat(harness): add carcsw Custom AI driver (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Use `--output-dir` to target a specific `journal/laps` directory, or set
 Settings to use a faster imported lap as the active coaching reference. Imported laps never count
 as the user's local PB.
 
+### Autonomous harness
+
+The in-sim harness tools live under `tools/ac_harness/`:
+
+```bash
+python -m tools.ac_harness.sequence_probe --wait-lap --strict
+python -m tools.ac_harness.custom_ai --car-index 0 probe
+```
+
+`custom_ai` creates CSP's `CarControls<N>.v0` mmap and waits for the matching
+`Car<N>.v0` readback. It does not drive in `probe` mode; use the explicit
+`drive` subcommand only on the AC rig after Custom AI is enabled for the track.
+
 ## Architecture
 
 See [docs/01_Vault/AcCopilotTrainer/00_System/Architecture Invariants.md](docs/01_Vault/AcCopilotTrainer/00_System/Architecture%20Invariants.md)

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2034,6 +2034,12 @@ function script.update(dt)
     if wsEpoch ~= nil then
       state._wsPrevOpenEpoch = wsEpoch
     end
+    if type(wsBridge.consumeSessionReplayRequest) == "function" then
+      local okReplay, replayRequested = pcall(wsBridge.consumeSessionReplayRequest)
+      if okReplay and replayRequested == true then
+        lifecyclePublisher.rearmSession()
+      end
+    end
     lifecyclePublisher.publishConnectionIfDue({
       dt = dt,
       car = car,

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -107,6 +107,10 @@ local helloSendCount = 0
 --- Monotonic transport-open counter. Incremented only from CSP's `onOpen`
 --- callback, including auto-reconnects that do not pass through `tryOpen`.
 local socketOpenEpoch = 0
+--- One-shot flag set when a late external tap subscribes to `session`.
+--- The entry script consumes it and re-arms lifecycle_publisher so the current
+--- event-driven session is replayed without making the sidecar topic-aware (#190).
+local sessionReplayRequested = false
 --- Resend hello every N M.tick frames (~0.2 s at 60 Hz) until hello_ack flips
 --- `sidecarProtocolReady`. Frame-paced so a frozen sim clock cannot stall it.
 local EXTERNAL_HELLO_RETRY_FRAMES = 12
@@ -322,6 +326,14 @@ function M.openEpoch()
   return socketOpenEpoch
 end
 
+--- One-shot signal: did an external client just subscribe to `session`?
+---@return boolean
+function M.consumeSessionReplayRequest()
+  local out = sessionReplayRequested
+  sessionReplayRequested = false
+  return out
+end
+
 --- Clear socket state (e.g. leaving track / new session). URL unchanged.
 function M.reset()
   close_socket_if_any(sock)
@@ -334,6 +346,7 @@ function M.reset()
   lastLaunchAttemptT = -1e9
   _recvQueue = {}
   sidecarProtocolReady = false
+  sessionReplayRequested = false
   -- Do not clear `spawnedAlive`: the console child can outlive this reset; clearing it risks a second spawn on port 8765 (Cursor #78).
   sidecarChildEverLaunched = false
   spawnFailStreak = 0
@@ -818,6 +831,18 @@ function M.pollInbound(maxPerTick)
               and ac and type(ac.log) == "function" then
             pcall(ac.log, "[COPILOT][SETUP-OPT] sidecar ack failed: " .. tostring(data.error))
           end
+        elseif t == "state.subscribe" then
+          local topics = data.topics
+          if type(topics) == "table" then
+            for _, topic in ipairs(topics) do
+              if topic == "session" then
+                sessionReplayRequested = true
+                break
+              end
+            end
+          end
+          -- Passive subscription envelope; sidecar owns fan-out. Lua only uses
+          -- a session subscription as a replay hint for the event-driven producer.
         elseif type(t) == "string" and t:sub(1, 6) == "state." then
           -- Passive telemetry envelopes (`state.snapshot`, etc.) are fanned by
           -- the sidecar to peers; Lua does not register handlers for them.

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -59,10 +59,17 @@ def _runtime() -> lupa.LuaRuntime:
     rt.execute(f'package.path = package.path .. ";{p}/?.lua"')
     g = rt.globals()
 
+    def _to_lua(value):
+        if isinstance(value, dict):
+            return rt.table_from({k: _to_lua(v) for k, v in value.items()})
+        if isinstance(value, list):
+            return rt.table_from({i + 1: _to_lua(v) for i, v in enumerate(value)})
+        return value
+
     def _parse(s):
         if not isinstance(s, str):
             s = str(s)
-        return rt.table_from(json.loads(s))
+        return _to_lua(json.loads(s))
 
     def _stringify(t, pretty=False):
         # Content is irrelevant to these tests (we assert on state + return
@@ -306,3 +313,29 @@ def test_stale_onopen_from_replaced_socket_is_ignored():
 
     assert _epoch(rt) == epoch_before
     assert int(rt.eval("_ws_sent")) == sent_before
+
+
+def test_state_subscribe_session_sets_one_shot_replay_request():
+    # Issue #190: a late-attaching sequence probe subscribes mid-session. The
+    # sidecar is topic-agnostic, so Lua must treat a `session` subscription as a
+    # request to re-emit the current event-driven session snapshot.
+    rt = _runtime()
+    _open(rt)
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert rt.eval('require("ws_bridge").consumeSessionReplayRequest()') is False
+
+    _inject(rt, {"v": 1, "type": "state.subscribe", "topics": ["connection", "session"]})
+
+    assert rt.eval('require("ws_bridge").consumeSessionReplayRequest()') is True
+    assert rt.eval('require("ws_bridge").consumeSessionReplayRequest()') is False
+
+
+def test_state_subscribe_without_session_does_not_request_replay():
+    rt = _runtime()
+    _open(rt)
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+
+    _inject(rt, {"v": 1, "type": "state.subscribe", "topics": ["connection", "tire_temps"]})
+    _inject(rt, {"v": 1, "type": "state.unsubscribe", "topics": ["session"]})
+
+    assert rt.eval('require("ws_bridge").consumeSessionReplayRequest()') is False

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -15,11 +15,10 @@ diagnostic/client frame that merely carries a ``topic`` key cannot satisfy the c
 
 CONDITIONAL topics are present only under specific circumstances, so a short or mid-session tap may
 legitimately miss them — this is NOT a producer fault:
-  * ``session`` — an EVENT (session start / track-car change / reconnect). A tap that connects
-    mid-session misses it: sidecar fan-out is topic-agnostic and `publishSessionIfChanged`
-    suppresses the same key until a reconnect/change, so subscribing does not replay it. To assert
-    ``session`` / session-before-lap, tap from session start (``--strict --wait-lap``) or, as a
-    future enhancement, have the trainer re-emit ``session`` to late-attaching subscribers.
+  * ``session`` — an EVENT (session start / track-car change / reconnect). As of #190, a late
+    tap subscribing to ``session`` asks the trainer to re-emit the unchanged current session.
+    Older recordings, or captures that did not send ``state.subscribe``, can still miss it, so
+    window mode keeps it conditional while strict mode requires it.
   * ``lap``   — needs a lap boundary in the window (use ``--wait-lap``).
   * ``delta`` — needs a reference lap (``state.bestSortedTrace``) AND an s/f-aligned clock, so it is
     ALWAYS reported as a note (never required) — requiring it would false-fail a healthy


### PR DESCRIPTION
## Summary
- Adds `tools/ac_harness/custom_ai.py`: pure CSP `cai_car_controls` packer, live-verified `cai_car_data` prefix parser, Windows named-mapping writer/reader, safe `teleport_to=1` reset, first-gear/autoclutch launch helpers, and live `probe`/`drive`/`drive-line` CLI modes.
- Adds `tools/ac_harness/ai_line.py`: conservative `fast_lane.ai` parser matching the trainer Lua stride, Pure Pursuit steering with the live-verified steer sign, and position-return lap detection for hotlap mode.
- Replays the current `session` snapshot when a late external tap subscribes to `session`, so mid-session L1.5 probes get a deterministic session frame without making the sidecar topic-aware.
- Documents the harness entrypoints in `README.md`, updates `sequence_probe` wording, and saves the vault/current-focus resume block for the in-sim gate.

## Verification
- `./.venv/bin/python -m pytest -q tests/test_custom_ai.py tests/test_ai_line.py tests/test_ws_bridge_hello_handshake.py tests/test_sequence_probe.py tests/test_lifecycle_publisher.py` at `fd516a1` -> 64 passed.
- Clean temp worktree `/tmp/acct-pr201-0dbc.2E4LOl` at final head `0dbc784`: `PYTHON=/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python make ci-fast` -> 920 passed, 71 skipped, coverage 84.32%, Bandit/policy/CSP checks OK.
- GitHub checks on the code head `fd516a1`: CI `build`, `Canonical docs exist`, and `conformance` passed; final docs-only head `0dbc784` is expected to rerun those checks after this push.
- CLI smoke on carcsw commit: `python3 tools/ac_harness/custom_ai.py --help` and `python3 -m tools.ac_harness.custom_ai --help`.

## In-sim gate
Draft until the tracked `custom_ai.py drive-line` path is run on the AC rig with Custom AI enabled and observed to move car 0 / complete a position-return lap, then the L1.5 probe is observed receiving the replayed `session` plus lap/coaching sequence. Current blocker is environmental: this checkout is running on macOS, while AC/CSP is Windows-only and the repo handoff records that launching AC still requires the rig/operator control path. The implementation intentionally does not expose `SimState.restart_session`; the live-verified safe reset is `teleport_to=1`.

Refs #190. Follow-on from #180 producer completion.
