### PR TITLE
docs(vault): post-merge handoff for PR #214

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:14:30Z
+last_updated: 2026-06-16T09:19:15Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -65,6 +65,7 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-16** — PR [#214](https://github.com/agorokh/ac-copilot-trainer/pull/214) **MERGED** at `3e9c927` — removed the PyYAML runtime dependency from the PR-pain allowlist gate after PR #198 exposed a failing post-merge `score` run. Adds `tools/pr_pain/config.py`, routes `.github/workflows/pr-pain-detection.yml` through it, and reuses it for `extra_bot_logins`. Classification: `.github/workflows/` changed; post-merge `PR pain detection / score` succeeded on the merge commit. Active focus remains #190.
 - **2026-06-16** — PR [#200](https://github.com/agorokh/ac-copilot-trainer/pull/200) **MERGED** at `ee25118` — detect-and-retry AC entry launcher; closes [#177](https://github.com/agorokh/ac-copilot-trainer/issues/177). Adds `tools/ac_harness/entry_launcher.py`, a pluggable `EntryLauncher`, default `ColdRestartActuator`, atomic `race.ini` `SPAWN_SET=PIT` normalization, retry/relaunch loop around `DrivingEntryDetector`, and CLI timing knobs. Classification: no post-merge flags. Mac-side verification is complete; live Windows/AC rig verification remains the next runtime smoke. Active focus remains #190.
 - **2026-06-16** — PR [#207](https://github.com/agorokh/ac-copilot-trainer/pull/207) **MERGED** at `0c637e3` — MoTeC CSV reference-lap importer plus opt-in imported-reference activation; closes [#79](https://github.com/agorokh/ac-copilot-trainer/issues/79). Imported laps write schema-v1 `source="imported"` / `import_format="motec_csv"` archive JSON and can drive realtime coaching only when faster than the local PB, without overwriting local PB persistence. Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#203](https://github.com/agorokh/ac-copilot-trainer/pull/203) **MERGED** at `e5103be` — sidecar physical-peripheral protocol (`telemetry_tick`, `haptic_event`), derived haptic cues, haptics/screen routing, signed slip, partial tyre maps, legacy `ac-copilot-screen-*` classification; closes [#118](https://github.com/agorokh/ac-copilot-trainer/issues/118). No migration/env/deps/script/workflow post-merge flags; active focus remains #190.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:14:30Z
+last_updated: 2026-06-16T09:19:15Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -26,6 +26,12 @@ relates_to:
 ---
 
 # Next session handoff
+
+## What was delivered (2026-06-16 — PR #214 PR-pain PyYAML-free allowlist follow-up)
+
+**PR [#214](https://github.com/agorokh/ac-copilot-trainer/pull/214) MERGED** `2026-06-16T09:18:15Z` as squash [`3e9c927`](https://github.com/agorokh/ac-copilot-trainer/commit/3e9c9277d867c52b6f78e8b61fe8b437895f9691). This was an owned follow-up from the #179 closeout: PR #198's post-merge `PR pain detection / score` job failed because GitHub's Python 3.11 runner did not include PyYAML. The workflow now calls `python3 -m tools.pr_pain.config` instead of importing PyYAML inline, using a repo-local parser for the owned `.github/pr-pain-config.yml` top-level list shape. `tools.pr_pain.pain_score._load_extra_bots` reuses the same parser for `extra_bot_logins`.
+
+**Verification:** local `make ci-fast PYTHON=/Users/arseny_gorokh/.codex/worktrees/issue-179/ac-copilot-trainer/.venv/bin/python` passed (`920 passed, 74 skipped`, coverage 81.10%). GitHub checks on PR #214 were green (`build`, `Canonical docs exist`, `conformance`, CodeRabbit, Cursor Bugbot; Sourcery/Gemini/Codex review bots were quota-limited as comments only). GraphQL `reviewThreads` returned no nodes. The real post-merge proof also passed: PR #214's merge-triggered `PR pain detection / score` run succeeded on Ubuntu 24.04 / Python 3.11 and logged the expected allowlist skip for `agorokh/ac-copilot-trainer` without PyYAML. Post-merge classification: `.github/workflows/` changed; review triggers/permissions/secrets touched only by replacing the allowlist parser call. **Focus remains #190**.
 
 ## What was delivered (2026-06-16 — #177 / PR #200 detect-and-retry entry launcher)
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #214.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).