### PR TITLE
docs(vault): #244 Stanley steering LIVE-VERIFIED on the rig

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,10 +3,11 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T10:35:00Z
+last_updated: 2026-06-19T19:35:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
+  - AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
   - AcCopilotTrainer/10_Rig/esp32-jc3248w535-screen-v1.md
   - AcCopilotTrainer/10_Rig/physical-rig-integration-epic-59.md
   - AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
@@ -22,13 +23,18 @@ relates_to:
 
 **Active focus (2026-06-19) — HANDOFF, see [#244](https://github.com/agorokh/ac-copilot-trainer/issues/244):** Part G **racing driver** **MERGED** ([#241](https://github.com/agorokh/ac-copilot-trainer/issues/241) / PR [#242](https://github.com/agorokh/ac-copilot-trainer/pull/242) `372156a`): follows `fast_lane.ai`'s embedded speed profile with braking points/trail braking; **gear bug fixed** (was stuck in 1st — limiter below shift point) → now shifts 1→4, **146 km/h** (was 52). `tools/ac_harness/racing_telemetry.py` records human laps. **The wall is STEERING** (pure-pursuit cuts apexes → corners crawl, lap INVALID → no `lap`/`delta` telemetry). **Next:** record 5–10 human GT3 laps → build a path-tracking steering controller from real corner speeds/braking points. Full state: [`racing-driver-and-controller-2026-06-17`](../03_Investigations/racing-driver-and-controller-2026-06-17.md). Parallel hot path: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) Parts E–F.
 
-**Active focus update (2026-06-19) — #244 / draft PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248):**
-Stanley steering and human-profile replay support are built and off-sim verified (`uv run --extra dev
-make ci-fast` passed: `1131 passed, 75 skipped`, coverage `82.67%`). Review fixes are included:
-human-profile samples now align to fast-line lap-distance fractions, not ordinal point index. Runtime
-proof is still blocked: Tailscale ping reaches `pc` / `100.75.251.87`, but harness daemon health/TCP
-probes on `9876` and `8765` time out, and SSH denies access. Keep #244 and #154 open until the Windows
-rig proves a VALID Magione lap at human-comparable pace with `lap`/`delta` telemetry/HUD evidence.
+**Active focus update (2026-06-19 LATER) — #244 / PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248) MERGED + LIVE-VERIFIED on the rig:**
+Ran `/autonomous-deliver 244` **on `AG_PC` itself** (prior Mac→rig blocker moot). The merged Stanley
+controller from the human profile drove Magione via carcsw, no human → **3 AC VALID laps** (best
+**106.8 s**, max **207.6 km/h**, gears 1–6, 0 stuck), and the sidecar tap showed **`delta=2935`** live
+delta-to-reference + `coaching.snapshot=3797` — **the `lap`/`delta` telemetry wall is broken**. The
+trainer captured the agent's lap as its coaching reference (lap archives written). **Residual:** best
+clean lap is ~85% of the human's relaxed pace (106.8 s vs 90.7 s / 83.5 vs 98.7 km/h); the literal
+`avg ≳100 km/h` bar is unmet and an aggressive-throttle tuning pass REGRESSED (TC-off wheelspin), so the
+merged defaults are near-optimal. The last ~15% is separable controller-sophistication on
+`racing_driver.py` → stays as remaining Part-G scope on #244 (no new overlapping issue). **#244 + #154
+stay OPEN** for the pace bar; operator decides whether the wall-break + telemetry milestone closes
+Part-G-core. Full write-up: [`stanley-steering-live-verified-2026-06-19`](../03_Investigations/stanley-steering-live-verified-2026-06-19.md).
 
 **Parallel runtime hotfix (2026-06-19) — #246 / PR #249 MERGED; issue remains open for live proof:**
 PR [#249](https://github.com/agorokh/ac-copilot-trainer/pull/249) merged at
@@ -86,6 +92,13 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-19** — PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248) **MERGED** at
+  `88249bf` — Stanley steering + `RacingDriver.from_human_profile` ([#244](https://github.com/agorokh/ac-copilot-trainer/issues/244)).
+  **LIVE-VERIFIED on `AG_PC`**: 3 AC VALID laps via carcsw (best 106.8 s, 207.6 km/h, gears 1–6),
+  sidecar `delta=2935` + `coaching.snapshot=3797`, agent lap captured as trainer reference. The
+  steering/telemetry wall is broken. Residual: pace ~85% of human (`avg ≳100 km/h` bar unmet; defaults
+  near-optimal, aggressive tuning regressed) → remaining Part-G scope on #244. #244/#154 stay OPEN.
+  See [`stanley-steering-live-verified-2026-06-19`](../03_Investigations/stanley-steering-live-verified-2026-06-19.md).
 - **2026-06-19** — PR [#249](https://github.com/agorokh/ac-copilot-trainer/pull/249) **MERGED** at
   `4e2a310` — mitigates [#246](https://github.com/agorokh/ac-copilot-trainer/issues/246) by replacing
   synchronous lap-complete archive writes with a queued per-frame `lapArchive.createWriteJob`, temp-file

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T10:35:00Z
+last_updated: 2026-06-19T19:35:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
   - AcCopilotTrainer/00_System/Current Focus.md
   - AcCopilotTrainer/00_System/Project State.md
   - AcCopilotTrainer/03_Investigations/racing-driver-and-controller-2026-06-17.md
@@ -30,7 +31,38 @@ relates_to:
 
 # Next session handoff
 
-## Resume here (2026-06-19 — #244 / PR #248 DRAFT: Stanley steering built; rig daemon blocks live proof)
+## Resume here (2026-06-19 LATER — #244 PR #248 MERGED + LIVE-VERIFIED on the rig: steering wall broken; pace residual remains)
+
+**Ran `/autonomous-deliver 244` ON the rig (`AG_PC`)** — the prior "Mac can't reach the rig" blocker
+was moot. PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248) **MERGED** (`88249bf`).
+Full write-up: [[stanley-steering-live-verified-2026-06-19]]. Evidence comment:
+[#244#issuecomment-4754057626](https://github.com/agorokh/ac-copilot-trainer/issues/244#issuecomment-4754057626).
+
+**PROVEN live (the wall is broken).** Merged `RacingDriver.from_human_profile(...)` Stanley controller
+drove car 0 around Magione via carcsw, no human → **3 AC VALID laps** (`completedLaps` 0→3, trainer
+`lap` frames `valid:true`), best flying lap **106.8 s**, max **207.6 km/h**, gears 1–6, 0 stuck. Sidecar
+tap: **`delta=2935`** live delta-to-reference + `coaching.snapshot=3797` — the lap/delta telemetry that
+was missing now flows. The trainer captured the agent's lap as its coaching reference
+(`journal/laps/lap_*_106813_*.json` + persisted `ks_porsche_911_gt3_r_2016__magione.json`). Screenshots
+inspected (`.scratch/part-g/stanley_*.png`).
+
+**Residual (why #244/#154 stay OPEN).** Best clean lap 106.8 s / avg ~83.5 km/h = ~85% of the human's
+relaxed laps (90.7 s / 98.7 km/h, `.scratch/part-g/human_laps.csv`). The literal `avg ≳100 km/h` bar is
+**not met**; an aggressive-throttle tuning pass REGRESSED to 124.6 s (TC-off wheelspin) → merged defaults
+are near the controller's stable optimum. Closing the last ~15% is separable controller-sophistication
+(use human gas/brake trace directly, or MPC) and touches `racing_driver.py` (#244's file group), so it
+stays as remaining Part-G scope on #244 — **not** a new overlapping issue. Operator decision: accept the
+wall-break + telemetry milestone as Part-G-core-done (pace tracked), or hold #244 for the pace bar.
+
+**Rig state left:** `surfaces.ini` Custom-AI edit (`[SURFACE_0] WAV_PITCH=extended-0` +
+`[_EXTRA_PERMISSIONS] ALLOW_CUSTOM_AI_MANIPULATION=1`) was **restored to stock** from
+`surfaces.ini.bak-precustomai`; AC/sidecar/daemon stopped. Live driver: `.scratch/part-g/race_drive_stanley.py`.
+
+**#246 (lap-freeze) note:** archives still land off-frame (5 lap archives written during the drive) and
+the delta stream stayed continuous across S/F crossings — supportive but NOT a rigorous freeze
+measurement; #246 still needs a focused render-timing capture at S/F.
+
+## Resume here (2026-06-19 — #244 / PR #248 [SUPERSEDED — now MERGED + live-verified above]: Stanley steering built; rig daemon blocks live proof)
 
 **Read [#244](https://github.com/agorokh/ac-copilot-trainer/issues/244) and draft PR
 [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248) first.** This is EPIC

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
@@ -1,0 +1,67 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-06-19
+updated: 2026-06-19
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/244
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/00_System/Current Focus.md
+  - AcCopilotTrainer/03_Investigations/racing-driver-and-controller-2026-06-17.md
+  - AcCopilotTrainer/03_Investigations/autonomous-drive-live-verified-2026-06-16.md
+  - AcCopilotTrainer/03_Investigations/csp-custom-ai-mmap-interface-2026-06-16.md
+---
+
+# Stanley steering from human profile — LIVE-VERIFIED on the rig (EPIC #154 Part G, #244)
+
+**The steering wall is broken.** PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248)
+(merged `88249bf`) Stanley controller, driven from the committed human profile
+(`tests/fixtures/racing_human_profile_magione.csv`), drove car 0 around Magione via the carcsw
+Custom-AI mmap with **no human**, and AC scored the laps **VALID** with full `lap`/`delta` coaching
+telemetry flowing — the exact signal that was missing while PurePursuit understeered into INVALID
+laps. Run on `AG_PC` (this session ran *on the rig*, so the cross-session "Mac can't reach the rig"
+blocker was moot).
+
+## What was observed (operator-grade)
+
+- **Launch:** harness daemon `--launch-mode cm` + `autodrive_magione.cmpreset` → `POST /session/start`
+  → `outcome=driving` first try (non-elevated CM-IPC; my shell was non-elevated). AC on track,
+  trainer auto-loaded (coaching widget + track map + overlay all live).
+- **Hijack:** `read_car_data()` non-None → CSP accepted Custom-AI manipulation. Confirms the
+  `surfaces.ini` edit (below).
+- **Baseline drive (merged defaults, `pace=1.0 brake_g=1.4`):** **3 valid laps**, AC
+  `completedLaps` 0→3; best flying lap **iLast=106813 ms (1:46.8)**; max **207.6 km/h**; gears 1–6;
+  peak brake 1.00; 25 brake events; **0 stuck/teleport**. Steering never saturated on the line
+  (peak ~0.16 in corners) — no understeer wall.
+- **Telemetry (sidecar WS tap):** over the run — `coaching.snapshot=3797`, **`delta=2935`** (live
+  delta-to-reference, e.g. `delta_s=-0.012/-0.017/-0.028`), `tire_temps=1899`, `connection=379`,
+  `session=3`, **`lap`** frames all `"valid": true`.
+- **Reference capture:** the trainer wrote a schema-v1 lap archive per lap
+  (`journal/laps/lap_*_2_106813_*.json`) and persisted `ks_porsche_911_gt3_r_2016__magione.json` —
+  i.e. **an agent-driven Stanley lap became the trainer's coaching reference and later laps were
+  coached against it.** This is the EPIC #154 L2/L3 throughline end-to-end.
+- Screenshots inspected (`.scratch/part-g/stanley_*.png`): in-cockpit, 6th gear on the straight,
+  car on the racing surface, coaching widget active.
+
+## The residual: pace (honest)
+
+Human reference laps (`.scratch/part-g/human_laps.csv`) were **~90.7 s / avg ~98.7 km/h** (relaxed
+data-collection laps, max 228 km/h). The Stanley best clean lap is **106.8 s / avg ~83.5 km/h ≈ 85%
+of human**. The issue's literal `avg ≳100 km/h` sub-bar is **not** met. A tuning pass (more
+aggressive corner-exit throttle `throttle_scale=3.5 base_gas=0.10 traction_lift=0.45`, later braking
+`brake_g=1.55`) **regressed** to 124.6 s — TC-off wheelspin/overshoot costs more than it gains, so
+**the merged defaults are near the controller's stable optimum** for this car/track. Closing the
+final ~15% is separable controller-sophistication work (use the human gas/brake trace directly, or
+MPC), **not** a wall — and it touches `racing_driver.py` (the #244 file group), so it stays as
+remaining Part-G scope on #244 rather than a new overlapping issue.
+
+## Rig recipe used (reusable)
+
+- `extension/config/new_behaviour.ini` → `[CUSTOM_AI] ENABLED=1` (already set).
+- Track `content/tracks/magione/data/surfaces.ini`: `[SURFACE_0] WAV_PITCH=extended-0` (extended-
+  physics trigger) + `[_EXTRA_PERMISSIONS]` `ALLOW_CUSTOM_AI_MANIPULATION=1`. Offline-hash only;
+  restore from `surfaces.ini.bak-precustomai` when done. Confirmed authoritative vs the CSP doc
+  `cup.acstuff.club/docs/csp/other-things/custom-ai`.
+- Live driver: `.scratch/part-g/race_drive_stanley.py` (uses `RacingDriver.from_human_profile`);
+  validity oracle = AC `completedLaps@132` + trainer `lap.valid`; tap = `.scratch/part-g/tap_logger.py`.


### PR DESCRIPTION
Vault-only handoff for the `/autonomous-deliver 244` live-verification session on the rig (`AG_PC`).

**What this records (docs only, strictly under `docs/01_Vault/**`):**
- New investigation note `stanley-steering-live-verified-2026-06-19.md` — merged PR #248 Stanley controller drove Magione via carcsw, no human → **3 AC VALID laps** (best 106.8s, 207.6 km/h, gears 1–6, 0 stuck), sidecar tap **`delta=2935`** + `coaching.snapshot=3797`, agent lap captured as the trainer's coaching reference. The steering/telemetry wall is broken.
- Honest residual recorded: pace ~85% of human (`avg ≳100 km/h` bar unmet; aggressive tuning regressed → merged defaults near-optimal). Remaining Part-G scope stays on #244 (touches `racing_driver.py`).
- `Next Session Handoff.md` + `Current Focus.md` updated to the verified status (prior text still said "PR #248 DRAFT / rig blocks live proof"). Rig restored to stock.

Evidence comment: agorokh/ac-copilot-trainer#244 (issuecomment-4754057626).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
