### PR TITLE
feat(harness): Stanley steering from human profile (#244)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -24,10 +24,11 @@ relates_to:
 
 **Active focus update (2026-06-19) — #244 / draft PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248):**
 Stanley steering and human-profile replay support are built and off-sim verified (`uv run --extra dev
-make ci-fast` passed: `1128 passed, 75 skipped`, coverage `82.64%`). Runtime proof is still blocked:
-Tailscale ping reaches `pc` / `100.75.251.87`, but harness daemon health/TCP probes on `9876` and
-`8765` time out, and SSH denies access. Keep #244 and #154 open until the Windows rig proves a VALID
-Magione lap at human-comparable pace with `lap`/`delta` telemetry/HUD evidence.
+make ci-fast` passed: `1131 passed, 75 skipped`, coverage `82.67%`). Review fixes are included:
+human-profile samples now align to fast-line lap-distance fractions, not ordinal point index. Runtime
+proof is still blocked: Tailscale ping reaches `pc` / `100.75.251.87`, but harness daemon health/TCP
+probes on `9876` and `8765` time out, and SSH denies access. Keep #244 and #154 open until the Windows
+rig proves a VALID Magione lap at human-comparable pace with `lap`/`delta` telemetry/HUD evidence.
 
 **Infra (2026-05-20):** PR [#111](https://github.com/agorokh/ac-copilot-trainer/pull/111) closed the [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) agent-surface campaign (closeout doc only; five agent SHA alignments deferred). PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) memory-contract cursor rule fix remains on `main`.
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T06:30:00Z
+last_updated: 2026-06-19T10:35:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -21,6 +21,13 @@ relates_to:
 **Active focus (2026-06-17):** EPIC [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) — **Part F harness daemon shipped** ([#228](https://github.com/agorokh/ac-copilot-trainer/issues/228)/PR #229) and its on-rig launch gap fixed ([#232](https://github.com/agorokh/ac-copilot-trainer/issues/232) **CLOSED** / PR [#233](https://github.com/agorokh/ac-copilot-trainer/pull/233) **MERGED** `c556dfe`): the daemon now launches AC **de-elevated via Content Manager** (`--launch-mode cm`), live-verified hands-off on `AG_PC`. The autonomous self-test is now **one command** ([#235](https://github.com/agorokh/ac-copilot-trainer/issues/235) **CLOSED** / PR [#236](https://github.com/agorokh/ac-copilot-trainer/pull/236) **MERGED** `d051096`): `python -m tools.ac_harness.self_test` drives the daemon hands-off and asserts the live coaching pipeline — **LIVE PASS** (`coaching.snapshot=335, tire_temps=168, connection=34`, no human at the wheel). The vision-oracle **"eyes"** also landed ([#238](https://github.com/agorokh/ac-copilot-trainer/issues/238) **CLOSED** / PR [#239](https://github.com/agorokh/ac-copilot-trainer/pull/239) **MERGED** `3e677c7`): `tools.ac_harness.hud_capture` (stdlib ctypes GDI, no new dep) captures the live AC HUD hands-off with a render-liveness check — **LIVE-VERIFIED** (in-cockpit at Spa, HUD text legible). [#188](https://github.com/agorokh/ac-copilot-trainer/issues/188)/[#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) **CLOSED**. **The autonomous self-test now has launch + pipeline-assert + eyes, all hands-off + live-verified.**
 
 **Active focus (2026-06-19) — HANDOFF, see [#244](https://github.com/agorokh/ac-copilot-trainer/issues/244):** Part G **racing driver** **MERGED** ([#241](https://github.com/agorokh/ac-copilot-trainer/issues/241) / PR [#242](https://github.com/agorokh/ac-copilot-trainer/pull/242) `372156a`): follows `fast_lane.ai`'s embedded speed profile with braking points/trail braking; **gear bug fixed** (was stuck in 1st — limiter below shift point) → now shifts 1→4, **146 km/h** (was 52). `tools/ac_harness/racing_telemetry.py` records human laps. **The wall is STEERING** (pure-pursuit cuts apexes → corners crawl, lap INVALID → no `lap`/`delta` telemetry). **Next:** record 5–10 human GT3 laps → build a path-tracking steering controller from real corner speeds/braking points. Full state: [`racing-driver-and-controller-2026-06-17`](../03_Investigations/racing-driver-and-controller-2026-06-17.md). Parallel hot path: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) Parts E–F.
+
+**Active focus update (2026-06-19) — #244 / draft PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248):**
+Stanley steering and human-profile replay support are built and off-sim verified (`uv run --extra dev
+make ci-fast` passed: `1128 passed, 75 skipped`, coverage `82.64%`). Runtime proof is still blocked:
+Tailscale ping reaches `pc` / `100.75.251.87`, but harness daemon health/TCP probes on `9876` and
+`8765` time out, and SSH denies access. Keep #244 and #154 open until the Windows rig proves a VALID
+Magione lap at human-comparable pace with `lap`/`delta` telemetry/HUD evidence.
 
 **Infra (2026-05-20):** PR [#111](https://github.com/agorokh/ac-copilot-trainer/pull/111) closed the [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) agent-surface campaign (closeout doc only; five agent SHA alignments deferred). PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) memory-contract cursor rule fix remains on `main`.
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T06:30:00Z
+last_updated: 2026-06-19T10:35:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -29,6 +29,32 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-19 — #244 / PR #248 DRAFT: Stanley steering built; rig daemon blocks live proof)
+
+**Read [#244](https://github.com/agorokh/ac-copilot-trainer/issues/244) and draft PR
+[#248](https://github.com/agorokh/ac-copilot-trainer/pull/248) first.** This is EPIC
+[#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) Part G continuation after the
+human-lap fixture landed.
+
+**Delivered in PR #248.** `tools/ac_harness/ai_line.py` now has cyclic path projection plus a
+`StanleySteering` controller that preserves the harness sign convention (`steer > 0` turns right).
+`tools/ac_harness/racing_driver.py` defaults to Stanley steering, keeps
+`steering_mode="pure_pursuit"` for comparison, loads/resamples the committed
+`tests/fixtures/racing_human_profile_magione.csv`, and exposes
+`RacingDriver.from_human_profile(...)` so the captured human speed profile can drive the controller.
+Exports were added from `tools.ac_harness`.
+
+**Verification completed off-sim.** Targeted tests passed (`57 passed`), ruff format/check passed, and
+`uv run --extra dev make ci-fast` passed (`1128 passed, 75 skipped`, coverage `82.64%`). GitHub build,
+conformance, canonical-docs, and CodeRabbit checks passed on the draft PR; Cursor Bugbot was still
+pending when this handoff was written.
+
+**Runtime gate still open.** Mac-side rig probes reached Tailscale node `pc` / `100.75.251.87` by ping,
+but harness daemon health/TCP probes on ports `9876` and `8765` timed out, and SSH denied access
+(`Permission denied (publickey,keyboard-interactive)`). Do **not** close #244 or the #154 epic until
+the Windows rig daemon is reachable and this branch proves a VALID Magione lap at human-comparable
+pace with `lap`/`delta` telemetry/HUD evidence captured.
 
 ## Resume here (2026-06-19 — #241/#242 MERGED: racing driver on `main`; STEERING is the wall; human-lap data is next)
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -45,10 +45,13 @@ human-lap fixture landed.
 `RacingDriver.from_human_profile(...)` so the captured human speed profile can drive the controller.
 Exports were added from `tools.ac_harness`.
 
-**Verification completed off-sim.** Targeted tests passed (`57 passed`), ruff format/check passed, and
-`uv run --extra dev make ci-fast` passed (`1128 passed, 75 skipped`, coverage `82.64%`). GitHub build,
-conformance, canonical-docs, and CodeRabbit checks passed on the draft PR; Cursor Bugbot was still
-pending when this handoff was written.
+**Verification completed off-sim.** Targeted tests passed (`60 passed`), ruff format/check passed, and
+`uv run --extra dev make ci-fast` passed (`1131 passed, 75 skipped`, coverage `82.67%`). Gemini/Codex
+review threads were addressed and resolved: Stanley projection now computes segment geometry once for
+the final nearest segment, human-profile interpolation precomputes `norms`, and
+`RacingDriver.from_human_profile(...)` samples by fast-line lap-distance fraction instead of ordinal
+point index. GitHub build, conformance, canonical-docs, and CodeRabbit checks passed on the draft PR;
+Cursor Bugbot was still pending when this handoff was written.
 
 **Runtime gate still open.** Mac-side rig probes reached Tailscale node `pc` / `100.75.251.87` by ping,
 but harness daemon health/TCP probes on ports `9876` and `8765` timed out, and SSH denied access

--- a/tests/test_ac_harness_racing_driver.py
+++ b/tests/test_ac_harness_racing_driver.py
@@ -14,6 +14,7 @@ from tools.ac_harness.racing_driver import (
     load_ai_profile,
     load_human_profile,
     load_human_speed_profile,
+    load_human_speed_profile_for_line,
     load_speed_profile,
 )
 
@@ -97,6 +98,61 @@ def test_load_human_profile_parses_and_resamples_cyclically(tmp_path: Path):
     assert points[0].speed_mps == pytest.approx(20.0)
     assert points[1].brake == pytest.approx(0.5)
     assert speeds == pytest.approx([30.0, 20.0, 30.0, 40.0])  # m/s, wrapping across 1.0->0.0
+
+
+def test_load_human_profile_rejects_out_of_range_norm_pos(tmp_path: Path):
+    f = tmp_path / "human_profile.csv"
+    f.write_text(
+        "norm_pos,speed_kmh,brake,gas,min_speed_kmh\n"
+        "-0.25,72.0,0.000,1.000,60.0\n"
+        "0.75,144.0,0.500,0.000,80.0\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="norm_pos out of range"):
+        load_human_profile(f)
+
+
+def test_load_human_speed_profile_for_line_uses_distance_fraction(tmp_path: Path):
+    f = tmp_path / "human_profile.csv"
+    f.write_text(
+        "norm_pos,speed_kmh,brake,gas,min_speed_kmh\n"
+        "0.00,0.0,0.000,1.000,0.0\n"
+        "0.50,180.0,0.500,0.000,80.0\n",
+        encoding="utf-8",
+    )
+    # Cyclic segment lengths: 10, 30, 10, 30 -> point distance fractions 0, .125, .5, .625.
+    line = [
+        (0.0, 0.0, 0.0),
+        (10.0, 0.0, 0.0),
+        (10.0, 0.0, 30.0),
+        (0.0, 0.0, 30.0),
+    ]
+
+    speeds_kmh = [s * 3.6 for s in load_human_speed_profile_for_line(f, line)]
+
+    assert speeds_kmh == pytest.approx([0.0, 45.0, 180.0, 135.0])
+
+
+def test_racing_driver_from_human_profile_uses_line_distance_fraction(tmp_path: Path):
+    f = tmp_path / "human_profile.csv"
+    f.write_text(
+        "norm_pos,speed_kmh,brake,gas,min_speed_kmh\n"
+        "0.00,36.0,0.000,1.000,1.0\n"
+        "0.50,180.0,0.500,0.000,80.0\n",
+        encoding="utf-8",
+    )
+    line = [
+        (0.0, 0.0, 0.0),
+        (10.0, 0.0, 0.0),
+        (10.0, 0.0, 30.0),
+        (0.0, 0.0, 30.0),
+    ]
+
+    d = RacingDriver.from_human_profile(line, f, brake_g=1000.0)
+    speeds_kmh = [s * 3.6 for s in d.profile]
+
+    assert speeds_kmh == pytest.approx([36.0, 72.0, 180.0, 144.0])
 
 
 def test_real_magione_human_fixture_has_racing_pace():

--- a/tests/test_ac_harness_racing_driver.py
+++ b/tests/test_ac_harness_racing_driver.py
@@ -10,7 +10,10 @@ import pytest
 from tools.ac_harness.lap_driver import PHASE_LAP
 from tools.ac_harness.racing_driver import (
     RacingDriver,
+    human_profile_speed_profile,
     load_ai_profile,
+    load_human_profile,
+    load_human_speed_profile,
     load_speed_profile,
 )
 
@@ -76,6 +79,52 @@ def test_load_speed_profile_rejects_bad_extra_count(tmp_path: Path):
     f.write_bytes(bytes(blob))
     with pytest.raises(ValueError, match="AiPointExtra count"):
         load_speed_profile(f)
+
+
+def test_load_human_profile_parses_and_resamples_cyclically(tmp_path: Path):
+    f = tmp_path / "human_profile.csv"
+    f.write_text(
+        "norm_pos,speed_kmh,brake,gas,min_speed_kmh\n"
+        "0.25,72.0,0.000,1.000,60.0\n"
+        "0.75,144.0,0.500,0.000,80.0\n",
+        encoding="utf-8",
+    )
+
+    points = load_human_profile(f)
+    speeds = human_profile_speed_profile(points, 4)
+
+    assert len(points) == 2
+    assert points[0].speed_mps == pytest.approx(20.0)
+    assert points[1].brake == pytest.approx(0.5)
+    assert speeds == pytest.approx([30.0, 20.0, 30.0, 40.0])  # m/s, wrapping across 1.0->0.0
+
+
+def test_real_magione_human_fixture_has_racing_pace():
+    fixture = Path(__file__).parent / "fixtures" / "racing_human_profile_magione.csv"
+    speeds = load_human_speed_profile(fixture, 200)
+    speeds_kmh = [s * 3.6 for s in speeds]
+
+    assert len(speeds) == 200
+    assert max(speeds_kmh) > 220.0
+    assert min(speeds_kmh) < 45.0
+    assert 115.0 < sum(speeds_kmh) / len(speeds_kmh) < 130.0
+
+
+def test_racing_driver_from_human_profile_defaults_to_stanley(tmp_path: Path):
+    f = tmp_path / "human_profile.csv"
+    f.write_text(
+        "norm_pos,speed_kmh,brake,gas,min_speed_kmh\n"
+        "0.00,72.0,0.000,1.000,60.0\n"
+        "0.50,108.0,0.500,0.000,80.0\n",
+        encoding="utf-8",
+    )
+
+    line = _straight_line(10)
+    d = RacingDriver.from_human_profile(line, f)
+
+    assert d.steering_mode == "stanley"
+    assert len(d.profile) == len(line)
+    assert max(d.profile) * 3.6 > 90.0
 
 
 def test_backward_pass_creates_a_braking_point_before_a_slow_corner():
@@ -182,6 +231,15 @@ def test_step_lap_phase_brakes_over_profile():
     assert frame.gas == 0.0
 
 
+def test_step_lap_phase_uses_stanley_steering_by_default():
+    line = _straight_line(30)
+    d = RacingDriver(line, [30.0] * 30, pace=1.0, max_speed_kmh=120.0, brake_g=5.0)
+    d.phase = PHASE_LAP
+    frame = d.step((10.0, 0.0, -3.0), (1.0, 0.0, 0.0), speed_kmh=60.0, rpm=6000, gear=4, now=1.0)
+    assert d.steering_mode == "stanley"
+    assert frame.steer > 0.0
+
+
 def test_constructor_validates():
     line = _straight_line(10)
     with pytest.raises(ValueError, match="length mismatch"):
@@ -190,3 +248,5 @@ def test_constructor_validates():
         RacingDriver(line, [40.0] * 10, pace=1.5)
     with pytest.raises(ValueError, match="min_speed_kmh"):
         RacingDriver(line, [40.0] * 10, max_speed_kmh=30.0, min_speed_kmh=40.0)
+    with pytest.raises(ValueError, match="steering_mode"):
+        RacingDriver(line, [40.0] * 10, steering_mode="lookahead")

--- a/tests/test_ai_line.py
+++ b/tests/test_ai_line.py
@@ -12,13 +12,16 @@ aims the car to its right.
 
 from __future__ import annotations
 
+import math
 import struct
 
 import pytest
 
 from tools.ac_harness.ai_line import (
     ControlOutput,
+    PathProjection,
     PurePursuit,
+    StanleySteering,
     load_ai_line,
 )
 
@@ -33,7 +36,6 @@ def _right_turn_line() -> list[tuple[float, float, float]]:
     """A line that goes +x then curves toward +z (a right-hand turn for a +x-facing car)."""
     pts: list[tuple[float, float, float]] = [(i * 2.0, 5.0, 0.0) for i in range(20)]
     # quarter arc bending toward +z
-    import math
 
     cx, cz = pts[-1][0], pts[-1][2] + 20.0  # arc centre to the car's right (+z)
     for k in range(1, 25):
@@ -304,6 +306,84 @@ def test_control_output_unpacks_as_tuple():
         pytest.approx(pp.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), 50.0).brake),
         pytest.approx(pp.control((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), 50.0).steer),
     )
+
+
+# --------------------------------------------------------------------------- Stanley steering
+def test_stanley_projection_reports_signed_cross_track_error():
+    st = StanleySteering(_straight_line_along_x())
+
+    projection = st.project((5.0, -3.0))
+
+    assert isinstance(projection, PathProjection)
+    assert projection.segment_index == 2  # segment x=4 -> x=6
+    assert projection.t == pytest.approx(0.5)
+    assert projection.point == pytest.approx((5.0, 0.0))
+    assert projection.signed_cross_track_m == pytest.approx(3.0)
+    assert projection.distance_m == pytest.approx(3.0)
+
+
+def test_stanley_steer_zero_on_straight_when_aligned():
+    st = StanleySteering(_straight_line_along_x())
+    assert st.steer((10.0, 5.0, 0.0), (1.0, 0.0, 0.0), speed_kmh=80.0) == pytest.approx(0.0)
+
+
+def test_stanley_steers_right_when_line_is_to_car_right():
+    st = StanleySteering(_straight_line_along_x())
+    steer = st.steer((10.0, 5.0, -3.0), (1.0, 0.0, 0.0), speed_kmh=60.0)
+    assert steer > 0.0
+
+
+def test_stanley_steers_left_when_line_is_to_car_left():
+    st = StanleySteering(_straight_line_along_x())
+    steer = st.steer((10.0, 5.0, 3.0), (1.0, 0.0, 0.0), speed_kmh=60.0)
+    assert steer < 0.0
+
+
+def test_stanley_cross_track_term_softens_at_speed():
+    st = StanleySteering(_straight_line_along_x())
+    slow = st.steer((10.0, 5.0, -2.0), (1.0, 0.0, 0.0), speed_kmh=20.0)
+    fast = st.steer((10.0, 5.0, -2.0), (1.0, 0.0, 0.0), speed_kmh=160.0)
+    assert 0.0 < fast < slow
+
+
+def test_stanley_heading_error_turns_toward_path_tangent():
+    line = _right_turn_line()
+    st = StanleySteering(line)
+    mid_arc = line[28]
+    steer = st.steer(mid_arc, (1.0, 0.0, 0.0), speed_kmh=80.0)
+    assert steer > 0.0
+
+
+def test_stanley_heading_error_wraps_across_pi_boundary():
+    path_heading = math.radians(175.0)
+    car_heading = math.radians(-175.0)
+    line = [
+        (0.0, 5.0, 0.0),
+        (20.0 * math.cos(path_heading), 5.0, 20.0 * math.sin(path_heading)),
+    ]
+    st = StanleySteering(line)
+
+    steer = st.steer(
+        (0.0, 5.0, 0.0),
+        (math.cos(car_heading), 0.0, math.sin(car_heading)),
+        speed_kmh=80.0,
+    )
+
+    assert steer == pytest.approx(math.radians(-10.0) / st.max_steer_rad, abs=1e-3)
+    assert abs(steer) < 0.5
+
+
+def test_stanley_projection_uses_cyclic_closing_segment():
+    st = StanleySteering(_closed_loop_square(side=10.0))
+    projection = st.project((-1.0, 5.0))
+    assert projection.segment_index == 3  # closing segment (0,10) -> (0,0)
+    assert projection.t == pytest.approx(0.5)
+    assert projection.point == pytest.approx((0.0, 5.0))
+
+
+def test_stanley_rejects_degenerate_lines():
+    with pytest.raises(ValueError, match="no non-zero segments"):
+        StanleySteering([(0.0, 0.0, 0.0), (0.0, 5.0, 0.0)])
 
 
 # --------------------------------------------------------------------------- nearest / determinism

--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -11,7 +11,13 @@ synthesizer, and the schema-gated mock ``ac``/``car``/``sim`` tables.
 
 from __future__ import annotations
 
-from tools.ac_harness.ai_line import ControlOutput, PurePursuit, load_ai_line
+from tools.ac_harness.ai_line import (
+    ControlOutput,
+    PathProjection,
+    PurePursuit,
+    StanleySteering,
+    load_ai_line,
+)
 from tools.ac_harness.custom_ai import (
     CarControls,
     CarData,
@@ -102,6 +108,8 @@ __all__ = [
     "LapDriver",
     # Racing line loader + pure-pursuit controller.
     "ControlOutput",
+    "PathProjection",
     "PurePursuit",
+    "StanleySteering",
     "load_ai_line",
 ]

--- a/tools/ac_harness/ai_line.py
+++ b/tools/ac_harness/ai_line.py
@@ -427,7 +427,9 @@ class StanleySteering:
 
     def project(self, position: tuple[float, float]) -> PathProjection:
         """Project ``position`` to the nearest point on any cyclic line segment."""
-        best: PathProjection | None = None
+        best_i: int | None = None
+        best_t = 0.0
+        best_proj = (0.0, 0.0)
         best_d2 = float("inf")
         n = len(self._plane)
         for i in range(n):
@@ -444,22 +446,29 @@ class StanleySteering:
             d2 = off[0] * off[0] + off[1] * off[1]
             if d2 >= best_d2:
                 continue
-            seg_len = math.sqrt(seg2)
-            tangent = (dx / seg_len, dz / seg_len)
-            right = (-tangent[1], tangent[0])
-            signed = off[0] * right[0] + off[1] * right[1]
-            best = PathProjection(
-                segment_index=i,
-                t=t,
-                point=proj,
-                tangent=tangent,
-                signed_cross_track_m=signed,
-                distance_m=math.sqrt(d2),
-            )
+            best_i = i
+            best_t = t
+            best_proj = proj
             best_d2 = d2
-        if best is None:  # construction rejects all-zero lines; this is defensive.
+        if best_i is None:  # construction rejects all-zero lines; this is defensive.
             raise ValueError("Stanley steering line has no projectable segment")
-        return best
+        a = self._plane[best_i]
+        b = self._plane[(best_i + 1) % n]
+        dx = b[0] - a[0]
+        dz = b[1] - a[1]
+        seg_len = math.hypot(dx, dz)
+        tangent = (dx / seg_len, dz / seg_len)
+        right = (-tangent[1], tangent[0])
+        off = (best_proj[0] - position[0], best_proj[1] - position[1])
+        signed = off[0] * right[0] + off[1] * right[1]
+        return PathProjection(
+            segment_index=best_i,
+            t=best_t,
+            point=best_proj,
+            tangent=tangent,
+            signed_cross_track_m=signed,
+            distance_m=math.sqrt(best_d2),
+        )
 
     def steer(
         self,

--- a/tools/ac_harness/ai_line.py
+++ b/tools/ac_harness/ai_line.py
@@ -131,6 +131,18 @@ class ControlOutput:
         yield self.steer
 
 
+@dataclass(frozen=True)
+class PathProjection:
+    """Nearest projected point on the cyclic racing line."""
+
+    segment_index: int
+    t: float
+    point: tuple[float, float]
+    tangent: tuple[float, float]
+    signed_cross_track_m: float
+    distance_m: float
+
+
 def _horizontal(p: tuple[float, float, float]) -> tuple[float, float]:
     """Project an ``(x, y, z)`` point to the ground plane ``(x, z)`` (drop vertical ``y``)."""
     return (p[0], p[2])
@@ -367,6 +379,121 @@ class PurePursuit:
             return (_clamp(error / 20.0, 0.0, 1.0), 0.0)
         # Above target: brake scaled by excess, full brake once ~15 km/h+ over.
         return (0.0, _clamp(-error / 15.0, 0.0, 1.0))
+
+
+class StanleySteering:
+    """Stanley-style lateral path tracker over the same cyclic ``fast_lane.ai`` geometry.
+
+    Pure pursuit aims at a look-ahead point, which is stable at conservative speed but cuts apexes
+    when the controller starts carrying racing pace. Stanley steering uses the local path tangent
+    plus signed cross-track error instead: heading error points the nose along the path and the
+    cross-track term pulls the car back to the line, scaled down at speed.
+
+    ``steer > 0`` preserves the harness convention: command a right turn.
+    """
+
+    def __init__(
+        self,
+        line: list[tuple[float, float, float]],
+        *,
+        cross_track_gain: float = 0.75,
+        heading_gain: float = 1.0,
+        speed_softening_mps: float = 5.0,
+        max_steer_rad: float = 0.65,
+        max_cross_track_m: float = 10.0,
+    ) -> None:
+        if len(line) < 2:
+            raise ValueError("Stanley steering needs at least 2 line points")
+        if cross_track_gain <= 0 or heading_gain <= 0:
+            raise ValueError("cross_track_gain and heading_gain must be > 0")
+        if speed_softening_mps < 0 or max_steer_rad <= 0 or max_cross_track_m <= 0:
+            raise ValueError("speed_softening_mps, max_steer_rad, max_cross_track_m invalid")
+
+        self._plane = [_horizontal(p) for p in line]
+        self.cross_track_gain = cross_track_gain
+        self.heading_gain = heading_gain
+        self.speed_softening_mps = speed_softening_mps
+        self.max_steer_rad = max_steer_rad
+        self.max_cross_track_m = max_cross_track_m
+
+        has_nonzero_segment = False
+        for i, a in enumerate(self._plane):
+            b = self._plane[(i + 1) % len(self._plane)]
+            if math.hypot(b[0] - a[0], b[1] - a[1]) > 1e-9:
+                has_nonzero_segment = True
+                break
+        if not has_nonzero_segment:
+            raise ValueError("Stanley steering line has no non-zero segments")
+
+    def project(self, position: tuple[float, float]) -> PathProjection:
+        """Project ``position`` to the nearest point on any cyclic line segment."""
+        best: PathProjection | None = None
+        best_d2 = float("inf")
+        n = len(self._plane)
+        for i in range(n):
+            a = self._plane[i]
+            b = self._plane[(i + 1) % n]
+            dx = b[0] - a[0]
+            dz = b[1] - a[1]
+            seg2 = dx * dx + dz * dz
+            if seg2 <= 1e-18:
+                continue
+            t = _clamp(((position[0] - a[0]) * dx + (position[1] - a[1]) * dz) / seg2, 0.0, 1.0)
+            proj = (a[0] + t * dx, a[1] + t * dz)
+            off = (proj[0] - position[0], proj[1] - position[1])
+            d2 = off[0] * off[0] + off[1] * off[1]
+            if d2 >= best_d2:
+                continue
+            seg_len = math.sqrt(seg2)
+            tangent = (dx / seg_len, dz / seg_len)
+            right = (-tangent[1], tangent[0])
+            signed = off[0] * right[0] + off[1] * right[1]
+            best = PathProjection(
+                segment_index=i,
+                t=t,
+                point=proj,
+                tangent=tangent,
+                signed_cross_track_m=signed,
+                distance_m=math.sqrt(d2),
+            )
+            best_d2 = d2
+        if best is None:  # construction rejects all-zero lines; this is defensive.
+            raise ValueError("Stanley steering line has no projectable segment")
+        return best
+
+    def steer(
+        self,
+        position_xyz: tuple[float, float, float],
+        look_dir_xyz: tuple[float, float, float],
+        speed_kmh: float,
+    ) -> float:
+        """Return a steering fraction in ``[-1, 1]`` from pose + speed."""
+        car = _horizontal(position_xyz)
+        fwd = _horizontal(look_dir_xyz)
+        fwd_len = math.hypot(fwd[0], fwd[1])
+        if fwd_len < 1e-9:
+            return 0.0
+        fwd_unit = (fwd[0] / fwd_len, fwd[1] / fwd_len)
+
+        projection = self.project(car)
+        tangent = projection.tangent
+        dot = _clamp(fwd_unit[0] * tangent[0] + fwd_unit[1] * tangent[1], -1.0, 1.0)
+        # Positive cross means the path heading lies to the car's right.
+        cross = fwd_unit[0] * tangent[1] - fwd_unit[1] * tangent[0]
+        heading_error = math.atan2(cross, dot)
+
+        cte = _clamp(
+            projection.signed_cross_track_m,
+            -self.max_cross_track_m,
+            self.max_cross_track_m,
+        )
+        speed_mps = max(speed_kmh, 0.0) / 3.6
+        cross_track_term = math.atan2(
+            self.cross_track_gain * cte,
+            speed_mps + self.speed_softening_mps,
+        )
+        wheel_angle = self.heading_gain * heading_error + cross_track_term
+        return _clamp(wheel_angle / self.max_steer_rad, -1.0, 1.0)
 
 
 def _clamp(value: float, low: float, high: float) -> float:

--- a/tools/ac_harness/racing_driver.py
+++ b/tools/ac_harness/racing_driver.py
@@ -130,20 +130,23 @@ def load_human_profile(path: str | Path) -> list[HumanProfilePoint]:
             raise ValueError(f"human profile missing required column(s): {cols}")
         for line_no, row in enumerate(reader, start=2):
             try:
-                norm_pos = float(row["norm_pos"]) % 1.0
+                raw_norm_pos = float(row["norm_pos"])
                 speed_kmh = float(row["speed_kmh"])
                 brake = float(row["brake"])
                 gas = float(row["gas"])
                 min_speed_kmh = float(row.get("min_speed_kmh") or speed_kmh)
             except (TypeError, ValueError) as exc:
                 raise ValueError(f"human profile line {line_no} has non-numeric data") from exc
-            values = (norm_pos, speed_kmh, brake, gas, min_speed_kmh)
+            values = (raw_norm_pos, speed_kmh, brake, gas, min_speed_kmh)
             if not all(math.isfinite(v) for v in values):
                 raise ValueError(f"human profile line {line_no} has non-finite data")
+            if not 0.0 <= raw_norm_pos <= 1.0:
+                raise ValueError(f"human profile line {line_no} norm_pos out of range 0..1")
             if speed_kmh < 0 or min_speed_kmh < 0:
                 raise ValueError(f"human profile line {line_no} has negative speed")
             if not 0.0 <= brake <= 1.0 or not 0.0 <= gas <= 1.0:
                 raise ValueError(f"human profile line {line_no} gas/brake out of range 0..1")
+            norm_pos = 0.0 if raw_norm_pos == 1.0 else raw_norm_pos
             rows.append(
                 HumanProfilePoint(
                     norm_pos=norm_pos,
@@ -162,9 +165,13 @@ def load_human_profile(path: str | Path) -> list[HumanProfilePoint]:
     return rows
 
 
-def _cyclic_interpolate(points: list[HumanProfilePoint], norm_pos: float, field: str) -> float:
+def _cyclic_interpolate(
+    points: list[HumanProfilePoint],
+    norms: list[float],
+    norm_pos: float,
+    field: str,
+) -> float:
     """Interpolate a profile field on the cyclic ``0..1`` normalized track domain."""
-    norms = [p.norm_pos for p in points]
     target = norm_pos % 1.0
     idx = bisect_right(norms, target)
     if idx == 0:
@@ -191,18 +198,64 @@ def _cyclic_interpolate(points: list[HumanProfilePoint], norm_pos: float, field:
     return left_value + frac * (right_value - left_value)
 
 
-def human_profile_speed_profile(points: list[HumanProfilePoint], point_count: int) -> list[float]:
+def _line_normalized_positions(fast_line: list[tuple[float, float, float]]) -> list[float]:
+    """Return each racing-line point's distance fraction around the cyclic lap."""
+    if len(fast_line) < 2:
+        raise ValueError("fast_line needs at least two points")
+    plane = [_horizontal(p) for p in fast_line]
+    cumulative = [0.0]
+    total = 0.0
+    for i in range(1, len(plane)):
+        prev = plane[i - 1]
+        cur = plane[i]
+        total += math.hypot(cur[0] - prev[0], cur[1] - prev[1])
+        cumulative.append(total)
+    first = plane[0]
+    last = plane[-1]
+    total += math.hypot(first[0] - last[0], first[1] - last[1])
+    if total <= 1e-9:
+        raise ValueError("fast_line has zero cyclic length")
+    return [0.0 if total - d <= 1e-9 else d / total for d in cumulative]
+
+
+def human_profile_speed_profile(
+    points: list[HumanProfilePoint],
+    point_count: int,
+    *,
+    norm_positions: list[float] | None = None,
+) -> list[float]:
     """Resample a human profile to one target speed per racing-line point."""
     if point_count <= 0:
         raise ValueError("point_count must be > 0")
     if len(points) < 2:
         raise ValueError("human profile needs at least two rows")
-    return [_cyclic_interpolate(points, i / point_count, "speed_mps") for i in range(point_count)]
+    if norm_positions is None:
+        norm_positions = [i / point_count for i in range(point_count)]
+    if len(norm_positions) != point_count:
+        raise ValueError("norm_positions length must equal point_count")
+    for pos in norm_positions:
+        if not math.isfinite(pos) or not 0.0 <= pos < 1.0:
+            raise ValueError("norm_positions must be finite fractions in [0, 1)")
+    norms = [p.norm_pos for p in points]
+    return [_cyclic_interpolate(points, norms, pos, "speed_mps") for pos in norm_positions]
 
 
 def load_human_speed_profile(path: str | Path, point_count: int) -> list[float]:
     """Load and resample a human-lap CSV into a ``RacingDriver`` speed profile."""
     return human_profile_speed_profile(load_human_profile(path), point_count)
+
+
+def load_human_speed_profile_for_line(
+    path: str | Path,
+    fast_line: list[tuple[float, float, float]],
+) -> list[float]:
+    """Load a human-lap CSV and align it by distance fraction to ``fast_line`` points."""
+    profile = load_human_profile(path)
+    return human_profile_speed_profile(
+        profile,
+        len(fast_line),
+        norm_positions=_line_normalized_positions(fast_line),
+    )
 
 
 def _clamp(x: float, lo: float, hi: float) -> float:
@@ -231,7 +284,15 @@ class RacingDriver:
         kwargs.setdefault("pace", 1.0)
         kwargs.setdefault("max_speed_kmh", max(p.speed_mps for p in profile) * 3.6)
         kwargs.setdefault("min_speed_kmh", max(min(p.min_speed_mps for p in profile) * 3.6, 1.0))
-        return cls(fast_line, human_profile_speed_profile(profile, len(fast_line)), **kwargs)
+        return cls(
+            fast_line,
+            human_profile_speed_profile(
+                profile,
+                len(fast_line),
+                norm_positions=_line_normalized_positions(fast_line),
+            ),
+            **kwargs,
+        )
 
     def __init__(
         self,

--- a/tools/ac_harness/racing_driver.py
+++ b/tools/ac_harness/racing_driver.py
@@ -14,22 +14,21 @@ Where :mod:`lap_driver` is a ~50 km/h lane-keeper that *never brakes*, this driv
   so it does not just spin the wheels on corner exit;
 * **trail braking** — bleed the brake off as steering increases (coupled brake+steer).
 
-Steering reuses :class:`ai_line.PurePursuit`. The decision logic (:meth:`RacingDriver.step`) is pure
-and deterministic — CI-verified with synthetic lines, exactly like :class:`lap_driver.LapDriver`. A
-``pace`` fraction + ``max_speed_kmh`` cap scale the optimal profile into pure-pursuit's stable
-steering envelope; the *dynamics* (hard braking, trail braking, real corner-vs-straight speeds, full
-gearbox) are real racing — closing the gap to optimal pace needs a stronger steering controller
-(tracked follow-up, see #241).
+Steering defaults to :class:`ai_line.StanleySteering`, which tracks path tangent + cross-track error
+instead of cutting to a look-ahead point. The decision logic (:meth:`RacingDriver.step`) is pure and
+deterministic — CI-verified with synthetic lines, exactly like :class:`lap_driver.LapDriver`.
 """
 
 from __future__ import annotations
 
+import csv
 import math
 import struct
+from bisect import bisect_right
 from dataclasses import dataclass
 from pathlib import Path
 
-from tools.ac_harness.ai_line import PurePursuit, _horizontal
+from tools.ac_harness.ai_line import PurePursuit, StanleySteering, _horizontal
 from tools.ac_harness.lap_driver import PHASE_LAP, PHASE_OUT, DriveFrame
 
 # fast_lane.ai AiPointExtra block: speed@0, gas@4, brake@8 — 72-byte stride. Ground-truthed live
@@ -49,6 +48,17 @@ class AiPointProfile:
     speed_mps: float
     gas: float
     brake: float
+
+
+@dataclass(frozen=True)
+class HumanProfilePoint:
+    """Per-normalized-track-position target distilled from human laps."""
+
+    norm_pos: float
+    speed_mps: float
+    brake: float
+    gas: float
+    min_speed_mps: float
 
 
 def _parse_fast_lane_extra(data: bytes) -> list[AiPointProfile]:
@@ -103,6 +113,98 @@ def load_speed_profile(path: str | Path) -> list[float]:
     return [p.speed_mps for p in load_ai_profile(path)]
 
 
+def load_human_profile(path: str | Path) -> list[HumanProfilePoint]:
+    """Parse the human-lap profile CSV produced from ``racing_telemetry`` captures.
+
+    The committed Magione fixture is keyed by ``normalizedCarPosition`` and carries the human
+    speed/brake/gas targets used for #244. Values are returned sorted by ``norm_pos`` and speeds
+    are converted to m/s so they can feed :class:`RacingDriver` directly.
+    """
+    rows: list[HumanProfilePoint] = []
+    with Path(path).open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        required = {"norm_pos", "speed_kmh", "brake", "gas"}
+        missing = required.difference(reader.fieldnames or ())
+        if missing:
+            cols = ", ".join(sorted(missing))
+            raise ValueError(f"human profile missing required column(s): {cols}")
+        for line_no, row in enumerate(reader, start=2):
+            try:
+                norm_pos = float(row["norm_pos"]) % 1.0
+                speed_kmh = float(row["speed_kmh"])
+                brake = float(row["brake"])
+                gas = float(row["gas"])
+                min_speed_kmh = float(row.get("min_speed_kmh") or speed_kmh)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"human profile line {line_no} has non-numeric data") from exc
+            values = (norm_pos, speed_kmh, brake, gas, min_speed_kmh)
+            if not all(math.isfinite(v) for v in values):
+                raise ValueError(f"human profile line {line_no} has non-finite data")
+            if speed_kmh < 0 or min_speed_kmh < 0:
+                raise ValueError(f"human profile line {line_no} has negative speed")
+            if not 0.0 <= brake <= 1.0 or not 0.0 <= gas <= 1.0:
+                raise ValueError(f"human profile line {line_no} gas/brake out of range 0..1")
+            rows.append(
+                HumanProfilePoint(
+                    norm_pos=norm_pos,
+                    speed_mps=speed_kmh / 3.6,
+                    brake=brake,
+                    gas=gas,
+                    min_speed_mps=min_speed_kmh / 3.6,
+                )
+            )
+    if len(rows) < 2:
+        raise ValueError("human profile needs at least two rows")
+    rows.sort(key=lambda p: p.norm_pos)
+    for prev, cur in zip(rows, rows[1:], strict=False):
+        if abs(cur.norm_pos - prev.norm_pos) < 1e-9:
+            raise ValueError(f"human profile duplicate norm_pos: {cur.norm_pos:.6f}")
+    return rows
+
+
+def _cyclic_interpolate(points: list[HumanProfilePoint], norm_pos: float, field: str) -> float:
+    """Interpolate a profile field on the cyclic ``0..1`` normalized track domain."""
+    norms = [p.norm_pos for p in points]
+    target = norm_pos % 1.0
+    idx = bisect_right(norms, target)
+    if idx == 0:
+        left = points[-1]
+        right = points[0]
+        left_norm = left.norm_pos - 1.0
+        right_norm = right.norm_pos
+    elif idx == len(points):
+        left = points[-1]
+        right = points[0]
+        left_norm = left.norm_pos
+        right_norm = right.norm_pos + 1.0
+    else:
+        left = points[idx - 1]
+        right = points[idx]
+        left_norm = left.norm_pos
+        right_norm = right.norm_pos
+    span = right_norm - left_norm
+    if span <= 1e-12:
+        return float(getattr(left, field))
+    frac = (target - left_norm) / span
+    left_value = float(getattr(left, field))
+    right_value = float(getattr(right, field))
+    return left_value + frac * (right_value - left_value)
+
+
+def human_profile_speed_profile(points: list[HumanProfilePoint], point_count: int) -> list[float]:
+    """Resample a human profile to one target speed per racing-line point."""
+    if point_count <= 0:
+        raise ValueError("point_count must be > 0")
+    if len(points) < 2:
+        raise ValueError("human profile needs at least two rows")
+    return [_cyclic_interpolate(points, i / point_count, "speed_mps") for i in range(point_count)]
+
+
+def load_human_speed_profile(path: str | Path, point_count: int) -> list[float]:
+    """Load and resample a human-lap CSV into a ``RacingDriver`` speed profile."""
+    return human_profile_speed_profile(load_human_profile(path), point_count)
+
+
 def _clamp(x: float, lo: float, hi: float) -> float:
     return lo if x < lo else hi if x > hi else x
 
@@ -113,8 +215,23 @@ class RacingDriver:
     ``speed_profile`` is the per-point target speed (m/s) from :func:`load_speed_profile` (same
     length as ``fast_line``). The optimal profile is scaled by ``pace`` and capped at
     ``max_speed_kmh`` (pure-pursuit's stable steering envelope), then a backward pass at ``brake_g``
-    bakes in the braking points.
+    bakes in the braking points. Steering defaults to a Stanley cross-track controller so racing
+    pace does not aim through apexes the way look-ahead pure pursuit did.
     """
+
+    @classmethod
+    def from_human_profile(
+        cls,
+        fast_line: list[tuple[float, float, float]],
+        profile_csv: str | Path,
+        **kwargs,
+    ) -> RacingDriver:
+        """Construct from a normalized-position human-lap profile CSV."""
+        profile = load_human_profile(profile_csv)
+        kwargs.setdefault("pace", 1.0)
+        kwargs.setdefault("max_speed_kmh", max(p.speed_mps for p in profile) * 3.6)
+        kwargs.setdefault("min_speed_kmh", max(min(p.min_speed_mps for p in profile) * 3.6, 1.0))
+        return cls(fast_line, human_profile_speed_profile(profile, len(fast_line)), **kwargs)
 
     def __init__(
         self,
@@ -136,6 +253,12 @@ class RacingDriver:
         trail_release: float = 0.7,
         trail_min: float = 0.2,
         traction_lift: float = 0.6,
+        steering_mode: str = "stanley",
+        stanley_cross_track_gain: float = 0.75,
+        stanley_heading_gain: float = 1.0,
+        stanley_speed_softening_mps: float = 5.0,
+        stanley_max_steer_rad: float = 0.65,
+        stanley_max_cross_track_m: float = 10.0,
         rpm_up: float = 7000.0,
         rpm_dn: float = 4200.0,
         max_gear: int = 7,
@@ -160,6 +283,8 @@ class RacingDriver:
             raise ValueError("require 0 < min_speed_kmh <= max_speed_kmh")
         if brake_g <= 0 or brake_scale_mps <= 0 or throttle_scale_mps <= 0:
             raise ValueError("brake_g, brake_scale_mps, throttle_scale_mps must be > 0")
+        if steering_mode not in {"stanley", "pure_pursuit"}:
+            raise ValueError("steering_mode must be 'stanley' or 'pure_pursuit'")
 
         self.pursuit = PurePursuit(
             fast_line,
@@ -169,7 +294,16 @@ class RacingDriver:
             max_steer_curvature=max_steer_curvature,
             wheelbase_m=wheelbase_m,
         )
+        self.stanley = StanleySteering(
+            fast_line,
+            cross_track_gain=stanley_cross_track_gain,
+            heading_gain=stanley_heading_gain,
+            speed_softening_mps=stanley_speed_softening_mps,
+            max_steer_rad=stanley_max_steer_rad,
+            max_cross_track_m=stanley_max_cross_track_m,
+        )
         self.n = len(fast_line)
+        self.steering_mode = steering_mode
         self.lookahead_m = lookahead_m
         self.lookahead_time_s = lookahead_time_s
         self.brake_band_mps = brake_band_mps
@@ -315,7 +449,10 @@ class RacingDriver:
         ):
             self.phase = PHASE_LAP
 
-        steer = self.pursuit.control(position_xyz, look_dir_xyz, speed_kmh).steer
+        if self.steering_mode == "stanley":
+            steer = self.stanley.steer(position_xyz, look_dir_xyz, speed_kmh)
+        else:
+            steer = self.pursuit.control(position_xyz, look_dir_xyz, speed_kmh).steer
         if self.phase == PHASE_OUT:
             gas, brake = self.out_gas, 0.0
             steer = _clamp(steer, -self.out_steer_clamp, self.out_steer_clamp)


### PR DESCRIPTION
## Why

Issue #244's handoff says the racing driver now has racing longitudinal dynamics, but pure-pursuit steering is the wall: it cuts apexes / understeers at pace, invalidating laps and preventing `lap`/`delta` telemetry plus a clean coaching reference.

## Change

- Add `StanleySteering` in `tools/ac_harness/ai_line.py`: a pure cyclic path projection + heading-error/cross-track steering controller that preserves the harness convention (`steer > 0` turns right).
- Make `RacingDriver` default to Stanley steering while keeping `steering_mode="pure_pursuit"` available for comparison.
- Add human profile loading/resampling from `racing_human_profile_magione.csv`, plus `RacingDriver.from_human_profile(...)` so the committed human reference profile can directly drive target speeds.
- Align human profile samples to each fast-line point by cyclic lap-distance fraction instead of ordinal point index, so non-uniform `fast_lane.ai` density does not shift braking/apex-speed targets.
- Export the new path projection/Stanley controller from `tools.ac_harness`.
- Add vault handoff/current-focus updates for the remaining Windows rig gate.

## Verification

- `python3 -m pytest tests/test_ai_line.py tests/test_ac_harness_racing_driver.py` -> 60 passed.
- `python3 -m ruff check tools/ac_harness/ai_line.py tools/ac_harness/racing_driver.py tools/ac_harness/__init__.py tests/test_ai_line.py tests/test_ac_harness_racing_driver.py` -> passed.
- `python3 -m ruff format --check tools/ac_harness/ai_line.py tools/ac_harness/racing_driver.py tools/ac_harness/__init__.py tests/test_ai_line.py tests/test_ac_harness_racing_driver.py` -> passed.
- `uv run --extra dev make ci-fast` -> OK (`1131 passed, 75 skipped`, coverage 82.67%). Existing allowlist warnings for `.copier-answers.yml` and `doppler.yaml` remain warnings only.

## Runtime gate still required

This PR is code-complete/off-sim verified. Issue #244 is not complete until the Windows rig proves a VALID lap at human-comparable pace with `lap`/`delta` telemetry and evidence captured.

Refs #244. Refs #154.
