### PR TITLE
feat(harness): HUD framebuffer capture + render-liveness check — the vision oracle eyes (EPIC #154 Part G)

### DIFF
--- a/tests/test_ac_harness_hud_capture.py
+++ b/tests/test_ac_harness_hud_capture.py
@@ -1,0 +1,114 @@
+"""Tests for the EPIC #154 Part G HUD framebuffer capture (#238) — pure helpers + guards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.ac_harness import hud_capture
+from tools.ac_harness.hud_capture import (
+    LivenessScore,
+    _main,
+    bgra_to_rgb,
+    capture_bgra,
+    encode_png,
+    liveness_score,
+    region_rect,
+    save_png,
+)
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+# 2x2 top-down BGRA: per pixel (B, G, R, A).
+BGRA_2x2 = bytes([1, 2, 3, 255, 4, 5, 6, 255, 7, 8, 9, 255, 10, 11, 12, 255])
+
+
+def test_region_rect_named_regions():
+    assert region_rect("full", 3000, 1500) == (0, 0, 3000, 1500)
+    assert region_rect("left", 3000, 1500) == (0, 0, 1000, 1500)
+    x, y, w, h = region_rect("coaching", 3000, 1500)
+    assert (x, y) == (0, 0)
+    assert w == 1050 and h == 750  # 0.35 * 3000, 0.5 * 1500
+
+
+def test_region_rect_unknown_raises():
+    with pytest.raises(ValueError, match="unknown region"):
+        region_rect("nope", 100, 100)
+
+
+def test_liveness_score_detects_black_vs_content():
+    black = liveness_score(bytes(2000))
+    assert black.is_rendering() is False
+    content = liveness_score(bytes(range(256)) * 8)
+    assert content.is_rendering() is True
+    assert liveness_score(b"").is_rendering() is False
+
+
+def test_liveness_thresholds_configurable():
+    score = LivenessScore(mean=5.0, distinct=10)
+    assert score.is_rendering(min_mean=2.0, min_distinct=8) is True
+    assert score.is_rendering(min_mean=6.0) is False
+    assert score.is_rendering(min_distinct=20) is False
+
+
+def test_bgra_to_rgb_swaps_channels():
+    out_w, out_h, rgb = bgra_to_rgb(2, 2, BGRA_2x2)
+    assert (out_w, out_h) == (2, 2)
+    # BGR -> RGB per pixel.
+    assert rgb == bytes([3, 2, 1, 6, 5, 4, 9, 8, 7, 12, 11, 10])
+
+
+def test_bgra_to_rgb_downsamples_by_stride():
+    out_w, out_h, rgb = bgra_to_rgb(2, 2, BGRA_2x2, stride=2)
+    assert (out_w, out_h) == (1, 1)
+    assert rgb == bytes([3, 2, 1])  # only the top-left pixel
+
+
+def test_bgra_to_rgb_rejects_bad_stride():
+    with pytest.raises(ValueError, match="stride"):
+        bgra_to_rgb(2, 2, BGRA_2x2, stride=0)
+
+
+def test_encode_png_is_valid_and_carries_dims():
+    _, _, rgb = bgra_to_rgb(2, 2, BGRA_2x2)
+    png = encode_png(2, 2, rgb)
+    assert png.startswith(PNG_SIGNATURE)
+    # IHDR width/height live right after the 8-byte sig + 4-byte len + 4-byte "IHDR".
+    width = int.from_bytes(png[16:20], "big")
+    height = int.from_bytes(png[20:24], "big")
+    assert (width, height) == (2, 2)
+    assert png.endswith(b"IEND" + (0xAE426082).to_bytes(4, "big"))  # IEND CRC
+
+
+def test_encode_png_rejects_length_mismatch():
+    with pytest.raises(ValueError, match="rgb length"):
+        encode_png(2, 2, b"\x00\x00\x00")
+
+
+def test_save_png_writes_file(tmp_path: Path):
+    out = tmp_path / "hud.png"
+    w, h = save_png(str(out), 2, 2, BGRA_2x2)
+    assert (w, h) == (2, 2)
+    assert out.read_bytes().startswith(PNG_SIGNATURE)
+
+
+def test_capture_bgra_requires_windows(monkeypatch):
+    monkeypatch.setattr(hud_capture.sys, "platform", "linux")
+    with pytest.raises(RuntimeError, match="Windows-only"):
+        capture_bgra()
+
+
+@pytest.mark.parametrize(
+    ("bgra", "code"),
+    [
+        (bytes(range(256)) * 4, 0),  # content -> rendering -> exit 0
+        (bytes(4 * 16), 1),  # all-black -> exit 1
+    ],
+)
+def test_main_exit_code_from_liveness(monkeypatch, tmp_path: Path, bgra: bytes, code: int):
+    monkeypatch.setattr(
+        hud_capture, "capture_region", lambda name="full": (4, len(bgra) // 16, bgra)
+    )
+    out = tmp_path / "hud.png"
+    assert _main(["--out", str(out), "--region", "full"]) == code
+    assert out.read_bytes().startswith(PNG_SIGNATURE)

--- a/tests/test_ac_harness_hud_capture.py
+++ b/tests/test_ac_harness_hud_capture.py
@@ -51,6 +51,13 @@ def test_liveness_thresholds_configurable():
     assert score.is_rendering(min_distinct=20) is False
 
 
+def test_liveness_score_samples_large_buffer():
+    # > 50000 bytes exercises the step>1 sampling path (a full-screen capture is ~20 MB).
+    big_content = bytes(range(256)) * 400  # 102_400 bytes -> step = 2
+    assert liveness_score(big_content).is_rendering() is True
+    assert liveness_score(bytes(102_400)).is_rendering() is False  # all-black, sampled
+
+
 def test_bgra_to_rgb_swaps_channels():
     out_w, out_h, rgb = bgra_to_rgb(2, 2, BGRA_2x2)
     assert (out_w, out_h) == (2, 2)
@@ -67,6 +74,11 @@ def test_bgra_to_rgb_downsamples_by_stride():
 def test_bgra_to_rgb_rejects_bad_stride():
     with pytest.raises(ValueError, match="stride"):
         bgra_to_rgb(2, 2, BGRA_2x2, stride=0)
+
+
+def test_bgra_to_rgb_rejects_short_buffer():
+    with pytest.raises(ValueError, match="bgra length"):
+        bgra_to_rgb(2, 2, BGRA_2x2[:-4])  # one pixel short
 
 
 def test_encode_png_is_valid_and_carries_dims():

--- a/tools/ac_harness/hud_capture.py
+++ b/tools/ac_harness/hud_capture.py
@@ -73,6 +73,8 @@ def bgra_to_rgb(w: int, h: int, bgra: bytes, *, stride: int = 1) -> tuple[int, i
     """Convert a top-down BGRA buffer to packed RGB, optionally downsampling by ``stride``."""
     if stride < 1:
         raise ValueError("stride must be >= 1")
+    if len(bgra) < w * h * 4:
+        raise ValueError(f"bgra length {len(bgra)} < {w * h * 4} for {w}x{h} BGRA")
     out_w, out_h = w // stride, h // stride
     out = bytearray(out_w * out_h * 3)
     mv = memoryview(bgra)
@@ -142,11 +144,16 @@ def capture_bgra(x: int = 0, y: int = 0, w: int | None = None, h: int | None = N
     if h is None:
         h = user32.GetSystemMetrics(_SM_CYSCREEN)
     hdc = user32.GetDC(0)
+    if not hdc:
+        raise RuntimeError("GetDC failed")
     mdc = gdi32.CreateCompatibleDC(hdc)
     bmp = gdi32.CreateCompatibleBitmap(hdc, w, h)
-    gdi32.SelectObject(mdc, bmp)
     try:
-        gdi32.BitBlt(mdc, 0, 0, w, h, hdc, x, y, _SRCCOPY)
+        if not mdc or not bmp:
+            raise RuntimeError("CreateCompatibleDC/Bitmap failed")
+        gdi32.SelectObject(mdc, bmp)
+        if not gdi32.BitBlt(mdc, 0, 0, w, h, hdc, x, y, _SRCCOPY):
+            raise RuntimeError("BitBlt failed")
         bmi = _BMIH()
         bmi.biSize = ctypes.sizeof(_BMIH)
         bmi.biWidth = w
@@ -155,7 +162,8 @@ def capture_bgra(x: int = 0, y: int = 0, w: int | None = None, h: int | None = N
         bmi.biBitCount = 32
         bmi.biCompression = 0  # BI_RGB
         buf = (ctypes.c_char * (w * h * 4))()
-        gdi32.GetDIBits(mdc, bmp, 0, h, buf, ctypes.byref(bmi), _DIB_RGB_COLORS)
+        if gdi32.GetDIBits(mdc, bmp, 0, h, buf, ctypes.byref(bmi), _DIB_RGB_COLORS) == 0:
+            raise RuntimeError("GetDIBits failed")
         return w, h, bytes(buf)
     finally:
         gdi32.DeleteObject(bmp)

--- a/tools/ac_harness/hud_capture.py
+++ b/tools/ac_harness/hud_capture.py
@@ -1,0 +1,214 @@
+"""HUD framebuffer capture — the vision oracle's "eyes" (EPIC #154 Part G).
+
+The WS pipeline (`self_test` / `sequence_probe`) answers "is the trainer publishing?"; this module
+answers the independent question "does the HUD actually render?" — a black or frozen frame is a real
+failure the WS check can miss. It is a **stdlib `ctypes` GDI** desktop grab (no new dependency; the
+harness already uses `ctypes` in :mod:`shared_memory`), verified on the rig where AC runs
+borderless-windowed (a GDI grab captures it; it does not return black).
+
+The capture itself is Windows-only and live; the conversion / region / PNG / liveness helpers are
+pure and unit-tested. The agent-vision / OCR assertion of specific HUD strings is the consuming step
+(read the saved PNG), not part of this primitive.
+
+CLI: ``python -m tools.ac_harness.hud_capture --out hud.png --region coaching``
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+import zlib
+from dataclasses import dataclass
+
+# GDI / DIB constants.
+_SRCCOPY = 0x00CC0020
+_DIB_RGB_COLORS = 0
+_SM_CXSCREEN = 0
+_SM_CYSCREEN = 1
+
+# Named HUD regions as fractions of the primary screen (x, y, w, h). "coaching"/"left" target the
+# top-left where the trainer's coaching widget renders; "full" is the whole screen.
+_REGIONS: dict[str, tuple[float, float, float, float]] = {
+    "full": (0.0, 0.0, 1.0, 1.0),
+    "left": (0.0, 0.0, 1 / 3, 1.0),
+    "coaching": (0.0, 0.0, 0.35, 0.5),
+}
+
+
+@dataclass(frozen=True)
+class LivenessScore:
+    """Cheap "is the HUD rendering?" signal over a captured buffer."""
+
+    mean: float
+    distinct: int
+
+    def is_rendering(self, *, min_mean: float = 2.0, min_distinct: int = 8) -> bool:
+        """True unless the frame looks black/uniform (mean ~0 or almost no distinct values)."""
+        return self.mean > min_mean and self.distinct > min_distinct
+
+
+def region_rect(name: str, screen_w: int, screen_h: int) -> tuple[int, int, int, int]:
+    """Resolve a named region to an integer ``(x, y, w, h)`` rect on the given screen size."""
+    if name not in _REGIONS:
+        raise ValueError(f"unknown region {name!r} (expected one of {sorted(_REGIONS)})")
+    fx, fy, fw, fh = _REGIONS[name]
+    x = int(fx * screen_w)
+    y = int(fy * screen_h)
+    w = max(1, int(fw * screen_w))
+    h = max(1, int(fh * screen_h))
+    return x, y, w, h
+
+
+def liveness_score(bgra: bytes) -> LivenessScore:
+    """Mean byte + distinct-byte-value count over a (sampled) BGRA buffer — black-frame detector."""
+    if not bgra:
+        return LivenessScore(mean=0.0, distinct=0)
+    step = max(1, len(bgra) // 50000)
+    sample = bgra[::step]
+    return LivenessScore(mean=sum(sample) / len(sample), distinct=len(set(sample)))
+
+
+def bgra_to_rgb(w: int, h: int, bgra: bytes, *, stride: int = 1) -> tuple[int, int, bytes]:
+    """Convert a top-down BGRA buffer to packed RGB, optionally downsampling by ``stride``."""
+    if stride < 1:
+        raise ValueError("stride must be >= 1")
+    out_w, out_h = w // stride, h // stride
+    out = bytearray(out_w * out_h * 3)
+    mv = memoryview(bgra)
+    o = 0
+    for ry in range(out_h):
+        base = (ry * stride) * w * 4
+        for rx in range(out_w):
+            i = base + (rx * stride) * 4
+            out[o] = mv[i + 2]  # R
+            out[o + 1] = mv[i + 1]  # G
+            out[o + 2] = mv[i]  # B
+            o += 3
+    return out_w, out_h, bytes(out)
+
+
+def encode_png(w: int, h: int, rgb: bytes) -> bytes:
+    """Encode packed 8-bit RGB into a PNG (stdlib zlib; filter 0 per row)."""
+    if len(rgb) != w * h * 3:
+        raise ValueError(f"rgb length {len(rgb)} != {w * h * 3} for {w}x{h}")
+
+    def _chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        return (
+            struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+        )
+
+    raw = b"".join(b"\x00" + rgb[r * w * 3 : (r + 1) * w * 3] for r in range(h))
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(raw, 6))
+        + _chunk(b"IEND", b"")
+    )
+
+
+def capture_bgra(x: int = 0, y: int = 0, w: int | None = None, h: int | None = None):
+    """Capture a desktop rectangle as top-down BGRA via GDI BitBlt (Windows-only, live)."""
+    if sys.platform != "win32":
+        raise RuntimeError("hud_capture is Windows-only (GDI BitBlt)")
+    import ctypes
+    from ctypes import wintypes
+
+    user32 = ctypes.windll.user32
+    gdi32 = ctypes.windll.gdi32
+    try:
+        user32.SetProcessDPIAware()
+    except Exception:  # noqa: BLE001 - DPI awareness is best-effort
+        pass
+
+    class _BMIH(ctypes.Structure):
+        _fields_ = [
+            ("biSize", wintypes.DWORD),
+            ("biWidth", wintypes.LONG),
+            ("biHeight", wintypes.LONG),
+            ("biPlanes", wintypes.WORD),
+            ("biBitCount", wintypes.WORD),
+            ("biCompression", wintypes.DWORD),
+            ("biSizeImage", wintypes.DWORD),
+            ("biXPelsPerMeter", wintypes.LONG),
+            ("biYPelsPerMeter", wintypes.LONG),
+            ("biClrUsed", wintypes.DWORD),
+            ("biClrImportant", wintypes.DWORD),
+        ]
+
+    if w is None:
+        w = user32.GetSystemMetrics(_SM_CXSCREEN)
+    if h is None:
+        h = user32.GetSystemMetrics(_SM_CYSCREEN)
+    hdc = user32.GetDC(0)
+    mdc = gdi32.CreateCompatibleDC(hdc)
+    bmp = gdi32.CreateCompatibleBitmap(hdc, w, h)
+    gdi32.SelectObject(mdc, bmp)
+    try:
+        gdi32.BitBlt(mdc, 0, 0, w, h, hdc, x, y, _SRCCOPY)
+        bmi = _BMIH()
+        bmi.biSize = ctypes.sizeof(_BMIH)
+        bmi.biWidth = w
+        bmi.biHeight = -h  # top-down
+        bmi.biPlanes = 1
+        bmi.biBitCount = 32
+        bmi.biCompression = 0  # BI_RGB
+        buf = (ctypes.c_char * (w * h * 4))()
+        gdi32.GetDIBits(mdc, bmp, 0, h, buf, ctypes.byref(bmi), _DIB_RGB_COLORS)
+        return w, h, bytes(buf)
+    finally:
+        gdi32.DeleteObject(bmp)
+        gdi32.DeleteDC(mdc)
+        user32.ReleaseDC(0, hdc)
+
+
+def capture_region(name: str = "full"):
+    """Capture a named HUD region; returns ``(w, h, bgra)``."""
+    if sys.platform != "win32":
+        raise RuntimeError("hud_capture is Windows-only (GDI BitBlt)")
+    import ctypes
+
+    user32 = ctypes.windll.user32  # type: ignore[attr-defined]
+    sw = user32.GetSystemMetrics(_SM_CXSCREEN)
+    sh = user32.GetSystemMetrics(_SM_CYSCREEN)
+    x, y, w, h = region_rect(name, sw, sh)
+    return capture_bgra(x, y, w, h)
+
+
+def save_png(path: str, w: int, h: int, bgra: bytes, *, stride: int = 1) -> tuple[int, int]:
+    """Convert a BGRA buffer to PNG and write it; returns the saved ``(w, h)``."""
+    out_w, out_h, rgb = bgra_to_rgb(w, h, bgra, stride=stride)
+    with open(path, "wb") as fh:
+        fh.write(encode_png(out_w, out_h, rgb))
+    return out_w, out_h
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="HUD framebuffer capture (EPIC #154 Part G)")
+    parser.add_argument("--out", default="hud.png", help="Output PNG path")
+    parser.add_argument(
+        "--region", choices=sorted(_REGIONS), default="coaching", help="Capture region"
+    )
+    parser.add_argument(
+        "--stride", type=int, default=1, help="Downsample factor for the saved PNG (>=1)"
+    )
+    return parser
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    w, h, bgra = capture_region(args.region)
+    score = liveness_score(bgra)
+    out_w, out_h = save_png(args.out, w, h, bgra, stride=args.stride)
+    rendering = score.is_rendering()
+    print(
+        f"hud-capture: {'RENDERING' if rendering else 'BLACK/FROZEN'} "
+        f"region={args.region} {w}x{h} -> {args.out} ({out_w}x{out_h}) "
+        f"mean={score.mean:.1f} distinct={score.distinct}"
+    )
+    return 0 if rendering else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - rig-only CLI wiring
+    raise SystemExit(_main())


### PR DESCRIPTION
Adds `tools/ac_harness/hud_capture.py` — the vision oracle's eyes. Stdlib `ctypes` GDI desktop grab (**no new dependency**; AC runs borderless-windowed so a GDI grab captures it, not black — verified on `AG_PC`) + pure helpers: BGRA→RGB, named region crop (full/left/coaching), a stdlib PNG encoder, and a mean/distinct **render-liveness score** that flags a black/frozen frame. CLI `python -m tools.ac_harness.hud_capture --out hud.png --region coaching` saves a PNG for agent-vision HUD assertion and exits non-zero on a black frame. Independent of the WS pipeline check (#236) — catches the case where AC publishes frames but the HUD doesn't render. 13 unit tests (pure helpers on synthetic buffers + Windows guard); ruff-clean. Live AC-HUD capture posted as a comment. Closes #238. Refs #154.

## Summary by Sourcery

Introduce a Windows-only HUD framebuffer capture utility with liveness detection and a CLI for saving HUD screenshots and validating render activity.

New Features:
- Add a HUD framebuffer capture module that grabs desktop regions via Windows GDI and provides named HUD-region selection.
- Expose a CLI command to capture a HUD region to PNG, optionally downsampled, and exit non-zero on black or frozen frames.
- Provide a render-liveness scoring helper to detect black or uniform frames from BGRA buffers.

Tests:
- Add unit tests for region calculations, liveness scoring, BGRA-to-RGB conversion, PNG encoding, and Windows-guarded capture and CLI behavior.