### PR TITLE
feat(harness): Content Manager URL launch actuator for in-session daemon — de-elevated on-track entry (EPIC #154 Part F follow-up)

### DIFF
--- a/tests/test_ac_harness_daemon.py
+++ b/tests/test_ac_harness_daemon.py
@@ -114,6 +114,27 @@ def test_harness_daemon_requires_token() -> None:
         HarnessDaemon(HarnessDaemonConfig(token=""))
 
 
+def test_daemon_default_factory_selects_actuator_by_launch_mode(tmp_path) -> None:
+    from tools.ac_harness.entry_launcher import ColdRestartActuator, ContentManagerActuator
+
+    cm_daemon = HarnessDaemon(
+        HarnessDaemonConfig(
+            token="secret",
+            launch_mode="cm",
+            cm_preset=tmp_path / "drive.cmpreset",
+            cm_exe=tmp_path / "Content Manager.exe",
+        )
+    )
+    cm_launcher = cm_daemon._launcher_factory()
+    assert isinstance(cm_launcher.actuator, ContentManagerActuator)
+
+    acs_daemon = HarnessDaemon(
+        HarnessDaemonConfig(token="secret", launch_mode="acs", acs_exe=tmp_path / "acs.exe")
+    )
+    acs_launcher = acs_daemon._launcher_factory()
+    assert isinstance(acs_launcher.actuator, ColdRestartActuator)
+
+
 def test_serve_forever_shutdown_skips_stop_when_idle(monkeypatch) -> None:
     calls: list[str] = []
     daemon = HarnessDaemon(HarnessDaemonConfig(token="secret"))

--- a/tests/test_ac_harness_daemon.py
+++ b/tests/test_ac_harness_daemon.py
@@ -16,6 +16,7 @@ from tools.ac_harness.daemon import (
     HarnessDaemon,
     HarnessDaemonConfig,
     _extract_bearer_token,
+    _main,
     _token_ok,
     read_status_oracle,
     start_sidecar_process,
@@ -112,6 +113,19 @@ def test_stop_processes_terminates_sidecar_and_acs(monkeypatch) -> None:
 def test_harness_daemon_requires_token() -> None:
     with pytest.raises(ValueError, match="token"):
         HarnessDaemon(HarnessDaemonConfig(token=""))
+
+
+def test_config_default_launch_mode_matches_platform() -> None:
+    import sys
+
+    expected = "cm" if sys.platform == "win32" else "acs"
+    assert HarnessDaemonConfig(token="t").launch_mode == expected
+
+
+def test_cli_cm_mode_requires_preset() -> None:
+    # argparse error() raises SystemExit before constructing/serving the daemon.
+    with pytest.raises(SystemExit):
+        _main(["--token", "t", "--launch-mode", "cm"])
 
 
 def test_daemon_default_factory_selects_actuator_by_launch_mode(tmp_path) -> None:

--- a/tests/test_ac_harness_entry_launcher.py
+++ b/tests/test_ac_harness_entry_launcher.py
@@ -472,6 +472,16 @@ def test_make_actuator_validates_mode(mode: str, kwargs: dict, match: str):
         make_actuator(mode, **kwargs)
 
 
+def test_cli_acs_mode_requires_acs_exe():
+    with pytest.raises(SystemExit):
+        entry_launcher._main(["--launch-mode", "acs"])
+
+
+def test_cli_cm_mode_requires_preset():
+    with pytest.raises(SystemExit):
+        entry_launcher._main(["--launch-mode", "cm"])
+
+
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [

--- a/tests/test_ac_harness_entry_launcher.py
+++ b/tests/test_ac_harness_entry_launcher.py
@@ -369,6 +369,13 @@ def test_content_manager_quick_drive_url_encodes_preset_path():
     assert " " not in url  # no raw spaces survive into the URL
 
 
+def test_content_manager_resolves_relative_preset_to_absolute():
+    # A separate CM process reads presetFile with its own cwd, so it must be absolute.
+    actuator = ContentManagerActuator(preset="drive.cmpreset", cm_exe="cm.exe")
+    assert actuator.preset.is_absolute()
+    assert "drive.cmpreset" in actuator.quick_drive_url()
+
+
 def test_content_manager_launch_spawns_cm_with_url(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
     cm_exe = tmp_path / "Content Manager.exe"
@@ -385,7 +392,7 @@ def test_content_manager_launch_spawns_cm_with_url(monkeypatch, tmp_path: Path):
     event = actuator.launch()
 
     assert event.action == "launch"
-    assert launched == [[str(cm_exe), actuator.quick_drive_url()]]
+    assert launched == [[str(actuator.cm_exe), actuator.quick_drive_url()]]
     assert event.detail == actuator.quick_drive_url()
 
 
@@ -443,7 +450,7 @@ def test_content_manager_relaunch_kills_then_relaunches(monkeypatch, tmp_path: P
     event = actuator.relaunch()
 
     assert killed == [["taskkill", "/IM", "acs.exe", "/F", "/T"]]
-    assert launched == [[str(cm_exe), actuator.quick_drive_url()]]
+    assert launched == [[str(actuator.cm_exe), actuator.quick_drive_url()]]
     assert event.action == "relaunch"
     assert "killed acs.exe" in event.detail
 

--- a/tests/test_ac_harness_entry_launcher.py
+++ b/tests/test_ac_harness_entry_launcher.py
@@ -12,12 +12,15 @@ from tools.ac_harness import entry_launcher
 from tools.ac_harness.entry_launcher import (
     ActuatorEvent,
     ColdRestartActuator,
+    ContentManagerActuator,
     EntryActuator,
     EntryLauncher,
     EntryLauncherConfig,
+    EntryLaunchUnsupported,
     EntryOutcome,
     EntryPhase,
     classify_entry_phase,
+    make_actuator,
     normalize_race_ini_spawn_set,
 )
 from tools.ac_harness.shared_memory import (
@@ -353,6 +356,120 @@ def test_cold_restart_relaunch_reapplies_race_ini_normalization(monkeypatch, tmp
     assert launched == [[str(acs_exe.resolve())]]
     assert event.action == "relaunch"
     assert "SPAWN_SET=PIT" in event.detail
+
+
+def test_content_manager_quick_drive_url_encodes_preset_path():
+    preset = r"C:\Quick Drive\base test.cmpreset"
+    actuator = ContentManagerActuator(preset=preset, cm_exe="cm.exe")
+    url = actuator.quick_drive_url()
+
+    assert url.startswith("acmanager://race/quick?presetFile=")
+    assert "%20" in url  # spaces encoded
+    assert "%3A" in url  # colon encoded
+    assert " " not in url  # no raw spaces survive into the URL
+
+
+def test_content_manager_launch_spawns_cm_with_url(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+    cm_exe = tmp_path / "Content Manager.exe"
+    cm_exe.write_text("", encoding="utf-8")
+    preset = tmp_path / "drive.cmpreset"
+    preset.write_text("{}", encoding="utf-8")
+    launched: list[list[str]] = []
+
+    def popen(cmd, **kwargs):
+        launched.append(cmd)
+        return object()
+
+    actuator = ContentManagerActuator(preset=preset, cm_exe=cm_exe, popen=popen)
+    event = actuator.launch()
+
+    assert event.action == "launch"
+    assert launched == [[str(cm_exe), actuator.quick_drive_url()]]
+    assert event.detail == actuator.quick_drive_url()
+
+
+def test_content_manager_launch_requires_windows(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(entry_launcher.sys, "platform", "linux")
+    actuator = ContentManagerActuator(preset=tmp_path / "x.cmpreset", cm_exe=tmp_path / "cm.exe")
+
+    with pytest.raises(EntryLaunchUnsupported, match="Windows-only"):
+        actuator.launch()
+
+
+def test_content_manager_launch_missing_files(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+    # Missing CM exe.
+    actuator = ContentManagerActuator(
+        preset=tmp_path / "x.cmpreset", cm_exe=tmp_path / "missing.exe"
+    )
+    with pytest.raises(FileNotFoundError, match="Content Manager not found"):
+        actuator.launch()
+
+    # CM present but preset missing.
+    cm_exe = tmp_path / "cm.exe"
+    cm_exe.write_text("", encoding="utf-8")
+    actuator = ContentManagerActuator(preset=tmp_path / "missing.cmpreset", cm_exe=cm_exe)
+    with pytest.raises(FileNotFoundError, match="preset not found"):
+        actuator.launch()
+
+
+def test_content_manager_trigger_drive_unsupported_requests_relaunch():
+    actuator = ContentManagerActuator(preset="x.cmpreset", cm_exe="cm.exe")
+    event = actuator.trigger_drive()
+
+    assert event.supported is False
+    assert "relaunch" in event.detail
+
+
+def test_content_manager_relaunch_kills_then_relaunches(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+    cm_exe = tmp_path / "cm.exe"
+    cm_exe.write_text("", encoding="utf-8")
+    preset = tmp_path / "drive.cmpreset"
+    preset.write_text("{}", encoding="utf-8")
+    killed: list[list[str]] = []
+    launched: list[list[str]] = []
+
+    def runner(cmd, **kwargs):
+        killed.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    def popen(cmd, **kwargs):
+        launched.append(cmd)
+        return object()
+
+    actuator = ContentManagerActuator(preset=preset, cm_exe=cm_exe, runner=runner, popen=popen)
+    event = actuator.relaunch()
+
+    assert killed == [["taskkill", "/IM", "acs.exe", "/F", "/T"]]
+    assert launched == [[str(cm_exe), actuator.quick_drive_url()]]
+    assert event.action == "relaunch"
+    assert "killed acs.exe" in event.detail
+
+
+def test_make_actuator_cm_builds_content_manager_actuator(tmp_path: Path):
+    actuator = make_actuator("cm", cm_preset=tmp_path / "d.cmpreset", cm_exe=tmp_path / "cm.exe")
+    assert isinstance(actuator, ContentManagerActuator)
+    assert actuator.quick_drive_url().startswith("acmanager://race/quick?presetFile=")
+
+
+def test_make_actuator_acs_builds_cold_restart(tmp_path: Path):
+    actuator = make_actuator("acs", acs_exe=tmp_path / "acs.exe")
+    assert isinstance(actuator, ColdRestartActuator)
+
+
+@pytest.mark.parametrize(
+    ("mode", "kwargs", "match"),
+    [
+        ("cm", {}, "cm_preset"),
+        ("acs", {}, "acs_exe"),
+        ("nope", {"cm_preset": "x", "acs_exe": "y"}, "unknown launch_mode"),
+    ],
+)
+def test_make_actuator_validates_mode(mode: str, kwargs: dict, match: str):
+    with pytest.raises(ValueError, match=match):
+        make_actuator(mode, **kwargs)
 
 
 @pytest.mark.parametrize(

--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -23,8 +23,10 @@ from tools.ac_harness.custom_ai import (
     parse_car_data,
 )
 from tools.ac_harness.entry_launcher import (
+    LAUNCH_MODES,
     ActuatorEvent,
     ColdRestartActuator,
+    ContentManagerActuator,
     EntryActuator,
     EntryLauncher,
     EntryLauncherConfig,
@@ -33,6 +35,7 @@ from tools.ac_harness.entry_launcher import (
     EntryOutcome,
     EntryPhase,
     classify_entry_phase,
+    make_actuator,
     normalize_race_ini_spawn_set,
 )
 from tools.ac_harness.lap_driver import DriveFrame, LapDriver
@@ -62,8 +65,10 @@ __all__ = [
     "load_schema",
     "synthesize_trace",
     # L2 detect-and-retry entry actuator loop.
+    "LAUNCH_MODES",
     "ActuatorEvent",
     "ColdRestartActuator",
+    "ContentManagerActuator",
     "EntryActuator",
     "EntryLauncher",
     "EntryLauncherConfig",
@@ -72,6 +77,7 @@ __all__ = [
     "EntryOutcome",
     "EntryPhase",
     "classify_entry_phase",
+    "make_actuator",
     "normalize_race_ini_spawn_set",
     # L2 in-sim shared-memory oracle (on-track-entry detector).
     "AcGameStatus",

--- a/tools/ac_harness/daemon.py
+++ b/tools/ac_harness/daemon.py
@@ -8,7 +8,9 @@ HTTP API. Shared-memory snapshots from :mod:`shared_memory` are the on-track ora
 
 Endpoints (all except ``GET /health`` require ``Authorization: Bearer <token>``):
 
-* ``POST /session/start`` — cold-launch AC via :class:`EntryLauncher`
+* ``POST /session/start`` — launch AC via :class:`EntryLauncher`. ``launch_mode="cm"`` (default
+  on Windows) drives the de-elevated Content Manager URL path so ``acs.exe`` starts non-elevated
+  even when the daemon runs in an elevated shell; ``"acs"`` cold-launches ``acs.exe`` directly.
 * ``POST /sidecar/start`` — spawn ``python -m tools.ai_sidecar --external-bind …`` (requires
   a successful session start first)
 * ``GET /status`` — daemon + shared-memory oracle
@@ -32,11 +34,12 @@ from pathlib import Path
 from typing import Any
 
 from tools.ac_harness.entry_launcher import (
-    ColdRestartActuator,
+    LAUNCH_MODES,
     EntryLauncher,
     EntryLauncherConfig,
     EntryLaunchResult,
     EntryOutcome,
+    make_actuator,
 )
 from tools.ac_harness.shared_memory import (
     DrivingEntryDetector,
@@ -71,8 +74,11 @@ class HarnessDaemonConfig:
     bind_port: int = 9876
     token: str = ""
     repo_root: Path = field(default_factory=lambda: Path.cwd())
+    launch_mode: str = "acs"
     acs_exe: Path | None = None
     race_ini: Path | None = None
+    cm_exe: Path | None = None
+    cm_preset: Path | None = None
     sidecar_host: str = "0.0.0.0"
     sidecar_port: int = 8765
     launcher_config: EntryLauncherConfig = field(default_factory=EntryLauncherConfig)
@@ -192,7 +198,13 @@ class HarnessDaemon:
         race_ini = config.race_ini or _default_race_ini()
 
         def _default_launcher_factory() -> EntryLauncher:
-            actuator = ColdRestartActuator(acs_exe=acs, race_ini=race_ini)
+            actuator = make_actuator(
+                config.launch_mode,
+                acs_exe=acs,
+                race_ini=race_ini,
+                cm_exe=config.cm_exe,
+                cm_preset=config.cm_preset,
+            )
             return EntryLauncher(actuator, config=config.launcher_config)
 
         def _default_sidecar_starter() -> subprocess.Popen[Any]:
@@ -397,8 +409,19 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--repo-root", type=Path, default=Path.cwd(), help="Repo root (sidecar cwd)"
     )
-    parser.add_argument("--acs-exe", type=Path, help="Path to acs.exe")
-    parser.add_argument("--race-ini", type=Path, help="Path to race.ini")
+    parser.add_argument(
+        "--launch-mode",
+        choices=LAUNCH_MODES,
+        default="cm" if sys.platform == "win32" else "acs",
+        help=(
+            "cm = de-elevated Content Manager URL launch (default on Windows; survives the "
+            "elevated-shell/non-elevated-Steam split); acs = direct acs.exe launch"
+        ),
+    )
+    parser.add_argument("--acs-exe", type=Path, help="Path to acs.exe (--launch-mode acs)")
+    parser.add_argument("--race-ini", type=Path, help="Path to race.ini (--launch-mode acs)")
+    parser.add_argument("--cm-exe", type=Path, help="Path to Content Manager.exe (cm mode)")
+    parser.add_argument("--cm-preset", type=Path, help="Path to a Quick Drive .cmpreset (cm mode)")
     parser.add_argument("--sidecar-bind", default="0.0.0.0", help="Sidecar external bind host")
     parser.add_argument("--sidecar-port", type=int, default=8765, help="Sidecar port")
     return parser
@@ -411,8 +434,11 @@ def _main(argv: Sequence[str] | None = None) -> int:
         bind_port=args.port,
         token=args.token,
         repo_root=args.repo_root.resolve(),
+        launch_mode=args.launch_mode,
         acs_exe=args.acs_exe,
         race_ini=args.race_ini,
+        cm_exe=args.cm_exe,
+        cm_preset=args.cm_preset,
         sidecar_host=args.sidecar_bind,
         sidecar_port=args.sidecar_port,
     )

--- a/tools/ac_harness/daemon.py
+++ b/tools/ac_harness/daemon.py
@@ -74,7 +74,11 @@ class HarnessDaemonConfig:
     bind_port: int = 9876
     token: str = ""
     repo_root: Path = field(default_factory=lambda: Path.cwd())
-    launch_mode: str = "acs"
+    # Default to the de-elevated CM launch on the Windows rig (the only path that survives the
+    # elevated-shell / non-elevated-Steam split); acs.exe-direct elsewhere. Kept consistent with
+    # the CLI default so programmatic and CLI callers behave the same. ``cm`` mode requires a
+    # ``cm_preset`` — ``make_actuator`` raises if it is missing.
+    launch_mode: str = field(default_factory=lambda: "cm" if sys.platform == "win32" else "acs")
     acs_exe: Path | None = None
     race_ini: Path | None = None
     cm_exe: Path | None = None
@@ -428,7 +432,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 
 def _main(argv: Sequence[str] | None = None) -> int:
-    args = _build_arg_parser().parse_args(argv)
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.launch_mode == "cm" and args.cm_preset is None:
+        parser.error("--launch-mode cm requires --cm-preset (path to a Quick Drive .cmpreset)")
     config = HarnessDaemonConfig(
         bind_host=args.bind,
         bind_port=args.port,

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -19,6 +19,7 @@ import configparser
 import subprocess
 import sys
 import time
+import urllib.parse
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
@@ -201,6 +202,27 @@ def normalize_race_ini_spawn_set(
         raise
 
 
+def _taskkill(
+    process_name: str,
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> str:
+    """Best-effort ``taskkill`` of a process tree; returns a human-readable detail string."""
+
+    if sys.platform != "win32":
+        return f"{process_name} kill skipped on {sys.platform}"
+    result = runner(
+        ["taskkill", "/IM", process_name, "/F", "/T"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return f"killed {process_name}"
+    detail = (result.stderr or result.stdout or "").strip()
+    suffix = f": {detail}" if detail else " (process may not have been running)"
+    return f"taskkill {process_name} exited {result.returncode}{suffix}"
+
+
 class ColdRestartActuator:
     """Default no-new-dependency actuator: normalize state, kill, relaunch AC."""
 
@@ -254,19 +276,104 @@ class ColdRestartActuator:
         return ActuatorEvent("relaunch", f"{normalized.detail}; {launch.detail}")
 
     def _kill_existing(self) -> str:
+        return _taskkill(self.process_name, self._runner)
+
+
+class ContentManagerActuator:
+    """Content Manager IPC actuator — de-elevated on-track launch via the ``acmanager://`` URL.
+
+    Spawning ``Content Manager.exe "acmanager://race/quick?presetFile=<preset>"`` hands the URL to
+    the already-running (non-elevated) Content Manager through its single-instance IPC; CM runs the
+    Quick Drive preset (``QuickDrive.RunAsync``) and launches ``acs.exe`` as **its own** child —
+    i.e. non-elevated. That survives the rig's elevation split (elevated agent/daemon shell vs
+    non-elevated Steam + CM) that makes a direct ``acs.exe`` launch trip the Steam-integrity
+    mismatch. Verified live on ``AG_PC``: car on track in ~3 s, physics advancing at ~333 Hz
+    (EPIC #154 #232).
+
+    CM owns the immediate-start handshake, so there is no in-attempt Drive re-trigger:
+    :meth:`trigger_drive` reports ``supported=False`` and :class:`EntryLauncher` cold-relaunches
+    when the (genuinely non-deterministic) pre-drive menu-skip race loses.
+    """
+
+    DEFAULT_CM_EXE = Path(r"C:\Program Files (x86)\ContentManager\Content Manager.exe")
+
+    def __init__(
+        self,
+        *,
+        preset: str | Path,
+        cm_exe: str | Path | None = None,
+        process_name: str = "acs.exe",
+        runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+        popen: Callable[..., subprocess.Popen] = subprocess.Popen,
+    ) -> None:
+        self.preset = Path(preset).expanduser()
+        self.cm_exe = Path(cm_exe).expanduser() if cm_exe is not None else self.DEFAULT_CM_EXE
+        self.process_name = process_name
+        self._runner = runner
+        self._popen = popen
+
+    def quick_drive_url(self) -> str:
+        """``acmanager://race/quick?presetFile=<url-encoded preset path>`` (CM runs the preset)."""
+        return "acmanager://race/quick?presetFile=" + urllib.parse.quote(str(self.preset), safe="")
+
+    def normalize_prior_state(self) -> ActuatorEvent | None:
+        # Cold-start the menu-skip race: kill any stale acs.exe so each launch is deterministic.
+        return ActuatorEvent("normalize", _taskkill(self.process_name, self._runner))
+
+    def launch(self) -> ActuatorEvent:
         if sys.platform != "win32":
-            return f"{self.process_name} kill skipped on {sys.platform}"
-        result = self._runner(
-            ["taskkill", "/IM", self.process_name, "/F", "/T"],
-            check=False,
-            capture_output=True,
-            text=True,
+            raise EntryLaunchUnsupported("ContentManagerActuator launch is Windows-only")
+        if not self.cm_exe.exists():
+            raise FileNotFoundError(f"Content Manager not found: {self.cm_exe}")
+        if not self.preset.exists():
+            raise FileNotFoundError(f"Quick Drive preset not found: {self.preset}")
+        url = self.quick_drive_url()
+        self._popen([str(self.cm_exe), url])
+        return ActuatorEvent("launch", url)
+
+    def trigger_drive(self) -> ActuatorEvent:
+        return ActuatorEvent(
+            "trigger_drive",
+            "Content Manager owns immediate-start; relaunch on menu-skip-race timeout",
+            supported=False,
         )
-        if result.returncode == 0:
-            return f"killed {self.process_name}"
-        detail = (result.stderr or result.stdout or "").strip()
-        suffix = f": {detail}" if detail else " (process may not have been running)"
-        return f"taskkill {self.process_name} exited {result.returncode}{suffix}"
+
+    def relaunch(self) -> ActuatorEvent:
+        normalized = self.normalize_prior_state()
+        launch = self.launch()
+        if normalized is None:
+            return ActuatorEvent("relaunch", launch.detail)
+        return ActuatorEvent("relaunch", f"{normalized.detail}; {launch.detail}")
+
+
+LAUNCH_MODES = ("cm", "acs")
+
+
+def make_actuator(
+    launch_mode: str,
+    *,
+    acs_exe: str | Path | None = None,
+    race_ini: str | Path | None = None,
+    cm_exe: str | Path | None = None,
+    cm_preset: str | Path | None = None,
+) -> EntryActuator:
+    """Build the entry actuator for ``launch_mode``.
+
+    ``"cm"`` → :class:`ContentManagerActuator` (de-elevated CM-URL launch; needs ``cm_preset``).
+    ``"acs"`` → :class:`ColdRestartActuator` (direct ``acs.exe`` launch; needs ``acs_exe``).
+    """
+
+    if launch_mode == "cm":
+        if cm_preset is None:
+            raise ValueError(
+                "launch_mode='cm' requires a Content Manager Quick Drive preset (cm_preset)"
+            )
+        return ContentManagerActuator(preset=cm_preset, cm_exe=cm_exe)
+    if launch_mode == "acs":
+        if acs_exe is None:
+            raise ValueError("launch_mode='acs' requires acs_exe")
+        return ColdRestartActuator(acs_exe=acs_exe, race_ini=race_ini)
+    raise ValueError(f"unknown launch_mode: {launch_mode!r} (expected one of {LAUNCH_MODES})")
 
 
 class EntryLauncher:
@@ -413,8 +520,22 @@ class EntryLauncher:
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="AC detect-and-retry entry launcher")
-    parser.add_argument("--acs-exe", required=True, help="Path to Assetto Corsa acs.exe")
+    parser.add_argument(
+        "--launch-mode",
+        choices=LAUNCH_MODES,
+        default="acs",
+        help="cm = de-elevated Content Manager URL launch; acs = direct acs.exe (default)",
+    )
+    parser.add_argument("--acs-exe", help="Path to acs.exe (required for --launch-mode acs)")
     parser.add_argument("--race-ini", help="Path to Documents/Assetto Corsa/cfg/race.ini")
+    parser.add_argument(
+        "--cm-exe",
+        help="Path to Content Manager.exe (default: standard install; --launch-mode cm)",
+    )
+    parser.add_argument(
+        "--cm-preset",
+        help="Path to a Quick Drive .cmpreset (required for --launch-mode cm)",
+    )
     parser.add_argument("--max-launches", type=int, default=3)
     parser.add_argument("--attempt-timeout", type=float, default=30.0)
     parser.add_argument("--poll-interval", type=float, default=0.03)
@@ -428,7 +549,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def _main(argv: Sequence[str] | None = None) -> int:
     args = _build_arg_parser().parse_args(argv)
-    actuator = ColdRestartActuator(acs_exe=args.acs_exe, race_ini=args.race_ini)
+    actuator = make_actuator(
+        args.launch_mode,
+        acs_exe=args.acs_exe,
+        race_ini=args.race_ini,
+        cm_exe=args.cm_exe,
+        cm_preset=args.cm_preset,
+    )
     launcher = EntryLauncher(
         actuator,
         config=EntryLauncherConfig(

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -306,8 +306,11 @@ class ContentManagerActuator:
         runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
         popen: Callable[..., subprocess.Popen] = subprocess.Popen,
     ) -> None:
-        self.preset = Path(preset).expanduser()
-        self.cm_exe = Path(cm_exe).expanduser() if cm_exe is not None else self.DEFAULT_CM_EXE
+        # Resolve to absolute: the URL is read by a *separate* CM process with its own cwd, so a
+        # relative presetFile would break `File.ReadAllText`. Mirrors ColdRestartActuator.
+        self.preset = Path(preset).expanduser().resolve(strict=False)
+        cm = Path(cm_exe).expanduser() if cm_exe is not None else self.DEFAULT_CM_EXE
+        self.cm_exe = cm.resolve(strict=False)
         self.process_name = process_name
         self._runner = runner
         self._popen = popen

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -548,7 +548,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 
 def _main(argv: Sequence[str] | None = None) -> int:
-    args = _build_arg_parser().parse_args(argv)
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.launch_mode == "acs" and args.acs_exe is None:
+        parser.error("--launch-mode acs requires --acs-exe")
+    if args.launch_mode == "cm" and args.cm_preset is None:
+        parser.error("--launch-mode cm requires --cm-preset (path to a Quick Drive .cmpreset)")
     actuator = make_actuator(
         args.launch_mode,
         acs_exe=args.acs_exe,


### PR DESCRIPTION
## What & why

EPIC #154 **Part F** (in-session harness daemon, #229) shipped `/session/start` launching AC via
`ColdRestartActuator` → **`acs.exe` directly**. Verified on the rig (`AG_PC`): the agent/daemon
shell is **elevated** while **Steam and Content Manager run non-elevated**, so a child `acs.exe` is
elevated and trips the Steam-integrity mismatch ("Steam API has failed to initialize") — the merged
daemon's `/session/start` **can't get AC on track from the agent shell**. (The merge was verified
off-sim with a mocked launcher, so this never surfaced in CI.) `entry_launcher.py` already
anticipated this — its docstring lists "Content Manager IPC … as future actuator plugins."

## Change

- **`ContentManagerActuator`** (`entry_launcher.py`) implementing the existing `EntryActuator`
  Protocol. `launch()` spawns `Content Manager.exe "acmanager://race/quick?presetFile=<preset>"`;
  the new (even if elevated) CM instance forwards the URL via single-instance IPC to the **running
  non-elevated CM**, which runs the Quick Drive preset (`QuickDrive.RunAsync`) and starts `acs.exe`
  as **its own non-elevated child** → Steam matches. `trigger_drive()` is `supported=False` (CM owns
  immediate-start), so the existing detect-and-retry loop cold-relaunches when the (genuinely
  non-deterministic) pre-drive menu-skip race loses.
- Shared **`make_actuator(mode, …)`** factory + a `_taskkill` helper (de-duplicated from
  `ColdRestartActuator`).
- **`daemon.py`** gains `--launch-mode {cm,acs}` (**default `cm` on Windows**), `--cm-exe`,
  `--cm-preset`, wired through `HarnessDaemonConfig`.

## Verification

**Off-sim:** 12 new unit tests (URL encoding, launch/relaunch/normalize, `trigger_drive`→relaunch,
Windows guard, missing-file errors, `make_actuator` validation, daemon actuator selection by mode).
Full harness suite green (48 passed); my files ruff-clean (format + lint, ruff 0.15.17).

**On rig (operator-grade, observed `AG_PC`):** from the **elevated** agent shell,
`acmanager://race/quick?presetFile=…` via CM →
- `acs.exe` confirmed **non-elevated**;
- shared-memory oracle: `status=LIVE, is_in_pit=False`, **physics packets advancing at ~333 Hz**,
  **on track in ~3 s**, sustained 90 s;
- AC rendered the car on track (Porsche 911 GT3 R, Practice) — screenshot inspected.

The full daemon `/session/start` (cm mode) → `/sidecar/start` → WS `hello` round-trip is being
exercised live on the rig as the merge gate.

Closes #232. Refs #154.

## Summary by Sourcery

Introduce a configurable launch mode for the AC harness to support de-elevated Content Manager–based session starts alongside the existing direct acs.exe launcher.

New Features:
- Add ContentManagerActuator to launch Assetto Corsa via Content Manager Quick Drive URL IPC, enabling non-elevated acs.exe starts from an elevated daemon.
- Introduce a generic make_actuator factory and LAUNCH_MODES to construct either Content Manager or cold-restart actuators based on configuration.
- Extend the harness daemon and entry launcher CLIs and configs with launch-mode selection plus Content Manager executable and preset options, defaulting to Content Manager mode on Windows.

Enhancements:
- Refactor process tree termination into a shared _taskkill helper reused by multiple actuators.
- Export new actuator types, launch modes, and the actuator factory from the ac_harness package for external use.

Tests:
- Add unit tests for ContentManagerActuator URL encoding, launch behavior, error handling, and relaunch semantics.
- Add tests for the make_actuator factory to validate mode selection and parameter requirements.
- Add daemon tests to ensure the default launcher factory chooses the correct actuator based on launch-mode configuration.