### PR TITLE
feat(harness): prototype generated reference laps (#116)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/_index.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/_index.md
@@ -2,7 +2,7 @@
 type: index
 status: active
 created: 2026-03-28
-updated: 2026-04-22
+updated: 2026-06-16
 relates_to:
   - AcCopilotTrainer/00_System/Architecture Invariants.md
   - 00_Graph_Schema.md
@@ -22,3 +22,4 @@ Architecture Decision Records for this vault.
 - [dashboard-visual-design-figma](dashboard-visual-design-figma.md) — Figma file is source of truth for both HUD (shipped) and rig touchscreen (Phase 2); design tokens + cockpit-UX rules captured here.
 - [autonomous-self-test-harness](autonomous-self-test-harness.md) — agent test-drives the trainer with no human in the loop; layered pyramid (L0 lupa / L1 WS-tap / L1.5 in-sim probe / L2 daemon+CSP Custom AI / L3 human smoke); EPIC #154.
 - [delta-clock-boundary-alignment](delta-clock-boundary-alignment.md) — the `delta` WS topic publishes only when the lap clock is start/finish-aligned (`deltaRefStale`); WS is stricter than the HUD; teleport via guarded `car.resetCounter` (PR #185, #188 residual).
+- [rl-reference-lap-generation](rl-reference-lap-generation.md) — issue #116 go/no-go: defer RL runtime, pursue stdlib/off-sim generated reference laps in archive schema v1 with a persistence-payload bridge.

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/rl-reference-lap-generation.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/rl-reference-lap-generation.md
@@ -44,7 +44,8 @@ Pursue a deterministic generated-reference path first:
    `import_format: "generated_reference_v1"`.
 2. Keep the prototype stdlib-only and off-sim under `tools/ac_harness/reference_lap.py`.
 3. Provide an explicit bridge from archive rows to the live trainer persistence fragment:
-   `bestLapTrace`, `bestReferenceLapMs`, `bestLapMs`, `bestBrakePoints`, and `bestCornerFeatures`.
+   `bestLapTrace`, `bestReferenceLapMs`, `bestBrakePoints`, and `bestCornerFeatures`
+   while preserving the driver's existing `bestLapMs`.
 4. Treat future TUMFTM/CommonRoad output as another producer of the same object-frame list passed to
    `build_archive_record`; do not let solver-specific schemas leak into the trainer.
 

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/rl-reference-lap-generation.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/rl-reference-lap-generation.md
@@ -1,0 +1,80 @@
+---
+type: decision
+status: active
+created: 2026-06-16
+updated: 2026-06-16
+memory_tier: canonical
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/116
+relates_to:
+  - AcCopilotTrainer/01_Decisions/_index.md
+  - AcCopilotTrainer/01_Decisions/autonomous-self-test-harness.md
+  - AcCopilotTrainer/03_Investigations/pr-78-sidecar-autolaunch-lap-archive.md
+---
+
+# Decision: generated reference laps before RL training
+
+## Context
+
+Issue #116 asks whether this project should pursue RL training, TUMFTM-style trajectory generation, or deferral for
+reference-lap generation. The current repo already has a lap archive schema v1 (`lap_archive.lua`) and a live coaching
+path that loads `bestLapTrace` from the trainer persistence payload. EPIC #154 also established that deterministic
+L0/L1/L1.5 harnesses are the priority, while in-sim truth is handled by the Custom AI driver rather than replay.
+
+External grounding:
+
+- TUMFTM `global_racetrajectory_optimization` supports shortest-path, minimum-curvature, minimum-time, and powertrain
+  objectives, and its README notes minimum-time optimization needs more parameters and more compute than
+  minimum-curvature: https://github.com/TUMFTM/global_racetrajectory_optimization.
+- CommonRoad Raceline Planner exposes FTM shortest-path/minimum-curvature planner surfaces based on TUMFTM helpers:
+  https://commonroad-raceline-planner-feb47b.pages.gitlab.lrz.de/spp/.
+- AssettoCorsaGym is a real Assetto Corsa Gym/RL benchmark with SAC baselines, datasets, plugin setup, track occupancy
+  assets, and optional large dataset downloads: https://github.com/dasGringuen/assetto_corsa_gym.
+- Stable-Baselines3 SAC expects a continuous `Box` action space, so using SAC here would require a bounded action
+  interface plus a repeatable simulator loop, not just a Python dependency:
+  https://stable-baselines3.readthedocs.io/en/master/modules/sac.html.
+
+## Decision
+
+Defer RL training as a product/runtime feature. Do not add `assetto_corsa_gym`, `stable-baselines3`, PyTorch, GPU
+training, or simulator plugin dependencies to `make ci-fast`.
+
+Pursue a deterministic generated-reference path first:
+
+1. Generate reference traces into the existing lap archive schema v1 with `source: "imported"` and
+   `import_format: "generated_reference_v1"`.
+2. Keep the prototype stdlib-only and off-sim under `tools/ac_harness/reference_lap.py`.
+3. Provide an explicit bridge from archive rows to the live trainer persistence fragment:
+   `bestLapTrace`, `bestReferenceLapMs`, `bestLapMs`, `bestBrakePoints`, and `bestCornerFeatures`.
+4. Treat future TUMFTM/CommonRoad output as another producer of the same object-frame list passed to
+   `build_archive_record`; do not let solver-specific schemas leak into the trainer.
+
+## Runtime boundary
+
+Current prototype requirements:
+
+- Python 3.11+ stdlib only.
+- No Assetto Corsa process, Windows host, GPU, Gym, PyTorch, or TUMFTM dependency.
+- Covered by `tests/test_reference_lap.py`, so schema compatibility is checked inside `make ci-fast`.
+
+Future optional trajectory/RL work must stay isolated behind an opt-in command or extra, with fixture output committed
+only after conversion to schema v1. A real RL training loop needs a separate issue with simulator lifecycle,
+action-space bounds, data volume, and acceptance metrics.
+
+## How a generated reference enters the comparison path
+
+The generated archive record is the immutable dataset artifact. To make it active for live coaching, an importer should
+merge `build_trainer_reference_payload(record)` into the per-car/track trainer persistence JSON. On next load, the app's
+existing `applyLoaded` path normalizes `bestLapTrace`, builds `bestSortedTrace`, derives sector deltas, and exposes the
+reference to real-time coaching and `delta`.
+
+This PR intentionally stops at the generator/validator/bridge seam. It does not auto-install generated references into
+the live CSP data folder, because that write path needs a separate UI or explicit import command and in-sim validation.
+
+## Consequences
+
+- Issue #116 has an evidence-backed go/no-go: RL deferred, deterministic generated references accepted.
+- The prototype emits one schema-compatible reference lap today and can emit a trainer-state payload for a future
+  importer.
+- The main runtime remains dependency-free and CI remains game-free.
+- TUMFTM integration remains useful, but it is now a producer behind the archive adapter rather than an architectural
+  dependency of the trainer.

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -11,7 +11,7 @@
 --   {
 --     schema_version = 1,
 --     source = "in_game" | "imported",
---     import_format = nil | "motec_csv" | "ibt" | "delta",
+--     import_format = nil | "motec_csv" | "ibt" | "delta" | "generated_reference_v1",
 --     lap_uuid, session_uuid, exported_at,
 --     car = { id, displayName? },
 --     track = { id, layout?, lengthM? },

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.ac_harness.reference_lap import (
+    GENERATED_IMPORT_FORMAT,
+    TRACE_FIELDS,
+    LapArchiveSchemaError,
+    archive_trace_to_object_trace,
+    build_archive_record_from_scenario,
+    build_trainer_reference_payload,
+    main,
+    validate_lap_archive_record,
+)
+from tools.ac_harness.trace_replay import BRAKE_ENTRY_SPEED_KMH, BRAKE_SPLINE, synthesize_trace
+
+
+def test_generated_reference_archive_matches_lap_archive_schema_v1() -> None:
+    frames = synthesize_trace("brake_too_late")
+    record = build_archive_record_from_scenario(
+        "brake_too_late",
+        car_id="ks_mazda_miata",
+        track_id="magione",
+        track_length_m=2525.0,
+        exported_at="2026-06-16T00:00:00Z",
+    )
+
+    validate_lap_archive_record(record)
+    assert record["schema_version"] == 1
+    assert record["source"] == "imported"
+    assert record["import_format"] == GENERATED_IMPORT_FORMAT
+    assert record["car"]["id"] == "ks_mazda_miata"
+    assert record["track"]["id"] == "magione"
+    assert record["track"]["lengthM"] == pytest.approx(2525.0)
+    assert record["trace"]["fields"] == list(TRACE_FIELDS)
+    assert record["trace"]["samples_count"] == len(frames)
+    assert record["lap"]["lap_ms"] == round(frames[-1]["eMs"])
+    assert record["corners"][0]["brakePointSpline"] == pytest.approx(BRAKE_SPLINE)
+    assert record["corners"][0]["entrySpeed"] == pytest.approx(BRAKE_ENTRY_SPEED_KMH)
+
+
+def test_archive_trace_converts_to_live_best_lap_trace_shape() -> None:
+    record = build_archive_record_from_scenario("brake_too_late")
+    frames = archive_trace_to_object_trace(record)
+
+    assert len(frames) == record["trace"]["samples_count"]
+    assert tuple(frames[0].keys()) == TRACE_FIELDS
+    assert isinstance(frames[0]["gear"], int)
+    assert frames[0]["spline"] == pytest.approx(record["trace"]["samples"][0][0])
+
+
+def test_trainer_reference_payload_bridges_generated_archive_to_live_persistence() -> None:
+    record = build_archive_record_from_scenario("brake_too_late")
+    payload = build_trainer_reference_payload(record)
+
+    assert payload["bestLapMs"] == record["lap"]["lap_ms"]
+    assert payload["bestReferenceLapMs"] == record["lap"]["lap_ms"]
+    assert payload["bestLapTrace"][0]["spline"] == pytest.approx(0.0)
+    assert payload["bestLapTrace"][-1]["spline"] <= 1.0
+    assert payload["bestBrakePoints"][0]["spline"] == pytest.approx(BRAKE_SPLINE)
+    assert payload["bestBrakePoints"][0]["entrySpeed"] == pytest.approx(BRAKE_ENTRY_SPEED_KMH)
+    assert payload["bestBrakePoints"][0]["label"] == "T1"
+    assert payload["bestCornerFeatures"] == record["corners"]
+
+
+def test_validator_rejects_trace_field_order_drift() -> None:
+    record = build_archive_record_from_scenario("clean_lap")
+    record["trace"]["fields"] = list(reversed(record["trace"]["fields"]))
+
+    with pytest.raises(LapArchiveSchemaError, match="trace.fields"):
+        validate_lap_archive_record(record)
+
+
+def test_validator_rejects_non_monotonic_elapsed_time() -> None:
+    record = build_archive_record_from_scenario("clean_lap")
+    record["trace"]["samples"][2][TRACE_FIELDS.index("eMs")] = -1.0
+
+    with pytest.raises(LapArchiveSchemaError, match="monotonic"):
+        validate_lap_archive_record(record)
+
+
+def test_cli_emits_schema_valid_archive_json(tmp_path) -> None:
+    output = tmp_path / "generated_ref.json"
+    rc = main(
+        [
+            "--scenario",
+            "clean_lap",
+            "--car-id",
+            "ks_mazda_miata",
+            "--track-id",
+            "magione",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
+    record = json.loads(output.read_text(encoding="utf-8"))
+    validate_lap_archive_record(record)
+    assert record["car"]["id"] == "ks_mazda_miata"
+    assert record["track"]["id"] == "magione"
+
+
+def test_cli_can_emit_trainer_state_payload(tmp_path) -> None:
+    output = tmp_path / "generated_state.json"
+    rc = main(["--emit", "trainer-state", "--output", str(output)])
+
+    assert rc == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert set(payload) == {
+        "bestLapMs",
+        "bestReferenceLapMs",
+        "bestLapTrace",
+        "bestBrakePoints",
+        "bestCornerFeatures",
+    }
+    assert payload["bestLapTrace"]

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -116,7 +116,7 @@ def test_brake_corner_uses_full_tail_when_brake_never_releases() -> None:
     corner = record["corners"][0]
     assert corner["exitSpeed"] == pytest.approx(100.0)
     assert corner["minSpeed"] == pytest.approx(100.0)
-    assert corner["trailBrakeRatio"] == pytest.approx(1.0)
+    assert corner["trailBrakeRatio"] == pytest.approx(0.75)
 
 
 def test_validator_rejects_trace_field_order_drift() -> None:

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -56,7 +56,7 @@ def test_trainer_reference_payload_bridges_generated_archive_to_live_persistence
     record = build_archive_record_from_scenario("brake_too_late")
     payload = build_trainer_reference_payload(record)
 
-    assert payload["bestLapMs"] == record["lap"]["lap_ms"]
+    assert "bestLapMs" not in payload
     assert payload["bestReferenceLapMs"] == record["lap"]["lap_ms"]
     assert payload["bestLapTrace"][0]["spline"] == pytest.approx(0.0)
     assert payload["bestLapTrace"][-1]["spline"] <= 1.0
@@ -135,6 +135,22 @@ def test_validator_rejects_non_monotonic_elapsed_time() -> None:
         validate_lap_archive_record(record)
 
 
+def test_validator_requires_corners_key() -> None:
+    record = build_archive_record_from_scenario("clean_lap")
+    del record["corners"]
+
+    with pytest.raises(LapArchiveSchemaError, match="missing top-level key: corners"):
+        validate_lap_archive_record(record)
+
+
+def test_validator_rejects_lap_time_that_does_not_match_trace_elapsed() -> None:
+    record = build_archive_record_from_scenario("clean_lap")
+    record["lap"]["lap_ms"] += 5000
+
+    with pytest.raises(LapArchiveSchemaError, match="lap.lap_ms must match final trace eMs"):
+        validate_lap_archive_record(record)
+
+
 def test_cli_emits_schema_valid_archive_json(tmp_path) -> None:
     output = tmp_path / "generated_ref.json"
     rc = main(
@@ -164,7 +180,6 @@ def test_cli_can_emit_trainer_state_payload(tmp_path) -> None:
     assert rc == 0
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert set(payload) == {
-        "bestLapMs",
         "bestReferenceLapMs",
         "bestLapTrace",
         "bestBrakePoints",

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -9,6 +9,7 @@ from tools.ac_harness.reference_lap import (
     TRACE_FIELDS,
     LapArchiveSchemaError,
     archive_trace_to_object_trace,
+    build_archive_record,
     build_archive_record_from_scenario,
     build_trainer_reference_payload,
     main,
@@ -63,6 +64,59 @@ def test_trainer_reference_payload_bridges_generated_archive_to_live_persistence
     assert payload["bestBrakePoints"][0]["entrySpeed"] == pytest.approx(BRAKE_ENTRY_SPEED_KMH)
     assert payload["bestBrakePoints"][0]["label"] == "T1"
     assert payload["bestCornerFeatures"] == record["corners"]
+
+
+def test_brake_corner_uses_full_tail_when_brake_never_releases() -> None:
+    frames = [
+        {
+            "spline": 0.0,
+            "speed": 160.0,
+            "eMs": 0.0,
+            "throttle": 1.0,
+            "brake": 0.0,
+            "steer": 0.0,
+            "gear": 4,
+            "px": 0.0,
+            "py": 0.0,
+            "pz": 0.0,
+        },
+        {
+            "spline": 0.2,
+            "speed": 140.0,
+            "eMs": 1000.0,
+            "throttle": 0.0,
+            "brake": 1.0,
+            "steer": 0.1,
+            "gear": 4,
+            "px": 1.0,
+            "py": 0.0,
+            "pz": 0.0,
+        },
+        {
+            "spline": 0.3,
+            "speed": 100.0,
+            "eMs": 2000.0,
+            "throttle": 0.2,
+            "brake": 0.5,
+            "steer": 0.3,
+            "gear": 3,
+            "px": 2.0,
+            "py": 0.0,
+            "pz": 0.0,
+        },
+    ]
+
+    record = build_archive_record(
+        frames,
+        car_id="ks_mazda_miata",
+        track_id="magione",
+        exported_at="2026-06-16T00:00:00Z",
+    )
+
+    corner = record["corners"][0]
+    assert corner["exitSpeed"] == pytest.approx(100.0)
+    assert corner["minSpeed"] == pytest.approx(100.0)
+    assert corner["trailBrakeRatio"] == pytest.approx(1.0)
 
 
 def test_validator_rejects_trace_field_order_drift() -> None:

--- a/tests/test_repo_knowledge/test_mcp_server_import.py
+++ b/tests/test_repo_knowledge/test_mcp_server_import.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("mcp")
+pytest.importorskip("mcp.server.fastmcp")
 
 
 def test_mcp_server_module_imports() -> None:

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -109,16 +109,18 @@ def _first_brake_corner(rows: Sequence[Sequence[float]]) -> dict[str, Any] | Non
                 break
         window = braking[:release_offset]
         speeds = [candidate[speed_idx] for candidate in window]
+        brake_values = [candidate[brake_idx] for candidate in window]
         steer_values = [candidate[steer_idx] for candidate in window]
         throttle_values = [candidate[throttle_idx] for candidate in window]
+        max_brake = max(brake_values)
+        avg_brake = sum(brake_values) / len(brake_values)
         return {
             "label": "T1",
             "entrySpeed": row[speed_idx],
             "minSpeed": min(speeds),
             "exitSpeed": speeds[-1],
             "brakePointSpline": row[spline_idx],
-            "trailBrakeRatio": sum(1 for candidate in window if candidate[brake_idx] > 0.1)
-            / len(window),
+            "trailBrakeRatio": 0.0 if max_brake <= 1e-6 else min(1.0, avg_brake / max_brake),
             "throttleAvg": sum(throttle_values) / len(throttle_values),
             "steerReversals": 0,
             "tractionCircleProxy": max(abs(value) for value in steer_values),

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -102,11 +102,12 @@ def _first_brake_corner(rows: Sequence[Sequence[float]]) -> dict[str, Any] | Non
         if row[brake_idx] < 0.3:
             continue
         braking = rows[i:]
-        release_offset = 0
-        for release_offset, candidate in enumerate(braking):
-            if candidate[brake_idx] < 0.1 and release_offset > 0:
+        release_offset = len(braking)
+        for candidate_offset, candidate in enumerate(braking[1:], start=1):
+            if candidate[brake_idx] < 0.1:
+                release_offset = candidate_offset
                 break
-        window = braking[: max(1, release_offset)]
+        window = braking[:release_offset]
         speeds = [candidate[speed_idx] for candidate in window]
         steer_values = [candidate[steer_idx] for candidate in window]
         throttle_values = [candidate[throttle_idx] for candidate in window]

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -1,0 +1,379 @@
+"""Generated reference-lap archive adapter for issue #116.
+
+The trainer's durable lap data shape is the Lua ``lap_archive`` schema v1:
+columnar telemetry samples under ``trace`` plus lap, car, track, setup, corner,
+and coaching metadata. This module gives offline generators a Python-side seam
+for emitting that exact shape without Assetto Corsa, GPU training, or optional
+RL dependencies.
+
+The default CLI generator uses the existing deterministic synthetic traces from
+``trace_replay``. A future TUMFTM/CommonRoad adapter should feed its frames into
+``build_archive_record`` and inherit the same schema validator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from tools.ac_harness.trace_replay import available_scenarios, synthesize_trace
+
+TRACE_FIELDS: tuple[str, ...] = (
+    "spline",
+    "speed",
+    "eMs",
+    "throttle",
+    "brake",
+    "steer",
+    "gear",
+    "px",
+    "py",
+    "pz",
+)
+
+SCHEMA_VERSION = 1
+GENERATED_IMPORT_FORMAT = "generated_reference_v1"
+DEFAULT_TRACK_LENGTH_M = 4500.0
+
+
+class LapArchiveSchemaError(ValueError):
+    """Raised when a generated archive record does not match schema v1."""
+
+
+def _finite_float(raw: Any, field: str) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise LapArchiveSchemaError(f"{field} must be numeric, got {raw!r}") from exc
+    if not math.isfinite(value):
+        raise LapArchiveSchemaError(f"{field} must be finite, got {raw!r}")
+    return value
+
+
+def _stable_id(prefix: str, rows: Sequence[Sequence[float]]) -> str:
+    payload = json.dumps(rows, separators=(",", ":"), sort_keys=False)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}-{digest}"
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_trace_frame(frame: Mapping[str, Any], index: int) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for field in TRACE_FIELDS:
+        out[field] = _finite_float(frame.get(field), f"trace[{index}].{field}")
+    if out["spline"] < 0.0 or out["spline"] > 1.0:
+        raise LapArchiveSchemaError(f"trace[{index}].spline must be in [0, 1]")
+    return out
+
+
+def trace_to_columns(frames: Iterable[Mapping[str, Any]]) -> list[list[float]]:
+    """Convert object-style trace frames to lap-archive column rows."""
+    rows: list[list[float]] = []
+    last_elapsed = -math.inf
+    for index, frame in enumerate(frames):
+        normalized = _normalize_trace_frame(frame, index)
+        elapsed = normalized["eMs"]
+        if elapsed < last_elapsed:
+            raise LapArchiveSchemaError("trace eMs must be monotonic nondecreasing")
+        last_elapsed = elapsed
+        rows.append([normalized[field] for field in TRACE_FIELDS])
+    if len(rows) < 2:
+        raise LapArchiveSchemaError("reference trace needs at least two samples")
+    return rows
+
+
+def _first_brake_corner(rows: Sequence[Sequence[float]]) -> dict[str, Any] | None:
+    brake_idx = TRACE_FIELDS.index("brake")
+    speed_idx = TRACE_FIELDS.index("speed")
+    spline_idx = TRACE_FIELDS.index("spline")
+    throttle_idx = TRACE_FIELDS.index("throttle")
+    steer_idx = TRACE_FIELDS.index("steer")
+    for i, row in enumerate(rows):
+        if row[brake_idx] < 0.3:
+            continue
+        braking = rows[i:]
+        release_offset = 0
+        for release_offset, candidate in enumerate(braking):
+            if candidate[brake_idx] < 0.1 and release_offset > 0:
+                break
+        window = braking[: max(1, release_offset)]
+        speeds = [candidate[speed_idx] for candidate in window]
+        steer_values = [candidate[steer_idx] for candidate in window]
+        throttle_values = [candidate[throttle_idx] for candidate in window]
+        return {
+            "label": "T1",
+            "entrySpeed": row[speed_idx],
+            "minSpeed": min(speeds),
+            "exitSpeed": speeds[-1],
+            "brakePointSpline": row[spline_idx],
+            "trailBrakeRatio": sum(1 for candidate in window if candidate[brake_idx] > 0.1)
+            / len(window),
+            "throttleAvg": sum(throttle_values) / len(throttle_values),
+            "steerReversals": 0,
+            "tractionCircleProxy": max(abs(value) for value in steer_values),
+        }
+    return None
+
+
+def build_archive_record(
+    frames: Iterable[Mapping[str, Any]],
+    *,
+    car_id: str = "generated_car",
+    track_id: str = "generated_track",
+    track_length_m: float = DEFAULT_TRACK_LENGTH_M,
+    lap_n: int = 1,
+    exported_at: str | None = None,
+    lap_uuid: str | None = None,
+    session_uuid: str | None = None,
+    generator_name: str = "ac_harness.reference_lap",
+) -> dict[str, Any]:
+    """Build one generated-reference lap archive record.
+
+    ``frames`` are object traces with keys matching :data:`TRACE_FIELDS`. The
+    returned record is schema v1 and can be written as ``lap_*.json`` or
+    converted to the trainer persistence payload via
+    :func:`build_trainer_reference_payload`.
+    """
+    rows = trace_to_columns(frames)
+    lap_ms = int(round(rows[-1][TRACE_FIELDS.index("eMs")]))
+    if lap_ms <= 0:
+        raise LapArchiveSchemaError("lap_ms must be positive")
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "source": "imported",
+        "import_format": GENERATED_IMPORT_FORMAT,
+        "lap_uuid": lap_uuid or _stable_id("lap", rows),
+        "session_uuid": session_uuid or _stable_id("generated-session", rows[:8]),
+        "exported_at": exported_at or _iso_now(),
+        "car": {"id": car_id, "displayName": None},
+        "track": {
+            "id": track_id,
+            "layout": None,
+            "lengthM": _finite_float(track_length_m, "track_length_m"),
+        },
+        "conditions": {
+            "trackGripLevel": None,
+            "ambientTempC": None,
+            "trackTempC": None,
+            "weatherType": None,
+        },
+        "lap": {
+            "lap_n": int(lap_n),
+            "lap_ms": lap_ms,
+            "is_pb": True,
+            "is_valid": True,
+        },
+        "setup": {"hash": "", "path": None, "snapshot": {}},
+        "trace": {
+            "samples_count": len(rows),
+            "fields": list(TRACE_FIELDS),
+            "samples": rows,
+        },
+        "corners": [],
+        "coaching": {
+            "rules_hints": [
+                "Generated reference lap seed; validate in-sim before treating as driver truth."
+            ],
+            "sidecar_debrief": None,
+            "corner_advice_used": None,
+        },
+        "generator": {
+            "name": generator_name,
+            "version": 1,
+            "decision_issue": 116,
+        },
+    }
+    corner = _first_brake_corner(rows)
+    if corner is not None:
+        record["corners"].append(corner)
+    validate_lap_archive_record(record)
+    return record
+
+
+def build_archive_record_from_scenario(
+    scenario: str = "brake_too_late",
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Build a schema v1 archive record from a deterministic harness scenario."""
+    frames = synthesize_trace(scenario)
+    return build_archive_record(frames, generator_name=f"trace_replay:{scenario}", **kwargs)
+
+
+def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
+    """Raise :class:`LapArchiveSchemaError` unless ``record`` matches schema v1."""
+    if record.get("schema_version") != SCHEMA_VERSION:
+        raise LapArchiveSchemaError("schema_version must be 1")
+    if record.get("source") not in {"in_game", "imported"}:
+        raise LapArchiveSchemaError("source must be 'in_game' or 'imported'")
+    if record.get("source") == "imported" and not isinstance(record.get("import_format"), str):
+        raise LapArchiveSchemaError("imported records require string import_format")
+    for key in (
+        "lap_uuid",
+        "session_uuid",
+        "exported_at",
+        "car",
+        "track",
+        "lap",
+        "setup",
+        "trace",
+        "coaching",
+    ):
+        if key not in record:
+            raise LapArchiveSchemaError(f"missing top-level key: {key}")
+
+    lap = record["lap"]
+    if not isinstance(lap, Mapping):
+        raise LapArchiveSchemaError("lap must be an object")
+    lap_ms = _finite_float(lap.get("lap_ms"), "lap.lap_ms")
+    if lap_ms <= 0:
+        raise LapArchiveSchemaError("lap.lap_ms must be positive")
+
+    trace = record["trace"]
+    if not isinstance(trace, Mapping):
+        raise LapArchiveSchemaError("trace must be an object")
+    fields = trace.get("fields")
+    if fields != list(TRACE_FIELDS):
+        raise LapArchiveSchemaError(f"trace.fields must be {list(TRACE_FIELDS)!r}")
+    samples = trace.get("samples")
+    if not isinstance(samples, list):
+        raise LapArchiveSchemaError("trace.samples must be a list")
+    if trace.get("samples_count") != len(samples):
+        raise LapArchiveSchemaError("trace.samples_count must equal len(trace.samples)")
+    last_elapsed = -math.inf
+    for row_index, row in enumerate(samples):
+        if not isinstance(row, list) or len(row) != len(TRACE_FIELDS):
+            raise LapArchiveSchemaError(
+                f"trace.samples[{row_index}] must have {len(TRACE_FIELDS)} columns"
+            )
+        for field_index, value in enumerate(row):
+            parsed = _finite_float(value, f"trace.samples[{row_index}][{field_index}]")
+            if TRACE_FIELDS[field_index] == "spline" and (parsed < 0.0 or parsed > 1.0):
+                raise LapArchiveSchemaError(f"trace.samples[{row_index}].spline must be in [0, 1]")
+            if TRACE_FIELDS[field_index] == "eMs":
+                if parsed < last_elapsed:
+                    raise LapArchiveSchemaError("trace eMs must be monotonic nondecreasing")
+                last_elapsed = parsed
+
+
+def archive_trace_to_object_trace(record: Mapping[str, Any]) -> list[dict[str, float]]:
+    """Convert archive column rows into the live trainer's ``bestLapTrace`` shape."""
+    validate_lap_archive_record(record)
+    rows = record["trace"]["samples"]
+    frames: list[dict[str, float]] = []
+    for row in rows:
+        frame = {field: float(row[i]) for i, field in enumerate(TRACE_FIELDS)}
+        frame["gear"] = int(frame["gear"])
+        frames.append(frame)
+    return frames
+
+
+def _nearest_frame(frames: Sequence[Mapping[str, float]], spline: float) -> Mapping[str, float]:
+    return min(frames, key=lambda frame: abs(float(frame["spline"]) - spline))
+
+
+def _brake_points_from_corners(
+    record: Mapping[str, Any],
+    frames: Sequence[Mapping[str, float]],
+) -> list[dict[str, Any]]:
+    points: list[dict[str, Any]] = []
+    corners = record.get("corners", [])
+    if not isinstance(corners, list):
+        return points
+    for corner in corners:
+        if not isinstance(corner, Mapping):
+            continue
+        raw_spline = corner.get("brakePointSpline")
+        raw_entry = corner.get("entrySpeed")
+        if raw_spline is None or raw_entry is None:
+            continue
+        spline = _finite_float(raw_spline, "corner.brakePointSpline")
+        entry = _finite_float(raw_entry, "corner.entrySpeed")
+        nearest = _nearest_frame(frames, spline)
+        point: dict[str, Any] = {
+            "spline": spline,
+            "px": float(nearest["px"]),
+            "py": float(nearest["py"]),
+            "pz": float(nearest["pz"]),
+            "entrySpeed": entry,
+            "heading": 0.0,
+        }
+        label = corner.get("label")
+        if isinstance(label, str) and label:
+            point["label"] = label
+        points.append(point)
+    return points
+
+
+def build_trainer_reference_payload(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the live trainer persistence fragment for a generated reference.
+
+    The app currently loads ``bestLapTrace`` from its per-car/track persistence
+    JSON and archives completed laps separately. This function is the explicit
+    bridge: a future importer can merge this payload into the persistence file
+    while keeping the source archive record immutable.
+    """
+    frames = archive_trace_to_object_trace(record)
+    lap = record["lap"]
+    lap_ms = int(round(_finite_float(lap.get("lap_ms"), "lap.lap_ms")))
+    corners = record.get("corners", [])
+    return {
+        "bestLapMs": lap_ms,
+        "bestReferenceLapMs": lap_ms,
+        "bestLapTrace": frames,
+        "bestBrakePoints": _brake_points_from_corners(record, frames),
+        "bestCornerFeatures": corners if isinstance(corners, list) else [],
+    }
+
+
+def _json_text(payload: Mapping[str, Any], *, pretty: bool) -> str:
+    if pretty:
+        return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", choices=available_scenarios(), default="brake_too_late")
+    parser.add_argument("--car-id", default="generated_car")
+    parser.add_argument("--track-id", default="generated_track")
+    parser.add_argument("--track-length-m", type=float, default=DEFAULT_TRACK_LENGTH_M)
+    parser.add_argument("--lap-n", type=int, default=1)
+    parser.add_argument(
+        "--emit",
+        choices=("archive", "trainer-state"),
+        default="archive",
+        help="archive emits lap_archive schema v1; trainer-state emits the persistence fragment.",
+    )
+    parser.add_argument("--output", type=Path, help="Write JSON to this path instead of stdout.")
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args(argv)
+
+    record = build_archive_record_from_scenario(
+        args.scenario,
+        car_id=args.car_id,
+        track_id=args.track_id,
+        track_length_m=args.track_length_m,
+        lap_n=args.lap_n,
+    )
+    payload = build_trainer_reference_payload(record) if args.emit == "trainer-state" else record
+    text = _json_text(payload, pretty=args.pretty)
+    if args.output is None:
+        sys.stdout.write(text)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -228,6 +228,7 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
         "setup",
         "trace",
         "coaching",
+        "corners",
     ):
         if key not in record:
             raise LapArchiveSchemaError(f"missing top-level key: {key}")
@@ -248,6 +249,8 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
     samples = trace.get("samples")
     if not isinstance(samples, list):
         raise LapArchiveSchemaError("trace.samples must be a list")
+    if len(samples) < 2:
+        raise LapArchiveSchemaError("trace.samples must contain at least two rows")
     if trace.get("samples_count") != len(samples):
         raise LapArchiveSchemaError("trace.samples_count must equal len(trace.samples)")
     last_elapsed = -math.inf
@@ -264,6 +267,12 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
                 if parsed < last_elapsed:
                     raise LapArchiveSchemaError("trace eMs must be monotonic nondecreasing")
                 last_elapsed = parsed
+    if abs(lap_ms - round(last_elapsed)) > 1.0:
+        raise LapArchiveSchemaError("lap.lap_ms must match final trace eMs")
+
+    corners = record["corners"]
+    if not isinstance(corners, list):
+        raise LapArchiveSchemaError("corners must be a list")
 
 
 def archive_trace_to_object_trace(record: Mapping[str, Any]) -> list[dict[str, float]]:
@@ -328,7 +337,6 @@ def build_trainer_reference_payload(record: Mapping[str, Any]) -> dict[str, Any]
     lap_ms = int(round(_finite_float(lap.get("lap_ms"), "lap.lap_ms")))
     corners = record.get("corners", [])
     return {
-        "bestLapMs": lap_ms,
         "bestReferenceLapMs": lap_ms,
         "bestLapTrace": frames,
         "bestBrakePoints": _brake_points_from_corners(record, frames),


### PR DESCRIPTION
## Summary

- Add a stdlib-only `tools.ac_harness.reference_lap` generator/validator for lap archive schema v1.
- Add a trainer-state persistence bridge that maps generated archive records into `bestLapTrace`, `bestReferenceLapMs`, brake points, and corner features.
- Add an ADR for issue #116 choosing deterministic/off-sim generated reference laps now and deferring RL runtime dependencies.
- Harden the optional MCP smoke-test skip guard so full `make ci-fast` remains deterministic when the optional `mcp` extra is absent.

## Generated artifact proof

Generated with:

```bash
python3 -m tools.ac_harness.reference_lap --scenario brake_too_late --car-id ks_mazda_miata --track-id magione --track-length-m 2525 --output .scratch/issue-116-generated-reference-lap.json
python3 -m tools.ac_harness.reference_lap --scenario brake_too_late --emit trainer-state --output .scratch/issue-116-generated-trainer-state.json
```

Summary:

- `schema_version=1`
- `source=imported`
- `import_format=generated_reference_v1`
- `samples=164`
- trace fields: `spline`, `speed`, `eMs`, `throttle`, `brake`, `steer`, `gear`, `px`, `py`, `pz`
- `lap_ms=8150`
- first corner: `T1`, `brakePointSpline=0.2`, `entrySpeed=180.0`, `exitSpeed=90.0`, `trailBrakeRatio=1.0`

## Validation

- `python3 -m pytest tests/test_reference_lap.py -q`
- `python3 -m ruff check tools/ac_harness/reference_lap.py tests/test_reference_lap.py`
- `python3 -m ruff format --check tools/ac_harness/reference_lap.py tests/test_reference_lap.py`
- `python3 -m tools.ac_harness.reference_lap --scenario brake_too_late --car-id ks_mazda_miata --track-id magione --track-length-m 2525 --output .scratch/issue-116-generated-reference-lap.json`
- `python3 -m tools.ac_harness.reference_lap --scenario brake_too_late --emit trainer-state --output .scratch/issue-116-generated-trainer-state.json`
- `make ci-fast PYTHON=.venv/bin/python`

Closes #116
