### PR TITLE
perf: defer lap archive writes off lap boundary (#246)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -409,6 +409,7 @@ local td = throttleDet.new()
 local tires = tireMonitor.new()
 local pendingWsSidecarUrl = nil
 local pendingLapArchiveJobs = {}
+local pendingLapArchiveRecordPaths = {}
 local LAP_ARCHIVE_ROWS_PER_FRAME = 64
 
 -- Forward-declare so closures registered with wsBridge below capture the
@@ -447,11 +448,26 @@ local function pumpLapArchiveJobs()
       ac.log("[COPILOT][ARCHIVE] write failed: " .. tostring(pathOrErr))
     end
   end
-  if ok and type(pathOrErr) == "string"
-      and wsBridge and type(wsBridge.sendSetupExperimentRecord) == "function" then
+  if ok and type(pathOrErr) == "string" then
+    pendingLapArchiveRecordPaths[#pendingLapArchiveRecordPaths + 1] = pathOrErr
+  end
+end
+
+local function pumpLapArchiveNotifications()
+  if not (wsBridge and type(wsBridge.sendSetupExperimentRecord) == "function") then
+    return
+  end
+  while #pendingLapArchiveRecordPaths > 0 do
+    local path = pendingLapArchiveRecordPaths[1]
+    local sent = false
     pcall(function()
-      wsBridge.sendSetupExperimentRecord(pathOrErr)
+      sent = wsBridge.sendSetupExperimentRecord(path) == true
     end)
+    if sent then
+      table.remove(pendingLapArchiveRecordPaths, 1)
+    else
+      return
+    end
   end
 end
 
@@ -1909,7 +1925,6 @@ function script.update(dt)
   car = ac.getCar(0)
 
   autoPlaceOnce()
-  pumpLapArchiveJobs()
 
   -- Live-frame coaching tick (issue #72 rebuild).
   -- Inputs are LIVE FRAME values and persisted reference data, NOT lap aggregates.
@@ -2051,6 +2066,8 @@ function script.update(dt)
     wsBridge.configure(pendingWsSidecarUrl)
     pendingWsSidecarUrl = nil
   end
+  pumpLapArchiveJobs()
+  pumpLapArchiveNotifications()
 
   -- Issue #180 Part D step 2: lifecycle topics, published AFTER wsBridge.tick()/pollInbound()
   -- so they observe the CURRENT-frame WS state and always precede the `lap` boundary below

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -466,6 +466,7 @@ local function pumpLapArchiveNotifications()
     if sent then
       table.remove(pendingLapArchiveRecordPaths, 1)
     else
+      -- Keep the path queued; handshake/reconnect can become ready on a later frame.
       return
     end
   end

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -408,11 +408,52 @@ local brakes = newBrakes()
 local td = throttleDet.new()
 local tires = tireMonitor.new()
 local pendingWsSidecarUrl = nil
+local pendingLapArchiveJobs = {}
+local LAP_ARCHIVE_ROWS_PER_FRAME = 64
 
 -- Forward-declare so closures registered with wsBridge below capture the
 -- main state table as an upvalue (Lua resolves locals lexically at compile
 -- time; without this they would compile to globals and stay nil — issue #81).
 local state
+
+local function queueLapArchiveJob(archiveOpts)
+  local job, err = lapArchive.createWriteJob(
+    archiveOpts,
+    lapArchive.clampArchiveCapMB(config.lapArchiveMaxMB)
+  )
+  if not job then
+    if ac and type(ac.log) == "function" then
+      ac.log("[COPILOT][ARCHIVE] queue failed: " .. tostring(err))
+    end
+    return
+  end
+  pendingLapArchiveJobs[#pendingLapArchiveJobs + 1] = job
+  if ac and type(ac.log) == "function" then
+    ac.log("[COPILOT][ARCHIVE] queued async write samples=" .. tostring(job.samplesCount or 0)
+      .. " queue=" .. tostring(#pendingLapArchiveJobs))
+  end
+end
+
+local function pumpLapArchiveJobs()
+  local job = pendingLapArchiveJobs[1]
+  if not job then return end
+  local done, ok, pathOrErr = job:step(LAP_ARCHIVE_ROWS_PER_FRAME)
+  if not done then return end
+  table.remove(pendingLapArchiveJobs, 1)
+  if ac and type(ac.log) == "function" then
+    if ok then
+      ac.log("[COPILOT][ARCHIVE] wrote " .. tostring(pathOrErr))
+    else
+      ac.log("[COPILOT][ARCHIVE] write failed: " .. tostring(pathOrErr))
+    end
+  end
+  if ok and type(pathOrErr) == "string"
+      and wsBridge and type(wsBridge.sendSetupExperimentRecord) == "function" then
+    pcall(function()
+      wsBridge.sendSetupExperimentRecord(pathOrErr)
+    end)
+  end
+end
 
 wsBridge.configure(config.wsSidecarUrl or "")
 if wsBridge.setSetupExperimentStorePath then
@@ -1868,6 +1909,7 @@ function script.update(dt)
   car = ac.getCar(0)
 
   autoPlaceOnce()
+  pumpLapArchiveJobs()
 
   -- Live-frame coaching tick (issue #72 rebuild).
   -- Inputs are LIVE FRAME values and persisted reference data, NOT lap aggregates.
@@ -2376,10 +2418,9 @@ function script.update(dt)
       wsBridge.sendJson(lapPayload)
     end
 
-    -- Issue #77 Part C: archive this lap (trace + setup + corners + coaching).
-    -- Runs INDEPENDENTLY of sidecar / coaching success. Captures the dataset
-    -- for future RAG / classifier / fine-tune work. Forward-compatible schema
-    -- so imported MoTeC CSVs (Initiative B) drop into the same shape.
+    -- Issue #77 Part C / #246: archive this lap (trace + setup + corners + coaching).
+    -- Runs independently of sidecar / coaching success, but queue the file work
+    -- instead of compact-encoding/flushing the full trace on the S/F render frame.
     if config.lapArchiveEnabled ~= false and lastMs > 0 then
       local archiveOpts = {
         session_uuid = SESSION_UUID,
@@ -2402,23 +2443,7 @@ function script.update(dt)
         -- (Codex + Cursor Bugbot #78 post-5f0ce39).
         corner_advice = wsBridge.cornerAdvisorySnapshotForLap((state.lapsCompleted or 0) - 1),
       }
-      local rec = lapArchive.buildRecord(archiveOpts)
-      if rec then
-        local ok, pathOrErr = lapArchive.write(rec, lapArchive.clampArchiveCapMB(config.lapArchiveMaxMB))
-        if ac and type(ac.log) == "function" then
-          if ok then
-            ac.log("[COPILOT][ARCHIVE] wrote " .. tostring(pathOrErr))
-          else
-            ac.log("[COPILOT][ARCHIVE] write failed: " .. tostring(pathOrErr))
-          end
-        end
-        if ok and type(pathOrErr) == "string"
-            and wsBridge and type(wsBridge.sendSetupExperimentRecord) == "function" then
-          pcall(function()
-            wsBridge.sendSetupExperimentRecord(pathOrErr)
-          end)
-        end
-      end
+      queueLapArchiveJob(archiveOpts)
     end
 
     state.lapInvalidatedThisLap = false

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -62,6 +62,34 @@ local function lapArchiveDir()
   return persistence.lapArchiveDir()
 end
 
+local function traceSampleToColumnRow(s)
+  if type(s) ~= "table" or type(s.spline) ~= "number" then
+    return nil
+  end
+  local row = {}
+  for fi = 1, #TRACE_FIELDS do
+    local fname = TRACE_FIELDS[fi]
+    if fname == "spline" then
+      row[fi] = s.spline
+    else
+      row[fi] = tonumber(s[fname]) or 0
+    end
+  end
+  return row
+end
+
+local function countTraceRows(trace)
+  if type(trace) ~= "table" then return 0 end
+  local n = 0
+  for i = 1, #trace do
+    local s = trace[i]
+    if type(s) == "table" and type(s.spline) == "number" then
+      n = n + 1
+    end
+  end
+  return n
+end
+
 --- Settings UI calls `stats()` every frame; cache full-directory scan for a short TTL (Gemini #78).
 --- Uses `os.time` (wall-ish seconds), not `os.clock` (CPU time can stall the TTL — Cursor #78).
 local _statsCacheT = -1e9
@@ -110,17 +138,8 @@ local function traceToColumns(trace)
   if type(trace) ~= "table" then return {} end
   local out = {}
   for i = 1, #trace do
-    local s = trace[i]
-    if type(s) == "table" and type(s.spline) == "number" then
-      local row = {}
-      for fi = 1, #TRACE_FIELDS do
-        local fname = TRACE_FIELDS[fi]
-        if fname == "spline" then
-          row[fi] = s.spline
-        else
-          row[fi] = tonumber(s[fname]) or 0
-        end
-      end
+    local row = traceSampleToColumnRow(trace[i])
+    if row then
       out[#out + 1] = row
     end
   end
@@ -158,7 +177,7 @@ end
 ---  opts.rules_hints (string list), opts.sidecar_debrief (string|nil),
 ---  opts.corner_advice (table label->text|nil)
 ---@return table|nil
-function M.buildRecord(opts)
+local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
   if type(opts) ~= "table" then return nil end
   if not opts.lap_n or not opts.lap_ms or opts.lap_ms <= 0 then return nil end
 
@@ -188,7 +207,8 @@ function M.buildRecord(opts)
   local trackTemp = nil
   pcall(function() trackTemp = tonumber(sim and sim.trackTemperature) end)
 
-  local samplesColumnar = traceToColumns(opts.trace)
+  samplesColumnar = samplesColumnar or {}
+  samplesCount = tonumber(samplesCount) or #samplesColumnar
   local cornersOut = {}
   if type(opts.corners) == "table" then
     for i = 1, #opts.corners do
@@ -263,7 +283,7 @@ function M.buildRecord(opts)
       snapshot = flattenSetupSnapshot(opts.setup_snap),
     },
     trace = {
-      samples_count = #samplesColumnar,
+      samples_count = samplesCount,
       fields = traceFieldNames,
       samples = samplesColumnar,
     },
@@ -276,6 +296,11 @@ function M.buildRecord(opts)
           and opts.corner_advice or nil,
     },
   }
+end
+
+function M.buildRecord(opts)
+  local samplesColumnar = traceToColumns(type(opts) == "table" and opts.trace or nil)
+  return buildRecordEnvelope(opts, samplesColumnar, #samplesColumnar)
 end
 
 --- Walk archive dir, sum file sizes, delete oldest until total <= capMB.
@@ -356,15 +381,8 @@ function M.rotate(capMB)
   return #files - deleted, total / (1024 * 1024), deleted
 end
 
---- Write a record to disk. Returns (true, path) on success, (false, errmsg) on failure.
----@param rec table
----@param capMB number|nil
----@return boolean, string
-function M.write(rec, capMB)
-  if type(rec) ~= "table" then return false, "not a table" end
-  capMB = M.clampArchiveCapMB(capMB)
+local function archivePathForRecord(rec)
   local dir = lapArchiveDir()
-  persistence.ensureParentDirForFile(dir .. "/_dummy")  -- create dir
   local lapMs = (rec.lap and tonumber(rec.lap.lap_ms)) or 0
   local lapN = (rec.lap and tonumber(rec.lap.lap_n)) or 0
   local sessShort = tostring(rec.session_uuid or "x"):gsub("[^%w]", ""):sub(1, 8)
@@ -377,7 +395,19 @@ function M.write(rec, capMB)
   end
   local fname = string.format("lap_%s_%s_%d_%d_%s.json",
     fileTimestampUtc(), sessShort, lapN, lapMs, lapKey)
-  local path = dir .. "/" .. fname
+  return dir .. "/" .. fname
+end
+
+--- Write a record to disk. Returns (true, path) on success, (false, errmsg) on failure.
+---@param rec table
+---@param capMB number|nil
+---@return boolean, string
+function M.write(rec, capMB)
+  if type(rec) ~= "table" then return false, "not a table" end
+  capMB = M.clampArchiveCapMB(capMB)
+  local dir = lapArchiveDir()
+  persistence.ensureParentDirForFile(dir .. "/_dummy")  -- create dir
+  local path = archivePathForRecord(rec)
   -- Large trace arrays: compact JSON avoids pretty-print whitespace blowing the cap (Cursor #78).
   local raw = persistence.encodeJsonCompact(rec)
   if not raw then return false, "encodeJsonCompact returned nil" end
@@ -407,6 +437,210 @@ function M.write(rec, capMB)
   pcall(function() M.rotate(capMB) end)
   bustStatsCache()
   return true, path
+end
+
+local function jsonValue(value, label)
+  local raw = persistence.encodeJsonCompact(value)
+  if not raw then
+    return nil, "encodeJsonCompact returned nil for " .. tostring(label)
+  end
+  return raw, nil
+end
+
+--- Create a budgeted lap-archive write job.
+---
+--- This keeps the completed-lap frame from compact-encoding and flushing a
+--- whole trace on CSP's render thread. Call `job:step(maxRows)` once per frame;
+--- it writes at most `maxRows` trace rows, then returns `(done, ok, pathOrErr)`.
+---@param opts table
+---@param capMB number|nil
+---@return table|nil, string|nil
+function M.createWriteJob(opts, capMB)
+  if type(opts) ~= "table" then
+    return nil, "opts must be a table"
+  end
+  local samplesCount = countTraceRows(opts.trace)
+  local rec = buildRecordEnvelope(opts, {}, samplesCount)
+  if not rec then
+    return nil, "invalid archive record options"
+  end
+
+  capMB = M.clampArchiveCapMB(capMB)
+  local path = archivePathForRecord(rec)
+  local job = {
+    _state = "open",
+    _file = nil,
+    _path = path,
+    _tmpPath = path .. ".tmp",
+    _rec = rec,
+    _trace = opts.trace or {},
+    _sampleIndex = 1,
+    _samplesWritten = 0,
+    samplesCount = samplesCount,
+    done = false,
+    ok = nil,
+    result = nil,
+  }
+
+  function job:_write(chunk)
+    if chunk == nil or chunk == "" then return true, nil end
+    if not self._file then return false, "archive temp file is not open" end
+    local writeOk, writeRes = pcall(function() return self._file:write(chunk) end)
+    if not writeOk or not writeRes then
+      local msg = (not writeOk) and tostring(writeRes) or "write returned nil"
+      return false, "write failed: " .. msg
+    end
+    return true, nil
+  end
+
+  function job:_flush()
+    if not self._file then return true, nil end
+    local flushOk, flushRes = pcall(function() return self._file:flush() end)
+    if not flushOk or not flushRes then
+      local msg = (not flushOk) and tostring(flushRes) or "flush returned nil"
+      return false, "flush failed: " .. msg
+    end
+    return true, nil
+  end
+
+  function job:_fail(message)
+    if self._file then
+      pcall(function() self._file:close() end)
+      self._file = nil
+    end
+    pcall(os.remove, self._tmpPath)
+    self.done = true
+    self.ok = false
+    self.result = tostring(message or "archive job failed")
+    return true, false, self.result
+  end
+
+  function job:_writeField(name, value)
+    if value == nil then return true, nil end
+    local raw, encErr = jsonValue(value, name)
+    if not raw then return false, encErr end
+    local prefix = self._fieldWritten and "," or ""
+    local ok, err = self:_write(prefix .. "\"" .. name .. "\":" .. raw)
+    if not ok then return false, err end
+    self._fieldWritten = true
+    return true, nil
+  end
+
+  function job:_open()
+    persistence.ensureParentDirForFile(lapArchiveDir() .. "/_dummy")
+    local f, ferr = io.open(self._tmpPath, "w")
+    if not f then
+      return self:_fail("open failed: " .. tostring(ferr))
+    end
+    self._file = f
+    self._fieldWritten = false
+
+    local ok, err = self:_write("{")
+    if not ok then return self:_fail(err) end
+    local fields = {
+      { "schema_version", self._rec.schema_version },
+      { "source", self._rec.source },
+      { "import_format", self._rec.import_format },
+      { "lap_uuid", self._rec.lap_uuid },
+      { "session_uuid", self._rec.session_uuid },
+      { "exported_at", self._rec.exported_at },
+      { "car", self._rec.car },
+      { "track", self._rec.track },
+      { "conditions", self._rec.conditions },
+      { "lap", self._rec.lap },
+      { "setup", self._rec.setup },
+    }
+    for i = 1, #fields do
+      ok, err = self:_writeField(fields[i][1], fields[i][2])
+      if not ok then return self:_fail(err) end
+    end
+
+    local traceFieldsRaw
+    traceFieldsRaw, err = jsonValue(self._rec.trace.fields, "trace.fields")
+    if not traceFieldsRaw then return self:_fail(err) end
+    local prefix = self._fieldWritten and "," or ""
+    ok, err = self:_write(prefix
+      .. "\"trace\":{\"samples_count\":" .. tostring(self.samplesCount)
+      .. ",\"fields\":" .. traceFieldsRaw
+      .. ",\"samples\":[")
+    if not ok then return self:_fail(err) end
+    self._fieldWritten = true
+    self._state = "samples"
+    return false, nil, nil
+  end
+
+  function job:_finish()
+    local ok, err = self:_write("]}")
+    if not ok then return self:_fail(err) end
+    ok, err = self:_writeField("corners", self._rec.corners)
+    if not ok then return self:_fail(err) end
+    ok, err = self:_writeField("coaching", self._rec.coaching)
+    if not ok then return self:_fail(err) end
+    ok, err = self:_write("}")
+    if not ok then return self:_fail(err) end
+
+    local flushOk, flushRes = pcall(function() return self._file:flush() end)
+    if not flushOk or not flushRes then
+      local msg = (not flushOk) and tostring(flushRes) or "flush returned nil"
+      return self:_fail("flush failed: " .. msg)
+    end
+    local closeOk, closeRes = pcall(function() return self._file:close() end)
+    self._file = nil
+    if not closeOk or not closeRes then
+      local msg = (not closeOk) and tostring(closeRes) or "close returned nil"
+      return self:_fail("close failed: " .. msg)
+    end
+    local renameOk, renameRes = pcall(os.rename, self._tmpPath, self._path)
+    if not renameOk or renameRes == nil or renameRes == false then
+      local msg = (not renameOk) and tostring(renameRes) or "rename returned nil"
+      return self:_fail("rename failed: " .. msg)
+    end
+    pcall(function() M.rotate(capMB) end)
+    bustStatsCache()
+    self.done = true
+    self.ok = true
+    self.result = self._path
+    return true, true, self._path
+  end
+
+  function job:step(maxRows)
+    if self.done then
+      return true, self.ok == true, self.result
+    end
+    local rowsBudget = math.max(1, math.floor(tonumber(maxRows) or 64))
+    if self._state == "open" then
+      local done, ok, res = self:_open()
+      if done then return done, ok, res end
+    end
+    if self._state == "samples" then
+      local processed = 0
+      while self._sampleIndex <= #self._trace and processed < rowsBudget do
+        local row = traceSampleToColumnRow(self._trace[self._sampleIndex])
+        self._sampleIndex = self._sampleIndex + 1
+        processed = processed + 1
+        if row then
+          local raw, encErr = jsonValue(row, "trace.sample")
+          if not raw then return self:_fail(encErr) end
+          local prefix = self._samplesWritten > 0 and "," or ""
+          local ok, err = self:_write(prefix .. raw)
+          if not ok then return self:_fail(err) end
+          self._samplesWritten = self._samplesWritten + 1
+        end
+      end
+      if self._sampleIndex <= #self._trace then
+        local ok, err = self:_flush()
+        if not ok then return self:_fail(err) end
+        return false, nil, nil
+      end
+      self._state = "finish"
+    end
+    if self._state == "finish" then
+      return self:_finish()
+    end
+    return false, nil, nil
+  end
+
+  return job, nil
 end
 
 --- Lightweight stats for the Settings UI: count + total MB used.

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -62,10 +62,15 @@ local function lapArchiveDir()
   return persistence.lapArchiveDir()
 end
 
+local function isTraceSampleArchivable(s)
+  return type(s) == "table" and type(s.spline) == "number"
+end
+
 local function traceSampleToColumnRow(s)
-  if type(s) ~= "table" or type(s.spline) ~= "number" then
+  if not isTraceSampleArchivable(s) then
     return nil
   end
+  ---@cast s table
   local row = {}
   for fi = 1, #TRACE_FIELDS do
     local fname = TRACE_FIELDS[fi]
@@ -82,8 +87,7 @@ local function countTraceRows(trace)
   if type(trace) ~= "table" then return 0 end
   local n = 0
   for i = 1, #trace do
-    local s = trace[i]
-    if type(s) == "table" and type(s.spline) == "number" then
+    if isTraceSampleArchivable(trace[i]) then
       n = n + 1
     end
   end
@@ -566,6 +570,8 @@ function M.createWriteJob(opts, capMB)
     if not ok then return self:_fail(err) end
     self._fieldWritten = true
     self._state = "samples"
+    -- Fall through to sample writes in the same step so a new job does useful
+    -- bounded work immediately after opening the temp file.
     return false, nil, nil
   end
 
@@ -579,20 +585,18 @@ function M.createWriteJob(opts, capMB)
     ok, err = self:_write("}")
     if not ok then return self:_fail(err) end
 
-    local flushOk, flushRes = pcall(function() return self._file:flush() end)
-    if not flushOk or not flushRes then
-      local msg = (not flushOk) and tostring(flushRes) or "flush returned nil"
-      return self:_fail("flush failed: " .. msg)
-    end
+    ok, err = self:_flush()
+    if not ok then return self:_fail(err) end
     local closeOk, closeRes = pcall(function() return self._file:close() end)
     self._file = nil
     if not closeOk or not closeRes then
       local msg = (not closeOk) and tostring(closeRes) or "close returned nil"
       return self:_fail("close failed: " .. msg)
     end
-    local renameOk, renameRes = pcall(os.rename, self._tmpPath, self._path)
-    if not renameOk or renameRes == nil or renameRes == false then
-      local msg = (not renameOk) and tostring(renameRes) or "rename returned nil"
+    local renameOk, renameRes, renameErr = pcall(os.rename, self._tmpPath, self._path)
+    if not renameOk or not renameRes then
+      local msg = (not renameOk) and tostring(renameRes)
+        or tostring(renameErr or "rename returned nil")
       return self:_fail("rename failed: " .. msg)
     end
     pcall(function() M.rotate(capMB) end)

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -160,6 +160,9 @@ def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.P
 
 
 def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:
+    # This is an intentional source-structure regression test: if the lap
+    # boundary or WS pump sections are refactored, update these regex anchors
+    # with the implementation so the architectural guard remains meaningful.
     src = ENTRY.read_text(encoding="utf-8")
     match = re.search(
         r"-- Issue #77 Part C / #246: archive this lap.*?state\.lapInvalidatedThisLap = false",

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -171,3 +171,14 @@ def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:
     assert "queueLapArchiveJob(archiveOpts)" in block
     assert "lapArchive.write" not in block
     assert "lapArchive.buildRecord" not in block
+
+    ws_match = re.search(
+        r"wsBridge\.tick\(ch\.simSeconds\(sim\)\).*?-- Issue #180 Part D step 2",
+        src,
+        flags=re.S,
+    )
+    assert ws_match is not None
+    ws_block = ws_match.group(0)
+    assert ws_block.index("wsBridge.pollInbound(8)") < ws_block.index("pumpLapArchiveJobs()")
+    assert ws_block.index("pumpLapArchiveJobs()") < ws_block.index("pumpLapArchiveNotifications()")
+    assert "pendingLapArchiveRecordPaths" in src

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -1,0 +1,173 @@
+"""Regression coverage for #246 render-thread archive deferral."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from typing import Any
+
+import pytest
+
+lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip install lupa)")
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
+ENTRY = REPO / "src" / "ac_copilot_trainer" / "ac_copilot_trainer.lua"
+
+
+def _lua_to_py(value: Any) -> Any:
+    if hasattr(value, "items"):
+        items = list(value.items())
+        if not items:
+            return []
+        keys = [k for k, _ in items]
+        if all(isinstance(k, int) for k in keys):
+            ordered = sorted(keys)
+            if ordered == list(range(1, len(ordered) + 1)):
+                return [_lua_to_py(value[i]) for i in ordered]
+        return {str(k): _lua_to_py(v) for k, v in items}
+    return value
+
+
+def _runtime(tmp_path: pathlib.Path) -> lupa.LuaRuntime:
+    rt = lupa.LuaRuntime(unpack_returned_tuples=False)
+    modules_path = str(MODULES_DIR).replace("\\", "/")
+    script_config = str(tmp_path).replace("\\", "/")
+    rt.globals()["_script_config"] = script_config
+    rt.execute(
+        f"""
+        package.path = package.path .. ";{modules_path}/?.lua"
+        _logs = {{}}
+        ac = {{
+          FolderID = {{ ScriptConfig = 1 }},
+          getFolder = function(_) return _script_config end,
+          log = function(msg) _logs[#_logs + 1] = tostring(msg) end,
+        }}
+        """
+    )
+
+    def stringify(table: Any, _pretty: bool = False) -> str:
+        return json.dumps(_lua_to_py(table), separators=(",", ":"), sort_keys=True)
+
+    rt.globals()["JSON"] = rt.table_from({"stringify": stringify})
+    return rt
+
+
+def _step(rt: lupa.LuaRuntime, rows: int) -> dict[str, Any]:
+    result = rt.execute(
+        f"""
+        local done, ok, res = _job:step({rows})
+        return {{ done = done == true, ok = ok == true, res = res or "" }}
+        """
+    )
+    return _lua_to_py(result)
+
+
+def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.Path) -> None:
+    rt = _runtime(tmp_path)
+    rt.execute(
+        """
+        local trace = {}
+        for i = 1, 6 do
+          trace[i] = {
+            spline = (i - 1) / 5,
+            speed = 100 + i,
+            eMs = (i - 1) * 1000,
+            throttle = 0.5,
+            brake = 0.1,
+            steer = -0.2,
+            gear = 3,
+            px = i,
+            py = 0,
+            pz = i * 2,
+          }
+        end
+        _opts = {
+          session_uuid = "session-abc",
+          car = { id = "ks_porsche_911_gt3_r_2016" },
+          sim = {
+            trackName = "magione",
+            trackLengthM = 2507,
+            trackGripLevel = 0.98,
+            ambientTemperature = 21,
+            trackTemperature = 29,
+          },
+          lap_n = 3,
+          lap_ms = 81234,
+          is_pb = true,
+          is_valid = true,
+          trace = trace,
+          corners = {
+            { label = "T1", entrySpeed = 112, minSpeed = 71, exitSpeed = 96 },
+          },
+          setup_snap = {
+            path = "C:/Assetto Corsa/setups/magione.ini",
+            keys = {
+              { section = "TYRES", key = "PRESSURE_LF", value = "27.5" },
+            },
+          },
+          setup_ini_path = "C:/Assetto Corsa/setups/magione.ini",
+          setup_hash = "hash1234",
+          rules_hints = { { text = "Brake earlier at T1" } },
+          corner_advice = { T1 = "Trail brake to apex" },
+        }
+        local lapArchive = require("lap_archive")
+        local job, err = lapArchive.createWriteJob(_opts, 50)
+        assert(job, err)
+        _job = job
+        """
+    )
+
+    first = _step(rt, 2)
+    assert first["done"] is False
+    assert not list(tmp_path.rglob("lap_*.json"))
+    assert list(tmp_path.rglob("*.tmp")), "job should stage a temp file before completion"
+
+    final = first
+    for _ in range(10):
+        final = _step(rt, 2)
+        if final["done"]:
+            break
+
+    assert final["done"] is True
+    assert final["ok"] is True
+    archive_path = pathlib.Path(final["res"])
+    assert archive_path.is_file()
+    assert not archive_path.with_name(archive_path.name + ".tmp").exists()
+
+    record = json.loads(archive_path.read_text(encoding="utf-8"))
+    assert record["schema_version"] == 1
+    assert record["lap"]["lap_n"] == 3
+    assert record["lap"]["lap_ms"] == 81234
+    assert record["trace"]["samples_count"] == 6
+    assert len(record["trace"]["samples"]) == 6
+    assert record["trace"]["fields"] == [
+        "spline",
+        "speed",
+        "eMs",
+        "throttle",
+        "brake",
+        "steer",
+        "gear",
+        "px",
+        "py",
+        "pz",
+    ]
+    assert record["setup"]["hash"] == "hash1234"
+    assert record["coaching"]["rules_hints"] == ["Brake earlier at T1"]
+    assert record["coaching"]["corner_advice_used"]["T1"] == "Trail brake to apex"
+
+
+def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:
+    src = ENTRY.read_text(encoding="utf-8")
+    match = re.search(
+        r"-- Issue #77 Part C / #246: archive this lap.*?state\.lapInvalidatedThisLap = false",
+        src,
+        flags=re.S,
+    )
+    assert match is not None
+    block = match.group(0)
+    assert "queueLapArchiveJob(archiveOpts)" in block
+    assert "lapArchive.write" not in block
+    assert "lapArchive.buildRecord" not in block


### PR DESCRIPTION
## Summary
- queue lap archive writes at lap completion instead of compact-encoding/flushing the full trace on the S/F render frame
- add a budgeted per-frame archive writer that streams trace rows to a temp file and renames only after completion
- preserve setup experiment notification after the final archive path exists

## Verification
- `.scratch/venv-test/bin/python -m pytest tests/test_lap_archive_async.py -q`
- `.scratch/venv-test/bin/python -m pytest tests/test_ws_bridge_hello_handshake.py tests/test_lua_runtime_smoke.py -q`
- `make ci-fast PYTHON=.scratch/venv-test/bin/python`

Refs #246.