### PR TITLE
feat: export archived laps to CSV and MoTeC-compatible telemetry (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Completed laps are archived as JSON under the trainer data root at
 python -m tools.lap_archive_export --output exports/laps.csv /path/to/journal/laps
 ```
 
-For MoTeC i2 workflows, use `--format motec-csv`. See
+For MoTeC i2 workflows, use `--format motec-csv` on laps from one
+session/car/track. See
 [docs/10_Development/13_Lap_Archive_Export.md](docs/10_Development/13_Lap_Archive_Export.md)
 for supported channels and compatibility limits.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ pip install -e ".[dev]"
 make ci-fast
 ```
 
+## Lap Archive Export
+
+Completed laps are archived as JSON under the trainer data root at
+`journal/laps/lap_*.json`. Export them to stable analysis CSV:
+
+```bash
+python -m tools.lap_archive_export --output exports/laps.csv /path/to/journal/laps
+```
+
+For MoTeC i2 workflows, use `--format motec-csv`. See
+[docs/10_Development/13_Lap_Archive_Export.md](docs/10_Development/13_Lap_Archive_Export.md)
+for supported channels and compatibility limits.
+
 ## Architecture
 
 See [docs/01_Vault/AcCopilotTrainer/00_System/Architecture Invariants.md](docs/01_Vault/AcCopilotTrainer/00_System/Architecture%20Invariants.md)

--- a/docs/10_Development/13_Lap_Archive_Export.md
+++ b/docs/10_Development/13_Lap_Archive_Export.md
@@ -18,10 +18,12 @@ Run from the repository root:
 python -m tools.lap_archive_export --output exports/laps.csv /path/to/journal/laps
 ```
 
-Directories are expanded to sorted `lap_*.json` files. Laps with
-`lap.is_valid=false` are skipped by default; pass `--include-invalid` when you
-want to inspect invalidated laps. Analysis CSV exports stream archive files one
-at a time and replace the output only after the export completes.
+Directories are expanded to sorted `lap_*.json` files. Output paths are
+relative to the current working directory; absolute paths and `..` escapes are
+rejected. Laps with `lap.is_valid=false` are skipped by default; pass
+`--include-invalid` when you want to inspect invalidated laps. Analysis CSV
+exports stream archive files one at a time and replace the output only after
+the export completes.
 
 Stable columns:
 

--- a/docs/10_Development/13_Lap_Archive_Export.md
+++ b/docs/10_Development/13_Lap_Archive_Export.md
@@ -1,0 +1,72 @@
+# Lap Archive Export
+
+Issue #115 adds an offline exporter for trainer lap archives. The source files
+remain the schema-v1 JSON records written by the CSP app under:
+
+```text
+<AC Documents>/Assetto Corsa/cfg/extension/state/lua/ac_copilot_trainer/journal/laps/lap_*.json
+```
+
+The exact root comes from CSP `ac.FolderID.ScriptConfig`; the stable suffix is
+`ac_copilot_trainer/journal/laps/lap_*.json`.
+
+## Analysis CSV
+
+Run from the repository root:
+
+```bash
+python -m tools.lap_archive_export --output exports/laps.csv /path/to/journal/laps
+```
+
+Directories are expanded to sorted `lap_*.json` files. Laps with
+`lap.is_valid=false` are skipped by default; pass `--include-invalid` when you
+want to inspect invalidated laps.
+
+Stable columns:
+
+```text
+source_file, lap_uuid, session_uuid, car_id, track_id, lap_n, lap_ms,
+is_valid, sample_index, time_s, elapsed_ms, spline, lap_distance_m,
+speed_kmh, brake, throttle, steering, gear,
+position_x_m, position_y_m, position_z_m
+```
+
+`brake`, `throttle`, and `steering` preserve the normalized CSP values from the
+archive trace. `lap_distance_m` is derived from `spline * track.lengthM` when
+track length is present; otherwise it is blank. Missing trace fields export as
+blank cells so downstream notebooks can distinguish "missing" from zero.
+
+## MoTeC-Shaped CSV
+
+Run:
+
+```bash
+python -m tools.lap_archive_export \
+  --format motec-csv \
+  --output exports/laps_motec.csv \
+  /path/to/journal/laps
+```
+
+This writes a MoTeC-style CSV envelope: metadata rows, `Beacon Markers`, a
+channel-name row, a units row, and quoted data fields. Supported channels:
+
+```text
+Time (s), Ground Speed (km/h), Brake Pos (%), Throttle Pos (%),
+Steering (none), Gear (none), Spline (none), Lap Distance (m),
+Position X/Y/Z (m), Lap Number (none), Lap Time (s), Valid Lap (none)
+```
+
+Compatibility limits:
+
+- The exporter does not write native MoTeC `.ld` files.
+- MoTeC's public support guidance says the CSV format is exacting rather than
+  fully documented: every field should remain quoted, and beacon marker values
+  are seconds from the start of the log separated by spaces. See MoTeC forum
+  notes on [CSV formatting](https://forum.motec.com.au/viewtopic.php?f=26&t=3864)
+  and [CSV import licensing / conversion](https://forum.motec.com.au/viewtopic.php?f=26&t=4317).
+- i2 Pro CSV conversion/import may require the MoTeC CSV Dataset conversion
+  path or a dealer/import license. Treat this output as a deterministic bridge
+  file, not a guarantee that every i2 installation will import it without local
+  licensing or workspace adjustments.
+- `Steering` is the trainer's normalized CSP steer value, not a calibrated
+  steering-wheel angle in degrees.

--- a/docs/10_Development/13_Lap_Archive_Export.md
+++ b/docs/10_Development/13_Lap_Archive_Export.md
@@ -20,7 +20,8 @@ python -m tools.lap_archive_export --output exports/laps.csv /path/to/journal/la
 
 Directories are expanded to sorted `lap_*.json` files. Laps with
 `lap.is_valid=false` are skipped by default; pass `--include-invalid` when you
-want to inspect invalidated laps.
+want to inspect invalidated laps. Analysis CSV exports stream archive files one
+at a time and replace the output only after the export completes.
 
 Stable columns:
 
@@ -59,6 +60,16 @@ Position X/Y/Z (m), Lap Number (none), Lap Time (s), Valid Lap (none)
 Compatibility limits:
 
 - The exporter does not write native MoTeC `.ld` files.
+- `journal/laps` is an app-wide archive directory. `motec-csv` exports reject
+  mixed `session_uuid`, car, track, or track-layout inputs because the output
+  header describes one continuous outing. Export broad history with the
+  analysis CSV format, or pass a narrowed set of lap files that belong to one
+  compatible outing.
+- MoTeC header stats are computed with a bounded pre-scan over the selected
+  paths, then rows are streamed during the write. Beacon markers are based on
+  emitted sample time so marker values stay inside the exported log range;
+  the `Lap Time` channel still carries recorded `lap.lap_ms` when it is
+  present.
 - MoTeC's public support guidance says the CSV format is exacting rather than
   fully documented: every field should remain quoted, and beacon marker values
   are seconds from the start of the log separated by spaces. See MoTeC forum

--- a/tests/fixtures/lap_archive_invalid.json
+++ b/tests/fixtures/lap_archive_invalid.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "source": "in_game",
+  "import_format": null,
+  "lap_uuid": "lap-invalid",
+  "session_uuid": "session-a",
+  "exported_at": "2026-06-16T10:12:12Z",
+  "car": {
+    "id": "ks_abarth500_assetto_corse",
+    "displayName": null
+  },
+  "track": {
+    "id": "magione",
+    "layout": null,
+    "lengthM": 2525
+  },
+  "conditions": {},
+  "lap": {
+    "lap_n": 5,
+    "lap_ms": 88000,
+    "is_pb": false,
+    "is_valid": false
+  },
+  "setup": {
+    "hash": "abc123",
+    "snapshot": {}
+  },
+  "trace": {
+    "samples_count": 1,
+    "fields": ["spline", "speed", "eMs", "throttle", "brake", "steer", "gear", "px", "py", "pz"],
+    "samples": [
+      [0.25, 90.0, 20000, 0.4, 0.6, 0.2, 3, 11.0, 0.1, 21.0]
+    ]
+  },
+  "corners": [],
+  "coaching": {
+    "rules_hints": []
+  }
+}

--- a/tests/fixtures/lap_archive_missing_fields.json
+++ b/tests/fixtures/lap_archive_missing_fields.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "source": "in_game",
+  "import_format": null,
+  "lap_uuid": "lap-missing-fields",
+  "session_uuid": "session-b",
+  "exported_at": "2026-06-16T10:13:12Z",
+  "car": {
+    "id": "ks_abarth500_assetto_corse"
+  },
+  "track": {
+    "id": "magione"
+  },
+  "conditions": {},
+  "lap": {
+    "lap_n": 6,
+    "lap_ms": 91000,
+    "is_pb": false,
+    "is_valid": true
+  },
+  "setup": {
+    "hash": "",
+    "snapshot": {}
+  },
+  "trace": {
+    "samples_count": 1,
+    "fields": ["spline", "speed", "eMs"],
+    "samples": [
+      [0.4, 88.0, 5000]
+    ]
+  },
+  "corners": [],
+  "coaching": {
+    "rules_hints": []
+  }
+}

--- a/tests/fixtures/lap_archive_valid.json
+++ b/tests/fixtures/lap_archive_valid.json
@@ -28,7 +28,7 @@
   },
   "setup": {
     "hash": "abc123",
-    "path": "C:/Users/arsen/Documents/Assetto Corsa/setups/setup.ini",
+    "path": "C:/AssettoCorsa/Documents/setups/setup.ini",
     "snapshot": {
       "TYRES.PRESSURE_FRONT": "27.5"
     }

--- a/tests/fixtures/lap_archive_valid.json
+++ b/tests/fixtures/lap_archive_valid.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "source": "in_game",
+  "import_format": null,
+  "lap_uuid": "lap-valid",
+  "session_uuid": "session-a",
+  "exported_at": "2026-06-16T10:11:12Z",
+  "car": {
+    "id": "ks_abarth500_assetto_corse",
+    "displayName": null
+  },
+  "track": {
+    "id": "magione",
+    "layout": null,
+    "lengthM": 2525
+  },
+  "conditions": {
+    "trackGripLevel": 0.98,
+    "ambientTempC": 22,
+    "trackTempC": 30,
+    "weatherType": null
+  },
+  "lap": {
+    "lap_n": 4,
+    "lap_ms": 90000,
+    "is_pb": true,
+    "is_valid": true
+  },
+  "setup": {
+    "hash": "abc123",
+    "path": "C:/Users/arsen/Documents/Assetto Corsa/setups/setup.ini",
+    "snapshot": {
+      "TYRES.PRESSURE_FRONT": "27.5"
+    }
+  },
+  "trace": {
+    "samples_count": 3,
+    "fields": ["spline", "speed", "eMs", "throttle", "brake", "steer", "gear", "px", "py", "pz"],
+    "samples": [
+      [0.0, 100.0, 0, 1.0, 0.0, 0.0, 2, 10.0, 0.1, 20.0],
+      [0.5, 150.5, 45000, 0.7, 0.2, -0.05, 4, 20.0, 0.2, 30.0],
+      [1.0, 120.0, 90000, 0.3, 0.0, 0.1, 3, 30.0, 0.3, 40.0]
+    ]
+  },
+  "corners": [],
+  "coaching": {
+    "rules_hints": [],
+    "sidecar_debrief": null,
+    "corner_advice_used": null
+  }
+}

--- a/tests/test_lap_archive_export.py
+++ b/tests/test_lap_archive_export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import json
 from pathlib import Path
 
 from tools import lap_archive_export
@@ -87,6 +88,53 @@ def test_motec_csv_export_writes_quoted_header_units_and_rows(tmp_path: Path) ->
     assert rows[12][3] == "70"
 
 
+def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path) -> None:
+    first = tmp_path / "lap_001.json"
+    second = tmp_path / "lap_002.json"
+    out = tmp_path / "fallback_motec.csv"
+
+    first.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "lap_uuid": "lap-without-ms-1",
+                "session_uuid": "session-fallback",
+                "lap": {"lap_n": 1, "is_valid": True},
+                "trace": {
+                    "fields": ["eMs", "speed"],
+                    "samples": [[0, 80.0], [1000, 100.0], [3000, 110.0]],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    second.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "lap_uuid": "lap-without-ms-2",
+                "session_uuid": "session-fallback",
+                "lap": {"lap_n": 2, "lap_ms": 0, "is_valid": True},
+                "trace": {
+                    "fields": ["eMs", "speed"],
+                    "samples": [[0, 90.0], [2000, 120.0]],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    count = lap_archive_export.export_motec_csv([first, second], out)
+
+    assert count == 5
+    with out.open("r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[8] == ["Beacon Markers", "3 5"]
+    data_rows = rows[11:]
+    assert [row[0] for row in data_rows] == ["0", "1", "3", "3", "5"]
+    assert [row[12] for row in data_rows] == ["3", "3", "3", "2", "2"]
+
+
 def test_cli_writes_csv(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
     out = tmp_path / "cli.csv"
 
@@ -96,3 +144,15 @@ def test_cli_writes_csv(tmp_path: Path, capsys) -> None:  # type: ignore[no-unty
     assert rc == 0
     assert "wrote 3 sample rows" in captured.out
     assert _rows(out)[0]["lap_uuid"] == "lap-valid"
+
+
+def test_cli_rejects_missing_input_path(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    out = tmp_path / "cli.csv"
+    missing = tmp_path / "missing.json"
+
+    rc = lap_archive_export.main(["--output", str(out), str(missing)])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "input path does not exist" in captured.err
+    assert not out.exists()

--- a/tests/test_lap_archive_export.py
+++ b/tests/test_lap_archive_export.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from tools import lap_archive_export
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def test_csv_export_produces_stable_columns_from_fixture(tmp_path: Path) -> None:
+    out = tmp_path / "lap.csv"
+    count = lap_archive_export.export_csv([_FIXTURES / "lap_archive_valid.json"], out)
+
+    rows = _rows(out)
+    assert count == 3
+    assert rows
+    assert list(rows[0]) == list(lap_archive_export.CSV_COLUMNS)
+    assert rows[1]["source_file"] == "lap_archive_valid.json"
+    assert rows[1]["speed_kmh"] == "150.5"
+    assert rows[1]["brake"] == "0.2"
+    assert rows[1]["throttle"] == "0.7"
+    assert rows[1]["steering"] == "-0.05"
+    assert rows[1]["gear"] == "4"
+    assert rows[1]["spline"] == "0.5"
+    assert rows[1]["lap_distance_m"] == "1262.5"
+    assert rows[1]["position_x_m"] == "20"
+    assert rows[1]["position_y_m"] == "0.2"
+    assert rows[1]["position_z_m"] == "30"
+
+
+def test_invalid_laps_are_filtered_by_default_and_can_be_included(tmp_path: Path) -> None:
+    default_out = tmp_path / "default.csv"
+    include_out = tmp_path / "include.csv"
+    inputs = [
+        _FIXTURES / "lap_archive_valid.json",
+        _FIXTURES / "lap_archive_invalid.json",
+    ]
+
+    default_count = lap_archive_export.export_csv(inputs, default_out)
+    include_count = lap_archive_export.export_csv(inputs, include_out, include_invalid=True)
+
+    assert default_count == 3
+    assert {row["lap_uuid"] for row in _rows(default_out)} == {"lap-valid"}
+    assert include_count == 4
+    assert {row["lap_uuid"] for row in _rows(include_out)} == {"lap-valid", "lap-invalid"}
+
+
+def test_missing_trace_fields_export_as_blank_cells(tmp_path: Path) -> None:
+    out = tmp_path / "missing.csv"
+
+    count = lap_archive_export.export_csv([_FIXTURES / "lap_archive_missing_fields.json"], out)
+
+    assert count == 1
+    row = _rows(out)[0]
+    assert row["lap_uuid"] == "lap-missing-fields"
+    assert row["speed_kmh"] == "88"
+    assert row["time_s"] == "5"
+    assert row["brake"] == ""
+    assert row["throttle"] == ""
+    assert row["steering"] == ""
+    assert row["gear"] == ""
+    assert row["position_x_m"] == ""
+    assert row["lap_distance_m"] == ""
+
+
+def test_motec_csv_export_writes_quoted_header_units_and_rows(tmp_path: Path) -> None:
+    out = tmp_path / "lap_motec.csv"
+
+    count = lap_archive_export.export_motec_csv([_FIXTURES / "lap_archive_valid.json"], out)
+
+    assert count == 3
+    with out.open("r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[0][:2] == ["Driver", "AC Copilot Trainer"]
+    assert rows[8][0] == "Beacon Markers"
+    assert rows[9][:4] == ["Time", "Ground Speed", "Brake Pos", "Throttle Pos"]
+    assert rows[10][:4] == ["s", "km/h", "%", "%"]
+    assert rows[12][0] == "45"
+    assert rows[12][1] == "150.5"
+    assert rows[12][2] == "20"
+    assert rows[12][3] == "70"
+
+
+def test_cli_writes_csv(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    out = tmp_path / "cli.csv"
+
+    rc = lap_archive_export.main(["--output", str(out), str(_FIXTURES / "lap_archive_valid.json")])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "wrote 3 sample rows" in captured.out
+    assert _rows(out)[0]["lap_uuid"] == "lap-valid"

--- a/tests/test_lap_archive_export.py
+++ b/tests/test_lap_archive_export.py
@@ -39,8 +39,8 @@ def _write_archive(
                 "track": {"id": track_id},
                 "lap": lap,
                 "trace": {
-                    "fields": fields or ["eMs", "speed"],
-                    "samples": samples or [[0, 80.0]],
+                    "fields": ["eMs", "speed"] if fields is None else fields,
+                    "samples": [[0, 80.0]] if samples is None else samples,
                 },
             }
         ),
@@ -48,8 +48,9 @@ def _write_archive(
     )
 
 
-def test_csv_export_produces_stable_columns_from_fixture(tmp_path: Path) -> None:
-    out = tmp_path / "lap.csv"
+def test_csv_export_produces_stable_columns_from_fixture(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    out = Path("lap.csv")
     count = lap_archive_export.export_csv([_FIXTURES / "lap_archive_valid.json"], out)
 
     rows = _rows(out)
@@ -69,9 +70,12 @@ def test_csv_export_produces_stable_columns_from_fixture(tmp_path: Path) -> None
     assert rows[1]["position_z_m"] == "30"
 
 
-def test_invalid_laps_are_filtered_by_default_and_can_be_included(tmp_path: Path) -> None:
-    default_out = tmp_path / "default.csv"
-    include_out = tmp_path / "include.csv"
+def test_invalid_laps_are_filtered_by_default_and_can_be_included(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    default_out = Path("default.csv")
+    include_out = Path("include.csv")
     inputs = [
         _FIXTURES / "lap_archive_valid.json",
         _FIXTURES / "lap_archive_invalid.json",
@@ -86,8 +90,9 @@ def test_invalid_laps_are_filtered_by_default_and_can_be_included(tmp_path: Path
     assert {row["lap_uuid"] for row in _rows(include_out)} == {"lap-valid", "lap-invalid"}
 
 
-def test_missing_trace_fields_export_as_blank_cells(tmp_path: Path) -> None:
-    out = tmp_path / "missing.csv"
+def test_missing_trace_fields_export_as_blank_cells(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    out = Path("missing.csv")
 
     count = lap_archive_export.export_csv([_FIXTURES / "lap_archive_missing_fields.json"], out)
 
@@ -104,8 +109,9 @@ def test_missing_trace_fields_export_as_blank_cells(tmp_path: Path) -> None:
     assert row["lap_distance_m"] == ""
 
 
-def test_motec_csv_export_writes_quoted_header_units_and_rows(tmp_path: Path) -> None:
-    out = tmp_path / "lap_motec.csv"
+def test_motec_csv_export_writes_quoted_header_units_and_rows(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    out = Path("lap_motec.csv")
 
     count = lap_archive_export.export_motec_csv([_FIXTURES / "lap_archive_valid.json"], out)
 
@@ -122,10 +128,11 @@ def test_motec_csv_export_writes_quoted_header_units_and_rows(tmp_path: Path) ->
     assert rows[12][3] == "70"
 
 
-def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path) -> None:
+def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
     first = tmp_path / "lap_001.json"
     second = tmp_path / "lap_002.json"
-    out = tmp_path / "fallback_motec.csv"
+    out = Path("fallback_motec.csv")
 
     _write_archive(
         first,
@@ -152,10 +159,11 @@ def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path) -> 
     assert [row[12] for row in data_rows] == ["3", "3", "3", "2", "2"]
 
 
-def test_motec_csv_beacons_follow_exported_sample_range(tmp_path: Path) -> None:
+def test_motec_csv_beacons_follow_exported_sample_range(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
     first = tmp_path / "lap_001.json"
     second = tmp_path / "lap_002.json"
-    out = tmp_path / "sparse_motec.csv"
+    out = Path("sparse_motec.csv")
     _write_archive(
         first,
         lap_uuid="complete-lap",
@@ -184,10 +192,41 @@ def test_motec_csv_beacons_follow_exported_sample_range(tmp_path: Path) -> None:
     assert [row[12] for row in data_rows] == ["3", "3", "91", "91"]
 
 
-def test_motec_csv_rejects_mixed_session_inputs(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+def test_motec_csv_ignores_empty_trace_for_beacons_and_offsets(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
     first = tmp_path / "lap_001.json"
     second = tmp_path / "lap_002.json"
-    out = tmp_path / "mixed_motec.csv"
+    out = Path("empty_trace_motec.csv")
+    _write_archive(
+        first,
+        lap_uuid="empty-trace-lap",
+        lap_n=1,
+        lap_ms=90000,
+        samples=[],
+    )
+    _write_archive(
+        second,
+        lap_uuid="timed-lap",
+        lap_n=2,
+        lap_ms=3000,
+        samples=[[0, 90.0], [3000, 120.0]],
+    )
+
+    count = lap_archive_export.export_motec_csv([first, second], out)
+
+    assert count == 2
+    with out.open("r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[5][5] == "3"
+    assert rows[8] == ["Beacon Markers", "3"]
+    assert [row[0] for row in rows[11:]] == ["0", "3"]
+
+
+def test_motec_csv_rejects_mixed_session_inputs(tmp_path: Path, monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    first = tmp_path / "lap_001.json"
+    second = tmp_path / "lap_002.json"
+    out = Path("mixed_motec.csv")
     _write_archive(first, lap_uuid="session-a-lap", session_uuid="session-a")
     _write_archive(second, lap_uuid="session-b-lap", session_uuid="session-b")
 
@@ -201,8 +240,9 @@ def test_motec_csv_rejects_mixed_session_inputs(tmp_path: Path, capsys) -> None:
     assert not out.exists()
 
 
-def test_cli_writes_csv(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
-    out = tmp_path / "cli.csv"
+def test_cli_writes_csv(tmp_path: Path, monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    out = Path("cli.csv")
 
     rc = lap_archive_export.main(["--output", str(out), str(_FIXTURES / "lap_archive_valid.json")])
 
@@ -212,9 +252,10 @@ def test_cli_writes_csv(tmp_path: Path, capsys) -> None:  # type: ignore[no-unty
     assert _rows(out)[0]["lap_uuid"] == "lap-valid"
 
 
-def test_cli_rejects_missing_input_path(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
-    out = tmp_path / "cli.csv"
-    missing = tmp_path / "missing.json"
+def test_cli_rejects_missing_input_path(tmp_path: Path, monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    out = Path("cli.csv")
+    missing = Path("missing.json")
 
     rc = lap_archive_export.main(["--output", str(out), str(missing)])
 
@@ -222,3 +263,29 @@ def test_cli_rejects_missing_input_path(tmp_path: Path, capsys) -> None:  # type
     assert rc == 2
     assert "input path does not exist" in captured.err
     assert not out.exists()
+
+
+def test_cli_rejects_absolute_output_path(tmp_path: Path, monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "absolute.csv"
+
+    rc = lap_archive_export.main(["--output", str(out), str(_FIXTURES / "lap_archive_valid.json")])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "output path must be relative" in captured.err
+    assert not out.exists()
+
+
+def test_cli_rejects_escaping_output_path(tmp_path: Path, monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.chdir(tmp_path)
+    escaped = tmp_path.parent / "escaped-laps.csv"
+
+    rc = lap_archive_export.main(
+        ["--output", "../escaped-laps.csv", str(_FIXTURES / "lap_archive_valid.json")]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "output path must stay within" in captured.err
+    assert not escaped.exists()

--- a/tests/test_lap_archive_export.py
+++ b/tests/test_lap_archive_export.py
@@ -14,6 +14,40 @@ def _rows(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(fh))
 
 
+def _write_archive(
+    path: Path,
+    *,
+    lap_uuid: str,
+    session_uuid: str = "session-fallback",
+    car_id: str = "ks_abarth500_assetto_corse",
+    track_id: str = "magione",
+    lap_n: int = 1,
+    lap_ms: int | None = None,
+    fields: list[str] | None = None,
+    samples: list[list[float | int]] | None = None,
+) -> None:
+    lap: dict[str, object] = {"lap_n": lap_n, "is_valid": True}
+    if lap_ms is not None:
+        lap["lap_ms"] = lap_ms
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "lap_uuid": lap_uuid,
+                "session_uuid": session_uuid,
+                "car": {"id": car_id},
+                "track": {"id": track_id},
+                "lap": lap,
+                "trace": {
+                    "fields": fields or ["eMs", "speed"],
+                    "samples": samples or [[0, 80.0]],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_csv_export_produces_stable_columns_from_fixture(tmp_path: Path) -> None:
     out = tmp_path / "lap.csv"
     count = lap_archive_export.export_csv([_FIXTURES / "lap_archive_valid.json"], out)
@@ -93,35 +127,18 @@ def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path) -> 
     second = tmp_path / "lap_002.json"
     out = tmp_path / "fallback_motec.csv"
 
-    first.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "lap_uuid": "lap-without-ms-1",
-                "session_uuid": "session-fallback",
-                "lap": {"lap_n": 1, "is_valid": True},
-                "trace": {
-                    "fields": ["eMs", "speed"],
-                    "samples": [[0, 80.0], [1000, 100.0], [3000, 110.0]],
-                },
-            }
-        ),
-        encoding="utf-8",
+    _write_archive(
+        first,
+        lap_uuid="lap-without-ms-1",
+        lap_n=1,
+        samples=[[0, 80.0], [1000, 100.0], [3000, 110.0]],
     )
-    second.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "lap_uuid": "lap-without-ms-2",
-                "session_uuid": "session-fallback",
-                "lap": {"lap_n": 2, "lap_ms": 0, "is_valid": True},
-                "trace": {
-                    "fields": ["eMs", "speed"],
-                    "samples": [[0, 90.0], [2000, 120.0]],
-                },
-            }
-        ),
-        encoding="utf-8",
+    _write_archive(
+        second,
+        lap_uuid="lap-without-ms-2",
+        lap_n=2,
+        lap_ms=0,
+        samples=[[0, 90.0], [2000, 120.0]],
     )
 
     count = lap_archive_export.export_motec_csv([first, second], out)
@@ -133,6 +150,55 @@ def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path) -> 
     data_rows = rows[11:]
     assert [row[0] for row in data_rows] == ["0", "1", "3", "3", "5"]
     assert [row[12] for row in data_rows] == ["3", "3", "3", "2", "2"]
+
+
+def test_motec_csv_beacons_follow_exported_sample_range(tmp_path: Path) -> None:
+    first = tmp_path / "lap_001.json"
+    second = tmp_path / "lap_002.json"
+    out = tmp_path / "sparse_motec.csv"
+    _write_archive(
+        first,
+        lap_uuid="complete-lap",
+        lap_n=1,
+        lap_ms=3000,
+        samples=[[0, 80.0], [3000, 100.0]],
+    )
+    _write_archive(
+        second,
+        lap_uuid="sparse-lap",
+        lap_n=2,
+        lap_ms=91000,
+        samples=[[0, 90.0], [5000, 120.0]],
+    )
+
+    count = lap_archive_export.export_motec_csv([first, second], out)
+
+    assert count == 4
+    with out.open("r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.reader(fh))
+    assert rows[5][5] == "8"
+    assert rows[6][1] == "8"
+    assert rows[8] == ["Beacon Markers", "3 8"]
+    data_rows = rows[11:]
+    assert [row[0] for row in data_rows] == ["0", "3", "3", "8"]
+    assert [row[12] for row in data_rows] == ["3", "3", "91", "91"]
+
+
+def test_motec_csv_rejects_mixed_session_inputs(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    first = tmp_path / "lap_001.json"
+    second = tmp_path / "lap_002.json"
+    out = tmp_path / "mixed_motec.csv"
+    _write_archive(first, lap_uuid="session-a-lap", session_uuid="session-a")
+    _write_archive(second, lap_uuid="session-b-lap", session_uuid="session-b")
+
+    rc = lap_archive_export.main(
+        ["--format", "motec-csv", "--output", str(out), str(first), str(second)]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "motec-csv inputs must contain one session/car/track" in captured.err
+    assert not out.exists()
 
 
 def test_cli_writes_csv(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -1,0 +1,410 @@
+"""Export AC Copilot Trainer per-lap archives to analysis CSV files.
+
+The trainer writes one JSON file per completed lap under ``journal/laps``. This
+module reads those immutable archives and writes either a stable generic CSV or
+a best-effort MoTeC-shaped CSV for i2's CSV conversion path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from collections.abc import Iterable, Iterator, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any, TextIO
+
+LAP_ARCHIVE_SCHEMA_VERSION = 1
+
+CSV_COLUMNS: tuple[str, ...] = (
+    "source_file",
+    "lap_uuid",
+    "session_uuid",
+    "car_id",
+    "track_id",
+    "lap_n",
+    "lap_ms",
+    "is_valid",
+    "sample_index",
+    "time_s",
+    "elapsed_ms",
+    "spline",
+    "lap_distance_m",
+    "speed_kmh",
+    "brake",
+    "throttle",
+    "steering",
+    "gear",
+    "position_x_m",
+    "position_y_m",
+    "position_z_m",
+)
+
+_TRACE_TO_CSV: dict[str, str] = {
+    "eMs": "elapsed_ms",
+    "spline": "spline",
+    "speed": "speed_kmh",
+    "brake": "brake",
+    "throttle": "throttle",
+    "steer": "steering",
+    "gear": "gear",
+    "px": "position_x_m",
+    "py": "position_y_m",
+    "pz": "position_z_m",
+}
+
+_MOTEC_CHANNELS: tuple[tuple[str, str, str], ...] = (
+    ("Time", "s", "time_s"),
+    ("Ground Speed", "km/h", "speed_kmh"),
+    ("Brake Pos", "%", "brake_pct"),
+    ("Throttle Pos", "%", "throttle_pct"),
+    ("Steering", "none", "steering"),
+    ("Gear", "none", "gear"),
+    ("Spline", "none", "spline"),
+    ("Lap Distance", "m", "lap_distance_m"),
+    ("Position X", "m", "position_x_m"),
+    ("Position Y", "m", "position_y_m"),
+    ("Position Z", "m", "position_z_m"),
+    ("Lap Number", "none", "lap_n"),
+    ("Lap Time", "s", "lap_time_s"),
+    ("Valid Lap", "none", "valid_lap"),
+)
+
+
+class LapArchiveExportError(ValueError):
+    """Raised when an archive cannot be read as a schema-v1 lap archive."""
+
+
+def iter_lap_archive_paths(inputs: Iterable[str | Path]) -> Iterator[Path]:
+    """Yield input files, expanding directories to sorted ``lap_*.json`` files."""
+    for raw in inputs:
+        path = Path(raw)
+        if path.is_dir():
+            yield from sorted(path.glob("lap_*.json"))
+        else:
+            yield path
+
+
+def _as_finite_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(out):
+        return None
+    return out
+
+
+def _format_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return ""
+        text = f"{value:.6f}".rstrip("0").rstrip(".")
+        return text if text and text != "-0" else "0"
+    return str(value)
+
+
+def load_lap_archive(path: str | Path) -> dict[str, Any]:
+    """Load one JSON archive file and validate the minimal schema envelope."""
+    archive_path = Path(path)
+    try:
+        parsed = json.loads(archive_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise LapArchiveExportError(f"{archive_path}: invalid JSON: {exc}") from exc
+    except OSError as exc:
+        raise LapArchiveExportError(f"{archive_path}: cannot read: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise LapArchiveExportError(f"{archive_path}: root must be an object")
+    if parsed.get("schema_version") != LAP_ARCHIVE_SCHEMA_VERSION:
+        raise LapArchiveExportError(
+            f"{archive_path}: schema_version must be {LAP_ARCHIVE_SCHEMA_VERSION}"
+        )
+    trace = parsed.get("trace")
+    if not isinstance(trace, dict):
+        raise LapArchiveExportError(f"{archive_path}: trace must be an object")
+    if not isinstance(trace.get("fields"), list):
+        raise LapArchiveExportError(f"{archive_path}: trace.fields must be an array")
+    if not isinstance(trace.get("samples"), list):
+        raise LapArchiveExportError(f"{archive_path}: trace.samples must be an array")
+    return parsed
+
+
+def lap_is_valid(record: dict[str, Any]) -> bool:
+    """Return whether this archive lap should be exported by default."""
+    lap = record.get("lap")
+    if not isinstance(lap, dict):
+        return True
+    return lap.get("is_valid") is not False
+
+
+def _field_map(record: dict[str, Any]) -> dict[str, int]:
+    fields = record.get("trace", {}).get("fields", [])
+    out: dict[str, int] = {}
+    for idx, name in enumerate(fields):
+        if isinstance(name, str) and name not in out:
+            out[name] = idx
+    return out
+
+
+def _sample_value(sample: Any, fields: dict[str, int], name: str) -> float | None:
+    if not isinstance(sample, list):
+        return None
+    idx = fields.get(name)
+    if idx is None or idx >= len(sample):
+        return None
+    return _as_finite_float(sample[idx])
+
+
+def _metadata(record: dict[str, Any], source_path: Path) -> dict[str, Any]:
+    lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
+    car = record.get("car") if isinstance(record.get("car"), dict) else {}
+    track = record.get("track") if isinstance(record.get("track"), dict) else {}
+    return {
+        "source_file": source_path.name,
+        "lap_uuid": record.get("lap_uuid"),
+        "session_uuid": record.get("session_uuid"),
+        "car_id": car.get("id"),
+        "track_id": track.get("id"),
+        "lap_n": lap.get("lap_n"),
+        "lap_ms": lap.get("lap_ms"),
+        "is_valid": lap.get("is_valid", True) is not False,
+    }
+
+
+def iter_csv_rows(
+    archives: Iterable[tuple[Path, dict[str, Any]]],
+) -> Iterator[dict[str, Any]]:
+    """Yield normalized per-sample rows from loaded archive records."""
+    for source_path, record in archives:
+        fields = _field_map(record)
+        trace = record.get("trace", {})
+        samples = trace.get("samples", [])
+        meta = _metadata(record, source_path)
+        track = record.get("track") if isinstance(record.get("track"), dict) else {}
+        track_len_m = _as_finite_float(track.get("lengthM"))
+        for index, sample in enumerate(samples):
+            row = {column: None for column in CSV_COLUMNS}
+            row.update(meta)
+            row["sample_index"] = index
+            for trace_name, column in _TRACE_TO_CSV.items():
+                row[column] = _sample_value(sample, fields, trace_name)
+            elapsed_ms = row["elapsed_ms"]
+            if elapsed_ms is not None:
+                row["time_s"] = elapsed_ms / 1000.0
+            spline = row["spline"]
+            if spline is not None and track_len_m is not None:
+                row["lap_distance_m"] = spline * track_len_m
+            yield row
+
+
+def _loaded_archives(
+    inputs: Iterable[str | Path],
+    *,
+    include_invalid: bool,
+) -> list[tuple[Path, dict[str, Any]]]:
+    archives: list[tuple[Path, dict[str, Any]]] = []
+    for path in iter_lap_archive_paths(inputs):
+        record = load_lap_archive(path)
+        if include_invalid or lap_is_valid(record):
+            archives.append((path, record))
+    return archives
+
+
+def export_csv(
+    inputs: Iterable[str | Path],
+    output: str | Path,
+    *,
+    include_invalid: bool = False,
+) -> int:
+    """Write stable analysis CSV rows. Returns rows written."""
+    archives = _loaded_archives(inputs, include_invalid=include_invalid)
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    rows_written = 0
+    with output_path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        writer.writeheader()
+        for row in iter_csv_rows(archives):
+            writer.writerow({column: _format_cell(row.get(column)) for column in CSV_COLUMNS})
+            rows_written += 1
+    return rows_written
+
+
+def _parse_exported_at(record: dict[str, Any]) -> datetime | None:
+    raw = record.get("exported_at")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _motec_header(
+    archives: Sequence[tuple[Path, dict[str, Any]]], rows: list[dict[str, Any]]
+) -> list[list[Any]]:
+    first = archives[0][1] if archives else {}
+    first_meta = _metadata(first, archives[0][0]) if archives else {}
+    first_dt = _parse_exported_at(first)
+    log_date = first_dt.strftime("%d/%m/%Y") if first_dt else ""
+    log_time = first_dt.strftime("%I:%M:%S %p") if first_dt else ""
+    end_time = max((_as_finite_float(row.get("time_s")) or 0.0 for row in rows), default=0.0)
+    end_distance = max(
+        (_as_finite_float(row.get("lap_distance_m")) or 0.0 for row in rows),
+        default=0.0,
+    )
+    sample_rate = _sample_rate_hz(rows)
+    beacon_markers = _beacon_markers(archives)
+    return [
+        ["Driver", "AC Copilot Trainer", "", "", "Vehicle ID", first_meta.get("car_id") or ""],
+        ["Device", "AC Copilot Trainer"],
+        [
+            "Comment",
+            "Exported from AC Copilot Trainer schema-v1 lap archives",
+            "",
+            "",
+            "Session",
+            first_meta.get("session_uuid") or "",
+        ],
+        ["Log Date", log_date, "", "", "Origin Time", "0.000", "s"],
+        ["Log Time", log_time, "", "", "Start Time", "0.000", "s"],
+        [
+            "Sample Rate",
+            _format_cell(sample_rate),
+            "Hz",
+            "",
+            "End Time",
+            _format_cell(end_time),
+            "s",
+        ],
+        ["Duration", _format_cell(end_time), "s", "", "Start Distance", "0", "m"],
+        ["Range", "entire outing", "", "", "End Distance", _format_cell(end_distance), "m"],
+        ["Beacon Markers", " ".join(_format_cell(marker) for marker in beacon_markers)],
+    ]
+
+
+def _sample_rate_hz(rows: Sequence[dict[str, Any]]) -> float | None:
+    times = [_as_finite_float(row.get("time_s")) for row in rows]
+    finite = [time for time in times if time is not None]
+    if len(finite) < 2:
+        return None
+    duration = finite[-1] - finite[0]
+    if duration <= 0:
+        return None
+    return (len(finite) - 1) / duration
+
+
+def _beacon_markers(archives: Sequence[tuple[Path, dict[str, Any]]]) -> list[float]:
+    markers: list[float] = []
+    offset = 0.0
+    for _, record in archives:
+        lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
+        lap_ms = _as_finite_float(lap.get("lap_ms"))
+        if lap_ms is None or lap_ms <= 0:
+            continue
+        offset += lap_ms / 1000.0
+        markers.append(offset)
+    return markers
+
+
+def _rows_for_motec(archives: Sequence[tuple[Path, dict[str, Any]]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    offset_s = 0.0
+    for archive in archives:
+        record = archive[1]
+        lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
+        lap_ms = _as_finite_float(lap.get("lap_ms"))
+        lap_s = lap_ms / 1000.0 if lap_ms is not None else None
+        for row in iter_csv_rows([archive]):
+            motec = dict(row)
+            raw_time = _as_finite_float(row.get("time_s"))
+            motec["time_s"] = (offset_s + raw_time) if raw_time is not None else offset_s
+            brake = _as_finite_float(row.get("brake"))
+            throttle = _as_finite_float(row.get("throttle"))
+            motec["brake_pct"] = brake * 100.0 if brake is not None else None
+            motec["throttle_pct"] = throttle * 100.0 if throttle is not None else None
+            motec["lap_time_s"] = lap_s
+            motec["valid_lap"] = 1 if row.get("is_valid") is True else 0
+            rows.append(motec)
+        if lap_s is not None and lap_s > 0:
+            offset_s += lap_s
+    return rows
+
+
+def export_motec_csv(
+    inputs: Iterable[str | Path],
+    output: str | Path,
+    *,
+    include_invalid: bool = False,
+) -> int:
+    """Write a MoTeC-shaped CSV. Returns sample rows written.
+
+    This is not a native MoTeC ``.ld`` writer. The output intentionally follows
+    the public i2 CSV-import conventions: metadata rows, a channel row, a units
+    row, and quoted fields.
+    """
+    archives = _loaded_archives(inputs, include_invalid=include_invalid)
+    rows = _rows_for_motec(archives)
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, quoting=csv.QUOTE_ALL, lineterminator="\n")
+        for header_row in _motec_header(archives, rows):
+            writer.writerow([_format_cell(value) for value in header_row])
+        writer.writerow([name for name, _, _ in _MOTEC_CHANNELS])
+        writer.writerow([unit for _, unit, _ in _MOTEC_CHANNELS])
+        for row in rows:
+            writer.writerow([_format_cell(row.get(key)) for _, _, key in _MOTEC_CHANNELS])
+    return len(rows)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "inputs", nargs="+", help="Archive JSON files or directories containing lap_*.json"
+    )
+    parser.add_argument("-o", "--output", required=True, help="Output CSV path")
+    parser.add_argument(
+        "--format",
+        choices=("csv", "motec-csv"),
+        default="csv",
+        help="Export format (default: csv)",
+    )
+    parser.add_argument(
+        "--include-invalid",
+        action="store_true",
+        help="Include laps with lap.is_valid=false; skipped by default",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, *, stderr: TextIO | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    err = stderr if stderr is not None else sys.stderr
+    try:
+        if args.format == "csv":
+            count = export_csv(args.inputs, args.output, include_invalid=args.include_invalid)
+        else:
+            count = export_motec_csv(args.inputs, args.output, include_invalid=args.include_invalid)
+    except LapArchiveExportError as exc:
+        print(f"lap-archive-export: {exc}", file=err)
+        return 2
+    print(f"wrote {count} sample rows to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -84,8 +84,12 @@ def iter_lap_archive_paths(inputs: Iterable[str | Path]) -> Iterator[Path]:
         path = Path(raw)
         if path.is_dir():
             yield from sorted(path.glob("lap_*.json"))
-        else:
+        elif path.is_file():
             yield path
+        else:
+            raise LapArchiveExportError(
+                f"{path}: input path does not exist or is not a file/directory"
+            )
 
 
 def _as_finite_float(value: Any) -> float | None:
@@ -253,19 +257,16 @@ def _parse_exported_at(record: dict[str, Any]) -> datetime | None:
 
 
 def _motec_header(
-    archives: Sequence[tuple[Path, dict[str, Any]]], rows: list[dict[str, Any]]
+    archives: Sequence[tuple[Path, dict[str, Any]]], stats: dict[str, Any]
 ) -> list[list[Any]]:
     first = archives[0][1] if archives else {}
     first_meta = _metadata(first, archives[0][0]) if archives else {}
     first_dt = _parse_exported_at(first)
     log_date = first_dt.strftime("%d/%m/%Y") if first_dt else ""
     log_time = first_dt.strftime("%I:%M:%S %p") if first_dt else ""
-    end_time = max((_as_finite_float(row.get("time_s")) or 0.0 for row in rows), default=0.0)
-    end_distance = max(
-        (_as_finite_float(row.get("lap_distance_m")) or 0.0 for row in rows),
-        default=0.0,
-    )
-    sample_rate = _sample_rate_hz(rows)
+    end_time = _as_finite_float(stats.get("end_time_s")) or 0.0
+    end_distance = _as_finite_float(stats.get("end_distance_m")) or 0.0
+    sample_rate = _as_finite_float(stats.get("sample_rate_hz"))
     beacon_markers = _beacon_markers(archives)
     return [
         ["Driver", "AC Copilot Trainer", "", "", "Vehicle ID", first_meta.get("car_id") or ""],
@@ -295,38 +296,46 @@ def _motec_header(
     ]
 
 
-def _sample_rate_hz(rows: Sequence[dict[str, Any]]) -> float | None:
-    times = [_as_finite_float(row.get("time_s")) for row in rows]
-    finite = [time for time in times if time is not None]
-    if len(finite) < 2:
-        return None
-    duration = finite[-1] - finite[0]
-    if duration <= 0:
-        return None
-    return (len(finite) - 1) / duration
-
-
 def _beacon_markers(archives: Sequence[tuple[Path, dict[str, Any]]]) -> list[float]:
     markers: list[float] = []
     offset = 0.0
     for _, record in archives:
-        lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
-        lap_ms = _as_finite_float(lap.get("lap_ms"))
-        if lap_ms is None or lap_ms <= 0:
+        duration_s = _lap_duration_s(record)
+        if duration_s <= 0:
             continue
-        offset += lap_ms / 1000.0
+        offset += duration_s
         markers.append(offset)
     return markers
 
 
-def _rows_for_motec(archives: Sequence[tuple[Path, dict[str, Any]]]) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
+def _lap_duration_s(record: dict[str, Any]) -> float:
+    lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
+    lap_ms = _as_finite_float(lap.get("lap_ms"))
+    if lap_ms is not None and lap_ms > 0:
+        return lap_ms / 1000.0
+
+    fields = _field_map(record)
+    samples = record.get("trace", {}).get("samples", [])
+    max_elapsed_ms = max(
+        (
+            value
+            for sample in samples
+            if (value := _sample_value(sample, fields, "eMs")) is not None
+        ),
+        default=None,
+    )
+    if max_elapsed_ms is None or max_elapsed_ms <= 0:
+        return 0.0
+    return max_elapsed_ms / 1000.0
+
+
+def _iter_motec_rows(
+    archives: Sequence[tuple[Path, dict[str, Any]]],
+) -> Iterator[dict[str, Any]]:
     offset_s = 0.0
     for archive in archives:
         record = archive[1]
-        lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
-        lap_ms = _as_finite_float(lap.get("lap_ms"))
-        lap_s = lap_ms / 1000.0 if lap_ms is not None else None
+        duration_s = _lap_duration_s(record)
         for row in iter_csv_rows([archive]):
             motec = dict(row)
             raw_time = _as_finite_float(row.get("time_s"))
@@ -335,12 +344,48 @@ def _rows_for_motec(archives: Sequence[tuple[Path, dict[str, Any]]]) -> list[dic
             throttle = _as_finite_float(row.get("throttle"))
             motec["brake_pct"] = brake * 100.0 if brake is not None else None
             motec["throttle_pct"] = throttle * 100.0 if throttle is not None else None
-            motec["lap_time_s"] = lap_s
+            motec["lap_time_s"] = duration_s if duration_s > 0 else None
             motec["valid_lap"] = 1 if row.get("is_valid") is True else 0
-            rows.append(motec)
-        if lap_s is not None and lap_s > 0:
-            offset_s += lap_s
-    return rows
+            yield motec
+        offset_s += duration_s
+
+
+def _motec_stats(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    row_count = 0
+    finite_time_count = 0
+    first_time_s: float | None = None
+    last_time_s: float | None = None
+    end_time_s = 0.0
+    end_distance_m = 0.0
+
+    for row in rows:
+        row_count += 1
+        time_s = _as_finite_float(row.get("time_s"))
+        if time_s is not None:
+            if first_time_s is None:
+                first_time_s = time_s
+            last_time_s = time_s
+            end_time_s = max(end_time_s, time_s)
+            finite_time_count += 1
+        distance_m = _as_finite_float(row.get("lap_distance_m"))
+        if distance_m is not None:
+            end_distance_m = max(end_distance_m, distance_m)
+
+    sample_rate_hz = None
+    if (
+        first_time_s is not None
+        and last_time_s is not None
+        and finite_time_count >= 2
+        and last_time_s > first_time_s
+    ):
+        sample_rate_hz = (finite_time_count - 1) / (last_time_s - first_time_s)
+
+    return {
+        "row_count": row_count,
+        "end_time_s": end_time_s,
+        "end_distance_m": end_distance_m,
+        "sample_rate_hz": sample_rate_hz,
+    }
 
 
 def export_motec_csv(
@@ -356,18 +401,20 @@ def export_motec_csv(
     row, and quoted fields.
     """
     archives = _loaded_archives(inputs, include_invalid=include_invalid)
-    rows = _rows_for_motec(archives)
+    stats = _motec_stats(_iter_motec_rows(archives))
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    rows_written = 0
     with output_path.open("w", encoding="utf-8", newline="") as fh:
         writer = csv.writer(fh, quoting=csv.QUOTE_ALL, lineterminator="\n")
-        for header_row in _motec_header(archives, rows):
+        for header_row in _motec_header(archives, stats):
             writer.writerow([_format_cell(value) for value in header_row])
         writer.writerow([name for name, _, _ in _MOTEC_CHANNELS])
         writer.writerow([unit for _, unit, _ in _MOTEC_CHANNELS])
-        for row in rows:
+        for row in _iter_motec_rows(archives):
             writer.writerow([_format_cell(row.get(key)) for _, _, key in _MOTEC_CHANNELS])
-    return len(rows)
+            rows_written += 1
+    return rows_written
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -12,6 +12,7 @@ import csv
 import json
 import math
 import sys
+import tempfile
 from collections.abc import Iterable, Iterator, Sequence
 from datetime import datetime
 from pathlib import Path
@@ -224,8 +225,32 @@ def _iter_loaded_archives(
             yield path, record
 
 
-def _temporary_output_path(output_path: Path) -> Path:
-    return output_path.with_name(f".{output_path.name}.tmp")
+def _resolve_output_path(output: str | Path) -> Path:
+    raw_path = Path(output)
+    if raw_path.is_absolute():
+        raise LapArchiveExportError(f"{raw_path}: output path must be relative")
+
+    base_dir = Path.cwd().resolve()
+    output_path = (base_dir / raw_path).resolve()
+    try:
+        output_path.relative_to(base_dir)
+    except ValueError as exc:
+        raise LapArchiveExportError(f"{raw_path}: output path must stay within {base_dir}") from exc
+    if output_path.exists() and output_path.is_dir():
+        raise LapArchiveExportError(f"{raw_path}: output path must be a file")
+    return output_path
+
+
+def _open_temporary_output(output_path: Path) -> tempfile._TemporaryFileWrapper[str]:
+    return tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        newline="",
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
 
 
 def export_csv(
@@ -235,21 +260,24 @@ def export_csv(
     include_invalid: bool = False,
 ) -> int:
     """Write stable analysis CSV rows. Returns rows written."""
-    output_path = Path(output)
+    output_path = _resolve_output_path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = _temporary_output_path(output_path)
+    tmp_path: Path | None = None
     rows_written = 0
     try:
-        with tmp_path.open("w", encoding="utf-8", newline="") as fh:
+        with _open_temporary_output(output_path) as fh:
+            tmp_path = Path(fh.name)
             writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS, lineterminator="\n")
             writer.writeheader()
             archives = _iter_loaded_archives(inputs, include_invalid=include_invalid)
             for row in iter_csv_rows(archives):
                 writer.writerow({column: _format_cell(row.get(column)) for column in CSV_COLUMNS})
                 rows_written += 1
+        assert tmp_path is not None
         tmp_path.replace(output_path)
     except Exception:
-        tmp_path.unlink(missing_ok=True)
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
         raise
     return rows_written
 
@@ -364,10 +392,7 @@ def _lap_duration_s(record: dict[str, Any]) -> float:
 
 
 def _lap_export_duration_s(record: dict[str, Any]) -> float:
-    trace_duration_s = _trace_duration_s(record)
-    if trace_duration_s > 0:
-        return trace_duration_s
-    return _lap_duration_s(record)
+    return _trace_duration_s(record)
 
 
 def _iter_motec_archive_rows(
@@ -380,7 +405,9 @@ def _iter_motec_archive_rows(
     for row in iter_csv_rows([archive]):
         motec = dict(row)
         raw_time = _as_finite_float(row.get("time_s"))
-        motec["time_s"] = (offset_s + raw_time) if raw_time is not None else offset_s
+        if raw_time is None:
+            continue
+        motec["time_s"] = offset_s + raw_time
         brake = _as_finite_float(row.get("brake"))
         throttle = _as_finite_float(row.get("throttle"))
         motec["brake_pct"] = brake * 100.0 if brake is not None else None
@@ -435,7 +462,7 @@ def _scan_motec_archives(archives: Iterable[tuple[Path, dict[str, Any]]]) -> dic
                 end_distance_m = max(end_distance_m, distance_m)
 
         duration_s = _lap_export_duration_s(record)
-        if duration_s > 0:
+        if duration_s > 0 and row_count > 0:
             beacon_markers.append(offset_s + duration_s)
         offset_s += duration_s
 
@@ -472,12 +499,13 @@ def export_motec_csv(
     """
     paths = list(iter_lap_archive_paths(inputs))
     stats = _scan_motec_archives(_iter_loaded_archives(paths, include_invalid=include_invalid))
-    output_path = Path(output)
+    output_path = _resolve_output_path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = _temporary_output_path(output_path)
+    tmp_path: Path | None = None
     rows_written = 0
     try:
-        with tmp_path.open("w", encoding="utf-8", newline="") as fh:
+        with _open_temporary_output(output_path) as fh:
+            tmp_path = Path(fh.name)
             writer = csv.writer(fh, quoting=csv.QUOTE_ALL, lineterminator="\n")
             first_archive = stats.get("first_archive")
             for header_row in _motec_header(first_archive, stats):
@@ -488,9 +516,11 @@ def export_motec_csv(
             for row in _iter_motec_rows(archives):
                 writer.writerow([_format_cell(row.get(key)) for _, _, key in _MOTEC_CHANNELS])
                 rows_written += 1
+        assert tmp_path is not None
         tmp_path.replace(output_path)
     except Exception:
-        tmp_path.unlink(missing_ok=True)
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
         raise
     return rows_written
 

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -213,17 +213,19 @@ def iter_csv_rows(
             yield row
 
 
-def _loaded_archives(
+def _iter_loaded_archives(
     inputs: Iterable[str | Path],
     *,
     include_invalid: bool,
-) -> list[tuple[Path, dict[str, Any]]]:
-    archives: list[tuple[Path, dict[str, Any]]] = []
+) -> Iterator[tuple[Path, dict[str, Any]]]:
     for path in iter_lap_archive_paths(inputs):
         record = load_lap_archive(path)
         if include_invalid or lap_is_valid(record):
-            archives.append((path, record))
-    return archives
+            yield path, record
+
+
+def _temporary_output_path(output_path: Path) -> Path:
+    return output_path.with_name(f".{output_path.name}.tmp")
 
 
 def export_csv(
@@ -233,16 +235,22 @@ def export_csv(
     include_invalid: bool = False,
 ) -> int:
     """Write stable analysis CSV rows. Returns rows written."""
-    archives = _loaded_archives(inputs, include_invalid=include_invalid)
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = _temporary_output_path(output_path)
     rows_written = 0
-    with output_path.open("w", encoding="utf-8", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS, lineterminator="\n")
-        writer.writeheader()
-        for row in iter_csv_rows(archives):
-            writer.writerow({column: _format_cell(row.get(column)) for column in CSV_COLUMNS})
-            rows_written += 1
+    try:
+        with tmp_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS, lineterminator="\n")
+            writer.writeheader()
+            archives = _iter_loaded_archives(inputs, include_invalid=include_invalid)
+            for row in iter_csv_rows(archives):
+                writer.writerow({column: _format_cell(row.get(column)) for column in CSV_COLUMNS})
+                rows_written += 1
+        tmp_path.replace(output_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
     return rows_written
 
 
@@ -257,17 +265,17 @@ def _parse_exported_at(record: dict[str, Any]) -> datetime | None:
 
 
 def _motec_header(
-    archives: Sequence[tuple[Path, dict[str, Any]]], stats: dict[str, Any]
+    first_archive: tuple[Path, dict[str, Any]] | None, stats: dict[str, Any]
 ) -> list[list[Any]]:
-    first = archives[0][1] if archives else {}
-    first_meta = _metadata(first, archives[0][0]) if archives else {}
+    first = first_archive[1] if first_archive else {}
+    first_meta = _metadata(first, first_archive[0]) if first_archive else {}
     first_dt = _parse_exported_at(first)
     log_date = first_dt.strftime("%d/%m/%Y") if first_dt else ""
     log_time = first_dt.strftime("%I:%M:%S %p") if first_dt else ""
     end_time = _as_finite_float(stats.get("end_time_s")) or 0.0
     end_distance = _as_finite_float(stats.get("end_distance_m")) or 0.0
     sample_rate = _as_finite_float(stats.get("sample_rate_hz"))
-    beacon_markers = _beacon_markers(archives)
+    beacon_markers = stats.get("beacon_markers", [])
     return [
         ["Driver", "AC Copilot Trainer", "", "", "Vehicle ID", first_meta.get("car_id") or ""],
         ["Device", "AC Copilot Trainer"],
@@ -296,24 +304,42 @@ def _motec_header(
     ]
 
 
-def _beacon_markers(archives: Sequence[tuple[Path, dict[str, Any]]]) -> list[float]:
-    markers: list[float] = []
-    offset = 0.0
-    for _, record in archives:
-        duration_s = _lap_duration_s(record)
-        if duration_s <= 0:
-            continue
-        offset += duration_s
-        markers.append(offset)
-    return markers
+_MOTEC_GROUP_FIELDS = ("session_uuid", "car_id", "track_id", "track_layout")
 
 
-def _lap_duration_s(record: dict[str, Any]) -> float:
-    lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
-    lap_ms = _as_finite_float(lap.get("lap_ms"))
-    if lap_ms is not None and lap_ms > 0:
-        return lap_ms / 1000.0
+def _motec_group_key(record: dict[str, Any]) -> tuple[Any, Any, Any, Any]:
+    car = record.get("car") if isinstance(record.get("car"), dict) else {}
+    track = record.get("track") if isinstance(record.get("track"), dict) else {}
+    return (
+        record.get("session_uuid"),
+        car.get("id"),
+        track.get("id"),
+        track.get("layout"),
+    )
 
+
+def _format_motec_group_key(key: tuple[Any, Any, Any, Any]) -> str:
+    return ", ".join(
+        f"{name}={_format_cell(value) or '<blank>'}"
+        for name, value in zip(_MOTEC_GROUP_FIELDS, key, strict=True)
+    )
+
+
+def _validate_motec_group(
+    path: Path,
+    key: tuple[Any, Any, Any, Any],
+    expected: tuple[Any, Any, Any, Any],
+) -> None:
+    if key == expected:
+        return
+    raise LapArchiveExportError(
+        f"{path}: motec-csv inputs must contain one session/car/track; "
+        f"first archive is {_format_motec_group_key(expected)}, "
+        f"this archive is {_format_motec_group_key(key)}"
+    )
+
+
+def _trace_duration_s(record: dict[str, Any]) -> float:
     fields = _field_map(record)
     samples = record.get("trace", {}).get("samples", [])
     max_elapsed_ms = max(
@@ -329,28 +355,56 @@ def _lap_duration_s(record: dict[str, Any]) -> float:
     return max_elapsed_ms / 1000.0
 
 
+def _lap_duration_s(record: dict[str, Any]) -> float:
+    lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
+    lap_ms = _as_finite_float(lap.get("lap_ms"))
+    if lap_ms is not None and lap_ms > 0:
+        return lap_ms / 1000.0
+    return _trace_duration_s(record)
+
+
+def _lap_export_duration_s(record: dict[str, Any]) -> float:
+    trace_duration_s = _trace_duration_s(record)
+    if trace_duration_s > 0:
+        return trace_duration_s
+    return _lap_duration_s(record)
+
+
+def _iter_motec_archive_rows(
+    archive: tuple[Path, dict[str, Any]],
+    *,
+    offset_s: float,
+) -> Iterator[dict[str, Any]]:
+    record = archive[1]
+    lap_time_s = _lap_duration_s(record)
+    for row in iter_csv_rows([archive]):
+        motec = dict(row)
+        raw_time = _as_finite_float(row.get("time_s"))
+        motec["time_s"] = (offset_s + raw_time) if raw_time is not None else offset_s
+        brake = _as_finite_float(row.get("brake"))
+        throttle = _as_finite_float(row.get("throttle"))
+        motec["brake_pct"] = brake * 100.0 if brake is not None else None
+        motec["throttle_pct"] = throttle * 100.0 if throttle is not None else None
+        motec["lap_time_s"] = lap_time_s if lap_time_s > 0 else None
+        motec["valid_lap"] = 1 if row.get("is_valid") is True else 0
+        yield motec
+
+
 def _iter_motec_rows(
-    archives: Sequence[tuple[Path, dict[str, Any]]],
+    archives: Iterable[tuple[Path, dict[str, Any]]],
 ) -> Iterator[dict[str, Any]]:
     offset_s = 0.0
     for archive in archives:
         record = archive[1]
-        duration_s = _lap_duration_s(record)
-        for row in iter_csv_rows([archive]):
-            motec = dict(row)
-            raw_time = _as_finite_float(row.get("time_s"))
-            motec["time_s"] = (offset_s + raw_time) if raw_time is not None else offset_s
-            brake = _as_finite_float(row.get("brake"))
-            throttle = _as_finite_float(row.get("throttle"))
-            motec["brake_pct"] = brake * 100.0 if brake is not None else None
-            motec["throttle_pct"] = throttle * 100.0 if throttle is not None else None
-            motec["lap_time_s"] = duration_s if duration_s > 0 else None
-            motec["valid_lap"] = 1 if row.get("is_valid") is True else 0
-            yield motec
-        offset_s += duration_s
+        yield from _iter_motec_archive_rows(archive, offset_s=offset_s)
+        offset_s += _lap_export_duration_s(record)
 
 
-def _motec_stats(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+def _scan_motec_archives(archives: Iterable[tuple[Path, dict[str, Any]]]) -> dict[str, Any]:
+    first_archive: tuple[Path, dict[str, Any]] | None = None
+    expected_key: tuple[Any, Any, Any, Any] | None = None
+    beacon_markers: list[float] = []
+    offset_s = 0.0
     row_count = 0
     finite_time_count = 0
     first_time_s: float | None = None
@@ -358,18 +412,32 @@ def _motec_stats(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
     end_time_s = 0.0
     end_distance_m = 0.0
 
-    for row in rows:
-        row_count += 1
-        time_s = _as_finite_float(row.get("time_s"))
-        if time_s is not None:
-            if first_time_s is None:
-                first_time_s = time_s
-            last_time_s = time_s
-            end_time_s = max(end_time_s, time_s)
-            finite_time_count += 1
-        distance_m = _as_finite_float(row.get("lap_distance_m"))
-        if distance_m is not None:
-            end_distance_m = max(end_distance_m, distance_m)
+    for archive in archives:
+        path, record = archive
+        key = _motec_group_key(record)
+        if expected_key is None:
+            expected_key = key
+            first_archive = archive
+        else:
+            _validate_motec_group(path, key, expected_key)
+
+        for row in _iter_motec_archive_rows(archive, offset_s=offset_s):
+            row_count += 1
+            time_s = _as_finite_float(row.get("time_s"))
+            if time_s is not None:
+                if first_time_s is None:
+                    first_time_s = time_s
+                last_time_s = time_s
+                end_time_s = max(end_time_s, time_s)
+                finite_time_count += 1
+            distance_m = _as_finite_float(row.get("lap_distance_m"))
+            if distance_m is not None:
+                end_distance_m = max(end_distance_m, distance_m)
+
+        duration_s = _lap_export_duration_s(record)
+        if duration_s > 0:
+            beacon_markers.append(offset_s + duration_s)
+        offset_s += duration_s
 
     sample_rate_hz = None
     if (
@@ -381,10 +449,12 @@ def _motec_stats(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
         sample_rate_hz = (finite_time_count - 1) / (last_time_s - first_time_s)
 
     return {
+        "first_archive": first_archive,
         "row_count": row_count,
         "end_time_s": end_time_s,
         "end_distance_m": end_distance_m,
         "sample_rate_hz": sample_rate_hz,
+        "beacon_markers": beacon_markers,
     }
 
 
@@ -400,20 +470,28 @@ def export_motec_csv(
     the public i2 CSV-import conventions: metadata rows, a channel row, a units
     row, and quoted fields.
     """
-    archives = _loaded_archives(inputs, include_invalid=include_invalid)
-    stats = _motec_stats(_iter_motec_rows(archives))
+    paths = list(iter_lap_archive_paths(inputs))
+    stats = _scan_motec_archives(_iter_loaded_archives(paths, include_invalid=include_invalid))
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = _temporary_output_path(output_path)
     rows_written = 0
-    with output_path.open("w", encoding="utf-8", newline="") as fh:
-        writer = csv.writer(fh, quoting=csv.QUOTE_ALL, lineterminator="\n")
-        for header_row in _motec_header(archives, stats):
-            writer.writerow([_format_cell(value) for value in header_row])
-        writer.writerow([name for name, _, _ in _MOTEC_CHANNELS])
-        writer.writerow([unit for _, unit, _ in _MOTEC_CHANNELS])
-        for row in _iter_motec_rows(archives):
-            writer.writerow([_format_cell(row.get(key)) for _, _, key in _MOTEC_CHANNELS])
-            rows_written += 1
+    try:
+        with tmp_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, quoting=csv.QUOTE_ALL, lineterminator="\n")
+            first_archive = stats.get("first_archive")
+            for header_row in _motec_header(first_archive, stats):
+                writer.writerow([_format_cell(value) for value in header_row])
+            writer.writerow([name for name, _, _ in _MOTEC_CHANNELS])
+            writer.writerow([unit for _, unit, _ in _MOTEC_CHANNELS])
+            archives = _iter_loaded_archives(paths, include_invalid=include_invalid)
+            for row in _iter_motec_rows(archives):
+                writer.writerow([_format_cell(row.get(key)) for _, _, key in _MOTEC_CHANNELS])
+                rows_written += 1
+        tmp_path.replace(output_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
     return rows_written
 
 


### PR DESCRIPTION
## Summary
- Add `python -m tools.lap_archive_export` for schema-v1 lap archive JSON export.
- Support stable analysis CSV plus best-effort `--format motec-csv` with metadata, channel/unit rows, quoted fields, and beacon markers.
- Add fixture archive tests for valid laps, invalid-lap filtering, missing trace fields, CLI smoke, and MoTeC-shaped output.
- Document input/output paths, supported channels, and MoTeC/i2 compatibility limits.

## Verification
- `python3 -m pytest -q tests/test_lap_archive_export.py` -> 5 passed.
- `python3 -m ruff check tools/lap_archive_export.py tests/test_lap_archive_export.py` -> all checks passed.
- `python3 -m tools.lap_archive_export --output /tmp/ac-copilot-laps.csv tests/fixtures/lap_archive_valid.json tests/fixtures/lap_archive_missing_fields.json` -> wrote 4 sample rows; inspected stable columns and blank missing-field cells.
- `python3 -m tools.lap_archive_export --format motec-csv --output /tmp/ac-copilot-laps-motec.csv tests/fixtures/lap_archive_valid.json tests/fixtures/lap_archive_missing_fields.json` -> wrote 4 sample rows; inspected quoted metadata, channel/unit rows, beacon markers, and throttle/brake percent conversion.
- `make ci-fast PYTHON=.venv/bin/python` -> OK (885 passed, 74 skipped, coverage 80.43%; Bandit no issues; policy/CSP checks OK). The local venv was installed with `.[dev]` and `.[knowledge]` because system `python3` lacked pytest-cov and MCP extras.

Closes #115