### PR TITLE
fix(harness): correct carcsw spline_position offset (live-probed) + package exports (#190)

### DIFF
--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -11,6 +11,7 @@ synthesizer, and the schema-gated mock ``ac``/``car``/``sim`` tables.
 
 from __future__ import annotations
 
+from tools.ac_harness.ai_line import ControlOutput, PurePursuit, load_ai_line
 from tools.ac_harness.custom_ai import (
     CarControls,
     CarData,
@@ -93,4 +94,8 @@ __all__ = [
     # Autonomous lap driver (orchestrates pure-pursuit + actuator into clean laps).
     "DriveFrame",
     "LapDriver",
+    # Racing line loader + pure-pursuit controller.
+    "ControlOutput",
+    "PurePursuit",
+    "load_ai_line",
 ]

--- a/tools/ac_harness/custom_ai.py
+++ b/tools/ac_harness/custom_ai.py
@@ -27,9 +27,10 @@ The control offsets we actually drive with (gas@0, brake@4, clutch@8, steer@12, 
 gear_dn@21, autoclutch_on_start@41, autoclutch_on_change@42, teleport_to@40) and the Car<N>
 read offsets (gear@28, rpm@32, speed_kmh@36, look@64, position@88) were confirmed against
 ``acpmf_physics`` ground truth and by observing the car drive a full clean lap. Two caveats from
-that verification: (1) **``spline_position`` (DATA_SPLINE_POSITION_OFFSET=448) reads GARBAGE**
-(values like -5..+10, not 0..1) — do NOT trust it; use ``acpmf_graphics`` ``normalizedCarPosition``
-/ position-return for lap progress instead. (2) The engine only drives the wheels when the car is
+that verification: (1) **``spline_position``** is now read at the LIVE-PROBED offset 240 (the old
+doc-extracted 448 read garbage); it tracks lap progress 0..1 but stays OFF the drive path — lap
+progress uses ``acpmf_graphics`` ``normalizedCarPosition`` / position-return — so a residual error
+here cannot affect driving. (2) The engine only drives the wheels when the car is
 in a real gear (AC ``gear`` encoding: **0=Reverse, 1=NEUTRAL, 2=1st**) AND ``autoclutch_on_start``
 + ``autoclutch_on_change`` are set; a manually-written clutch value FIGHTS the autoclutch and kills
 drive, so leave ``clutch`` at 0. See the vault investigation
@@ -75,7 +76,11 @@ CTRL_GAS_OFFSET = 0  # f32, 0..1            VERIFY LIVE
 CTRL_BRAKE_OFFSET = 4  # f32, 0..1          VERIFY LIVE
 CTRL_CLUTCH_OFFSET = 8  # f32, 0..1         VERIFY LIVE
 CTRL_STEER_OFFSET = 12  # f32, -1..1        VERIFY LIVE
-CTRL_HANDBRAKE_OFFSET = 16  # f32, 0..1     VERIFY LIVE
+# handbrake: UNVERIFIED — the doc lists it as a BOOL in the bool group (after kers), not an f32 at
+# 16, so bytes 16..19 are doc-unconfirmed. We always write 0.0 (handbrake unused), which drove for
+# hours with no ill effect, so the current pack is empirically harmless; but VERIFY this offset (or
+# rewire to the bool field) before ever commanding a non-zero handbrake.  VERIFY LIVE
+CTRL_HANDBRAKE_OFFSET = 16  # f32, 0..1     VERIFY LIVE (write 0.0 only; see note)
 CTRL_GEAR_UP_OFFSET = 20  # bool (1 byte)   VERIFY LIVE
 CTRL_GEAR_DN_OFFSET = 21  # bool (1 byte)   VERIFY LIVE
 CTRL_DRS_OFFSET = 22  # bool (1 byte)       VERIFY LIVE
@@ -116,12 +121,15 @@ DATA_SPEED_KMH_OFFSET = 36  # f32                        VERIFY LIVE
 DATA_VELOCITY_OFFSET = 40  # float3                      VERIFY LIVE
 DATA_LOOK_OFFSET = 64  # float3 (forward unit vector)    VERIFY LIVE
 DATA_POSITION_OFFSET = 88  # float3 (world x, y, z)      VERIFY LIVE
-DATA_SPLINE_POSITION_OFFSET = 448  # f32 — WRONG/GARBAGE LIVE (read -5..+10, not 0..1). DO NOT
-# USE. Kept only to document the bad offset; lap progress comes from acpmf_graphics
-# normalizedCarPosition / position-return. TODO(#190): find the real offset or drop this field.
+DATA_SPLINE_POSITION_OFFSET = 240  # f32, 0..1 around the lap. LIVE-PROBED 2026-06-16: 448 (the
+# old doc-extracted guess) read garbage (-5..+10); offset 240 tracks lap progress monotonically
+# (0.00 -> 0.24 over a quarter-lap drive). Offsets 360/480 alias the same value. Full 0->1->wrap
+# range not yet exercised, and it stays OFF the drive path (lap progress uses position-return), so
+# a residual error here cannot affect driving.
 
-# Bytes that must be readable to decode every field we parse (spline_position + its 4 bytes).
-CAR_DATA_MIN_BYTES = DATA_SPLINE_POSITION_OFFSET + 4  # 452
+# Bytes that must be readable to decode every field we parse. position@88 (+12) is the furthest
+# *control* field; spline_position@240 (+4) sets the floor. Keep a generous margin.
+CAR_DATA_MIN_BYTES = DATA_SPLINE_POSITION_OFFSET + 4  # 244
 # Doc says allocate 512 to read the full struct; we map that so an offset that is slightly
 # off (pre-verification) still lands inside the mapped view rather than over-reading.
 CAR_DATA_BUFFER_BYTES = 512


### PR DESCRIPTION
Follow-ups to the merged #209, from its review threads + the adversarial verification workflow.

## Changes
- **`spline_position` offset 448 → 240 (live-probed).** A byte-probe drove the car ~¼ lap and scanned `Car0`: the old doc-extracted **448 read garbage (−5..+10)**; **240 tracks lap progress monotonically (0.00 → 0.24)** (360/480 alias it). Stays OFF the drive path (lap progress uses position-return / `acpmf_graphics`), so any residual error can't affect driving. `CAR_DATA_MIN_BYTES` follows (244); the existing parametric parse tests cover the new offset.
- **`handbrake@16` documented as unverified.** The CSP doc lists handbrake as a *bool* in the bool group, not an f32 at 16. We only ever write `0.0` (drove for hours with no ill effect), so the pack is empirically harmless — documented as "VERIFY before commanding non-zero" rather than rewired blindly.
- **Package exports.** `PurePursuit` / `load_ai_line` / `ControlOutput` are now exported from `tools.ac_harness` (closes the `from tools.ac_harness import PurePursuit` gap).

## Verification
61 harness tests pass; ruff clean; package import verified.

## Tracked remaining follow-up (not in this PR)
Clamp the curvature look-ahead window to the line length — a **latent** defect that only affects *closed lines shorter than ~40 m*; real km-scale `fast_lane` tracks never produce one, so it cannot trigger in production.

Refs #154, #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)