### PR TITLE
docs(vault): #244 human beaten 90.7s->83.5s (frontier controller)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T22:30:00Z
+last_updated: 2026-06-20T01:30:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/frontier-controller-ggv-2026-06-19.md
   - AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
@@ -31,6 +31,28 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-20 — #244 FRONTIER: HUMAN BEATEN 90.7s→83.5s; Stage 4 line is the path to ~70s)
+
+**The autonomous controller now beats the human and is repeatable + AC-valid.** Live on AG_PC, GT3 R,
+carcsw: **106.8s (old) → 95.3 (GGV) → 91.8 (curvature-FF) → 90.28 (Stage 2, 1.2g) → 86.4 (1.35g) →
+83.5s (1.5g, real-GT3 grip)**; human relaxed = 90.7s. Every lap `lap.valid=true` with `delta`
+telemetry (sidecar tap). Branch `feat/issue-244-frontier-racing-controller`, draft PR
+[#256](https://github.com/agorokh/ac-copilot-trainer/pull/256) (Stages 1–3 + grip self-play, 25
+tests, ruff clean). Evidence: [#244#issuecomment-4754911396](https://github.com/agorokh/ac-copilot-trainer/issues/244#issuecomment-4754911396).
+Full write-up: [[frontier-controller-ggv-2026-06-19]] (UPDATE section).
+
+**Winning live config** (`.scratch/part-g/race_drive_ff.py`): `steering_mode="curvature_ff"`,
+`ff_sign=-1` (Magione; from `corr(human_steer, line_kappa)=+0.93`), `ax_feedforward=True`,
+`accel_peak_g≈1.1`, `lat_grip_g=1.5`, slip limiter `r_eff=0.347`. Curvature-FF holds the line so
+Stanley only trims (Stanley alone saturated); that unlocked Stage 2; grip self-play found 1.5g is the
+ceiling (1.6g fails — keep-last-valid).
+
+**Next → Stage 4 (toward ~70s):** at 1.5g the apexes are LINE-limited (stock `fast_lane` tighter than
+optimal). Build an offline min-curvature optimized line (TUMFTM-style QP, corridor bounded by the
+human no-cut envelope), re-run the GGV profiler on it, bake `(x,y,kappa,v_target)`. QSS ceiling on the
+current line is ~78s at 1.5g; a better line + speed-dependent aero lateral grip push toward ~70s.
+**Rig left clean** (surfaces stock, daemon/AC stopped). Merge PR #256 when CI/bots green.
 
 ## Resume here (2026-06-19 NIGHT — #244 FRONTIER controller: GGV profiler LIVE 95.3s; Stage 3 lateral is the wall to beat human 90.7s)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/frontier-controller-ggv-2026-06-19.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/frontier-controller-ggv-2026-06-19.md
@@ -14,6 +14,33 @@ relates_to:
 
 # Frontier racing controller — GGV friction-circle profiler (EPIC #154 Part G, #244)
 
+## UPDATE 2026-06-19 NIGHT — HUMAN BEATEN: 90.7s → 83.5s (Stage 3 + grip self-play)
+
+Live on AG_PC, repeatable, all AC-valid (sidecar `lap.valid=true` + `delta` streaming):
+
+| controller | flying lap |
+|---|---|
+| old Stanley | 106.8s |
+| Stage 1 GGV profile | 95.3s |
+| + Stage 3 curvature-FF lateral | 91.8s |
+| + Stage 2 ax-FF + slip limiter (1.2g) | 90.28s (beats human) |
+| + grip self-play 1.35g / 1.5g | 86.4s / **83.5s** |
+| human (relaxed) | 90.7s |
+
+- **Stage 3 = `CurvatureFeedforwardSteering`**: FF supplies the steady-state wheel angle for the line
+  curvature (calibrated `fit_steer_feedforward`, ~96% of steer variance; sign from
+  `corr(human_steer, line_kappa)=+0.93` → `ff_sign=-1` for Magione). Stanley alone saturated at racing
+  pace; with FF it only trims → the car holds the line. This unlocked Stage 2 (ax-FF + slip limiter,
+  which had regressed on bare Stanley).
+- **Grip self-play (`lat_grip_g`)**: relaxed human used ~1.2g lateral; pushed the envelope —
+  **1.5g is the verified ceiling** (1.6g fails: 6 teleports, car can't hold). Keep-last-valid.
+- **Winning config**: `steering_mode="curvature_ff"`, `ff_sign=-1`, `ax_feedforward=True`,
+  `accel_peak_g≈1.1`, `lat_grip_g=1.5`, slip limiter (r_eff 0.347). Live driver
+  `.scratch/part-g/race_drive_ff.py`. PR [#256](https://github.com/agorokh/ac-copilot-trainer/pull/256).
+- **Path to ~70s (Stage 4)**: at 1.5g the apexes are LINE-limited (stock `fast_lane` tighter than
+  optimal). Min-curvature optimized line (TUMFTM QP, bounded by the human no-cut envelope) → QSS ~78s
+  and below. Optional: speed-dependent aero lateral grip for fast corners.
+
 Push from consumer-grade to RESEARCHER-grade pace, grounded in a 15-agent deep-research workflow +
 adversarial red-team + multi-model council (Gemini) + empirical plant-ID from `human_laps.csv`.
 PR [#256](https://github.com/agorokh/ac-copilot-trainer/pull/256) (branch


### PR DESCRIPTION
Vault SAVE: the frontier controller now beats the human — 106.8->95.3->91.8->90.28->86.4->83.5s, repeatable + AC-valid (curvature-FF lateral + ax-FF + grip self-play to 1.5g). Stage 4 (optimized line) is the path to ~70s. Updates the handoff + frontier note. Strictly docs/01_Vault/**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)