### PR TITLE
docs(vault): post-merge handoff for PR #204

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:41:26Z
+last_updated: 2026-06-16T09:47:56Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -65,6 +65,7 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-16** — PR [#204](https://github.com/agorokh/ac-copilot-trainer/pull/204) **MERGED** at `dc93b1b` — closed [#115](https://github.com/agorokh/ac-copilot-trainer/issues/115) with `tools.lap_archive_export`, a streamed lap-archive CSV exporter plus deterministic MoTeC-shaped CSV bridge, documented in [`13_Lap_Archive_Export`](../../../10_Development/13_Lap_Archive_Export.md). Output paths are contained under cwd, invalid laps are skipped by default, mixed MoTeC inputs are rejected, and post-merge classification found no flags. Active focus remains #190.
 - **2026-06-16** — PR [#202](https://github.com/agorokh/ac-copilot-trainer/pull/202) **MERGED** at `d71bca3` — closed [#156](https://github.com/agorokh/ac-copilot-trainer/issues/156) by removing `scripts/` `sys.path` pollution from hook/manifest tests and adding `tools.testing.script_imports`, a path-aware file loader with sibling-script support that does not expose `scripts/mcp` as a namespace package. Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#205](https://github.com/agorokh/ac-copilot-trainer/pull/205) **MERGED** at `6d0ddc8` — generated reference-lap prototype for [#116](https://github.com/agorokh/ac-copilot-trainer/issues/116). Adds stdlib-only `tools.ac_harness.reference_lap`, schema-v1 `generated_reference_v1` archive emission, trainer-state bridge preserving driver PBs, validator hardening, and ADR [`rl-reference-lap-generation`](../01_Decisions/rl-reference-lap-generation.md) deferring RL runtime dependencies. Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#214](https://github.com/agorokh/ac-copilot-trainer/pull/214) **MERGED** at `3e9c927` — removed the PyYAML runtime dependency from the PR-pain allowlist gate after PR #198 exposed a failing post-merge `score` run. Adds `tools/pr_pain/config.py`, routes `.github/workflows/pr-pain-detection.yml` through it, and reuses it for `extra_bot_logins`. Classification: `.github/workflows/` changed; post-merge `PR pain detection / score` succeeded on the merge commit. Active focus remains #190.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:45:00Z
+last_updated: 2026-06-16T09:47:56Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -26,6 +26,16 @@ relates_to:
 ---
 
 # Next session handoff
+
+## What was delivered (2026-06-16 - #115 / PR #204 lap telemetry export)
+
+**[#115](https://github.com/agorokh/ac-copilot-trainer/issues/115) CLOSED / PR [#204](https://github.com/agorokh/ac-copilot-trainer/pull/204) MERGED** `2026-06-16T09:44:11Z` as squash [`dc93b1b`](https://github.com/agorokh/ac-copilot-trainer/commit/dc93b1be5b78ea16067cdfef9ab42a77bf058d62). Archived lap JSON can now be exported with `python -m tools.lap_archive_export`, either as a stable generic CSV or as a deterministic MoTeC-shaped CSV bridge file.
+
+**Shipped behavior:** the exporter streams generic CSV rows from one or more archive files/directories, skips invalid laps by default, supports `--include-invalid`, and writes stable columns covering lap identity plus sample telemetry. `--format motec-csv` emits quoted MoTeC-style metadata/channel/unit/data rows with beacon markers, rejects mixed session/car/track/layout inputs, preserves recorded `lap_ms` where present, and falls back to trace timing when needed. Output writes are constrained to relative paths under the current working directory, reject absolute or escaping paths, and replace the final file through a unique temporary sibling. Usage and MoTeC import caveats live in [`10_Development/13_Lap_Archive_Export`](../../../10_Development/13_Lap_Archive_Export.md).
+
+**Verification:** focused exporter tests passed after final hardening (`12 passed` in `tests/test_lap_archive_export.py`). Full local parity passed on the merged branch with `make ci-fast PYTHON=.venv/bin/python` (`930 passed, 74 skipped`, coverage 81.56%; ruff, bandit, docs policy, root allowlist warnings, CSP API/UI checks all completed). Observed CLI proof produced a 4-row generic CSV and a 3-row MoTeC CSV under `.scratch/issue-115/`; absolute output and `..` escape attempts were rejected without creating files; mixed-session MoTeC input was rejected without a partial output. GitHub checks for PR #204 were green (`build`, `Canonical docs exist`, `conformance`, CodeRabbit, Cursor Bugbot; Sourcery skipped/rate-limited). GraphQL `reviewThreads` audit found no current unresolved blocking threads before merge. Post-merge classification: no migration/env/deps/script/workflow flags.
+
+**What remains:** no #115 follow-up is required. This was an off-sim archive/export utility; no live Windows AC/CSP rig verification is required for the shipped behavior. Active focus remains #190 / carcsw productionization.
 
 ## What was delivered (2026-06-16 — #156 / PR #202 optional MCP smoke isolation)
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #204.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).