### PR TITLE
feat: add MoTeC reference lap import (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ pip install -e ".[dev]"
 make ci-fast
 ```
 
+## MoTeC Reference Lap Import
+
+Convert a MoTeC CSV export into the trainer's `journal/laps/` schema-v1 archive:
+
+```bash
+python -m tools.import_motec sample.csv --car <car_id> --track <track_id> --track-length <meters>
+```
+
+Use `--output-dir` to target a specific `journal/laps` directory, or set
+`AC_COPILOT_LAP_ARCHIVE_DIR`. In-game, enable **Prefer imported reference over local PB** in
+Settings to use a faster imported lap as the active coaching reference. Imported laps never count
+as the user's local PB.
+
 ## Architecture
 
 See [docs/01_Vault/AcCopilotTrainer/00_System/Architecture Invariants.md](docs/01_Vault/AcCopilotTrainer/00_System/Architecture%20Invariants.md)

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -94,6 +94,8 @@ local CONFIG_DEFAULTS = {
   lapArchiveEnabled = true,
   --- Hard cap on archive disk usage in MB. Oldest files deleted first.
   lapArchiveMaxMB = 500,
+  --- Issue #79: imported MoTeC laps are reference candidates only when explicitly enabled.
+  useImportedReference = false,
 }
 
 --- Shallow copy so `CONFIG_DEFAULTS` is never aliased or mutated by `ac.storage()` (review #58).
@@ -117,6 +119,7 @@ local _wsUrlStorage = nil
 local _approachMetersStorage = nil
 local _lapArchiveEnabledStorage = nil
 local _lapArchiveMaxMBStorage = nil
+local _useImportedReferenceStorage = nil
 if ac and type(ac.storage) == "function" then
   local ok1, sv1 = pcall(ac.storage, "ac_copilot_trainer.wsSidecarUrl_v1", "")
   if ok1 and sv1 and type(sv1.get) == "function" then
@@ -135,6 +138,10 @@ if ac and type(ac.storage) == "function" then
   if ok4 and sv4 and type(sv4.get) == "function" then
     _lapArchiveMaxMBStorage = sv4
   end
+  local ok5, sv5 = pcall(ac.storage, "ac_copilot_trainer.useImportedReference_v1", 0)
+  if ok5 and sv5 and type(sv5.get) == "function" then
+    _useImportedReferenceStorage = sv5
+  end
 end
 
 local function isDedicatedPerKeyConfig(key)
@@ -142,6 +149,7 @@ local function isDedicatedPerKeyConfig(key)
     or key == "approachMeters"
     or key == "lapArchiveEnabled"
     or key == "lapArchiveMaxMB"
+    or key == "useImportedReference"
 end
 
 local function coercePersistedConfigValue(defaultValue, storedValue)
@@ -274,6 +282,15 @@ local function loadConfig()
       end
     end
   end
+  if _useImportedReferenceStorage and type(_useImportedReferenceStorage.get) == "function" then
+    local ok, val = pcall(function() return _useImportedReferenceStorage:get() end)
+    if ok and val ~= nil then
+      local n = tonumber(val)
+      if n ~= nil then
+        cfg.useImportedReference = (n ~= 0)
+      end
+    end
+  end
   cfg.lapArchiveMaxMB = lapArchive.clampArchiveCapMB(cfg.lapArchiveMaxMB)
   return cfg
 end
@@ -289,6 +306,8 @@ local SESSION_UUID = string.format(
   math.random(0, 0xFFFF),
   math.random(0, 0xFFFF)
 )
+
+local refreshActiveReference
 
 --- Persist `approachMeters` to per-key storage and log the change so we can
 --- verify the slider is wired correctly (issue #75 round 5: user reported the
@@ -320,6 +339,17 @@ local function setLapArchiveMaxMBAndPersist(mb)
   config.lapArchiveMaxMB = m
   if _lapArchiveMaxMBStorage and type(_lapArchiveMaxMBStorage.set) == "function" then
     pcall(function() _lapArchiveMaxMBStorage:set(m) end)
+  end
+end
+
+local function setUseImportedReferenceAndPersist(enabled)
+  config.useImportedReference = enabled and true or false
+  local v = config.useImportedReference and 1 or 0
+  if _useImportedReferenceStorage and type(_useImportedReferenceStorage.set) == "function" then
+    pcall(function() _useImportedReferenceStorage:set(v) end)
+  end
+  if refreshActiveReference then
+    pcall(refreshActiveReference)
   end
 end
 
@@ -572,6 +602,11 @@ local function applyExternalConfigSet(key, value)
     setLapArchiveMaxMBAndPersist(n)
     return true, nil
   end
+  if key == "useImportedReference" then
+    if type(value) ~= "boolean" then return false, "value must be boolean" end
+    setUseImportedReferenceAndPersist(value)
+    return true, nil
+  end
   if key == "wsSidecarUrl" then
     if type(value) ~= "string" then
       return false, "value must be string"
@@ -746,6 +781,94 @@ local function cloneCornerFeats(f)
   return out
 end
 
+local function cloneSegments(segs)
+  if not segs or type(segs) ~= "table" then
+    return {}
+  end
+  local out = {}
+  for i = 1, #segs do
+    local s = segs[i]
+    if type(s) == "table" then
+      local row = {}
+      for k, v in pairs(s) do
+        row[k] = v
+      end
+      out[#out + 1] = row
+    end
+  end
+  return out
+end
+
+local function speedAtSpline(trace, spline)
+  if type(trace) ~= "table" or #trace == 0 or type(spline) ~= "number" then
+    return 0
+  end
+  local best = trace[1]
+  local bestD = math.huge
+  for i = 1, #trace do
+    local sp = tonumber(trace[i].spline)
+    if sp ~= nil then
+      local d = math.abs(sp - spline)
+      d = math.min(d, 1 - d)
+      if d < bestD then
+        bestD = d
+        best = trace[i]
+      end
+    end
+  end
+  return tonumber(best and best.speed) or 0
+end
+
+local function brakePointsFromTrace(trace)
+  local out = {}
+  if type(trace) ~= "table" then
+    return out
+  end
+  local braking = false
+  for i = 1, #trace do
+    local p = trace[i]
+    local b = tonumber(p and p.brake) or 0
+    if b > 0.12 and not braking then
+      out[#out + 1] = {
+        spline = tonumber(p.spline) or 0,
+        px = tonumber(p.px) or 0,
+        py = tonumber(p.py) or 0,
+        pz = tonumber(p.pz) or 0,
+        entrySpeed = tonumber(p.speed) or 0,
+        heading = 0,
+      }
+      braking = true
+    elseif b < 0.04 then
+      braking = false
+    end
+  end
+  return out
+end
+
+local function brakePointsFromSegments(trace, segments)
+  local out = {}
+  if type(segments) ~= "table" then
+    return out
+  end
+  for i = 1, #segments do
+    local seg = segments[i]
+    if type(seg) == "table" and seg.kind == "corner" then
+      local sp = tonumber(seg.brakeSpline) or tonumber(seg.s0)
+      if sp ~= nil then
+        out[#out + 1] = {
+          spline = sp,
+          px = 0,
+          py = 0,
+          pz = 0,
+          entrySpeed = speedAtSpline(trace, sp),
+          heading = 0,
+        }
+      end
+    end
+  end
+  return out
+end
+
 --- Build ``telemetry.corners`` for sidecar ranking / debrief (issues #49, #46).
 local function buildSidecarTelemetryCorners(feats)
   if not feats or type(feats) ~= "table" or #feats == 0 then
@@ -829,8 +952,19 @@ state = {
   -- Defaults true: no delta until the first clean lap is started (an out-lap clock is mid-track).
   deltaRefStale = true,
   bestLapTrace = {},
+  -- Local in-game PB/reference snapshot. When an imported reference is active,
+  -- realtime code still reads `bestLapTrace`, but persistence saves these local fields.
+  localBestLapTrace = {},
+  localBestBrakePoints = {},
+  localBestTrackSegments = {},
+  localBestCornerFeatures = {},
+  localBestReferenceLapMs = nil,
   --- Lap time (ms) for the lap that produced `bestLapTrace`; used to omit stale trace from saves when PB improves without a new reference trace.
   bestReferenceLapMs = nil,
+  activeReferenceSource = nil,
+  activeReferenceFormat = nil,
+  activeReferenceLapMs = nil,
+  activeReferencePath = nil,
   bestSortedTrace = nil,
   bestSectorMs = { 0, 0, 0 },
   sectorIndex = 1,
@@ -958,6 +1092,86 @@ local function rebuildBestReference()
   state.cornerSteerSideCacheKey = nil
 end
 
+local function cacheLocalReferenceState()
+  state.localBestLapTrace = copyTrace(state.bestLapTrace or {})
+  state.localBestBrakePoints = copyBpList(state.brakingPoints.best or {})
+  state.localBestTrackSegments = cloneSegments(state.trackSegments or {})
+  state.localBestCornerFeatures = cloneCornerFeats(state.bestCornerFeatures or {})
+  state.localBestReferenceLapMs = state.bestReferenceLapMs
+end
+
+local function restoreLocalReferenceState()
+  state.bestLapTrace = copyTrace(state.localBestLapTrace or {})
+  state.brakingPoints.best = copyBpList(state.localBestBrakePoints or {})
+  state.trackSegments = cloneSegments(state.localBestTrackSegments or {})
+  state.bestCornerFeatures = cloneCornerFeats(state.localBestCornerFeatures or {})
+  state.bestReferenceLapMs = state.localBestReferenceLapMs
+  if state.bestLapTrace and #state.bestLapTrace >= 2 then
+    state.racingBestLine = racingLine.traceToLine(state.bestLapTrace)
+  else
+    state.racingBestLine = {}
+  end
+  state.activeReferenceSource = (#(state.bestLapTrace or {}) >= 2) and "in_game" or nil
+  state.activeReferenceFormat = nil
+  state.activeReferenceLapMs = state.bestReferenceLapMs or state.bestLapMs
+  state.activeReferencePath = nil
+  rebuildBestReference()
+  realtimeCoaching.rebuildSegmentIndex(state.trackSegments or {})
+end
+
+local function applyImportedReference(imported)
+  if type(imported) ~= "table" or type(imported.trace) ~= "table" or #imported.trace < 2 then
+    return false
+  end
+  local trace = copyTrace(imported.trace)
+  local brakesForImport = brakePointsFromTrace(trace)
+  local segments = cornerAnalysis.buildSegments(trace, brakesForImport)
+  if #brakesForImport == 0 then
+    brakesForImport = brakePointsFromSegments(trace, segments)
+  end
+  local feats = cornerAnalysis.cornerFeaturesForLap(trace, segments)
+  state.bestLapTrace = trace
+  state.bestReferenceLapMs = tonumber(imported.lapMs)
+  state.brakingPoints.best = brakesForImport
+  state.trackSegments = segments
+  state.bestCornerFeatures = feats
+  state.racingBestLine = racingLine.traceToLine(trace)
+  state.activeReferenceSource = "imported"
+  state.activeReferenceFormat = imported.importFormat or "motec_csv"
+  state.activeReferenceLapMs = tonumber(imported.lapMs)
+  state.activeReferencePath = imported.path
+  rebuildBestReference()
+  realtimeCoaching.rebuildSegmentIndex(segments)
+  if ac and type(ac.log) == "function" then
+    ac.log(string.format(
+      "[COPILOT][REFERENCE] activated imported %s reference lap %.0f ms (%d trace, %d brakes, %d segs)",
+      tostring(state.activeReferenceFormat),
+      tonumber(imported.lapMs) or 0,
+      #trace,
+      #brakesForImport,
+      #segments
+    ))
+  end
+  return true
+end
+
+refreshActiveReference = function()
+  if not state then
+    return
+  end
+  restoreLocalReferenceState()
+  local imported = persistence.chooseImportedReference(
+    state.bestLapMs,
+    persistence.bestImportedReference(car, sim),
+    config.useImportedReference == true
+  )
+  if imported then
+    applyImportedReference(imported)
+  elseif ac and type(ac.log) == "function" then
+    ac.log("[COPILOT][REFERENCE] active reference: " .. tostring(state.activeReferenceSource or "none"))
+  end
+end
+
 local function applyLoaded(data)
   if not data or type(data) ~= "table" then
     return
@@ -1005,21 +1219,26 @@ local function applyLoaded(data)
   if data.bestCornerFeatures and type(data.bestCornerFeatures) == "table" then
     state.bestCornerFeatures = data.bestCornerFeatures
   end
+  state.activeReferenceSource = (#(state.bestLapTrace or {}) >= 2) and "in_game" or nil
+  state.activeReferenceFormat = nil
+  state.activeReferenceLapMs = state.bestReferenceLapMs or state.bestLapMs
+  state.activeReferencePath = nil
 end
 
 local function persistPayload()
   -- Always persist non-empty `bestLapTrace` together with `bestReferenceLapMs` so a new PB time
   -- does not erase a still-valid reference trace when the span guard rejected the new lap's trace.
+  local useLocalSnapshot = state.activeReferenceSource == "imported"
   return {
     bestLapMs = state.bestLapMs,
-    bestBrakePoints = state.brakingPoints.best,
-    bestLapTrace = state.bestLapTrace,
-    bestReferenceLapMs = state.bestReferenceLapMs,
-    trackSegments = state.trackSegments,
+    bestBrakePoints = useLocalSnapshot and state.localBestBrakePoints or state.brakingPoints.best,
+    bestLapTrace = useLocalSnapshot and state.localBestLapTrace or state.bestLapTrace,
+    bestReferenceLapMs = useLocalSnapshot and state.localBestReferenceLapMs or state.bestReferenceLapMs,
+    trackSegments = useLocalSnapshot and state.localBestTrackSegments or state.trackSegments,
     lapFeatureHistory = state.lapFeatureHistory,
     setupHash = state.setupHash,
     setupSnapshot = state.lastSetupSnap,
-    bestCornerFeatures = state.bestCornerFeatures,
+    bestCornerFeatures = useLocalSnapshot and state.localBestCornerFeatures or state.bestCornerFeatures,
   }
 end
 
@@ -1062,7 +1281,16 @@ local function resetRuntimeAfterLeavingTrack()
   state.lastResetCounter = nil  -- re-prime teleport detection on next track entry
   state.deltaRefStale = true  -- re-entry: no boundary-aligned clock yet, delta silent until first lap
   state.bestLapTrace = {}
+  state.localBestLapTrace = {}
+  state.localBestBrakePoints = {}
+  state.localBestTrackSegments = {}
+  state.localBestCornerFeatures = {}
+  state.localBestReferenceLapMs = nil
   state.bestReferenceLapMs = nil
+  state.activeReferenceSource = nil
+  state.activeReferenceFormat = nil
+  state.activeReferenceLapMs = nil
+  state.activeReferencePath = nil
   state.bestSortedTrace = nil
   state.bestSectorMs = { 0, 0, 0 }
   state.sectorIndex = 1
@@ -1174,6 +1402,8 @@ local function tryLoadDisk()
     return
   end
   applyLoaded(persistence.load(car, sim))
+  cacheLocalReferenceState()
+  refreshActiveReference()
   state.initialized = true
 end
 
@@ -1418,6 +1648,31 @@ function script.windowMain(_dt)
   })
 end
 
+local function formatReferenceLapMs(ms)
+  local n = tonumber(ms)
+  if not n or n <= 0 then
+    return "n/a"
+  end
+  local total = math.floor(n + 0.5)
+  local minutes = math.floor(total / 60000)
+  local seconds = math.floor((total % 60000) / 1000)
+  local millis = total % 1000
+  return string.format("%d:%02d.%03d", minutes, seconds, millis)
+end
+
+local function referenceStatusLine()
+  if state.activeReferenceSource == "imported" then
+    return "Active reference: imported "
+      .. tostring(state.activeReferenceFormat or "motec_csv")
+      .. " "
+      .. formatReferenceLapMs(state.activeReferenceLapMs)
+  end
+  if state.activeReferenceSource == "in_game" then
+    return "Active reference: your PB " .. formatReferenceLapMs(state.activeReferenceLapMs)
+  end
+  return "Active reference: none"
+end
+
 function script.windowSettings(_dt)
   sim = ac.getSim()
   if not sim or sim.isInMainMenu then
@@ -1450,9 +1705,13 @@ function script.windowSettings(_dt)
     -- Issue #77 Part C: lap archive stats for Settings UI.
     lapArchiveStats = lapArchive.stats,
     lapArchiveClampCapMB = lapArchive.clampArchiveCapMB,
+    referenceStatus = referenceStatusLine(),
+    referenceLapsDir = persistence.lapArchiveDir(),
     setApproachMeters = setApproachMetersAndPersist,
     setLapArchiveEnabled = setLapArchiveEnabledAndPersist,
     setLapArchiveMaxMB = setLapArchiveMaxMBAndPersist,
+    setUseImportedReference = setUseImportedReferenceAndPersist,
+    openReferenceLapsFolder = persistence.openLapArchiveDir,
   })
   if config.enableRenderDiagnostics then
     renderDiag.drawUI()
@@ -2026,7 +2285,11 @@ function script.update(dt)
     local isPbThisLap = lastMs > 0 and (state.bestLapMs == nil or lastMs <= state.bestLapMs)
 
     local prevBestBp = copyBpList(state.brakingPoints.best)
+    local localBestChanged = false
     if lastMs > 0 and (state.bestLapMs == nil or lastMs <= state.bestLapMs) then
+      if state.activeReferenceSource == "imported" then
+        restoreLocalReferenceState()
+      end
       state.bestLapMs = lastMs
       state.brakingPoints.best = copyBpList(state.brakingPoints.session)
       if traceAnalyticsOk and #feats > 0 then
@@ -2044,6 +2307,11 @@ function script.update(dt)
       end
       -- Guards failed: keep prior `bestLapTrace` / `bestReferenceLapMs`; persist still saves both with `bestReferenceLapMs`.
       rebuildBestReference()
+      localBestChanged = true
+    end
+    if localBestChanged then
+      cacheLocalReferenceState()
+      refreshActiveReference()
     end
     state.brakingPoints.last = copyBpList(state.brakingPoints.session)
     state.brakingPoints.session = {}

--- a/src/ac_copilot_trainer/modules/hud_settings.lua
+++ b/src/ac_copilot_trainer/modules/hud_settings.lua
@@ -20,6 +20,8 @@ local M = {}
 ---@field focusPracticeUi table|nil
 ---@field setLapArchiveEnabled fun(boolean)|nil
 ---@field setLapArchiveMaxMB fun(number)|nil
+---@field setUseImportedReference fun(boolean)|nil
+---@field openReferenceLapsFolder fun():boolean,string|nil
 
 ---@param mode "strictTrue"|"notFalse"
 --- `strictTrue`: matches `if not config.k` / `if config.k then` (only explicit `true` is on).
@@ -264,6 +266,40 @@ function M.draw(vm)
       if ok and count and mb then
         ui.text(string.format("Archived: %d laps, %.1f MB", count, mb))
       end
+    end
+  end
+
+  ui.separator()
+  ui.textColored("Reference lap", rgbm(0.78, 0.8, 0.88, 1))
+  do
+    ui.text(tostring(vm.referenceStatus or "Active reference: none"))
+    local cur = cfg.useImportedReference == true
+    if type(ui.checkbox) ~= "function" then
+      ui.text("Prefer imported reference over local PB: " .. (cur and "on" or "off"))
+    else
+      pcall(function()
+        if ui.checkbox("Prefer imported reference over local PB", cur) then
+          local enabled = not cur
+          if vm.setUseImportedReference and type(vm.setUseImportedReference) == "function" then
+            pcall(vm.setUseImportedReference, enabled)
+          else
+            cfg.useImportedReference = enabled
+          end
+        end
+      end)
+    end
+    local dir = tostring(vm.referenceLapsDir or "")
+    if ui.button ~= nil then
+      pcall(function()
+        if ui.button("Open reference laps folder") then
+          if vm.openReferenceLapsFolder and type(vm.openReferenceLapsFolder) == "function" then
+            pcall(vm.openReferenceLapsFolder)
+          end
+        end
+      end)
+    end
+    if dir ~= "" then
+      textWrappedMaybe(dir)
     end
   end
 

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -59,7 +59,7 @@ local TRACE_FIELDS = {
 }
 
 local function lapArchiveDir()
-  return persistence.dataDir() .. "/journal/laps"
+  return persistence.lapArchiveDir()
 end
 
 --- Settings UI calls `stats()` every frame; cache full-directory scan for a short TTL (Gemini #78).

--- a/src/ac_copilot_trainer/modules/persistence.lua
+++ b/src/ac_copilot_trainer/modules/persistence.lua
@@ -83,12 +83,16 @@ function M.dataDir()
   return base .. "/" .. APP_SUBDIR
 end
 
+function M.lapArchiveDir()
+  return M.dataDir() .. "/journal/laps"
+end
+
 function M.dataPath(car, sim)
   return M.dataDir() .. "/" .. M.sessionKey(car, sim) .. ".json"
 end
 
 local function jsonEncode(t)
-  if JSON and type(JSON.stringify) == "function" then
+  if JSON and JSON.stringify ~= nil then
     local ok, out = pcall(JSON.stringify, t, true)
     if ok and type(out) == "string" then
       return out
@@ -99,7 +103,7 @@ end
 
 --- One-line JSON for JSONL append (no pretty-print newlines).
 local function jsonEncodeCompact(t)
-  if JSON and type(JSON.stringify) == "function" then
+  if JSON and JSON.stringify ~= nil then
     local ok, out = pcall(JSON.stringify, t, false)
     if ok and type(out) == "string" then
       return out
@@ -116,7 +120,7 @@ local function jsonDecode(s)
   if not s or s == "" then
     return nil
   end
-  if JSON and type(JSON.parse) == "function" then
+  if JSON and JSON.parse ~= nil then
     local ok, out = pcall(JSON.parse, s)
     if ok and type(out) == "table" then
       return out
@@ -242,6 +246,37 @@ function M.ensureParentDirForFile(path)
   ensureDir(path)
 end
 
+--- Open the shared lap archive folder in Windows Explorer when CSP exposes a process launcher.
+---@return boolean ok, string message
+function M.openLapArchiveDir()
+  local dir = M.lapArchiveDir()
+  M.ensureParentDirForFile(dir .. "/_dummy")
+  if type(os) == "table" and type(os.runConsoleProcess) == "function" then
+    local ok, accepted, err = pcall(function()
+      return os.runConsoleProcess({
+        filename = "explorer.exe",
+        arguments = { dir },
+        workingDirectory = dir,
+        timeout = 0,
+        terminateWithScript = false,
+        inheritEnvironment = true,
+      }, function() end)
+    end)
+    if ok and accepted ~= false and accepted ~= nil then
+      return true, dir
+    end
+    return false, tostring(err or accepted or "runConsoleProcess returned nil")
+  end
+  if package and package.config and package.config:sub(1, 1) == "\\" and pathSafeForShell(dir) then
+    local winDir = dir:gsub("/", "\\")
+    local ok = pcall(os.execute, 'start "" "' .. winDir .. '"')
+    if ok then
+      return true, dir
+    end
+  end
+  return false, "folder opener unavailable"
+end
+
 --- Serialize a table to JSON when CSP `JSON.stringify` is available.
 ---@param t table
 ---@return string|nil
@@ -261,6 +296,158 @@ end
 ---@return table|nil
 function M.decodeJson(s)
   return jsonDecode(s)
+end
+
+local function archiveRecordCarTrackMatches(rec, car, sim)
+  if type(rec) ~= "table" then
+    return false
+  end
+  local recCar = rec.car and rec.car.id
+  local recTrack = rec.track and rec.track.id
+  if type(recCar) ~= "string" or recCar == "" or type(recTrack) ~= "string" or recTrack == "" then
+    return false
+  end
+  local carId = M.archiveCarIdFromCar(car) or ch.sanitizeId(ch.safeCarIdRaw(), "unknown")
+  local trackId = M.archiveTrackIdFromSim(sim) or ch.sanitizeId(ch.safeTrackIdRaw(), "unknown")
+  if recCar ~= carId or recTrack ~= trackId then
+    return false
+  end
+  local recLayout = rec.track and rec.track.layout
+  if type(recLayout) == "string" and recLayout ~= "" then
+    local curLayout = ch.safeTrackLayoutRaw()
+    if type(curLayout) == "string" and curLayout ~= "" and recLayout ~= ch.sanitizeId(curLayout, "") then
+      return false
+    end
+  end
+  return true
+end
+
+local function archiveTraceToObjects(rec)
+  if type(rec) ~= "table" or type(rec.trace) ~= "table" then
+    return {}
+  end
+  local fields = rec.trace.fields
+  local samples = rec.trace.samples
+  if type(fields) ~= "table" or type(samples) ~= "table" then
+    return {}
+  end
+  local idx = {}
+  for i = 1, #fields do
+    if type(fields[i]) == "string" then
+      idx[fields[i]] = i
+    end
+  end
+  if not idx.spline or not idx.speed or not idx.eMs then
+    return {}
+  end
+  local out = {}
+  for i = 1, #samples do
+    local row = samples[i]
+    if type(row) == "table" then
+      local spline = tonumber(row[idx.spline])
+      local speed = tonumber(row[idx.speed])
+      local eMs = tonumber(row[idx.eMs])
+      if spline ~= nil and speed ~= nil and eMs ~= nil then
+        out[#out + 1] = {
+          spline = spline,
+          speed = speed,
+          eMs = eMs,
+          throttle = tonumber(row[idx.throttle]) or 0,
+          brake = tonumber(row[idx.brake]) or 0,
+          steer = tonumber(row[idx.steer]) or 0,
+          gear = tonumber(row[idx.gear]) or 0,
+          px = tonumber(row[idx.px]) or 0,
+          py = tonumber(row[idx.py]) or 0,
+          pz = tonumber(row[idx.pz]) or 0,
+        }
+      end
+    end
+  end
+  table.sort(out, function(a, b)
+    return (a.spline or 0) < (b.spline or 0)
+  end)
+  return out
+end
+
+M.archiveTraceToObjects = archiveTraceToObjects
+
+local function readLapRecord(path)
+  local f = io.open(path, "r")
+  if not f then
+    return nil
+  end
+  local raw = f:read("*a")
+  f:close()
+  return jsonDecode(raw)
+end
+
+--- Find the fastest valid imported MoTeC reference lap for the current car/track.
+---@param car ac.StateCar|nil
+---@param sim ac.StateSim|nil
+---@return table|nil reference
+function M.bestImportedReference(car, sim)
+  local dir = M.lapArchiveDir()
+  local best = nil
+  pcall(function()
+    if not (io and type(io.scanDir) == "function") then
+      return
+    end
+    local files = io.scanDir(dir, "lap_*.json")
+    if type(files) ~= "table" then
+      return
+    end
+    for i = 1, #files do
+      local name = files[i]
+      if type(name) == "string" then
+        local path = dir .. "/" .. name
+        local rec = readLapRecord(path)
+        local lap = rec and rec.lap
+        local lapMs = lap and tonumber(lap.lap_ms)
+        if rec
+            and rec.schema_version == 1
+            and rec.source == "imported"
+            and rec.import_format == "motec_csv"
+            and type(lap) == "table"
+            and lap.is_valid ~= false
+            and lapMs ~= nil
+            and lapMs > 0
+            and archiveRecordCarTrackMatches(rec, car, sim) then
+          local trace = archiveTraceToObjects(rec)
+          if #trace >= 2 and (best == nil or lapMs < best.lapMs) then
+            best = {
+              source = "imported",
+              importFormat = rec.import_format,
+              lapMs = lapMs,
+              trace = trace,
+              path = path,
+              record = rec,
+            }
+          end
+        end
+      end
+    end
+  end)
+  return best
+end
+
+--- Apply the user-facing import preference without mutating the user's local PB.
+---@param localBestMs number|nil
+---@param importedRef table|nil
+---@param enabled boolean
+---@return table|nil
+function M.chooseImportedReference(localBestMs, importedRef, enabled)
+  if enabled ~= true or type(importedRef) ~= "table" then
+    return nil
+  end
+  local importedMs = tonumber(importedRef.lapMs)
+  if importedMs == nil or importedMs <= 0 then
+    return nil
+  end
+  local localMs = tonumber(localBestMs)
+  if localMs ~= nil and localMs > 0 and importedMs >= localMs then
+    return nil
+  end
+  return importedRef
 end
 
 ---@return table|nil

--- a/tests/test_import_motec.py
+++ b/tests/test_import_motec.py
@@ -1,0 +1,216 @@
+"""MoTeC CSV import tests for issue #79."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from tools.import_motec import (
+    ImportOptions,
+    MotecImportError,
+    default_output_dir,
+    import_file,
+    main,
+    parse_motec_csv,
+)
+
+
+def _write_csv(path: Path, rows: list[list[object]]) -> None:
+    path.write_text(
+        "\n".join(",".join(str(cell) for cell in row) for row in rows), encoding="utf-8"
+    )
+
+
+def test_import_motec_writes_schema_v1_reference_lap(tmp_path: Path) -> None:
+    csv_path = tmp_path / "motec.csv"
+    _write_csv(
+        csv_path,
+        [
+            ["Lap", "Time", "Distance", "Speed", "Throttle", "Brake", "Steering", "Gear"],
+            ["", "s", "m", "km/h", "%", "%", "deg", ""],
+            [1, 0.0, 0, 100, 0, 0, 0, 2],
+            [1, 2.5, 250, 140, 50, 0, 45, 3],
+            [1, 5.0, 500, 120, 100, 20, 90, 4],
+            [1, 7.5, 750, 130, 80, 0, 45, 4],
+            [1, 10.0, 1000, 150, 100, 0, 0, 5],
+        ],
+    )
+
+    results = import_file(
+        csv_path,
+        ImportOptions(
+            car="ks_porsche_911_gt3_rs",
+            track="ks_magione",
+            output_dir=tmp_path / "laps",
+            track_length_m=1000,
+        ),
+    )
+
+    assert len(results) == 1
+    record = json.loads(results[0].path.read_text(encoding="utf-8"))
+    assert record["schema_version"] == 1
+    assert record["source"] == "imported"
+    assert record["import_format"] == "motec_csv"
+    assert record["lap"]["is_pb"] is False
+    assert record["lap"]["is_valid"] is True
+    assert record["car"]["id"] == "ks_porsche_911_gt3_rs"
+    assert record["track"]["id"] == "ks_magione"
+    assert record["trace"]["fields"] == [
+        "spline",
+        "speed",
+        "eMs",
+        "throttle",
+        "brake",
+        "steer",
+        "gear",
+        "px",
+        "py",
+        "pz",
+    ]
+    assert record["trace"]["samples_count"] == 2000
+    assert len(record["trace"]["samples"]) == 2000
+    mid = record["trace"]["samples"][1000]
+    assert mid[0] == pytest.approx(0.5, abs=1e-9)
+    assert mid[3] == pytest.approx(1.0)
+    assert mid[4] == pytest.approx(0.2)
+    assert mid[5] == pytest.approx(0.2)  # 90 deg / default 450 deg steering lock
+    assert record["lap"]["lap_ms"] == pytest.approx(9995, abs=5)
+
+
+def test_import_motec_splits_multi_lap_csv(tmp_path: Path) -> None:
+    csv_path = tmp_path / "multi.csv"
+    _write_csv(
+        csv_path,
+        [
+            ["Lap", "Time", "distance_m", "speed_kmh", "tps", "bps", "steering_angle", "gear"],
+            [1, 0, 0, 80, 0.0, 0.0, 0.0, 2],
+            [1, 5, 500, 120, 1.0, 0.0, 0.2, 3],
+            [2, 0, 0, 90, 0.0, 0.0, 0.0, 2],
+            [2, 4, 500, 130, 1.0, 0.0, 0.2, 3],
+        ],
+    )
+
+    results = import_file(
+        csv_path,
+        ImportOptions(car="car", track="track", output_dir=tmp_path / "laps", track_length_m=500),
+    )
+
+    assert [r.lap_number for r in results] == [1, 2]
+    assert len(list((tmp_path / "laps").glob("lap_imported_*_motec_*.json"))) == 2
+
+
+def test_import_motec_respects_radian_steering_units(tmp_path: Path) -> None:
+    csv_path = tmp_path / "rad.csv"
+    _write_csv(
+        csv_path,
+        [
+            ["Time", "Distance", "Speed", "Throttle", "Brake", "Steering", "Gear"],
+            ["s", "m", "km/h", "", "", "rad", ""],
+            [0, 0, 100, 0, 0, 0, 2],
+            [1, 100, 100, 1, 0, math.pi / 2, 3],
+        ],
+    )
+
+    results = import_file(
+        csv_path,
+        ImportOptions(car="car", track="track", output_dir=tmp_path / "laps", track_length_m=100),
+    )
+    record = json.loads(results[0].path.read_text(encoding="utf-8"))
+
+    assert record["trace"]["samples"][-1][5] == pytest.approx(0.2, abs=0.01)
+
+
+def test_import_motec_reports_missing_required_columns(tmp_path: Path) -> None:
+    csv_path = tmp_path / "bad.csv"
+    _write_csv(csv_path, [["Time", "Distance", "Speed"], [0, 0, 100], [1, 100, 120]])
+
+    with pytest.raises(MotecImportError, match="could not find a header"):
+        parse_motec_csv(csv_path)
+
+
+def test_import_motec_integrates_elapsed_without_time_column(tmp_path: Path) -> None:
+    csv_path = tmp_path / "integrated.csv"
+    _write_csv(
+        csv_path,
+        [
+            ["Spline", "Speed", "Throttle", "Brake", "Steering", "Gear"],
+            ["", "mph", "%", "%", "", ""],
+            [0.0, 60, 0, 0, 0, "N"],
+            [0.5, 60, 50, 10, 0.5, 3],
+            [0.5, 70, 70, 0, 0.2, 4],
+            [1.0, 60, 100, 0, 0, "R"],
+        ],
+    )
+
+    results = import_file(
+        csv_path,
+        ImportOptions(
+            car="car",
+            track="track",
+            output_dir=tmp_path / "laps",
+            track_length_m=1000,
+        ),
+    )
+    record = json.loads(results[0].path.read_text(encoding="utf-8"))
+    samples = record["trace"]["samples"]
+
+    assert record["lap"]["lap_ms"] > 30_000
+    assert samples[1000][1] == pytest.approx(70 * 1.609344)
+    assert samples[1000][2] > samples[999][2]
+    assert samples[1000][3] == pytest.approx(0.7)
+    assert samples[1000][4] == pytest.approx(0.0)
+    assert samples[-1][6] == -1
+
+
+def test_import_motec_main_uses_csp_state_default_output_dir(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    csv_path = tmp_path / "cli.csv"
+    _write_csv(
+        csv_path,
+        [
+            ["Time", "Distance", "Speed", "Throttle", "Brake", "Steering", "Gear"],
+            [0, 0, 100, 0, 0, 0, 2],
+            [1, 100, 100, 1, 0, 0, 3],
+        ],
+    )
+
+    rc = main(
+        [
+            str(csv_path),
+            "--car",
+            "car",
+            "--track",
+            "track",
+            "--csp-state-dir",
+            str(tmp_path / "state"),
+            "--samples",
+            "8",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "lap_ms=875" in out
+    assert (tmp_path / "state" / "ac_copilot_trainer" / "journal" / "laps").exists()
+
+
+def test_default_output_dir_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    opts = ImportOptions(car="car", track="track")
+
+    monkeypatch.setenv("AC_COPILOT_LAP_ARCHIVE_DIR", str(tmp_path / "env-laps"))
+    assert default_output_dir(opts) == tmp_path / "env-laps"
+
+    monkeypatch.delenv("AC_COPILOT_LAP_ARCHIVE_DIR")
+    monkeypatch.setenv("AC_COPILOT_CSP_STATE_DIR", str(tmp_path / "state-env"))
+    assert (
+        default_output_dir(opts)
+        == tmp_path / "state-env" / "ac_copilot_trainer" / "journal" / "laps"
+    )
+
+    monkeypatch.delenv("AC_COPILOT_CSP_STATE_DIR")
+    monkeypatch.chdir(tmp_path)
+    assert default_output_dir(opts) == tmp_path / "journal" / "laps"

--- a/tests/test_reference_activation.py
+++ b/tests/test_reference_activation.py
@@ -1,0 +1,149 @@
+"""Imported reference-lap activation tests for issue #79."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+REPO = Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
+
+
+def _to_lua(lua: Any, value: Any) -> Any:
+    if isinstance(value, dict):
+        tbl = lua.table()
+        for k, v in value.items():
+            tbl[k] = _to_lua(lua, v)
+        return tbl
+    if isinstance(value, list):
+        tbl = lua.table()
+        for i, v in enumerate(value, start=1):
+            tbl[i] = _to_lua(lua, v)
+        return tbl
+    return value
+
+
+def _runtime(tmp_path: Path, files: list[str]):
+    rt = lupa.LuaRuntime(unpack_returned_tuples=False)
+    modules_path = str(MODULES_DIR).replace("\\", "/")
+    root = str(tmp_path).replace("\\", "/")
+    quoted_files = ", ".join(repr(name) for name in files)
+    rt.execute(
+        f"""
+        ac = {{
+          FolderID = {{ ScriptConfig = 2 }},
+          getFolder = function(_) return {root!r} end,
+          getTrackLayout = function() return "" end,
+        }}
+        io.scanDir = function(_, _) return {{ {quoted_files} }} end
+        package.path = package.path .. ";{modules_path}/?.lua"
+        """
+    )
+
+    def json_parse(raw: str) -> Any:
+        return _to_lua(rt, json.loads(str(raw)))
+
+    rt.globals()["JSON"] = rt.table_from({"parse": json_parse})
+    return rt
+
+
+def _record(
+    lap_ms: int, *, car: str = "car_a", track: str = "track_a", valid: bool = True
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "source": "imported",
+        "import_format": "motec_csv",
+        "car": {"id": car},
+        "track": {"id": track, "layout": None},
+        "lap": {"lap_ms": lap_ms, "is_valid": valid},
+        "trace": {
+            "fields": [
+                "spline",
+                "speed",
+                "eMs",
+                "throttle",
+                "brake",
+                "steer",
+                "gear",
+                "px",
+                "py",
+                "pz",
+            ],
+            "samples": [
+                [0.0, 100, 0, 1, 0, 0, 2, 0, 0, 0],
+                [0.5, 120, lap_ms / 2, 1, 0.5, 0.1, 3, 0, 0, 0],
+                [0.99, 140, lap_ms, 1, 0, 0, 4, 0, 0, 0],
+            ],
+        },
+    }
+
+
+def test_best_imported_reference_scans_fastest_matching_car_track(tmp_path: Path) -> None:
+    laps = tmp_path / "ac_copilot_trainer" / "journal" / "laps"
+    laps.mkdir(parents=True)
+    (laps / "lap_imported_slow.json").write_text(json.dumps(_record(100_000)), encoding="utf-8")
+    (laps / "lap_imported_fast.json").write_text(json.dumps(_record(90_000)), encoding="utf-8")
+    (laps / "lap_imported_wrong_track.json").write_text(
+        json.dumps(_record(80_000, track="other_track")),
+        encoding="utf-8",
+    )
+    (laps / "lap_imported_invalid.json").write_text(
+        json.dumps(_record(70_000, valid=False)),
+        encoding="utf-8",
+    )
+
+    rt = _runtime(
+        tmp_path,
+        [
+            "lap_imported_slow.json",
+            "lap_imported_fast.json",
+            "lap_imported_wrong_track.json",
+            "lap_imported_invalid.json",
+        ],
+    )
+    ref = rt.execute(
+        """
+        local p = require("persistence")
+        return p.bestImportedReference({ id = "car_a" }, { trackName = "track_a" })
+        """
+    )
+
+    assert ref["lapMs"] == 90_000
+    assert len(ref["trace"]) == 3
+    assert ref["source"] == "imported"
+
+
+def test_choose_imported_reference_requires_flag_and_faster_lap(tmp_path: Path) -> None:
+    rt = _runtime(tmp_path, [])
+    result = rt.execute(
+        """
+        local p = require("persistence")
+        local imported = { lapMs = 90000 }
+        return {
+          disabled = p.chooseImportedReference(100000, imported, false) ~= nil,
+          faster = p.chooseImportedReference(100000, imported, true).lapMs,
+          noLocal = p.chooseImportedReference(nil, imported, true).lapMs,
+          slower = p.chooseImportedReference(80000, imported, true) ~= nil,
+        }
+        """
+    )
+
+    assert result["disabled"] is False
+    assert result["faster"] == 90_000
+    assert result["noLocal"] == 90_000
+    assert result["slower"] is False
+
+
+def test_settings_ui_exposes_reference_lap_controls() -> None:
+    src = (MODULES_DIR / "hud_settings.lua").read_text(encoding="utf-8")
+
+    assert "Reference lap" in src
+    assert "useImportedReference" in src
+    assert "Prefer imported reference over local PB" in src
+    assert "Open reference laps folder" in src

--- a/tools/import_motec/__init__.py
+++ b/tools/import_motec/__init__.py
@@ -1,0 +1,611 @@
+"""MoTeC CSV importer for AC Copilot Trainer lap archive records.
+
+The importer is intentionally stdlib-only: it converts a MoTeC-style CSV into
+the same schema-v1 JSON records written by ``modules/lap_archive.lua`` so the
+Lua app has one lap/reference format to consume.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+TRACE_FIELDS = ["spline", "speed", "eMs", "throttle", "brake", "steer", "gear", "px", "py", "pz"]
+DEFAULT_SAMPLE_COUNT = 2000
+
+CHANNEL_ALIASES: dict[str, tuple[str, ...]] = {
+    "time": (
+        "time",
+        "times",
+        "timestamp",
+        "elapsedtime",
+        "laptime",
+        "timeelapsed",
+    ),
+    "distance": (
+        "distance",
+        "dist",
+        "distancem",
+        "distance_m",
+        "lapdistance",
+        "lapdistancem",
+        "s",
+    ),
+    "spline": (
+        "spline",
+        "splineposition",
+        "normalizeddistance",
+        "lapdistancepct",
+        "lapdistancepercent",
+    ),
+    "speed": ("speed", "speedkmh", "speed_kmh", "vehiclespeed", "gpsspeed", "v"),
+    "throttle": (
+        "throttle",
+        "throttlepct",
+        "throttlepercent",
+        "throttleposition",
+        "throttlepos",
+        "tps",
+    ),
+    "brake": ("brake", "brakepct", "brakepercent", "brakepressure", "brakepedal", "bps"),
+    "steer": (
+        "steer",
+        "steering",
+        "steeringangle",
+        "steering_angle",
+        "steerangle",
+        "steerangledeg",
+        "sa",
+    ),
+    "gear": ("gear", "gearnumber", "selectedgear"),
+    "lap": ("lap", "lapnumber", "lapno", "lapnum"),
+    "px": ("px", "posx", "positionx", "worldx", "x"),
+    "py": ("py", "posy", "positiony", "worldy", "y"),
+    "pz": ("pz", "posz", "positionz", "worldz", "z"),
+}
+
+REQUIRED_CHANNELS = ("speed", "throttle", "brake", "steer", "gear")
+
+
+class MotecImportError(ValueError):
+    """Raised for user-correctable CSV/import problems."""
+
+
+@dataclass(frozen=True)
+class ImportOptions:
+    car: str
+    track: str
+    layout: str | None = None
+    output_dir: Path | None = None
+    csp_state_dir: Path | None = None
+    track_length_m: float | None = None
+    sample_count: int = DEFAULT_SAMPLE_COUNT
+    steering_lock_deg: float = 450.0
+    speed_unit: str = "auto"
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    path: Path
+    lap_ms: int
+    samples_count: int
+    lap_number: int
+
+
+@dataclass(frozen=True)
+class ParsedCsv:
+    header: list[str]
+    units: list[str]
+    mapping: dict[str, int]
+    rows: list[list[str]]
+
+
+def _norm_header(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.strip().lower())
+
+
+def _parse_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    if s.endswith("%"):
+        s = s[:-1].strip()
+    if "," in s and "." not in s and s.count(",") == 1:
+        s = s.replace(",", ".")
+    try:
+        out = float(s)
+    except ValueError:
+        return None
+    if not math.isfinite(out):
+        return None
+    return out
+
+
+def _parse_time_seconds(value: str | None) -> float | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    direct = _parse_float(s)
+    if direct is not None:
+        return direct
+    parts = s.split(":")
+    if len(parts) not in (2, 3):
+        return None
+    try:
+        nums = [float(p.replace(",", ".")) for p in parts]
+    except ValueError:
+        return None
+    if len(nums) == 2:
+        minutes, seconds = nums
+        return minutes * 60.0 + seconds
+    hours, minutes, seconds = nums
+    return hours * 3600.0 + minutes * 60.0 + seconds
+
+
+def _parse_gear(value: str | None) -> int:
+    if value is None:
+        return 0
+    s = str(value).strip().upper()
+    if s == "R":
+        return -1
+    if s == "N":
+        return 0
+    n = _parse_float(s)
+    if n is None:
+        return 0
+    return int(round(n))
+
+
+def _channel_mapping(header: list[str]) -> dict[str, int]:
+    normalized = {_norm_header(name): idx for idx, name in enumerate(header)}
+    mapping: dict[str, int] = {}
+    for channel, aliases in CHANNEL_ALIASES.items():
+        for alias in aliases:
+            key = _norm_header(alias)
+            if key in normalized:
+                mapping[channel] = normalized[key]
+                break
+    return mapping
+
+
+def _mapping_ok(mapping: dict[str, int]) -> bool:
+    has_position = "distance" in mapping or "spline" in mapping
+    return has_position and all(ch in mapping for ch in REQUIRED_CHANNELS)
+
+
+def _looks_like_units(row: list[str], mapping: dict[str, int]) -> bool:
+    if not row:
+        return False
+    unitish = 0
+    nonnumeric = 0
+    for idx in set(mapping.values()):
+        if idx >= len(row):
+            continue
+        raw = row[idx].strip().lower()
+        if not raw:
+            continue
+        if _parse_float(raw) is None:
+            nonnumeric += 1
+        if any(token in raw for token in ("%", "deg", "rad", "km/h", "kph", "m/s", "mph", "s")):
+            unitish += 1
+    return nonnumeric >= 2 and unitish >= 1
+
+
+def parse_motec_csv(path: Path) -> ParsedCsv:
+    rows: list[list[str]]
+    try:
+        with path.open("r", encoding="utf-8-sig", newline="") as fh:
+            rows = [row for row in csv.reader(fh) if any(cell.strip() for cell in row)]
+    except UnicodeDecodeError:
+        with path.open("r", encoding="cp1252", newline="") as fh:
+            rows = [row for row in csv.reader(fh) if any(cell.strip() for cell in row)]
+
+    for i, row in enumerate(rows):
+        mapping = _channel_mapping(row)
+        if _mapping_ok(mapping):
+            units: list[str] = []
+            data_start = i + 1
+            if data_start < len(rows) and _looks_like_units(rows[data_start], mapping):
+                units = rows[data_start]
+                data_start += 1
+            return ParsedCsv(header=row, units=units, mapping=mapping, rows=rows[data_start:])
+
+    required = "distance/spline plus speed, throttle, brake, steer, and gear columns"
+    raise MotecImportError(f"could not find a header row with {required}")
+
+
+def _cell(row: list[str], idx: int | None) -> str | None:
+    if idx is None or idx >= len(row):
+        return None
+    return row[idx]
+
+
+def _unit(parsed: ParsedCsv, channel: str) -> str:
+    idx = parsed.mapping.get(channel)
+    if idx is None or idx >= len(parsed.units):
+        name = parsed.header[idx] if idx is not None and idx < len(parsed.header) else ""
+        return name.lower()
+    return f"{parsed.header[idx]} {parsed.units[idx]}".lower()
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def _normalize_pedal(value: float, max_abs: float, unit: str) -> float:
+    if "%" in unit or max_abs > 1.5:
+        value = value / 100.0
+    return _clamp(value, 0.0, 1.0)
+
+
+def _normalize_speed(value: float, unit: str, override: str) -> float:
+    mode = override.lower()
+    if mode == "mph" or (mode == "auto" and "mph" in unit):
+        return value * 1.609344
+    if mode in {"mps", "m/s"} or (mode == "auto" and ("m/s" in unit or "ms-1" in unit)):
+        return value * 3.6
+    return value
+
+
+def _normalize_steer(value: float, max_abs: float, unit: str, steering_lock_deg: float) -> float:
+    if "rad" in unit:
+        value = math.degrees(value)
+    elif max_abs <= 1.2:
+        return _clamp(value, -1.0, 1.0)
+    elif max_abs <= math.tau + 0.25 and "deg" not in unit:
+        value = math.degrees(value)
+    lock = steering_lock_deg if steering_lock_deg > 0 else 450.0
+    return _clamp(value / lock, -1.0, 1.0)
+
+
+def _group_rows(parsed: ParsedCsv) -> list[tuple[int, list[list[str]]]]:
+    lap_idx = parsed.mapping.get("lap")
+    if lap_idx is None:
+        return [(1, parsed.rows)]
+    ordered: list[tuple[int, list[list[str]]]] = []
+    by_key: dict[int, list[list[str]]] = {}
+    for row in parsed.rows:
+        lap_raw = _parse_float(_cell(row, lap_idx))
+        lap_no = int(lap_raw) if lap_raw is not None else 1
+        if lap_no not in by_key:
+            by_key[lap_no] = []
+            ordered.append((lap_no, by_key[lap_no]))
+        by_key[lap_no].append(row)
+    return ordered
+
+
+def _interpolate(points: list[dict[str, float]], target: float, field: str) -> float:
+    if target <= points[0]["spline"]:
+        return points[0][field]
+    if target >= points[-1]["spline"]:
+        return points[-1][field]
+    lo = 0
+    hi = len(points) - 1
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if points[mid]["spline"] <= target:
+            lo = mid
+        else:
+            hi = mid
+    a = points[lo]
+    b = points[hi]
+    span = b["spline"] - a["spline"]
+    if span <= 0:
+        return a[field]
+    frac = (target - a["spline"]) / span
+    return a[field] + (b[field] - a[field]) * frac
+
+
+def _integrated_elapsed_ms(points: list[dict[str, float]], track_length_m: float) -> None:
+    elapsed = 0.0
+    points[0]["eMs"] = 0.0
+    for i in range(1, len(points)):
+        prev = points[i - 1]
+        cur = points[i]
+        ds = max(0.0, cur["spline"] - prev["spline"]) * track_length_m
+        speed_kmh = max(1.0, (prev["speed"] + cur["speed"]) * 0.5)
+        elapsed += (ds / (speed_kmh / 3.6)) * 1000.0
+        cur["eMs"] = elapsed
+
+
+def _resample(points: list[dict[str, float]], sample_count: int) -> list[list[float]]:
+    out: list[list[float]] = []
+    count = max(2, sample_count)
+    for i in range(count):
+        target = i / count
+        row: list[float] = []
+        for field in TRACE_FIELDS:
+            value = _interpolate(points, target, field)
+            if field == "gear":
+                value = int(round(value))
+            row.append(value)
+        out.append(row)
+    return out
+
+
+def _points_for_lap(
+    parsed: ParsedCsv, rows: list[list[str]], opts: ImportOptions
+) -> list[dict[str, float]]:
+    m = parsed.mapping
+    raw: list[dict[str, float]] = []
+    max_throttle = 0.0
+    max_brake = 0.0
+    max_steer = 0.0
+    for row in rows:
+        speed = _parse_float(_cell(row, m.get("speed")))
+        throttle = _parse_float(_cell(row, m.get("throttle")))
+        brake = _parse_float(_cell(row, m.get("brake")))
+        steer = _parse_float(_cell(row, m.get("steer")))
+        gear = _parse_gear(_cell(row, m.get("gear")))
+        pos = _parse_float(_cell(row, m.get("spline")))
+        distance = _parse_float(_cell(row, m.get("distance")))
+        if speed is None or throttle is None or brake is None or steer is None:
+            continue
+        if pos is None and distance is None:
+            continue
+        max_throttle = max(max_throttle, abs(throttle))
+        max_brake = max(max_brake, abs(brake))
+        max_steer = max(max_steer, abs(steer))
+        raw.append(
+            {
+                "raw_pos": pos if pos is not None else distance,
+                "raw_distance": distance,
+                "speed": speed,
+                "throttle": throttle,
+                "brake": brake,
+                "steer": steer,
+                "gear": float(gear),
+                "px": _parse_float(_cell(row, m.get("px"))) or 0.0,
+                "py": _parse_float(_cell(row, m.get("py"))) or 0.0,
+                "pz": _parse_float(_cell(row, m.get("pz"))) or 0.0,
+                "time_s": _parse_time_seconds(_cell(row, m.get("time"))),
+            }
+        )
+
+    if len(raw) < 2:
+        raise MotecImportError("lap has fewer than two usable telemetry rows")
+
+    if "spline" in m and "distance" not in m:
+        pos_values = [p["raw_pos"] for p in raw]
+        max_pos = max(pos_values)
+        min_pos = min(pos_values)
+        if max_pos > 1.5 or min_pos < -0.05:
+            span = max_pos - min_pos
+            if span <= 0:
+                raise MotecImportError("spline/distance column has no usable span")
+            for p in raw:
+                p["spline"] = _clamp((p["raw_pos"] - min_pos) / span, 0.0, 1.0)
+            track_length = opts.track_length_m or span
+        else:
+            for p in raw:
+                p["spline"] = _clamp(p["raw_pos"], 0.0, 1.0)
+            track_length = opts.track_length_m or 1.0
+    else:
+        distances = [
+            p["raw_distance"] if p["raw_distance"] is not None else p["raw_pos"] for p in raw
+        ]
+        start = min(distances)
+        span = opts.track_length_m or (max(distances) - start)
+        if span <= 0:
+            raise MotecImportError("distance column has no usable span; pass --track-length")
+        for p, d in zip(raw, distances, strict=True):
+            p["spline"] = _clamp((d - start) / span, 0.0, 1.0)
+        track_length = span
+
+    throttle_unit = _unit(parsed, "throttle")
+    brake_unit = _unit(parsed, "brake")
+    steer_unit = _unit(parsed, "steer")
+    speed_unit = _unit(parsed, "speed")
+    time_values = [p["time_s"] for p in raw if p["time_s"] is not None]
+    time_origin = min(time_values) if time_values else None
+
+    points: list[dict[str, float]] = []
+    for p in raw:
+        e_ms = 0.0
+        if p["time_s"] is not None and time_origin is not None:
+            e_ms = max(0.0, (p["time_s"] - time_origin) * 1000.0)
+        points.append(
+            {
+                "spline": p["spline"],
+                "speed": _normalize_speed(p["speed"], speed_unit, opts.speed_unit),
+                "eMs": e_ms,
+                "throttle": _normalize_pedal(p["throttle"], max_throttle, throttle_unit),
+                "brake": _normalize_pedal(p["brake"], max_brake, brake_unit),
+                "steer": _normalize_steer(
+                    p["steer"], max_steer, steer_unit, opts.steering_lock_deg
+                ),
+                "gear": p["gear"],
+                "px": p["px"],
+                "py": p["py"],
+                "pz": p["pz"],
+            }
+        )
+
+    points.sort(key=lambda item: item["spline"])
+    deduped: list[dict[str, float]] = []
+    for p in points:
+        if deduped and abs(deduped[-1]["spline"] - p["spline"]) < 1e-9:
+            deduped[-1] = p
+        else:
+            deduped.append(p)
+    if len(deduped) < 2:
+        raise MotecImportError("lap has fewer than two unique spline positions")
+    if not time_values:
+        _integrated_elapsed_ms(deduped, track_length)
+    return deduped
+
+
+def _record_for_lap(
+    samples: list[list[float]],
+    opts: ImportOptions,
+    *,
+    lap_ms: int,
+    lap_number: int,
+    session_uuid: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "source": "imported",
+        "import_format": "motec_csv",
+        "lap_uuid": uuid.uuid4().hex[:16],
+        "session_uuid": session_uuid,
+        "exported_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "car": {"id": opts.car, "displayName": None},
+        "track": {"id": opts.track, "layout": opts.layout, "lengthM": opts.track_length_m},
+        "conditions": {
+            "trackGripLevel": None,
+            "ambientTempC": None,
+            "trackTempC": None,
+            "weatherType": None,
+        },
+        "lap": {"lap_n": lap_number, "lap_ms": lap_ms, "is_pb": False, "is_valid": True},
+        "setup": {"hash": "", "path": None, "snapshot": {}},
+        "trace": {
+            "samples_count": len(samples),
+            "fields": TRACE_FIELDS,
+            "samples": samples,
+        },
+        "corners": [],
+        "coaching": {"rules_hints": [], "sidecar_debrief": None, "corner_advice_used": None},
+    }
+
+
+def default_output_dir(opts: ImportOptions) -> Path:
+    env_laps = os.environ.get("AC_COPILOT_LAP_ARCHIVE_DIR")
+    if env_laps:
+        return Path(env_laps)
+    csp_state = opts.csp_state_dir or (
+        Path(os.environ["AC_COPILOT_CSP_STATE_DIR"])
+        if os.environ.get("AC_COPILOT_CSP_STATE_DIR")
+        else None
+    )
+    if csp_state is not None:
+        return csp_state / "ac_copilot_trainer" / "journal" / "laps"
+    if os.name == "nt":
+        docs = Path.home() / "Documents" / "Assetto Corsa"
+        candidate = (
+            docs
+            / "cfg"
+            / "extension"
+            / "state"
+            / "lua"
+            / "app"
+            / "AC_Copilot_Trainer"
+            / "ac_copilot_trainer"
+            / "journal"
+            / "laps"
+        )
+        return candidate
+    return Path.cwd() / "journal" / "laps"
+
+
+def import_file(input_csv: Path, opts: ImportOptions) -> list[ImportResult]:
+    parsed = parse_motec_csv(input_csv)
+    output_dir = opts.output_dir or default_output_dir(opts)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    session_uuid = uuid.uuid4().hex[:12]
+    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    results: list[ImportResult] = []
+
+    for ordinal, (lap_number, rows) in enumerate(_group_rows(parsed), start=1):
+        points = _points_for_lap(parsed, rows, opts)
+        samples = _resample(points, opts.sample_count)
+        lap_ms = int(round(max(row[2] for row in samples)))
+        record = _record_for_lap(
+            samples,
+            opts,
+            lap_ms=lap_ms,
+            lap_number=lap_number if lap_number > 0 else ordinal,
+            session_uuid=session_uuid,
+        )
+        lap_key = f"{lap_number if lap_number > 0 else ordinal:02d}"
+        filename = f"lap_imported_{timestamp}_{session_uuid}_motec_{lap_ms}_{lap_key}.json"
+        path = output_dir / filename
+        path.write_text(
+            json.dumps(record, separators=(",", ":"), allow_nan=False), encoding="utf-8"
+        )
+        results.append(
+            ImportResult(
+                path=path, lap_ms=lap_ms, samples_count=len(samples), lap_number=lap_number
+            )
+        )
+    return results
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Import a MoTeC CSV as AC Copilot lap archive JSON"
+    )
+    parser.add_argument("input_csv", type=Path)
+    parser.add_argument(
+        "--car", required=True, help="Assetto Corsa car id, e.g. ks_porsche_911_gt3_rs"
+    )
+    parser.add_argument("--track", required=True, help="Assetto Corsa track id, e.g. ks_magione")
+    parser.add_argument("--layout", default=None, help="Optional AC track layout id")
+    parser.add_argument(
+        "--output-dir", type=Path, default=None, help="Destination journal/laps directory"
+    )
+    parser.add_argument(
+        "--csp-state-dir",
+        type=Path,
+        default=None,
+        help="CSP ScriptConfig app dir; appends ac_copilot_trainer/journal/laps",
+    )
+    parser.add_argument(
+        "--track-length",
+        dest="track_length_m",
+        type=float,
+        default=None,
+        help="Track length in meters. Defaults to the distance column span.",
+    )
+    parser.add_argument("--samples", dest="sample_count", type=int, default=DEFAULT_SAMPLE_COUNT)
+    parser.add_argument("--steering-lock-deg", type=float, default=450.0)
+    parser.add_argument(
+        "--speed-unit", choices=("auto", "kmh", "mph", "mps", "m/s"), default="auto"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    opts = ImportOptions(
+        car=args.car,
+        track=args.track,
+        layout=args.layout,
+        output_dir=args.output_dir,
+        csp_state_dir=args.csp_state_dir,
+        track_length_m=args.track_length_m,
+        sample_count=args.sample_count,
+        steering_lock_deg=args.steering_lock_deg,
+        speed_unit=args.speed_unit,
+    )
+    try:
+        results = import_file(args.input_csv, opts)
+    except MotecImportError as exc:
+        parser.exit(2, f"import_motec: {exc}\n")
+    for result in results:
+        detail = (
+            f"{result.path} lap={result.lap_number} "
+            f"lap_ms={result.lap_ms} samples={result.samples_count}"
+        )
+        print(detail)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/import_motec/__main__.py
+++ b/tools/import_motec/__main__.py
@@ -1,0 +1,10 @@
+"""CLI entrypoint for ``python -m tools.import_motec``."""
+
+from __future__ import annotations
+
+import sys
+
+from . import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a stdlib-only MoTeC CSV importer that emits schema-v1 imported lap archive JSON
- activate faster imported MoTeC laps as an opt-in reference without overwriting local PB persistence
- add Settings controls/status for imported references plus importer/activation coverage

Closes #79.

## Verification
- `make ci-fast PYTHON=.venv/bin/python`
- artifact CLI smoke: `python3 -m tools.import_motec ... --output-dir .scratch/issue79-import-check/laps` produced a 2000-sample imported schema-v1 lap JSON
