### PR TITLE
fix(test): isolate optional MCP smoke (#156)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,30 +2,7 @@
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-from pathlib import Path
-from types import ModuleType
-
 import pytest
-
-
-def load_script_module(module_name: str, path: Path) -> ModuleType:
-    """Load a repo script by file path without putting ``scripts/`` on ``sys.path``."""
-    cached = sys.modules.get(module_name)
-    if isinstance(cached, ModuleType):
-        return cached
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Could not load spec for {module_name} at {path}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    try:
-        spec.loader.exec_module(module)
-    except Exception:
-        sys.modules.pop(module_name, None)
-        raise
-    return module
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,30 @@
 
 from __future__ import annotations
 
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
 import pytest
+
+
+def load_script_module(module_name: str, path: Path) -> ModuleType:
+    """Load a repo script by file path without putting ``scripts/`` on ``sys.path``."""
+    cached = sys.modules.get(module_name)
+    if isinstance(cached, ModuleType):
+        return cached
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load spec for {module_name} at {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/test_gate_classifier_oracle.py
+++ b/tests/test_gate_classifier_oracle.py
@@ -24,13 +24,26 @@ THIS repo on every PR.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load_script_module(module_name: str, path: Path):
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
 
 # #338 SHIM RECONCILIATION: when hook_memory_gate.py is a governance-hub shim, the classifier
 # (`_classify`) lives in the hub, not in the thin delegator — the import below would fail and the
@@ -41,14 +54,17 @@ if "governance shim" in (REPO_ROOT / "scripts" / "hook_memory_gate.py").read_tex
         allow_module_level=True,
     )
 
-from hook_memory_gate import _classify  # noqa: E402
-from hook_memory_manifest import (  # noqa: E402
-    DEFAULT_CODE_PATH_PREFIXES,
-    DEFAULT_CODE_PATH_TOP_LEVEL,
-    load_manifest,
-    oracle_classification_failures,
-    repo_code_path_prefixes,
+_gate = _load_script_module("_test_hook_memory_gate", REPO_ROOT / "scripts" / "hook_memory_gate.py")
+_manifest = _load_script_module(
+    "_test_gate_hook_memory_manifest", REPO_ROOT / "scripts" / "hook_memory_manifest.py"
 )
+
+_classify = _gate._classify
+DEFAULT_CODE_PATH_PREFIXES = _manifest.DEFAULT_CODE_PATH_PREFIXES
+DEFAULT_CODE_PATH_TOP_LEVEL = _manifest.DEFAULT_CODE_PATH_TOP_LEVEL
+load_manifest = _manifest.load_manifest
+oracle_classification_failures = _manifest.oracle_classification_failures
+repo_code_path_prefixes = _manifest.repo_code_path_prefixes
 
 
 def test_oracle_repo_manifest_classifies_declared_dirs_as_code() -> None:

--- a/tests/test_gate_classifier_oracle.py
+++ b/tests/test_gate_classifier_oracle.py
@@ -24,26 +24,12 @@ THIS repo on every PR.
 
 from __future__ import annotations
 
-import importlib.util
-import sys
 from pathlib import Path
 
 import pytest
+from conftest import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-
-
-def _load_script_module(module_name: str, path: Path):
-    cached = sys.modules.get(module_name)
-    if cached is not None:
-        return cached
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
 
 # #338 SHIM RECONCILIATION: when hook_memory_gate.py is a governance-hub shim, the classifier
 # (`_classify`) lives in the hub, not in the thin delegator — the import below would fail and the
@@ -54,9 +40,9 @@ if "governance shim" in (REPO_ROOT / "scripts" / "hook_memory_gate.py").read_tex
         allow_module_level=True,
     )
 
-_gate = _load_script_module("_test_hook_memory_gate", REPO_ROOT / "scripts" / "hook_memory_gate.py")
-_manifest = _load_script_module(
-    "_test_gate_hook_memory_manifest", REPO_ROOT / "scripts" / "hook_memory_manifest.py"
+_gate = load_script_module("_test_hook_memory_gate", REPO_ROOT / "scripts" / "hook_memory_gate.py")
+_manifest = load_script_module(
+    "_test_hook_memory_manifest", REPO_ROOT / "scripts" / "hook_memory_manifest.py"
 )
 
 _classify = _gate._classify

--- a/tests/test_gate_classifier_oracle.py
+++ b/tests/test_gate_classifier_oracle.py
@@ -27,7 +27,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import load_script_module
+
+from tools.testing.script_imports import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_hook_memory_gate.py
+++ b/tests/test_hook_memory_gate.py
@@ -935,11 +935,10 @@ def test_lang_mutation_regex_lookbehind_distinguishes_method_from_builtin() -> N
     tests bring; pins the regex semantics directly for the Cursor PR #194
     MEDIUM finding.
     """
-    import sys
-    from pathlib import Path as _Path
+    from tools.testing.script_imports import load_script_module
 
-    sys.path.insert(0, str(_Path(__file__).resolve().parents[1] / "scripts"))
-    from hook_memory_gate import _indirect_exec_is_mutation
+    hook_memory_gate = load_script_module("_test_hook_memory_gate_regex", SCRIPT)
+    _indirect_exec_is_mutation = hook_memory_gate._indirect_exec_is_mutation
 
     # Bare builtins → mutation (still gated).
     assert _indirect_exec_is_mutation('python -c \'compile("x","<s>","exec")\'')

--- a/tests/test_hook_memory_manifest.py
+++ b/tests/test_hook_memory_manifest.py
@@ -6,29 +6,15 @@ per-repo manifest data so propagation can't clobber child code dirs.
 
 from __future__ import annotations
 
-import importlib.util
-import sys
 from pathlib import Path
+
+from conftest import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-
-def _load_hook_memory_manifest():
-    module_name = "_test_hook_memory_manifest"
-    cached = sys.modules.get(module_name)
-    if cached is not None:
-        return cached
-    spec = importlib.util.spec_from_file_location(
-        module_name, REPO_ROOT / "scripts" / "hook_memory_manifest.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-_manifest = _load_hook_memory_manifest()
+_manifest = load_script_module(
+    "_test_hook_memory_manifest", REPO_ROOT / "scripts" / "hook_memory_manifest.py"
+)
 DEFAULT_CODE_DIR_TOP_LEVEL = _manifest.DEFAULT_CODE_DIR_TOP_LEVEL
 DEFAULT_CODE_PATH_PREFIXES = _manifest.DEFAULT_CODE_PATH_PREFIXES
 DEFAULT_CODE_PATH_TOP_LEVEL = _manifest.DEFAULT_CODE_PATH_TOP_LEVEL

--- a/tests/test_hook_memory_manifest.py
+++ b/tests/test_hook_memory_manifest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from conftest import load_script_module
+from tools.testing.script_imports import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_hook_memory_manifest.py
+++ b/tests/test_hook_memory_manifest.py
@@ -6,22 +6,37 @@ per-repo manifest data so propagation can't clobber child code dirs.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from hook_memory_manifest import (  # noqa: E402 — sys.path tweak above
-    DEFAULT_CODE_DIR_TOP_LEVEL,
-    DEFAULT_CODE_PATH_PREFIXES,
-    DEFAULT_CODE_PATH_TOP_LEVEL,
-    load_repo_section,
-    repo_code_dir_top_level,
-    repo_code_path_prefixes,
-    repo_code_path_top_level,
-    repo_tier3_workspace_id,
-)
+
+def _load_hook_memory_manifest():
+    module_name = "_test_hook_memory_manifest"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(
+        module_name, REPO_ROOT / "scripts" / "hook_memory_manifest.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_manifest = _load_hook_memory_manifest()
+DEFAULT_CODE_DIR_TOP_LEVEL = _manifest.DEFAULT_CODE_DIR_TOP_LEVEL
+DEFAULT_CODE_PATH_PREFIXES = _manifest.DEFAULT_CODE_PATH_PREFIXES
+DEFAULT_CODE_PATH_TOP_LEVEL = _manifest.DEFAULT_CODE_PATH_TOP_LEVEL
+load_repo_section = _manifest.load_repo_section
+repo_code_dir_top_level = _manifest.repo_code_dir_top_level
+repo_code_path_prefixes = _manifest.repo_code_path_prefixes
+repo_code_path_top_level = _manifest.repo_code_path_top_level
+repo_tier3_workspace_id = _manifest.repo_tier3_workspace_id
 
 # ---------------------------------------------------------------------------
 # load_repo_section
@@ -147,7 +162,7 @@ def test_tier3_workspace_id_ignores_empty_string() -> None:
 # ---------------------------------------------------------------------------
 
 
-from hook_memory_manifest import resolve_workspace  # noqa: E402
+resolve_workspace = _manifest.resolve_workspace
 
 
 def _manifest_with_workspaces(*names: str) -> dict:
@@ -216,7 +231,7 @@ def test_resolve_workspace_tier3_id_hyphen_underscore_tolerant(tmp_path: Path) -
 # ---------------------------------------------------------------------------
 
 
-from hook_memory_manifest import _fallback_manifest_from_text  # noqa: E402
+_fallback_manifest_from_text = _manifest._fallback_manifest_from_text
 
 
 def test_fallback_parser_preserves_repo_code_dirs_list() -> None:

--- a/tests/test_hook_repo_root.py
+++ b/tests/test_hook_repo_root.py
@@ -2,14 +2,31 @@
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from hook_repo_root import worktree_root_for  # noqa: E402
+
+def _load_hook_repo_root():
+    module_name = "_test_hook_repo_root"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(
+        module_name, REPO_ROOT / "scripts" / "hook_repo_root.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_hook_repo_root = _load_hook_repo_root()
+worktree_root_for = _hook_repo_root.worktree_root_for
 
 
 def _git(cwd: Path, *args: str) -> None:

--- a/tests/test_hook_repo_root.py
+++ b/tests/test_hook_repo_root.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from conftest import load_script_module
+from tools.testing.script_imports import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 

--- a/tests/test_hook_repo_root.py
+++ b/tests/test_hook_repo_root.py
@@ -2,30 +2,17 @@
 
 from __future__ import annotations
 
-import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
+from conftest import load_script_module
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-
-def _load_hook_repo_root():
-    module_name = "_test_hook_repo_root"
-    cached = sys.modules.get(module_name)
-    if cached is not None:
-        return cached
-    spec = importlib.util.spec_from_file_location(
-        module_name, REPO_ROOT / "scripts" / "hook_repo_root.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-_hook_repo_root = _load_hook_repo_root()
+_hook_repo_root = load_script_module(
+    "_test_hook_repo_root", REPO_ROOT / "scripts" / "hook_repo_root.py"
+)
 worktree_root_for = _hook_repo_root.worktree_root_for
 
 

--- a/tests/test_memory_endpoint_resolver.py
+++ b/tests/test_memory_endpoint_resolver.py
@@ -10,19 +10,35 @@ within the Tailscale trust boundary (registry-named host or ``*.ts.net`` /
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
-from hook_memory_manifest import (  # noqa: E402
-    EndpointCandidate,
-    _is_tailnet_shaped,
-    _split_endpoint,
-    resolve_memory_endpoints,
-)
+
+def _load_hook_memory_manifest():
+    module_name = "_test_hook_memory_manifest_endpoint"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(
+        module_name, REPO_ROOT / "scripts" / "hook_memory_manifest.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_manifest = _load_hook_memory_manifest()
+EndpointCandidate = _manifest.EndpointCandidate
+_is_tailnet_shaped = _manifest._is_tailnet_shaped
+_split_endpoint = _manifest._split_endpoint
+resolve_memory_endpoints = _manifest.resolve_memory_endpoints
 
 WORKSPACE = "agent_factory_steward"
 TSNET_HOST = "m2pro.tail31ce1b.ts.net"

--- a/tests/test_memory_endpoint_resolver.py
+++ b/tests/test_memory_endpoint_resolver.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import load_script_module
+
+from tools.testing.script_imports import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_memory_endpoint_resolver.py
+++ b/tests/test_memory_endpoint_resolver.py
@@ -10,31 +10,16 @@ within the Tailscale trust boundary (registry-named host or ``*.ts.net`` /
 
 from __future__ import annotations
 
-import importlib.util
-import sys
 from pathlib import Path
 
 import pytest
+from conftest import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-
-def _load_hook_memory_manifest():
-    module_name = "_test_hook_memory_manifest_endpoint"
-    cached = sys.modules.get(module_name)
-    if cached is not None:
-        return cached
-    spec = importlib.util.spec_from_file_location(
-        module_name, REPO_ROOT / "scripts" / "hook_memory_manifest.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-_manifest = _load_hook_memory_manifest()
+_manifest = load_script_module(
+    "_test_hook_memory_manifest", REPO_ROOT / "scripts" / "hook_memory_manifest.py"
+)
 EndpointCandidate = _manifest.EndpointCandidate
 _is_tailnet_shaped = _manifest._is_tailnet_shaped
 _split_endpoint = _manifest._split_endpoint

--- a/tests/test_script_imports.py
+++ b/tests/test_script_imports.py
@@ -1,0 +1,43 @@
+"""Tests for script-import helpers used by repo hook tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.testing.script_imports import load_script_module
+
+
+def test_load_script_module_supports_sibling_import_without_sys_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sibling_name = "_test_script_imports_sibling"
+    monkeypatch.delitem(sys.modules, sibling_name, raising=False)
+    monkeypatch.delitem(sys.modules, "_test_script_imports_parent", raising=False)
+    (tmp_path / f"{sibling_name}.py").write_text("VALUE = 'loaded sibling'\n", encoding="utf-8")
+    (tmp_path / "parent.py").write_text(
+        f"import {sibling_name}\nVALUE = {sibling_name}.VALUE\n",
+        encoding="utf-8",
+    )
+    before_path = list(sys.path)
+
+    module = load_script_module("_test_script_imports_parent", tmp_path / "parent.py")
+
+    assert module.VALUE == "loaded sibling"
+    assert sys.path == before_path
+
+
+def test_load_script_module_rejects_module_name_path_collision(tmp_path: Path) -> None:
+    first = tmp_path / "first.py"
+    second = tmp_path / "second.py"
+    first.write_text("VALUE = 'first'\n", encoding="utf-8")
+    second.write_text("VALUE = 'second'\n", encoding="utf-8")
+
+    module = load_script_module("_test_script_imports_collision", first)
+
+    assert module.VALUE == "first"
+    with pytest.raises(ImportError, match="already loaded"):
+        load_script_module("_test_script_imports_collision", second)

--- a/tools/testing/__init__.py
+++ b/tools/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Test support helpers."""

--- a/tools/testing/script_imports.py
+++ b/tools/testing/script_imports.py
@@ -1,0 +1,36 @@
+"""Helpers for importing repo scripts in tests without mutating ``sys.path``."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def load_script_module(module_name: str, path: Path) -> ModuleType:
+    """Load a repo script by file path without putting its directory on ``sys.path``."""
+    resolved_path = path.resolve()
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        if not isinstance(cached, ModuleType):
+            raise ImportError(f"{module_name!r} is already bound to a non-module object")
+        cached_path = getattr(cached, "__file__", None)
+        if cached_path is not None and Path(cached_path).resolve() == resolved_path:
+            return cached
+        raise ImportError(
+            f"{module_name!r} is already loaded from {cached_path!r}; "
+            f"refusing to reuse it for {resolved_path}"
+        )
+
+    spec = importlib.util.spec_from_file_location(module_name, resolved_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load spec for {module_name} at {resolved_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module

--- a/tools/testing/script_imports.py
+++ b/tools/testing/script_imports.py
@@ -2,10 +2,44 @@
 
 from __future__ import annotations
 
+import importlib.abc
+import importlib.machinery
 import importlib.util
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
+
+
+class _SiblingScriptFinder(importlib.abc.MetaPathFinder):
+    """Import same-directory script modules without exposing packages on ``sys.path``."""
+
+    def __init__(self, script_dir: Path) -> None:
+        self._script_dir = script_dir
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object | None,
+        target: ModuleType | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if "." in fullname:
+            return None
+        candidate = self._script_dir / f"{fullname}.py"
+        if not candidate.is_file():
+            return None
+        return importlib.util.spec_from_file_location(fullname, candidate)
+
+
+@contextmanager
+def _sibling_script_imports(script_dir: Path) -> Iterator[None]:
+    finder = _SiblingScriptFinder(script_dir)
+    sys.meta_path.insert(0, finder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
 
 
 def load_script_module(module_name: str, path: Path) -> ModuleType:
@@ -29,7 +63,8 @@ def load_script_module(module_name: str, path: Path) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     try:
-        spec.loader.exec_module(module)
+        with _sibling_script_imports(resolved_path.parent):
+            spec.loader.exec_module(module)
     except Exception:
         sys.modules.pop(module_name, None)
         raise


### PR DESCRIPTION
## Summary
- Preserve the current `main` FastMCP availability guard for the optional MCP smoke, which skips when `mcp.server.fastmcp` is unavailable or only the repo-local `scripts/mcp` namespace is visible.
- Replace `scripts/` `sys.path` imports in hook/manifest tests with file-based imports via `tools.testing.script_imports.load_script_module`.
- Make the shared script loader path-aware so a reused module name cannot silently return a module loaded from a different script file.
- Support same-directory sibling script imports during direct file loading without leaving `scripts/` on `sys.path` or exposing `scripts/mcp/` as a namespace package.

Fixes #156.

## Verification
- `.scratch/venv-issue156/bin/python -m pytest tests/test_script_imports.py tests/test_memory_endpoint_resolver.py tests/test_hook_memory_manifest.py tests/test_hook_repo_root.py tests/test_hook_memory_gate.py tests/test_gate_classifier_oracle.py tests/test_repo_knowledge/ -q` -> 70 passed, 3 skipped.
- `/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python -m pytest tests/test_repo_knowledge/test_mcp_server_import.py -q` -> 1 passed with `mcp.server.fastmcp` installed.
- `make ci-fast PYTHON=.scratch/venv-issue156/bin/python` -> OK: 928 passed, 75 skipped.