### PR TITLE
feat(sidecar): add telemetry haptic peripheral protocol (#118)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
@@ -2,7 +2,7 @@
 type: decision
 status: active
 created: 2026-04-21
-updated: 2026-04-21
+updated: 2026-06-16
 relates_to:
   - AcCopilotTrainer/03_Investigations/csp-web-socket-api.md
   - AcCopilotTrainer/10_Rig/esp32-jc3248w535-screen-v1.md
@@ -39,11 +39,12 @@ We want a **second** WS client — the rig-mounted ESP32 touchscreen — to read
    | Lua/sidecar → haptics | `haptic_event` | `{ event, channel, intensity, duration_ms, ts_sim? }` |
 
    `client_class` is optional for backward compatibility. Known classes:
-   `external`, `lua`, `screen`, `haptics`, `physical`, `browser`. The
-   sidecar uses classes only for high-rate physical-peripheral routing:
-   `telemetry_tick` goes to `screen`, `haptics`, and `physical`; `haptic_event`
-   goes to `haptics` and `physical`. Neither message is echoed back to the Lua
-   peer.
+   `external`, `lua`, `screen`, `haptics`, `physical`, `browser`. Legacy
+   firmware clients whose `client` starts with `ac-copilot-screen` are treated
+   as `screen` even when they omit `client_class`. The sidecar uses classes only
+   for high-rate physical-peripheral routing: `telemetry_tick` goes to `screen`,
+   `haptics`, and `physical`; `haptic_event` goes to `haptics` and `physical`.
+   Neither message is echoed back to the Lua peer.
 
 3. **Physical peripheral payloads.**
 
@@ -52,7 +53,8 @@ We want a **second** WS client — the rig-mounted ESP32 touchscreen — to read
    `speed_kmh`, `rpm`, `gear`, `throttle` (0-1), `brake` (0-1), `steer`
    (-1..1), `lat_g`, and `long_g`. Optional fields include `lap_time_ms`,
    `slip`, `abs_active`, `brake_lock`, `wheel_lock`, `tyre_temps_c`, and
-   `tyre_pressures_psi`; tyre maps use `fl`, `fr`, `rl`, `rr`.
+   `tyre_pressures_psi`; tyre maps may include any non-empty subset of `fl`,
+   `fr`, `rl`, `rr`.
 
    `haptic_event` is a bounded actuator command for a haptic peripheral.
    Expected cadence: event-driven, capped by the sidecar at 25 Hz per

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
@@ -25,7 +25,7 @@ We want a **second** WS client — the rig-mounted ESP32 touchscreen — to read
 
    | Direction | Type | Body |
    |---|---|---|
-   | client → server | `hello` | `{ client }` |
+   | client → server | `hello` | `{ client, client_class? }` |
    | server → client | `hello_ack` | `{ server_version, capabilities[] }` |
    | client → server | `config.get` | `{ key }` |
    | server → client | `config.value` | `{ key, value }` |
@@ -35,14 +35,39 @@ We want a **second** WS client — the rig-mounted ESP32 touchscreen — to read
    | server → client | `action.ack` | `{ name, applied: bool, reason?: string }` |
    | client → server | `state.subscribe` / `state.unsubscribe` | `{ topics: [...] }` |
    | server → client | `state.snapshot` | `{ topic, payload, ts_sim }` |
+   | Lua/sidecar → peripheral | `telemetry_tick` | `{ seq?, ts_sim?, payload }` |
+   | Lua/sidecar → haptics | `haptic_event` | `{ event, channel, intensity, duration_ms, ts_sim? }` |
 
-3. **Auth and binding.**
+   `client_class` is optional for backward compatibility. Known classes:
+   `external`, `lua`, `screen`, `haptics`, `physical`, `browser`. The
+   sidecar uses classes only for high-rate physical-peripheral routing:
+   `telemetry_tick` goes to `screen`, `haptics`, and `physical`; `haptic_event`
+   goes to `haptics` and `physical`. Neither message is echoed back to the Lua
+   peer.
+
+3. **Physical peripheral payloads.**
+
+   `telemetry_tick` is the normalized sim sample for physical clients. Expected
+   cadence: 10-20 Hz, capped by the sidecar at 20 Hz. Required payload fields:
+   `speed_kmh`, `rpm`, `gear`, `throttle` (0-1), `brake` (0-1), `steer`
+   (-1..1), `lat_g`, and `long_g`. Optional fields include `lap_time_ms`,
+   `slip`, `abs_active`, `brake_lock`, `wheel_lock`, `tyre_temps_c`, and
+   `tyre_pressures_psi`; tyre maps use `fl`, `fr`, `rl`, `rr`.
+
+   `haptic_event` is a bounded actuator command for a haptic peripheral.
+   Expected cadence: event-driven, capped by the sidecar at 25 Hz per
+   `(event, channel)`. Required fields: `event` (`pedal_rumble`, `slip_buzz`,
+   `lateral_g`, `wind`, `gear_shift`), `channel` (`pedal`, `pedal_left`,
+   `pedal_right`, `seat_left`, `seat_right`, `fan`, `shaker`), `intensity`
+   (0-1), and `duration_ms` (1-1000).
+
+4. **Auth and binding.**
    - Default sidecar bind stays `127.0.0.1:8765`. **No regression** for users who never connect an external client.
    - New sidecar CLI flag `--external-bind <host>` (e.g. `0.0.0.0`) requires `--token <secret>` for non-loopback binds, or the sidecar refuses to start.
    - External clients must send `X-AC-Copilot-Token: <secret>` on the WS upgrade request. Missing/wrong token → 401 and immediate close.
    - Token lives in `firmware/screen/secrets/sidecar.h` (gitignored) on the ESP32 side; the sidecar reads it from `--token`.
 
-4. **Config key surface.** Expose the existing `CONFIG_DEFAULTS` keys through the new messages. No new storage — reuse the per-key `ac.storage("<key>_v1", default)` pattern already in `ac_copilot_trainer.lua`. The Lua side handler in `ws_bridge.pollInbound` writes via the existing wrappers.
+5. **Config key surface.** Expose the existing `CONFIG_DEFAULTS` keys through the new messages. No new storage — reuse the per-key `ac.storage("<key>_v1", default)` pattern already in `ac_copilot_trainer.lua`. The Lua side handler in `ws_bridge.pollInbound` writes via the existing wrappers.
 
 ## Consequences
 

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -134,6 +134,8 @@ def test_validate_inbound_accepts_known_types() -> None:
     assert ep.validate_inbound({"v": 1, "type": "action", "name": "toggleFocusPractice"}) is None
     assert ep.validate_inbound({"v": 1, "type": "state.subscribe", "topics": ["lap"]}) is None
     assert ep.validate_inbound(_telemetry_tick()) is None
+    assert ep.validate_inbound(_telemetry_tick(slip=-0.35)) is None
+    assert ep.validate_inbound(_telemetry_tick(tyre_temps_c={"fl": 74.1})) is None
     assert ep.validate_inbound(_haptic_event()) is None
 
 
@@ -157,6 +159,18 @@ def test_validate_inbound_rejects_invalid() -> None:
     )
     assert "payload" in (ep.validate_inbound({"v": 1, "type": "telemetry_tick"}) or "")
     assert "throttle must be <= 1" in (ep.validate_inbound(_telemetry_tick(throttle=1.2)) or "")
+    assert "lap_time_ms must be >= 0" in (
+        ep.validate_inbound(_telemetry_tick(lap_time_ms=-1)) or ""
+    )
+    assert "requires at least one corner" in (
+        ep.validate_inbound(_telemetry_tick(tyre_temps_c={})) or ""
+    )
+    assert "not a known corner" in (
+        ep.validate_inbound(_telemetry_tick(tyre_temps_c={"front_left": 74.1})) or ""
+    )
+    assert "tyre_temps_c.fl requires a finite number" in (
+        ep.validate_inbound(_telemetry_tick(tyre_temps_c={"fl": "hot"})) or ""
+    )
     assert "intensity must be <= 1" in (ep.validate_inbound(_haptic_event(intensity=1.4)) or "")
     assert "unknown type" in (ep.validate_inbound({"v": 1, "type": "explode"}) or "")
 
@@ -385,7 +399,7 @@ def test_telemetry_tick_routes_to_physical_clients_and_generates_haptic_event() 
                 ws_connect(f"ws://127.0.0.1:{port}/") as haptics,
             ):
                 await _hello(lua, "trainer-lua", ep.CLIENT_CLASS_LUA)
-                await _hello(screen, "screen-01", ep.CLIENT_CLASS_SCREEN)
+                await _hello(screen, "ac-copilot-screen-01")
                 await _hello(haptics, "uno-haptics-01", ep.CLIENT_CLASS_HAPTICS)
 
                 await lua.send(json.dumps(_telemetry_tick(), separators=(",", ":")))
@@ -405,6 +419,40 @@ def test_telemetry_tick_routes_to_physical_clients_and_generates_haptic_event() 
     assert haptics_second["channel"] == "pedal"
     assert haptics_second["intensity"] == pytest.approx(0.84)
     assert ep.validate_inbound(haptics_second) is None
+
+
+def test_telemetry_tick_without_ts_sim_still_generates_haptic_event() -> None:
+    """Derived haptic events omit absent timestamps instead of failing validation."""
+
+    async def _hello(ws, client: str, client_class: str) -> None:
+        await ws.send(
+            json.dumps({"v": 1, "type": "hello", "client": client, "client_class": client_class})
+        )
+        await asyncio.wait_for(ws.recv(), timeout=2.0)
+
+    async def _run() -> dict:
+        async with _running_sidecar() as port:
+            async with (
+                ws_connect(f"ws://127.0.0.1:{port}/") as lua,
+                ws_connect(f"ws://127.0.0.1:{port}/") as haptics,
+            ):
+                await _hello(lua, "trainer-lua", ep.CLIENT_CLASS_LUA)
+                await _hello(haptics, "uno-haptics-01", ep.CLIENT_CLASS_HAPTICS)
+                frame = _telemetry_tick(abs_active=False, brake=0.0, slip=-0.35)
+                frame.pop("ts_sim")
+
+                await lua.send(json.dumps(frame, separators=(",", ":")))
+                haptics_first = json.loads(await asyncio.wait_for(haptics.recv(), timeout=2.0))
+                haptics_second = json.loads(await asyncio.wait_for(haptics.recv(), timeout=2.0))
+                assert haptics_first["type"] == ep.TYPE_TELEMETRY_TICK
+                return haptics_second
+
+    event = asyncio.run(_run())
+    assert event["type"] == ep.TYPE_HAPTIC_EVENT
+    assert event["event"] == "slip_buzz"
+    assert event["intensity"] == pytest.approx(0.35)
+    assert "ts_sim" not in event
+    assert ep.validate_inbound(event) is None
 
 
 def test_haptic_event_routes_only_to_haptics_class_clients() -> None:

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -28,9 +28,10 @@ from websockets.asyncio.server import serve as ws_serve  # noqa: E402
 
 from tools.ai_sidecar import external_protocol as ep  # noqa: E402
 from tools.ai_sidecar.server import (  # noqa: E402
-    _external_peers,
     _handler,
     _is_loopback,
+    _RateLimiter,
+    _reset_external_state,
     make_token_check,
 )
 
@@ -48,7 +49,7 @@ def _free_port() -> int:
 async def _running_sidecar(token: str | None = None) -> AsyncIterator[int]:
     port = _free_port()
     process_request = make_token_check(token)
-    _external_peers.clear()
+    _reset_external_state()
     try:
         async with ws_serve(
             lambda ws: _handler(ws, reply_coaching=True),
@@ -58,7 +59,45 @@ async def _running_sidecar(token: str | None = None) -> AsyncIterator[int]:
         ):
             yield port
     finally:
-        _external_peers.clear()
+        _reset_external_state()
+
+
+def _telemetry_tick(**payload_overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "speed_kmh": 112.0,
+        "rpm": 5400.0,
+        "gear": 3,
+        "throttle": 0.72,
+        "brake": 0.84,
+        "steer": -0.13,
+        "lat_g": 0.42,
+        "long_g": -0.78,
+        "lap_time_ms": 42123.0,
+        "abs_active": True,
+        "tyre_temps_c": {"fl": 74.1, "fr": 73.8, "rl": 72.4, "rr": 72.9},
+    }
+    payload.update(payload_overrides)
+    return {
+        "v": 1,
+        "type": ep.TYPE_TELEMETRY_TICK,
+        "seq": 7,
+        "ts_sim": 123.45,
+        "payload": payload,
+    }
+
+
+def _haptic_event(**overrides: object) -> dict[str, object]:
+    frame: dict[str, object] = {
+        "v": 1,
+        "type": ep.TYPE_HAPTIC_EVENT,
+        "event": "pedal_rumble",
+        "channel": "pedal",
+        "intensity": 0.8,
+        "duration_ms": 80,
+        "ts_sim": 123.45,
+    }
+    frame.update(overrides)
+    return frame
 
 
 def test_make_token_check_returns_none_without_token() -> None:
@@ -76,6 +115,17 @@ def test_is_loopback_classification() -> None:
 
 def test_validate_inbound_accepts_known_types() -> None:
     assert ep.validate_inbound({"v": 1, "type": "hello", "client": "screen-01"}) is None
+    assert (
+        ep.validate_inbound(
+            {
+                "v": 1,
+                "type": "hello",
+                "client": "uno-haptics-01",
+                "client_class": ep.CLIENT_CLASS_HAPTICS,
+            }
+        )
+        is None
+    )
     assert ep.validate_inbound({"v": 1, "type": "config.get", "key": "hudEnabled"}) is None
     assert (
         ep.validate_inbound({"v": 1, "type": "config.set", "key": "hudEnabled", "value": True})
@@ -83,6 +133,8 @@ def test_validate_inbound_accepts_known_types() -> None:
     )
     assert ep.validate_inbound({"v": 1, "type": "action", "name": "toggleFocusPractice"}) is None
     assert ep.validate_inbound({"v": 1, "type": "state.subscribe", "topics": ["lap"]}) is None
+    assert ep.validate_inbound(_telemetry_tick()) is None
+    assert ep.validate_inbound(_haptic_event()) is None
 
 
 def test_validate_inbound_rejects_invalid() -> None:
@@ -91,6 +143,10 @@ def test_validate_inbound_rejects_invalid() -> None:
         ep.validate_inbound({"v": True, "type": "hello", "client": "screen-01"}) or ""
     )
     assert "non-empty 'client'" in (ep.validate_inbound({"v": 1, "type": "hello"}) or "")
+    assert "unknown client_class" in (
+        ep.validate_inbound({"v": 1, "type": "hello", "client": "x", "client_class": "toaster"})
+        or ""
+    )
     assert "non-empty 'key'" in (ep.validate_inbound({"v": 1, "type": "config.get"}) or "")
     assert "value" in (ep.validate_inbound({"v": 1, "type": "config.set", "key": "k"}) or "")
     assert "unknown action" in (
@@ -99,6 +155,9 @@ def test_validate_inbound_rejects_invalid() -> None:
     assert "unknown topic" in (
         ep.validate_inbound({"v": 1, "type": "state.subscribe", "topics": ["pit_window"]}) or ""
     )
+    assert "payload" in (ep.validate_inbound({"v": 1, "type": "telemetry_tick"}) or "")
+    assert "throttle must be <= 1" in (ep.validate_inbound(_telemetry_tick(throttle=1.2)) or "")
+    assert "intensity must be <= 1" in (ep.validate_inbound(_haptic_event(intensity=1.4)) or "")
     assert "unknown type" in (ep.validate_inbound({"v": 1, "type": "explode"}) or "")
 
 
@@ -306,3 +365,105 @@ def test_config_set_round_trip_via_hub() -> None:
     assert forwarded["value"] is False
     assert ack_back["type"] == "config.ack"
     assert ack_back["applied"] is True
+
+
+def test_telemetry_tick_routes_to_physical_clients_and_generates_haptic_event() -> None:
+    """Fixture telemetry from Lua reaches physical clients and derives a haptic event."""
+
+    async def _hello(ws, client: str, client_class: str | None = None) -> dict:
+        frame: dict[str, object] = {"v": 1, "type": "hello", "client": client}
+        if client_class is not None:
+            frame["client_class"] = client_class
+        await ws.send(json.dumps(frame))
+        return json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+
+    async def _run() -> tuple[dict, dict, dict]:
+        async with _running_sidecar() as port:
+            async with (
+                ws_connect(f"ws://127.0.0.1:{port}/") as lua,
+                ws_connect(f"ws://127.0.0.1:{port}/") as screen,
+                ws_connect(f"ws://127.0.0.1:{port}/") as haptics,
+            ):
+                await _hello(lua, "trainer-lua", ep.CLIENT_CLASS_LUA)
+                await _hello(screen, "screen-01", ep.CLIENT_CLASS_SCREEN)
+                await _hello(haptics, "uno-haptics-01", ep.CLIENT_CLASS_HAPTICS)
+
+                await lua.send(json.dumps(_telemetry_tick(), separators=(",", ":")))
+                screen_frame = json.loads(await asyncio.wait_for(screen.recv(), timeout=2.0))
+                haptics_first = json.loads(await asyncio.wait_for(haptics.recv(), timeout=2.0))
+                haptics_second = json.loads(await asyncio.wait_for(haptics.recv(), timeout=2.0))
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(lua.recv(), timeout=0.1)
+                return screen_frame, haptics_first, haptics_second
+
+    screen_frame, haptics_first, haptics_second = asyncio.run(_run())
+    assert screen_frame["type"] == ep.TYPE_TELEMETRY_TICK
+    assert screen_frame["payload"]["speed_kmh"] == 112.0
+    assert haptics_first["type"] == ep.TYPE_TELEMETRY_TICK
+    assert haptics_second["type"] == ep.TYPE_HAPTIC_EVENT
+    assert haptics_second["event"] == "pedal_rumble"
+    assert haptics_second["channel"] == "pedal"
+    assert haptics_second["intensity"] == pytest.approx(0.84)
+    assert ep.validate_inbound(haptics_second) is None
+
+
+def test_haptic_event_routes_only_to_haptics_class_clients() -> None:
+    async def _hello(ws, client: str, client_class: str) -> None:
+        await ws.send(
+            json.dumps({"v": 1, "type": "hello", "client": client, "client_class": client_class})
+        )
+        await asyncio.wait_for(ws.recv(), timeout=2.0)
+
+    async def _run() -> dict:
+        async with _running_sidecar() as port:
+            async with (
+                ws_connect(f"ws://127.0.0.1:{port}/") as lua,
+                ws_connect(f"ws://127.0.0.1:{port}/") as screen,
+                ws_connect(f"ws://127.0.0.1:{port}/") as haptics,
+            ):
+                await _hello(lua, "trainer-lua", ep.CLIENT_CLASS_LUA)
+                await _hello(screen, "screen-01", ep.CLIENT_CLASS_SCREEN)
+                await _hello(haptics, "uno-haptics-01", ep.CLIENT_CLASS_HAPTICS)
+                await lua.send(json.dumps(_haptic_event(), separators=(",", ":")))
+                routed = json.loads(await asyncio.wait_for(haptics.recv(), timeout=2.0))
+                for ws in (lua, screen):
+                    with pytest.raises(asyncio.TimeoutError):
+                        await asyncio.wait_for(ws.recv(), timeout=0.1)
+                return routed
+
+    routed = asyncio.run(_run())
+    assert routed["type"] == ep.TYPE_HAPTIC_EVENT
+    assert routed["event"] == "pedal_rumble"
+
+
+def test_telemetry_tick_with_no_physical_client_is_noop_not_lua_echo() -> None:
+    async def _run() -> None:
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as lua:
+                await lua.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "hello",
+                            "client": "trainer-lua",
+                            "client_class": ep.CLIENT_CLASS_LUA,
+                        }
+                    )
+                )
+                await asyncio.wait_for(lua.recv(), timeout=2.0)
+                await lua.send(json.dumps(_telemetry_tick(), separators=(",", ":")))
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(lua.recv(), timeout=0.1)
+
+    asyncio.run(_run())
+
+
+def test_peripheral_rate_limiter_blocks_until_interval_elapsed() -> None:
+    now = [100.0]
+    limiter = _RateLimiter(clock=lambda: now[0])
+    assert limiter.allow(("telemetry_tick",), max_hz=20.0)
+    assert not limiter.allow(("telemetry_tick",), max_hz=20.0)
+    now[0] += 0.049
+    assert not limiter.allow(("telemetry_tick",), max_hz=20.0)
+    now[0] += 0.001
+    assert limiter.allow(("telemetry_tick",), max_hz=20.0)

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -11,6 +11,7 @@ All frames are JSON objects. Unknown ``type`` values are rejected by
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 # Envelope key that identifies a v1 external-client frame.
@@ -18,6 +19,30 @@ ENVELOPE_KEY = "v"
 ENVELOPE_VERSION = 1
 TYPE_KEY = "type"
 SERVER_VERSION = "1.0.0"
+CLIENT_CLASS_KEY = "client_class"
+
+# Optional client classes advertised in `hello`. Existing clients that omit the
+# field keep working as generic external peers.
+CLIENT_CLASS_EXTERNAL = "external"
+CLIENT_CLASS_LUA = "lua"
+CLIENT_CLASS_SCREEN = "screen"
+CLIENT_CLASS_HAPTICS = "haptics"
+CLIENT_CLASS_PHYSICAL = "physical"
+CLIENT_CLASS_BROWSER = "browser"
+KNOWN_CLIENT_CLASSES: frozenset[str] = frozenset(
+    {
+        CLIENT_CLASS_EXTERNAL,
+        CLIENT_CLASS_LUA,
+        CLIENT_CLASS_SCREEN,
+        CLIENT_CLASS_HAPTICS,
+        CLIENT_CLASS_PHYSICAL,
+        CLIENT_CLASS_BROWSER,
+    }
+)
+PHYSICAL_CLIENT_CLASSES: frozenset[str] = frozenset(
+    {CLIENT_CLASS_SCREEN, CLIENT_CLASS_HAPTICS, CLIENT_CLASS_PHYSICAL}
+)
+HAPTIC_CLIENT_CLASSES: frozenset[str] = frozenset({CLIENT_CLASS_HAPTICS, CLIENT_CLASS_PHYSICAL})
 
 # Client → server.
 TYPE_HELLO = "hello"
@@ -43,6 +68,32 @@ TYPE_ERROR = "error"
 # Issue #86 Part D: replies to the screen for setup operations.
 TYPE_SETUP_LIST_RESULT = "setup.list.result"
 TYPE_SETUP_LOAD_ACK = "setup.load.ack"
+# Issue #118: high-rate physical-peripheral frames. `telemetry_tick` is sent
+# from the Lua loopback peer to physical clients; the sidecar can derive and
+# route `haptic_event` frames to haptic-class clients.
+TYPE_TELEMETRY_TICK = "telemetry_tick"
+TYPE_HAPTIC_EVENT = "haptic_event"
+
+KNOWN_HAPTIC_EVENTS: frozenset[str] = frozenset(
+    {
+        "pedal_rumble",
+        "slip_buzz",
+        "lateral_g",
+        "wind",
+        "gear_shift",
+    }
+)
+KNOWN_HAPTIC_CHANNELS: frozenset[str] = frozenset(
+    {
+        "pedal",
+        "pedal_left",
+        "pedal_right",
+        "seat_left",
+        "seat_right",
+        "fan",
+        "shaker",
+    }
+)
 
 # Capabilities advertised in `hello_ack` so clients can branch on optional
 # server features without a v2 bump.
@@ -51,6 +102,8 @@ SERVER_CAPABILITIES: tuple[str, ...] = (
     TYPE_CONFIG_SET,
     TYPE_ACTION,
     TYPE_STATE_SUBSCRIBE,
+    TYPE_TELEMETRY_TICK,
+    TYPE_HAPTIC_EVENT,
 )
 
 # Names a client may invoke via `action`. Mirrors the Lua dispatcher in
@@ -114,6 +167,126 @@ def make_error(message: str, *, ref_type: str | None = None) -> dict[str, Any]:
     return out
 
 
+def _is_finite_number(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int | float)
+        and math.isfinite(float(value))
+    )
+
+
+def _validate_number(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    min_value: float | None = None,
+    max_value: float | None = None,
+) -> str | None:
+    value = payload.get(key)
+    if not _is_finite_number(value):
+        return f"{key} requires a finite number"
+    f_value = float(value)
+    if min_value is not None and f_value < min_value:
+        return f"{key} must be >= {min_value:g}"
+    if max_value is not None and f_value > max_value:
+        return f"{key} must be <= {max_value:g}"
+    return None
+
+
+def _validate_optional_number(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    min_value: float | None = None,
+    max_value: float | None = None,
+) -> str | None:
+    if key not in payload:
+        return None
+    return _validate_number(payload, key, min_value=min_value, max_value=max_value)
+
+
+def _validate_corner_number_map(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return f"{key} requires an object"
+    for corner in ("fl", "fr", "rl", "rr"):
+        if corner not in value:
+            return f"{key} requires '{corner}'"
+        if not _is_finite_number(value[corner]):
+            return f"{key}.{corner} requires a finite number"
+    return None
+
+
+def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
+    err = _validate_optional_number(frame, "ts_sim", min_value=0)
+    if err is not None:
+        return err
+    seq = frame.get("seq")
+    if seq is not None and (isinstance(seq, bool) or not isinstance(seq, int) or seq < 0):
+        return "seq must be a non-negative integer"
+    payload = frame.get("payload")
+    if not isinstance(payload, dict):
+        return "telemetry_tick requires object 'payload'"
+    required_ranges = {
+        "speed_kmh": (0, None),
+        "rpm": (0, None),
+        "throttle": (0, 1),
+        "brake": (0, 1),
+        "steer": (-1, 1),
+        "lat_g": (None, None),
+        "long_g": (None, None),
+    }
+    for key, (min_value, max_value) in required_ranges.items():
+        err = _validate_number(payload, key, min_value=min_value, max_value=max_value)
+        if err is not None:
+            return err
+    gear = payload.get("gear")
+    if isinstance(gear, bool) or not isinstance(gear, int | str):
+        return "gear requires an integer or string"
+    for key in ("lap_time_ms", "slip"):
+        err = _validate_optional_number(payload, key, min_value=0)
+        if err is not None:
+            return err
+    for key in ("tyre_temps_c", "tyre_pressures_psi"):
+        err = _validate_corner_number_map(payload, key)
+        if err is not None:
+            return err
+    for key in ("abs_active", "brake_lock", "wheel_lock"):
+        if key in payload and not isinstance(payload[key], bool):
+            return f"{key} must be a boolean"
+    return None
+
+
+def _validate_haptic_event(frame: dict[str, Any]) -> str | None:
+    err = _validate_optional_number(frame, "ts_sim", min_value=0)
+    if err is not None:
+        return err
+    event = frame.get("event")
+    if not isinstance(event, str) or not event:
+        return "haptic_event requires non-empty 'event'"
+    if event not in KNOWN_HAPTIC_EVENTS:
+        return f"unknown haptic event: {event!r}"
+    channel = frame.get("channel")
+    if not isinstance(channel, str) or not channel:
+        return "haptic_event requires non-empty 'channel'"
+    if channel not in KNOWN_HAPTIC_CHANNELS:
+        return f"unknown haptic channel: {channel!r}"
+    err = _validate_number(frame, "intensity", min_value=0, max_value=1)
+    if err is not None:
+        return err
+    duration_ms = frame.get("duration_ms")
+    if (
+        isinstance(duration_ms, bool)
+        or not isinstance(duration_ms, int)
+        or duration_ms < 1
+        or duration_ms > 1000
+    ):
+        return "duration_ms must be an integer between 1 and 1000"
+    return None
+
+
 def validate_inbound(frame: dict[str, Any]) -> str | None:
     """Return ``None`` if ``frame`` is structurally valid, else an error string."""
     version = frame.get(ENVELOPE_KEY)
@@ -125,6 +298,10 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
     if t == TYPE_HELLO:
         if not isinstance(frame.get("client"), str) or not frame["client"]:
             return "hello requires non-empty 'client'"
+        client_class = frame.get(CLIENT_CLASS_KEY)
+        if client_class is not None:
+            if not isinstance(client_class, str) or client_class not in KNOWN_CLIENT_CLASSES:
+                return f"unknown client_class: {client_class!r}"
         return None
     if t == TYPE_CONFIG_GET:
         if not isinstance(frame.get("key"), str) or not frame["key"]:
@@ -161,6 +338,10 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
     if t in (TYPE_SETUP_LIST_RESULT, TYPE_SETUP_LOAD_ACK):
         # Server-to-client replies forwarded from the Lua peer — accept silently.
         return None
+    if t == TYPE_TELEMETRY_TICK:
+        return _validate_telemetry_tick(frame)
+    if t == TYPE_HAPTIC_EVENT:
+        return _validate_haptic_event(frame)
     if t in (TYPE_STATE_SUBSCRIBE, TYPE_STATE_UNSUBSCRIBE):
         topics = frame.get("topics")
         if not isinstance(topics, list) or not topics:

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -206,14 +206,17 @@ def _validate_optional_number(
 
 
 def _validate_corner_number_map(payload: dict[str, Any], key: str) -> str | None:
-    value = payload.get(key)
-    if value is None:
+    if key not in payload:
         return None
+    value = payload[key]
     if not isinstance(value, dict):
         return f"{key} requires an object"
-    for corner in ("fl", "fr", "rl", "rr"):
-        if corner not in value:
-            return f"{key} requires '{corner}'"
+    if not value:
+        return f"{key} requires at least one corner"
+    known_corners = frozenset({"fl", "fr", "rl", "rr"})
+    for corner in value:
+        if corner not in known_corners:
+            return f"{key}.{corner} is not a known corner"
         if not _is_finite_number(value[corner]):
             return f"{key}.{corner} requires a finite number"
     return None
@@ -245,10 +248,12 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
     gear = payload.get("gear")
     if isinstance(gear, bool) or not isinstance(gear, int | str):
         return "gear requires an integer or string"
-    for key in ("lap_time_ms", "slip"):
-        err = _validate_optional_number(payload, key, min_value=0)
-        if err is not None:
-            return err
+    err = _validate_optional_number(payload, "lap_time_ms", min_value=0)
+    if err is not None:
+        return err
+    err = _validate_optional_number(payload, "slip")
+    if err is not None:
+        return err
     for key in ("tyre_temps_c", "tyre_pressures_psi"):
         err = _validate_corner_number_map(payload, key)
         if err is not None:

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -29,6 +29,7 @@ from tools.ai_sidecar.external_protocol import (
     AUTH_HEADER,
     CLIENT_CLASS_EXTERNAL,
     CLIENT_CLASS_KEY,
+    CLIENT_CLASS_SCREEN,
     CLIENT_HEADER,
     ENVELOPE_KEY,
     HAPTIC_CLIENT_CLASSES,
@@ -82,6 +83,7 @@ _external_peer_classes: dict[Any, str] = {}
 
 TELEMETRY_TICK_MAX_HZ = 20.0
 HAPTIC_EVENT_MAX_HZ = 25.0
+LEGACY_SCREEN_CLIENT_PREFIXES = ("ac-copilot-screen",)
 
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 CLIENT_TO_SERVER_TYPES = frozenset(
@@ -367,6 +369,16 @@ def _peer_class(peer: Any) -> str:
     return _external_peer_classes.get(peer, CLIENT_CLASS_EXTERNAL)
 
 
+def _client_class_from_hello(data: dict[str, Any]) -> str:
+    client_class = data.get(CLIENT_CLASS_KEY)
+    if isinstance(client_class, str):
+        return client_class
+    client = data.get("client")
+    if isinstance(client, str) and client.startswith(LEGACY_SCREEN_CLIENT_PREFIXES):
+        return CLIENT_CLASS_SCREEN
+    return CLIENT_CLASS_EXTERNAL
+
+
 def _targets_for_classes(*, exclude: Any, classes: frozenset[str]) -> list[Any]:
     return [
         peer for peer in _external_peers if peer is not exclude and _peer_class(peer) in classes
@@ -387,33 +399,33 @@ def _build_haptic_events_from_telemetry(frame: dict[str, Any]) -> list[dict[str,
     events: list[dict[str, Any]] = []
     ts_sim = frame.get("ts_sim")
     if payload.get("abs_active") or payload.get("brake_lock") or payload.get("wheel_lock"):
-        events.append(
-            {
-                "v": 1,
-                "type": TYPE_HAPTIC_EVENT,
-                "event": "pedal_rumble",
-                "channel": "pedal",
-                "intensity": max(0.2, _clamp_01(payload.get("brake"))),
-                "duration_ms": 80,
-                "ts_sim": ts_sim,
-                "source": "sidecar.telemetry_tick",
-            }
-        )
+        event: dict[str, Any] = {
+            "v": 1,
+            "type": TYPE_HAPTIC_EVENT,
+            "event": "pedal_rumble",
+            "channel": "pedal",
+            "intensity": max(0.2, _clamp_01(payload.get("brake"))),
+            "duration_ms": 80,
+            "source": "sidecar.telemetry_tick",
+        }
+        if ts_sim is not None:
+            event["ts_sim"] = ts_sim
+        events.append(event)
 
     slip = payload.get("slip")
     if not isinstance(slip, bool) and isinstance(slip, int | float) and abs(float(slip)) >= 0.2:
-        events.append(
-            {
-                "v": 1,
-                "type": TYPE_HAPTIC_EVENT,
-                "event": "slip_buzz",
-                "channel": "pedal",
-                "intensity": _clamp_01(abs(float(slip))),
-                "duration_ms": 60,
-                "ts_sim": ts_sim,
-                "source": "sidecar.telemetry_tick",
-            }
-        )
+        event = {
+            "v": 1,
+            "type": TYPE_HAPTIC_EVENT,
+            "event": "slip_buzz",
+            "channel": "pedal",
+            "intensity": _clamp_01(abs(float(slip))),
+            "duration_ms": 60,
+            "source": "sidecar.telemetry_tick",
+        }
+        if ts_sim is not None:
+            event["ts_sim"] = ts_sim
+        events.append(event)
     return events
 
 
@@ -457,9 +469,7 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
     if t == TYPE_HELLO:
         # Track this peer for fan-out and acknowledge directly.
         _external_peers.add(websocket)
-        client_class = data.get(CLIENT_CLASS_KEY)
-        if not isinstance(client_class, str):
-            client_class = CLIENT_CLASS_EXTERNAL
+        client_class = _client_class_from_hello(data)
         _external_peer_classes[websocket] = client_class
         logger.info(
             "external hello accepted peer=%s client=%s class=%s peers=%d",

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -17,6 +17,8 @@ import ipaddress
 import json
 import logging
 import secrets
+import time
+from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
@@ -25,8 +27,12 @@ from tools.ai_sidecar import observability
 from tools.ai_sidecar.coaching.llm_coach import debrief_feature_enabled
 from tools.ai_sidecar.external_protocol import (
     AUTH_HEADER,
+    CLIENT_CLASS_EXTERNAL,
+    CLIENT_CLASS_KEY,
     CLIENT_HEADER,
     ENVELOPE_KEY,
+    HAPTIC_CLIENT_CLASSES,
+    PHYSICAL_CLIENT_CLASSES,
     TYPE_ACTION,
     TYPE_ACTION_ACK,
     TYPE_CONFIG_ACK,
@@ -34,6 +40,7 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_CONFIG_SET,
     TYPE_CONFIG_VALUE,
     TYPE_ERROR,
+    TYPE_HAPTIC_EVENT,
     TYPE_HELLO,
     TYPE_HELLO_ACK,
     TYPE_KEY,
@@ -44,6 +51,7 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_STATE_SNAPSHOT,
     TYPE_STATE_SUBSCRIBE,
     TYPE_STATE_UNSUBSCRIBE,
+    TYPE_TELEMETRY_TICK,
     make_error,
     make_hello_ack,
     validate_inbound,
@@ -70,6 +78,10 @@ _ollama_followup_sem: asyncio.Semaphore | None = None
 # Connected external-protocol peers (any client that has spoken a `{v,type}`
 # frame, including the Lua loopback client). Used for hub-style fan-out.
 _external_peers: set[Any] = set()
+_external_peer_classes: dict[Any, str] = {}
+
+TELEMETRY_TICK_MAX_HZ = 20.0
+HAPTIC_EVENT_MAX_HZ = 25.0
 
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 CLIENT_TO_SERVER_TYPES = frozenset(
@@ -97,11 +109,42 @@ SERVER_TO_CLIENT_TYPES = frozenset(
         TYPE_ACTION_ACK,
         TYPE_STATE_SNAPSHOT,
         TYPE_ERROR,
+        # Issue #118: emitted by the loopback Lua peer / sidecar toward
+        # physical peripherals only, never echoed back to Lua.
+        TYPE_TELEMETRY_TICK,
+        TYPE_HAPTIC_EVENT,
         # Issue #86 Part D: replies the Lua peer sends back to the screen.
         TYPE_SETUP_LIST_RESULT,
         TYPE_SETUP_LOAD_ACK,
     }
 )
+
+
+class _RateLimiter:
+    def __init__(self, clock: Callable[[], float] = time.monotonic) -> None:
+        self._clock = clock
+        self._last_sent: dict[tuple[str, ...], float] = {}
+
+    def reset(self) -> None:
+        self._last_sent.clear()
+
+    def allow(self, key: tuple[str, ...], max_hz: float) -> bool:
+        now = self._clock()
+        min_interval = 1.0 / max_hz
+        last = self._last_sent.get(key)
+        if last is not None and now - last < min_interval:
+            return False
+        self._last_sent[key] = now
+        return True
+
+
+_peripheral_rate_limiter = _RateLimiter()
+
+
+def _reset_external_state() -> None:
+    _external_peers.clear()
+    _external_peer_classes.clear()
+    _peripheral_rate_limiter.reset()
 
 
 def _get_ollama_followup_sem() -> asyncio.Semaphore:
@@ -292,12 +335,15 @@ def make_process_request(token: str | None):
 
 async def _broadcast_external(frame: dict[str, Any], *, exclude: Any) -> None:
     """Forward a ``{v,type}`` frame to every external peer except ``exclude``."""
-    if not _external_peers:
-        return
-    payload = json.dumps(frame, separators=(",", ":"))
     targets = [p for p in _external_peers if p is not exclude]
+    await _broadcast_targets(frame, targets=targets)
+
+
+async def _broadcast_targets(frame: dict[str, Any], *, targets: list[Any]) -> None:
+    """Forward a v1 frame to an explicit peer list."""
     if not targets:
         return
+    payload = json.dumps(frame, separators=(",", ":"))
     results = await asyncio.gather(*[_safe_send_raw(p, payload) for p in targets])
     for p, err in zip(targets, results, strict=True):
         if err is not None:
@@ -305,6 +351,7 @@ async def _broadcast_external(frame: dict[str, Any], *, exclude: Any) -> None:
                 "broadcast send failed peer=%s err=%s", getattr(p, "remote_address", None), err
             )
             _external_peers.discard(p)
+            _external_peer_classes.pop(p, None)
 
 
 def _has_loopback_target(*, exclude: Any) -> bool:
@@ -314,6 +361,78 @@ def _has_loopback_target(*, exclude: Any) -> bool:
         if _is_loopback_peer(peer):
             return True
     return False
+
+
+def _peer_class(peer: Any) -> str:
+    return _external_peer_classes.get(peer, CLIENT_CLASS_EXTERNAL)
+
+
+def _targets_for_classes(*, exclude: Any, classes: frozenset[str]) -> list[Any]:
+    return [
+        peer for peer in _external_peers if peer is not exclude and _peer_class(peer) in classes
+    ]
+
+
+def _clamp_01(value: Any, default: float = 0.0) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return default
+    return max(0.0, min(1.0, float(value)))
+
+
+def _build_haptic_events_from_telemetry(frame: dict[str, Any]) -> list[dict[str, Any]]:
+    payload = frame.get("payload")
+    if not isinstance(payload, dict):
+        return []
+
+    events: list[dict[str, Any]] = []
+    ts_sim = frame.get("ts_sim")
+    if payload.get("abs_active") or payload.get("brake_lock") or payload.get("wheel_lock"):
+        events.append(
+            {
+                "v": 1,
+                "type": TYPE_HAPTIC_EVENT,
+                "event": "pedal_rumble",
+                "channel": "pedal",
+                "intensity": max(0.2, _clamp_01(payload.get("brake"))),
+                "duration_ms": 80,
+                "ts_sim": ts_sim,
+                "source": "sidecar.telemetry_tick",
+            }
+        )
+
+    slip = payload.get("slip")
+    if not isinstance(slip, bool) and isinstance(slip, int | float) and abs(float(slip)) >= 0.2:
+        events.append(
+            {
+                "v": 1,
+                "type": TYPE_HAPTIC_EVENT,
+                "event": "slip_buzz",
+                "channel": "pedal",
+                "intensity": _clamp_01(abs(float(slip))),
+                "duration_ms": 60,
+                "ts_sim": ts_sim,
+                "source": "sidecar.telemetry_tick",
+            }
+        )
+    return events
+
+
+async def _route_peripheral_frame(
+    frame: dict[str, Any],
+    *,
+    exclude: Any,
+    classes: frozenset[str],
+    rate_key: tuple[str, ...],
+    max_hz: float,
+) -> None:
+    targets = _targets_for_classes(exclude=exclude, classes=classes)
+    if not targets:
+        logger.debug("no peripheral targets for type=%s classes=%s", frame.get(TYPE_KEY), classes)
+        return
+    if not _peripheral_rate_limiter.allow(rate_key, max_hz):
+        logger.debug("peripheral frame rate-limited type=%s key=%s", frame.get(TYPE_KEY), rate_key)
+        return
+    await _broadcast_targets(frame, targets=targets)
 
 
 async def _safe_send_raw(websocket: Any, payload: str) -> Exception | None:
@@ -338,10 +457,15 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
     if t == TYPE_HELLO:
         # Track this peer for fan-out and acknowledge directly.
         _external_peers.add(websocket)
+        client_class = data.get(CLIENT_CLASS_KEY)
+        if not isinstance(client_class, str):
+            client_class = CLIENT_CLASS_EXTERNAL
+        _external_peer_classes[websocket] = client_class
         logger.info(
-            "external hello accepted peer=%s client=%s peers=%d",
+            "external hello accepted peer=%s client=%s class=%s peers=%d",
             peer,
             data.get("client", "?"),
+            client_class,
             len(_external_peers),
         )
         await _safe_send(websocket, make_hello_ack())
@@ -363,6 +487,36 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
         return
     if t not in CLIENT_TO_SERVER_TYPES and t not in SERVER_TO_CLIENT_TYPES:
         await _safe_send(websocket, make_error(f"unsupported type: {t!r}", ref_type=t))
+        return
+    if t == TYPE_TELEMETRY_TICK:
+        await _route_peripheral_frame(
+            data,
+            exclude=websocket,
+            classes=PHYSICAL_CLIENT_CLASSES,
+            rate_key=(TYPE_TELEMETRY_TICK,),
+            max_hz=TELEMETRY_TICK_MAX_HZ,
+        )
+        for event in _build_haptic_events_from_telemetry(data):
+            event_err = validate_inbound(event)
+            if event_err is not None:
+                logger.warning("generated haptic_event invalid: %s", event_err)
+                continue
+            await _route_peripheral_frame(
+                event,
+                exclude=websocket,
+                classes=HAPTIC_CLIENT_CLASSES,
+                rate_key=(TYPE_HAPTIC_EVENT, event["event"], event["channel"]),
+                max_hz=HAPTIC_EVENT_MAX_HZ,
+            )
+        return
+    if t == TYPE_HAPTIC_EVENT:
+        await _route_peripheral_frame(
+            data,
+            exclude=websocket,
+            classes=HAPTIC_CLIENT_CLASSES,
+            rate_key=(TYPE_HAPTIC_EVENT, str(data.get("event")), str(data.get("channel"))),
+            max_hz=HAPTIC_EVENT_MAX_HZ,
+        )
         return
     if (
         t in CLIENT_TO_SERVER_TYPES
@@ -528,6 +682,7 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
                     bg_task.add_done_callback(_followup_done)
     finally:
         _external_peers.discard(websocket)
+        _external_peer_classes.pop(websocket, None)
         for t in list(pending_followups):
             if not t.done():
                 t.cancel()
@@ -542,7 +697,7 @@ async def _run(host: str, port: int, reply_coaching: bool, token: str | None) ->
         raise SystemExit('websockets is required. Install: pip install -e ".[coaching]"') from e
 
     process_request = make_process_request(token)
-    _external_peers.clear()
+    _reset_external_state()
     try:
         async with websockets.serve(
             lambda ws: _handler(ws, reply_coaching),
@@ -560,7 +715,7 @@ async def _run(host: str, port: int, reply_coaching: bool, token: str | None) ->
             )
             await asyncio.Future()
     finally:
-        _external_peers.clear()
+        _reset_external_state()
 
 
 def _is_loopback(host: str) -> bool:


### PR DESCRIPTION
## Summary
- add v1 client classes plus telemetry_tick and haptic_event validation
- route telemetry ticks only to physical peripheral classes and haptic events only to haptic classes
- derive a bounded pedal haptic event from telemetry fixtures and document payload/frequency contract

## Tests
- /Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python -m ruff check tools/ai_sidecar/external_protocol.py tools/ai_sidecar/server.py tests/test_ai_sidecar_external.py
- /Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python -m pytest -q tests/test_ai_sidecar_external.py tests/test_ws_topic_allowlist.py

Refs #118