### PR TITLE
docs(vault): close #190 — Part E complete (handoff + focus)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T11:13:39Z
+last_updated: 2026-06-16T22:30:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -17,6 +17,8 @@ relates_to:
 # Current focus
 
 **Repo:** ac-copilot-trainer.
+
+**Active focus (2026-06-16):** [#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) **CLOSED** — EPIC [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) Part E (carcsw driver + L1.5 sequence probe + session replay) is on `main` and live-verified. **Next EPIC thread:** Part F harness daemon for full L2 hands-off (operator-gated control channel). Parallel hot path unchanged: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) Parts E–F.
 
 **Infra (2026-05-20):** PR [#111](https://github.com/agorokh/ac-copilot-trainer/pull/111) closed the [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) agent-surface campaign (closeout doc only; five agent SHA alignments deferred). PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) memory-contract cursor rule fix remains on `main`.
 
@@ -65,6 +67,7 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-16** — **#190 CLOSED** — EPIC #154 Part E complete. Merged PRs: [#191](https://github.com/agorokh/ac-copilot-trainer/pull/191) L1.5 probe, [#209](https://github.com/agorokh/ac-copilot-trainer/pull/209)/[#221](https://github.com/agorokh/ac-copilot-trainer/pull/221)/[#222](https://github.com/agorokh/ac-copilot-trainer/pull/222)/[#223](https://github.com/agorokh/ac-copilot-trainer/pull/223) carcsw driver, [#201](https://github.com/agorokh/ac-copilot-trainer/pull/201) session replay for late taps. Live-verified autonomous lap + coaching on Magione. Next EPIC thread: Part F harness daemon.
 - **2026-06-16** — PR [#206](https://github.com/agorokh/ac-copilot-trainer/pull/206) **MERGED** at `7d87f96` — closed [#114](https://github.com/agorokh/ac-copilot-trainer/issues/114) with setup experiment tracking and suggestions. Adds `tools.ai_sidecar.setup_optimizer`, JSONL experiment rebuild/live recording from lap archives, setup A/B comparison, deterministic expected-improvement suggestion, CLI + v1 websocket frames, Lua store registration/recording, path safety, corrupt-store/missing-dir guards, and docs in [`13_Setup_Experiments`](../../../10_Development/13_Setup_Experiments.md). Classification: no post-merge flags. Active focus remains #190.
 - **2026-06-16** — PR [#204](https://github.com/agorokh/ac-copilot-trainer/pull/204) **MERGED** at `dc93b1b` — closed [#115](https://github.com/agorokh/ac-copilot-trainer/issues/115) with `tools.lap_archive_export`, a streamed lap-archive CSV exporter plus deterministic MoTeC-shaped CSV bridge, documented in [`13_Lap_Archive_Export`](../../../10_Development/13_Lap_Archive_Export.md). Output paths are contained under cwd, invalid laps are skipped by default, mixed MoTeC inputs are rejected, and post-merge classification found no flags. Active focus remains #190.
 - **2026-06-16** — PR [#202](https://github.com/agorokh/ac-copilot-trainer/pull/202) **MERGED** at `d71bca3` — closed [#156](https://github.com/agorokh/ac-copilot-trainer/issues/156) by removing `scripts/` `sys.path` pollution from hook/manifest tests and adding `tools.testing.script_imports`, a path-aware file loader with sibling-script support that does not expose `scripts/mcp` as a namespace package. Classification: no post-merge flags. Active focus remains #190.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-16T20:05:00Z
+last_updated: 2026-06-16T22:30:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -26,6 +26,22 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-16 — #190 CLOSED; EPIC #154 Part E complete)
+
+**[#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) CLOSED.** All Part E deliverables are merged on `main` and verified:
+
+| Deliverable | PR(s) | Verification |
+|-------------|-------|--------------|
+| L1.5 WS sequence probe | [#191](https://github.com/agorokh/ac-copilot-trainer/pull/191) (`2f092da`) | 16+ unit tests; **live PASS** on real drive (2026-06-15) |
+| carcsw Custom-AI mmap driver + PurePursuit + LapDriver | [#209](https://github.com/agorokh/ac-copilot-trainer/pull/209), [#221](https://github.com/agorokh/ac-copilot-trainer/pull/221), [#222](https://github.com/agorokh/ac-copilot-trainer/pull/222), [#223](https://github.com/agorokh/ac-copilot-trainer/pull/223) | 61+ pure tests; **live full lap + trainer coaching** on Magione (2026-06-16) — see [`autonomous-drive-live-verified-2026-06-16`](../03_Investigations/autonomous-drive-live-verified-2026-06-16.md) |
+| Session replay for late-attaching L1.5 taps | [#201](https://github.com/agorokh/ac-copilot-trainer/pull/201) (`f6f2ed5`) | Lupa regression (`test_state_subscribe_session_sets_one_shot_replay_request`); in-sim smoke deferred to next rig pass |
+
+**This session (autonomous-deliver):** `make ci-fast` on `main` @ `f6f2ed5` → **935 passed, 74 skipped**, coverage 81%+; focused #190 suites → **114 passed**. Rig SSH from macOS unavailable (no key); live gates already satisfied by prior AG_PC session.
+
+**Next (EPIC #154):** Part F — in-session harness daemon (auto-login + unlocked desktop + AC launch without operator) for full L2 hands-off. Until then, the working loop is: operator launches AC once → agent runs `lap_driver` / `sequence_probe` autonomously. Latent follow-up: live smoke that mid-session `state.subscribe` to `session` triggers replay (low priority; off-sim covered).
+
+---
 
 ## What was delivered (2026-06-16 — EPIC #154 Part E: carcsw driver PRODUCTIONIZED + merged)
 


### PR DESCRIPTION
## Summary
- Closes [#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) in vault memory: Part E (carcsw driver + L1.5 probe + session replay) is merged and verified.
- Refreshes `Next Session Handoff.md` resume block with deliverable table, verification evidence, and next EPIC #154 Part F pointer.
- Updates `Current Focus.md` active focus away from #190 toward Part F harness daemon.

## Verification
- Issue #190 closed on GitHub with merge/verification table.
- `make ci-fast` @ `f6f2ed5`: 935 passed, 74 skipped.
- Focused #190 test suites: 114 passed.

Refs #190

Made with [Cursor](https://cursor.com)