### PR TITLE
chore: gitignore local artifacts (.tmp, backups, tools/acc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,16 @@ htmlcov/
 # Scratch / local experiments
 .scratch/
 tools/_scratch/
+.tmp/
+
+# Operator-local config backups (e.g. ACC config snapshots) — local data, never committed.
+backups/
+
+# Stray machine-local tooling (e.g. MOZA R3 profile script) — not repo source.
+tools/acc/
+
+# Ephemeral scheduled-tasks lock (local runtime state)
+.claude/scheduled_tasks.lock
 
 # Local backups of pre-shim governance hook bodies (issue #338 hub-and-spoke migration).
 scripts/.governance-vendored-bak/


### PR DESCRIPTION
## Why
These untracked local-only paths weren't gitignored, so they showed up as **~107k lines of "uncommitted" noise** in the working tree / diff view (and made it look like a huge diff vs `main`):
- `.tmp/` (12 MB) — throwaway PR-audit scratch from past sessions (`pr91`/`pr100` review-comment JSON dumps, `sidecar.log`).
- `backups/` — operator-local ACC config snapshots.
- `tools/acc/` — a stray machine-local MOZA R3 profile script.
- `.claude/scheduled_tasks.lock` — ephemeral runtime lock.

None are repo source; none were ever committed.

## Effect
Non-destructive — the files stay on disk; git just stops tracking/showing them. `git status` is now clean except the operator's intentional `.cursor/mcp.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)