### PR TITLE
feat(harness): frontier racing controller — GGV friction-circle profiler (#244 Part G)

### DIFF
--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -1,0 +1,216 @@
+"""Tests for the GGV friction-circle minimum-time speed profiler (tools.ac_harness.ggv_profile).
+
+Pure-math, no game. Covers the red-team-mandated guards: curvature accuracy, friction-ellipse
+corners, forward-backward correctness/feasibility on a synthetic track, GGV de-contamination
+(straight-line high-speed bins must not poison lateral grip), and build determinism.
+"""
+
+from __future__ import annotations
+
+import math
+
+from tools.ac_harness.ggv_profile import (
+    GGVModel,
+    build_ggv_speed_profile,
+    curvature_profile,
+    forward_backward_profile,
+    ggv_from_telemetry,
+    menger_curvature,
+    seg_lengths,
+)
+
+G = 9.81
+
+
+def _circle(radius: float, n: int) -> list[tuple[float, float, float]]:
+    return [
+        (radius * math.cos(2 * math.pi * i / n), 0.0, radius * math.sin(2 * math.pi * i / n))
+        for i in range(n)
+    ]
+
+
+def _flat_ggv(mu=1.0, brake=1.0, drive=1.0, n=2.0) -> GGVModel:
+    return GGVModel(
+        mu_lat_g=mu,
+        k_aero_lat=0.0,
+        brake_b0_g=brake,
+        brake_b1=0.0,
+        drive_b0_g=drive,
+        drive_b1=0.0,
+        drive_min_g=0.3,
+        ellipse_n=n,
+    )
+
+
+# --- curvature -------------------------------------------------------------
+def test_menger_curvature_circle():
+    r = 50.0
+    pts = [(r * math.cos(a), r * math.sin(a)) for a in (0.0, 0.1, 0.2)]
+    assert abs(menger_curvature(*pts) - 1.0 / r) < 1e-3
+
+
+def test_curvature_profile_constant_on_circle():
+    r = 40.0
+    plane = [(p[0], p[2]) for p in _circle(r, 400)]
+    kappa = curvature_profile(plane, smooth_win=2, span=3)
+    # interior points: curvature ~ 1/r within a few percent
+    mid = kappa[50:350]
+    assert all(abs(k - 1.0 / r) < 0.05 * (1.0 / r) for k in mid), (min(mid), max(mid), 1 / r)
+
+
+def test_curvature_zero_on_straight():
+    plane = [(float(i), 0.0) for i in range(50)] + [(49.0 - i, 5.0) for i in range(50)]
+    kappa = curvature_profile(plane, smooth_win=1, span=2)
+    assert kappa[20] < 1e-3  # mid-straight
+
+
+# --- friction ellipse ------------------------------------------------------
+def test_ellipse_corners():
+    ggv = _flat_ggv(mu=1.2, brake=2.0, n=2.0)
+    v = 30.0
+    # no lateral -> full braking
+    assert abs(ggv.ax_brake_avail(0.0, v) - ggv.ax_brake_max(v)) < 1e-6
+    # at the lateral limit -> ~zero braking left
+    assert ggv.ax_brake_avail(ggv.ay_max(v), v) < 1e-3
+    # interior is between, monotone decreasing in lateral usage
+    a_lo = ggv.ax_brake_avail(0.3 * ggv.ay_max(v), v)
+    a_hi = ggv.ax_brake_avail(0.7 * ggv.ay_max(v), v)
+    assert ggv.ax_brake_max(v) > a_lo > a_hi > 0.0
+
+
+def test_aero_braking_rises_with_speed():
+    ggv = GGVModel(
+        mu_lat_g=1.2,
+        k_aero_lat=0.0,
+        brake_b0_g=0.9,
+        brake_b1=0.025,
+        drive_b0_g=0.8,
+        drive_b1=0.0,
+        drive_min_g=0.3,
+        ellipse_n=1.5,
+    )
+    assert ggv.ax_brake_max(60.0) > ggv.ax_brake_max(10.0)  # downforce
+
+
+# --- forward-backward profile ---------------------------------------------
+def test_profile_constant_on_circle_equals_apex():
+    r = 60.0
+    plane = [(p[0], p[2]) for p in _circle(r, 600)]
+    seg = seg_lengths(plane)
+    kappa = curvature_profile(plane, smooth_win=2, span=3)
+    ggv = _flat_ggv(mu=1.0)
+    v, _ = forward_backward_profile(kappa, seg, ggv, v_top_ms=200.0, v_floor_ms=1.0)
+    apex = math.sqrt(ggv.ay_max(0.0) * r)  # sqrt(mu*g*R)
+    mid = v[100:500]
+    assert all(abs(x - apex) < 0.06 * apex for x in mid), (min(mid), max(mid), apex)
+
+
+def test_profile_brakes_into_corner_and_respects_vtop():
+    # long straight (kappa 0) into a tight arc: speed must fall toward the arc apex before it
+    n_straight, r, n_arc = 300, 25.0, 120
+    straight = [(float(i) * 3.0, 0.0) for i in range(n_straight)]
+    cx = straight[-1][0]
+    arc = [
+        (cx + r * math.sin(a), r - r * math.cos(a))
+        for a in (math.pi * 2 * i / (n_arc * 4) for i in range(n_arc))
+    ]
+    plane = straight + arc
+    seg = seg_lengths(plane)
+    kappa = curvature_profile(plane, smooth_win=1, span=2)
+    ggv = _flat_ggv(mu=1.1, brake=1.3)
+    v, _ = forward_backward_profile(kappa, seg, ggv, v_top_ms=80.0, v_floor_ms=2.0)
+    assert max(v) <= 80.0 + 1e-6  # v_top respected
+    assert v[n_straight + n_arc // 2] < v[50]  # slowed in the arc vs early straight
+    # braking happened on the straight before the arc (speed decreasing approaching the corner)
+    assert v[n_straight - 5] < v[n_straight - 60]
+
+
+def test_profile_deterministic():
+    r = 45.0
+    plane = [(p[0], p[2]) for p in _circle(r, 300)]
+    seg = seg_lengths(plane)
+    kappa = curvature_profile(plane, smooth_win=2, span=3)
+    ggv = _flat_ggv()
+    a, _ = forward_backward_profile(kappa, seg, ggv)
+    b, _ = forward_backward_profile(kappa, seg, ggv)
+    assert a == b
+
+
+# --- GGV de-contamination from telemetry ----------------------------------
+def _rows(speed_kmh, lat_max, lon_brake_max, n):
+    # deterministic spread 0..max via index fraction
+    out = []
+    for i in range(n):
+        f = (i % 100) / 99.0
+        out.append(
+            {
+                "speed_kmh": str(speed_kmh),
+                "accg_lat": str(lat_max * f),
+                "accg_lon": str(-lon_brake_max * f),
+            }
+        )
+    return out
+
+
+def test_ggv_decontamination_lateral_not_poisoned_by_straights():
+    # mid-speed bin: real hard cornering (up to 1.3g). high-speed bin: straight-line only (0.1g lat)
+    rows = _rows(60, 1.3, 1.2, 1500) + _rows(210, 0.1, 2.6, 1500)
+    ggv = ggv_from_telemetry(rows, min_samples=50)
+    # lateral grip reflects the cornering bin (~1.2-1.3g), NOT dragged toward 0.1
+    assert ggv.mu_lat_g > 1.0, ggv.provenance["lat_model"]
+    # high-speed bin tagged as non-cornering; mid-speed bin tagged cornering
+    bins = ggv.provenance["bins"]
+    assert bins[60]["cornered"] is True
+    assert bins[210]["cornered"] is False
+    # braking grip rises with speed (aero) — fitted slope positive
+    assert ggv.ax_brake_max(55.0) > ggv.ax_brake_max(15.0)
+
+
+def test_ggv_no_aero_lateral_extrapolation():
+    rows = _rows(60, 1.3, 1.2, 1500) + _rows(210, 0.1, 2.6, 1500)
+    ggv = ggv_from_telemetry(rows, min_samples=50)
+    assert ggv.k_aero_lat == 0.0  # honest: no high-speed cornering data -> no aero-lateral claim
+    assert ggv.ay_max(10.0) == ggv.ay_max(58.0)  # flat lateral grip
+
+
+# --- end-to-end build determinism on a synthetic line ----------------------
+def test_build_ggv_speed_profile_deterministic_and_capped(tmp_path):
+    import csv as _csv
+
+    csvp = tmp_path / "tele.csv"
+    with csvp.open("w", newline="") as fh:
+        w = _csv.writer(fh)
+        w.writerow(["speed_kmh", "accg_lat", "accg_lon"])
+        for r in _rows(60, 1.3, 1.2, 1500) + _rows(200, 0.1, 2.6, 1500):
+            w.writerow([r["speed_kmh"], r["accg_lat"], r["accg_lon"]])
+    line = _circle(50.0, 400)
+    v1, g1, s1 = build_ggv_speed_profile(line, csvp, v_top_kmh=180.0)
+    v2, g2, s2 = build_ggv_speed_profile(line, csvp, v_top_kmh=180.0)
+    assert v1 == v2 and s1 == s2
+    assert max(v1) <= 180.0 / 3.6 + 1e-6
+    assert len(v1) == len(line)
+
+
+# --- RacingDriver.from_ggv_profile wiring ----------------------------------
+def test_from_ggv_profile_uses_target_verbatim_and_steps():
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    line = _circle(50.0, 400)
+    vt = [30.0] * len(line)  # constant 30 m/s target
+    d = RacingDriver.from_ggv_profile(line, vt, steering_mode="stanley")
+    assert d.profile == vt  # FINAL profile used verbatim: no cap, no fixed-brake_g backward pass
+    f = d.step((50.0, 0.0, 0.0), (0.0, 0.0, 1.0), 100.0, 6000.0, 4, 1.0)
+    assert 0.0 <= f.gas <= 1.0 and 0.0 <= f.brake <= 1.0 and -1.0 <= f.steer <= 1.0
+    # over the 30 m/s target at 100 km/h (27.8 m/s)? 100km/h=27.8 < 30 so should not be max-braking
+    f2 = d.step((50.0, 0.0, 0.0), (0.0, 0.0, 1.0), 200.0, 6000.0, 5, 2.0)  # 55 m/s >> 30 target
+    assert f2.brake > 0.5  # well over target -> braking
+
+
+def test_from_ggv_profile_length_mismatch_raises():
+    import pytest
+
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    line = _circle(50.0, 100)
+    with pytest.raises(ValueError):
+        RacingDriver.from_ggv_profile(line, [30.0] * 50)

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -194,6 +194,22 @@ def test_build_ggv_speed_profile_deterministic_and_capped(tmp_path):
     assert len(v1) == len(line)
 
 
+def test_lat_grip_override_raises_apex_and_overrides_model(tmp_path):
+    import csv as _csv
+
+    csvp = tmp_path / "tele.csv"
+    with csvp.open("w", newline="") as fh:
+        w = _csv.writer(fh)
+        w.writerow(["speed_kmh", "accg_lat", "accg_lon"])
+        for r in _rows(60, 1.3, 1.2, 1500) + _rows(200, 0.1, 2.6, 1500):
+            w.writerow([r["speed_kmh"], r["accg_lat"], r["accg_lon"]])
+    line = _circle(50.0, 400)
+    lo, glo, _ = build_ggv_speed_profile(line, csvp, v_top_kmh=300.0)
+    hi, ghi, _ = build_ggv_speed_profile(line, csvp, v_top_kmh=300.0, lat_grip_g=1.6)
+    assert ghi.mu_lat_g == 1.6 and ghi.mu_lat_g > glo.mu_lat_g
+    assert max(hi) > max(lo)  # higher lateral grip -> higher apex speed on the circle
+
+
 # --- RacingDriver.from_ggv_profile wiring ----------------------------------
 def test_from_ggv_profile_uses_target_verbatim_and_steps():
     from tools.ac_harness.racing_driver import RacingDriver

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 import math
 
 from tools.ac_harness.ggv_profile import (
+    CurvatureFeedforwardSteering,
     GGVModel,
     build_ggv_speed_profile,
     curvature_profile,
+    fit_steer_feedforward,
     forward_backward_profile,
     ggv_from_telemetry,
     menger_curvature,
     seg_lengths,
+    signed_curvature_profile,
 )
 
 G = 9.81
@@ -268,3 +271,52 @@ def test_ff_adds_braking_when_profile_decelerates():
     _, b_ff = d_ff._longitudinal(10, 30.0 * 3.6, 0.0)
     _, b_no = d_no._longitudinal(10, 30.0 * 3.6, 0.0)
     assert b_ff >= b_no  # feedforward brakes at least as hard into the decel
+
+
+# --- Stage 3: signed curvature + steer feedforward fit + lateral controller ---
+def test_signed_curvature_consistent_sign_on_circle():
+    plane = [(p[0], p[2]) for p in _circle(40.0, 400)]
+    sk = signed_curvature_profile(plane, smooth_win=2, span=3)
+    mid = sk[50:350]
+    assert all((x > 0) == (mid[0] > 0) for x in mid)  # one consistent turn direction
+    assert all(abs(abs(x) - 1.0 / 40.0) < 0.05 / 40.0 for x in mid)  # magnitude ~ 1/R
+
+
+def test_fit_steer_feedforward_recovers_coeffs():
+    # synthetic: steer = 4.0*kappa + 0.002*(v^2*kappa) exactly
+    c1_true, c2_true = 4.0, 0.002
+    rows = []
+    for i in range(400):
+        v = 20.0 + 0.2 * i  # m/s spread
+        kappa = 0.01 + 0.00005 * (i % 50)
+        ay = v * v * kappa
+        steer = c1_true * kappa + c2_true * ay
+        rows.append({"speed_kmh": str(v * 3.6), "accg_lat": str(ay / G), "steer": str(steer)})
+    c1, c2, rms, n = fit_steer_feedforward(rows, min_lat_g=0.0, min_kmh=0.0)
+    assert abs(c1 - c1_true) < 0.05 and abs(c2 - c2_true) < 1e-4
+    assert rms < 0.02 and n == 400
+
+
+def test_curvature_ff_steering_in_range_and_uses_curvature():
+    line = _circle(50.0, 400)
+    cff = CurvatureFeedforwardSteering(
+        line, c1=5.0, c2=0.0, ff_sign=1.0, fb_weight=0.0, preview_m=2.0
+    )
+    # facing along +x at a point on the circle; FF should command a nonzero, in-range steer
+    s = cff.steer((50.0, 0.0, 0.0), (0.0, 0.0, 1.0), 80.0)
+    assert -1.0 <= s <= 1.0
+    # zero coefficients + zero feedback -> zero steer (pure FF off)
+    flat = CurvatureFeedforwardSteering(line, c1=0.0, c2=0.0, ff_sign=1.0, fb_weight=0.0)
+    assert abs(flat.steer((50.0, 0.0, 0.0), (0.0, 0.0, 1.0), 80.0)) < 1e-9
+
+
+def test_racing_driver_curvature_ff_mode_steps():
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    line = _circle(50.0, 200)
+    d = RacingDriver.from_ggv_profile(
+        line, [30.0] * 200, steering_mode="curvature_ff", ff_c1=5.0, ff_c2=0.002
+    )
+    assert d.cff is not None
+    f = d.step((50.0, 0.0, 0.0), (0.0, 0.0, 1.0), 100.0, 6000.0, 4, 1.0)
+    assert -1.0 <= f.steer <= 1.0

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -214,3 +214,57 @@ def test_from_ggv_profile_length_mismatch_raises():
     line = _circle(50.0, 100)
     with pytest.raises(ValueError):
         RacingDriver.from_ggv_profile(line, [30.0] * 50)
+
+
+# --- Stage 2: slip ratio + slip limiter + ax feedforward -------------------
+def test_slip_ratio_sign_and_deadzone():
+    from tools.ac_harness.racing_driver import slip_ratio
+
+    r, v = 0.33, 30.0
+    omega_match = v / r  # wheel surface speed == body speed -> ~0 slip
+    assert abs(slip_ratio(omega_match, r, v)) < 1e-6
+    assert slip_ratio(omega_match * 1.2, r, v) > 0.1  # wheelspin
+    assert slip_ratio(omega_match * 0.8, r, v) < -0.1  # locking
+    assert slip_ratio(omega_match, r, 0.1) == 0.0  # near-stationary deadzone
+
+
+def test_slip_limited_controls_clamps_only():
+    from tools.ac_harness.racing_driver import slip_limited_controls
+
+    # below thresholds: untouched
+    g, b = slip_limited_controls(1.0, 0.0, 0.05, 0.0)
+    assert g == 1.0
+    # wheelspin: gas cut, never raised
+    g2, _ = slip_limited_controls(1.0, 0.0, 0.40, 0.0, accel_slip_target=0.16, cut_gain=4.0)
+    assert 0.0 <= g2 < 1.0
+    # lockup: brake cut
+    _, b2 = slip_limited_controls(0.0, 1.0, 0.0, -0.40, brake_slip_target=0.16, cut_gain=4.0)
+    assert 0.0 <= b2 < 1.0
+    # extreme slip drives the command toward zero, never negative
+    g3, b3 = slip_limited_controls(1.0, 1.0, 2.0, -2.0)
+    assert g3 == 0.0 and b3 == 0.0
+
+
+def test_profile_ax_feedforward_sign():
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    line = _circle(50.0, 100)
+    d = RacingDriver.from_ggv_profile(line, [30.0] * 100)
+    assert abs(d._profile_ax(10)) < 1e-6  # constant profile -> no demanded accel
+    d.profile[11] = 20.0
+    assert d._profile_ax(10) < 0  # next point slower -> decelerate
+    d.profile[11] = 40.0
+    assert d._profile_ax(10) > 0  # next point faster -> accelerate
+
+
+def test_ff_adds_braking_when_profile_decelerates():
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    line = _circle(50.0, 100)
+    d_ff = RacingDriver.from_ggv_profile(line, [30.0] * 100, ax_feedforward=True)
+    d_no = RacingDriver.from_ggv_profile(line, [30.0] * 100, ax_feedforward=False)
+    d_ff.profile[11] = 10.0
+    d_no.profile[11] = 10.0
+    _, b_ff = d_ff._longitudinal(10, 30.0 * 3.6, 0.0)
+    _, b_no = d_no._longitudinal(10, 30.0 * 3.6, 0.0)
+    assert b_ff >= b_no  # feedforward brakes at least as hard into the decel

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -30,6 +30,8 @@ import math
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
+from tools.ac_harness.ai_line import StanleySteering, _horizontal
+
 G = 9.81
 
 
@@ -263,6 +265,74 @@ def curvature_profile(
     return [menger_curvature(p[(i - span) % n], p[i], p[(i + span) % n]) for i in range(n)]
 
 
+def signed_curvature_profile(
+    plane: list[tuple[float, float]], *, smooth_win: int = 3, span: int = 3
+) -> list[float]:
+    """Per-point SIGNED curvature (1/m) of a cyclic line: magnitude = Menger, sign = turn direction.
+
+    Sign is the planar cross product of consecutive chords (``> 0`` one way, ``< 0`` the other). The
+    absolute mapping to "left/right" depends on the (x, z) handedness and is reconciled live by the
+    controller's ``ff_sign`` flag; what matters here is that the sign is consistent along the line.
+    """
+    p = _smooth_cyclic(plane, smooth_win)
+    n = len(p)
+    out = []
+    for i in range(n):
+        a = p[(i - span) % n]
+        b = p[i]
+        c = p[(i + span) % n]
+        mag = menger_curvature(a, b, c)
+        v1x, v1z = b[0] - a[0], b[1] - a[1]
+        v2x, v2z = c[0] - b[0], c[1] - b[1]
+        cross = v1x * v2z - v1z * v2x
+        out.append(mag if cross >= 0 else -mag)
+    return out
+
+
+def fit_steer_feedforward(
+    rows: list[dict], *, min_lat_g: float = 0.3, min_kmh: float = 15.0
+) -> tuple[float, float, float, int]:
+    """Calibrate a bicycle-model steer feedforward from human telemetry.
+
+    Fits the normalized steer command ``steer ≈ c1*kappa + c2*(v^2*kappa)`` where the human's own
+    instantaneous curvature ``kappa = a_y / v^2`` and ``a_y = accg_lat*g`` (signed). ``c1`` is the
+    geometric (Ackermann) term ``L/steer_scale``; ``c2`` the understeer term ``K_ug/steer_scale``
+    (both absorb the unknown rad-per-unit-steer of the actuator). Returns ``(c1, c2, rms_frac, n)``;
+    ``rms_frac`` is the residual RMS as a fraction of the steer RMS (lower = better calibrated).
+    """
+    x11 = x12 = x22 = y1 = y2 = 0.0
+    samples: list[tuple[float, float, float]] = []
+    for r in rows:
+        try:
+            v = float(r["speed_kmh"]) / 3.6
+            ay = float(r["accg_lat"]) * G
+            st = float(r["steer"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if v < min_kmh / 3.6 or abs(float(r["accg_lat"])) < min_lat_g:
+            continue
+        kappa = ay / (v * v)
+        x1, x2 = kappa, ay  # x2 == v^2 * kappa
+        x11 += x1 * x1
+        x12 += x1 * x2
+        x22 += x2 * x2
+        y1 += x1 * st
+        y2 += x2 * st
+        samples.append((x1, x2, st))
+    n = len(samples)
+    if n < 50:
+        return (0.0, 0.0, 1.0, n)
+    det = x11 * x22 - x12 * x12
+    if abs(det) < 1e-12:
+        return (0.0, 0.0, 1.0, n)
+    c1 = (y1 * x22 - y2 * x12) / det
+    c2 = (x11 * y2 - x12 * y1) / det
+    sse = sum((c1 * a + c2 * b - s) ** 2 for a, b, s in samples)
+    sst = sum(s * s for _, _, s in samples)
+    rms_frac = (sse / sst) ** 0.5 if sst > 0 else 1.0
+    return (c1, c2, rms_frac, n)
+
+
 def seg_lengths(plane: list[tuple[float, float]]) -> list[float]:
     n = len(plane)
     return [
@@ -381,3 +451,73 @@ def build_ggv_speed_profile(
         "ggv": ggv.provenance,
     }
     return v, ggv, summ
+
+
+class CurvatureFeedforwardSteering:
+    """Curvature-feedforward + Stanley-feedback lateral controller (Stage 3).
+
+    ``delta = ff_sign*(c1*kappa + c2*v^2*kappa)``  (feedforward from the LINE's signed curvature,
+    with ``v^2*kappa`` a_y-capped) ``+ fb_weight * Stanley(cross-track + heading)`` (feedback).
+
+    Bare Stanley only corrects error; at racing corner speeds it saturates and the car runs wide.
+    The feedforward supplies the steady-state wheel angle the curve needs (calibrated from human
+    telemetry via :func:`fit_steer_feedforward`), so Stanley only trims the residual — the car can
+    carry the GGV profile's corner speeds. ``ff_sign`` reconciles the line curvature sign convention
+    with the actuator's ``steer>0=right`` live (flip if the car veers off on the first corner).
+    """
+
+    def __init__(
+        self,
+        line: list[tuple[float, float, float]],
+        *,
+        c1: float,
+        c2: float,
+        ff_sign: float = 1.0,
+        ay_cap_mps2: float = 14.0,
+        preview_m: float = 6.0,
+        fb_weight: float = 0.6,
+        smooth_win: int = 3,
+        span: int = 3,
+        **stanley_kwargs,
+    ) -> None:
+        self._plane = [(p[0], p[2]) for p in line]
+        self._kappa = signed_curvature_profile(self._plane, smooth_win=smooth_win, span=span)
+        self._seg = seg_lengths(self._plane)
+        self.n = len(self._plane)
+        self.c1 = c1
+        self.c2 = c2
+        self.ff_sign = ff_sign
+        self.ay_cap = ay_cap_mps2
+        self.preview_m = preview_m
+        self.fb_weight = fb_weight
+        self._stanley = StanleySteering(line, **stanley_kwargs)
+
+    def _nearest(self, car: tuple[float, float]) -> int:
+        best_i, best = 0, float("inf")
+        for i, p in enumerate(self._plane):
+            d = (p[0] - car[0]) ** 2 + (p[1] - car[1]) ** 2
+            if d < best:
+                best, best_i = d, i
+        return best_i
+
+    def _advance(self, idx: int, dist_m: float) -> int:
+        rem, i = dist_m, idx
+        for _ in range(self.n):
+            s = self._seg[i]
+            if s >= rem:
+                return (i + 1) % self.n
+            rem -= s
+            i = (i + 1) % self.n
+        return idx
+
+    def steer(self, position_xyz, look_dir_xyz, speed_kmh: float) -> float:
+        """Return steering in ``[-1, 1]`` (``>0`` = right) from pose + speed."""
+        car = _horizontal(position_xyz)
+        look = self._advance(self._nearest(car), self.preview_m)
+        k = self._kappa[look]
+        v = max(speed_kmh, 0.0) / 3.6
+        ay = min(v * v * abs(k), self.ay_cap)  # cap a_y (grip-bounded understeer term)
+        ff = self.ff_sign * (self.c1 * k + self.c2 * (ay if k >= 0 else -ay))
+        fb = self._stanley.steer(position_xyz, look_dir_xyz, speed_kmh)
+        out = ff + self.fb_weight * fb
+        return -1.0 if out < -1.0 else 1.0 if out > 1.0 else out

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -440,7 +440,7 @@ def build_ggv_speed_profile(
         ggv = replace(ggv, drive_b0_g=accel_peak_g, drive_b1=-(accel_peak_g - 0.4) / 60.0)
     if lat_grip_g is not None:
         # grip self-play: the relaxed human under-corners (~1.2 g), a real GT3 R does ~1.5 g. Push
-        # the lateral envelope up to raise apex speeds; kept honest live by validity (back off if cut).
+        # the lateral envelope up to raise apex speeds; kept honest live by validity.
         ggv = replace(ggv, mu_lat_g=lat_grip_g, ay_cap_g=max(ggv.ay_cap_g, lat_grip_g + 0.1))
     v, ax = forward_backward_profile(kappa, seg, ggv, v_top_ms=v_top_kmh / 3.6)
     total = sum(seg)

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -439,8 +439,8 @@ def build_ggv_speed_profile(
         # traction-shaped accel: peak low-speed, ~0.4 g by 60 m/s (power/drag fade)
         ggv = replace(ggv, drive_b0_g=accel_peak_g, drive_b1=-(accel_peak_g - 0.4) / 60.0)
     if lat_grip_g is not None:
-        # grip self-play: the relaxed human under-corners (~1.2 g); a real GT3 R does ~1.5 g. Push the
-        # lateral envelope up to raise apex speeds, kept honest live by validity (back off if it cuts).
+        # grip self-play: the relaxed human under-corners (~1.2 g), a real GT3 R does ~1.5 g. Push
+        # the lateral envelope up to raise apex speeds; kept honest live by validity (back off if cut).
         ggv = replace(ggv, mu_lat_g=lat_grip_g, ay_cap_g=max(ggv.ay_cap_g, lat_grip_g + 0.1))
     v, ax = forward_backward_profile(kappa, seg, ggv, v_top_ms=v_top_kmh / 3.6)
     total = sum(seg)

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -419,6 +419,7 @@ def build_ggv_speed_profile(
     smooth_win: int = 3,
     span: int = 3,
     accel_peak_g: float | None = None,
+    lat_grip_g: float | None = None,
 ) -> tuple[list[float], GGVModel, dict]:
     """End-to-end offline build: fit GGV from telemetry, compute the QSS profile on ``fast_line``.
 
@@ -437,6 +438,10 @@ def build_ggv_speed_profile(
     if accel_peak_g is not None:
         # traction-shaped accel: peak low-speed, ~0.4 g by 60 m/s (power/drag fade)
         ggv = replace(ggv, drive_b0_g=accel_peak_g, drive_b1=-(accel_peak_g - 0.4) / 60.0)
+    if lat_grip_g is not None:
+        # grip self-play: the relaxed human under-corners (~1.2 g); a real GT3 R does ~1.5 g. Push the
+        # lateral envelope up to raise apex speeds, kept honest live by validity (back off if it cuts).
+        ggv = replace(ggv, mu_lat_g=lat_grip_g, ay_cap_g=max(ggv.ay_cap_g, lat_grip_g + 0.1))
     v, ax = forward_backward_profile(kappa, seg, ggv, v_top_ms=v_top_kmh / 3.6)
     total = sum(seg)
     laptime = sum(seg[i] / max(0.5, 0.5 * (v[i] + v[(i + 1) % len(v)])) for i in range(len(v)))

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import csv
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 G = 9.81
@@ -348,16 +348,25 @@ def build_ggv_speed_profile(
     v_top_kmh: float = 232.0,
     smooth_win: int = 3,
     span: int = 3,
+    accel_peak_g: float | None = None,
 ) -> tuple[list[float], GGVModel, dict]:
     """End-to-end offline build: fit GGV from telemetry, compute the QSS profile on ``fast_line``.
 
     Returns (v_target_mps aligned to fast_line points, GGVModel, summary dict). The v_target list is
     drop-in for :class:`RacingDriver` (one m/s target per line point).
+
+    ``accel_peak_g`` overrides the (under-driven, human-fit) drive accel with a traction-shaped
+    curve peaking at ``accel_peak_g`` low-speed and fading with speed. The human barely used the gas
+    (0.24-0.97 g), so the fitted accel is far below the car's capability; an aggressive accel target
+    is made TC-off-safe live by ``slip_limited_controls``. Braking/lateral are left as fitted.
     """
     plane = [(p[0], p[2]) for p in fast_line]
     seg = seg_lengths(plane)
     kappa = curvature_profile(plane, smooth_win=smooth_win, span=span)
     ggv = ggv_from_telemetry(_read_csv(human_csv))
+    if accel_peak_g is not None:
+        # traction-shaped accel: peak low-speed, ~0.4 g by 60 m/s (power/drag fade)
+        ggv = replace(ggv, drive_b0_g=accel_peak_g, drive_b1=-(accel_peak_g - 0.4) / 60.0)
     v, ax = forward_backward_profile(kappa, seg, ggv, v_top_ms=v_top_kmh / 3.6)
     total = sum(seg)
     laptime = sum(seg[i] / max(0.5, 0.5 * (v[i] + v[(i + 1) % len(v)])) for i in range(len(v)))

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -1,0 +1,374 @@
+"""GGV friction-circle minimum-time speed profiler (EPIC #154 Part G / #244 frontier controller).
+
+Offline, pure-Python (stdlib ``math`` only), deterministic, CI-testable. Builds a speed-dependent
+grip model (GGV) from human telemetry and computes a forward-backward quasi-steady-state
+``v_target`` profile over a racing line - replacing the consumer-grade fixed-``brake_g`` backward
+pass that merely replays *relaxed* human speeds. This is the engine of the frontier controller:
+it exploits the friction circle + the aero rise of braking grip the old controller threw away.
+
+Grounded in the 2026-06-19 15-agent deep-research synthesis + adversarial red-team and the empirical
+plant-ID from ``human_laps.csv``. Red-team guardrails honored here:
+
+* **GGV de-contamination** - ``ay_max(v)`` is fitted as ``mu*g + k_aero*v^2`` (downforce is
+  quadratic) to ONLY low/mid-speed bins with real cornering data; the high-speed lateral bins are
+  straight-line-braking artifacts (nobody corners at 220 km/h in relaxed laps) and are NOT trusted -
+  the aero term is extrapolated upward instead. Each bin carries provenance (sample count + lateral
+  spread) so a bin without cornering coverage never sets ``ay_max``.
+* **95th-percentile, not peak** - robust to single-frame mmap glitches; self-play grows from here.
+* **Curvature** - arc-length-aware Menger curvature on smoothed coordinates (no phantom apexes from
+  the non-equispaced 1754-point line).
+* **Friction-ellipse exponent fitted** from the ``(accg_lat, accg_lon)`` hull edge, not guessed.
+
+The online controller never imports the fitter: it consumes the baked ``v_target`` list. Everything
+here is plain arithmetic so CI verifies it with synthetic lines + synthetic telemetry, no game.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+
+G = 9.81
+
+
+# ---------------------------------------------------------------------------
+# GGV grip model (speed-dependent friction circle), fitted from telemetry.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class GGVModel:
+    """Speed-dependent grip limits (in g) + the friction-ellipse exponent.
+
+    ``ay_max(v)`` lateral and ``ax_brake_max(v)`` braking are the load-bearing curves;
+    ``ax_drive_max`` is the (weakly identified) accel cap. ``ellipse_n`` couples them:
+    available longitudinal g at lateral usage ``ay`` is ``ax_max * (1 - (ay/ay_max)^n)^(1/n)``.
+    """
+
+    mu_lat_g: float  # ay_max(v) = mu_lat_g + k_aero_lat * v_ms^2
+    k_aero_lat: float
+    brake_b0_g: float  # ax_brake_max(v) = brake_b0_g + brake_b1 * v_ms
+    brake_b1: float
+    drive_b0_g: float  # ax_drive_max(v) = max(drive_min_g, drive_b0_g + drive_b1 * v_ms)
+    drive_b1: float
+    drive_min_g: float
+    ellipse_n: float
+    ay_cap_g: float = 1.8  # hard sanity cap on extrapolated lateral grip
+    ax_brake_cap_g: float = 3.4
+    provenance: dict = field(default_factory=dict)
+
+    def ay_max(self, v_ms: float) -> float:
+        return min(self.ay_cap_g, self.mu_lat_g + self.k_aero_lat * v_ms * v_ms) * G
+
+    def ax_brake_max(self, v_ms: float) -> float:
+        return min(self.ax_brake_cap_g, max(0.5, self.brake_b0_g + self.brake_b1 * v_ms)) * G
+
+    def ax_drive_max(self, v_ms: float) -> float:
+        return max(self.drive_min_g, self.drive_b0_g + self.drive_b1 * v_ms) * G
+
+    def ax_brake_avail(self, ay_used: float, v_ms: float) -> float:
+        """Braking g still available given lateral g already used (friction ellipse)."""
+        aymax = self.ay_max(v_ms)
+        if aymax <= 1e-6:
+            return self.ax_brake_max(v_ms)
+        frac = min(1.0, abs(ay_used) / aymax)
+        return self.ax_brake_max(v_ms) * (max(0.0, 1.0 - frac**self.ellipse_n)) ** (
+            1.0 / self.ellipse_n
+        )
+
+    def ax_drive_avail(self, ay_used: float, v_ms: float) -> float:
+        aymax = self.ay_max(v_ms)
+        if aymax <= 1e-6:
+            return self.ax_drive_max(v_ms)
+        frac = min(1.0, abs(ay_used) / aymax)
+        return self.ax_drive_max(v_ms) * (max(0.0, 1.0 - frac**self.ellipse_n)) ** (
+            1.0 / self.ellipse_n
+        )
+
+
+def _pct(xs: list[float], q: float) -> float:
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    return s[min(len(s) - 1, int(q * len(s)))]
+
+
+def _linfit(xs: list[float], ys: list[float], ws: list[float] | None = None) -> tuple[float, float]:
+    """Weighted least squares y = a + b*x -> (a, b)."""
+    if ws is None:
+        ws = [1.0] * len(xs)
+    sw = sum(ws)
+    if sw <= 0 or len(xs) < 2:
+        return (ys[0] if ys else 0.0, 0.0)
+    mx = sum(w * x for w, x in zip(ws, xs, strict=False)) / sw
+    my = sum(w * y for w, y in zip(ws, ys, strict=False)) / sw
+    sxx = sum(w * (x - mx) ** 2 for w, x in zip(ws, xs, strict=False))
+    sxy = sum(w * (x - mx) * (y - my) for w, x, y in zip(ws, xs, ys, strict=False))
+    b = sxy / sxx if sxx > 1e-12 else 0.0
+    return (my - b * mx, b)
+
+
+def ggv_from_telemetry(
+    rows: list[dict],
+    *,
+    bin_kmh: float = 10.0,
+    pct: float = 0.95,
+    min_corner_lat_g: float = 0.9,
+    min_samples: int = 40,
+) -> GGVModel:
+    """Fit a :class:`GGVModel` from telemetry rows (dicts w/ speed_kmh, accg_lat, accg_lon).
+
+    Per speed bin: 95th-pct |lat|, braking (-lon) and accel (+lon) g, with sample count and lateral
+    spread. ``ay_max(v)=mu*g+k*v^2`` is fitted ONLY on bins with real cornering coverage (lat spread
+    >= ``min_lat_spread_g`` and >= ``min_samples``); braking/accel fitted linearly. Ellipse exponent
+    from the radial hull of ``(lat, lon)``.
+    """
+    lat_b: dict[int, list[float]] = {}
+    brk_b: dict[int, list[float]] = {}
+    acc_b: dict[int, list[float]] = {}
+    hull: list[tuple[float, float]] = []  # (|lat|, |lon|) in g
+    for r in rows:
+        try:
+            v = float(r["speed_kmh"])
+            al = abs(float(r["accg_lat"]))
+            ao = float(r["accg_lon"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        b = int(v // bin_kmh) * int(bin_kmh)
+        lat_b.setdefault(b, []).append(al)
+        (brk_b if ao < 0 else acc_b).setdefault(b, []).append(abs(ao))
+        if al > 0.2 or abs(ao) > 0.2:
+            hull.append((al, abs(ao)))
+
+    # Lateral grip: ONLY bins where the car DEMONSTRABLY cornered hard count (p95 lateral high).
+    # The high-speed bins are straight-line-braking artifacts (low lateral) and must NOT pull the
+    # fit down (red-team contamination guard). There is no high-speed cornering data on this track,
+    # so we do NOT claim an aero lateral term (k_aero_lat=0) - that would be extrapolating into an
+    # empty corner of the envelope. mu_lat = demonstrated peak mechanical lateral grip.
+    cov: dict[int, dict] = {}
+    corner_p95: list[float] = []
+    for b, vals in sorted(lat_b.items()):
+        spread = (max(vals) - min(vals)) if vals else 0.0
+        p95 = _pct(vals, pct)
+        cov[b] = {
+            "n": len(vals),
+            "lat_spread_g": round(spread, 3),
+            "lat_p95_g": round(p95, 3),
+            "cornered": bool(len(vals) >= min_samples and p95 >= min_corner_lat_g and b >= 30),
+        }
+        if cov[b]["cornered"]:
+            corner_p95.append(p95)
+    mu_lat = max(corner_p95) if corner_p95 else 1.2
+    k_aero = 0.0
+    n_corner_bins = len(corner_p95)
+
+    # braking fit (linear in v) on bins with samples
+    xs_b, ys_b, ws_b = [], [], []
+    for b, vals in sorted(brk_b.items()):
+        if len(vals) >= min_samples and b >= 30:
+            xs_b.append((b + bin_kmh / 2) / 3.6)
+            ys_b.append(_pct(vals, pct))
+            ws_b.append(float(len(vals)))
+    brake_b0, brake_b1 = _linfit(xs_b, ys_b, ws_b) if len(xs_b) >= 2 else (1.0, 0.0)
+
+    # accel fit (linear) - weakly identified (human under-drove), kept conservative
+    xs_a, ys_a, ws_a = [], [], []
+    for b, vals in sorted(acc_b.items()):
+        if len(vals) >= min_samples and b >= 30:
+            xs_a.append((b + bin_kmh / 2) / 3.6)
+            ys_a.append(_pct(vals, pct))
+            ws_a.append(float(len(vals)))
+    drive_b0, drive_b1 = _linfit(xs_a, ys_a, ws_a) if len(xs_a) >= 2 else (0.8, 0.0)
+
+    # ellipse exponent from radial hull edge: near the boundary (lat/aymax)^n + (lon/axmax)^n ~ 1.
+    n_fit = _fit_ellipse_n(hull, mu_lat, k_aero, brake_b0, brake_b1)
+
+    prov = {
+        "bins": cov,
+        "lat_corner_bins": n_corner_bins,
+        "lat_model": f"ay_max(v)={mu_lat:.3f}+{k_aero:.5f}*v_ms^2 g [mech peak; no aero-lat]",
+        "brake_model": f"ax_brake(v)={brake_b0:.3f}+{brake_b1:.5f}*v_ms (g)",
+        "accel_model": f"ax_drive(v)={drive_b0:.3f}+{drive_b1:.5f}*v_ms (g)",
+        "ellipse_n": round(n_fit, 3),
+    }
+    return GGVModel(
+        mu_lat_g=mu_lat,
+        k_aero_lat=max(0.0, k_aero),
+        brake_b0_g=brake_b0,
+        brake_b1=max(0.0, brake_b1),
+        drive_b0_g=drive_b0,
+        drive_b1=drive_b1,
+        drive_min_g=0.35,
+        ellipse_n=n_fit,
+        provenance=prov,
+    )
+
+
+def _fit_ellipse_n(hull: list[tuple[float, float]], mu_lat, k_aero, brake_b0, brake_b1) -> float:
+    """Pick n in [1,2] minimizing the hull-edge residual of (lat/aymax)^n + (lon/axmax)^n = 1."""
+    if len(hull) < 20:
+        return 1.5
+    # use a coarse speed-independent envelope for the fit (peak mechanical), robust enough for n
+    aymax = max(0.8, mu_lat + k_aero * (20.0**2))  # ~70 km/h
+    axmax = max(0.8, brake_b0 + brake_b1 * 25.0)
+    # keep only near-boundary points (top decile radial in normalized space)
+    norm = [(lat / aymax, lon / axmax) for lat, lon in hull]
+    rad = sorted(norm, key=lambda p: -(p[0] ** 2 + p[1] ** 2))[: max(20, len(norm) // 10)]
+    best_n, best_err = 1.5, 1e18
+    n = 1.0
+    while n <= 2.01:
+        err = sum((x**n + y**n - 1.0) ** 2 for x, y in rad)
+        if err < best_err:
+            best_err, best_n = err, n
+        n += 0.05
+    return best_n
+
+
+# ---------------------------------------------------------------------------
+# Curvature (arc-length-aware Menger, smoothed) + forward-backward profiler.
+# ---------------------------------------------------------------------------
+def _smooth_cyclic(pts: list[tuple[float, float]], win: int) -> list[tuple[float, float]]:
+    n = len(pts)
+    if win <= 0 or n < 3:
+        return list(pts)
+    out = []
+    for i in range(n):
+        sx = sz = 0.0
+        for k in range(-win, win + 1):
+            p = pts[(i + k) % n]
+            sx += p[0]
+            sz += p[1]
+        m = 2 * win + 1
+        out.append((sx / m, sz / m))
+    return out
+
+
+def menger_curvature(a, b, c) -> float:
+    """Menger curvature 1/R of the circumcircle through 3 planar points (arc-length-aware)."""
+    ab = math.hypot(b[0] - a[0], b[1] - a[1])
+    bc = math.hypot(c[0] - b[0], c[1] - b[1])
+    ca = math.hypot(a[0] - c[0], a[1] - c[1])
+    if ab < 1e-9 or bc < 1e-9 or ca < 1e-9:
+        return 0.0
+    area2 = abs((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]))  # 2*area
+    return 2.0 * area2 / (ab * bc * ca)
+
+
+def curvature_profile(
+    plane: list[tuple[float, float]], *, smooth_win: int = 3, span: int = 3
+) -> list[float]:
+    """Per-point curvature (1/m) of a cyclic line: smooth coords, then Menger over +/-span."""
+    p = _smooth_cyclic(plane, smooth_win)
+    n = len(p)
+    return [menger_curvature(p[(i - span) % n], p[i], p[(i + span) % n]) for i in range(n)]
+
+
+def seg_lengths(plane: list[tuple[float, float]]) -> list[float]:
+    n = len(plane)
+    return [
+        math.hypot(plane[(i + 1) % n][0] - plane[i][0], plane[(i + 1) % n][1] - plane[i][1])
+        for i in range(n)
+    ]
+
+
+def forward_backward_profile(
+    kappa: list[float],
+    seg: list[float],
+    ggv: GGVModel,
+    *,
+    v_top_ms: float = 64.0,
+    v_floor_ms: float = 8.0,
+    passes: int = 4,
+) -> tuple[list[float], list[float]]:
+    """Quasi-steady-state minimum-time speed profile over a cyclic line.
+
+    1. apex speed from lateral grip (fixed-point, grip depends on v);
+    2. backward pass: braking limited by the friction ellipse with speed-dependent grip;
+    3. forward pass: accel limited by ellipse + traction/power cap.
+    Returns (v_target_ms per point, ax_ff per point [m/s^2, +accel/-decel]).
+    """
+    n = len(kappa)
+    # 1) apex (fixed-point on v because ay_max depends on v)
+    v = [v_top_ms] * n
+    for i in range(n):
+        k = kappa[i]
+        if k > 1e-6:
+            vi = v_top_ms
+            for _ in range(8):
+                vi = min(v_top_ms, math.sqrt(ggv.ay_max(vi) / k))
+            v[i] = max(v_floor_ms, vi)
+    # 2) backward (braking) - ellipse uses the lateral g implied by apex usage
+    for _ in range(passes):
+        for j in range(n):
+            i = (n - 1 - j) % n
+            nx = (i + 1) % n
+            ds = seg[i]
+            if ds <= 1e-6:  # coincident points must share speed, else propagation chain breaks
+                if v[nx] < v[i]:
+                    v[i] = max(v_floor_ms, v[nx])
+                continue
+            ay_used = v[i] * v[i] * kappa[i]
+            ax = ggv.ax_brake_avail(ay_used, v[i])
+            cap = math.sqrt(v[nx] * v[nx] + 2.0 * ax * ds)
+            if cap < v[i]:
+                v[i] = max(v_floor_ms, cap)
+    # 3) forward (accel)
+    for _ in range(passes):
+        for i in range(n):
+            pv = (i - 1) % n
+            ds = seg[pv]
+            if ds <= 1e-6:  # coincident points must share speed
+                if v[pv] < v[i]:
+                    v[i] = max(v_floor_ms, v[pv])
+                continue
+            ay_used = v[pv] * v[pv] * kappa[pv]
+            ax = ggv.ax_drive_avail(ay_used, v[pv])
+            cap = math.sqrt(v[pv] * v[pv] + 2.0 * ax * ds)
+            if cap < v[i]:
+                v[i] = max(v_floor_ms, cap)
+    v = [min(v_top_ms, x) for x in v]
+    # ax feedforward from the profile (central, cyclic): a = v*dv/ds
+    ax_ff = []
+    for i in range(n):
+        nx = (i + 1) % n
+        ds = seg[i]
+        ax_ff.append(((v[nx] * v[nx] - v[i] * v[i]) / (2.0 * ds)) if ds > 1e-6 else 0.0)
+    return v, ax_ff
+
+
+def _read_csv(path: str | Path) -> list[dict]:
+    with Path(path).open("r", encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def build_ggv_speed_profile(
+    fast_line: list[tuple[float, float, float]],
+    human_csv: str | Path,
+    *,
+    v_top_kmh: float = 232.0,
+    smooth_win: int = 3,
+    span: int = 3,
+) -> tuple[list[float], GGVModel, dict]:
+    """End-to-end offline build: fit GGV from telemetry, compute the QSS profile on ``fast_line``.
+
+    Returns (v_target_mps aligned to fast_line points, GGVModel, summary dict). The v_target list is
+    drop-in for :class:`RacingDriver` (one m/s target per line point).
+    """
+    plane = [(p[0], p[2]) for p in fast_line]
+    seg = seg_lengths(plane)
+    kappa = curvature_profile(plane, smooth_win=smooth_win, span=span)
+    ggv = ggv_from_telemetry(_read_csv(human_csv))
+    v, ax = forward_backward_profile(kappa, seg, ggv, v_top_ms=v_top_kmh / 3.6)
+    total = sum(seg)
+    laptime = sum(seg[i] / max(0.5, 0.5 * (v[i] + v[(i + 1) % len(v)])) for i in range(len(v)))
+    summ = {
+        "points": len(v),
+        "length_m": round(total, 1),
+        "qss_laptime_s": round(laptime, 2),
+        "qss_avg_kmh": round(total / laptime * 3.6, 1),
+        "vmax_kmh": round(max(v) * 3.6, 1),
+        "vmin_kmh": round(min(v) * 3.6, 1),
+        "max_kappa": round(max(kappa), 4),
+        "ggv": ggv.provenance,
+    }
+    return v, ggv, summ

--- a/tools/ac_harness/racing_driver.py
+++ b/tools/ac_harness/racing_driver.py
@@ -262,6 +262,44 @@ def _clamp(x: float, lo: float, hi: float) -> float:
     return lo if x < lo else hi if x > hi else x
 
 
+def slip_ratio(wheel_omega: float, wheel_radius_m: float, v_body_mps: float) -> float:
+    """Longitudinal slip ratio ``(omega*r - v) / v`` for one wheel.
+
+    >0 = the wheel is spinning faster than the ground (wheelspin under power); <0 = the wheel is
+    slower (locking under braking). Computed from ``wheelAngularSpeed`` (rad/s) read from
+    ``acpmf_physics`` — NOT AC's ``wheelSlip`` field, which is a combined Pacejka NDslip magnitude
+    on a different scale (red-team #B fix).
+    """
+    if v_body_mps < 0.5:
+        return 0.0
+    return (wheel_omega * wheel_radius_m - v_body_mps) / v_body_mps
+
+
+def slip_limited_controls(
+    gas: float,
+    brake: float,
+    drive_slip: float,
+    min_slip: float,
+    *,
+    accel_slip_target: float = 0.16,
+    brake_slip_target: float = 0.16,
+    cut_gain: float = 4.0,
+) -> tuple[float, float]:
+    """Software TC/ABS: clamp gas/brake from measured slip ratios (the TC-off-safe enabler).
+
+    ``drive_slip`` is the driven (rear) wheels' slip ratio; ``min_slip`` is the most-negative slip
+    over all wheels (lockup indicator). These are PURE CLAMPS — they can only reduce gas/brake, so
+    they make the car safer/slower, never command more (red-team: ship clamps first). Above
+    ``accel_slip_target`` gas is cut proportionally (kill wheelspin); below ``-brake_slip_target``
+    brake is released (anti-lock). Returns the limited ``(gas, brake)``.
+    """
+    if drive_slip > accel_slip_target:
+        gas *= max(0.0, 1.0 - cut_gain * (drive_slip - accel_slip_target))
+    if min_slip < -brake_slip_target:
+        brake *= max(0.0, 1.0 - cut_gain * (-min_slip - brake_slip_target))
+    return _clamp(gas, 0.0, 1.0), _clamp(brake, 0.0, 1.0)
+
+
 class RacingDriver:
     """Drive ``fast_line`` at racing dynamics from any starting state (pits, off-line, on-line).
 
@@ -326,6 +364,14 @@ class RacingDriver:
         kwargs.setdefault("brake_scale_mps", 2.5)
         kwargs.setdefault("throttle_scale_mps", 4.0)
         kwargs.setdefault("base_gas", 0.1)
+        # Stage 2 infra (ax feedforward) is OFF by default: live-verified that enabling it on the
+        # Stanley lateral controller REGRESSES (95.3s -> 104-110s) — the more aggressive longitudinal
+        # carries more speed into corners than Stanley can hold (steer saturates). Unlocked once
+        # Stage 3 (curvature-feedforward lateral) lands. Opt in with ax_feedforward=True.
+        kwargs.setdefault("ax_feedforward", False)
+        kwargs.setdefault("ff_gain", 1.0)
+        kwargs.setdefault("ff_drive_g", 1.0)
+        kwargs.setdefault("ff_brake_g", 2.2)
         return cls(fast_line, list(v_target_mps), **kwargs)
 
     def __init__(
@@ -368,6 +414,10 @@ class RacingDriver:
         min_lap_m: float = 1800.0,
         return_radius_m: float = 12.0,
         profile_is_final: bool = False,
+        ax_feedforward: bool = False,
+        ff_gain: float = 1.0,
+        ff_drive_g: float = 1.0,
+        ff_brake_g: float = 2.0,
     ) -> None:
         if len(fast_line) != len(speed_profile):
             raise ValueError(
@@ -400,6 +450,10 @@ class RacingDriver:
         )
         self.n = len(fast_line)
         self.steering_mode = steering_mode
+        self.ax_feedforward = ax_feedforward
+        self.ff_gain = ff_gain
+        self.ff_drive_g = ff_drive_g
+        self.ff_brake_g = ff_brake_g
         self.lookahead_m = lookahead_m
         self.lookahead_time_s = lookahead_time_s
         self.brake_band_mps = brake_band_mps
@@ -477,19 +531,57 @@ class RacingDriver:
         )
         return min(self.profile[idx], self.profile[look_idx]) * 3.6
 
+    def _profile_ax(self, idx: int) -> float:
+        """Acceleration (m/s^2, signed) the profile itself demands from ``idx`` to the next point.
+
+        ``a = (v_next^2 - v_idx^2) / (2 ds)`` along the cyclic line — this is the feedforward term:
+        in a braking zone it is strongly negative, on corner exit strongly positive. Tracking it
+        directly (instead of only chasing the speed error) removes the ~one-step lag that left the
+        Stage-1 controller ~10% below its own minimum-time profile.
+        """
+        nxt = (idx + 1) % self.n
+        ds = self.pursuit.segment_lengths[idx]
+        if ds <= 1e-6:
+            return 0.0
+        return (self.profile[nxt] * self.profile[nxt] - self.profile[idx] * self.profile[idx]) / (
+            2.0 * ds
+        )
+
     def _longitudinal(self, idx: int, speed_kmh: float, steer: float) -> tuple[float, float]:
-        """Racing throttle/brake toward the brake-feasible profile (trail braking + traction)."""
+        """Racing throttle/brake toward the profile: speed-error feedback + optional ax feedforward.
+
+        With ``ax_feedforward`` the profile's demanded accel (:meth:`_profile_ax`) drives a baseline
+        gas/brake via a coarse inverse model (``ff_drive_g``/``ff_brake_g`` caps); the speed error
+        term only trims the residual. Without it, the original proportional law is unchanged.
+        """
         v_cur = speed_kmh / 3.6
         target = self.target_speed_kmh(idx, speed_kmh) / 3.6
         lat = min(abs(steer), 1.0)  # cornering load proxy (steer fraction, saturated)
         err = v_cur - target
-        if err > self.brake_band_mps:
-            brake = _clamp((err - self.brake_band_mps) / self.brake_scale_mps, 0.0, 1.0)
+        ax_ff = self.ff_gain * self._profile_ax(idx) if self.ax_feedforward else 0.0
+        # Braking demand = MAX of (overspeed feedback) and (profile-decel feedforward) — never their
+        # SUM (summing double-brakes -> over-slow into corners). The FF term anticipates the braking
+        # point, but is gated off when the car is already well below target (don't brake when slow).
+        fb_brake = (
+            _clamp((err - self.brake_band_mps) / self.brake_scale_mps, 0.0, 1.0)
+            if err > self.brake_band_mps
+            else 0.0
+        )
+        ff_brake = (
+            _clamp(-ax_ff / (self.ff_brake_g * 9.81), 0.0, 1.0)
+            if (ax_ff < 0.0 and err > -self.brake_band_mps)
+            else 0.0
+        )
+        brake = max(fb_brake, ff_brake)
+        if brake > 0.0:
             # trail braking: bleed brake off as steering loads the front, but keep some mid-corner.
             brake *= max(self.trail_min, 1.0 - self.trail_release * lat)
             return 0.0, brake
-        # Under/at target: throttle toward it, lifting as steering loads the car (anti-wheelspin).
-        gas = _clamp((target - v_cur) / self.throttle_scale_mps + self.base_gas, 0.0, 1.0)
+        # Under/at target: throttle toward it + accel feedforward, lifting as steering loads grip.
+        gas = (target - v_cur) / self.throttle_scale_mps + self.base_gas
+        if ax_ff > 0.0:
+            gas += ax_ff / (self.ff_drive_g * 9.81)
+        gas = _clamp(gas, 0.0, 1.0)
         gas *= max(0.0, 1.0 - self.traction_lift * lat)
         return gas, 0.0
 

--- a/tools/ac_harness/racing_driver.py
+++ b/tools/ac_harness/racing_driver.py
@@ -365,9 +365,9 @@ class RacingDriver:
         kwargs.setdefault("throttle_scale_mps", 4.0)
         kwargs.setdefault("base_gas", 0.1)
         # Stage 2 infra (ax feedforward) is OFF by default: live-verified that enabling it on the
-        # Stanley lateral controller REGRESSES (95.3s -> 104-110s) — the more aggressive longitudinal
-        # carries more speed into corners than Stanley can hold (steer saturates). Unlocked once
-        # Stage 3 (curvature-feedforward lateral) lands. Opt in with ax_feedforward=True.
+        # Stanley lateral controller REGRESSES (95.3s -> 104-110s) — aggressive longitudinal carries
+        # more speed into corners than Stanley can hold (steer saturates). Unlocked once Stage 3
+        # (curvature-feedforward lateral) lands. Opt in with ax_feedforward=True.
         kwargs.setdefault("ax_feedforward", False)
         kwargs.setdefault("ff_gain", 1.0)
         kwargs.setdefault("ff_drive_g", 1.0)

--- a/tools/ac_harness/racing_driver.py
+++ b/tools/ac_harness/racing_driver.py
@@ -294,6 +294,40 @@ class RacingDriver:
             **kwargs,
         )
 
+    @classmethod
+    def from_ggv_profile(
+        cls,
+        fast_line: list[tuple[float, float, float]],
+        v_target_mps: list[float],
+        **kwargs,
+    ) -> RacingDriver:
+        """Construct from a baked GGV friction-circle minimum-time profile (one m/s target/point).
+
+        ``v_target_mps`` comes from :func:`tools.ac_harness.ggv_profile.build_ggv_speed_profile`; it
+        is the FINAL target (apex + speed-dependent braking baked in), so it is used verbatim:
+        no pace scaling, no speed cap, no fixed-``brake_g`` backward pass.
+
+        Longitudinal defaults are tuned for tracking a GGV profile (not the legacy lane-keeper): the
+        braking points are already in ``v_target``, so the re-braking look-ahead is minimised and
+        the brake/throttle response is tighter. Live-verified on Magione: 106.8s legacy -> 95.3s.
+        """
+        if len(v_target_mps) != len(fast_line):
+            raise ValueError(
+                f"v_target ({len(v_target_mps)}) and line ({len(fast_line)}) length mismatch"
+            )
+        kwargs["profile_is_final"] = True
+        kwargs.setdefault("max_speed_kmh", max(max(v_target_mps) * 3.6, 1.0) + 5.0)
+        kwargs.setdefault("min_speed_kmh", 1.0)
+        kwargs.setdefault("pace", 1.0)
+        # GGV-appropriate longitudinal tracking defaults (the profile already bakes braking points,
+        # so don't re-brake via a long look-ahead; respond tighter to the target).
+        kwargs.setdefault("lookahead_m", 4.0)
+        kwargs.setdefault("lookahead_time_s", 0.15)
+        kwargs.setdefault("brake_scale_mps", 2.5)
+        kwargs.setdefault("throttle_scale_mps", 4.0)
+        kwargs.setdefault("base_gas", 0.1)
+        return cls(fast_line, list(v_target_mps), **kwargs)
+
     def __init__(
         self,
         fast_line: list[tuple[float, float, float]],
@@ -333,6 +367,7 @@ class RacingDriver:
         stuck_throttle: float = 0.1,
         min_lap_m: float = 1800.0,
         return_radius_m: float = 12.0,
+        profile_is_final: bool = False,
     ) -> None:
         if len(fast_line) != len(speed_profile):
             raise ValueError(
@@ -388,11 +423,18 @@ class RacingDriver:
         self.min_lap_m = min_lap_m
         self.return_radius_m = return_radius_m
 
-        # Scaled + capped target, then brake-feasible backward pass -> per-point m/s target.
-        cap = max_speed_kmh / 3.6
-        floor = min_speed_kmh / 3.6
-        scaled = [_clamp(pace * s, floor, cap) for s in speed_profile]
-        self.profile = self._backward_pass(scaled, brake_g)
+        # Target speed (m/s) per point. In GGV mode the profile is ALREADY the friction-circle
+        # minimum-time target (braking/apex baked in by tools.ac_harness.ggv_profile), so we use it
+        # verbatim - no pace scaling, no max_speed cap, no fixed-brake_g backward pass (that is the
+        # exact consumer-grade step #244's frontier controller replaces). Otherwise (legacy human/
+        # fast_lane profile) keep the scale + cap + backward pass.
+        if profile_is_final:
+            self.profile = list(speed_profile)
+        else:
+            cap = max_speed_kmh / 3.6
+            floor = min_speed_kmh / 3.6
+            scaled = [_clamp(pace * s, floor, cap) for s in speed_profile]
+            self.profile = self._backward_pass(scaled, brake_g)
 
         # Mutable run state (mirrors LapDriver).
         self.phase = PHASE_OUT

--- a/tools/ac_harness/racing_driver.py
+++ b/tools/ac_harness/racing_driver.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tools.ac_harness.ai_line import PurePursuit, StanleySteering, _horizontal
+from tools.ac_harness.ggv_profile import CurvatureFeedforwardSteering
 from tools.ac_harness.lap_driver import PHASE_LAP, PHASE_OUT, DriveFrame
 
 # fast_lane.ai AiPointExtra block: speed@0, gas@4, brake@8 — 72-byte stride. Ground-truthed live
@@ -418,6 +419,12 @@ class RacingDriver:
         ff_gain: float = 1.0,
         ff_drive_g: float = 1.0,
         ff_brake_g: float = 2.0,
+        ff_c1: float = 0.0,
+        ff_c2: float = 0.0,
+        ff_sign: float = 1.0,
+        cff_preview_m: float = 6.0,
+        cff_fb_weight: float = 0.6,
+        cff_ay_cap_mps2: float = 14.0,
     ) -> None:
         if len(fast_line) != len(speed_profile):
             raise ValueError(
@@ -429,8 +436,8 @@ class RacingDriver:
             raise ValueError("require 0 < min_speed_kmh <= max_speed_kmh")
         if brake_g <= 0 or brake_scale_mps <= 0 or throttle_scale_mps <= 0:
             raise ValueError("brake_g, brake_scale_mps, throttle_scale_mps must be > 0")
-        if steering_mode not in {"stanley", "pure_pursuit"}:
-            raise ValueError("steering_mode must be 'stanley' or 'pure_pursuit'")
+        if steering_mode not in {"stanley", "pure_pursuit", "curvature_ff"}:
+            raise ValueError("steering_mode must be 'stanley', 'pure_pursuit', or 'curvature_ff'")
 
         self.pursuit = PurePursuit(
             fast_line,
@@ -447,6 +454,24 @@ class RacingDriver:
             speed_softening_mps=stanley_speed_softening_mps,
             max_steer_rad=stanley_max_steer_rad,
             max_cross_track_m=stanley_max_cross_track_m,
+        )
+        self.cff = (
+            CurvatureFeedforwardSteering(
+                fast_line,
+                c1=ff_c1,
+                c2=ff_c2,
+                ff_sign=ff_sign,
+                ay_cap_mps2=cff_ay_cap_mps2,
+                preview_m=cff_preview_m,
+                fb_weight=cff_fb_weight,
+                cross_track_gain=stanley_cross_track_gain,
+                heading_gain=stanley_heading_gain,
+                speed_softening_mps=stanley_speed_softening_mps,
+                max_steer_rad=stanley_max_steer_rad,
+                max_cross_track_m=stanley_max_cross_track_m,
+            )
+            if steering_mode == "curvature_ff"
+            else None
         )
         self.n = len(fast_line)
         self.steering_mode = steering_mode
@@ -644,7 +669,9 @@ class RacingDriver:
         ):
             self.phase = PHASE_LAP
 
-        if self.steering_mode == "stanley":
+        if self.steering_mode == "curvature_ff":
+            steer = self.cff.steer(position_xyz, look_dir_xyz, speed_kmh)
+        elif self.steering_mode == "stanley":
             steer = self.stanley.steer(position_xyz, look_dir_xyz, speed_kmh)
         else:
             steer = self.pursuit.control(position_xyz, look_dir_xyz, speed_kmh).steer


### PR DESCRIPTION
## Frontier racing controller — EPIC #154 Part G / #244 (staged)

Pushes the autonomous controller from consumer-grade toward RESEARCHER-grade pace. Grounded in a 15-agent deep-research synthesis + adversarial red-team and an empirical vehicle plant-ID from `human_laps.csv`, and **live-verified on the rig (`AG_PC`)** lap by lap.

### Why the old controller was slow
The merged `RacingDriver` replays the *relaxed* human speed profile with a single fixed `brake_g=1.4` backward pass. It ignores the friction circle, the **aerodynamic rise of braking grip** (we measured **0.95g at 40 km/h → ~3g at 200+**), an optimized line, and feedforward. Live it drove **106.8s** — 15% slower than the human's relaxed 90.7s, and pushing throttle harder regressed (TC-off wheelspin).

### Stage 1 (this PR so far): GGV friction-circle minimum-time speed profile
New `tools/ac_harness/ggv_profile.py` (pure stdlib, deterministic, CI-tested):
- **De-contaminated GGV fit** from telemetry: lateral grip = demonstrated mechanical peak (high-speed straight-line bins are *not* allowed to poison it — red-team guard); braking = aero-rising linear-in-v; **friction-ellipse exponent fitted** from the `(accg_lat, accg_lon)` hull.
- **Arc-length-aware Menger curvature** on smoothed coords (no phantom apexes from the non-equispaced 1754-pt line).
- **Forward-backward QSS profiler** → `v_target(s)` with apex + speed-dependent braking baked in.
- `RacingDriver.from_ggv_profile()` tracks it verbatim (no speed cap, no fixed-`brake_g` re-brake) with GGV-tuned longitudinal defaults.

**Live result (Magione, Porsche GT3 R, carcsw, no human):** old Stanley **106.8s → GGV 95.3s** flying lap, AC-valid, 0 stuck, 216 km/h. QSS ceiling is 86.2s; the remaining ~9s tracking loss is the **Stage 2a** target.

### Remaining staged work (this branch will continue)
- **Stage 2a:** `ax` feedforward (command the profile's required accel, not just chase speed error) + slip-ratio traction/ABS guard computed from `wheelAngularSpeed` (the real slip ratio, not AC's `wheelSlip` NDslip) — closes tracking loss + enables harder, wheelspin-safe exits.
- **Stage 3:** curvature-feedforward + velocity-scheduled feedback lateral (Stanley alone saturates at racing pace).
- **Stage 4:** offline min-curvature optimized line (higher apex than the stock fast_lane line); validity bounded by the human's no-cut envelope.

Targets: beat the human (≤90.7s), then toward a ~70s hotlap. Each stage is live-A/B'd against the banked baseline; nothing stacked.

Tests: 13 GGV unit tests (curvature, ellipse, forward-backward feasibility, de-contamination, determinism) + `from_ggv_profile` wiring; ruff clean.

Refs #154, #244. Full research write-up + plant-ID in the vault handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
