### PR TITLE
feat(setup): add experiment tracking and suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Enable in Content Manager → Settings → Apps.
 
 **Python sidecar auto-launch (issue #77):** `start_sidecar.bat` walks upward from the app folder until it finds `tools/ai_sidecar` (your full git checkout). If you install only the Lua folder into `apps/lua/`, set environment variable `AC_COPILOT_REPO_ROOT` to the repository root before starting AC, or run `python -m tools.ai_sidecar` manually.
 
+**Setup experiments (issue #114):** lap archives under `journal/laps` can be rebuilt into a setup experiment table and queried for A/B comparisons or the next setup suggestion:
+```bash
+python -m tools.ai_sidecar --setup-rebuild-experiments "<...>/journal/laps"
+python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" --setup-suggest
+```
+See [docs/10_Development/13_Setup_Experiments.md](docs/10_Development/13_Setup_Experiments.md).
+
 ## Development
 
 ```bash

--- a/docs/10_Development/12_WS_Sidecar_Protocol.md
+++ b/docs/10_Development/12_WS_Sidecar_Protocol.md
@@ -83,6 +83,22 @@ Lua currently ignores this event (logging only in Python); future versions may s
 
 **Fixture ranking (issue #49):** `python -m tools.ai_sidecar --compare-laps slower.json reference.json` prints JSON for corner-level improvement suggestions (requires `telemetry.corners` in both files).
 
+**Setup optimization (issue #114):**
+
+- Lua → sidecar: `{"v":1,"type":"setup.experiment.record","archive_path":".../journal/laps/lap_...json"}` ingests one PR #78 lap archive into `journal/setup_experiments/experiments.jsonl`.
+- client → sidecar: `{"v":1,"type":"setup.compare","baseline_setup":"old","candidate_setup":"new"}` returns `setup.compare.result` with A/B improvement, confidence, and significance.
+- client → sidecar: `{"v":1,"type":"setup.suggest","car_id":"...","track_id":"..."}` returns `setup.suggest.result` with the next setup candidate and rationale.
+
+CLI equivalents:
+
+```bash
+python -m tools.ai_sidecar --setup-rebuild-experiments "<...>/journal/laps"
+python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" --setup-compare old new
+python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" --setup-suggest
+```
+
+See [13_Setup_Experiments.md](13_Setup_Experiments.md) for data location, reset, and rebuild.
+
 ## Tests
 
 `tests/test_ai_sidecar_protocol.py` — `prepare_outbound_message` unit tests and asyncio WebSocket round-trip (requires `websockets`). `tests/test_llm_coach.py` — Ollama debrief helpers with mocked HTTP (issue **#46**).

--- a/docs/10_Development/12_WS_Sidecar_Protocol.md
+++ b/docs/10_Development/12_WS_Sidecar_Protocol.md
@@ -85,6 +85,7 @@ Lua currently ignores this event (logging only in Python); future versions may s
 
 **Setup optimization (issue #114):**
 
+- Lua → sidecar: `{"v":1,"type":"setup.experiment.store","store_path":".../journal/setup_experiments/experiments.jsonl"}` registers the canonical store after handshake so compare/suggest can use rebuilt rows immediately after sidecar restart.
 - Lua → sidecar: `{"v":1,"type":"setup.experiment.record","archive_path":".../journal/laps/lap_...json"}` ingests one PR #78 lap archive into `journal/setup_experiments/experiments.jsonl`.
 - client → sidecar: `{"v":1,"type":"setup.compare","baseline_setup":"old","candidate_setup":"new"}` returns `setup.compare.result` with A/B improvement, confidence, and significance.
 - client → sidecar: `{"v":1,"type":"setup.suggest","car_id":"...","track_id":"..."}` returns `setup.suggest.result` with the next setup candidate and rationale.
@@ -95,6 +96,7 @@ CLI equivalents:
 python -m tools.ai_sidecar --setup-rebuild-experiments "<...>/journal/laps"
 python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" --setup-compare old new
 python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" --setup-suggest
+python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" --host 127.0.0.1 --port 8765
 ```
 
 See [13_Setup_Experiments.md](13_Setup_Experiments.md) for data location, reset, and rebuild.

--- a/docs/10_Development/13_Setup_Experiments.md
+++ b/docs/10_Development/13_Setup_Experiments.md
@@ -29,8 +29,16 @@ After a lap archive is written, Lua sends a best-effort v1 sidecar message:
 {"v":1,"type":"setup.experiment.record","archive_path":".../journal/laps/lap_...json"}
 ```
 
-The sidecar reads that archived lap and upserts one experiment row. If the
-sidecar was disconnected, no lap data is lost; rebuild from `journal/laps`.
+After the v1 sidecar handshake, Lua also registers the canonical store path:
+
+```json
+{"v":1,"type":"setup.experiment.store","store_path":".../journal/setup_experiments/experiments.jsonl"}
+```
+
+The sidecar reads archived laps and upserts experiment rows. If the sidecar was
+disconnected, no lap data is lost; rebuild from `journal/laps`. The store
+registration lets WebSocket compare/suggest requests use rebuilt rows
+immediately after sidecar restart.
 
 ## Rebuild And Reset
 
@@ -45,6 +53,13 @@ Use a custom store path for tests or exports:
 ```bash
 python -m tools.ai_sidecar --setup-rebuild-experiments "<...>/journal/laps" \
   --setup-store /tmp/ac-copilot-experiments.jsonl
+```
+
+Manual server launches can seed WebSocket compare/suggest from an existing
+store:
+
+```bash
+python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl"
 ```
 
 Reset experiments by deleting `journal/setup_experiments/experiments.jsonl`, or

--- a/docs/10_Development/13_Setup_Experiments.md
+++ b/docs/10_Development/13_Setup_Experiments.md
@@ -1,0 +1,78 @@
+# Setup Experiment Tracking
+
+Issue **#114** adds an offline setup-optimization layer on top of the PR #78
+lap archive.
+
+## Data Location
+
+The trainer writes lap archives under:
+
+```text
+<AC ScriptConfig>/ac_copilot_trainer/journal/laps/lap_*.json
+```
+
+The sidecar derives setup experiments from those files and stores compact JSONL
+rows under:
+
+```text
+<AC ScriptConfig>/ac_copilot_trainer/journal/setup_experiments/experiments.jsonl
+```
+
+Each row contains the source lap path, car/track ids, conditions, lap time,
+setup hash/path/name, and numeric setup parameters from `setup.snapshot`.
+
+## Live Recording
+
+After a lap archive is written, Lua sends a best-effort v1 sidecar message:
+
+```json
+{"v":1,"type":"setup.experiment.record","archive_path":".../journal/laps/lap_...json"}
+```
+
+The sidecar reads that archived lap and upserts one experiment row. If the
+sidecar was disconnected, no lap data is lost; rebuild from `journal/laps`.
+
+## Rebuild And Reset
+
+Rebuild the experiment store from lap archives:
+
+```bash
+python -m tools.ai_sidecar --setup-rebuild-experiments "<...>/journal/laps"
+```
+
+Use a custom store path for tests or exports:
+
+```bash
+python -m tools.ai_sidecar --setup-rebuild-experiments "<...>/journal/laps" \
+  --setup-store /tmp/ac-copilot-experiments.jsonl
+```
+
+Reset experiments by deleting `journal/setup_experiments/experiments.jsonl`, or
+rebuild it from the current lap archive directory.
+
+## A/B Comparison
+
+Compare two setup identifiers. The identifier can be a setup hash, setup name,
+or setup path:
+
+```bash
+python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" \
+  --setup-compare baseline aggressive
+```
+
+The report includes per-setup sample counts, mean/stdev lap time, improvement
+in ms and percent, confidence, one-sided p-value, and a significance flag.
+
+## Next Suggestion
+
+Ask for the next candidate:
+
+```bash
+python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" \
+  --setup-suggest --setup-car-id ks_porsche_911_gt3_r_2016 --setup-track-id magione
+```
+
+The suggestion uses a deterministic Gaussian-kernel surrogate over observed
+numeric setup params and selects the one- or two-parameter move with the highest
+expected improvement. It returns the base setup, changed params, predicted lap
+time, uncertainty, expected improvement, and rationale.

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -385,6 +385,12 @@ local pendingWsSidecarUrl = nil
 local state
 
 wsBridge.configure(config.wsSidecarUrl or "")
+if wsBridge.setSetupExperimentStorePath then
+  pcall(function()
+    wsBridge.setSetupExperimentStorePath(
+      persistence.dataDir() .. "/journal/setup_experiments/experiments.jsonl")
+  end)
+end
 
 -- Issue #81: external WS clients (rig touchscreen) drive these via the sidecar.
 -- Each handler returns (applied:boolean, reason:string|nil); the bridge fans an

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2117,6 +2117,12 @@ function script.update(dt)
             ac.log("[COPILOT][ARCHIVE] write failed: " .. tostring(pathOrErr))
           end
         end
+        if ok and type(pathOrErr) == "string"
+            and wsBridge and type(wsBridge.sendSetupExperimentRecord) == "function" then
+          pcall(function()
+            wsBridge.sendSetupExperimentRecord(pathOrErr)
+          end)
+        end
       end
     end
 

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -801,6 +801,9 @@ function M.pollInbound(maxPerTick)
           -- Sidecar-local setup optimizer replies. Lua only initiates record
           -- store registration and record ingestion; compare/suggest are for
           -- external clients, so accept these quietly if fanned back.
+          if t == "setup.experiment.store.ack" and data.ok == false then
+            setupExperimentStoreSent = false
+          end
           if (t == "setup.experiment.store.ack" or t == "setup.experiment.record.ack")
               and data.ok == false
               and ac and type(ac.log) == "function" then

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -767,6 +767,16 @@ function M.pollInbound(maxPerTick)
           -- Sidecar / trainer lifecycle frames — intentionally ignored here
           -- (see comment after the generic-dispatch block). Do not route them
           -- through the request-handler `else` or they spam diagnostics.
+        elseif t == "setup.experiment.record.ack"
+            or t == "setup.compare.result"
+            or t == "setup.suggest.result" then
+          -- Sidecar-local setup optimizer replies. Lua only initiates record
+          -- ingestion after archive writes; compare/suggest are for external
+          -- clients, so accept these quietly if the sidecar fans them back.
+          if t == "setup.experiment.record.ack" and data.ok == false
+              and ac and type(ac.log) == "function" then
+            pcall(ac.log, "[COPILOT][SETUP-OPT] record failed: " .. tostring(data.error))
+          end
         elseif type(t) == "string" and t:sub(1, 6) == "state." then
           -- Passive telemetry envelopes (`state.snapshot`, etc.) are fanned by
           -- the sidecar to peers; Lua does not register handlers for them.
@@ -987,6 +997,21 @@ function M.publishTopic(topic, payload)
     type = "state.snapshot",
     topic = topic,
     payload = payload or {},
+  })
+end
+
+--- Notify the Python sidecar that a PR #78 lap archive is available for setup
+--- experiment ingestion. Best-effort: if the v1 sidecar registration is not
+--- ready, the offline rebuild command can still recover from `journal/laps`.
+---@param archivePath string|nil
+---@return boolean
+function M.sendSetupExperimentRecord(archivePath)
+  if type(archivePath) ~= "string" or archivePath == "" then return false end
+  if not (sock and externalHelloAcked) then return false end
+  return M.sendJson({
+    v = PROTOCOL_VERSION,
+    type = "setup.experiment.record",
+    archive_path = archivePath,
   })
 end
 

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -1059,10 +1059,20 @@ end
 
 --- Send the setup experiment store path after the v1 sidecar handshake.
 ---@return boolean
+local function setupExperimentPathFramesAllowed()
+  local u = tostring(url or ""):lower()
+  local host = u:match("^wss?://%[([^%]]+)%]") or u:match("^wss?://([^:/]+)")
+  if host == "localhost" or host == "::1" then
+    return true
+  end
+  return type(host) == "string" and host:match("^127%.%d+%.%d+%.%d+$") ~= nil
+end
+
 function M.sendSetupExperimentStorePath()
   if type(setupExperimentStorePath) ~= "string" or setupExperimentStorePath == "" then return false end
   if setupExperimentStoreSent then return true end
   if not (sock and externalHelloAcked) then return false end
+  if not setupExperimentPathFramesAllowed() then return false end
   if setupExperimentStoreRetryFrames < SETUP_EXPERIMENT_STORE_RETRY_FRAMES then
     setupExperimentStoreRetryFrames = setupExperimentStoreRetryFrames + 1
     return false
@@ -1087,6 +1097,7 @@ end
 function M.sendSetupExperimentRecord(archivePath)
   if type(archivePath) ~= "string" or archivePath == "" then return false end
   if not (sock and externalHelloAcked) then return false end
+  if not setupExperimentPathFramesAllowed() then return false end
   return M.sendJson({
     v = PROTOCOL_VERSION,
     type = "setup.experiment.record",

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -110,6 +110,11 @@ local EXTERNAL_HELLO_RETRY_FRAMES = 12
 --- Emit at most one hello-retry diagnostic per this many actual sends so a
 --- (briefly) unresponsive sidecar cannot spam the CSP console (Qodo on PR #91).
 local EXTERNAL_HELLO_LOG_EVERY_SENDS = 10
+--- Canonical setup experiment JSONL path, registered with the trusted local
+--- sidecar after each v1 handshake so compare/suggest can read rebuilt rows
+--- immediately after sidecar restart.
+local setupExperimentStorePath = nil
+local setupExperimentStoreSent = false
 --- Forward declaration — assigned where `tryOpen` is defined (used before spawn).
 local tryOpen
 
@@ -138,6 +143,7 @@ function M.configure(u)
   nonzeroExitStreak = 0
   spawnAbandonUntilT = -1e9
   lastBackoffTryOpenT = -1e9
+  setupExperimentStoreSent = false
 end
 
 --- Issue #77 Part A: spawn the Python sidecar if it isn't already listening.
@@ -167,6 +173,7 @@ function M.startSidecarIfNeeded(appDir)
     sock = nil
     lastTry = -RECONNECT_SEC
     sidecarProtocolReady = false
+    setupExperimentStoreSent = false
     -- One-shot zombie cleanup: do not keep closing a user-opened manual socket (Codex #78).
     sidecarChildEverLaunched = false
   end
@@ -319,6 +326,7 @@ function M.reset()
   nonzeroExitStreak = 0
   spawnAbandonUntilT = -1e9
   lastBackoffTryOpenT = -1e9
+  setupExperimentStoreSent = false
 end
 
 --- Drop queued sidecar response without closing the socket (e.g. lap counter reset).
@@ -459,6 +467,7 @@ tryOpen = function()
   end
   _recvQueue = {}
   sidecarProtocolReady = false
+  setupExperimentStoreSent = false
   -- Mark that we owe the sidecar a hello on this socket. The actual send is
   -- retried from M.tick() until `sidecarProtocolReady` flips (set when the
   -- sidecar's v1 hello_ack arrives) — this is the only reliable signal that
@@ -486,6 +495,7 @@ tryOpen = function()
       sidecarProtocolReady = false
       externalHelloAcked = false
       externalHelloPending = true
+      setupExperimentStoreSent = false
       helloRetryFrames = 0
       helloSendCount = 0
       -- Always announce hello on onOpen. The previous "inline hello + dedup"
@@ -512,6 +522,7 @@ tryOpen = function()
         sock = nil
         lastTry = -RECONNECT_SEC
         sidecarProtocolReady = false
+        setupExperimentStoreSent = false
       end
     end,
     encoding = "utf8",
@@ -646,6 +657,7 @@ function M.pollInbound(maxPerTick)
           -- legacy-inclusive `sidecarProtocolReady` — gates the v1 publish path
           -- and the hello-retry stop (chatgpt-codex P1 on PR #171).
           externalHelloAcked = true
+          M.sendSetupExperimentStorePath()
         end
         if t == "error" then
           if ac and type(ac.log) == "function" then
@@ -767,15 +779,17 @@ function M.pollInbound(maxPerTick)
           -- Sidecar / trainer lifecycle frames — intentionally ignored here
           -- (see comment after the generic-dispatch block). Do not route them
           -- through the request-handler `else` or they spam diagnostics.
-        elseif t == "setup.experiment.record.ack"
+        elseif t == "setup.experiment.store.ack"
+            or t == "setup.experiment.record.ack"
             or t == "setup.compare.result"
             or t == "setup.suggest.result" then
           -- Sidecar-local setup optimizer replies. Lua only initiates record
-          -- ingestion after archive writes; compare/suggest are for external
-          -- clients, so accept these quietly if the sidecar fans them back.
-          if t == "setup.experiment.record.ack" and data.ok == false
+          -- store registration and record ingestion; compare/suggest are for
+          -- external clients, so accept these quietly if fanned back.
+          if (t == "setup.experiment.store.ack" or t == "setup.experiment.record.ack")
+              and data.ok == false
               and ac and type(ac.log) == "function" then
-            pcall(ac.log, "[COPILOT][SETUP-OPT] record failed: " .. tostring(data.error))
+            pcall(ac.log, "[COPILOT][SETUP-OPT] sidecar ack failed: " .. tostring(data.error))
           end
         elseif type(t) == "string" and t:sub(1, 6) == "state." then
           -- Passive telemetry envelopes (`state.snapshot`, etc.) are fanned by
@@ -969,6 +983,7 @@ function M.sendJson(payload)
     sock = nil
     lastTry = -RECONNECT_SEC
     sidecarProtocolReady = false
+    setupExperimentStoreSent = false
     return false
   end
   return true
@@ -998,6 +1013,36 @@ function M.publishTopic(topic, payload)
     topic = topic,
     payload = payload or {},
   })
+end
+
+--- Register the canonical setup experiment JSONL path with the sidecar.
+---@param storePath string|nil
+---@return boolean
+function M.setSetupExperimentStorePath(storePath)
+  if type(storePath) ~= "string" or storePath == "" then return false end
+  setupExperimentStorePath = storePath
+  setupExperimentStoreSent = false
+  if sock and externalHelloAcked then
+    return M.sendSetupExperimentStorePath()
+  end
+  return true
+end
+
+--- Send the setup experiment store path after the v1 sidecar handshake.
+---@return boolean
+function M.sendSetupExperimentStorePath()
+  if type(setupExperimentStorePath) ~= "string" or setupExperimentStorePath == "" then return false end
+  if setupExperimentStoreSent then return true end
+  if not (sock and externalHelloAcked) then return false end
+  local ok = M.sendJson({
+    v = PROTOCOL_VERSION,
+    type = "setup.experiment.store",
+    store_path = setupExperimentStorePath,
+  })
+  if ok then
+    setupExperimentStoreSent = true
+  end
+  return ok
 end
 
 --- Notify the Python sidecar that a PR #78 lap archive is available for setup

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -113,11 +113,13 @@ local EXTERNAL_HELLO_RETRY_FRAMES = 12
 --- Emit at most one hello-retry diagnostic per this many actual sends so a
 --- (briefly) unresponsive sidecar cannot spam the CSP console (Qodo on PR #91).
 local EXTERNAL_HELLO_LOG_EVERY_SENDS = 10
+local SETUP_EXPERIMENT_STORE_RETRY_FRAMES = 300
 --- Canonical setup experiment JSONL path, registered with the trusted local
 --- sidecar after each v1 handshake so compare/suggest can read rebuilt rows
 --- immediately after sidecar restart.
 local setupExperimentStorePath = nil
 local setupExperimentStoreSent = false
+local setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
 --- Forward declaration — assigned where `tryOpen` is defined (used before spawn).
 local tryOpen
 
@@ -147,6 +149,7 @@ function M.configure(u)
   spawnAbandonUntilT = -1e9
   lastBackoffTryOpenT = -1e9
   setupExperimentStoreSent = false
+  setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
 end
 
 --- Issue #77 Part A: spawn the Python sidecar if it isn't already listening.
@@ -177,6 +180,7 @@ function M.startSidecarIfNeeded(appDir)
     lastTry = -RECONNECT_SEC
     sidecarProtocolReady = false
     setupExperimentStoreSent = false
+    setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
     -- One-shot zombie cleanup: do not keep closing a user-opened manual socket (Codex #78).
     sidecarChildEverLaunched = false
   end
@@ -337,6 +341,7 @@ function M.reset()
   spawnAbandonUntilT = -1e9
   lastBackoffTryOpenT = -1e9
   setupExperimentStoreSent = false
+  setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
 end
 
 --- Drop queued sidecar response without closing the socket (e.g. lap counter reset).
@@ -478,6 +483,7 @@ tryOpen = function()
   _recvQueue = {}
   sidecarProtocolReady = false
   setupExperimentStoreSent = false
+  setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
   -- Mark that we owe the sidecar a hello on this socket. The actual send is
   -- retried from M.tick() until `sidecarProtocolReady` flips (set when the
   -- sidecar's v1 hello_ack arrives) — this is the only reliable signal that
@@ -511,6 +517,7 @@ tryOpen = function()
       externalHelloAcked = false
       externalHelloPending = true
       setupExperimentStoreSent = false
+      setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
       helloRetryFrames = 0
       helloSendCount = 0
       -- Always announce hello on onOpen. The previous "inline hello + dedup"
@@ -538,6 +545,7 @@ tryOpen = function()
         lastTry = -RECONNECT_SEC
         sidecarProtocolReady = false
         setupExperimentStoreSent = false
+        setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
       end
     end,
     encoding = "utf8",
@@ -803,6 +811,7 @@ function M.pollInbound(maxPerTick)
           -- external clients, so accept these quietly if fanned back.
           if t == "setup.experiment.store.ack" and data.ok == false then
             setupExperimentStoreSent = false
+            setupExperimentStoreRetryFrames = 0
           end
           if (t == "setup.experiment.store.ack" or t == "setup.experiment.record.ack")
               and data.ok == false
@@ -1002,6 +1011,7 @@ function M.sendJson(payload)
     lastTry = -RECONNECT_SEC
     sidecarProtocolReady = false
     setupExperimentStoreSent = false
+    setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
     return false
   end
   return true
@@ -1040,6 +1050,7 @@ function M.setSetupExperimentStorePath(storePath)
   if type(storePath) ~= "string" or storePath == "" then return false end
   setupExperimentStorePath = storePath
   setupExperimentStoreSent = false
+  setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
   if sock and externalHelloAcked then
     return M.sendSetupExperimentStorePath()
   end
@@ -1052,6 +1063,10 @@ function M.sendSetupExperimentStorePath()
   if type(setupExperimentStorePath) ~= "string" or setupExperimentStorePath == "" then return false end
   if setupExperimentStoreSent then return true end
   if not (sock and externalHelloAcked) then return false end
+  if setupExperimentStoreRetryFrames < SETUP_EXPERIMENT_STORE_RETRY_FRAMES then
+    setupExperimentStoreRetryFrames = setupExperimentStoreRetryFrames + 1
+    return false
+  end
   local ok = M.sendJson({
     v = PROTOCOL_VERSION,
     type = "setup.experiment.store",
@@ -1059,6 +1074,7 @@ function M.sendSetupExperimentStorePath()
   })
   if ok then
     setupExperimentStoreSent = true
+    setupExperimentStoreRetryFrames = 0
   end
   return ok
 end

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -958,6 +958,7 @@ function M.tick(simTime)
       end
     elseif externalHelloAcked then
       externalHelloPending = false
+      M.sendSetupExperimentStorePath()
     end
     return
   end

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -550,6 +550,55 @@ def test_setup_record_returns_error_when_store_write_fails(
     assert "disk full" in result["error"]
 
 
+def test_setup_record_preserves_seeded_store_for_suggest(tmp_path: Path) -> None:
+    from tools.ai_sidecar import server as srv
+
+    seed_dir = tmp_path / "seed" / "journal" / "laps"
+    _write_setup_lap(seed_dir, "seed-a", "old", 100_000, 64)
+    _write_setup_lap(seed_dir, "seed-b", "new", 98_000, 66)
+    seeded = rebuild_experiments(seed_dir)
+    seeded_store = Path(seeded["store_path"])
+
+    live_lap = _write_setup_lap(
+        tmp_path / "live" / "journal" / "laps", "live-a", "live", 99_000, 65
+    )
+
+    async def _run() -> tuple[dict, dict]:
+        async with _running_sidecar() as port:
+            srv._setup_experiment_store_path = seeded_store
+            srv._setup_experiment_store_seeded = True
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.experiment.record",
+                            "archive_path": str(live_lap),
+                        }
+                    )
+                )
+                record_ack = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                await ws.send(json.dumps({"v": 1, "type": "setup.suggest"}))
+                suggest = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                return record_ack, suggest
+
+    try:
+        record_ack, suggest = asyncio.run(_run())
+    finally:
+        srv._setup_experiment_store_path = None
+        srv._setup_experiment_store_seeded = False
+
+    assert record_ack["type"] == ep.TYPE_SETUP_EXPERIMENT_RECORD_ACK
+    assert record_ack["ok"] is True
+    assert record_ack["active_store_path"] == str(seeded_store)
+    assert record_ack["store_path"] != str(seeded_store)
+    assert suggest["type"] == ep.TYPE_SETUP_SUGGEST_RESULT
+    assert suggest["ok"] is True
+    assert suggest["experiments_used"] == 2
+
+
 def test_setup_compare_returns_error_when_store_load_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -34,6 +34,7 @@ from tools.ai_sidecar.server import (  # noqa: E402
     _is_loopback,
     make_token_check,
 )
+from tools.ai_sidecar.setup_optimizer import rebuild_experiments  # noqa: E402
 
 
 def _free_port() -> int:
@@ -129,6 +130,16 @@ def test_validate_inbound_accepts_known_types() -> None:
         ep.validate_inbound(
             {
                 "v": 1,
+                "type": "setup.experiment.store",
+                "store_path": "journal/setup_experiments/experiments.jsonl",
+            }
+        )
+        is None
+    )
+    assert (
+        ep.validate_inbound(
+            {
+                "v": 1,
                 "type": "setup.compare",
                 "baseline_setup": "old",
                 "candidate_setup": "new",
@@ -156,6 +167,7 @@ def test_validate_inbound_rejects_invalid() -> None:
     assert "archive_path" in (
         ep.validate_inbound({"v": 1, "type": "setup.experiment.record"}) or ""
     )
+    assert "store_path" in (ep.validate_inbound({"v": 1, "type": "setup.experiment.store"}) or "")
     assert "baseline_setup" in (ep.validate_inbound({"v": 1, "type": "setup.compare"}) or "")
     assert "unknown type" in (ep.validate_inbound({"v": 1, "type": "explode"}) or "")
 
@@ -349,6 +361,42 @@ def test_setup_experiment_record_and_suggest_roundtrip(tmp_path: Path) -> None:
     assert result["type"] == ep.TYPE_SETUP_SUGGEST_RESULT
     assert result["ok"] is True
     assert result["candidate"]["changed_params"]
+
+
+def test_setup_experiment_store_registration_loads_rebuilt_rows(tmp_path: Path) -> None:
+    async def _run() -> tuple[dict, dict]:
+        from tools.ai_sidecar import server as srv
+
+        srv._setup_experiment_store_path = None
+        lap_dir = tmp_path / "journal" / "laps"
+        _write_setup_lap(lap_dir, "lap-a", "old", 100_000, 64)
+        _write_setup_lap(lap_dir, "lap-b", "new", 98_000, 66)
+        rebuilt = rebuild_experiments(lap_dir)
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.experiment.store",
+                            "store_path": rebuilt["store_path"],
+                        }
+                    )
+                )
+                store_ack = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                await ws.send(json.dumps({"v": 1, "type": "setup.suggest"}))
+                suggest = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                return store_ack, suggest
+
+    store_ack, suggest = asyncio.run(_run())
+    assert store_ack["type"] == ep.TYPE_SETUP_EXPERIMENT_STORE_ACK
+    assert store_ack["ok"] is True
+    assert store_ack["records"] == 2
+    assert suggest["type"] == ep.TYPE_SETUP_SUGGEST_RESULT
+    assert suggest["ok"] is True
+    assert suggest["candidate"]["changed_params"]
 
 
 def test_config_set_round_trip_via_hub() -> None:

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -19,6 +19,7 @@ import json
 import socket
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import pytest
 
@@ -42,6 +43,41 @@ def _free_port() -> int:
         return s.getsockname()[1]
     finally:
         s.close()
+
+
+def _write_setup_lap(
+    lap_dir: Path,
+    name: str,
+    setup_hash: str,
+    lap_ms: int,
+    front_bias: int,
+) -> Path:
+    lap_dir.mkdir(parents=True, exist_ok=True)
+    path = lap_dir / f"lap_20260616-000000_{name}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "lap_uuid": name,
+                "session_uuid": "sess",
+                "exported_at": "2026-06-16T00:00:00Z",
+                "car": {"id": "ks_porsche_911_gt3_r_2016"},
+                "track": {"id": "magione"},
+                "conditions": {"trackGripLevel": 0.98},
+                "lap": {"lap_n": 1, "lap_ms": lap_ms, "is_valid": True},
+                "setup": {
+                    "hash": setup_hash,
+                    "path": f"C:/setups/{setup_hash}.ini",
+                    "snapshot": {
+                        "FRONT_BIAS.VALUE": str(front_bias),
+                        "WING_2.VALUE": "9",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
 
 
 @asynccontextmanager
@@ -83,6 +119,24 @@ def test_validate_inbound_accepts_known_types() -> None:
     )
     assert ep.validate_inbound({"v": 1, "type": "action", "name": "toggleFocusPractice"}) is None
     assert ep.validate_inbound({"v": 1, "type": "state.subscribe", "topics": ["lap"]}) is None
+    assert (
+        ep.validate_inbound(
+            {"v": 1, "type": "setup.experiment.record", "archive_path": "journal/laps/lap_1.json"}
+        )
+        is None
+    )
+    assert (
+        ep.validate_inbound(
+            {
+                "v": 1,
+                "type": "setup.compare",
+                "baseline_setup": "old",
+                "candidate_setup": "new",
+            }
+        )
+        is None
+    )
+    assert ep.validate_inbound({"v": 1, "type": "setup.suggest", "track_id": "magione"}) is None
 
 
 def test_validate_inbound_rejects_invalid() -> None:
@@ -99,6 +153,10 @@ def test_validate_inbound_rejects_invalid() -> None:
     assert "unknown topic" in (
         ep.validate_inbound({"v": 1, "type": "state.subscribe", "topics": ["pit_window"]}) or ""
     )
+    assert "archive_path" in (
+        ep.validate_inbound({"v": 1, "type": "setup.experiment.record"}) or ""
+    )
+    assert "baseline_setup" in (ep.validate_inbound({"v": 1, "type": "setup.compare"}) or "")
     assert "unknown type" in (ep.validate_inbound({"v": 1, "type": "explode"}) or "")
 
 
@@ -256,6 +314,41 @@ def test_external_request_errors_when_no_loopback_lua_peer() -> None:
     err = asyncio.run(_run())
     assert err["type"] == ep.TYPE_ERROR
     assert "no loopback Lua peer connected" in err["message"]
+
+
+def test_setup_experiment_record_and_suggest_roundtrip(tmp_path: Path) -> None:
+    async def _run() -> dict:
+        from tools.ai_sidecar import server as srv
+
+        srv._setup_experiment_store_path = None
+        lap_dir = tmp_path / "journal" / "laps"
+        first = _write_setup_lap(lap_dir, "lap-a", "old", 100_000, 64)
+        second = _write_setup_lap(lap_dir, "lap-b", "new", 98_000, 66)
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                for lap_path in (first, second):
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "v": 1,
+                                "type": "setup.experiment.record",
+                                "archive_path": str(lap_path),
+                            }
+                        )
+                    )
+                    ack = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                    assert ack["type"] == ep.TYPE_SETUP_EXPERIMENT_RECORD_ACK
+                    assert ack["ok"] is True
+                await ws.send(json.dumps({"v": 1, "type": "setup.suggest"}))
+                raw = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                return json.loads(raw)
+
+    result = asyncio.run(_run())
+    assert result["type"] == ep.TYPE_SETUP_SUGGEST_RESULT
+    assert result["ok"] is True
+    assert result["candidate"]["changed_params"]
 
 
 def test_config_set_round_trip_via_hub() -> None:

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -472,6 +472,84 @@ def test_setup_experiment_store_registration_loads_rebuilt_rows(tmp_path: Path) 
     assert suggest["candidate"]["changed_params"]
 
 
+def test_setup_store_registration_returns_error_when_count_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.ai_sidecar import server as srv
+
+    def _boom(_store_path: Path) -> int:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(srv, "_setup_store_record_count", _boom)
+    store = tmp_path / "journal" / "setup_experiments" / "experiments.jsonl"
+
+    async def _run() -> dict:
+        srv._setup_experiment_store_path = None
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.experiment.store",
+                            "store_path": str(store),
+                        }
+                    )
+                )
+                return json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+
+    try:
+        result = asyncio.run(_run())
+    finally:
+        srv._setup_experiment_store_path = None
+
+    assert result["type"] == ep.TYPE_SETUP_EXPERIMENT_STORE_ACK
+    assert result["ok"] is False
+    assert "permission denied" in result["error"]
+
+
+def test_setup_record_returns_error_when_store_write_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.ai_sidecar import server as srv
+
+    def _boom(_archive_path: str) -> dict:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(srv, "_record_lap_archive_safe", _boom)
+    lap_path = tmp_path / "journal" / "laps" / "lap_20260616-000001_lap-a.json"
+
+    async def _run() -> dict:
+        srv._setup_experiment_store_path = None
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.experiment.record",
+                            "archive_path": str(lap_path),
+                        }
+                    )
+                )
+                return json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+
+    try:
+        result = asyncio.run(_run())
+    finally:
+        srv._setup_experiment_store_path = None
+
+    assert result["type"] == ep.TYPE_SETUP_EXPERIMENT_RECORD_ACK
+    assert result["ok"] is False
+    assert "disk full" in result["error"]
+
+
 def test_setup_compare_returns_error_when_store_load_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -472,6 +472,47 @@ def test_setup_experiment_store_registration_loads_rebuilt_rows(tmp_path: Path) 
     assert suggest["candidate"]["changed_params"]
 
 
+def test_setup_compare_returns_error_when_store_load_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.ai_sidecar import server as srv
+
+    def _boom(_store_path: Path, **_kwargs: object) -> dict:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(srv, "_compare_setup_store", _boom)
+
+    async def _run() -> dict:
+        srv._setup_experiment_store_path = (
+            tmp_path / "journal" / "setup_experiments" / "experiments.jsonl"
+        )
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.compare",
+                            "baseline_setup": "old",
+                            "candidate_setup": "new",
+                        }
+                    )
+                )
+                return json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+
+    try:
+        result = asyncio.run(_run())
+    finally:
+        srv._setup_experiment_store_path = None
+
+    assert result["type"] == ep.TYPE_SETUP_COMPARE_RESULT
+    assert result["ok"] is False
+    assert "permission denied" in result["error"]
+
+
 def test_config_set_round_trip_via_hub() -> None:
     """Two peers: A sends config.set, B receives it; B's ack reaches A."""
 

--- a/tests/test_setup_optimizer.py
+++ b/tests/test_setup_optimizer.py
@@ -1,0 +1,200 @@
+"""Setup experiment tracking and next-setup suggestions (issue #114)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tools.ai_sidecar.server import (
+    _run_setup_compare,
+    _run_setup_rebuild,
+    _run_setup_suggest,
+)
+from tools.ai_sidecar.setup_optimizer import (
+    _candidate_grid,
+    compare_setups,
+    load_records,
+    rebuild_experiments,
+    record_from_lap_archive,
+    record_lap_archive,
+    suggest_next_setup,
+)
+
+
+def _lap(
+    *,
+    lap_uuid: str,
+    setup_hash: str,
+    setup_name: str,
+    lap_ms: int,
+    front_bias: int,
+    rear_wing: int,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "source": "in_game",
+        "lap_uuid": lap_uuid,
+        "session_uuid": "sess-1",
+        "exported_at": f"2026-06-16T00:00:{int(lap_uuid[-1]):02d}Z",
+        "car": {"id": "ks_porsche_911_gt3_r_2016"},
+        "track": {"id": "magione", "layout": None, "lengthM": 2525},
+        "conditions": {"trackGripLevel": 0.97, "ambientTempC": 22},
+        "lap": {"lap_n": int(lap_uuid[-1]), "lap_ms": lap_ms, "is_valid": True},
+        "setup": {
+            "hash": setup_hash,
+            "path": f"C:/Users/arsen/Documents/Assetto Corsa/setups/car/magione/{setup_name}.ini",
+            "snapshot": {
+                "FRONT_BIAS.VALUE": str(front_bias),
+                "WING_2.VALUE": str(rear_wing),
+                "ABS.VALUE": "7",
+            },
+        },
+    }
+
+
+def _write_laps(lap_dir: Path) -> list[Path]:
+    lap_dir.mkdir(parents=True)
+    specs = [
+        ("lap-a1", "old", "baseline", 100_000, 64, 8),
+        ("lap-a2", "old", "baseline", 101_000, 64, 8),
+        ("lap-a3", "old", "baseline", 99_000, 64, 8),
+        ("lap-b4", "new", "candidate", 98_000, 66, 9),
+        ("lap-b5", "new", "candidate", 97_500, 66, 9),
+        ("lap-b6", "new", "candidate", 98_200, 66, 9),
+        ("lap-c7", "wing10", "wing10", 99_300, 66, 10),
+    ]
+    paths = []
+    for i, spec in enumerate(specs, start=1):
+        path = lap_dir / f"lap_20260616-00000{i}_{spec[0]}.json"
+        path.write_text(
+            json.dumps(
+                _lap(
+                    *(),
+                    **dict(
+                        zip(
+                            (
+                                "lap_uuid",
+                                "setup_hash",
+                                "setup_name",
+                                "lap_ms",
+                                "front_bias",
+                                "rear_wing",
+                            ),
+                            spec,
+                            strict=True,
+                        )
+                    ),
+                )
+            ),
+            encoding="utf-8",
+        )
+        paths.append(path)
+    return paths
+
+
+def test_record_from_lap_archive_extracts_setup_params() -> None:
+    rec = record_from_lap_archive(
+        _lap(
+            lap_uuid="lap-a1",
+            setup_hash="old",
+            setup_name="baseline",
+            lap_ms=100_000,
+            front_bias=64,
+            rear_wing=8,
+        ),
+        source_path="C:/journal/laps/lap_1.json",
+    )
+    assert rec["experiment_id"] == "lap-a1"
+    assert rec["lap"]["lap_ms"] == 100_000
+    assert rec["setup"]["hash"] == "old"
+    assert rec["setup"]["name"] == "baseline"
+    assert rec["setup"]["params"]["FRONT_BIAS.VALUE"] == 64.0
+    assert rec["conditions"]["trackGripLevel"] == 0.97
+
+
+def test_rebuild_compare_and_suggest(tmp_path: Path) -> None:
+    lap_dir = tmp_path / "journal" / "laps"
+    _write_laps(lap_dir)
+
+    summary = rebuild_experiments(lap_dir)
+    assert summary["records"] == 7
+    store = Path(summary["store_path"])
+    records = load_records(store)
+    assert len(records) == 7
+
+    comparison = compare_setups(records, baseline_setup="old", candidate_setup="new")
+    assert comparison["ok"] is True
+    assert comparison["improvement_ms"] > 1500
+    assert comparison["confidence"] > 0.95
+    assert comparison["significant"] is True
+
+    suggestion = suggest_next_setup(records, car_id="ks_porsche_911_gt3_r_2016", track_id="magione")
+    assert suggestion["ok"] is True
+    assert suggestion["method"] == "rbf_surrogate_expected_improvement"
+    assert suggestion["candidate"]["changed_params"]
+    assert suggestion["surrogate"]["expected_improvement_ms"] >= 0
+    assert suggestion["rationale"]
+
+
+def test_candidate_grid_clamps_nonnegative_params() -> None:
+    records = [
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-a1",
+                setup_hash="best",
+                setup_name="best",
+                lap_ms=98_000,
+                front_bias=0,
+                rear_wing=8,
+            )
+        ),
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-b2",
+                setup_hash="slower",
+                setup_name="slower",
+                lap_ms=99_000,
+                front_bias=1,
+                rear_wing=8,
+            )
+        ),
+    ]
+    best = min(records, key=lambda rec: rec["lap"]["lap_ms"])
+
+    grid = _candidate_grid(records, best, ["FRONT_BIAS.VALUE"])
+
+    assert grid
+    assert all(candidate["FRONT_BIAS.VALUE"] >= 0 for candidate in grid)
+
+
+def test_record_lap_archive_upserts_without_duplicates(tmp_path: Path) -> None:
+    lap_dir = tmp_path / "journal" / "laps"
+    path = _write_laps(lap_dir)[0]
+    store = tmp_path / "experiments.jsonl"
+
+    first = record_lap_archive(path, store_path=store)
+    second = record_lap_archive(path, store_path=store)
+
+    assert first["inserted"] == 1
+    assert second["updated"] == 1
+    assert len(load_records(store)) == 1
+
+
+def test_setup_optimizer_cli_smoke(tmp_path: Path, capsys) -> None:
+    lap_dir = tmp_path / "journal" / "laps"
+    _write_laps(lap_dir)
+    store = tmp_path / "store.jsonl"
+
+    _run_setup_rebuild(str(lap_dir), str(store))
+    rebuild_out = json.loads(capsys.readouterr().out)
+    assert rebuild_out["records"] == 7
+
+    _run_setup_compare(str(store), "old", "new")
+    compare_out = json.loads(capsys.readouterr().out)
+    assert compare_out["significant"] is True
+
+    _run_setup_suggest(str(store), "ks_porsche_911_gt3_r_2016", "magione")
+    suggest_out = json.loads(capsys.readouterr().out)
+    assert suggest_out["ok"] is True
+    assert suggest_out["candidate"]["changed_params"]

--- a/tests/test_setup_optimizer.py
+++ b/tests/test_setup_optimizer.py
@@ -6,12 +6,15 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from tools.ai_sidecar.server import (
     _run_setup_compare,
     _run_setup_rebuild,
     _run_setup_suggest,
 )
 from tools.ai_sidecar.setup_optimizer import (
+    SetupExperimentError,
     _candidate_grid,
     compare_setups,
     load_records,
@@ -179,6 +182,14 @@ def test_record_lap_archive_upserts_without_duplicates(tmp_path: Path) -> None:
     assert first["inserted"] == 1
     assert second["updated"] == 1
     assert len(load_records(store)) == 1
+
+
+def test_load_records_rejects_corrupt_store(tmp_path: Path) -> None:
+    store = tmp_path / "experiments.jsonl"
+    store.write_text('{"ok": true}\nnot-json\n', encoding="utf-8")
+
+    with pytest.raises(SetupExperimentError, match=r"experiments\.jsonl:2"):
+        load_records(store)
 
 
 def test_rebuild_experiments_deduplicates_experiment_ids(tmp_path: Path) -> None:

--- a/tests/test_setup_optimizer.py
+++ b/tests/test_setup_optimizer.py
@@ -181,6 +181,47 @@ def test_record_lap_archive_upserts_without_duplicates(tmp_path: Path) -> None:
     assert len(load_records(store)) == 1
 
 
+def test_rebuild_experiments_deduplicates_experiment_ids(tmp_path: Path) -> None:
+    lap_dir = tmp_path / "journal" / "laps"
+    lap_dir.mkdir(parents=True)
+    (lap_dir / "lap_20260616-000001_first.json").write_text(
+        json.dumps(
+            _lap(
+                lap_uuid="lap-d1",
+                setup_hash="old",
+                setup_name="baseline",
+                lap_ms=100_000,
+                front_bias=64,
+                rear_wing=8,
+            )
+        ),
+        encoding="utf-8",
+    )
+    (lap_dir / "lap_20260616-000002_second.json").write_text(
+        json.dumps(
+            _lap(
+                lap_uuid="lap-d1",
+                setup_hash="new",
+                setup_name="candidate",
+                lap_ms=98_000,
+                front_bias=66,
+                rear_wing=9,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    summary = rebuild_experiments(lap_dir)
+    records = load_records(summary["store_path"])
+
+    assert summary["records"] == 1
+    assert summary["duplicates"] == [
+        {"path": str(lap_dir / "lap_20260616-000002_second.json"), "experiment_id": "lap-d1"}
+    ]
+    assert len(records) == 1
+    assert records[0]["setup"]["hash"] == "new"
+
+
 def test_setup_optimizer_cli_smoke(tmp_path: Path, capsys) -> None:
     lap_dir = tmp_path / "journal" / "laps"
     _write_laps(lap_dir)

--- a/tests/test_setup_optimizer.py
+++ b/tests/test_setup_optimizer.py
@@ -192,6 +192,19 @@ def test_load_records_rejects_corrupt_store(tmp_path: Path) -> None:
         load_records(store)
 
 
+def test_rebuild_experiments_rejects_missing_lap_dir_without_rewriting_store(
+    tmp_path: Path,
+) -> None:
+    store = tmp_path / "experiments.jsonl"
+    original = '{"sentinel": true}\n'
+    store.write_text(original, encoding="utf-8")
+
+    with pytest.raises(SetupExperimentError, match="existing directory"):
+        rebuild_experiments(tmp_path / "missing" / "laps", store_path=store)
+
+    assert store.read_text(encoding="utf-8") == original
+
+
 def test_rebuild_experiments_deduplicates_experiment_ids(tmp_path: Path) -> None:
     lap_dir = tmp_path / "journal" / "laps"
     lap_dir.mkdir(parents=True)

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -167,6 +167,30 @@ def test_setup_store_registration_failure_is_backed_off():
     assert int(rt.eval("_ws_sent")) == sent_after_failed_ack
 
 
+def test_setup_path_frames_require_loopback_url():
+    rt = _runtime()
+    rt.execute('local wb = require("ws_bridge"); wb.configure("ws://192.0.2.10:8765"); wb.tick(0)')
+    assert rt.eval("_ws_on_recv ~= nil"), "socket should have opened on first tick"
+    rt.execute(
+        'require("ws_bridge").setSetupExperimentStorePath('
+        '"C:/Assetto Corsa/apps/lua/ac_copilot_trainer/journal/setup_experiments/experiments.jsonl"'
+        ")"
+    )
+    sent_before = int(rt.eval("_ws_sent"))
+
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+
+    assert int(rt.eval("_ws_sent")) == sent_before
+    assert (
+        rt.eval(
+            'require("ws_bridge").sendSetupExperimentRecord('
+            '"C:/Assetto Corsa/apps/lua/ac_copilot_trainer/journal/laps/lap_1.json")'
+        )
+        is False
+    )
+    assert int(rt.eval("_ws_sent")) == sent_before
+
+
 def test_legacy_protocol_frame_does_not_unblock_v1_publish():
     # chatgpt-codex P1 on PR #171: the v1 publish path must require the v1 hello
     # handshake, not just any-protocol readiness. A legacy protocol=1 reply (e.g.

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -167,6 +167,33 @@ def test_setup_store_registration_failure_is_backed_off():
     assert int(rt.eval("_ws_sent")) == sent_after_failed_ack
 
 
+def test_setup_store_registration_retries_after_backoff_without_inbound_frames():
+    rt = _runtime()
+    _open(rt)
+    rt.execute(
+        'require("ws_bridge").setSetupExperimentStorePath('
+        '"C:/Assetto Corsa/apps/lua/ac_copilot_trainer/journal/setup_experiments/experiments.jsonl"'
+        ")"
+    )
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    _inject(
+        rt,
+        {
+            "v": 1,
+            "type": "setup.experiment.store.ack",
+            "ok": False,
+            "error": "permission denied",
+        },
+    )
+    sent_after_failed_ack = int(rt.eval("_ws_sent"))
+
+    rt.execute('local wb = require("ws_bridge"); for _ = 1, 300 do wb.tick(0) end')
+    assert int(rt.eval("_ws_sent")) == sent_after_failed_ack
+
+    rt.execute('require("ws_bridge").tick(0)')
+    assert int(rt.eval("_ws_sent")) == sent_after_failed_ack + 1
+
+
 def test_setup_path_frames_require_loopback_url():
     rt = _runtime()
     rt.execute('local wb = require("ws_bridge"); wb.configure("ws://192.0.2.10:8765"); wb.tick(0)')

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -138,6 +138,35 @@ def test_hello_ack_registers_and_unblocks_publish():
     assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True
 
 
+def test_setup_store_registration_failure_is_backed_off():
+    rt = _runtime()
+    _open(rt)
+    rt.execute(
+        'require("ws_bridge").setSetupExperimentStorePath('
+        '"C:/Assetto Corsa/apps/lua/ac_copilot_trainer/journal/setup_experiments/experiments.jsonl"'
+        ")"
+    )
+    sent_before = int(rt.eval("_ws_sent"))
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    sent_after_registration = int(rt.eval("_ws_sent"))
+    assert sent_after_registration == sent_before + 1
+
+    _inject(
+        rt,
+        {
+            "v": 1,
+            "type": "setup.experiment.store.ack",
+            "ok": False,
+            "error": "permission denied",
+        },
+    )
+    sent_after_failed_ack = int(rt.eval("_ws_sent"))
+    for _ in range(20):
+        _inject(rt, {"v": 1, "type": "state.snapshot", "topic": "session", "payload": {}})
+
+    assert int(rt.eval("_ws_sent")) == sent_after_failed_ack
+
+
 def test_legacy_protocol_frame_does_not_unblock_v1_publish():
     # chatgpt-codex P1 on PR #171: the v1 publish path must require the v1 hello
     # handshake, not just any-protocol readiness. A legacy protocol=1 reply (e.g.

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -32,6 +32,7 @@ TYPE_STATE_UNSUBSCRIBE = "state.unsubscribe"
 # the Lua side enforces the in-pits gate and does the actual ac.loadSetup().
 TYPE_SETUP_LIST = "setup.list"
 TYPE_SETUP_LOAD = "setup.load"
+TYPE_SETUP_EXPERIMENT_STORE = "setup.experiment.store"
 TYPE_SETUP_EXPERIMENT_RECORD = "setup.experiment.record"
 TYPE_SETUP_COMPARE = "setup.compare"
 TYPE_SETUP_SUGGEST = "setup.suggest"
@@ -46,6 +47,7 @@ TYPE_ERROR = "error"
 # Issue #86 Part D: replies to the screen for setup operations.
 TYPE_SETUP_LIST_RESULT = "setup.list.result"
 TYPE_SETUP_LOAD_ACK = "setup.load.ack"
+TYPE_SETUP_EXPERIMENT_STORE_ACK = "setup.experiment.store.ack"
 TYPE_SETUP_EXPERIMENT_RECORD_ACK = "setup.experiment.record.ack"
 TYPE_SETUP_COMPARE_RESULT = "setup.compare.result"
 TYPE_SETUP_SUGGEST_RESULT = "setup.suggest.result"
@@ -166,6 +168,11 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
         if not (name_ok or path_ok):
             return "setup.load requires non-empty 'name' or 'path'"
         return None
+    if t == TYPE_SETUP_EXPERIMENT_STORE:
+        store_path = frame.get("store_path") or frame.get("path")
+        if not isinstance(store_path, str) or not store_path:
+            return "setup.experiment.store requires non-empty 'store_path'"
+        return None
     if t == TYPE_SETUP_EXPERIMENT_RECORD:
         archive_path = frame.get("archive_path") or frame.get("path")
         if not isinstance(archive_path, str) or not archive_path:
@@ -188,6 +195,7 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
         # Server-to-client replies forwarded from the Lua peer — accept silently.
         return None
     if t in (
+        TYPE_SETUP_EXPERIMENT_STORE_ACK,
         TYPE_SETUP_EXPERIMENT_RECORD_ACK,
         TYPE_SETUP_COMPARE_RESULT,
         TYPE_SETUP_SUGGEST_RESULT,

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -32,6 +32,9 @@ TYPE_STATE_UNSUBSCRIBE = "state.unsubscribe"
 # the Lua side enforces the in-pits gate and does the actual ac.loadSetup().
 TYPE_SETUP_LIST = "setup.list"
 TYPE_SETUP_LOAD = "setup.load"
+TYPE_SETUP_EXPERIMENT_RECORD = "setup.experiment.record"
+TYPE_SETUP_COMPARE = "setup.compare"
+TYPE_SETUP_SUGGEST = "setup.suggest"
 
 # Server → client.
 TYPE_HELLO_ACK = "hello_ack"
@@ -43,6 +46,9 @@ TYPE_ERROR = "error"
 # Issue #86 Part D: replies to the screen for setup operations.
 TYPE_SETUP_LIST_RESULT = "setup.list.result"
 TYPE_SETUP_LOAD_ACK = "setup.load.ack"
+TYPE_SETUP_EXPERIMENT_RECORD_ACK = "setup.experiment.record.ack"
+TYPE_SETUP_COMPARE_RESULT = "setup.compare.result"
+TYPE_SETUP_SUGGEST_RESULT = "setup.suggest.result"
 
 # Capabilities advertised in `hello_ack` so clients can branch on optional
 # server features without a v2 bump.
@@ -51,6 +57,8 @@ SERVER_CAPABILITIES: tuple[str, ...] = (
     TYPE_CONFIG_SET,
     TYPE_ACTION,
     TYPE_STATE_SUBSCRIBE,
+    TYPE_SETUP_COMPARE,
+    TYPE_SETUP_SUGGEST,
 )
 
 # Names a client may invoke via `action`. Mirrors the Lua dispatcher in
@@ -158,8 +166,32 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
         if not (name_ok or path_ok):
             return "setup.load requires non-empty 'name' or 'path'"
         return None
+    if t == TYPE_SETUP_EXPERIMENT_RECORD:
+        archive_path = frame.get("archive_path") or frame.get("path")
+        if not isinstance(archive_path, str) or not archive_path:
+            return "setup.experiment.record requires non-empty 'archive_path'"
+        return None
+    if t == TYPE_SETUP_COMPARE:
+        baseline = frame.get("baseline_setup")
+        candidate = frame.get("candidate_setup")
+        if not isinstance(baseline, str) or not baseline:
+            return "setup.compare requires non-empty 'baseline_setup'"
+        if not isinstance(candidate, str) or not candidate:
+            return "setup.compare requires non-empty 'candidate_setup'"
+        return None
+    if t == TYPE_SETUP_SUGGEST:
+        for key in ("car_id", "track_id"):
+            if key in frame and not isinstance(frame.get(key), str):
+                return f"setup.suggest optional '{key}' must be a string"
+        return None
     if t in (TYPE_SETUP_LIST_RESULT, TYPE_SETUP_LOAD_ACK):
         # Server-to-client replies forwarded from the Lua peer — accept silently.
+        return None
+    if t in (
+        TYPE_SETUP_EXPERIMENT_RECORD_ACK,
+        TYPE_SETUP_COMPARE_RESULT,
+        TYPE_SETUP_SUGGEST_RESULT,
+    ):
         return None
     if t in (TYPE_STATE_SUBSCRIBE, TYPE_STATE_UNSUBSCRIBE):
         topics = frame.get("topics")

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -662,12 +662,16 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
         return
 
     if t == TYPE_SETUP_COMPARE:
-        out = await asyncio.to_thread(
-            _compare_setup_store,
-            store_path,
-            baseline_setup=str(data.get("baseline_setup") or ""),
-            candidate_setup=str(data.get("candidate_setup") or ""),
-        )
+        try:
+            out = await asyncio.to_thread(
+                _compare_setup_store,
+                store_path,
+                baseline_setup=str(data.get("baseline_setup") or ""),
+                candidate_setup=str(data.get("candidate_setup") or ""),
+            )
+        except Exception as e:
+            logger.info("setup compare failed store=%s err=%s", store_path, e)
+            out = {"ok": False, "error": str(e)}
         await _safe_send(
             websocket,
             {
@@ -680,12 +684,16 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
         return
 
     if t == TYPE_SETUP_SUGGEST:
-        out = await asyncio.to_thread(
-            _suggest_setup_store,
-            store_path,
-            car_id=data.get("car_id"),
-            track_id=data.get("track_id"),
-        )
+        try:
+            out = await asyncio.to_thread(
+                _suggest_setup_store,
+                store_path,
+                car_id=data.get("car_id"),
+                track_id=data.get("track_id"),
+            )
+        except Exception as e:
+            logger.info("setup suggest failed store=%s err=%s", store_path, e)
+            out = {"ok": False, "error": str(e)}
         await _safe_send(
             websocket,
             {

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -98,6 +98,7 @@ _ollama_followup_sem: asyncio.Semaphore | None = None
 # frame, including the Lua loopback client). Used for hub-style fan-out.
 _external_peers: set[Any] = set()
 _setup_experiment_store_path: Path | None = None
+_setup_experiment_store_seeded = False
 _external_peer_classes: dict[Any, str] = {}
 
 TELEMETRY_TICK_MAX_HZ = 20.0
@@ -559,7 +560,7 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
     without inventing another daemon. Arbitrary file reads stay loopback-only:
     only the Lua peer may provide filesystem paths.
     """
-    global _setup_experiment_store_path
+    global _setup_experiment_store_path, _setup_experiment_store_seeded
 
     t = data.get(TYPE_KEY)
     if t == TYPE_SETUP_EXPERIMENT_STORE:
@@ -590,25 +591,31 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
             )
             return
         candidate_store_path = Path(store_path_text)
+        active_store_path = (
+            _setup_experiment_store_path
+            if _setup_experiment_store_seeded and _setup_experiment_store_path is not None
+            else candidate_store_path
+        )
         try:
             records_count = await asyncio.to_thread(
                 _setup_store_record_count,
-                candidate_store_path,
+                active_store_path,
             )
         except Exception as e:
-            logger.info("setup store registration failed store=%s err=%s", candidate_store_path, e)
+            logger.info("setup store registration failed store=%s err=%s", active_store_path, e)
             await _safe_send(
                 websocket,
                 {
                     ENVELOPE_KEY: ENVELOPE_VERSION,
                     TYPE_KEY: TYPE_SETUP_EXPERIMENT_STORE_ACK,
                     "ok": False,
-                    "store_path": str(candidate_store_path),
+                    "store_path": str(active_store_path),
                     "error": str(e),
                 },
             )
             return
-        _setup_experiment_store_path = candidate_store_path
+        if not _setup_experiment_store_seeded:
+            _setup_experiment_store_path = candidate_store_path
         await _safe_send(
             websocket,
             {
@@ -616,6 +623,8 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
                 TYPE_KEY: TYPE_SETUP_EXPERIMENT_STORE_ACK,
                 "ok": True,
                 "store_path": str(_setup_experiment_store_path),
+                "requested_store_path": str(candidate_store_path),
+                "seeded": _setup_experiment_store_seeded,
                 "records": records_count,
             },
         )
@@ -649,12 +658,16 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
                 },
             )
             return
-        _setup_experiment_store_path = Path(out["store_path"])
+        if not _setup_experiment_store_seeded:
+            _setup_experiment_store_path = Path(out["store_path"])
         await _safe_send(
             websocket,
             {
                 ENVELOPE_KEY: ENVELOPE_VERSION,
                 TYPE_KEY: TYPE_SETUP_EXPERIMENT_RECORD_ACK,
+                "active_store_path": str(_setup_experiment_store_path)
+                if _setup_experiment_store_path is not None
+                else None,
                 **out,
             },
         )
@@ -976,7 +989,7 @@ async def _run(
     token: str | None,
     setup_store: str | None = None,
 ) -> None:
-    global _setup_experiment_store_path
+    global _setup_experiment_store_path, _setup_experiment_store_seeded
     try:
         import websockets
     except ImportError as e:
@@ -985,6 +998,7 @@ async def _run(
     process_request = make_process_request(token)
     _reset_external_state()
     _setup_experiment_store_path = Path(setup_store) if setup_store else None
+    _setup_experiment_store_seeded = setup_store is not None
     try:
         async with websockets.serve(
             lambda ws: _handler(ws, reply_coaching),

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -27,6 +27,7 @@ from tools.ai_sidecar.external_protocol import (
     AUTH_HEADER,
     CLIENT_HEADER,
     ENVELOPE_KEY,
+    ENVELOPE_VERSION,
     TYPE_ACTION,
     TYPE_ACTION_ACK,
     TYPE_CONFIG_ACK,
@@ -37,10 +38,16 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_HELLO,
     TYPE_HELLO_ACK,
     TYPE_KEY,
+    TYPE_SETUP_COMPARE,
+    TYPE_SETUP_COMPARE_RESULT,
+    TYPE_SETUP_EXPERIMENT_RECORD,
+    TYPE_SETUP_EXPERIMENT_RECORD_ACK,
     TYPE_SETUP_LIST,
     TYPE_SETUP_LIST_RESULT,
     TYPE_SETUP_LOAD,
     TYPE_SETUP_LOAD_ACK,
+    TYPE_SETUP_SUGGEST,
+    TYPE_SETUP_SUGGEST_RESULT,
     TYPE_STATE_SNAPSHOT,
     TYPE_STATE_SUBSCRIBE,
     TYPE_STATE_UNSUBSCRIBE,
@@ -57,6 +64,14 @@ from tools.ai_sidecar.protocol import (
     prepare_outbound_message,
 )
 from tools.ai_sidecar.session import LapComparisonState
+from tools.ai_sidecar.setup_optimizer import (
+    SetupExperimentError,
+    compare_setups,
+    load_records,
+    rebuild_experiments,
+    record_lap_archive,
+    suggest_next_setup,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +85,7 @@ _ollama_followup_sem: asyncio.Semaphore | None = None
 # Connected external-protocol peers (any client that has spoken a `{v,type}`
 # frame, including the Lua loopback client). Used for hub-style fan-out.
 _external_peers: set[Any] = set()
+_setup_experiment_store_path: Path | None = None
 
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 CLIENT_TO_SERVER_TYPES = frozenset(
@@ -87,6 +103,9 @@ CLIENT_TO_SERVER_TYPES = frozenset(
         # "Loading…" forever.
         TYPE_SETUP_LIST,
         TYPE_SETUP_LOAD,
+        TYPE_SETUP_EXPERIMENT_RECORD,
+        TYPE_SETUP_COMPARE,
+        TYPE_SETUP_SUGGEST,
     }
 )
 SERVER_TO_CLIENT_TYPES = frozenset(
@@ -100,6 +119,16 @@ SERVER_TO_CLIENT_TYPES = frozenset(
         # Issue #86 Part D: replies the Lua peer sends back to the screen.
         TYPE_SETUP_LIST_RESULT,
         TYPE_SETUP_LOAD_ACK,
+        TYPE_SETUP_EXPERIMENT_RECORD_ACK,
+        TYPE_SETUP_COMPARE_RESULT,
+        TYPE_SETUP_SUGGEST_RESULT,
+    }
+)
+SIDECAR_LOCAL_TYPES = frozenset(
+    {
+        TYPE_SETUP_EXPERIMENT_RECORD,
+        TYPE_SETUP_COMPARE,
+        TYPE_SETUP_SUGGEST,
     }
 )
 
@@ -130,6 +159,35 @@ def _run_compare_laps(last_path: str, ref_path: str) -> None:
         extract_corner_table(ref),
     )
     print(json.dumps(ranked, indent=2))
+
+
+def _run_setup_record_lap(lap_path: str, store_path: str | None) -> None:
+    """CLI harness: one lap archive JSON → upsert one setup experiment row."""
+    try:
+        out = record_lap_archive(lap_path, store_path=store_path)
+    except SetupExperimentError as e:
+        raise SystemExit(f"setup-record-lap: {e}") from e
+    print(json.dumps(out, indent=2, sort_keys=True))
+
+
+def _run_setup_rebuild(lap_dir: str, store_path: str | None) -> None:
+    """CLI harness: rebuild the setup experiment table from lap archive files."""
+    out = rebuild_experiments(lap_dir, store_path=store_path)
+    print(json.dumps(out, indent=2, sort_keys=True))
+
+
+def _run_setup_compare(store_path: str, baseline: str, candidate: str) -> None:
+    out = compare_setups(
+        load_records(store_path),
+        baseline_setup=baseline,
+        candidate_setup=candidate,
+    )
+    print(json.dumps(out, indent=2, sort_keys=True))
+
+
+def _run_setup_suggest(store_path: str, car_id: str | None, track_id: str | None) -> None:
+    out = suggest_next_setup(load_records(store_path), car_id=car_id, track_id=track_id)
+    print(json.dumps(out, indent=2, sort_keys=True))
 
 
 def _peer_host(connection: Any) -> str | None:
@@ -325,6 +383,106 @@ async def _safe_send_raw(websocket: Any, payload: str) -> Exception | None:
     return None
 
 
+async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -> None:
+    """Handle setup optimizer frames in the sidecar itself.
+
+    The Lua app sends ``setup.experiment.record`` after writing a lap archive.
+    External clients can then ask the same sidecar for ``setup.compare`` or
+    ``setup.suggest`` without inventing another daemon.  Arbitrary file reads
+    stay loopback-only: only the Lua peer may provide ``archive_path``.
+    """
+    global _setup_experiment_store_path
+
+    t = data.get(TYPE_KEY)
+    if t == TYPE_SETUP_EXPERIMENT_RECORD:
+        if not _is_loopback_peer(websocket):
+            await _safe_send(
+                websocket,
+                {
+                    ENVELOPE_KEY: ENVELOPE_VERSION,
+                    TYPE_KEY: TYPE_SETUP_EXPERIMENT_RECORD_ACK,
+                    "ok": False,
+                    "error": "setup experiment recording is loopback-only",
+                },
+            )
+            return
+        archive_path = str(data.get("archive_path") or data.get("path") or "")
+        try:
+            out = record_lap_archive(archive_path, require_safe_path=True)
+        except SetupExperimentError as e:
+            await _safe_send(
+                websocket,
+                {
+                    ENVELOPE_KEY: ENVELOPE_VERSION,
+                    TYPE_KEY: TYPE_SETUP_EXPERIMENT_RECORD_ACK,
+                    "ok": False,
+                    "archive_path": archive_path,
+                    "error": str(e),
+                },
+            )
+            return
+        _setup_experiment_store_path = Path(out["store_path"])
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: TYPE_SETUP_EXPERIMENT_RECORD_ACK,
+                **out,
+            },
+        )
+        return
+
+    store_path = _setup_experiment_store_path
+    if store_path is None:
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: (
+                    TYPE_SETUP_COMPARE_RESULT
+                    if t == TYPE_SETUP_COMPARE
+                    else TYPE_SETUP_SUGGEST_RESULT
+                ),
+                "ok": False,
+                "error": "no setup experiment store is loaded yet",
+            },
+        )
+        return
+
+    if t == TYPE_SETUP_COMPARE:
+        out = compare_setups(
+            load_records(store_path),
+            baseline_setup=str(data.get("baseline_setup") or ""),
+            candidate_setup=str(data.get("candidate_setup") or ""),
+        )
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: TYPE_SETUP_COMPARE_RESULT,
+                "store_path": str(store_path),
+                **out,
+            },
+        )
+        return
+
+    if t == TYPE_SETUP_SUGGEST:
+        out = suggest_next_setup(
+            load_records(store_path),
+            car_id=data.get("car_id"),
+            track_id=data.get("track_id"),
+        )
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: TYPE_SETUP_SUGGEST_RESULT,
+                "store_path": str(store_path),
+                **out,
+            },
+        )
+
+
 async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
     """Process one ``{v,type}`` frame: validate, ack, fan-out as needed."""
     peer = getattr(websocket, "remote_address", None)
@@ -351,6 +509,9 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
             websocket,
             make_error("peer must send hello before other frame types", ref_type=t),
         )
+        return
+    if t in SIDECAR_LOCAL_TYPES:
+        await _handle_setup_experiment_frame(websocket, data)
         return
     if t in SERVER_TO_CLIENT_TYPES and not _is_loopback_peer(websocket):
         await _safe_send(
@@ -536,6 +697,7 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
 
 
 async def _run(host: str, port: int, reply_coaching: bool, token: str | None) -> None:
+    global _setup_experiment_store_path
     try:
         import websockets
     except ImportError as e:
@@ -543,6 +705,7 @@ async def _run(host: str, port: int, reply_coaching: bool, token: str | None) ->
 
     process_request = make_process_request(token)
     _external_peers.clear()
+    _setup_experiment_store_path = None
     try:
         async with websockets.serve(
             lambda ws: _handler(ws, reply_coaching),
@@ -604,6 +767,40 @@ def main() -> None:
         ),
     )
     p.add_argument(
+        "--setup-record-lap",
+        metavar="LAP_JSON",
+        help="Upsert one setup experiment row from a PR #78 lap archive JSON and exit.",
+    )
+    p.add_argument(
+        "--setup-rebuild-experiments",
+        metavar="LAP_DIR",
+        help="Rebuild setup experiment JSONL from a journal/laps directory and exit.",
+    )
+    p.add_argument(
+        "--setup-store",
+        metavar="EXPERIMENTS_JSONL",
+        help="Experiment JSONL path for setup record/rebuild/compare/suggest commands.",
+    )
+    p.add_argument(
+        "--setup-compare",
+        nargs=2,
+        metavar=("BASELINE_SETUP", "CANDIDATE_SETUP"),
+        help="Compare two setup identifiers from --setup-store and exit.",
+    )
+    p.add_argument(
+        "--setup-suggest",
+        action="store_true",
+        help="Return the next setup candidate from --setup-store and exit.",
+    )
+    p.add_argument(
+        "--setup-car-id", default=None, help="Optional car id filter for --setup-suggest."
+    )
+    p.add_argument(
+        "--setup-track-id",
+        default=None,
+        help="Optional track id filter for --setup-suggest.",
+    )
+    p.add_argument(
         "--no-reply",
         action="store_true",
         help=(
@@ -614,6 +811,22 @@ def main() -> None:
     args = p.parse_args()
     if args.compare_laps:
         _run_compare_laps(args.compare_laps[0], args.compare_laps[1])
+        return
+    if args.setup_record_lap:
+        _run_setup_record_lap(args.setup_record_lap, args.setup_store)
+        return
+    if args.setup_rebuild_experiments:
+        _run_setup_rebuild(args.setup_rebuild_experiments, args.setup_store)
+        return
+    if args.setup_compare:
+        if not args.setup_store:
+            raise SystemExit("--setup-compare requires --setup-store")
+        _run_setup_compare(args.setup_store, args.setup_compare[0], args.setup_compare[1])
+        return
+    if args.setup_suggest:
+        if not args.setup_store:
+            raise SystemExit("--setup-suggest requires --setup-store")
+        _run_setup_suggest(args.setup_store, args.setup_car_id, args.setup_track_id)
         return
     reply = not args.no_reply
 

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -42,6 +42,8 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_SETUP_COMPARE_RESULT,
     TYPE_SETUP_EXPERIMENT_RECORD,
     TYPE_SETUP_EXPERIMENT_RECORD_ACK,
+    TYPE_SETUP_EXPERIMENT_STORE,
+    TYPE_SETUP_EXPERIMENT_STORE_ACK,
     TYPE_SETUP_LIST,
     TYPE_SETUP_LIST_RESULT,
     TYPE_SETUP_LOAD,
@@ -67,6 +69,7 @@ from tools.ai_sidecar.session import LapComparisonState
 from tools.ai_sidecar.setup_optimizer import (
     SetupExperimentError,
     compare_setups,
+    is_supported_experiment_store_path,
     load_records,
     rebuild_experiments,
     record_lap_archive,
@@ -103,6 +106,7 @@ CLIENT_TO_SERVER_TYPES = frozenset(
         # "Loading…" forever.
         TYPE_SETUP_LIST,
         TYPE_SETUP_LOAD,
+        TYPE_SETUP_EXPERIMENT_STORE,
         TYPE_SETUP_EXPERIMENT_RECORD,
         TYPE_SETUP_COMPARE,
         TYPE_SETUP_SUGGEST,
@@ -119,6 +123,7 @@ SERVER_TO_CLIENT_TYPES = frozenset(
         # Issue #86 Part D: replies the Lua peer sends back to the screen.
         TYPE_SETUP_LIST_RESULT,
         TYPE_SETUP_LOAD_ACK,
+        TYPE_SETUP_EXPERIMENT_STORE_ACK,
         TYPE_SETUP_EXPERIMENT_RECORD_ACK,
         TYPE_SETUP_COMPARE_RESULT,
         TYPE_SETUP_SUGGEST_RESULT,
@@ -126,6 +131,7 @@ SERVER_TO_CLIENT_TYPES = frozenset(
 )
 SIDECAR_LOCAL_TYPES = frozenset(
     {
+        TYPE_SETUP_EXPERIMENT_STORE,
         TYPE_SETUP_EXPERIMENT_RECORD,
         TYPE_SETUP_COMPARE,
         TYPE_SETUP_SUGGEST,
@@ -386,14 +392,55 @@ async def _safe_send_raw(websocket: Any, payload: str) -> Exception | None:
 async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -> None:
     """Handle setup optimizer frames in the sidecar itself.
 
-    The Lua app sends ``setup.experiment.record`` after writing a lap archive.
-    External clients can then ask the same sidecar for ``setup.compare`` or
-    ``setup.suggest`` without inventing another daemon.  Arbitrary file reads
-    stay loopback-only: only the Lua peer may provide ``archive_path``.
+    The Lua app sends ``setup.experiment.store`` after the v1 handshake and
+    ``setup.experiment.record`` after writing a lap archive. External clients
+    can then ask the same sidecar for ``setup.compare`` or ``setup.suggest``
+    without inventing another daemon. Arbitrary file reads stay loopback-only:
+    only the Lua peer may provide filesystem paths.
     """
     global _setup_experiment_store_path
 
     t = data.get(TYPE_KEY)
+    if t == TYPE_SETUP_EXPERIMENT_STORE:
+        if not _is_loopback_peer(websocket):
+            await _safe_send(
+                websocket,
+                {
+                    ENVELOPE_KEY: ENVELOPE_VERSION,
+                    TYPE_KEY: TYPE_SETUP_EXPERIMENT_STORE_ACK,
+                    "ok": False,
+                    "error": "setup experiment store registration is loopback-only",
+                },
+            )
+            return
+        store_path_text = str(data.get("store_path") or data.get("path") or "")
+        if not is_supported_experiment_store_path(store_path_text):
+            await _safe_send(
+                websocket,
+                {
+                    ENVELOPE_KEY: ENVELOPE_VERSION,
+                    TYPE_KEY: TYPE_SETUP_EXPERIMENT_STORE_ACK,
+                    "ok": False,
+                    "store_path": store_path_text,
+                    "error": (
+                        "store_path must point to journal/setup_experiments/experiments.jsonl"
+                    ),
+                },
+            )
+            return
+        _setup_experiment_store_path = Path(store_path_text)
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: TYPE_SETUP_EXPERIMENT_STORE_ACK,
+                "ok": True,
+                "store_path": str(_setup_experiment_store_path),
+                "records": len(load_records(_setup_experiment_store_path)),
+            },
+        )
+        return
+
     if t == TYPE_SETUP_EXPERIMENT_RECORD:
         if not _is_loopback_peer(websocket):
             await _safe_send(
@@ -696,7 +743,13 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
             await asyncio.gather(*pending_followups, return_exceptions=True)
 
 
-async def _run(host: str, port: int, reply_coaching: bool, token: str | None) -> None:
+async def _run(
+    host: str,
+    port: int,
+    reply_coaching: bool,
+    token: str | None,
+    setup_store: str | None = None,
+) -> None:
     global _setup_experiment_store_path
     try:
         import websockets
@@ -705,7 +758,7 @@ async def _run(host: str, port: int, reply_coaching: bool, token: str | None) ->
 
     process_request = make_process_request(token)
     _external_peers.clear()
-    _setup_experiment_store_path = None
+    _setup_experiment_store_path = Path(setup_store) if setup_store else None
     try:
         async with websockets.serve(
             lambda ws: _handler(ws, reply_coaching),
@@ -779,7 +832,10 @@ def main() -> None:
     p.add_argument(
         "--setup-store",
         metavar="EXPERIMENTS_JSONL",
-        help="Experiment JSONL path for setup record/rebuild/compare/suggest commands.",
+        help=(
+            "Experiment JSONL path for setup record/rebuild/compare/suggest commands; "
+            "also seeds WS compare/suggest when serving."
+        ),
     )
     p.add_argument(
         "--setup-compare",
@@ -843,7 +899,7 @@ def main() -> None:
         raise SystemExit("--token is required for non-loopback bind addresses")
 
     try:
-        asyncio.run(_run(host, args.port, reply, args.token))
+        asyncio.run(_run(host, args.port, reply, args.token, args.setup_store))
     except KeyboardInterrupt:
         logger.info("sidecar stopped")
 

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -589,11 +589,26 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
                 },
             )
             return
-        _setup_experiment_store_path = Path(store_path_text)
-        records_count = await asyncio.to_thread(
-            _setup_store_record_count,
-            _setup_experiment_store_path,
-        )
+        candidate_store_path = Path(store_path_text)
+        try:
+            records_count = await asyncio.to_thread(
+                _setup_store_record_count,
+                candidate_store_path,
+            )
+        except Exception as e:
+            logger.info("setup store registration failed store=%s err=%s", candidate_store_path, e)
+            await _safe_send(
+                websocket,
+                {
+                    ENVELOPE_KEY: ENVELOPE_VERSION,
+                    TYPE_KEY: TYPE_SETUP_EXPERIMENT_STORE_ACK,
+                    "ok": False,
+                    "store_path": str(candidate_store_path),
+                    "error": str(e),
+                },
+            )
+            return
+        _setup_experiment_store_path = candidate_store_path
         await _safe_send(
             websocket,
             {
@@ -621,7 +636,8 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
         archive_path = str(data.get("archive_path") or data.get("path") or "")
         try:
             out = await asyncio.to_thread(_record_lap_archive_safe, archive_path)
-        except SetupExperimentError as e:
+        except Exception as e:
+            logger.info("setup experiment record failed archive=%s err=%s", archive_path, e)
             await _safe_send(
                 websocket,
                 {

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -196,6 +196,36 @@ def _run_setup_suggest(store_path: str, car_id: str | None, track_id: str | None
     print(json.dumps(out, indent=2, sort_keys=True))
 
 
+def _setup_store_record_count(store_path: str | Path) -> int:
+    return len(load_records(store_path))
+
+
+def _record_lap_archive_safe(archive_path: str) -> dict[str, Any]:
+    return record_lap_archive(archive_path, require_safe_path=True)
+
+
+def _compare_setup_store(
+    store_path: str | Path,
+    *,
+    baseline_setup: str,
+    candidate_setup: str,
+) -> dict[str, Any]:
+    return compare_setups(
+        load_records(store_path),
+        baseline_setup=baseline_setup,
+        candidate_setup=candidate_setup,
+    )
+
+
+def _suggest_setup_store(
+    store_path: str | Path,
+    *,
+    car_id: str | None,
+    track_id: str | None,
+) -> dict[str, Any]:
+    return suggest_next_setup(load_records(store_path), car_id=car_id, track_id=track_id)
+
+
 def _peer_host(connection: Any) -> str | None:
     peer = getattr(connection, "remote_address", None)
     if isinstance(peer, tuple) and peer:
@@ -429,6 +459,10 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
             )
             return
         _setup_experiment_store_path = Path(store_path_text)
+        records_count = await asyncio.to_thread(
+            _setup_store_record_count,
+            _setup_experiment_store_path,
+        )
         await _safe_send(
             websocket,
             {
@@ -436,7 +470,7 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
                 TYPE_KEY: TYPE_SETUP_EXPERIMENT_STORE_ACK,
                 "ok": True,
                 "store_path": str(_setup_experiment_store_path),
-                "records": len(load_records(_setup_experiment_store_path)),
+                "records": records_count,
             },
         )
         return
@@ -455,7 +489,7 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
             return
         archive_path = str(data.get("archive_path") or data.get("path") or "")
         try:
-            out = record_lap_archive(archive_path, require_safe_path=True)
+            out = await asyncio.to_thread(_record_lap_archive_safe, archive_path)
         except SetupExperimentError as e:
             await _safe_send(
                 websocket,
@@ -497,8 +531,9 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
         return
 
     if t == TYPE_SETUP_COMPARE:
-        out = compare_setups(
-            load_records(store_path),
+        out = await asyncio.to_thread(
+            _compare_setup_store,
+            store_path,
             baseline_setup=str(data.get("baseline_setup") or ""),
             candidate_setup=str(data.get("candidate_setup") or ""),
         )
@@ -514,8 +549,9 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
         return
 
     if t == TYPE_SETUP_SUGGEST:
-        out = suggest_next_setup(
-            load_records(store_path),
+        out = await asyncio.to_thread(
+            _suggest_setup_store,
+            store_path,
             car_id=data.get("car_id"),
             track_id=data.get("track_id"),
         )
@@ -528,6 +564,7 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
                 **out,
             },
         )
+        return
 
 
 async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:

--- a/tools/ai_sidecar/setup_optimizer.py
+++ b/tools/ai_sidecar/setup_optimizer.py
@@ -1,0 +1,682 @@
+"""Setup experiment store, A/B comparison, and deterministic next-setup suggestions.
+
+The Lua app already writes rich per-lap archives under ``journal/laps``.  This
+module turns those lap archives into a compact JSONL experiment table and keeps
+all optimizer math stdlib-only so the default sidecar install stays lightweight.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_STORE_NAME = "experiments.jsonl"
+DEFAULT_STORE_DIR = "setup_experiments"
+MAX_TUNABLE_PARAMS = 6
+MIN_EXPERIMENTS_FOR_SUGGESTION = 2
+
+COMMON_PARAM_PRIORITY: tuple[str, ...] = (
+    "FRONT_BIAS.VALUE",
+    "BRAKE_POWER_MULT.VALUE",
+    "ABS.VALUE",
+    "TRACTION_CONTROL.VALUE",
+    "WING_1.VALUE",
+    "WING_2.VALUE",
+    "ARB_FRONT.VALUE",
+    "ARB_REAR.VALUE",
+    "DIFF_POWER.VALUE",
+    "DIFF_COAST.VALUE",
+    "PRESSURE_LF.VALUE",
+    "PRESSURE_RF.VALUE",
+    "PRESSURE_LR.VALUE",
+    "PRESSURE_RR.VALUE",
+    "CAMBER_LF.VALUE",
+    "CAMBER_RF.VALUE",
+    "CAMBER_LR.VALUE",
+    "CAMBER_RR.VALUE",
+    "TOE_OUT_LF.VALUE",
+    "TOE_OUT_RF.VALUE",
+    "TOE_OUT_LR.VALUE",
+    "TOE_OUT_RR.VALUE",
+)
+
+
+class SetupExperimentError(ValueError):
+    """Raised when a lap archive cannot become a setup experiment."""
+
+
+def _as_finite_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(out):
+        return None
+    return out
+
+
+def _as_nonempty_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _path_text(path: str | os.PathLike[str] | None) -> str | None:
+    if path is None:
+        return None
+    text = str(path).strip()
+    return text or None
+
+
+def _stable_json(data: Any) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _stable_hash(data: Any, *, length: int = 16) -> str:
+    return hashlib.sha1(_stable_json(data).encode("utf-8")).hexdigest()[:length]
+
+
+def _setup_name(setup: dict[str, Any]) -> str | None:
+    path = _as_nonempty_str(setup.get("path"))
+    if path:
+        stem = Path(path.replace("\\", "/")).stem
+        if stem:
+            return stem
+    snapshot = setup.get("snapshot")
+    if isinstance(snapshot, dict):
+        for key in ("NAME", "ABOUT.NAME"):
+            name = _as_nonempty_str(snapshot.get(key))
+            if name:
+                return name
+    return None
+
+
+def _numeric_params(snapshot: Any) -> dict[str, float]:
+    if not isinstance(snapshot, dict):
+        return {}
+    out: dict[str, float] = {}
+    for raw_key, raw_value in sorted(snapshot.items(), key=lambda item: str(item[0])):
+        key = str(raw_key)
+        val = _as_finite_float(raw_value)
+        if val is not None:
+            out[key] = val
+    return out
+
+
+def _jsonable_conditions(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key, value in raw.items():
+        if isinstance(value, bool) or value is None:
+            out[str(key)] = value
+        elif isinstance(value, str):
+            out[str(key)] = value
+        else:
+            num = _as_finite_float(value)
+            if num is not None:
+                out[str(key)] = num
+    return out
+
+
+def default_store_path_for_lap(lap_path: str | os.PathLike[str]) -> Path:
+    """Return the canonical experiment JSONL path for a lap archive path."""
+    p = Path(lap_path)
+    parts = [part.lower() for part in p.parts]
+    if len(parts) >= 2 and parts[-2:] == ["laps", p.name.lower()]:
+        journal_dir = p.parent.parent
+        if journal_dir.name.lower() == "journal":
+            return journal_dir / DEFAULT_STORE_DIR / DEFAULT_STORE_NAME
+    return p.parent / DEFAULT_STORE_DIR / DEFAULT_STORE_NAME
+
+
+def default_store_path_for_lap_dir(lap_dir: str | os.PathLike[str]) -> Path:
+    p = Path(lap_dir)
+    if p.name.lower() == "laps" and p.parent.name.lower() == "journal":
+        return p.parent / DEFAULT_STORE_DIR / DEFAULT_STORE_NAME
+    return p / DEFAULT_STORE_DIR / DEFAULT_STORE_NAME
+
+
+def is_supported_lap_archive_path(path: str | os.PathLike[str]) -> bool:
+    """Conservative guard for sidecar-triggered lap imports."""
+    text = str(path).replace("\\", "/")
+    low = text.lower()
+    name = low.rsplit("/", 1)[-1]
+    return "/journal/laps/" in low and name.startswith("lap_") and name.endswith(".json")
+
+
+def load_lap_archive(path: str | os.PathLike[str]) -> dict[str, Any]:
+    try:
+        raw = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SetupExperimentError(f"cannot read lap archive: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SetupExperimentError(
+            f"invalid lap archive JSON: {exc.msg} at char {exc.pos}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise SetupExperimentError("lap archive root must be a JSON object")
+    return data
+
+
+def record_from_lap_archive(
+    lap_archive: dict[str, Any],
+    *,
+    source_path: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(lap_archive, dict):
+        raise SetupExperimentError("lap archive must be a JSON object")
+    lap = lap_archive.get("lap")
+    if not isinstance(lap, dict):
+        raise SetupExperimentError("lap archive missing lap object")
+    lap_ms = _as_finite_float(lap.get("lap_ms"))
+    if lap_ms is None or lap_ms <= 0:
+        raise SetupExperimentError("lap archive missing positive lap.lap_ms")
+
+    setup = lap_archive.get("setup")
+    if not isinstance(setup, dict):
+        raise SetupExperimentError("lap archive missing setup object")
+    snapshot = setup.get("snapshot")
+    if not isinstance(snapshot, dict) or not snapshot:
+        raise SetupExperimentError("lap archive missing setup.snapshot")
+
+    setup_hash = _as_nonempty_str(setup.get("hash")) or _stable_hash(snapshot, length=12)
+    params = _numeric_params(snapshot)
+    if not params:
+        raise SetupExperimentError("setup.snapshot has no numeric parameters")
+
+    car = lap_archive.get("car") if isinstance(lap_archive.get("car"), dict) else {}
+    track = lap_archive.get("track") if isinstance(lap_archive.get("track"), dict) else {}
+    lap_uuid = _as_nonempty_str(lap_archive.get("lap_uuid"))
+    source_text = _path_text(source_path)
+    identity_seed = {
+        "lap_uuid": lap_uuid,
+        "source_path": source_text,
+        "session_uuid": lap_archive.get("session_uuid"),
+        "lap_n": lap.get("lap_n"),
+        "lap_ms": lap_ms,
+        "setup_hash": setup_hash,
+    }
+    experiment_id = lap_uuid or _stable_hash(identity_seed)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "experiment_id": experiment_id,
+        "source_lap_path": source_text,
+        "source_lap_schema_version": lap_archive.get("schema_version"),
+        "session_uuid": lap_archive.get("session_uuid"),
+        "lap_uuid": lap_uuid,
+        "exported_at": lap_archive.get("exported_at"),
+        "car": {
+            "id": _as_nonempty_str(car.get("id")) or "unknown",
+            "displayName": car.get("displayName"),
+        },
+        "track": {
+            "id": _as_nonempty_str(track.get("id")) or "unknown",
+            "layout": track.get("layout"),
+            "lengthM": _as_finite_float(track.get("lengthM")),
+        },
+        "conditions": _jsonable_conditions(lap_archive.get("conditions")),
+        "lap": {
+            "lap_n": int(_as_finite_float(lap.get("lap_n")) or 0),
+            "lap_ms": int(round(lap_ms)),
+            "is_pb": lap.get("is_pb") is True,
+            "is_valid": lap.get("is_valid") is not False,
+        },
+        "setup": {
+            "hash": setup_hash,
+            "name": _setup_name(setup),
+            "path": _as_nonempty_str(setup.get("path")),
+            "params": params,
+            "param_count": len(params),
+        },
+    }
+
+
+def load_records(store_path: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    path = Path(store_path)
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                item = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(item, dict):
+                out.append(item)
+    return out
+
+
+def save_records(records: list[dict[str, Any]], store_path: str | os.PathLike[str]) -> None:
+    path = Path(store_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    records_sorted = sorted(
+        records,
+        key=lambda r: (
+            str(r.get("car", {}).get("id", "")),
+            str(r.get("track", {}).get("id", "")),
+            str(r.get("exported_at") or ""),
+            str(r.get("experiment_id") or ""),
+        ),
+    )
+    tmp = path.with_name(path.name + ".tmp")
+    with tmp.open("w", encoding="utf-8", newline="\n") as fh:
+        for rec in records_sorted:
+            fh.write(json.dumps(rec, sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+    tmp.replace(path)
+
+
+def upsert_records(
+    records: list[dict[str, Any]],
+    store_path: str | os.PathLike[str],
+) -> tuple[int, int]:
+    existing = load_records(store_path)
+    by_id: dict[str, dict[str, Any]] = {}
+    for rec in existing:
+        rid = _as_nonempty_str(rec.get("experiment_id"))
+        if rid:
+            by_id[rid] = rec
+    inserted = 0
+    updated = 0
+    for rec in records:
+        rid = _as_nonempty_str(rec.get("experiment_id"))
+        if not rid:
+            continue
+        if rid in by_id:
+            updated += 1
+        else:
+            inserted += 1
+        by_id[rid] = rec
+    save_records(list(by_id.values()), store_path)
+    return inserted, updated
+
+
+def record_lap_archive(
+    lap_path: str | os.PathLike[str],
+    *,
+    store_path: str | os.PathLike[str] | None = None,
+    require_safe_path: bool = False,
+) -> dict[str, Any]:
+    if require_safe_path and not is_supported_lap_archive_path(lap_path):
+        raise SetupExperimentError("archive_path must point under journal/laps/lap_*.json")
+    lap = load_lap_archive(lap_path)
+    rec = record_from_lap_archive(lap, source_path=lap_path)
+    store = Path(store_path) if store_path is not None else default_store_path_for_lap(lap_path)
+    inserted, updated = upsert_records([rec], store)
+    return {
+        "ok": True,
+        "store_path": str(store),
+        "experiment_id": rec["experiment_id"],
+        "setup_hash": rec["setup"]["hash"],
+        "lap_ms": rec["lap"]["lap_ms"],
+        "inserted": inserted,
+        "updated": updated,
+    }
+
+
+def rebuild_experiments(
+    lap_dir: str | os.PathLike[str],
+    *,
+    store_path: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    root = Path(lap_dir)
+    store = Path(store_path) if store_path is not None else default_store_path_for_lap_dir(root)
+    records: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+    for path in sorted(root.glob("lap_*.json")):
+        try:
+            records.append(record_from_lap_archive(load_lap_archive(path), source_path=path))
+        except SetupExperimentError as exc:
+            skipped.append({"path": str(path), "error": str(exc)})
+    save_records(records, store)
+    return {
+        "ok": True,
+        "store_path": str(store),
+        "records": len(records),
+        "skipped": skipped,
+    }
+
+
+def _setup_identifiers(record: dict[str, Any]) -> set[str]:
+    setup = record.get("setup")
+    if not isinstance(setup, dict):
+        return set()
+    out = set()
+    for key in ("hash", "name", "path"):
+        value = _as_nonempty_str(setup.get(key))
+        if value:
+            out.add(value)
+            out.add(value.lower())
+            out.add(value.replace("\\", "/").lower())
+            if key == "path":
+                stem = Path(value.replace("\\", "/")).stem
+                if stem:
+                    out.add(stem)
+                    out.add(stem.lower())
+    return out
+
+
+def _matches_setup(record: dict[str, Any], ident: str) -> bool:
+    raw = ident.strip()
+    if not raw:
+        return False
+    keys = {raw, raw.lower(), raw.replace("\\", "/").lower()}
+    return bool(_setup_identifiers(record) & keys)
+
+
+def _valid_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out = []
+    for rec in records:
+        lap = rec.get("lap")
+        setup = rec.get("setup")
+        if not isinstance(lap, dict) or not isinstance(setup, dict):
+            continue
+        lap_ms = _as_finite_float(lap.get("lap_ms"))
+        if lap_ms is None or lap_ms <= 0:
+            continue
+        if lap.get("is_valid") is False:
+            continue
+        if not isinstance(setup.get("params"), dict) or not setup.get("params"):
+            continue
+        out.append(rec)
+    return out
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def _sample_variance(values: list[float], mean: float) -> float:
+    if len(values) < 2:
+        return 0.0
+    return sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+
+
+def _normal_cdf(z: float) -> float:
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+def compare_setups(
+    records: list[dict[str, Any]],
+    *,
+    baseline_setup: str,
+    candidate_setup: str,
+    alpha: float = 0.05,
+) -> dict[str, Any]:
+    valid = _valid_records(records)
+    baseline = [float(rec["lap"]["lap_ms"]) for rec in valid if _matches_setup(rec, baseline_setup)]
+    candidate = [
+        float(rec["lap"]["lap_ms"]) for rec in valid if _matches_setup(rec, candidate_setup)
+    ]
+    if not baseline or not candidate:
+        return {
+            "ok": False,
+            "error": "both baseline_setup and candidate_setup need at least one valid lap",
+            "baseline_n": len(baseline),
+            "candidate_n": len(candidate),
+        }
+
+    b_mean = _mean(baseline)
+    c_mean = _mean(candidate)
+    b_var = _sample_variance(baseline, b_mean)
+    c_var = _sample_variance(candidate, c_mean)
+    improvement_ms = b_mean - c_mean
+    se = math.sqrt((b_var / len(baseline)) + (c_var / len(candidate)))
+    confidence = 0.5
+    p_value = None
+    z_score = None
+    if se > 0:
+        z_score = improvement_ms / se
+        confidence = _normal_cdf(z_score)
+        p_value = 1.0 - confidence
+    elif len(baseline) >= 2 and len(candidate) >= 2 and improvement_ms != 0:
+        confidence = 1.0 if improvement_ms > 0 else 0.0
+        p_value = 0.0 if improvement_ms > 0 else 1.0
+    significant = confidence >= (1.0 - alpha) and improvement_ms > 0
+
+    return {
+        "ok": True,
+        "baseline_setup": baseline_setup,
+        "candidate_setup": candidate_setup,
+        "baseline": {
+            "n": len(baseline),
+            "mean_ms": round(b_mean, 3),
+            "stdev_ms": round(math.sqrt(b_var), 3),
+        },
+        "candidate": {
+            "n": len(candidate),
+            "mean_ms": round(c_mean, 3),
+            "stdev_ms": round(math.sqrt(c_var), 3),
+        },
+        "improvement_ms": round(improvement_ms, 3),
+        "improvement_pct": round((improvement_ms / b_mean) * 100.0, 4),
+        "confidence": round(confidence, 4),
+        "p_value_one_sided": None if p_value is None else round(p_value, 6),
+        "z_score": None if z_score is None else round(z_score, 4),
+        "significant": significant,
+        "method": "welch_normal_approximation",
+    }
+
+
+def _filter_records(
+    records: list[dict[str, Any]],
+    *,
+    car_id: str | None = None,
+    track_id: str | None = None,
+) -> list[dict[str, Any]]:
+    valid = _valid_records(records)
+    if car_id:
+        valid = [r for r in valid if r.get("car", {}).get("id") == car_id]
+    if track_id:
+        valid = [r for r in valid if r.get("track", {}).get("id") == track_id]
+    return valid
+
+
+def _select_params(records: list[dict[str, Any]], best: dict[str, Any]) -> list[str]:
+    best_params = best["setup"]["params"]
+    all_keys = {key for rec in records for key in rec["setup"]["params"]}
+    varied: set[str] = set()
+    for key in all_keys:
+        vals = {_as_finite_float(rec["setup"]["params"].get(key)) for rec in records}
+        vals.discard(None)
+        if len(vals) > 1:
+            varied.add(key)
+    priority = {key: i for i, key in enumerate(COMMON_PARAM_PRIORITY)}
+    ranked = sorted(
+        [key for key in best_params if key in all_keys],
+        key=lambda key: (
+            0 if key in varied else 1,
+            priority.get(key, len(priority)),
+            key,
+        ),
+    )
+    return ranked[:MAX_TUNABLE_PARAMS]
+
+
+def _param_step(records: list[dict[str, Any]], key: str) -> float:
+    vals = sorted(
+        {
+            v
+            for rec in records
+            if (v := _as_finite_float(rec["setup"]["params"].get(key))) is not None
+        }
+    )
+    diffs = [b - a for a, b in zip(vals, vals[1:], strict=False) if b > a]
+    if diffs:
+        return max(min(diffs), 1.0 if all(float(v).is_integer() for v in vals) else 0.01)
+    return 1.0
+
+
+def _candidate_value(records: list[dict[str, Any]], key: str, value: float) -> float:
+    observed = [
+        v for rec in records if (v := _as_finite_float(rec["setup"]["params"].get(key))) is not None
+    ]
+    if observed and min(observed) >= 0 and value < 0:
+        return 0.0
+    return value
+
+
+def _candidate_grid(
+    records: list[dict[str, Any]], best: dict[str, Any], keys: list[str]
+) -> list[dict[str, float]]:
+    base = {key: float(best["setup"]["params"][key]) for key in keys}
+    candidates: dict[str, dict[str, float]] = {}
+
+    def add(params: dict[str, float]) -> None:
+        frozen = tuple((key, round(params[key], 6)) for key in keys)
+        candidates[str(frozen)] = dict(params)
+
+    for key in keys:
+        step = _param_step(records, key)
+        for sign in (-1.0, 1.0):
+            nxt = dict(base)
+            nxt[key] = _candidate_value(records, key, base[key] + sign * step)
+            add(nxt)
+
+    for i, key_a in enumerate(keys):
+        for key_b in keys[i + 1 :]:
+            step_a = _param_step(records, key_a)
+            step_b = _param_step(records, key_b)
+            for sign_a, sign_b in ((-1.0, -1.0), (-1.0, 1.0), (1.0, -1.0), (1.0, 1.0)):
+                nxt = dict(base)
+                nxt[key_a] = _candidate_value(records, key_a, base[key_a] + sign_a * step_a)
+                nxt[key_b] = _candidate_value(records, key_b, base[key_b] + sign_b * step_b)
+                add(nxt)
+    return list(candidates.values())
+
+
+def _distance(a: dict[str, float], b: dict[str, float], ranges: dict[str, float]) -> float:
+    total = 0.0
+    for key, scale in ranges.items():
+        total += ((a[key] - b[key]) / scale) ** 2
+    return math.sqrt(total)
+
+
+def _expected_improvement(best_y: float, mu: float, sigma: float) -> float:
+    if sigma <= 1e-9:
+        return max(best_y - mu, 0.0)
+    z = (best_y - mu) / sigma
+    phi = math.exp(-0.5 * z * z) / math.sqrt(2.0 * math.pi)
+    return (best_y - mu) * _normal_cdf(z) + sigma * phi
+
+
+def suggest_next_setup(
+    records: list[dict[str, Any]],
+    *,
+    car_id: str | None = None,
+    track_id: str | None = None,
+) -> dict[str, Any]:
+    scoped = _filter_records(records, car_id=car_id, track_id=track_id)
+    if len(scoped) < MIN_EXPERIMENTS_FOR_SUGGESTION:
+        return {
+            "ok": False,
+            "status": "not_enough_experiments",
+            "experiments_used": len(scoped),
+            "min_required": MIN_EXPERIMENTS_FOR_SUGGESTION,
+        }
+    best = min(scoped, key=lambda rec: float(rec["lap"]["lap_ms"]))
+    keys = _select_params(scoped, best)
+    if not keys:
+        return {"ok": False, "status": "no_tunable_numeric_params", "experiments_used": len(scoped)}
+
+    vectors = []
+    for rec in scoped:
+        params = rec["setup"]["params"]
+        if all(_as_finite_float(params.get(key)) is not None for key in keys):
+            vectors.append(
+                (
+                    {key: float(params[key]) for key in keys},
+                    float(rec["lap"]["lap_ms"]),
+                    rec,
+                )
+            )
+    if len(vectors) < MIN_EXPERIMENTS_FOR_SUGGESTION:
+        return {
+            "ok": False,
+            "status": "not_enough_complete_param_vectors",
+            "experiments_used": len(vectors),
+        }
+
+    ranges: dict[str, float] = {}
+    for key in keys:
+        vals = [vec[0][key] for vec in vectors]
+        ranges[key] = max(max(vals) - min(vals), _param_step(scoped, key), 1.0)
+    global_mean = _mean([y for _, y, _ in vectors])
+    global_var = _sample_variance([y for _, y, _ in vectors], global_mean)
+    global_std = max(math.sqrt(global_var), 1.0)
+    best_y = float(best["lap"]["lap_ms"])
+    observed = {tuple((key, round(vec[key], 6)) for key in keys) for vec, _, _ in vectors}
+
+    scored = []
+    for candidate in _candidate_grid(scoped, best, keys):
+        frozen = tuple((key, round(candidate[key], 6)) for key in keys)
+        if frozen in observed:
+            continue
+        weights = []
+        for vec, lap_ms, _ in vectors:
+            d = _distance(candidate, vec, ranges)
+            weights.append((math.exp(-0.5 * d * d), lap_ms))
+        weight_sum = sum(w for w, _ in weights)
+        if weight_sum <= 1e-9:
+            mu = global_mean
+            sigma = global_std
+        else:
+            mu = sum(w * y for w, y in weights) / weight_sum
+            local_var = sum(w * (y - mu) ** 2 for w, y in weights) / weight_sum
+            novelty = 1.0 / math.sqrt(1.0 + weight_sum)
+            sigma = math.sqrt(max(local_var, 0.0) + (global_std * novelty) ** 2)
+        ei = _expected_improvement(best_y, mu, sigma)
+        scored.append((ei, mu, sigma, candidate))
+    if not scored:
+        return {"ok": False, "status": "no_untried_candidate", "experiments_used": len(vectors)}
+
+    ei, mu, sigma, candidate = max(scored, key=lambda item: (item[0], -item[1]))
+    base_params = {key: float(best["setup"]["params"][key]) for key in keys}
+    changed = {
+        key: {"from": base_params[key], "to": candidate[key]}
+        for key in keys
+        if abs(candidate[key] - base_params[key]) > 1e-9
+    }
+    return {
+        "ok": True,
+        "status": "suggested",
+        "method": "rbf_surrogate_expected_improvement",
+        "experiments_used": len(vectors),
+        "base_setup": {
+            "hash": best["setup"]["hash"],
+            "name": best["setup"].get("name"),
+            "path": best["setup"].get("path"),
+            "lap_ms": best["lap"]["lap_ms"],
+        },
+        "candidate": {
+            "params": candidate,
+            "changed_params": changed,
+        },
+        "surrogate": {
+            "predicted_lap_ms": round(mu, 3),
+            "uncertainty_ms": round(sigma, 3),
+            "expected_improvement_ms": round(ei, 3),
+            "best_observed_lap_ms": int(round(best_y)),
+            "tunable_params": keys,
+        },
+        "rationale": [
+            f"Best observed setup {best['setup']['hash']} ran {int(round(best_y))} ms.",
+            "Candidates are one- or two-parameter moves around that setup.",
+            "The selected move maximizes expected improvement under a Gaussian-kernel surrogate.",
+        ],
+    }

--- a/tools/ai_sidecar/setup_optimizer.py
+++ b/tools/ai_sidecar/setup_optimizer.py
@@ -343,18 +343,29 @@ def rebuild_experiments(
 ) -> dict[str, Any]:
     root = Path(lap_dir)
     store = Path(store_path) if store_path is not None else default_store_path_for_lap_dir(root)
-    records: list[dict[str, Any]] = []
+    by_id: dict[str, dict[str, Any]] = {}
+    duplicates: list[dict[str, str]] = []
     skipped: list[dict[str, str]] = []
     for path in sorted(root.glob("lap_*.json")):
         try:
-            records.append(record_from_lap_archive(load_lap_archive(path), source_path=path))
+            rec = record_from_lap_archive(load_lap_archive(path), source_path=path)
         except SetupExperimentError as exc:
             skipped.append({"path": str(path), "error": str(exc)})
+            continue
+        rid = _as_nonempty_str(rec.get("experiment_id"))
+        if rid is None:
+            skipped.append({"path": str(path), "error": "missing experiment_id"})
+            continue
+        if rid in by_id:
+            duplicates.append({"path": str(path), "experiment_id": rid})
+        by_id[rid] = rec
+    records = list(by_id.values())
     save_records(records, store)
     return {
         "ok": True,
         "store_path": str(store),
         "records": len(records),
+        "duplicates": duplicates,
         "skipped": skipped,
     }
 

--- a/tools/ai_sidecar/setup_optimizer.py
+++ b/tools/ai_sidecar/setup_optimizer.py
@@ -348,6 +348,8 @@ def rebuild_experiments(
 ) -> dict[str, Any]:
     root = Path(lap_dir)
     store = Path(store_path) if store_path is not None else default_store_path_for_lap_dir(root)
+    if not root.is_dir():
+        raise SetupExperimentError(f"lap_dir must be an existing directory: {root}")
     by_id: dict[str, dict[str, Any]] = {}
     duplicates: list[dict[str, str]] = []
     skipped: list[dict[str, str]] = []

--- a/tools/ai_sidecar/setup_optimizer.py
+++ b/tools/ai_sidecar/setup_optimizer.py
@@ -152,6 +152,13 @@ def is_supported_lap_archive_path(path: str | os.PathLike[str]) -> bool:
     return "/journal/laps/" in low and name.startswith("lap_") and name.endswith(".json")
 
 
+def is_supported_experiment_store_path(path: str | os.PathLike[str]) -> bool:
+    """Conservative guard for Lua-registered setup experiment store paths."""
+    low = str(path).replace("\\", "/").lower()
+    suffix = "journal/setup_experiments/experiments.jsonl"
+    return low == suffix or low.endswith("/" + suffix)
+
+
 def load_lap_archive(path: str | os.PathLike[str]) -> dict[str, Any]:
     try:
         raw = Path(path).read_text(encoding="utf-8")

--- a/tools/ai_sidecar/setup_optimizer.py
+++ b/tools/ai_sidecar/setup_optimizer.py
@@ -255,16 +255,21 @@ def load_records(store_path: str | os.PathLike[str]) -> list[dict[str, Any]]:
         return []
     out: list[dict[str, Any]] = []
     with path.open("r", encoding="utf-8") as fh:
-        for line in fh:
+        for line_no, line in enumerate(fh, start=1):
             text = line.strip()
             if not text:
                 continue
             try:
                 item = json.loads(text)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(item, dict):
-                out.append(item)
+            except json.JSONDecodeError as e:
+                raise SetupExperimentError(
+                    f"invalid experiment store JSON at {path}:{line_no}: {e.msg}"
+                ) from e
+            if not isinstance(item, dict):
+                raise SetupExperimentError(
+                    f"invalid experiment store record at {path}:{line_no}: expected object"
+                )
+            out.append(item)
     return out
 
 


### PR DESCRIPTION
## Summary
- add a JSONL setup experiment store derived from PR #78 lap archives, including setup params, lap times, car/track ids, and conditions
- add setup A/B comparison with confidence/significance and deterministic expected-improvement setup suggestions
- wire live lap archive ingestion through the Lua -> sidecar v1 boundary and expose CLI/WS compare + suggest surfaces
- document data location, reset/rebuild, compare, and suggestion commands

Closes #114.

## Verification
- `.venv/bin/python -m pytest tests/test_setup_optimizer.py tests/test_ai_sidecar_external.py` (21 passed)
- `make ci-fast PYTHON=.venv/bin/python` (886 passed, 74 skipped, coverage 80.26%, bandit clean, policy checks OK)
- CLI smoke on synthetic lap archives:
  - rebuild: 7 records, 0 skipped
  - compare: `old` vs `new` improvement 2100 ms / 2.1%, confidence 0.9997, significant true
  - suggest: returned a concrete candidate with changed setup params and rationale
