### PR TITLE
feat(harness): carcsw Custom-AI mmap driver + pure-pursuit (EPIC #154 Part E)

### DIFF
--- a/tests/test_ai_line.py
+++ b/tests/test_ai_line.py
@@ -1,0 +1,246 @@
+"""Pure unit tests for the racing-line parser + pure-pursuit controller.
+
+No Assetto Corsa, no mmap, no filesystem track data: the binary parser is exercised against
+a synthetic ``fast_lane.ai`` buffer assembled at the documented version-7 offsets, and the
+controller against synthetic straight / curved lines built in memory. This mirrors the #175
+shared-memory oracle's split — the pure halves are CI-verifiable on any OS.
+
+The controller's coordinate convention (asserted here so it cannot silently flip):
+``(x, y, z)`` with ``y`` vertical; pursuit runs in the ``(x, z)`` ground plane; ``steer > 0``
+aims the car to its right.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from tools.ac_harness.ai_line import (
+    ControlOutput,
+    PurePursuit,
+    load_ai_line,
+)
+
+
+# --------------------------------------------------------------------------- fixtures
+def _straight_line_along_x(n: int = 50, step: float = 2.0) -> list[tuple[float, float, float]]:
+    """A flat straight running in +x at constant z=0, y=5 (ground height)."""
+    return [(i * step, 5.0, 0.0) for i in range(n)]
+
+
+def _right_turn_line() -> list[tuple[float, float, float]]:
+    """A line that goes +x then curves toward +z (a right-hand turn for a +x-facing car)."""
+    pts: list[tuple[float, float, float]] = [(i * 2.0, 5.0, 0.0) for i in range(20)]
+    # quarter arc bending toward +z
+    import math
+
+    cx, cz = pts[-1][0], pts[-1][2] + 20.0  # arc centre to the car's right (+z)
+    for k in range(1, 25):
+        ang = -math.pi / 2 + (math.pi / 2) * (k / 25)
+        pts.append((cx + 20.0 * math.cos(ang), 5.0, cz + 20.0 * math.sin(ang)))
+    return pts
+
+
+def _fast_lane_bytes(points: list[tuple[float, float, float]]) -> bytes:
+    """Assemble a minimal but structurally valid version-7 fast_lane.ai buffer.
+
+    Header (version=7, count, lapTime=0, sampleCount=0) + count*20-byte points
+    (x,y,z float, length float, id int32). No extra/grid block is needed: the parser only
+    reads the header and the main point block.
+    """
+    buf = bytearray()
+    buf += struct.pack("<4i", 7, len(points), 0, 0)
+    length = 0.0
+    prev: tuple[float, float, float] | None = None
+    for i, (x, y, z) in enumerate(points):
+        if prev is not None:
+            import math
+
+            length += math.dist((x, y, z), prev)
+        buf += struct.pack("<3f", x, y, z)
+        buf += struct.pack("<f", length)
+        buf += struct.pack("<i", i)
+        prev = (x, y, z)
+    return bytes(buf)
+
+
+# --------------------------------------------------------------------------- parser
+def test_load_ai_line_round_trips_positions(tmp_path):
+    pts = [(1.0, 5.0, 2.0), (3.0, 5.0, 4.0), (5.0, 5.0, 6.0)]
+    path = tmp_path / "fast_lane.ai"
+    path.write_bytes(_fast_lane_bytes(pts))
+
+    loaded = load_ai_line(path)
+
+    assert len(loaded) == 3
+    for got, want in zip(loaded, pts, strict=True):
+        assert got == pytest.approx(want)
+
+
+def test_load_ai_line_accepts_str_path(tmp_path):
+    pts = [(0.0, 0.0, 0.0), (1.0, 0.0, 1.0)]
+    path = tmp_path / "fast_lane.ai"
+    path.write_bytes(_fast_lane_bytes(pts))
+    assert len(load_ai_line(str(path))) == 2
+
+
+def test_load_ai_line_rejects_short_file(tmp_path):
+    path = tmp_path / "fast_lane.ai"
+    path.write_bytes(b"\x07\x00\x00")  # < 16-byte header
+    with pytest.raises(ValueError, match="too short"):
+        load_ai_line(path)
+
+
+def test_load_ai_line_rejects_non_positive_count(tmp_path):
+    path = tmp_path / "fast_lane.ai"
+    path.write_bytes(struct.pack("<4i", 7, 0, 0, 0))
+    with pytest.raises(ValueError, match="non-positive point count"):
+        load_ai_line(path)
+
+
+def test_load_ai_line_rejects_count_overflowing_file(tmp_path):
+    # count claims 1000 points but the file only carries the header.
+    path = tmp_path / "fast_lane.ai"
+    path.write_bytes(struct.pack("<4i", 7, 1000, 0, 0))
+    with pytest.raises(ValueError, match="does not fit the file"):
+        load_ai_line(path)
+
+
+def test_load_ai_line_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_ai_line(tmp_path / "nope.ai")
+
+
+# --------------------------------------------------------------------------- construction
+def test_pure_pursuit_requires_two_points():
+    with pytest.raises(ValueError, match="at least 2"):
+        PurePursuit([(0.0, 0.0, 0.0)])
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"lookahead_m": 0.0}, "lookahead_m"),
+        ({"target_speed_kmh": -1.0}, "speed caps"),
+        ({"min_corner_speed_kmh": 200.0}, "cannot exceed"),
+        ({"wheelbase_m": 0.0}, "must be > 0"),
+    ],
+)
+def test_pure_pursuit_validates_params(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        PurePursuit(_straight_line_along_x(), **kwargs)
+
+
+# --------------------------------------------------------------------------- steering sign
+def test_steer_zero_on_straight_when_aligned():
+    pp = PurePursuit(_straight_line_along_x())
+    # car on the line, facing +x: aim point is dead ahead -> no steer.
+    out = pp.control(position_xyz=(10.0, 5.0, 0.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=50.0)
+    assert isinstance(out, ControlOutput)
+    assert out.steer == pytest.approx(0.0, abs=1e-6)
+
+
+def test_steer_right_when_offset_left_of_line():
+    """Car is displaced to -z (its left) of a +x line; correcting back is a right turn."""
+    pp = PurePursuit(_straight_line_along_x())
+    out = pp.control(position_xyz=(10.0, 5.0, -3.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=50.0)
+    # aim point is at z=0 (to the car's right, +z) -> steer > 0.
+    assert out.steer > 0.0
+
+
+def test_steer_left_when_offset_right_of_line():
+    pp = PurePursuit(_straight_line_along_x())
+    out = pp.control(position_xyz=(10.0, 5.0, 3.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=50.0)
+    assert out.steer < 0.0
+
+
+def test_steer_sign_consistent_for_right_hand_curve():
+    """Driving a line that bends toward +z should command a positive (right) steer."""
+    pp = PurePursuit(_right_turn_line(), lookahead_m=10.0)
+    # place the car partway down the straight, aligned +x, just before the bend.
+    out = pp.control(position_xyz=(34.0, 5.0, 0.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=50.0)
+    assert out.steer > 0.0
+
+
+def test_steer_clamped_to_unit_range():
+    pp = PurePursuit(_right_turn_line(), lookahead_m=4.0, max_steer_curvature=0.01)
+    out = pp.control(position_xyz=(34.0, 5.0, 0.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=50.0)
+    assert -1.0 <= out.steer <= 1.0
+
+
+def test_aim_point_behind_commands_full_lock():
+    """If the look-ahead point is behind the car (facing backward), steer saturates."""
+    pp = PurePursuit(_straight_line_along_x())
+    # facing -x while the aim point is ahead in +x -> forward_offset < 0 -> full lock.
+    out = pp.control(position_xyz=(10.0, 5.0, -1.0), look_dir_xyz=(-1.0, 0.0, 0.0), speed_kmh=10.0)
+    assert abs(out.steer) == pytest.approx(1.0)
+
+
+def test_zero_heading_creeps_forward():
+    pp = PurePursuit(_straight_line_along_x())
+    out = pp.control(position_xyz=(0.0, 5.0, 0.0), look_dir_xyz=(0.0, 0.0, 0.0), speed_kmh=0.0)
+    assert out.gas > 0.0
+    assert out.brake == 0.0
+    assert out.steer == 0.0
+
+
+# --------------------------------------------------------------------------- longitudinal
+def test_throttle_when_below_target_on_straight():
+    pp = PurePursuit(_straight_line_along_x(), target_speed_kmh=90.0)
+    out = pp.control(position_xyz=(10.0, 5.0, 0.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=20.0)
+    assert out.gas > 0.0
+    assert out.brake == 0.0
+
+
+def test_brake_when_over_target_on_straight():
+    pp = PurePursuit(_straight_line_along_x(), target_speed_kmh=80.0)
+    out = pp.control(position_xyz=(10.0, 5.0, 0.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=120.0)
+    assert out.brake > 0.0
+    assert out.gas == 0.0
+
+
+def test_gas_and_brake_never_both_active():
+    pp = PurePursuit(_right_turn_line())
+    for speed in (0.0, 30.0, 60.0, 90.0, 130.0):
+        out = pp.control(
+            position_xyz=(20.0, 5.0, 0.0), look_dir_xyz=(1.0, 0.0, 0.0), speed_kmh=speed
+        )
+        assert out.gas == 0.0 or out.brake == 0.0
+        assert 0.0 <= out.gas <= 1.0
+        assert 0.0 <= out.brake <= 1.0
+
+
+def test_corner_lowers_target_speed_vs_straight():
+    """A tight corner should brake earlier (lower target) than a straight at the same speed."""
+    straight = PurePursuit(_straight_line_along_x(), target_speed_kmh=90.0)
+    curve = PurePursuit(_right_turn_line(), target_speed_kmh=90.0, min_corner_speed_kmh=45.0)
+    # At the same actual speed just below the cap, the curve's target is lower, so it asks for
+    # less gas (or brake) than the straight in the bend region.
+    s_out = straight.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), speed_kmh=80.0)
+    c_out = curve.control((44.0, 5.0, 18.0), (0.0, 0.0, 1.0), speed_kmh=80.0)
+    assert c_out.gas <= s_out.gas
+
+
+def test_control_output_unpacks_as_tuple():
+    pp = PurePursuit(_straight_line_along_x())
+    gas, brake, steer = pp.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), speed_kmh=50.0)
+    assert (gas, brake, steer) == (
+        pytest.approx(pp.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), 50.0).gas),
+        pytest.approx(pp.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), 50.0).brake),
+        pytest.approx(pp.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), 50.0).steer),
+    )
+
+
+# --------------------------------------------------------------------------- nearest / determinism
+def test_nearest_index_picks_closest_point():
+    pp = PurePursuit(_straight_line_along_x(step=2.0))  # points at x = 0,2,4,...
+    assert pp.nearest_index((9.0, 0.0)) == 4  # x=8 (index 4) is closest to 9
+    assert pp.nearest_index((0.1, 0.0)) == 0
+
+
+def test_control_is_deterministic():
+    pp = PurePursuit(_right_turn_line())
+    a = pp.control((20.0, 5.0, 1.0), (1.0, 0.0, 0.0), speed_kmh=55.0)
+    b = pp.control((20.0, 5.0, 1.0), (1.0, 0.0, 0.0), speed_kmh=55.0)
+    assert a == b

--- a/tests/test_ai_line.py
+++ b/tests/test_ai_line.py
@@ -212,14 +212,23 @@ def test_gas_and_brake_never_both_active():
 
 
 def test_corner_lowers_target_speed_vs_straight():
-    """A tight corner should brake earlier (lower target) than a straight at the same speed."""
+    """A tight corner must brake earlier (lower target) than a straight at the same speed.
+
+    Two things this test guards against (both real defects a prior version had — Bugbot/Sourcery):
+    (1) the car is placed MID-BEND, not at the arc tail where the curvature look-ahead runs off the
+    open synthetic line and reads ~0 (making the corner invisible); (2) the assertion is STRICT
+    ``<`` so deleting the corner-braking term would FAIL it, instead of passing on a 0.5==0.5 tie.
+    A small ``curvature_lookahead_m`` keeps the window inside the short synthetic arc.
+    """
+    curve_line = _right_turn_line()
     straight = PurePursuit(_straight_line_along_x(), target_speed_kmh=90.0)
-    curve = PurePursuit(_right_turn_line(), target_speed_kmh=90.0, min_corner_speed_kmh=45.0)
-    # At the same actual speed just below the cap, the curve's target is lower, so it asks for
-    # less gas (or brake) than the straight in the bend region.
+    curve = PurePursuit(
+        curve_line, target_speed_kmh=90.0, min_corner_speed_kmh=45.0, curvature_lookahead_m=8.0
+    )
+    mid = curve_line[28]  # a point in the middle of the quarter-arc (indices 20..43)
     s_out = straight.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), speed_kmh=80.0)
-    c_out = curve.control((44.0, 5.0, 18.0), (0.0, 0.0, 1.0), speed_kmh=80.0)
-    assert c_out.gas <= s_out.gas
+    c_out = curve.control((mid[0], 5.0, mid[2]), (0.0, 0.0, 1.0), speed_kmh=80.0)
+    assert c_out.gas < s_out.gas
 
 
 def test_control_output_unpacks_as_tuple():

--- a/tests/test_custom_ai.py
+++ b/tests/test_custom_ai.py
@@ -229,3 +229,13 @@ def test_section_name_templates_use_car_index():
     assert car_data_name(0) == "AcTools.CSP.NewBehaviour.CustomAI.Car0.v0"
     assert car_controls_name(3) == "AcTools.CSP.NewBehaviour.CustomAI.CarControls3.v0"
     assert car_data_name(3) == "AcTools.CSP.NewBehaviour.CustomAI.Car3.v0"
+
+
+def test_section_name_rejects_negative_car_index():
+    # A negative index would silently produce an invalid section name (e.g. CarControls-1.v0)
+    # that fails obscurely later; the builders reject it up front (CodeRabbit).
+    for bad in (-1, -5):
+        with pytest.raises(ValueError, match="car_index"):
+            car_controls_name(bad)
+        with pytest.raises(ValueError, match="car_index"):
+            car_data_name(bad)

--- a/tests/test_custom_ai.py
+++ b/tests/test_custom_ai.py
@@ -1,0 +1,231 @@
+"""Pure unit tests for the CSP Custom-AI mmap writer/reader (EPIC #154 actuator half).
+
+These exercise only the platform-independent halves of ``tools/ac_harness/custom_ai.py``:
+the ``CarControls`` / ``SimState`` packers and the ``parse_car_data`` reader. No Assetto
+Corsa, no Windows, no mmap — synthetic buffers built at the exact documented offsets, with
+pack -> reparse round-trips. The Windows ctypes plumbing is pragma-guarded and validated on
+the rig, so it is not imported here.
+
+Offsets are UNVERIFIED upstream; these tests pin the *byte layout the module commits to* so a
+future live-verification edit that shifts an offset is caught by a failing round-trip rather
+than silently mis-driving the car.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from tools.ac_harness.custom_ai import (
+    CAR_DATA_MIN_BYTES,
+    CONTROLS_BUFFER_BYTES,
+    CTRL_BRAKE_OFFSET,
+    CTRL_GAS_OFFSET,
+    CTRL_GEAR_DN_OFFSET,
+    CTRL_GEAR_UP_OFFSET,
+    CTRL_HANDBRAKE_OFFSET,
+    CTRL_STEER_OFFSET,
+    CTRL_TELEPORT_POS_OFFSET,
+    CTRL_TELEPORT_TO_OFFSET,
+    DATA_GEAR_OFFSET,
+    DATA_LOOK_OFFSET,
+    DATA_PACKET_ID_OFFSET,
+    DATA_POSITION_OFFSET,
+    DATA_RPM_OFFSET,
+    DATA_SPEED_KMH_OFFSET,
+    DATA_SPLINE_POSITION_OFFSET,
+    SIM_DISABLE_COLLISIONS_OFFSET,
+    SIM_EXTRA_SLEEP_MS_OFFSET,
+    SIM_PAUSE_OFFSET,
+    SIM_RESTART_SESSION_OFFSET,
+    SIM_STATE_BUFFER_BYTES,
+    TELEPORT_TO_CUSTOM,
+    TELEPORT_TO_PITS,
+    CarControls,
+    CarData,
+    SimState,
+    car_controls_name,
+    car_data_name,
+    parse_car_data,
+)
+
+
+# --------------------------------------------------------------------------- helpers
+def _car_data_bytes(
+    *,
+    packet_id: int,
+    gear: int,
+    rpm: float,
+    speed_kmh: float,
+    position: tuple[float, float, float],
+    look: tuple[float, float, float],
+    spline_position: float,
+) -> bytes:
+    """Build a cai_car_data buffer with the parsed fields at their documented offsets."""
+    buf = bytearray(CAR_DATA_MIN_BYTES)
+    struct.pack_into("<i", buf, DATA_PACKET_ID_OFFSET, packet_id)
+    struct.pack_into("<i", buf, DATA_GEAR_OFFSET, gear)
+    struct.pack_into("<f", buf, DATA_RPM_OFFSET, rpm)
+    struct.pack_into("<f", buf, DATA_SPEED_KMH_OFFSET, speed_kmh)
+    struct.pack_into("<3f", buf, DATA_POSITION_OFFSET, *position)
+    struct.pack_into("<3f", buf, DATA_LOOK_OFFSET, *look)
+    struct.pack_into("<f", buf, DATA_SPLINE_POSITION_OFFSET, spline_position)
+    return bytes(buf)
+
+
+# --------------------------------------------------------------------------- controls pack
+def test_car_controls_pack_buffer_is_zero_filled_and_sized():
+    buf = CarControls().pack()
+    assert len(buf) == CONTROLS_BUFFER_BYTES
+    assert buf == bytes(CONTROLS_BUFFER_BYTES)  # all-default -> every byte zero
+
+
+def test_car_controls_pack_floats_at_offsets():
+    buf = CarControls(gas=0.5, brake=0.25, steer=-0.75, handbrake=1.0).pack()
+    assert struct.unpack_from("<f", buf, CTRL_GAS_OFFSET)[0] == pytest.approx(0.5)
+    assert struct.unpack_from("<f", buf, CTRL_BRAKE_OFFSET)[0] == pytest.approx(0.25)
+    assert struct.unpack_from("<f", buf, CTRL_STEER_OFFSET)[0] == pytest.approx(-0.75)
+    assert struct.unpack_from("<f", buf, CTRL_HANDBRAKE_OFFSET)[0] == pytest.approx(1.0)
+
+
+def test_car_controls_pack_bools_at_offsets():
+    buf = CarControls(gear_up=True, gear_dn=False).pack()
+    assert buf[CTRL_GEAR_UP_OFFSET] == 1
+    assert buf[CTRL_GEAR_DN_OFFSET] == 0
+    buf2 = CarControls(gear_up=False, gear_dn=True).pack()
+    assert buf2[CTRL_GEAR_UP_OFFSET] == 0
+    assert buf2[CTRL_GEAR_DN_OFFSET] == 1
+
+
+def test_car_controls_clamps_out_of_range_inputs():
+    buf = CarControls(gas=2.0, brake=-1.0, steer=5.0, handbrake=-3.0, clutch=2.0).pack()
+    assert struct.unpack_from("<f", buf, CTRL_GAS_OFFSET)[0] == pytest.approx(1.0)
+    assert struct.unpack_from("<f", buf, CTRL_BRAKE_OFFSET)[0] == pytest.approx(0.0)
+    assert struct.unpack_from("<f", buf, CTRL_STEER_OFFSET)[0] == pytest.approx(1.0)  # +5 -> +1
+    assert struct.unpack_from("<f", buf, CTRL_HANDBRAKE_OFFSET)[0] == pytest.approx(0.0)
+
+
+def test_car_controls_steer_clamps_negative_extreme():
+    buf = CarControls(steer=-9.0).pack()
+    assert struct.unpack_from("<f", buf, CTRL_STEER_OFFSET)[0] == pytest.approx(-1.0)
+
+
+def test_car_controls_teleport_to_pits_byte():
+    buf = CarControls(teleport_to=TELEPORT_TO_PITS).pack()
+    assert buf[CTRL_TELEPORT_TO_OFFSET] == TELEPORT_TO_PITS
+
+
+def test_car_controls_teleport_custom_position_packed():
+    buf = CarControls(teleport_to=TELEPORT_TO_CUSTOM, teleport_pos=(10.0, -2.5, 33.0)).pack()
+    assert buf[CTRL_TELEPORT_TO_OFFSET] == TELEPORT_TO_CUSTOM
+    assert struct.unpack_from("<3f", buf, CTRL_TELEPORT_POS_OFFSET) == pytest.approx(
+        (10.0, -2.5, 33.0)
+    )
+
+
+def test_default_controls_have_no_teleport():
+    buf = CarControls().pack()
+    assert buf[CTRL_TELEPORT_TO_OFFSET] == 0
+
+
+# --------------------------------------------------------------------------- car data parse
+def test_parse_car_data_decodes_fields_at_documented_offsets():
+    raw = _car_data_bytes(
+        packet_id=777,
+        gear=3,
+        rpm=6500.0,
+        speed_kmh=142.5,
+        position=(100.0, 1.5, -200.0),
+        look=(0.0, 0.0, 1.0),
+        spline_position=0.42,
+    )
+    data = parse_car_data(raw)
+    assert isinstance(data, CarData)
+    assert data.packet_id == 777
+    assert data.gear == 3
+    assert data.rpm == pytest.approx(6500.0)
+    assert data.speed_kmh == pytest.approx(142.5)
+    assert data.position == pytest.approx((100.0, 1.5, -200.0))
+    assert data.look == pytest.approx((0.0, 0.0, 1.0))
+    assert data.spline_position == pytest.approx(0.42)
+
+
+def test_parse_car_data_accepts_full_512_byte_buffer():
+    # A real read maps 512 bytes; parsing a longer-than-minimum buffer must still work.
+    raw = bytearray(512)
+    struct.pack_into("<i", raw, DATA_PACKET_ID_OFFSET, 9)
+    struct.pack_into("<f", raw, DATA_SPLINE_POSITION_OFFSET, 0.99)
+    data = parse_car_data(bytes(raw))
+    assert data.packet_id == 9
+    assert data.spline_position == pytest.approx(0.99)
+
+
+def test_parse_car_data_rejects_short_buffer():
+    with pytest.raises(ValueError, match="too short"):
+        parse_car_data(bytes(CAR_DATA_MIN_BYTES - 1))
+
+
+def test_car_data_as_dict_round_trip():
+    data = parse_car_data(
+        _car_data_bytes(
+            packet_id=1,
+            gear=-1,
+            rpm=0.0,
+            speed_kmh=0.0,
+            position=(1.0, 2.0, 3.0),
+            look=(4.0, 5.0, 6.0),
+            spline_position=0.0,
+        )
+    )
+    d = data.as_dict()
+    assert d["gear"] == -1
+    assert d["position"] == pytest.approx((1.0, 2.0, 3.0))
+    assert d["look"] == pytest.approx((4.0, 5.0, 6.0))
+    assert set(d) == {
+        "packet_id",
+        "gear",
+        "rpm",
+        "speed_kmh",
+        "position",
+        "look",
+        "spline_position",
+    }
+
+
+# --------------------------------------------------------------------------- sim state pack
+def test_sim_state_pack_buffer_is_zero_filled_and_sized():
+    buf = SimState().pack()
+    assert len(buf) == SIM_STATE_BUFFER_BYTES
+    assert buf == bytes(SIM_STATE_BUFFER_BYTES)
+
+
+def test_sim_state_pack_flags_at_offsets():
+    buf = SimState(
+        pause=True, restart_session=True, disable_collisions=True, extra_sleep_ms=7
+    ).pack()
+    assert buf[SIM_PAUSE_OFFSET] == 1
+    assert buf[SIM_RESTART_SESSION_OFFSET] == 1
+    assert buf[SIM_DISABLE_COLLISIONS_OFFSET] == 1
+    assert buf[SIM_EXTRA_SLEEP_MS_OFFSET] == 7
+
+
+def test_sim_state_partial_flags():
+    buf = SimState(pause=True).pack()
+    assert buf[SIM_PAUSE_OFFSET] == 1
+    assert buf[SIM_RESTART_SESSION_OFFSET] == 0
+    assert buf[SIM_DISABLE_COLLISIONS_OFFSET] == 0
+
+
+def test_sim_state_extra_sleep_masks_to_byte():
+    # extra_sleep_ms is a single byte; values >255 must wrap, not corrupt adjacent bytes.
+    buf = SimState(extra_sleep_ms=257).pack()
+    assert buf[SIM_EXTRA_SLEEP_MS_OFFSET] == 1
+
+
+# --------------------------------------------------------------------------- section names
+def test_section_name_templates_use_car_index():
+    assert car_controls_name(0) == "AcTools.CSP.NewBehaviour.CustomAI.CarControls0.v0"
+    assert car_data_name(0) == "AcTools.CSP.NewBehaviour.CustomAI.Car0.v0"
+    assert car_controls_name(3) == "AcTools.CSP.NewBehaviour.CustomAI.CarControls3.v0"
+    assert car_data_name(3) == "AcTools.CSP.NewBehaviour.CustomAI.Car3.v0"

--- a/tests/test_lap_driver.py
+++ b/tests/test_lap_driver.py
@@ -1,0 +1,173 @@
+"""Pure-logic tests for :mod:`tools.ac_harness.lap_driver` (no mmap, no AC, no real clock).
+
+Mirrors ``test_ai_line`` / ``test_custom_ai``: feed :meth:`LapDriver.step` synthetic poses + a
+monotonic ``now`` and assert the phase machine, gear pulses, OUT-phase shaping, position-return
+lap detection, and stuck/recovery signalling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.ac_harness.lap_driver import PHASE_LAP, PHASE_OUT, LapDriver
+
+# A simple straight racing line down +z (the controller only does planar (x, z) geometry).
+STRAIGHT_LINE = [(0.0, 0.0, float(z)) for z in range(0, 400, 2)]
+
+
+def _driver(**kw) -> LapDriver:
+    return LapDriver(STRAIGHT_LINE, **kw)
+
+
+def test_starts_in_out_phase() -> None:
+    assert _driver().phase == PHASE_OUT
+
+
+def test_out_phase_clamps_steer_and_floors_gas() -> None:
+    d = _driver(out_steer_clamp=0.35, out_gas=0.30)
+    # Car far off the line (x=40) so pure pursuit wants a big steer; OUT must clamp it.
+    f = d.step((40.0, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=5.0, rpm=3000, gear=2, now=0.0)
+    assert f.phase == PHASE_OUT
+    assert abs(f.steer) <= 0.35 + 1e-9
+    assert f.gas >= 0.30 - 1e-9
+    assert f.brake == 0.0
+
+
+def test_merges_out_to_lap_when_close_and_fast() -> None:
+    d = _driver(merge_distance_m=9.0, merge_speed_kmh=10.0)
+    # On the line (x~0), moving: should switch to LAP.
+    f = d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=42.0, rpm=3800, gear=2, now=0.1)
+    assert f.phase == PHASE_LAP
+
+
+def test_no_merge_when_close_but_too_slow() -> None:
+    d = _driver(merge_distance_m=9.0, merge_speed_kmh=10.0)
+    f = d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=4.0, rpm=1200, gear=2, now=0.1)
+    assert f.phase == PHASE_OUT
+
+
+def test_shift_out_of_neutral() -> None:
+    # gear 1 == NEUTRAL in AC encoding -> must request an up-shift toward 1st (gear 2).
+    d = _driver()
+    f = d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=0.0, rpm=900, gear=1, now=0.0)
+    assert f.gear_up is True
+    assert f.gear_dn is False
+
+
+def test_upshift_above_rpm_then_cooldown_blocks_second() -> None:
+    d = _driver(rpm_up=7800.0, max_gear=4, shift_cooldown_s=0.35)
+    f1 = d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=60.0, rpm=8200, gear=2, now=1.0)
+    assert f1.gear_up is True
+    # within cooldown -> no second shift even though rpm still high
+    f2 = d.step((0.5, 0.0, 52.0), (0.0, 0.0, 1.0), speed_kmh=61.0, rpm=8200, gear=3, now=1.1)
+    assert f2.gear_up is False
+    # after cooldown -> shifts again
+    f3 = d.step((0.5, 0.0, 54.0), (0.0, 0.0, 1.0), speed_kmh=62.0, rpm=8200, gear=3, now=1.6)
+    assert f3.gear_up is True
+
+
+def test_no_upshift_at_max_gear() -> None:
+    d = _driver(rpm_up=7800.0, max_gear=3)
+    f = d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=60.0, rpm=8200, gear=3, now=2.0)
+    assert f.gear_up is False
+
+
+def test_downshift_below_rpm_when_rolling() -> None:
+    d = _driver(rpm_dn=3200.0)
+    f = d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=30.0, rpm=2800, gear=3, now=3.0)
+    assert f.gear_dn is True
+    assert f.gear_up is False
+
+
+def test_no_downshift_in_first_gear() -> None:
+    d = _driver(rpm_dn=3200.0)
+    f = d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=10.0, rpm=2000, gear=2, now=3.0)
+    assert f.gear_dn is False
+
+
+def test_stuck_triggers_recovery_after_threshold() -> None:
+    d = _driver(stuck_speed_kmh=3.0, stuck_seconds=5.0)
+    # Pinned against something: slow while asking for throttle (gas>0.4 via OUT floor).
+    pose = ((5.0, 0.0, 10.0), (0.0, 0.0, 1.0))
+    f0 = d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=0.0)
+    assert f0.needs_recovery is False
+    f1 = d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=4.9)
+    assert f1.needs_recovery is False
+    f2 = d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=5.2)
+    assert f2.needs_recovery is True
+
+
+def test_recovery_clears_when_moving_again() -> None:
+    d = _driver(stuck_seconds=5.0)
+    pose = ((5.0, 0.0, 10.0), (0.0, 0.0, 1.0))
+    d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=0.0)
+    moving = d.step(*pose, speed_kmh=30.0, rpm=4000, gear=2, now=3.0)
+    assert moving.needs_recovery is False
+    # clock advances past the original threshold but the stuck timer was reset
+    again = d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=6.0)
+    assert again.needs_recovery is False
+
+
+def test_on_recovery_resets_to_out_phase() -> None:
+    d = _driver()
+    d.step((0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=42.0, rpm=3800, gear=2, now=0.1)
+    assert d.phase == PHASE_LAP
+    d.on_recovery()
+    assert d.phase == PHASE_OUT
+
+
+def test_position_return_lap_detection() -> None:
+    # Small min_lap + radius so we can close a lap with a short synthetic path.
+    d = _driver(min_lap_m=30.0, return_radius_m=3.0, merge_distance_m=50.0, merge_speed_kmh=1.0)
+    # First LAP-phase frame anchors the lap at the car's position.
+    f = d.step((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), speed_kmh=42.0, rpm=3800, gear=2, now=0.0)
+    assert f.phase == PHASE_LAP and f.lap_completed is False
+    # Drive out ~40 m down +z (no closure: too far from anchor).
+    seen_completed = False
+    for i, z in enumerate(range(2, 42, 2), start=1):
+        fr = d.step(
+            (0.0, 0.0, float(z)), (0.0, 0.0, 1.0), speed_kmh=42.0, rpm=3800, gear=2, now=0.1 * i
+        )
+        assert fr.lap_completed is False
+    # Now travel back to within the return radius of the anchor (0,0): lap closes once distance
+    # travelled has exceeded min_lap_m (we've covered ~40 out + ~40 back > 30).
+    n = 50
+    for z in range(40, -2, -2):
+        n += 1
+        fr = d.step(
+            (0.0, 0.0, float(z)), (0.0, 0.0, 1.0), speed_kmh=42.0, rpm=3800, gear=2, now=0.1 * n
+        )
+        if fr.lap_completed:
+            seen_completed = True
+            break
+    assert seen_completed
+
+
+def test_lap_not_counted_in_out_phase() -> None:
+    # In OUT phase, lap_completed is always False regardless of motion.
+    d = _driver(min_lap_m=1.0, return_radius_m=100.0, merge_distance_m=0.0)  # never merges
+    f = d.step((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), speed_kmh=42.0, rpm=3800, gear=2, now=0.0)
+    assert f.phase == PHASE_OUT
+    assert f.lap_completed is False
+
+
+def test_steer_sign_matches_pure_pursuit_right_positive() -> None:
+    # PurePursuit defines right_unit = (-fwd_z, fwd_x); for fwd=+z that is -x, so the car's right
+    # is the -x side. A car at x=+3 facing +z has the line (x=0) on its right -> steer > 0 (right);
+    # a car at x=-3 has it on its left -> steer < 0. (Verified live: steer>0 turns the car right.)
+    d_right = _driver(merge_distance_m=100.0, merge_speed_kmh=1.0)
+    f_right = d_right.step(
+        (3.0, 0.0, 10.0), (0.0, 0.0, 1.0), speed_kmh=40.0, rpm=3800, gear=2, now=0.0
+    )
+    assert f_right.phase == PHASE_LAP
+    assert f_right.steer > 0.0
+
+    d_left = _driver(merge_distance_m=100.0, merge_speed_kmh=1.0)
+    f_left = d_left.step(
+        (-3.0, 0.0, 10.0), (0.0, 0.0, 1.0), speed_kmh=40.0, rpm=3800, gear=2, now=0.0
+    )
+    assert f_left.steer < 0.0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_lap_driver.py
+++ b/tests/test_lap_driver.py
@@ -169,5 +169,50 @@ def test_steer_sign_matches_pure_pursuit_right_positive() -> None:
     assert f_left.steer < 0.0
 
 
+def test_stuck_recovery_fires_in_out_phase_low_throttle() -> None:
+    # Regression (Bugbot): OUT phase floors gas at out_gas=0.30, which is BELOW the old gas>0.4
+    # trigger, so a car stuck while driving out of the pits never recovered. stuck_throttle=0.1
+    # (< out_gas) fixes it.
+    d = _driver(
+        out_gas=0.30,
+        stuck_throttle=0.1,
+        stuck_speed_kmh=3.0,
+        stuck_seconds=5.0,
+        merge_distance_m=9.0,
+    )
+    # Zero look vector -> PurePursuit creeps at gas 0.30 (the exact low-throttle case Bugbot named);
+    # far off-line so it stays OUT. gas lands in (0.1, 0.4], which the OLD gas>0.4 trigger missed.
+    pose = ((40.0, 0.0, 50.0), (0.0, 0.0, 0.0))
+    f0 = d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=0.0)
+    assert f0.phase == PHASE_OUT and 0.1 < f0.gas <= 0.4 and f0.needs_recovery is False
+    assert d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=4.9).needs_recovery is False
+    assert d.step(*pose, speed_kmh=0.0, rpm=4000, gear=2, now=5.2).needs_recovery is True
+
+
+def test_upshift_gated_by_speed() -> None:
+    # Gear speed-gate (workflow finding): high RPM at low speed must NOT upshift (don't shift up
+    # while wheels spin against a standstill); above 20 km/h it does.
+    blocked = _driver(rpm_up=7800.0, max_gear=4).step(
+        (0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=15.0, rpm=8200, gear=2, now=1.0
+    )
+    assert blocked.gear_up is False
+    allowed = _driver(rpm_up=7800.0, max_gear=4).step(
+        (0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=25.0, rpm=8200, gear=2, now=1.0
+    )
+    assert allowed.gear_up is True
+
+
+def test_downshift_gated_by_speed() -> None:
+    # Low RPM but near-standstill (<5 km/h) must NOT downshift; above 5 km/h it does.
+    blocked = _driver(rpm_dn=3200.0).step(
+        (0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=4.0, rpm=2800, gear=3, now=3.0
+    )
+    assert blocked.gear_dn is False
+    allowed = _driver(rpm_dn=3200.0).step(
+        (0.5, 0.0, 50.0), (0.0, 0.0, 1.0), speed_kmh=6.0, rpm=2800, gear=3, now=3.0
+    )
+    assert allowed.gear_dn is True
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -11,6 +11,16 @@ synthesizer, and the schema-gated mock ``ac``/``car``/``sim`` tables.
 
 from __future__ import annotations
 
+from tools.ac_harness.custom_ai import (
+    CarControls,
+    CarData,
+    CustomAIController,
+    SimState,
+    SimStateController,
+    car_controls_name,
+    car_data_name,
+    parse_car_data,
+)
 from tools.ac_harness.entry_launcher import (
     ActuatorEvent,
     ColdRestartActuator,
@@ -70,4 +80,13 @@ __all__ = [
     "SharedMemoryUnavailable",
     "parse_graphics",
     "parse_physics",
+    # Custom-AI external-control actuator (autonomous drive of car 0).
+    "CarControls",
+    "CarData",
+    "CustomAIController",
+    "SimState",
+    "SimStateController",
+    "car_controls_name",
+    "car_data_name",
+    "parse_car_data",
 ]

--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -34,6 +34,7 @@ from tools.ac_harness.entry_launcher import (
     classify_entry_phase,
     normalize_race_ini_spawn_set,
 )
+from tools.ac_harness.lap_driver import DriveFrame, LapDriver
 from tools.ac_harness.shared_memory import (
     AcGameStatus,
     DrivingEntryDetector,
@@ -89,4 +90,7 @@ __all__ = [
     "car_controls_name",
     "car_data_name",
     "parse_car_data",
+    # Autonomous lap driver (orchestrates pure-pursuit + actuator into clean laps).
+    "DriveFrame",
+    "LapDriver",
 ]

--- a/tools/ac_harness/ai_line.py
+++ b/tools/ac_harness/ai_line.py
@@ -241,7 +241,6 @@ class PurePursuit:
         not need three near-collinear points (which produce numerically noisy circumcircles).
         Returned unsigned: corner *tightness* sets the speed target, direction does not.
         """
-        n = len(self._plane)
         mid = self._advance(start_index, self.curvature_lookahead_m * 0.5)
         end = self._advance(start_index, self.curvature_lookahead_m)
         p0 = self._plane[start_index]
@@ -263,8 +262,10 @@ class PurePursuit:
         arc = in_len + out_len
         if arc < 1e-6:
             return 0.0
-        # discard the wrap segment's spurious length if the walk wrapped past start (rare).
-        _ = n
+        # NOTE: on a *closed* line shorter than ``curvature_lookahead_m`` the advance walk wraps
+        # past start and folds the in/out headings, degrading this estimate; real ``fast_lane``
+        # tracks are km-scale so it never triggers in production. Clamping the window to the line
+        # length is a tracked follow-up (#190).
         return turn / arc
 
     def control(

--- a/tools/ac_harness/ai_line.py
+++ b/tools/ac_harness/ai_line.py
@@ -1,0 +1,364 @@
+"""Racing-line source + pure-pursuit controller so ``carcsw`` drives a real lap.
+
+EPIC #154 needs car 0 to drive an actual lap of the track **with no human** so the
+trainer's WS producers and the L1.5 probe have real motion to observe. The CSP Custom AI
+mmap interface (``CarControls0`` write section) gives us the actuators — gas / brake /
+steer at 333 Hz — but it does not tell us *where to go*. This module supplies the "where":
+
+1. :func:`load_ai_line` reads Assetto Corsa's own ``fast_lane.ai`` — the same ideal-line
+   spline the built-in AI follows — so we drive a geometrically valid line instead of
+   guessing waypoints. We reuse Kunos's data rather than authoring our own line.
+2. :class:`PurePursuit` turns that line + the live car pose (position, forward vector,
+   speed) into ``(gas, brake, steer)``. Pure pursuit is the standard
+   "steer toward a point a fixed look-ahead distance down the path" geometric controller:
+   simple, deterministic, no tuning matrices, and stable enough to complete a clean lap of
+   a road course at a capped ~80-100 km/h.
+
+Everything here is **pure and deterministic** — no clock, no mmap, no Assetto Corsa. The
+binary parser works on any OS from a ``Path`` (the file is just bytes), and the controller
+is plain arithmetic. That is what lets CI on the Mac verify the steering sign and the
+throttle/brake logic with synthetic in-memory lines, exactly like the #175 oracle.
+
+Coordinate convention (matches AC / the ``Car0`` mmap section): a point is ``(x, y, z)``
+with **y vertical**. The car drives on the ground plane, so all pursuit geometry is done in
+the horizontal ``(x, z)`` plane and the ``y`` component is carried through but ignored by
+the controller. A right-handed turn (steer > 0) corresponds to the look-ahead point lying
+to the car's right of its current heading.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# fast_lane.ai binary layout.
+#
+# Ground-truthed against magione's fast_lane.ai (1754 points, 830628 bytes) AND the
+# canonical Content-Manager source (gro-ove/actools AcTools/AiFile/AiSpline.cs + AiPoint.cs).
+# A "version 7" spline is laid out little-endian as:
+#
+#   int32 version        @ 0    (== 7 for current AC)
+#   int32 count          @ 4    (number of main points)
+#   int32 lapTime        @ 8    (usually 0; not needed here)
+#   int32 sampleCount    @ 12   (usually 0; not needed here)
+#   AiPoint[count]       @ 16   each 20 bytes:
+#       float x          @ +0
+#       float y          @ +4    (vertical)
+#       float z          @ +8
+#       float length     @ +12   (cumulative arc length from start, metres)
+#       int32 id         @ +16   (sequential 0..count-1)
+#   int32 extraCount     @ 16 + count*20   (== count; used here only as a parse cross-check)
+#   ... AiPointExtra[] + optional grid block follow; NOT read.
+#
+# We deliberately parse only the leading header + the float3 position of each main point
+# (plus a cheap structural cross-check on extraCount). The extra block and grid encode
+# side-limits and a spatial lookup grid that pure-pursuit does not use; parsing them would
+# add fragility (their layout drifts across CSP/track-tool versions) for no benefit.
+# ---------------------------------------------------------------------------
+_HEADER_STRUCT = struct.Struct("<4i")  # version, count, lapTime, sampleCount
+_HEADER_SIZE = _HEADER_STRUCT.size  # 16
+_POINT_SIZE = 20  # float x,y,z + float length + int32 id
+_EXPECTED_VERSION = 7
+
+
+def load_ai_line(path: str | Path) -> list[tuple[float, float, float]]:
+    """Parse an Assetto Corsa ``fast_lane.ai`` and return its centre-line as ``(x, y, z)``.
+
+    ``path`` points at ``<AC_ROOT>/content/tracks/<track>/ai/fast_lane.ai``. The returned
+    list is ordered along the racing direction and (for a closed circuit) loops back near
+    the start; pure pursuit treats it as a cyclic path.
+
+    Robustness over completeness: only the version-7 header and each point's float3 position
+    are decoded. ``version`` is checked against the known value (7) but a mismatch only warns
+    via :class:`ValueError` when the layout is *structurally* impossible — if the header looks
+    sane (positive count that fits the file at the documented 20-byte stride) we proceed even
+    on an unexpected version, because the position layout has been stable across versions and
+    a hard fail would needlessly block driving on a slightly-newer spline.
+
+    Raises :class:`FileNotFoundError` if the file is missing and :class:`ValueError` if the
+    bytes cannot be a fast_lane spline (too short, non-positive count, or a count that does
+    not fit the file at the documented stride).
+    """
+    data = Path(path).read_bytes()
+    if len(data) < _HEADER_SIZE:
+        raise ValueError(
+            f"fast_lane.ai too short to hold a header: {len(data)} < {_HEADER_SIZE} bytes"
+        )
+
+    version, count, _lap_time, _sample_count = _HEADER_STRUCT.unpack_from(data, 0)
+    if count <= 0:
+        raise ValueError(f"fast_lane.ai declares a non-positive point count: {count}")
+
+    points_end = _HEADER_SIZE + count * _POINT_SIZE
+    if points_end > len(data):
+        raise ValueError(
+            f"fast_lane.ai count={count} does not fit the file: needs {points_end} bytes "
+            f"for the main point block but file is {len(data)} bytes "
+            f"(version={version}, expected {_EXPECTED_VERSION})"
+        )
+
+    line: list[tuple[float, float, float]] = []
+    offset = _HEADER_SIZE
+    for _ in range(count):
+        x, y, z = struct.unpack_from("<3f", data, offset)
+        line.append((x, y, z))
+        offset += _POINT_SIZE
+    return line
+
+
+# ---------------------------------------------------------------------------
+# Pure-pursuit controller.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ControlOutput:
+    """One actuator frame for the ``CarControls0`` mmap section.
+
+    ``gas`` / ``brake`` are in ``0..1``; ``steer`` is in ``-1..1`` where **positive steers
+    the car to its right**. A tuple is also exposed via iteration so callers can do
+    ``gas, brake, steer = controller.control(...)``.
+    """
+
+    gas: float
+    brake: float
+    steer: float
+
+    def __iter__(self):  # noqa: ANN204 - simple 3-tuple unpacking helper
+        yield self.gas
+        yield self.brake
+        yield self.steer
+
+
+def _horizontal(p: tuple[float, float, float]) -> tuple[float, float]:
+    """Project an ``(x, y, z)`` point to the ground plane ``(x, z)`` (drop vertical ``y``)."""
+    return (p[0], p[2])
+
+
+def _dist2(a: tuple[float, float], b: tuple[float, float]) -> float:
+    """Squared planar distance — cheaper than ``hypot`` for nearest-point comparisons."""
+    dx = a[0] - b[0]
+    dz = a[1] - b[1]
+    return dx * dx + dz * dz
+
+
+class PurePursuit:
+    """Geometric path-follower: steer toward a point a fixed look-ahead down the racing line.
+
+    Construction precomputes the planar projection and the cumulative arc length of the line
+    so :meth:`control` is cheap (a windowed nearest search + a look-ahead walk). The line is
+    treated as **cyclic** (a closed circuit) so the look-ahead wraps past the start/finish
+    instead of running off the end of the array.
+
+    Tuning knobs (all metres / km·h⁻¹, chosen for a road car at a capped pace):
+
+    * ``lookahead_m`` — how far down the line to aim. ~10-20 m: short enough to track tight
+      corners, long enough to damp oscillation on straights.
+    * ``target_speed_kmh`` — the pace cap on straights; the controller bleeds below this into
+      corners based on the upcoming line curvature.
+    * ``min_corner_speed_kmh`` — the floor it will slow to for the sharpest modelled corner.
+    * ``wheelbase_m`` — used to convert the pure-pursuit curvature into a steering fraction;
+      with ``max_steer_curvature`` it sets how much line curvature saturates the wheel.
+    """
+
+    def __init__(
+        self,
+        line: list[tuple[float, float, float]],
+        *,
+        lookahead_m: float = 14.0,
+        target_speed_kmh: float = 90.0,
+        min_corner_speed_kmh: float = 45.0,
+        wheelbase_m: float = 2.5,
+        max_steer_curvature: float = 0.18,
+        curvature_lookahead_m: float = 30.0,
+    ) -> None:
+        if len(line) < 2:
+            raise ValueError("pure pursuit needs at least 2 line points")
+        if lookahead_m <= 0:
+            raise ValueError("lookahead_m must be > 0")
+        if target_speed_kmh <= 0 or min_corner_speed_kmh <= 0:
+            raise ValueError("speed caps must be > 0")
+        if min_corner_speed_kmh > target_speed_kmh:
+            raise ValueError("min_corner_speed_kmh cannot exceed target_speed_kmh")
+        if wheelbase_m <= 0 or max_steer_curvature <= 0 or curvature_lookahead_m <= 0:
+            raise ValueError("wheelbase_m, max_steer_curvature, curvature_lookahead_m must be > 0")
+
+        self._line = line
+        self._plane = [_horizontal(p) for p in line]
+        self.lookahead_m = lookahead_m
+        self.target_speed_kmh = target_speed_kmh
+        self.min_corner_speed_kmh = min_corner_speed_kmh
+        self.wheelbase_m = wheelbase_m
+        self.max_steer_curvature = max_steer_curvature
+        self.curvature_lookahead_m = curvature_lookahead_m
+
+        # Cumulative arc length along the *cyclic* line: cum[i] is the distance from point 0
+        # to point i, and the segment closing the loop (last -> first) is included so the
+        # look-ahead walk can wrap. This lets us step a fixed number of metres down the path.
+        self._seg_len: list[float] = []
+        n = len(self._plane)
+        for i in range(n):
+            a = self._plane[i]
+            b = self._plane[(i + 1) % n]
+            self._seg_len.append(math.hypot(b[0] - a[0], b[1] - a[1]))
+
+    def nearest_index(self, position: tuple[float, float]) -> int:
+        """Index of the line point planar-closest to ``position`` (full scan; pure)."""
+        best_i = 0
+        best_d = _dist2(self._plane[0], position)
+        for i in range(1, len(self._plane)):
+            d = _dist2(self._plane[i], position)
+            if d < best_d:
+                best_d = d
+                best_i = i
+        return best_i
+
+    def _advance(self, start_index: int, distance_m: float) -> int:
+        """Walk ``distance_m`` along the cyclic line from ``start_index``; return the index.
+
+        Steps point-to-point accumulating segment lengths until the budget is spent, wrapping
+        at the end of the array (closed circuit). The returned index is the first point at or
+        beyond ``distance_m`` ahead — the aim point.
+        """
+        n = len(self._plane)
+        idx = start_index
+        remaining = distance_m
+        # Bound the walk to one full lap so a degenerate (zero-length) line cannot loop forever.
+        for _ in range(n):
+            step = self._seg_len[idx]
+            if step >= remaining:
+                return (idx + 1) % n
+            remaining -= step
+            idx = (idx + 1) % n
+        return (start_index + n - 1) % n
+
+    def _curvature_ahead(self, start_index: int) -> float:
+        """Estimate path curvature (1/radius, m⁻¹) over the next ``curvature_lookahead_m``.
+
+        Uses the turn angle between the heading into the look-ahead window and the heading
+        out of it, divided by the arc length walked — a robust discrete curvature that does
+        not need three near-collinear points (which produce numerically noisy circumcircles).
+        Returned unsigned: corner *tightness* sets the speed target, direction does not.
+        """
+        n = len(self._plane)
+        mid = self._advance(start_index, self.curvature_lookahead_m * 0.5)
+        end = self._advance(start_index, self.curvature_lookahead_m)
+        p0 = self._plane[start_index]
+        p1 = self._plane[mid]
+        p2 = self._plane[end]
+
+        in_x, in_z = p1[0] - p0[0], p1[1] - p0[1]
+        out_x, out_z = p2[0] - p1[0], p2[1] - p1[1]
+        in_len = math.hypot(in_x, in_z)
+        out_len = math.hypot(out_x, out_z)
+        if in_len < 1e-6 or out_len < 1e-6:
+            return 0.0
+
+        # Signed turn angle between the two heading vectors via atan2(cross, dot): stable for
+        # all angles including near-180°, unlike acos(dot) which loses precision near ±1.
+        cross = in_x * out_z - in_z * out_x
+        dot = in_x * out_x + in_z * out_z
+        turn = abs(math.atan2(cross, dot))
+        arc = in_len + out_len
+        if arc < 1e-6:
+            return 0.0
+        # discard the wrap segment's spurious length if the walk wrapped past start (rare).
+        _ = n
+        return turn / arc
+
+    def control(
+        self,
+        position_xyz: tuple[float, float, float],
+        look_dir_xyz: tuple[float, float, float],
+        speed_kmh: float,
+    ) -> ControlOutput:
+        """Compute one ``(gas, brake, steer)`` frame from the live car pose.
+
+        ``position_xyz`` is the car's world position and ``look_dir_xyz`` its forward
+        direction (both as read from the ``Car0`` mmap section; ``y`` is vertical and
+        ignored). ``speed_kmh`` is the current ground speed.
+
+        Steering: project the vector from the car to the look-ahead point into the car's
+        local frame (forward / right). The pure-pursuit curvature is
+        ``2 * lateral_offset / lookahead²``; we map that to ``-1..1`` via the wheelbase and
+        ``max_steer_curvature`` so a curvature at the saturation value pins the wheel.
+        ``steer > 0`` means the aim point is to the car's right.
+
+        Longitudinal: pick a target speed that falls from ``target_speed_kmh`` toward
+        ``min_corner_speed_kmh`` as the upcoming curvature tightens, then apply throttle if
+        below target and brake if above — a deadband-free proportional law clamped to 0..1.
+        """
+        car = _horizontal(position_xyz)
+        fwd = _horizontal(look_dir_xyz)
+        fwd_len = math.hypot(fwd[0], fwd[1])
+        if fwd_len < 1e-9:
+            # No usable heading (car stationary at spawn with zero look vector): creep forward
+            # straight so the very first frames still command motion rather than freezing.
+            return ControlOutput(gas=0.3, brake=0.0, steer=0.0)
+        fwd_unit = (fwd[0] / fwd_len, fwd[1] / fwd_len)
+        # The car's "right" normal in the (x, z) ground plane. We DEFINE steer>0 == aim point
+        # to the car's right, and pin that to the +z side when facing +x (the convention the
+        # tests lock down): for fwd=(1,0) we need right=(0,1)=+z, i.e. right = (-fwd_z, fwd_x).
+        right_unit = (-fwd_unit[1], fwd_unit[0])
+
+        nearest = self.nearest_index(car)
+        aim_idx = self._advance(nearest, self.lookahead_m)
+        aim = self._plane[aim_idx]
+        to_aim = (aim[0] - car[0], aim[1] - car[1])
+
+        forward_offset = to_aim[0] * fwd_unit[0] + to_aim[1] * fwd_unit[1]
+        lateral_offset = to_aim[0] * right_unit[0] + to_aim[1] * right_unit[1]
+
+        steer = self._steer_from_offsets(forward_offset, lateral_offset)
+        gas, brake = self._longitudinal(nearest, speed_kmh)
+        return ControlOutput(gas=gas, brake=brake, steer=steer)
+
+    def _steer_from_offsets(self, forward_offset: float, lateral_offset: float) -> float:
+        """Map the look-ahead point's local offset to a steering fraction in ``-1..1``.
+
+        Pure-pursuit curvature to reach a point at local ``(forward, lateral)`` with chord
+        length ``L`` is ``kappa = 2*lateral / L²``. We normalise by ``max_steer_curvature``
+        (the curvature that saturates the wheel) and clamp. ``wheelbase_m`` is folded into the
+        normalisation so a longer car asks for proportionally more wheel at the same path
+        curvature, matching real Ackermann behaviour. If the aim point is behind the car
+        (``forward_offset <= 0`` — e.g. recovering from a spin) steer hard toward it.
+        """
+        chord2 = forward_offset * forward_offset + lateral_offset * lateral_offset
+        if chord2 < 1e-9:
+            return 0.0
+        if forward_offset <= 0.0:
+            # Aim point is behind: command full lock in its lateral direction to swing around.
+            return _clamp(math.copysign(1.0, lateral_offset), -1.0, 1.0)
+        curvature = 2.0 * lateral_offset / chord2
+        steer = curvature * self.wheelbase_m / self.max_steer_curvature
+        return _clamp(steer, -1.0, 1.0)
+
+    def _longitudinal(self, nearest_index: int, speed_kmh: float) -> tuple[float, float]:
+        """Proportional throttle/brake toward a curvature-scaled target speed.
+
+        The target falls linearly from ``target_speed_kmh`` to ``min_corner_speed_kmh`` as the
+        upcoming curvature rises from 0 to ``max_steer_curvature``. Below target we feed gas
+        proportional to the deficit; above target we brake proportional to the excess. Only
+        one of gas/brake is ever non-zero, so the actuator frame is unambiguous.
+        """
+        curvature = self._curvature_ahead(nearest_index)
+        tightness = _clamp(curvature / self.max_steer_curvature, 0.0, 1.0)
+        target = self.target_speed_kmh - tightness * (
+            self.target_speed_kmh - self.min_corner_speed_kmh
+        )
+        error = target - speed_kmh
+        if error >= 0.0:
+            # Below target: throttle scaled by deficit, full gas once ~20 km/h+ down.
+            return (_clamp(error / 20.0, 0.0, 1.0), 0.0)
+        # Above target: brake scaled by excess, full brake once ~15 km/h+ over.
+        return (0.0, _clamp(-error / 15.0, 0.0, 1.0))
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    """Clamp ``value`` to ``[low, high]`` (kept local so the module has no numpy dependency)."""
+    if value < low:
+        return low
+    if value > high:
+        return high
+    return value

--- a/tools/ac_harness/custom_ai.py
+++ b/tools/ac_harness/custom_ai.py
@@ -1,0 +1,573 @@
+"""CSP Custom-AI external-control mmap writer + reader (EPIC #154 — autonomous drive).
+
+This is the **actuator** half of the autonomous self-test: it drives car 0 in Assetto
+Corsa with no human at the wheel by writing to CSP's *Custom AI* external-control shared
+memory at ~333 Hz, and reads back the car's state so the L1.5 probe + shared-memory oracle
+can verify the drive. Source: ``cup.acstuff.club/docs/csp/other-things/custom-ai``; full
+notes in the vault under
+``docs/01_Vault/AcCopilotTrainer/03_Investigations/csp-custom-ai-mmap-interface-2026-06-16.md``.
+
+The interface is three Windows named shared-memory sections, parametrised by car index
+``<N>`` (``0`` == the player car):
+
+* ``AcTools.CSP.NewBehaviour.CustomAI.CarControls<N>.v0`` — WRITE. The external app
+  **creates** this section; that creation is the signal that hijacks the car. CSP responds
+  by creating the matching ``Car<N>.v0`` read section (so a non-``None`` :meth:`read_car_data`
+  is the confirmation that CSP accepted the hijack).
+* ``AcTools.CSP.NewBehaviour.CustomAI.Car<N>.v0`` — READ. Car telemetry, created by CSP.
+* ``AcTools.CSP.NewBehaviour.CustomAI.SimState.v0`` — pause / restart / collision control.
+
+The CRITICAL design split (so CI on any OS can verify the byte layout with zero AC / zero
+Windows): the dataclasses and ``pack`` / ``parse`` helpers are **pure** ``struct`` code,
+importable and testable everywhere. The Windows-only ctypes mmap plumbing
+(:class:`CustomAIController`, :class:`SimStateController`) is pragma-guarded.
+
+OFFSETS — LIVE-VERIFIED 2026-06-16 (Magione, Porsche 911 GT3 R, CSP Custom AI hijack of car 0).
+The control offsets we actually drive with (gas@0, brake@4, clutch@8, steer@12, gear_up@20,
+gear_dn@21, autoclutch_on_start@41, autoclutch_on_change@42, teleport_to@40) and the Car<N>
+read offsets (gear@28, rpm@32, speed_kmh@36, look@64, position@88) were confirmed against
+``acpmf_physics`` ground truth and by observing the car drive a full clean lap. Two caveats from
+that verification: (1) **``spline_position`` (DATA_SPLINE_POSITION_OFFSET=448) reads GARBAGE**
+(values like -5..+10, not 0..1) — do NOT trust it; use ``acpmf_graphics`` ``normalizedCarPosition``
+/ position-return for lap progress instead. (2) The engine only drives the wheels when the car is
+in a real gear (AC ``gear`` encoding: **0=Reverse, 1=NEUTRAL, 2=1st**) AND ``autoclutch_on_start``
++ ``autoclutch_on_change`` are set; a manually-written clutch value FIGHTS the autoclutch and kills
+drive, so leave ``clutch`` at 0. See the vault investigation
+``03_Investigations/autonomous-drive-live-verified-2026-06-16.md``. Offsets not on the drive path
+(DRS/KERS/teleport_pos/teleport_dir/autoshift, and the full Car<N> wheel/damage block) remain
+doc-extracted (``VERIFY LIVE``) until exercised.
+
+ctypes discipline (the #175 oracle's hard-won lesson): every kernel32 call has
+``restype`` and ``argtypes`` declared, or a 64-bit handle / pointer silently overflows the
+default C ``int`` and raises ``OverflowError``. Section names are wide strings
+(``c_wchar_p``). For WRITING a *new* section we use ``CreateFileMappingW`` (the controls
+section must exist for CSP to notice it) rather than ``OpenFileMappingW``; the read side
+opens-existing-only so it returns ``None`` until CSP has created ``Car<N>.v0``.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from dataclasses import dataclass
+
+# Reuse the canonical exception from the read-side oracle rather than defining a second,
+# distinct class: a caller catching ``SharedMemoryUnavailable`` around either the reader or
+# this writer then catches both. (Two same-named classes from two modules silently fail to
+# match across an ``except`` boundary — the #175 footgun in a different guise.)
+from tools.ac_harness.shared_memory import SharedMemoryUnavailable
+
+# ---------------------------------------------------------------------------
+# Section-name templates. ``<N>`` is the car index; 0 == the player car. The external app
+# CREATES CarControls<N>; CSP creates Car<N> in response. SimState is a single global.
+# ---------------------------------------------------------------------------
+CAR_CONTROLS_NAME_TEMPLATE = "AcTools.CSP.NewBehaviour.CustomAI.CarControls{index}.v0"
+CAR_DATA_NAME_TEMPLATE = "AcTools.CSP.NewBehaviour.CustomAI.Car{index}.v0"
+SIM_STATE_NAME = "AcTools.CSP.NewBehaviour.CustomAI.SimState.v0"
+
+# ---------------------------------------------------------------------------
+# cai_car_controls layout (WRITE — what we feed CSP to drive the car).  VERIFY LIVE: every
+# offset below is doc-extracted from the Custom AI page and UNCONFIRMED against a live CSP
+# build. We allocate a generous, zero-filled buffer (CONTROLS_BUFFER_BYTES) so that fields
+# we do not set read as 0/false and an offset that is slightly off cannot run past the map.
+# ---------------------------------------------------------------------------
+CTRL_GAS_OFFSET = 0  # f32, 0..1            VERIFY LIVE
+CTRL_BRAKE_OFFSET = 4  # f32, 0..1          VERIFY LIVE
+CTRL_CLUTCH_OFFSET = 8  # f32, 0..1         VERIFY LIVE
+CTRL_STEER_OFFSET = 12  # f32, -1..1        VERIFY LIVE
+CTRL_HANDBRAKE_OFFSET = 16  # f32, 0..1     VERIFY LIVE
+CTRL_GEAR_UP_OFFSET = 20  # bool (1 byte)   VERIFY LIVE
+CTRL_GEAR_DN_OFFSET = 21  # bool (1 byte)   VERIFY LIVE
+CTRL_DRS_OFFSET = 22  # bool (1 byte)       VERIFY LIVE
+CTRL_KERS_OFFSET = 23  # bool (1 byte)      VERIFY LIVE
+CTRL_TELEPORT_TO_OFFSET = 40  # byte: 0=none, 1=pits, 2=custom (teleport_pos/dir)  VERIFY LIVE
+CTRL_AUTOCLUTCH_ON_START_OFFSET = 41  # bool (1 byte)   VERIFY LIVE
+CTRL_AUTOCLUTCH_ON_CHANGE_OFFSET = 42  # bool (1 byte)  VERIFY LIVE
+CTRL_AUTOBLIP_OFFSET = 43  # bool (1 byte)              VERIFY LIVE
+CTRL_TELEPORT_POS_OFFSET = 44  # float3 (x, y, z)       VERIFY LIVE
+CTRL_TELEPORT_DIR_OFFSET = 56  # float3 (x, y, z)       VERIFY LIVE
+CTRL_AUTOSHIFT_ACTIVE_OFFSET = 68  # bool (1 byte)      VERIFY LIVE
+
+# teleport_to byte values.
+TELEPORT_NONE = 0
+TELEPORT_TO_PITS = 1
+TELEPORT_TO_CUSTOM = 2
+
+# Generous zero-filled buffer for the controls section (doc recommends >= the struct size;
+# 256 bytes leaves headroom past autoshift_active@68 for any field we have not modelled).
+CONTROLS_BUFFER_BYTES = 256
+
+# ---------------------------------------------------------------------------
+# cai_car_data layout (READ — car state CSP publishes for the hijacked car).  VERIFY LIVE:
+# doc-extracted, UNCONFIRMED. We map CAR_DATA_BUFFER_BYTES and parse only the fields the
+# harness needs; the rest of the documented struct (wheels[4], damage, lap times, …) is left
+# unparsed until a live build confirms the layout.
+# ---------------------------------------------------------------------------
+DATA_PACKET_ID_OFFSET = 0  # i32                         VERIFY LIVE
+DATA_GAS_OFFSET = 4  # f32                               VERIFY LIVE
+DATA_BRAKE_OFFSET = 8  # f32                             VERIFY LIVE
+DATA_CLUTCH_OFFSET = 12  # f32                           VERIFY LIVE
+DATA_STEER_OFFSET = 16  # f32 (degrees)                  VERIFY LIVE
+DATA_HANDBRAKE_OFFSET = 20  # f32                        VERIFY LIVE
+DATA_FUEL_OFFSET = 24  # f32                             VERIFY LIVE
+DATA_GEAR_OFFSET = 28  # i32                             VERIFY LIVE
+DATA_RPM_OFFSET = 32  # f32                              VERIFY LIVE
+DATA_SPEED_KMH_OFFSET = 36  # f32                        VERIFY LIVE
+DATA_VELOCITY_OFFSET = 40  # float3                      VERIFY LIVE
+DATA_LOOK_OFFSET = 64  # float3 (forward unit vector)    VERIFY LIVE
+DATA_POSITION_OFFSET = 88  # float3 (world x, y, z)      VERIFY LIVE
+DATA_SPLINE_POSITION_OFFSET = 448  # f32 — WRONG/GARBAGE LIVE (read -5..+10, not 0..1). DO NOT
+# USE. Kept only to document the bad offset; lap progress comes from acpmf_graphics
+# normalizedCarPosition / position-return. TODO(#190): find the real offset or drop this field.
+
+# Bytes that must be readable to decode every field we parse (spline_position + its 4 bytes).
+CAR_DATA_MIN_BYTES = DATA_SPLINE_POSITION_OFFSET + 4  # 452
+# Doc says allocate 512 to read the full struct; we map that so an offset that is slightly
+# off (pre-verification) still lands inside the mapped view rather than over-reading.
+CAR_DATA_BUFFER_BYTES = 512
+
+# ---------------------------------------------------------------------------
+# SimState layout (sim control).  VERIFY LIVE.
+#   bool pause@0, bool restart_session@1, bool disable_collisions@2, byte extra_sleep_ms@3
+# ---------------------------------------------------------------------------
+SIM_PAUSE_OFFSET = 0  # bool (1 byte)               VERIFY LIVE
+SIM_RESTART_SESSION_OFFSET = 1  # bool (1 byte)      VERIFY LIVE
+SIM_DISABLE_COLLISIONS_OFFSET = 2  # bool (1 byte)   VERIFY LIVE
+SIM_EXTRA_SLEEP_MS_OFFSET = 3  # byte                VERIFY LIVE
+SIM_STATE_BUFFER_BYTES = 16  # tiny struct; map a small zero-filled buffer
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    """Clamp ``value`` to ``[low, high]``.
+
+    CSP applies controls verbatim; an out-of-range gas/steer would be undefined behaviour
+    for the physics, so we clamp at the boundary the same way an in-game axis would saturate.
+    """
+    return low if value < low else high if value > high else value
+
+
+@dataclass(frozen=True)
+class CarControls:
+    """The control inputs we write to ``CarControls<N>`` to drive the car.
+
+    Floats are saturating (gas/brake/clutch/handbrake to ``0..1``, steer to ``-1..1``) so a
+    caller passing a slightly out-of-range value gets the same clamped behaviour a physical
+    axis would. ``teleport_to`` selects pits (:data:`TELEPORT_TO_PITS`) or a custom position
+    (:data:`TELEPORT_TO_CUSTOM`, using ``teleport_pos``); ``teleport_pos`` is ignored unless
+    ``teleport_to == TELEPORT_TO_CUSTOM``.
+    """
+
+    gas: float = 0.0
+    brake: float = 0.0
+    clutch: float = 0.0
+    steer: float = 0.0
+    handbrake: float = 0.0
+    gear_up: bool = False
+    gear_dn: bool = False
+    autoclutch_on_start: bool = False
+    autoclutch_on_change: bool = False
+    teleport_to: int = TELEPORT_NONE
+    teleport_pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+    def pack(self) -> bytes:
+        """Serialise into a zero-filled :data:`CONTROLS_BUFFER_BYTES` buffer at the offsets.
+
+        Every byte not written by a field stays 0 (the buffer is zero-filled), so unset
+        controls — clutch, the autoclutch/autoblip flags, teleport_dir — read as 0/false on
+        the CSP side. Floats are little-endian (Windows x86-64); bools are a single ``0x01`` /
+        ``0x00`` byte.
+        """
+        buf = bytearray(CONTROLS_BUFFER_BYTES)
+        struct.pack_into("<f", buf, CTRL_GAS_OFFSET, _clamp(self.gas, 0.0, 1.0))
+        struct.pack_into("<f", buf, CTRL_BRAKE_OFFSET, _clamp(self.brake, 0.0, 1.0))
+        struct.pack_into("<f", buf, CTRL_CLUTCH_OFFSET, _clamp(self.clutch, 0.0, 1.0))
+        struct.pack_into("<f", buf, CTRL_STEER_OFFSET, _clamp(self.steer, -1.0, 1.0))
+        struct.pack_into("<f", buf, CTRL_HANDBRAKE_OFFSET, _clamp(self.handbrake, 0.0, 1.0))
+        struct.pack_into("<?", buf, CTRL_GEAR_UP_OFFSET, self.gear_up)
+        struct.pack_into("<?", buf, CTRL_GEAR_DN_OFFSET, self.gear_dn)
+        struct.pack_into("<?", buf, CTRL_AUTOCLUTCH_ON_START_OFFSET, self.autoclutch_on_start)
+        struct.pack_into("<?", buf, CTRL_AUTOCLUTCH_ON_CHANGE_OFFSET, self.autoclutch_on_change)
+        struct.pack_into("<B", buf, CTRL_TELEPORT_TO_OFFSET, self.teleport_to & 0xFF)
+        px, py, pz = self.teleport_pos
+        struct.pack_into("<3f", buf, CTRL_TELEPORT_POS_OFFSET, px, py, pz)
+        return bytes(buf)
+
+
+@dataclass(frozen=True)
+class CarData:
+    """The subset of ``Car<N>`` car-state fields the harness decodes (UNVERIFIED offsets)."""
+
+    packet_id: int
+    gear: int
+    rpm: float
+    speed_kmh: float
+    position: tuple[float, float, float]
+    look: tuple[float, float, float]
+    spline_position: float
+
+    def as_dict(self) -> dict[str, object]:
+        """Flat dict for the L1.5 probe / diag (mirrors the WS-tap frame shape)."""
+        return {
+            "packet_id": self.packet_id,
+            "gear": self.gear,
+            "rpm": self.rpm,
+            "speed_kmh": self.speed_kmh,
+            "position": self.position,
+            "look": self.look,
+            "spline_position": self.spline_position,
+        }
+
+
+def parse_car_data(buf: bytes) -> CarData:
+    """Decode a ``Car<N>`` byte buffer into a :class:`CarData` (pure, platform-independent).
+
+    ``buf`` must be at least :data:`CAR_DATA_MIN_BYTES`. Integers/floats are little-endian
+    (Windows x86-64). Offsets are UNVERIFIED — see the module docstring.
+    """
+    if len(buf) < CAR_DATA_MIN_BYTES:
+        raise ValueError(f"cai_car_data buffer too short: {len(buf)} < {CAR_DATA_MIN_BYTES} bytes")
+    packet_id = struct.unpack_from("<i", buf, DATA_PACKET_ID_OFFSET)[0]
+    gear = struct.unpack_from("<i", buf, DATA_GEAR_OFFSET)[0]
+    rpm = struct.unpack_from("<f", buf, DATA_RPM_OFFSET)[0]
+    speed_kmh = struct.unpack_from("<f", buf, DATA_SPEED_KMH_OFFSET)[0]
+    position = struct.unpack_from("<3f", buf, DATA_POSITION_OFFSET)
+    look = struct.unpack_from("<3f", buf, DATA_LOOK_OFFSET)
+    spline_position = struct.unpack_from("<f", buf, DATA_SPLINE_POSITION_OFFSET)[0]
+    return CarData(
+        packet_id=packet_id,
+        gear=gear,
+        rpm=rpm,
+        speed_kmh=speed_kmh,
+        position=position,
+        look=look,
+        spline_position=spline_position,
+    )
+
+
+@dataclass(frozen=True)
+class SimState:
+    """Sim-control flags written to the global ``SimState`` section."""
+
+    pause: bool = False
+    restart_session: bool = False
+    disable_collisions: bool = False
+    extra_sleep_ms: int = 0
+
+    def pack(self) -> bytes:
+        """Serialise into a zero-filled :data:`SIM_STATE_BUFFER_BYTES` buffer."""
+        buf = bytearray(SIM_STATE_BUFFER_BYTES)
+        struct.pack_into("<?", buf, SIM_PAUSE_OFFSET, self.pause)
+        struct.pack_into("<?", buf, SIM_RESTART_SESSION_OFFSET, self.restart_session)
+        struct.pack_into("<?", buf, SIM_DISABLE_COLLISIONS_OFFSET, self.disable_collisions)
+        struct.pack_into("<B", buf, SIM_EXTRA_SLEEP_MS_OFFSET, self.extra_sleep_ms & 0xFF)
+        return bytes(buf)
+
+
+def car_controls_name(car_index: int) -> str:
+    """Name of the WRITE (controls) section for ``car_index`` (0 == player)."""
+    return CAR_CONTROLS_NAME_TEMPLATE.format(index=car_index)
+
+
+def car_data_name(car_index: int) -> str:
+    """Name of the READ (car-state) section CSP creates for ``car_index`` (0 == player)."""
+    return CAR_DATA_NAME_TEMPLATE.format(index=car_index)
+
+
+# ---------------------------------------------------------------------------
+# Windows-only ctypes mmap plumbing (not exercised by CI; validated on the rig).
+#
+# WRITE side uses CreateFileMappingW(INVALID_HANDLE_VALUE, …) to CREATE a page-file-backed
+# named section: CSP only hijacks the car once the CarControls<N> section EXISTS, so we must
+# create it, not open it. READ side uses OpenFileMappingW (open-existing-only) so it returns
+# None until CSP has created Car<N> in response — mirroring shared_memory.py's opener.
+# ---------------------------------------------------------------------------
+def _kernel32():  # pragma: no cover - rig-only
+    """A kernel32 handle with ALL used functions' argtypes/restype declared.
+
+    Mandatory on 64-bit: without argtypes ctypes defaults each argument to C ``int`` and a
+    64-bit handle / mapped address overflows it (``OverflowError: int too long to convert``).
+    ``restype = HANDLE / LPVOID`` (both ``c_void_p``) makes ctypes hand back a Python ``int``
+    for a valid pointer and ``None`` for NULL, so ``if handle`` / ``if not address`` is the
+    correct portable NULL check. Mirrors ``shared_memory._kernel32`` exactly, plus the
+    create/write functions this module additionally needs.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    k = ctypes.WinDLL("kernel32", use_last_error=True)
+    # CreateFileMappingW(hFile, lpAttributes, flProtect, dwMaxHi, dwMaxLo, lpName) -> HANDLE.
+    k.CreateFileMappingW.restype = wintypes.HANDLE
+    k.CreateFileMappingW.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPCWSTR,
+    ]
+    k.OpenFileMappingW.restype = wintypes.HANDLE
+    k.OpenFileMappingW.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.LPCWSTR]
+    k.MapViewOfFile.restype = wintypes.LPVOID
+    k.MapViewOfFile.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_size_t,
+    ]
+    k.UnmapViewOfFile.restype = wintypes.BOOL
+    k.UnmapViewOfFile.argtypes = [wintypes.LPCVOID]
+    k.CloseHandle.restype = wintypes.BOOL
+    k.CloseHandle.argtypes = [wintypes.HANDLE]
+    return k
+
+
+class _WritableSection:  # pragma: no cover - Windows ctypes view; validated on the rig
+    """A read/write view of a Windows named section we CREATED (held until :meth:`close`)."""
+
+    def __init__(self, handle: object, address: object, length: int) -> None:
+        self._handle = handle
+        self._address = address
+        self._length = length
+
+    def write(self, data: bytes) -> None:
+        import ctypes
+
+        if len(data) > self._length:
+            raise ValueError(f"write {len(data)} > mapped {self._length} bytes")
+        ctypes.memmove(self._address, data, len(data))
+
+    def close(self) -> None:
+        if self._address is None and self._handle is None:
+            return
+        kernel32 = _kernel32()
+        if self._address is not None:
+            kernel32.UnmapViewOfFile(self._address)
+            self._address = None
+        if self._handle is not None:
+            kernel32.CloseHandle(self._handle)
+            self._handle = None
+
+
+class _ReadableSection:  # pragma: no cover - Windows ctypes view; validated on the rig
+    """A read view of an EXISTING Windows named section (held until :meth:`close`)."""
+
+    def __init__(self, handle: object, address: object, length: int) -> None:
+        self._handle = handle
+        self._address = address
+        self._length = length
+
+    def read(self, n: int) -> bytes:
+        import ctypes
+
+        if n > self._length:
+            raise ValueError(f"read {n} > mapped {self._length} bytes")
+        return ctypes.string_at(self._address, n)
+
+    def close(self) -> None:
+        if self._address is None and self._handle is None:
+            return
+        kernel32 = _kernel32()
+        if self._address is not None:
+            kernel32.UnmapViewOfFile(self._address)
+            self._address = None
+        if self._handle is not None:
+            kernel32.CloseHandle(self._handle)
+            self._handle = None
+
+
+def _create_writable_section(name: str, length: int) -> _WritableSection:  # pragma: no cover - rig
+    """Create a new page-file-backed named section, mapped read/write (Windows only).
+
+    ``INVALID_HANDLE_VALUE`` (-1) backs the section by the page file rather than a real file;
+    ``PAGE_READWRITE`` (0x04) + ``FILE_MAP_WRITE`` (0x02) gives us a writable view. If the
+    section already exists (e.g. a prior crashed run), ``CreateFileMappingW`` returns a handle
+    to it — which is fine; we just remap and overwrite.
+    """
+    import ctypes
+
+    if sys.platform != "win32":
+        raise SharedMemoryUnavailable(
+            f"Custom-AI section ({name!r}) is Windows-only; this is {sys.platform!r}"
+        )
+    invalid_handle_value = ctypes.c_void_p(-1)
+    page_readwrite = 0x04
+    file_map_write = 0x02
+    kernel32 = _kernel32()
+
+    handle = kernel32.CreateFileMappingW(
+        invalid_handle_value, None, page_readwrite, 0, length, name
+    )
+    if not handle:
+        raise SharedMemoryUnavailable(
+            f"CreateFileMappingW failed for {name!r}: WinError {ctypes.get_last_error()}"
+        )
+    address = kernel32.MapViewOfFile(handle, file_map_write, 0, 0, length)
+    if not address:
+        err = ctypes.get_last_error()
+        kernel32.CloseHandle(handle)
+        raise SharedMemoryUnavailable(f"MapViewOfFile (write) failed for {name!r}: WinError {err}")
+    return _WritableSection(handle, address, length)
+
+
+def _open_readable_section(name: str, length: int) -> _ReadableSection | None:  # pragma: no cover
+    """Open an EXISTING named section read-only, or return ``None`` if it does not exist.
+
+    Tries the bare ``name`` then ``Local\\<name>`` (same logon-session namespace), mirroring
+    ``shared_memory._win_open_existing``. Returns ``None`` (not raising) when the section is
+    absent, because the Car<N> section legitimately does not exist until CSP has created it in
+    response to our CarControls<N> — its absence is the "not hijacked yet" signal, not an
+    error.
+    """
+    import ctypes
+
+    if sys.platform != "win32":
+        raise SharedMemoryUnavailable(
+            f"Custom-AI section ({name!r}) is Windows-only; this is {sys.platform!r}"
+        )
+    file_map_read = 0x0004
+    kernel32 = _kernel32()
+
+    handle = None
+    for tag in (name, f"Local\\{name}"):
+        handle = kernel32.OpenFileMappingW(file_map_read, False, tag)
+        if handle:
+            break
+    if not handle:
+        return None  # CSP has not created Car<N> yet — not hijacked.
+    address = kernel32.MapViewOfFile(handle, file_map_read, 0, 0, length)
+    if not address:
+        err = ctypes.get_last_error()
+        kernel32.CloseHandle(handle)
+        raise SharedMemoryUnavailable(f"MapViewOfFile (read) failed for {name!r}: WinError {err}")
+    return _ReadableSection(handle, address, length)
+
+
+class CustomAIController:  # pragma: no cover - Windows/rig-only; validated against live AC
+    """Drives one car via the CSP Custom-AI mmap interface (Windows only).
+
+    Constructing this CREATES the ``CarControls<N>`` section — the act that hijacks the car;
+    keep the instance alive for the whole drive (closing it releases the section and hands the
+    car back). :meth:`read_car_data` opens ``Car<N>`` lazily and returns ``None`` until CSP has
+    created it (confirming the hijack landed). Context manager; releases both sections on exit.
+    """
+
+    def __init__(self, car_index: int = 0) -> None:
+        self.car_index = car_index
+        self._controls = _create_writable_section(
+            car_controls_name(car_index), CONTROLS_BUFFER_BYTES
+        )
+        self._car_data: _ReadableSection | None = None
+
+    def write_controls(
+        self,
+        gas: float,
+        brake: float,
+        steer: float,
+        *,
+        handbrake: float = 0.0,
+        clutch: float = 0.0,
+        gear_up: bool = False,
+        gear_dn: bool = False,
+        autoclutch_on_start: bool = False,
+        autoclutch_on_change: bool = False,
+    ) -> None:
+        """Write one frame of controls. Call at ~333 Hz (≈3 ms) for smooth driving.
+
+        ``autoclutch_on_start`` lets CSP manage the launch clutch from a standstill (without it the
+        car-setup autoclutch holds the clutch disengaged and the engine free-revs with no drive);
+        ``autoclutch_on_change`` does the same across gear changes.
+        """
+        controls = CarControls(
+            gas=gas,
+            brake=brake,
+            steer=steer,
+            handbrake=handbrake,
+            clutch=clutch,
+            gear_up=gear_up,
+            gear_dn=gear_dn,
+            autoclutch_on_start=autoclutch_on_start,
+            autoclutch_on_change=autoclutch_on_change,
+        )
+        self._controls.write(controls.pack())
+
+    def teleport_to_pits(self) -> None:
+        """Write a one-frame teleport-to-pits command (``teleport_to == TELEPORT_TO_PITS``)."""
+        self._controls.write(CarControls(teleport_to=TELEPORT_TO_PITS).pack())
+
+    def read_car_data(self) -> dict[str, object] | None:
+        """Read CSP's car-state for this car, or ``None`` until ``Car<N>`` exists (not hijacked).
+
+        Opens the read section lazily on first success and caches it; while the section is
+        absent it keeps returning ``None`` so a caller can poll for the hijack to land.
+        """
+        if self._car_data is None:
+            self._car_data = _open_readable_section(
+                car_data_name(self.car_index), CAR_DATA_BUFFER_BYTES
+            )
+            if self._car_data is None:
+                return None
+        return parse_car_data(self._car_data.read(CAR_DATA_MIN_BYTES)).as_dict()
+
+    def close(self) -> None:
+        """Release both sections — releasing ``CarControls<N>`` hands the car back to AC."""
+        if self._car_data is not None:
+            self._car_data.close()
+            self._car_data = None
+        self._controls.close()
+
+    def __enter__(self) -> CustomAIController:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+class SimStateController:  # pragma: no cover - Windows/rig-only; validated against live AC
+    """Pause / restart-session / disable-collisions via the global ``SimState`` section.
+
+    Like :class:`CustomAIController`, constructing it CREATES the section; keep it alive while
+    you need sim control. Context manager; releases the section on exit.
+    """
+
+    def __init__(self) -> None:
+        self._section = _create_writable_section(SIM_STATE_NAME, SIM_STATE_BUFFER_BYTES)
+
+    def write_state(
+        self,
+        *,
+        pause: bool = False,
+        restart_session: bool = False,
+        disable_collisions: bool = False,
+        extra_sleep_ms: int = 0,
+    ) -> None:
+        """Write the full SimState flag set in one frame."""
+        self._section.write(
+            SimState(
+                pause=pause,
+                restart_session=restart_session,
+                disable_collisions=disable_collisions,
+                extra_sleep_ms=extra_sleep_ms,
+            ).pack()
+        )
+
+    def pause(self, paused: bool = True) -> None:
+        """Pause (or unpause) the sim."""
+        self.write_state(pause=paused)
+
+    def restart_session(self) -> None:
+        """Request a session restart (one-frame pulse)."""
+        self.write_state(restart_session=True)
+
+    def disable_collisions(self, disabled: bool = True) -> None:
+        """Disable (or re-enable) collisions for the hijacked car."""
+        self.write_state(disable_collisions=disabled)
+
+    def close(self) -> None:
+        self._section.close()
+
+    def __enter__(self) -> SimStateController:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/tools/ac_harness/custom_ai.py
+++ b/tools/ac_harness/custom_ai.py
@@ -263,14 +263,22 @@ class SimState:
         return bytes(buf)
 
 
+def _validate_car_index(car_index: int) -> int:
+    """Reject a negative ``car_index`` early. Otherwise it silently produces an invalid section
+    name (e.g. ``CarControls-1.v0``) that fails later in a non-obvious way (CodeRabbit)."""
+    if car_index < 0:
+        raise ValueError(f"car_index must be >= 0 (0 == player car), got {car_index}")
+    return car_index
+
+
 def car_controls_name(car_index: int) -> str:
     """Name of the WRITE (controls) section for ``car_index`` (0 == player)."""
-    return CAR_CONTROLS_NAME_TEMPLATE.format(index=car_index)
+    return CAR_CONTROLS_NAME_TEMPLATE.format(index=_validate_car_index(car_index))
 
 
 def car_data_name(car_index: int) -> str:
     """Name of the READ (car-state) section CSP creates for ``car_index`` (0 == player)."""
-    return CAR_DATA_NAME_TEMPLATE.format(index=car_index)
+    return CAR_DATA_NAME_TEMPLATE.format(index=_validate_car_index(car_index))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ac_harness/lap_driver.py
+++ b/tools/ac_harness/lap_driver.py
@@ -1,0 +1,282 @@
+"""Autonomous lap driver — orchestrates :mod:`ai_line` (where to go) and :mod:`custom_ai`
+(how to actuate) into a car that drives clean laps of a real track with no human.
+
+This is the orchestration keystone of EPIC #154 Part E (#190). :class:`PurePursuit` gives a
+steering/throttle frame for following the racing line, but a real drive also needs: shifting out
+of neutral and managing gears, getting **out of the pit box** when the car spawns/resets there
+(pure pursuit alone full-locks in place off-line), detecting lap completion without the unreliable
+``cai_car_data`` spline (LIVE-VERIFIED garbage; see :mod:`custom_ai`), and recovering from a stuck
+state. :class:`LapDriver` folds those into one controller.
+
+Design mirrors the rest of ``ac_harness``: the decision logic is **pure and deterministic**
+(:meth:`LapDriver.step` takes the live pose + clock and returns a control frame; no mmap, no real
+clock, no Assetto Corsa) so CI verifies it on any OS with synthetic inputs, exactly like
+:class:`ai_line.PurePursuit`. The Windows-only run loop (:meth:`LapDriver.run`) that wires it to a
+:class:`custom_ai.CustomAIController` at ~80 Hz is pragma-guarded and validated on the rig — it was
+proven over a 30-minute continuous zero-crash drive of Magione.
+
+Live-verified behaviour baked in (2026-06-16, Porsche 911 GT3 R at Magione):
+* AC ``gear`` encoding is **0=Reverse, 1=NEUTRAL, 2=1st** — so "in gear" means ``gear >= 2``.
+* The launch needs ``autoclutch_on_start`` + ``autoclutch_on_change`` (the controller always sets
+  them); a manually-written clutch fights the autoclutch, so we never touch it.
+* ``steer > 0`` turns the car right (matches :class:`ai_line.PurePursuit`).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from tools.ac_harness.ai_line import ControlOutput, PurePursuit, _horizontal
+
+# Phases. OUT = getting from the pit box / off-line back onto the racing line; LAP = following it.
+PHASE_OUT = "OUT"
+PHASE_LAP = "LAP"
+
+
+@dataclass(frozen=True)
+class DriveFrame:
+    """One decision from :meth:`LapDriver.step` — a control frame plus harness signals.
+
+    ``gas`` / ``brake`` ``0..1``, ``steer`` ``-1..1`` (>0 = right). ``gear_up`` / ``gear_dn`` are
+    one-frame shift pulses. ``phase`` is :data:`PHASE_OUT` / :data:`PHASE_LAP`. ``lap_completed``
+    is True on the single frame a full lap closes (position-return). ``needs_recovery`` is True
+    when the car has been stuck (slow while asking for throttle) past the threshold — the run loop
+    answers it with a teleport-to-pits.
+    """
+
+    gas: float
+    brake: float
+    steer: float
+    gear_up: bool
+    gear_dn: bool
+    phase: str
+    lap_completed: bool
+    needs_recovery: bool
+
+
+def _planar_nearest_distance_m(
+    pursuit: PurePursuit, position_xyz: tuple[float, float, float]
+) -> float:
+    """Planar (x, z) distance from ``position_xyz`` to the closest racing-line point, in metres."""
+    car = _horizontal(position_xyz)
+    idx = pursuit.nearest_index(car)
+    px, pz = pursuit._plane[idx]
+    return math.hypot(px - car[0], pz - car[1])
+
+
+class LapDriver:
+    """Drive one car around ``fast_line`` from any starting state (pits, off-line, on-line).
+
+    Pure tuning + state; feed live telemetry to :meth:`step`. ``merge_distance_m`` is how close to
+    the line (and ``merge_speed_kmh`` how fast) the car must be to switch OUT→LAP. In OUT the steer
+    is clamped to ``out_steer_clamp`` and gas floored to ``out_gas`` so the car drives *forward* out
+    of the box instead of full-locking in place. Gears: shift up out of neutral and above
+    ``rpm_up`` (capped at ``max_gear``), down below ``rpm_dn``. Lap completion is position-return:
+    a lap closes when the car has travelled ``min_lap_m`` and is back within ``return_radius_m`` of
+    the lap-start anchor (``cai_car_data`` spline is unusable — see module docstring).
+    """
+
+    def __init__(
+        self,
+        fast_line: list[tuple[float, float, float]],
+        *,
+        lookahead_m: float = 10.0,
+        target_speed_kmh: float = 50.0,
+        min_corner_speed_kmh: float = 26.0,
+        max_steer_curvature: float = 0.16,
+        curvature_lookahead_m: float = 38.0,
+        merge_distance_m: float = 9.0,
+        merge_speed_kmh: float = 10.0,
+        out_steer_clamp: float = 0.35,
+        out_gas: float = 0.30,
+        rpm_up: float = 7800.0,
+        rpm_dn: float = 3200.0,
+        max_gear: int = 3,
+        shift_cooldown_s: float = 0.35,
+        stuck_speed_kmh: float = 3.0,
+        stuck_seconds: float = 5.0,
+        min_lap_m: float = 1800.0,
+        return_radius_m: float = 12.0,
+    ) -> None:
+        self.pursuit = PurePursuit(
+            fast_line,
+            lookahead_m=lookahead_m,
+            target_speed_kmh=target_speed_kmh,
+            min_corner_speed_kmh=min_corner_speed_kmh,
+            max_steer_curvature=max_steer_curvature,
+            curvature_lookahead_m=curvature_lookahead_m,
+        )
+        self.merge_distance_m = merge_distance_m
+        self.merge_speed_kmh = merge_speed_kmh
+        self.out_steer_clamp = out_steer_clamp
+        self.out_gas = out_gas
+        self.rpm_up = rpm_up
+        self.rpm_dn = rpm_dn
+        self.max_gear = max_gear
+        self.shift_cooldown_s = shift_cooldown_s
+        self.stuck_speed_kmh = stuck_speed_kmh
+        self.stuck_seconds = stuck_seconds
+        self.min_lap_m = min_lap_m
+        self.return_radius_m = return_radius_m
+
+        # Mutable run state.
+        self.phase = PHASE_OUT
+        self._last_shift_s = -1e9
+        self._stuck_since: float | None = None
+        self._lap_anchor: tuple[float, float] | None = None
+        self._lap_distance_m = 0.0
+        self._prev_plane: tuple[float, float] | None = None
+
+    def _gear_pulse(self, rpm: float, gear: int, speed_kmh: float, now: float) -> tuple[bool, bool]:
+        """Decide a one-frame shift. Shift out of neutral (gear<2), up past ``rpm_up`` (while
+        moving, capped at ``max_gear``), down past ``rpm_dn`` (only while rolling and above 1st).
+        Rate-limited by ``shift_cooldown_s`` so one rising edge is one shift."""
+        if now - self._last_shift_s <= self.shift_cooldown_s:
+            return (False, False)
+        if gear < 2:
+            self._last_shift_s = now
+            return (True, False)
+        if rpm > self.rpm_up and gear < self.max_gear and speed_kmh > 20.0:
+            self._last_shift_s = now
+            return (True, False)
+        if rpm < self.rpm_dn and gear > 2 and speed_kmh > 5.0:
+            self._last_shift_s = now
+            return (False, True)
+        return (False, False)
+
+    def _accumulate_lap(self, car_plane: tuple[float, float]) -> bool:
+        """Track distance travelled + position-return lap closure. Returns True the frame a lap
+        closes. Anchored at the first LAP-phase position; resets the anchor on closure."""
+        if self._lap_anchor is None:
+            self._lap_anchor = car_plane
+            self._lap_distance_m = 0.0
+            self._prev_plane = car_plane
+            return False
+        if self._prev_plane is not None:
+            self._lap_distance_m += math.hypot(
+                car_plane[0] - self._prev_plane[0], car_plane[1] - self._prev_plane[1]
+            )
+        self._prev_plane = car_plane
+        if self._lap_distance_m >= self.min_lap_m:
+            back = math.hypot(
+                car_plane[0] - self._lap_anchor[0], car_plane[1] - self._lap_anchor[1]
+            )
+            if back <= self.return_radius_m:
+                self._lap_anchor = car_plane
+                self._lap_distance_m = 0.0
+                return True
+        return False
+
+    def step(
+        self,
+        position_xyz: tuple[float, float, float],
+        look_dir_xyz: tuple[float, float, float],
+        speed_kmh: float,
+        rpm: float,
+        gear: int,
+        now: float,
+    ) -> DriveFrame:
+        """Pure: one control decision from the live pose + monotonic clock ``now`` (seconds)."""
+        dist_to_line = _planar_nearest_distance_m(self.pursuit, position_xyz)
+
+        if (
+            self.phase == PHASE_OUT
+            and dist_to_line < self.merge_distance_m
+            and speed_kmh > self.merge_speed_kmh
+        ):
+            self.phase = PHASE_LAP
+
+        out: ControlOutput = self.pursuit.control(position_xyz, look_dir_xyz, speed_kmh)
+        gas, brake, steer = out.gas, out.brake, out.steer
+        if self.phase == PHASE_OUT:
+            gas = max(gas, self.out_gas)
+            brake = 0.0
+            steer = max(-self.out_steer_clamp, min(self.out_steer_clamp, steer))
+
+        gear_up, gear_dn = self._gear_pulse(rpm, gear, speed_kmh, now)
+
+        needs_recovery = False
+        if speed_kmh < self.stuck_speed_kmh and gas > 0.4:
+            if self._stuck_since is None:
+                self._stuck_since = now
+            elif now - self._stuck_since > self.stuck_seconds:
+                needs_recovery = True
+        else:
+            self._stuck_since = None
+
+        lap_completed = (
+            self._accumulate_lap(_horizontal(position_xyz)) if self.phase == PHASE_LAP else False
+        )
+
+        return DriveFrame(
+            gas=gas,
+            brake=brake,
+            steer=steer,
+            gear_up=gear_up,
+            gear_dn=gear_dn,
+            phase=self.phase,
+            lap_completed=lap_completed,
+            needs_recovery=needs_recovery,
+        )
+
+    def on_recovery(self) -> None:
+        """Reset transient state after the run loop teleports the car to pits — re-enter OUT and
+        clear the stuck timer and the lap anchor (the car is no longer on its lap)."""
+        self.phase = PHASE_OUT
+        self._stuck_since = None
+        self._lap_anchor = None
+        self._lap_distance_m = 0.0
+        self._prev_plane = None
+
+    def run(self, controller, *, seconds: float, on_lap=None):  # pragma: no cover - rig-only
+        """Drive ``controller`` (a :class:`custom_ai.CustomAIController`) for ``seconds`` at ~80 Hz.
+
+        Pulls the live pose from ``controller.read_car_data()``, feeds :meth:`step`, writes the
+        frame, and on ``needs_recovery`` teleports to pits and re-enters OUT. Calls ``on_lap(n)``
+        on each completed lap. Returns the completed-lap count. Windows/rig-only.
+        """
+        import time
+
+        laps = 0
+        t0 = time.time()
+        try:
+            while time.time() - t0 < seconds:
+                cd = controller.read_car_data()
+                if not cd:
+                    time.sleep(0.02)
+                    continue
+                frame = self.step(
+                    cd["position"],
+                    cd["look"],
+                    cd["speed_kmh"],
+                    cd["rpm"],
+                    cd["gear"],
+                    time.time() - t0,
+                )
+                if frame.needs_recovery:
+                    for _ in range(5):
+                        controller.teleport_to_pits()
+                        time.sleep(0.1)
+                    time.sleep(0.8)
+                    self.on_recovery()
+                    continue
+                controller.write_controls(
+                    frame.gas,
+                    frame.brake,
+                    frame.steer,
+                    gear_up=frame.gear_up,
+                    gear_dn=frame.gear_dn,
+                    autoclutch_on_start=True,
+                    autoclutch_on_change=True,
+                )
+                if frame.lap_completed:
+                    laps += 1
+                    if on_lap is not None:
+                        on_lap(laps)
+                time.sleep(0.012)
+        finally:
+            for _ in range(20):
+                controller.write_controls(0.0, 0.6, 0.0)
+                time.sleep(0.05)
+        return laps

--- a/tools/ac_harness/lap_driver.py
+++ b/tools/ac_harness/lap_driver.py
@@ -96,6 +96,7 @@ class LapDriver:
         shift_cooldown_s: float = 0.35,
         stuck_speed_kmh: float = 3.0,
         stuck_seconds: float = 5.0,
+        stuck_throttle: float = 0.1,
         min_lap_m: float = 1800.0,
         return_radius_m: float = 12.0,
     ) -> None:
@@ -117,6 +118,7 @@ class LapDriver:
         self.shift_cooldown_s = shift_cooldown_s
         self.stuck_speed_kmh = stuck_speed_kmh
         self.stuck_seconds = stuck_seconds
+        self.stuck_throttle = stuck_throttle
         self.min_lap_m = min_lap_m
         self.return_radius_m = return_radius_m
 
@@ -196,8 +198,11 @@ class LapDriver:
 
         gear_up, gear_dn = self._gear_pulse(rpm, gear, speed_kmh, now)
 
+        # Stuck = barely moving while we are commanding meaningful throttle. The threshold must sit
+        # BELOW out_gas (OUT-phase floors gas at 0.30) and the PurePursuit zero-look creep (0.30),
+        # or a car stuck in OUT phase would never trip recovery (Bugbot).
         needs_recovery = False
-        if speed_kmh < self.stuck_speed_kmh and gas > 0.4:
+        if speed_kmh < self.stuck_speed_kmh and gas > self.stuck_throttle:
             if self._stuck_since is None:
                 self._stuck_since = now
             elif now - self._stuck_since > self.stuck_seconds:
@@ -239,9 +244,11 @@ class LapDriver:
         import time
 
         laps = 0
-        t0 = time.time()
+        # monotonic(): immune to wall-clock/NTP jumps that would corrupt elapsed-time + the
+        # stuck/cooldown timers fed to step() (CodeRabbit).
+        t0 = time.monotonic()
         try:
-            while time.time() - t0 < seconds:
+            while time.monotonic() - t0 < seconds:
                 cd = controller.read_car_data()
                 if not cd:
                     time.sleep(0.02)
@@ -252,7 +259,7 @@ class LapDriver:
                     cd["speed_kmh"],
                     cd["rpm"],
                     cd["gear"],
-                    time.time() - t0,
+                    time.monotonic() - t0,
                 )
                 if frame.needs_recovery:
                     for _ in range(5):


### PR DESCRIPTION
Closes part of #190 (EPIC #154 Part E). The **actuation keystone** of the autonomous self-test: drives car 0 in Assetto Corsa with **no human** via CSP's Custom-AI external-control mmap, plus a pure-pursuit controller on Kunos's `fast_lane.ai`.

## Live-verified end to end (2026-06-16)
The agent drove a **full clean lap of Magione** (no human at the wheel) with this code, and the AC Copilot Trainer **captured a reference lap and coached the car in real time**. Full evidence + verified facts in the vault: `03_Investigations/autonomous-drive-live-verified-2026-06-16.md` (#196). Status posted to [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154).

## What's here
- **`tools/ac_harness/custom_ai.py`** — `cai_car_controls` writer + `cai_car_data` reader. Pure `struct` pack/parse (CI-testable on any OS) + pragma-guarded Windows ctypes mmap plumbing. `CustomAIController` creates `CarControls<N>` (the act that hijacks the car); CSP creates `Car<N>` in response (non-None `read_car_data` == hijack confirmed). `teleport_to_pits()` reset; `SimStateController` pause/restart. **Control + Car0 offsets LIVE-VERIFIED** against `acpmf_physics` and an observed full lap.
- **`tools/ac_harness/ai_line.py`** — `load_ai_line()` (fast_lane.ai v7 parser) + `PurePursuit` (line + pose → gas/brake/steer). Steer sign **verified live** (steer>0 = right). Pure/deterministic — CI verifies the geometry with synthetic lines.
- **42 pure unit tests** (17 custom_ai + 25 ai_line), green locally (`ruff format`/`check` clean, `pytest` 42 passed). `__init__` exports the actuator API.

## Verified facts baked into the code/docstrings
- AC `gear`: **0=Reverse, 1=NEUTRAL, 2=1st**; launch needs gear≥2 + `autoclutch_on_start`+`autoclutch_on_change` (leave `clutch` 0 — a manual value fights the autoclutch).
- `teleport_to@40=1` = pits = the safe reset (`restart_session` is poison — opens an un-dismissable AC menu).
- `Car0` `pos@88`/`look@64`/`gear@28`/`rpm@32`/`speed@36` == physics. **`spline_position@448` reads GARBAGE — flagged, do not use.**

## Draft — follow-ups before ready
- [ ] Promote the `.scratch` lap-driver orchestration (gear mgmt + **pit-out** + **position-return lap detection**, proven over a 30-min zero-crash run) into a module + tests.
- [ ] Resolve `spline_position` (find real offset or drop the field).
- [ ] Flip remaining per-constant `VERIFY LIVE` markers to VERIFIED for the on-drive-path offsets.

Refs #154, #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)