### PR TITLE
fix(ci): treat 'merge already in progress' as benign in vault-automerge (#253)

### DIFF
--- a/.github/workflows/vault-automerge.yml
+++ b/.github/workflows/vault-automerge.yml
@@ -60,6 +60,14 @@ jobs:
           set -euo pipefail
           auto_log="$(mktemp)"
           if ! gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --auto --delete-branch 2>&1 | tee "$auto_log"; then
+            # Benign race: GitHub is already squash-merging this PR (or it just
+            # merged). `mergePullRequest` returns "Merge already in progress" /
+            # "already merged" — the PR lands fine, so this is success, not a red check.
+            if grep -qiE '(merge already in progress|already in progress|already( been)? merged)' "$auto_log"; then
+              echo "::notice::Squash merge already in progress (or PR already merged); GitHub will complete it. Treating as success."
+              rm -f "$auto_log"
+              exit 0
+            fi
             if grep -qiE '(not enabled|disabled|protected|required)' "$auto_log"; then
               echo "::warning::Auto-merge could not be enabled (likely branch protection / required reviews missing). A human must merge."
               gh pr comment "$PR_NUMBER" --repo "$REPO" --body \


### PR DESCRIPTION
## What

Fixes the false-red `guard-and-automerge` check on vault-only PRs.

The **Enable auto-merge (squash)** step runs `gh pr merge --squash --auto --delete-branch`. When GitHub is already squash-merging the PR, `mergePullRequest` returns:

```
GraphQL: Merge already in progress (mergePullRequest)
```

`gh` exits 1, so the step (and job) concluded **failure** — even though the PR merges successfully. Every vault-only PR therefore showed a misleading red check on success (e.g. PR #252 merged at `9b1b3cd` but the run concluded failure).

## Change

Add one error-handling branch (before the existing branch-protection branch) that matches the already-merging / already-merged GraphQL messages, logs a `::notice::`, and `exit 0` — mirroring how the step already handles `not enabled|disabled|protected|required`.

```bash
if grep -qiE '(merge already in progress|already in progress|already( been)? merged)' "$auto_log"; then
  echo "::notice::Squash merge already in progress (or PR already merged); GitHub will complete it. Treating as success."
  rm -f "$auto_log"
  exit 0
fi
```

Genuine failures (`not mergeable`, permission denied, etc.) still surface as red. Verified the regex against sample messages:

| Message | Result |
|---|---|
| `Merge already in progress (mergePullRequest)` | benign → exit 0 |
| `Pull request is already merged` | benign → exit 0 |
| `has already been merged` | benign → exit 0 |
| `Pull request is not mergeable` | surfaced (red) |
| permission denied | surfaced (red) |

Change is **strictly** to `.github/workflows/vault-automerge.yml` (8 lines added). YAML validated.

## Verify

The next vault-only PR should show `guard-and-automerge` **green** while still auto-merging.

Closes #253

## Summary by Sourcery

Bug Fixes:
- Treat "merge already in progress" and similar GitHub merge messages as a successful outcome in the vault automerge workflow instead of failing the job.