### PR TITLE
docs(vault): #246 lap-freeze CLOSED — live-verified on the rig

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T19:35:00Z
+last_updated: 2026-06-19T19:45:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -36,14 +36,13 @@ merged defaults are near-optimal. The last ~15% is separable controller-sophisti
 stay OPEN** for the pace bar; operator decides whether the wall-break + telemetry milestone closes
 Part-G-core. Full write-up: [`stanley-steering-live-verified-2026-06-19`](../03_Investigations/stanley-steering-live-verified-2026-06-19.md).
 
-**Parallel runtime hotfix (2026-06-19) — #246 / PR #249 MERGED; issue remains open for live proof:**
-PR [#249](https://github.com/agorokh/ac-copilot-trainer/pull/249) merged at
-[`4e2a310`](https://github.com/agorokh/ac-copilot-trainer/commit/4e2a310232beb19ae6c261ca024411512185379a)
-and moves lap-archive writes off the lap-complete/SF frame. Archive JSON now streams through a bounded
-per-frame write job with temp-file finalization; setup-experiment record notifications retry after WS
-tick/poll until the sidecar send succeeds. Local `ci-fast` and GitHub build/conformance passed; review
-threads resolved. [#246](https://github.com/agorokh/ac-copilot-trainer/issues/246) is still open
-because the remaining proof is a Windows AC lap-crossing run showing the visual freeze is gone.
+**Runtime hotfix (2026-06-19) — #246 / PR #249 MERGED + CLOSED (live-verified):**
+PR [#249](https://github.com/agorokh/ac-copilot-trainer/pull/249) (`4e2a310`) moved lap-archive writes
+off the lap-complete/SF frame. **[#246](https://github.com/agorokh/ac-copilot-trainer/issues/246)
+CLOSED** on the rig this session: timestamped tap of the script-frame `coaching.snapshot` stream
+showed max gap **255 ms** (at S/F: 217 ms / 255 ms, not ~2 s); archives still land off-frame, laps
+`valid=True`. The ~2 s render freeze is gone. Evidence:
+[#246#issuecomment-4754133099](https://github.com/agorokh/ac-copilot-trainer/issues/246#issuecomment-4754133099).
 
 **Infra (2026-05-20):** PR [#111](https://github.com/agorokh/ac-copilot-trainer/pull/111) closed the [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) agent-surface campaign (closeout doc only; five agent SHA alignments deferred). PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) memory-contract cursor rule fix remains on `main`.
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T19:35:00Z
+last_updated: 2026-06-19T19:45:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
   - AcCopilotTrainer/00_System/Current Focus.md
@@ -58,9 +58,13 @@ wall-break + telemetry milestone as Part-G-core-done (pace tracked), or hold #24
 `[_EXTRA_PERMISSIONS] ALLOW_CUSTOM_AI_MANIPULATION=1`) was **restored to stock** from
 `surfaces.ini.bak-precustomai`; AC/sidecar/daemon stopped. Live driver: `.scratch/part-g/race_drive_stanley.py`.
 
-**#246 (lap-freeze) note:** archives still land off-frame (5 lap archives written during the drive) and
-the delta stream stayed continuous across S/F crossings — supportive but NOT a rigorous freeze
-measurement; #246 still needs a focused render-timing capture at S/F.
+**#246 (lap-freeze) — CLOSED this session (LIVE-VERIFIED).** Timestamped tap of the script-frame
+`coaching.snapshot` stream (`.scratch/part-g/freeze_probe.py`) over a 250 s drive: median gap 103 ms,
+max **255 ms**; at both S/F crossings the max stall was **217 ms / 255 ms** (not ~2 s). Archives still
+land off-frame (`lap_*_1_128111_*.json`, `lap_*_2_106859_*.json`, both `valid=True`). PR #249 (`4e2a310`)
+confirmed; closed with evidence ([#246#issuecomment-4754133099](https://github.com/agorokh/ac-copilot-trainer/issues/246#issuecomment-4754133099)).
+`setup.experiment.record` is a trainer→sidecar internal frame (not tap-visible); its retry path stays
+covered by `tests/test_lap_archive_async.py`.
 
 ## Resume here (2026-06-19 — #244 / PR #248 [SUPERSEDED — now MERGED + live-verified above]: Stanley steering built; rig daemon blocks live proof)
 


### PR DESCRIPTION
Vault-only handoff update: #246 (lap-complete render-thread freeze) live-verified on AG_PC and CLOSED. Timestamped script-frame coaching.snapshot tap over a 250s drive showed max gap 255ms (S/F: 217/255ms, not ~2s); archives still land off-frame, laps valid. Updates the handoff #246 note + Current Focus. Strictly under docs/01_Vault/**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)