### PR TITLE
feat(harness): one-command autonomous self-test runner — hands-off pipeline assertion (EPIC #154 Part G)

### DIFF
--- a/tests/test_ac_harness_self_test.py
+++ b/tests/test_ac_harness_self_test.py
@@ -1,0 +1,142 @@
+"""Tests for the EPIC #154 Part G autonomous self-test runner (#235)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tools.ac_harness import self_test
+from tools.ac_harness.self_test import (
+    SelfTestConfig,
+    SelfTestReport,
+    _main,
+    run_self_test,
+)
+
+PASS_FRAMES = [
+    {"type": "state.snapshot", "topic": t}
+    for t in ("connection", "tire_temps", "coaching.snapshot")
+]
+FAIL_FRAMES = [{"type": "state.snapshot", "topic": "connection"}]  # missing two continuous topics
+
+
+class FakeHttp:
+    """Records (method, url) calls; returns a canned response by URL substring."""
+
+    def __init__(self, responses: dict[str, tuple[int, dict]]):
+        self.responses = responses
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, method, url, *, token, timeout=30.0):
+        self.calls.append((method, url))
+        for key, resp in self.responses.items():
+            if key in url:
+                return resp
+        return (404, {"ok": False, "error": "not found"})
+
+    def hit(self, fragment: str) -> bool:
+        return any(fragment in url for _, url in self.calls)
+
+
+def _tap(frames=None, exc=None):
+    async def _inner(url, *, seconds=20.0, wait_for_lap=False):
+        if exc is not None:
+            raise exc
+        return list(frames or [])
+
+    return _inner
+
+
+def _cfg(**kw) -> SelfTestConfig:
+    return SelfTestConfig(token="t", **kw)
+
+
+def _ok_session():
+    return {
+        "/session/start": (200, {"ok": True, "outcome": "driving", "reason": "sustained"}),
+        "/sidecar/start": (200, {"ok": True, "pid": 1}),
+        "/session/stop": (200, {"ok": True}),
+    }
+
+
+def test_self_test_pass():
+    http = FakeHttp(_ok_session())
+    report = asyncio.run(run_self_test(_cfg(), http=http, tap=_tap(PASS_FRAMES)))
+    assert report.ok is True
+    assert report.stage == "pipeline"
+    assert report.sequence_ok is True
+    assert report.session_outcome == "driving"
+    assert report.counts.get("coaching.snapshot") == 1
+    assert http.hit("/session/stop")
+
+
+def test_self_test_pipeline_fail():
+    http = FakeHttp(_ok_session())
+    report = asyncio.run(run_self_test(_cfg(), http=http, tap=_tap(FAIL_FRAMES)))
+    assert report.ok is False
+    assert report.stage == "pipeline"
+    assert report.sequence_ok is False
+    assert http.hit("/session/stop")
+
+
+def test_self_test_session_start_fails_skips_sidecar():
+    http = FakeHttp(
+        {"/session/start": (409, {"ok": False, "outcome": "failed", "reason": "no drive"})}
+    )
+    report = asyncio.run(run_self_test(_cfg(), http=http, tap=_tap(PASS_FRAMES)))
+    assert report.ok is False
+    assert report.stage == "session_start"
+    assert report.session_reason == "no drive"
+    assert not http.hit("/sidecar/start")
+
+
+def test_self_test_sidecar_fail_stops_session():
+    resp = _ok_session()
+    resp["/sidecar/start"] = (409, {"ok": False, "error": "no loopback Lua peer"})
+    http = FakeHttp(resp)
+    report = asyncio.run(run_self_test(_cfg(), http=http, tap=_tap(PASS_FRAMES)))
+    assert report.ok is False
+    assert report.stage == "sidecar_start"
+    assert report.error == "no loopback Lua peer"
+    assert http.hit("/session/stop")
+
+
+def test_self_test_tap_raises_stops_session():
+    http = FakeHttp(_ok_session())
+    report = asyncio.run(
+        run_self_test(_cfg(), http=http, tap=_tap(exc=RuntimeError("hello handshake timed out")))
+    )
+    assert report.ok is False
+    assert report.stage == "pipeline_tap"
+    assert "hello handshake timed out" in (report.error or "")
+    assert http.hit("/session/stop")
+
+
+def test_self_test_keep_skips_stop():
+    http = FakeHttp(_ok_session())
+    report = asyncio.run(run_self_test(_cfg(keep=True), http=http, tap=_tap(PASS_FRAMES)))
+    assert report.ok is True
+    assert not http.hit("/session/stop")
+
+
+def test_report_summary_renders_pass_and_fail():
+    ok = SelfTestReport(ok=True, stage="pipeline", session_outcome="driving", sequence_ok=True)
+    assert "PASS" in ok.summary()
+    bad = SelfTestReport(ok=False, stage="session_start", error="no drive")
+    assert "FAIL" in bad.summary()
+    assert "no drive" in bad.summary()
+
+
+def test_main_requires_token():
+    with pytest.raises(SystemExit):
+        _main([])
+
+
+@pytest.mark.parametrize(("ok", "code"), [(True, 0), (False, 1)])
+def test_main_exit_code(monkeypatch, ok: bool, code: int):
+    async def fake_run(config, **kwargs):
+        return SelfTestReport(ok=ok, stage="pipeline", sequence_ok=ok)
+
+    monkeypatch.setattr(self_test, "run_self_test", fake_run)
+    assert _main(["--token", "t"]) == code

--- a/tools/ac_harness/self_test.py
+++ b/tools/ac_harness/self_test.py
@@ -1,0 +1,219 @@
+"""One-command autonomous self-test (EPIC #154 Part G).
+
+Drives the in-session harness daemon (#228/#229) **hands-off from the agent's own shell** and
+asserts the trainer's live coaching pipeline — no human at the wheel:
+
+    POST /session/start (cm)  -> wait for the shared-memory detector to report "driving"
+    POST /sidecar/start       -> sidecar up on the external bind
+    tap the sidecar WS        -> assert the L1.5 producer contract (sequence_probe)
+    POST /session/stop        -> cleanup (unless --keep)
+
+It catches the class of bugs that only surface in-game and that a human currently finds by
+driving — e.g. the trainer never registering as a v1 WS peer (#170), tire-temp 0-index shift
+(#180) — by asserting the live ``connection`` / ``tire_temps`` / ``coaching.snapshot`` streams
+and the ``session``->``lap`` ordering. The carcsw lap (``lap_driver``) is an optional follow-up
+step, not required: the pipeline ticks whenever car 0 is on track.
+
+Run on the rig (loopback to the daemon + sidecar):
+
+    python -m tools.ac_harness.self_test --token <DAEMON_TOKEN>
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from tools.ac_harness.sequence_probe import evaluate_sequence, tap_frames
+
+HttpCall = Callable[..., tuple[int, dict[str, Any]]]
+TapCall = Callable[..., Awaitable[list[dict]]]
+
+
+@dataclass
+class SelfTestConfig:
+    """Inputs for one self-test run (the daemon is the persistent rig service)."""
+
+    token: str
+    daemon_url: str = "http://127.0.0.1:9876"
+    sidecar_url: str = "ws://127.0.0.1:8765"
+    tap_seconds: float = 20.0
+    wait_lap: bool = False
+    strict: bool = False
+    keep: bool = False
+    session_timeout: float = 150.0
+
+
+@dataclass
+class SelfTestReport:
+    """Structured result of a self-test run."""
+
+    ok: bool
+    stage: str
+    session_outcome: str = ""
+    session_reason: str = ""
+    sidecar_ok: bool = False
+    sequence_ok: bool | None = None
+    counts: dict[str, int] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    def summary(self) -> str:
+        lines = [f"self-test: {'PASS' if self.ok else 'FAIL'} (stage={self.stage})"]
+        if self.session_outcome:
+            lines.append(f"  session: outcome={self.session_outcome} reason={self.session_reason}")
+        lines.append(f"  sidecar: {'up' if self.sidecar_ok else 'not started'}")
+        if self.sequence_ok is not None:
+            lines.append(f"  pipeline: {'ok' if self.sequence_ok else 'FAILED'}")
+            if self.counts:
+                lines.append(
+                    "  frames: " + ", ".join(f"{k}={v}" for k, v in sorted(self.counts.items()))
+                )
+            for note in self.notes:
+                lines.append(f"  note: {note}")
+        if self.error:
+            lines.append(f"  error: {self.error}")
+        return "\n".join(lines)
+
+
+def _http(
+    method: str, url: str, *, token: str, timeout: float = 30.0
+) -> tuple[int, dict[str, Any]]:
+    """Token-authenticated JSON request to the daemon (stdlib only)."""
+    req = urllib.request.Request(url, method=method, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - loopback daemon
+            body = resp.read().decode("utf-8")
+            return resp.status, (json.loads(body) if body else {})
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        return exc.code, (json.loads(body) if body else {})
+
+
+async def run_self_test(
+    config: SelfTestConfig,
+    *,
+    http: HttpCall = _http,
+    tap: TapCall = tap_frames,
+) -> SelfTestReport:
+    """Drive the daemon → sidecar → pipeline assertion and return a structured report.
+
+    ``http`` and ``tap`` are injectable so the orchestration is unit-testable without a game.
+    """
+
+    # 1) Launch AC on track (cm mode) via the daemon.
+    _, body = http(
+        "POST",
+        f"{config.daemon_url}/session/start",
+        token=config.token,
+        timeout=config.session_timeout,
+    )
+    outcome = str(body.get("outcome", ""))
+    reason = str(body.get("reason", ""))
+    if not body.get("ok"):
+        return SelfTestReport(
+            ok=False,
+            stage="session_start",
+            session_outcome=outcome,
+            session_reason=reason,
+            error="session did not reach driving",
+        )
+
+    # 2) Start the sidecar (external bind + token).
+    _, sb = http("POST", f"{config.daemon_url}/sidecar/start", token=config.token, timeout=30.0)
+    if not sb.get("ok"):
+        _stop(config, http)
+        return SelfTestReport(
+            ok=False,
+            stage="sidecar_start",
+            session_outcome=outcome,
+            session_reason=reason,
+            error=str(sb.get("error", "sidecar failed to start")),
+        )
+
+    # 3) Tap the live pipeline and evaluate the L1.5 contract.
+    try:
+        frames = await tap(
+            config.sidecar_url, seconds=config.tap_seconds, wait_for_lap=config.wait_lap
+        )
+        result = evaluate_sequence(
+            frames, strict_lifecycle=config.strict, require_lap=config.wait_lap
+        )
+    except Exception as exc:  # noqa: BLE001 - surface any tap/eval failure as a FAIL report
+        if not config.keep:
+            _stop(config, http)
+        return SelfTestReport(
+            ok=False,
+            stage="pipeline_tap",
+            session_outcome=outcome,
+            session_reason=reason,
+            sidecar_ok=True,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        if not config.keep:
+            _stop(config, http)
+
+    return SelfTestReport(
+        ok=result.ok,
+        stage="pipeline",
+        session_outcome=outcome,
+        session_reason=reason,
+        sidecar_ok=True,
+        sequence_ok=result.ok,
+        counts=dict(result.counts),
+        notes=list(result.notes),
+    )
+
+
+def _stop(config: SelfTestConfig, http: HttpCall) -> None:
+    try:
+        http("POST", f"{config.daemon_url}/session/stop", token=config.token, timeout=30.0)
+    except Exception:  # noqa: BLE001 - best-effort cleanup
+        pass
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Autonomous self-test runner (EPIC #154 Part G) — drive the harness daemon"
+    )
+    parser.add_argument("--token", required=True, help="Daemon bearer token")
+    parser.add_argument("--daemon-url", default="http://127.0.0.1:9876", help="Harness daemon URL")
+    parser.add_argument("--sidecar-url", default="ws://127.0.0.1:8765", help="Sidecar WS URL")
+    parser.add_argument(
+        "--seconds", type=float, default=20.0, help="Fixed tap window (window mode)"
+    )
+    parser.add_argument(
+        "--wait-lap", action="store_true", help="Wait for on-track + a lap boundary, then assert"
+    )
+    parser.add_argument(
+        "--strict", action="store_true", help="Require session + lap and enforce session→lap order"
+    )
+    parser.add_argument("--keep", action="store_true", help="Do not /session/stop on exit")
+    return parser
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    config = SelfTestConfig(
+        token=args.token,
+        daemon_url=args.daemon_url,
+        sidecar_url=args.sidecar_url,
+        tap_seconds=args.seconds,
+        wait_lap=args.wait_lap,
+        strict=args.strict,
+        keep=args.keep,
+    )
+    report = asyncio.run(run_self_test(config))
+    print(report.summary())
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - rig-only CLI wiring
+    raise SystemExit(_main())


### PR DESCRIPTION
## What & why (EPIC #154 Part G — first slice)

With the de-elevated CM launch landed (#232/#233), the agent can now get AC on track + start the
sidecar + tap the WS pipeline **hands-off from its own (elevated) shell**. This packages that into
**one command** so the agent (or rig-CI) can answer "is the trainer actually coaching correctly?"
without a human at the wheel.

It catches the class of bugs that only surface in-game — e.g. the trainer never registering as a v1
WS peer (#170), tire-temp 0-index shift (#180) — by asserting the live producer pipeline. It does
**not** require a full carcsw lap (the flakiest component): the pipeline ticks whenever car 0 is on
track, so this slice is reliably verifiable.

## Change (`tools/ac_harness/self_test.py`, tests)

`python -m tools.ac_harness.self_test --token <DAEMON_TOKEN>` drives the running harness daemon:

1. `POST /session/start` (cm) → wait for the shared-memory detector to report `driving`.
2. `POST /sidecar/start` → sidecar up on the external bind.
3. Tap the sidecar WS and assert the L1.5 contract via `sequence_probe.evaluate_sequence`
   (`connection` + `tire_temps` + `coaching.snapshot` streaming; `session`→`lap` ordering).
4. Structured **PASS/FAIL report** (per-topic frame counts, session outcome, stage).
5. `POST /session/stop` (unless `--keep`).

`http` and `tap` are injectable, so the orchestration is unit-tested with a mock daemon + mock tap
(no game): pass, pipeline-fail, session-start-fail (skips sidecar), sidecar-fail (stops session),
tap-raises (stops session), `--keep`, report rendering, CLI exit codes + required `--token`.

## Verification

**Off-sim:** 10 new tests; full harness + sequence-probe suites green (79 passed); ruff-clean.

**On rig (operator-grade):** run live against the daemon (cm mode) on `AG_PC` — one command,
hands-off → on track → sidecar → live pipeline asserted → PASS with observed per-topic frame counts.
Evidence posted as a PR comment.

Closes #235. Refs #154.

## Summary by Sourcery

Introduce an autonomous, one-command self-test runner that drives the harness daemon end-to-end to validate the live coaching pipeline.

New Features:
- Add a self-test CLI that starts a harness session, spins up the sidecar, taps the WebSocket pipeline, and reports structured PASS/FAIL results.
- Support configurable tap window, lap-wait, strict lifecycle checks, and optional session retention for self-test runs.

Tests:
- Add unit tests covering successful and failing self-test flows, error handling, CLI argument requirements, and exit codes using injectable HTTP and tap mocks.