### PR TITLE
chore(governance): force governed hook shims to LF on checkout (#190)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
 *.bat text eol=crlf
 *.sh text eol=lf
 *.bash text eol=lf
+
+# Governed governance-hook shims (scripts/hook_*.py) are byte-identity-gated against an LF
+# canonical (tests/test_public_governance_conformance.py pins its sha256). Force LF on checkout so
+# the conformance check passes on Windows too — a CRLF working-tree copy hashes differently and
+# fails the pin locally even though the LF blob (what CI sees) matches.
+scripts/hook_*.py text eol=lf


### PR DESCRIPTION
## What
Adds `scripts/hook_*.py text eol=lf` to `.gitattributes`.

## Why
The governed governance-hook shims are byte-identity-gated against an **LF** canonical (`tests/test_public_governance_conformance.py` pins its sha256 = `d28fab…`). No eol rule covered them, so on Windows they checked out **CRLF** → the conformance test hashed a CRLF copy (`93ecba8…`) and failed the pin **locally**, even though the LF blob CI sees matches. (Verified: `git show HEAD:scripts/hook_memory_gate.py | sha256sum` = `d28fab` = pin; working-tree CRLF copy = `93ecba8`.)

## Effect
LF checkout on every platform. Committed blobs are already LF, so **no shim content changes** and the pin is untouched. Confirmed locally: shims re-check-out as LF (`d28fab`), and `tests/test_public_governance_conformance.py` now **passes on Windows** (was failing). CI (Linux/LF) was always green.

Refs #154, #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure governance hook shim scripts are always checked out with LF line endings to keep their hash stable across platforms.

Build:
- Add .gitattributes rule to enforce LF line endings for governance hook shim Python scripts.

Tests:
- Prevent governance conformance hash pin tests from failing on Windows due to CRLF line endings.

Chores:
- Align governance hook shim handling with repository line-ending policies to avoid platform-specific mismatches.