### PR TITLE
docs(vault): post-merge handoff for #233 — de-elevated CM launch actuator (EPIC #154)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-17T04:00:00Z
+last_updated: 2026-06-17T06:00:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -18,7 +18,7 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
-**Active focus (2026-06-16):** [#188](https://github.com/agorokh/ac-copilot-trainer/issues/188) **CLOSED** — on-rig probe confirmed `car.resetCounter` is **present** (`value=2`); closed as moot (the #199 wrap-deferral is defensive-only for resetCounter-less builds). [#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) **CLOSED**. Next EPIC [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) thread: **Part F harness daemon (#228)** — note `feat/issue-228-harness-daemon` has uncommitted local WIP and `origin` diverged (+5). Parallel hot path: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) Parts E–F.
+**Active focus (2026-06-17):** EPIC [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) — **Part F harness daemon shipped** ([#228](https://github.com/agorokh/ac-copilot-trainer/issues/228)/PR #229) and its on-rig launch gap fixed ([#232](https://github.com/agorokh/ac-copilot-trainer/issues/232) **CLOSED** / PR [#233](https://github.com/agorokh/ac-copilot-trainer/pull/233) **MERGED** `c556dfe`): the daemon now launches AC **de-elevated via Content Manager** (`--launch-mode cm`), live-verified hands-off on `AG_PC` (`/session/start`→driving, `/sidecar/start`→WS `hello_ack`). [#188](https://github.com/agorokh/ac-copilot-trainer/issues/188)/[#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) **CLOSED**. **Next #154 thread: Part G** — compose the full unattended loop + screenshot/vision HUD oracle + determinism-lock + false-green KPI (<5%). Parallel hot path: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) Parts E–F.
 
 **Infra (2026-05-20):** PR [#111](https://github.com/agorokh/ac-copilot-trainer/pull/111) closed the [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) agent-surface campaign (closeout doc only; five agent SHA alignments deferred). PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) memory-contract cursor rule fix remains on `main`.
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,10 +2,11 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-17T04:20:00Z
+last_updated: 2026-06-17T06:00:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
+  - AcCopilotTrainer/03_Investigations/cm-url-deelevated-launch-2026-06-16.md
   - AcCopilotTrainer/03_Investigations/autonomous-drive-live-verified-2026-06-16.md
   - AcCopilotTrainer/03_Investigations/issue-188-wrap-skew-rig-verification.md
   - AcCopilotTrainer/00_System/invariants/_index.md
@@ -27,6 +28,46 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-17 — EPIC #154 #232/#233 MERGED: de-elevated CM launch — hands-off L2 keystone landed)
+
+**Ran autonomous-deliver on the rig `AG_PC` (elevated agent shell).** Found and closed the live gap
+in the merged Part F daemon (#229): it launched `acs.exe` **directly**, which trips the Steam-integrity
+mismatch from the elevated shell (Steam + CM run **non-elevated**). The EPIC spec'd a CM-URL launch;
+the merge took an `acs.exe` shortcut.
+
+**[#232](https://github.com/agorokh/ac-copilot-trainer/issues/232) CLOSED / PR
+[#233](https://github.com/agorokh/ac-copilot-trainer/pull/233) MERGED** (squash `c556dfe`). New
+`ContentManagerActuator` (`tools/ac_harness/entry_launcher.py`) launches via
+`Content Manager.exe "acmanager://race/quick?presetFile=<abs preset>"` → CM-IPC forwards to the
+running **non-elevated** CM → `acs.exe` starts **non-elevated**. `make_actuator(mode)` + daemon
+`--launch-mode {cm,acs}` (default **cm** on Windows), `--cm-exe`, `--cm-preset`. Reuses the shipped
+detect-and-retry loop; `trigger_drive` is unsupported so the loop cold-relaunches on the menu-skip
+race. Full method + gotchas: [`03_Investigations/cm-url-deelevated-launch-2026-06-16`](../03_Investigations/cm-url-deelevated-launch-2026-06-16.md).
+
+**Operator-grade live verification (PASS, observed):** daemon in elevated shell →
+`POST /session/start` (cm) → `outcome:"driving"` (shared-mem detector, sustained); `acs.exe`
+**non-elevated**; on track in ~3 s; physics ~333 Hz; AC rendered on track (screenshot inspected).
+`POST /sidecar/start` → external WS `hello_ack`. Guard: `/sidecar/start` before session → 409.
+Off-sim: 15 new tests, ruff-clean; CI green; 6 bot threads (cursor/sourcery/coderabbit) all resolved
+(fail-fast CLI validation, platform-aware defaults, absolute-path resolution).
+
+**Next (EPIC #154 — toward fully hands-off L2):** all chain pieces now exist (launch ✓ via #233,
+sidecar ✓, carcsw drive ✓ #190, asserts ✓ L1.5/oracle). Remaining **Part G**: (1) compose the full
+unattended loop into one harness command (launch→sidecar→carcsw drive a lap→assert→reset); (2)
+**screenshot/vision HUD oracle** (most rig-uniquely verifiable; "if you're not screenshotting it, it's
+not delivered"); (3) determinism-lock preset + CSP precondition assert; (4) false-green-rate KPI < 5%.
+For a real carcsw drive on magione, re-apply the track `surfaces.ini` Custom-AI permission (reverted to
+stock) + create a magione `.cmpreset` (the `base test.cmpreset` used here is Porsche@Spa).
+
+**Rig-local nit (not filed):** `tests/test_import_motec.py::test_default_output_dir_precedence` FAILS on
+any box with a real AC install (incl. this rig) — `default_output_dir` discovers the live AC CSP state
+dir, so the test's cwd-fallback assertion doesn't hold. Pre-existing, local-only (green on clean CI);
+the test should monkeypatch the AC-state-dir lookup to be hermetic.
+
+**Local `main` divergence (unchanged, intentional):** `dd5c613` (untrack local-baked `.cursor/hooks.json`)
+is the operator's deliberately-unpushed Windows-Cursor adaptation — left as-is; vault/feature work branches
+off `origin/main`. The merged `feat/issue-228` WIP was confirmed stale and discarded.
 
 ## Resume here (2026-06-16 LATER — #188 CLOSED on the rig; ran on AG_PC directly)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
@@ -13,6 +13,7 @@ Technical deep-dives and root-cause analyses from development sessions.
 
 | Node | Summary |
 |------|---------|
+| [cm-url-deelevated-launch-2026-06-16.md](cm-url-deelevated-launch-2026-06-16.md) | De-elevated `acmanager://race/quick` launch (CM-IPC forward) gets AC on track non-elevated from the elevated agent shell — the hands-off L2 keystone (#232/#233). |
 | [csp-cdata-callable-guards.md](csp-cdata-callable-guards.md) | `type(vec2)` returns "cdata" not "function" in CSP/LuaJIT — use nil-checks |
 | [csp-web-socket-api.md](csp-web-socket-api.md) | CSP web.socket is callback-based; sock(data) to send; reconnect:true required |
 | [ac-storage-persistence.md](ac-storage-persistence.md) | ac.storage table-form silently fails; use per-key form for persistence |

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/cm-url-deelevated-launch-2026-06-16.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/cm-url-deelevated-launch-2026-06-16.md
@@ -1,0 +1,69 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-06-16
+updated: 2026-06-16
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/232
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/03_Investigations/steam-elevation-mismatch-ac-launch-2026-06-16.md
+  - AcCopilotTrainer/03_Investigations/menu-skip-race-and-shared-memory-oracle-2026-06-14.md
+  - AcCopilotTrainer/03_Investigations/garage-to-track-autonomous-entry-2026-06-13.md
+  - AcCopilotTrainer/03_Investigations/autonomous-drive-live-verified-2026-06-16.md
+---
+
+# De-elevated Content Manager launch — hands-off on-track entry from an elevated agent shell (EPIC #154 #232)
+
+**The keystone for fully hands-off L2.** Lets the harness daemon (running in the rig's elevated
+agent shell) get AC on track without a human, surviving the elevation split that breaks a direct
+`acs.exe` launch.
+
+## The problem (found live on `AG_PC`)
+
+- The agent/daemon shell on the rig is **elevated**; **Steam and Content Manager run non-elevated**
+  (see [[steam-elevation-mismatch-ac-launch-2026-06-16]]).
+- A child `acs.exe` of the elevated daemon is **elevated** → Steam-integrity mismatch
+  ("Steam API has failed to initialize"). So the merged Part F daemon's `acs.exe`-direct
+  `/session/start` (`ColdRestartActuator`) **cannot** get AC on track from the agent shell. The
+  Part F merge was verified off-sim (mocked launcher), so this never surfaced in CI.
+
+## The fix (verified)
+
+Spawn `Content Manager.exe "acmanager://race/quick?presetFile=<preset>"` **from the elevated
+shell**. The new (even elevated) CM instance forwards the URL via CM single-instance IPC to the
+**running non-elevated** CM, which runs the Quick Drive preset and launches `acs.exe` as **its own
+non-elevated child** → Steam matches.
+
+- URL → CM `ProcessRaceQuick` → `QuickDrive.RunAsync(serializedPreset)` (it **runs** the race;
+  the `loadPreset` flag would only *show* it). Source: `gro-ove/actools`
+  `AcManager/Tools/ArgumentsHandler.Race.cs`. `presetFile=` is URL-encoded; CM does
+  `File.ReadAllText(presetFile)`.
+- `acmanager://` handler = `C:\Program Files (x86)\ContentManager\Content Manager.exe "%1"`.
+- **`explorer.exe "acmanager://…"` did NOT work** (URL never reached CM); spawning `CM.exe` with
+  the URL **did** (forwards to the running instance). UIPI allows elevated→non-elevated, so the
+  forward succeeds.
+
+**Verified facts (rig, 2026-06-16):** `acs.exe` **non-elevated**; **on track in ~3 s**; shared-memory
+oracle `status=LIVE, is_in_pit=false`, physics advancing at **~333 Hz**, sustained 90 s.
+
+## Productionized — `ContentManagerActuator` (#232 / PR #233)
+
+`tools/ac_harness/entry_launcher.py` `ContentManagerActuator` implements the existing
+`EntryActuator` Protocol; `trigger_drive` is `supported=False` so the shipped detect-and-retry loop
+cold-relaunches when the (still non-deterministic, see [[menu-skip-race-and-shared-memory-oracle-2026-06-14]])
+pre-drive menu-skip race loses. `make_actuator(mode)` picks `cm` vs `acs`; the daemon defaults to
+`cm` on Windows (`--launch-mode`, `--cm-exe`, `--cm-preset`).
+
+**Live daemon acceptance (elevated shell):** `/session/start` (cm) → `outcome:"driving"` →
+`/sidecar/start` → external WS `hello_ack`; `/sidecar/start` before session → 409.
+
+## Gotchas
+
+- The shared-memory mmap **persists stale** after AC exits (frozen packet IDs read `LIVE`). Confirm
+  on-track by packet **advancement**, not a single read.
+- A token written by Windows `print` carries a trailing `\r`; bash `$(cat)` strips `\n` but not
+  `\r` → 33-char token vs a `.strip()`ed 32-char client → daemon 401. Write tokens with no trailing
+  whitespace.
+- `ThreadingHTTPServer` sets `allow_reuse_address`, so a stale daemon and a new one can both bind
+  9876 and race requests — kill stale listeners first.


### PR DESCRIPTION
Vault-only: post-merge knowledge node + handoff/focus refresh after #232/PR #233 (de-elevated Content Manager launch actuator) merged (`c556dfe`). Diff strictly under `docs/01_Vault/**`. Refs #154.

## Summary by Sourcery

Document the de-elevated Content Manager launch flow as the keystone for hands-off L2 and refresh vault handoff/focus notes after merging the Part F harness daemon fixes.

Documentation:
- Add a canonical investigation note detailing the CM URL-based de-elevated launch path and its verification on the AG_PC rig.
- Update next-session handoff and current-focus system docs to reflect the merged Part F harness daemon, the CM-based launch actuator, and the remaining Part G work items.