### PR TITLE
docs(vault): post-merge handoff for PR #249

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T06:30:00Z
+last_updated: 2026-06-19T08:15:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -21,6 +21,15 @@ relates_to:
 **Active focus (2026-06-17):** EPIC [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) — **Part F harness daemon shipped** ([#228](https://github.com/agorokh/ac-copilot-trainer/issues/228)/PR #229) and its on-rig launch gap fixed ([#232](https://github.com/agorokh/ac-copilot-trainer/issues/232) **CLOSED** / PR [#233](https://github.com/agorokh/ac-copilot-trainer/pull/233) **MERGED** `c556dfe`): the daemon now launches AC **de-elevated via Content Manager** (`--launch-mode cm`), live-verified hands-off on `AG_PC`. The autonomous self-test is now **one command** ([#235](https://github.com/agorokh/ac-copilot-trainer/issues/235) **CLOSED** / PR [#236](https://github.com/agorokh/ac-copilot-trainer/pull/236) **MERGED** `d051096`): `python -m tools.ac_harness.self_test` drives the daemon hands-off and asserts the live coaching pipeline — **LIVE PASS** (`coaching.snapshot=335, tire_temps=168, connection=34`, no human at the wheel). The vision-oracle **"eyes"** also landed ([#238](https://github.com/agorokh/ac-copilot-trainer/issues/238) **CLOSED** / PR [#239](https://github.com/agorokh/ac-copilot-trainer/pull/239) **MERGED** `3e677c7`): `tools.ac_harness.hud_capture` (stdlib ctypes GDI, no new dep) captures the live AC HUD hands-off with a render-liveness check — **LIVE-VERIFIED** (in-cockpit at Spa, HUD text legible). [#188](https://github.com/agorokh/ac-copilot-trainer/issues/188)/[#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) **CLOSED**. **The autonomous self-test now has launch + pipeline-assert + eyes, all hands-off + live-verified.**
 
 **Active focus (2026-06-19) — HANDOFF, see [#244](https://github.com/agorokh/ac-copilot-trainer/issues/244):** Part G **racing driver** **MERGED** ([#241](https://github.com/agorokh/ac-copilot-trainer/issues/241) / PR [#242](https://github.com/agorokh/ac-copilot-trainer/pull/242) `372156a`): follows `fast_lane.ai`'s embedded speed profile with braking points/trail braking; **gear bug fixed** (was stuck in 1st — limiter below shift point) → now shifts 1→4, **146 km/h** (was 52). `tools/ac_harness/racing_telemetry.py` records human laps. **The wall is STEERING** (pure-pursuit cuts apexes → corners crawl, lap INVALID → no `lap`/`delta` telemetry). **Next:** record 5–10 human GT3 laps → build a path-tracking steering controller from real corner speeds/braking points. Full state: [`racing-driver-and-controller-2026-06-17`](../03_Investigations/racing-driver-and-controller-2026-06-17.md). Parallel hot path: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) Parts E–F.
+
+**Parallel runtime hotfix (2026-06-19) — #246 / PR #249 MERGED; issue remains open for live proof:**
+PR [#249](https://github.com/agorokh/ac-copilot-trainer/pull/249) merged at
+[`4e2a310`](https://github.com/agorokh/ac-copilot-trainer/commit/4e2a310232beb19ae6c261ca024411512185379a)
+and moves lap-archive writes off the lap-complete/SF frame. Archive JSON now streams through a bounded
+per-frame write job with temp-file finalization; setup-experiment record notifications retry after WS
+tick/poll until the sidecar send succeeds. Local `ci-fast` and GitHub build/conformance passed; review
+threads resolved. [#246](https://github.com/agorokh/ac-copilot-trainer/issues/246) is still open
+because the remaining proof is a Windows AC lap-crossing run showing the visual freeze is gone.
 
 **Infra (2026-05-20):** PR [#111](https://github.com/agorokh/ac-copilot-trainer/pull/111) closed the [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) agent-surface campaign (closeout doc only; five agent SHA alignments deferred). PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) memory-contract cursor rule fix remains on `main`.
 
@@ -69,6 +78,12 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-19** — PR [#249](https://github.com/agorokh/ac-copilot-trainer/pull/249) **MERGED** at
+  `4e2a310` — mitigates [#246](https://github.com/agorokh/ac-copilot-trainer/issues/246) by replacing
+  synchronous lap-complete archive writes with a queued per-frame `lapArchive.createWriteJob`, temp-file
+  streaming/finalization, and retrying `setup.experiment.record` notifications after WS tick/poll.
+  Classification: no post-merge flags. **Issue #246 remains open until live AC rig proof confirms the
+  S/F render freeze is gone.**
 - **2026-06-19** — PR [#242](https://github.com/agorokh/ac-copilot-trainer/pull/242) **MERGED** at `372156a` — closed [#241](https://github.com/agorokh/ac-copilot-trainer/issues/241) with `tools/ac_harness/racing_driver.py` (speed-profile following, braking points, trail braking, traction throttle; 12 tests) + `tools/ac_harness/racing_telemetry.py` (human-lap CSV recorder). Gear bug fixed (1→4 shifts, 146 km/h). Classification: no post-merge flags. **Next:** human-lap capture + path-tracking steering controller ([#244](https://github.com/agorokh/ac-copilot-trainer/issues/244)).
 - **2026-06-16** — **#188 CLOSED** (on the rig, autonomous-deliver). Direct probe on `AG_PC`: `car.resetCounter` **present** (`[COPILOT][WRAP-SKEW-PROBE] resetCounter present=true value=2`) → teleports fully handled → closed as moot ([close comment](https://github.com/agorokh/ac-copilot-trainer/issues/188#issuecomment-4725615887)). No code change (the #199 defensive deferral stays). New rig-ops node: [steam-elevation-mismatch-ac-launch-2026-06-16](../03_Investigations/steam-elevation-mismatch-ac-launch-2026-06-16.md).
 - **2026-06-16** — **#190 CLOSED** — EPIC #154 Part E complete. Merged PRs: [#191](https://github.com/agorokh/ac-copilot-trainer/pull/191) L1.5 probe, [#209](https://github.com/agorokh/ac-copilot-trainer/pull/209)/[#221](https://github.com/agorokh/ac-copilot-trainer/pull/221)/[#222](https://github.com/agorokh/ac-copilot-trainer/pull/222)/[#223](https://github.com/agorokh/ac-copilot-trainer/pull/223) carcsw driver, [#201](https://github.com/agorokh/ac-copilot-trainer/pull/201) session replay for late taps. Live-verified autonomous lap + coaching on Magione. Next EPIC thread: Part F harness daemon.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T06:30:00Z
+last_updated: 2026-06-19T08:15:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -29,6 +29,37 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-19 — #246 / PR #249 MERGED: lap archive writes moved off the S/F frame; live freeze proof pending)
+
+**[#246](https://github.com/agorokh/ac-copilot-trainer/issues/246) remains OPEN pending live
+Windows/AC proof.** PR [#249](https://github.com/agorokh/ac-copilot-trainer/pull/249) **MERGED**
+`2026-06-19T08:05:01Z` as squash
+[`4e2a310`](https://github.com/agorokh/ac-copilot-trainer/commit/4e2a310232beb19ae6c261ca024411512185379a).
+The PR title used `#246` rather than a closing keyword, so GitHub did not auto-close it. Leave it
+open until a rig run proves the freeze is gone, then close with evidence.
+
+**What changed.** The lap-complete boundary no longer builds and writes the full lap archive on the
+render/CSP script frame. It now queues `lapArchive.createWriteJob(...)`; the app pumps a bounded
+`LAP_ARCHIVE_ROWS_PER_FRAME = 64` slice after `wsBridge.tick()` / `wsBridge.pollInbound()`. Archive
+records stream schema-v1 JSON to `*.tmp`, flush/close, atomically rename to final `*.json`, rotate the
+archive, and then queue setup-experiment notification. `setup.experiment.record` paths are retained
+and retried until `sendSetupExperimentRecord()` returns true, covering sidecar startup/reconnect.
+
+**Verification completed off-rig.** Local `make ci-fast PYTHON=.scratch/venv-test/bin/python` passed
+(`1117 passed, 75 skipped`, coverage 82.51%). Focused archive regression
+`tests/test_lap_archive_async.py` proves multi-step temp-file streaming and asserts the lap boundary
+queues work instead of calling `lapArchive.write` / `lapArchive.buildRecord`; it also asserts archive
+pumping happens after WS tick/poll and before notification retry. GitHub build + conformance passed;
+GraphQL review threads resolved; CodeRabbit confirmed the final fix. Post-merge classification: no
+migration/env/deps/script/workflow flags.
+
+**Live proof still needed.** On `AG_PC` / Windows AC, drive a lap crossing at Magione (human driving
+is fine) and confirm the old ~2 s visual freeze at S/F is gone. Also confirm the completed archive
+still lands and the sidecar receives `setup.experiment.record` after reconnect/startup. If PASS, close
+[#246](https://github.com/agorokh/ac-copilot-trainer/issues/246) with the merge commit, lap-crossing
+observation, archive path, and sidecar notification evidence. If FAIL, keep #246 open and file the
+remaining hot path separately.
 
 ## Resume here (2026-06-19 — #241/#242 MERGED: racing driver on `main`; STEERING is the wall; human-lap data is next)
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #249.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).