### PR TITLE
docs(vault): post-merge handoff for PR #202

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:36:28Z
+last_updated: 2026-06-16T09:41:26Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -65,6 +65,7 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-16** — PR [#202](https://github.com/agorokh/ac-copilot-trainer/pull/202) **MERGED** at `d71bca3` — closed [#156](https://github.com/agorokh/ac-copilot-trainer/issues/156) by removing `scripts/` `sys.path` pollution from hook/manifest tests and adding `tools.testing.script_imports`, a path-aware file loader with sibling-script support that does not expose `scripts/mcp` as a namespace package. Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#205](https://github.com/agorokh/ac-copilot-trainer/pull/205) **MERGED** at `6d0ddc8` — generated reference-lap prototype for [#116](https://github.com/agorokh/ac-copilot-trainer/issues/116). Adds stdlib-only `tools.ac_harness.reference_lap`, schema-v1 `generated_reference_v1` archive emission, trainer-state bridge preserving driver PBs, validator hardening, and ADR [`rl-reference-lap-generation`](../01_Decisions/rl-reference-lap-generation.md) deferring RL runtime dependencies. Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#214](https://github.com/agorokh/ac-copilot-trainer/pull/214) **MERGED** at `3e9c927` — removed the PyYAML runtime dependency from the PR-pain allowlist gate after PR #198 exposed a failing post-merge `score` run. Adds `tools/pr_pain/config.py`, routes `.github/workflows/pr-pain-detection.yml` through it, and reuses it for `extra_bot_logins`. Classification: `.github/workflows/` changed; post-merge `PR pain detection / score` succeeded on the merge commit. Active focus remains #190.
 - **2026-06-16** — PR [#200](https://github.com/agorokh/ac-copilot-trainer/pull/200) **MERGED** at `ee25118` — detect-and-retry AC entry launcher; closes [#177](https://github.com/agorokh/ac-copilot-trainer/issues/177). Adds `tools/ac_harness/entry_launcher.py`, a pluggable `EntryLauncher`, default `ColdRestartActuator`, atomic `race.ini` `SPAWN_SET=PIT` normalization, retry/relaunch loop around `DrivingEntryDetector`, and CLI timing knobs. Classification: no post-merge flags. Mac-side verification is complete; live Windows/AC rig verification remains the next runtime smoke. Active focus remains #190.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -27,6 +27,16 @@ relates_to:
 
 # Next session handoff
 
+## What was delivered (2026-06-16 — #156 / PR #202 optional MCP smoke isolation)
+
+**[#156](https://github.com/agorokh/ac-copilot-trainer/issues/156) CLOSED / PR [#202](https://github.com/agorokh/ac-copilot-trainer/pull/202) MERGED** `2026-06-16T09:38:49Z` as squash [`d71bca3`](https://github.com/agorokh/ac-copilot-trainer/commit/d71bca31f3db221bfc9c78273f84477c6bf372a5). The full local suite without `[knowledge]` no longer fails the optional MCP server smoke because hook/manifest tests no longer leak `scripts/` onto `sys.path` during collection.
+
+**Shipped behavior:** hook and manifest tests now import repo scripts through `tools.testing.script_imports.load_script_module` instead of `sys.path.insert(.../scripts)`. The helper is path-aware, fails closed on module-name/path collisions, and supports same-directory sibling `.py` imports through a temporary meta-path finder without leaving `scripts/` globally visible or exposing `scripts/mcp/` as a top-level namespace package. The current `main` FastMCP availability guard for `tests/test_repo_knowledge/test_mcp_server_import.py` was preserved during rebase.
+
+**Verification:** no-knowledge regression group passed (`70 passed, 3 skipped` across `tests/test_script_imports.py`, hook/manifest tests, and `tests/test_repo_knowledge/`); knowledge-enabled smoke passed with `/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python -m pytest tests/test_repo_knowledge/test_mcp_server_import.py -q` (`1 passed`); final-base local `make ci-fast PYTHON=.scratch/venv-issue156/bin/python` passed (`928 passed, 75 skipped`, coverage 81.16%). GitHub checks on PR #202 were green on the final merged head (`build`, `Canonical docs exist`, `conformance`, CodeRabbit, Cursor Bugbot; Sourcery skipped/rate-limited). GraphQL `reviewThreads` returned no active threads. Post-merge classification: no migration/env/deps/script/workflow flags.
+
+**What remains:** no #156 follow-up is required. Active focus remains #190 / carcsw productionization.
+
 ## What was delivered (2026-06-16 — #116 / PR #205 generated reference-lap prototype)
 
 **[#116](https://github.com/agorokh/ac-copilot-trainer/issues/116) CLOSED / PR [#205](https://github.com/agorokh/ac-copilot-trainer/pull/205) MERGED** `2026-06-16T09:34:53Z` as squash [`6d0ddc8`](https://github.com/agorokh/ac-copilot-trainer/commit/6d0ddc845570ca973b9a2d88cce20dda4def4a30). The repo now has a stdlib-only generated reference-lap adapter, `python -m tools.ac_harness.reference_lap`, that emits lap archive schema v1 records with `source="imported"` / `import_format="generated_reference_v1"` and can also emit a trainer-state persistence fragment for `bestReferenceLapMs`, `bestLapTrace`, `bestBrakePoints`, and `bestCornerFeatures` while preserving the driver's `bestLapMs`.


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #202.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).