### PR TITLE
docs(vault): post-merge handoff for PR #206

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:47:56Z
+last_updated: 2026-06-16T11:13:39Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -65,6 +65,7 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-16** — PR [#206](https://github.com/agorokh/ac-copilot-trainer/pull/206) **MERGED** at `7d87f96` — closed [#114](https://github.com/agorokh/ac-copilot-trainer/issues/114) with setup experiment tracking and suggestions. Adds `tools.ai_sidecar.setup_optimizer`, JSONL experiment rebuild/live recording from lap archives, setup A/B comparison, deterministic expected-improvement suggestion, CLI + v1 websocket frames, Lua store registration/recording, path safety, corrupt-store/missing-dir guards, and docs in [`13_Setup_Experiments`](../../../10_Development/13_Setup_Experiments.md). Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#204](https://github.com/agorokh/ac-copilot-trainer/pull/204) **MERGED** at `dc93b1b` — closed [#115](https://github.com/agorokh/ac-copilot-trainer/issues/115) with `tools.lap_archive_export`, a streamed lap-archive CSV exporter plus deterministic MoTeC-shaped CSV bridge, documented in [`13_Lap_Archive_Export`](../../../10_Development/13_Lap_Archive_Export.md). Output paths are contained under cwd, invalid laps are skipped by default, mixed MoTeC inputs are rejected, and post-merge classification found no flags. Active focus remains #190.
 - **2026-06-16** — PR [#202](https://github.com/agorokh/ac-copilot-trainer/pull/202) **MERGED** at `d71bca3` — closed [#156](https://github.com/agorokh/ac-copilot-trainer/issues/156) by removing `scripts/` `sys.path` pollution from hook/manifest tests and adding `tools.testing.script_imports`, a path-aware file loader with sibling-script support that does not expose `scripts/mcp` as a namespace package. Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#205](https://github.com/agorokh/ac-copilot-trainer/pull/205) **MERGED** at `6d0ddc8` — generated reference-lap prototype for [#116](https://github.com/agorokh/ac-copilot-trainer/issues/116). Adds stdlib-only `tools.ac_harness.reference_lap`, schema-v1 `generated_reference_v1` archive emission, trainer-state bridge preserving driver PBs, validator hardening, and ADR [`rl-reference-lap-generation`](../01_Decisions/rl-reference-lap-generation.md) deferring RL runtime dependencies. Classification: no post-merge flags. Active focus remains #190.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T09:47:56Z
+last_updated: 2026-06-16T11:13:39Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -26,6 +26,16 @@ relates_to:
 ---
 
 # Next session handoff
+
+## What was delivered (2026-06-16 - #114 / PR #206 setup experiment tracking)
+
+**[#114](https://github.com/agorokh/ac-copilot-trainer/issues/114) CLOSED / PR [#206](https://github.com/agorokh/ac-copilot-trainer/pull/206) MERGED** `2026-06-16T11:10:51Z` as squash [`7d87f96`](https://github.com/agorokh/ac-copilot-trainer/commit/7d87f96ea6179d8d39f3610db49678c25752d632). The trainer now has a setup experiment layer: lap archives can be rebuilt into a JSONL experiment store, compared as old-vs-new setup A/B evidence, and queried for deterministic expected-improvement setup suggestions.
+
+**Shipped behavior:** `tools.ai_sidecar.setup_optimizer` extracts schema-v1 lap archives into `journal/setup_experiments/experiments.jsonl`, records live lap archives idempotently, deduplicates rebuilds by `experiment_id`, rejects corrupt stores, and refuses missing lap directories before rewriting any store. The sidecar exposes CLI and v1 websocket surfaces for `setup.experiment.store`, `setup.experiment.record`, `setup.compare`, and `setup.suggest`; blocking file/stat work is offloaded from the async websocket loop and handler failures return structured `{ok:false,error}` frames. Lua registers the canonical store path after the v1 handshake, records newly archived laps, retries failed store registration from `tick()` with backoff, and does not send path-bearing setup frames to non-loopback websocket URLs.
+
+**Verification:** local focused suites passed (`44 passed` across `tests/test_ai_sidecar_external.py`, `tests/test_setup_optimizer.py`, and `tests/test_ws_bridge_hello_handshake.py`; final Lua handshake file `11 passed`). Final local parity after all review hardening passed with `make ci-fast PYTHON=.venv/bin/python` (`935 passed, 74 skipped`, coverage 81.21%; ruff, bandit, docs policy, CSP API/UI checks complete). GitHub checks on PR #206 were green on head `07be4cc` (`build`, `Canonical docs exist`, `conformance`, CodeRabbit, Cursor Bugbot; Sourcery/Gemini quota-limited as comments only). GraphQL `reviewThreads` returned no unresolved non-outdated threads before merge. Post-merge classification: no migration/env/deps/script/workflow flags.
+
+**What remains:** no #114 follow-up is required. This was verified off-sim through CLI, websocket, and Lupa harnesses from macOS; the next Windows/AC rig pass should smoke that real lap archives advance the experiment store and `setup.suggest` returns only after rows exist. Active focus remains #190 / carcsw productionization.
 
 ## What was delivered (2026-06-16 - #115 / PR #204 lap telemetry export)
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #206.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).