### PR TITLE
docs(vault): post-merge handoff for PR #205

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:19:15Z
+last_updated: 2026-06-16T09:36:28Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -65,6 +65,7 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-16** — PR [#205](https://github.com/agorokh/ac-copilot-trainer/pull/205) **MERGED** at `6d0ddc8` — generated reference-lap prototype for [#116](https://github.com/agorokh/ac-copilot-trainer/issues/116). Adds stdlib-only `tools.ac_harness.reference_lap`, schema-v1 `generated_reference_v1` archive emission, trainer-state bridge preserving driver PBs, validator hardening, and ADR [`rl-reference-lap-generation`](../01_Decisions/rl-reference-lap-generation.md) deferring RL runtime dependencies. Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#214](https://github.com/agorokh/ac-copilot-trainer/pull/214) **MERGED** at `3e9c927` — removed the PyYAML runtime dependency from the PR-pain allowlist gate after PR #198 exposed a failing post-merge `score` run. Adds `tools/pr_pain/config.py`, routes `.github/workflows/pr-pain-detection.yml` through it, and reuses it for `extra_bot_logins`. Classification: `.github/workflows/` changed; post-merge `PR pain detection / score` succeeded on the merge commit. Active focus remains #190.
 - **2026-06-16** — PR [#200](https://github.com/agorokh/ac-copilot-trainer/pull/200) **MERGED** at `ee25118` — detect-and-retry AC entry launcher; closes [#177](https://github.com/agorokh/ac-copilot-trainer/issues/177). Adds `tools/ac_harness/entry_launcher.py`, a pluggable `EntryLauncher`, default `ColdRestartActuator`, atomic `race.ini` `SPAWN_SET=PIT` normalization, retry/relaunch loop around `DrivingEntryDetector`, and CLI timing knobs. Classification: no post-merge flags. Mac-side verification is complete; live Windows/AC rig verification remains the next runtime smoke. Active focus remains #190.
 - **2026-06-16** — PR [#207](https://github.com/agorokh/ac-copilot-trainer/pull/207) **MERGED** at `0c637e3` — MoTeC CSV reference-lap importer plus opt-in imported-reference activation; closes [#79](https://github.com/agorokh/ac-copilot-trainer/issues/79). Imported laps write schema-v1 `source="imported"` / `import_format="motec_csv"` archive JSON and can drive realtime coaching only when faster than the local PB, without overwriting local PB persistence. Classification: no post-merge flags. Active focus remains #190.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -27,6 +27,18 @@ relates_to:
 
 # Next session handoff
 
+## What was delivered (2026-06-16 — #116 / PR #205 generated reference-lap prototype)
+
+**[#116](https://github.com/agorokh/ac-copilot-trainer/issues/116) CLOSED / PR [#205](https://github.com/agorokh/ac-copilot-trainer/pull/205) MERGED** `2026-06-16T09:34:53Z` as squash [`6d0ddc8`](https://github.com/agorokh/ac-copilot-trainer/commit/6d0ddc845570ca973b9a2d88cce20dda4def4a30). The repo now has a stdlib-only generated reference-lap adapter, `python -m tools.ac_harness.reference_lap`, that emits lap archive schema v1 records with `source="imported"` / `import_format="generated_reference_v1"` and can also emit a trainer-state persistence fragment for `bestReferenceLapMs`, `bestLapTrace`, `bestBrakePoints`, and `bestCornerFeatures` while preserving the driver's `bestLapMs`.
+
+**Decision captured:** [`01_Decisions/rl-reference-lap-generation`](../01_Decisions/rl-reference-lap-generation.md) chooses deterministic/off-sim generated references now and defers RL runtime dependencies (TUMFTM/CommonRoad/Gym/SB3) until there is a proven importer path and real acceptance need. Future solver output should enter through the same object-frame list passed to `build_archive_record`, not leak solver schemas into the trainer.
+
+**Review hardening shipped before merge:** generated brake windows include unreleased braking tails; the bridge no longer overwrites driver PBs; the validator requires `corners`, rejects `lap.lap_ms` / final-trace `eMs` mismatches, and keeps `trailBrakeRatio` aligned with live `corner_analysis` (`avgBrake / maxBrake`).
+
+**Verification:** local focused `tests/test_reference_lap.py` passed (`10 passed`); full merged-branch local `make ci-fast PYTHON=.venv/bin/python` passed (`929 passed, 75 skipped`, coverage 81.32%); GitHub checks on PR #205 were green on the merged head (`build`, `Canonical docs exist`, `conformance`, CodeRabbit, Cursor Bugbot; Sourcery skipped). GraphQL `reviewThreads` showed every thread resolved before merge. Generated artifact smoke emitted both archive JSON and trainer-state JSON under `.scratch/`. Post-merge classification: no migration/env/deps/script/workflow flags.
+
+**Runtime caveat:** this is intentionally off-sim and does not prove an RL agent or external optimizer can produce a faster lap in AC. The next real integration step is an importer/activation path that consumes generated archive records the same way PR #207 consumes MoTeC imports. Active focus remains #190 / carcsw productionization.
+
 ## What was delivered (2026-06-16 — #188 / PR #199 defensive wrap-shaped teleport reset)
 
 **[#199](https://github.com/agorokh/ac-copilot-trainer/pull/199) MERGED** `2026-06-16T09:31:34Z` as squash [`f03dea6`](https://github.com/agorokh/ac-copilot-trainer/commit/f03dea6c094fefee947d52b7a7b38b7172833d2d). This is the defensive code branch for [#188](https://github.com/agorokh/ac-copilot-trainer/issues/188): CSP builds lacking `car.resetCounter` now defer wrap-shaped same-lap spline rewinds by one frame instead of treating them as definitely-normal lap wraps.


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #205.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).