### PR TITLE
fix(ci): remove PyYAML dependency from PR pain allowlist

### DIFF
--- a/.github/workflows/pr-pain-detection.yml
+++ b/.github/workflows/pr-pain-detection.yml
@@ -121,38 +121,9 @@ jobs:
           SOURCE_REPO: ${{ steps.resolve.outputs.repo }}
         run: |
           set -euo pipefail
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          # PyYAML is preinstalled on ubuntu-latest runners; if it ever
-          # disappears (alternate runner image, fork running this on a
-          # custom-runner repo, etc.) fail loudly per repo
-          # `errors-silent-fallbacks` policy. Auto-`pip install` would
-          # introduce network variability into a workflow path designed
-          # to be deterministic — Qodo round-15 finding.
-          import os, sys, pathlib, json
-          try:
-              import yaml
-          except ImportError:
-              print(
-                  "::error::PyYAML is required for the allowlist parser but not "
-                  "installed on this runner. On ubuntu-latest it ships in the "
-                  "default Python; on alternate images add `pip install pyyaml` "
-                  "to a setup step before this job (do NOT silently install it "
-                  "here — keep this workflow deterministic).",
-                  file=sys.stderr,
-              )
-              raise SystemExit(1)
-          cfg_path = pathlib.Path(".github/pr-pain-config.yml")
-          if not cfg_path.exists():
-              print("enabled=false")
-              print("dry_run=false")
-              raise SystemExit(0)
-          cfg = yaml.safe_load(cfg_path.read_text()) or {}
-          repo = os.environ["SOURCE_REPO"]
-          enabled = repo in (cfg.get("enabled_repos") or [])
-          dry_run = repo in (cfg.get("dry_run_repos") or [])
-          print(f"enabled={'true' if enabled else 'false'}")
-          print(f"dry_run={'true' if dry_run else 'false'}")
-          PY
+          python3 -m tools.pr_pain.config \
+            --config .github/pr-pain-config.yml \
+            --repo "$SOURCE_REPO" >> "$GITHUB_OUTPUT"
 
       - name: Score PR
         id: score

--- a/tests/test_pr_pain.py
+++ b/tests/test_pr_pain.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from tools.pr_pain import config as pain_config
 from tools.pr_pain import file_issue, pain_score
 
 # ---------------------------------------------------------------------------
@@ -821,6 +822,39 @@ def test_load_extra_bots_merges_yaml_into_known_set(
     assert pain_score._is_bot("coderabbitai", None) is True
     # Unknown logins still treated as human.
     assert pain_score._is_bot("regular-human", "User") is False
+
+
+def test_load_pain_config_parses_workflow_allowlists_without_pyyaml(tmp_path: Path) -> None:
+    cfg = tmp_path / "pr-pain-config.yml"
+    cfg.write_text(
+        """
+enabled_repos:
+  - agorokh/template-repo
+  # - agorokh/disabled-repo
+dry_run_repos: [agorokh/ac-copilot-trainer]
+extra_bot_logins:
+  - Exotic-Review-Bot
+""",
+        encoding="utf-8",
+    )
+
+    parsed = pain_config.load_pain_config(cfg)
+
+    assert parsed["enabled_repos"] == frozenset({"agorokh/template-repo"})
+    assert parsed["dry_run_repos"] == frozenset({"agorokh/ac-copilot-trainer"})
+    assert parsed["extra_bot_logins"] == frozenset({"Exotic-Review-Bot"})
+
+
+def test_pain_config_main_emits_github_outputs(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    cfg = tmp_path / "pr-pain-config.yml"
+    cfg.write_text("enabled_repos: []\ndry_run_repos:\n  - agorokh/ac-copilot-trainer\n")
+
+    rc = pain_config.main(["--config", str(cfg), "--repo", "agorokh/ac-copilot-trainer"])
+
+    assert rc == 0
+    assert capsys.readouterr().out == "enabled=false\ndry_run=true\n"
 
 
 def test_load_extra_bots_handles_missing_or_malformed_config(

--- a/tools/pr_pain/config.py
+++ b/tools/pr_pain/config.py
@@ -1,0 +1,107 @@
+"""Read the PR pain workflow config without a runtime PyYAML dependency."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_LIST_KEYS = frozenset({"enabled_repos", "dry_run_repos", "extra_bot_logins"})
+PainConfig = dict[str, frozenset[str]]
+
+
+def _strip_comment(line: str) -> str:
+    return line.split("#", 1)[0].rstrip()
+
+
+def _clean_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value.strip()
+
+
+def _parse_inline_list(raw_value: str, *, line_no: int) -> list[str]:
+    value = raw_value.strip()
+    if value == "[]":
+        return []
+    if not (value.startswith("[") and value.endswith("]")):
+        raise ValueError(f"line {line_no}: expected an inline list like [item] or a block list")
+    body = value[1:-1].strip()
+    if not body:
+        return []
+    return [item for item in (_clean_scalar(part) for part in body.split(",")) if item]
+
+
+def parse_pain_config(text: str) -> PainConfig:
+    """Parse the simple top-level list schema used by pr-pain-config.yml.
+
+    This deliberately supports only the config shape owned by the workflow:
+    top-level list keys with either ``key: []`` / ``key: [a, b]`` or block list
+    values. Unknown keys are ignored so future config can be added safely.
+    """
+    parsed: dict[str, list[str]] = {key: [] for key in _LIST_KEYS}
+    current_key: str | None = None
+
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        line = _strip_comment(raw_line)
+        if not line.strip():
+            continue
+
+        if line[0].isspace():
+            if current_key is None:
+                continue
+            item = line.strip()
+            if not item.startswith("-"):
+                raise ValueError(f"line {line_no}: expected '- value' list item")
+            value = _clean_scalar(item[1:])
+            if value:
+                parsed[current_key].append(value)
+            continue
+
+        if ":" not in line:
+            raise ValueError(f"line {line_no}: expected 'key: value'")
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        raw_value = raw_value.strip()
+        if key not in _LIST_KEYS:
+            current_key = None
+            continue
+        if raw_value:
+            parsed[key] = _parse_inline_list(raw_value, line_no=line_no)
+            current_key = None
+        else:
+            parsed[key] = []
+            current_key = key
+
+    return {key: frozenset(values) for key, values in parsed.items()}
+
+
+def load_pain_config(config_path: str | Path = ".github/pr-pain-config.yml") -> PainConfig:
+    path = Path(config_path)
+    if not path.is_file():
+        return {key: frozenset() for key in _LIST_KEYS}
+    return parse_pain_config(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit GitHub Actions outputs for PR pain allowlist state."
+    )
+    parser.add_argument("--config", default=".github/pr-pain-config.yml")
+    parser.add_argument("--repo", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_pain_config(args.config)
+    except ValueError as exc:
+        print(f"::error::Invalid PR pain config: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"enabled={'true' if args.repo in config['enabled_repos'] else 'false'}")
+    print(f"dry_run={'true' if args.repo in config['dry_run_repos'] else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via workflow.
+    raise SystemExit(main())

--- a/tools/pr_pain/pain_score.py
+++ b/tools/pr_pain/pain_score.py
@@ -73,29 +73,18 @@ _known_bots_cache: frozenset[str] | None = None
 def _load_extra_bots(config_path: str = _DEFAULT_PAIN_CONFIG) -> frozenset[str]:
     """Return the `extra_bot_logins` set from `.github/pr-pain-config.yml`.
 
-    Empty set if the file is absent, malformed, or PyYAML isn't installed —
-    the caller transparently falls back to ``_BUILTIN_KNOWN_BOTS`` so the
-    function never raises during scoring. Bot detection inflates score by
-    3x per missed bot (0.1 → 0.3 weight), so making this list extensible
-    without a code change is a maintainability win.
+    Empty set if the file is absent or malformed; the caller transparently
+    falls back to ``_BUILTIN_KNOWN_BOTS`` so the function never raises during
+    scoring. Bot detection inflates score by 3x per missed bot (0.1 → 0.3
+    weight), so making this list extensible without a code change is a
+    maintainability win.
     """
     try:
-        import yaml  # type: ignore[import-not-found]
-    except ImportError:
-        return frozenset()
-    from pathlib import Path as _Path
+        from tools.pr_pain.config import load_pain_config
 
-    p = _Path(config_path)
-    if not p.is_file():
+        return frozenset(bot.lower() for bot in load_pain_config(config_path)["extra_bot_logins"])
+    except (OSError, ValueError):
         return frozenset()
-    try:
-        data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
-    except yaml.YAMLError:
-        return frozenset()
-    extras = data.get("extra_bot_logins") if isinstance(data, dict) else None
-    if not isinstance(extras, list):
-        return frozenset()
-    return frozenset(str(x).lower() for x in extras if isinstance(x, str))
 
 
 def _known_bots() -> frozenset[str]:


### PR DESCRIPTION
## Summary
- replace the PR pain allowlist workflow's inline PyYAML parser with a repo-local parser for the owned config shape
- reuse the parser for extra bot login loading so scoring no longer needs PyYAML for config reads
- add focused coverage for allowlist parsing and GitHub Actions output emission

## Why
The post-merge PR pain detection run for PR #198 failed in the allowlist step because the runner's Python 3.11 environment did not include PyYAML. This keeps the workflow deterministic without adding a network install step.

## Verification
- make ci-fast PYTHON=/Users/arseny_gorokh/.codex/worktrees/issue-179/ac-copilot-trainer/.venv/bin/python
- python -m tools.pr_pain.config --config .github/pr-pain-config.yml --repo agorokh/ac-copilot-trainer
