### PR TITLE
feat(egress): vendor hostname-clean egress client, drop per-repo GH_PAT (governance-hub#75)

### DIFF
--- a/.fleet-governance-vendor/runtime/inference_egress/__init__.py
+++ b/.fleet-governance-vendor/runtime/inference_egress/__init__.py
@@ -1,0 +1,36 @@
+# OWNER: @agorokh
+"""Fleet inference-egress client package (the third governed asset class, governance-hub#67).
+
+Reference-not-vendor: import from ``$FLEET_GOVERNANCE_ROOT/runtime``
+(``from inference_egress import resolve_api_key, auth_headers, ...``); do not copy this
+package into a spoke (conformance forbids a re-vendored drifted copy). ADR
+``adr-2026-06-19-inference-egress-client-canonical-home``.
+"""
+
+from __future__ import annotations
+
+from .client import (
+    DEFAULT_BASE_URL,
+    DIAL_PROXY_HOST_MARKER,
+    app_label_headers,
+    auth_headers,
+    host_matches_marker,
+    is_dial_host,
+    normalized_base_url,
+    request_headers,
+    resolve_api_key,
+    safe_url_hostname,
+)
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "DIAL_PROXY_HOST_MARKER",
+    "app_label_headers",
+    "auth_headers",
+    "host_matches_marker",
+    "is_dial_host",
+    "normalized_base_url",
+    "request_headers",
+    "resolve_api_key",
+    "safe_url_hostname",
+]

--- a/.fleet-governance-vendor/runtime/inference_egress/client.py
+++ b/.fleet-governance-vendor/runtime/inference_egress/client.py
@@ -1,0 +1,184 @@
+# OWNER: @agorokh
+"""Fleet inference-egress client: the ONE canonical resolver for provider
+``base_url`` / API key / auth header / ``X-App-Label``. The third governed asset class
+(after hooks and skills) per ADR ``adr-2026-06-19-inference-egress-client-canonical-home``
+(governance-hub#67).
+
+Reference-not-vendor: spokes IMPORT this from ``$FLEET_GOVERNANCE_ROOT/runtime``, they do
+not copy it (conformance forbids a re-vendored copy). Extracted close to verbatim from the
+fleet's de-facto shared client (agent-factory ``tools/process_miner/distill.py``); the logic
+is proven in production, so this is an extraction, not a rewrite.
+
+Provider-auth authority: this module is the runtime embodiment of
+``adr-2026-05-19-subscription-routing-contract`` (the authority for ALL provider auth on this
+fleet). DIAL uses ``Api-Key``; OpenAI / OpenRouter / generic OpenAI-compatible
+endpoints use ``Authorization: Bearer``. ``DIAL_API_KEY_PROJECT`` is preferred for ingestion
+workloads. The opt-in ``X-App-Label`` header carries per-consumer attribution to the
+inference-governance gateway (dial-sandbox#506); set it so a consumer's egress is governable.
+
+Pure stdlib, no network in this module (callers own the HTTP). Env-var NAMES are parameters
+with distill-compatible defaults, so the process-miner and the bespoke consumers
+(alpaca / disclosures / stock_hero) share one implementation.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import urllib.parse
+from pathlib import Path
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def _deployment_default_dial_host() -> str:
+    """The deployment default DIAL proxy host, read from the sibling ``dial_host.txt`` file.
+
+    The internal infra hostname lives in ``dial_host.txt`` (PRIVATE hub only), NOT in this module,
+    because this module is byte-vendored into PUBLIC spokes (governance-hub#75) and must carry no
+    internal hostname. The sidecar is co-located in ``$FLEET_GOVERNANCE_ROOT/runtime`` (which every
+    spoke already imports), so runtime DIAL detection is unchanged fleet-wide with no env rollout.
+    Read by path off ``__file__`` so it resolves whether this file is imported as part of the
+    ``inference_egress`` package or loaded standalone. Absent in a public vendored copy (which
+    excludes ``dial_host.txt``) -> empty, and callers fall back to ``$DIAL_PROXY_HOST``.
+    """
+    try:
+        text = (Path(__file__).resolve().parent / "dial_host.txt").read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped.lower()
+    return ""
+
+
+# Deployment default DIAL proxy host (empty in a public vendored copy that excludes the sidecar).
+DIAL_PROXY_HOST_MARKER = _deployment_default_dial_host()
+
+
+@functools.lru_cache(maxsize=32)
+def _extra_host_markers(raw: str) -> tuple[str, ...]:
+    """Lowercase markers from a comma-separated env value; cached by raw string so an
+    edit invalidates cheaply. Tests that change the env must call ``cache_clear()``."""
+    raw = (raw or "").strip()
+    if not raw:
+        return ()
+    return tuple(dict.fromkeys(m.strip().lower() for m in raw.split(",") if m.strip()))
+
+
+def safe_url_hostname(url: str) -> str:
+    """Lowercase hostname for ``url``, or empty if missing or ``urlparse`` raises."""
+    try:
+        return (urllib.parse.urlparse(url).hostname or "").lower()
+    except ValueError:
+        return ""
+
+
+def host_matches_marker(host: str, marker: str) -> bool:
+    """Whether ``host`` matches ``marker`` (exact hostname or a registrable subdomain).
+
+    Registrable-boundary match (``host == m`` or ``host endswith '.' + m``) so that
+    ``api.openai.com`` matches ``openai.com`` but ``evilopenai.com`` does not.
+    """
+    h = (host or "").lower()
+    m = (marker or "").lower()
+    return bool(h) and bool(m) and (h == m or h.endswith("." + m))
+
+
+def is_dial_host(
+    host: str, *, host_env: str = "DIAL_PROXY_HOST", extra_hosts_env: str = "DIAL_EXTRA_HOSTS"
+) -> bool:
+    """Whether ``host`` is the DIAL proxy (registrable-boundary match).
+
+    The primary marker is ``$DIAL_PROXY_HOST`` when set, else the deployment default
+    ``DIAL_PROXY_HOST_MARKER`` (provided out of band — see ``_deployment_default_dial_host``).
+    Honors ``$DIAL_EXTRA_HOSTS`` (comma-separated) for reverse-proxy / tailnet-served DIAL
+    relay hosts.
+    """
+    primary = os.environ.get(host_env, "").strip() or DIAL_PROXY_HOST_MARKER
+    extras = _extra_host_markers(os.environ.get(extra_hosts_env, ""))
+    return host_matches_marker(host, primary) or any(
+        host_matches_marker(host, marker) for marker in extras
+    )
+
+
+def normalized_base_url(explicit: str | None = None, *, base_url_env: str = "DISTILL_BASE_URL") -> str:
+    """Strip and default the base URL; prepend ``https://`` when the scheme is omitted."""
+    raw = (explicit if explicit is not None else os.environ.get(base_url_env)) or DEFAULT_BASE_URL
+    raw = raw.strip()
+    if not raw:
+        return DEFAULT_BASE_URL
+    if "://" not in raw:
+        raw = "https://" + raw
+    return raw
+
+
+def resolve_api_key(
+    url: str,
+    *,
+    global_key_env: str = "DISTILL_API_KEY",
+    openrouter_env: str = "OPENROUTER_API_KEY",
+    openai_env: str = "OPENAI_API_KEY",
+    dial_project_env: str = "DIAL_API_KEY_PROJECT",
+    dial_env: str = "DIAL_API_KEY",
+) -> str | None:
+    """Resolve the API key for the host in ``url`` (per-request URL).
+
+    A global override (``$DISTILL_API_KEY`` by default) wins. Otherwise the hostname of
+    ``url`` selects the provider key, so a per-call ``base_url`` override cannot attach the
+    wrong credential. DIAL prefers ``$DIAL_API_KEY_PROJECT`` (higher rate limit for
+    ingestion) then falls back to ``$DIAL_API_KEY``.
+    """
+    override = os.environ.get(global_key_env, "").strip()
+    if override:
+        return override
+    host = safe_url_hostname(url)
+    if host == "openrouter.ai" or host.endswith(".openrouter.ai"):
+        return os.environ.get(openrouter_env, "").strip() or None
+    if host == "api.openai.com" or host.endswith(".openai.com"):
+        return os.environ.get(openai_env, "").strip() or None
+    if is_dial_host(host):
+        project_key = os.environ.get(dial_project_env, "").strip()
+        if project_key:
+            return project_key
+        return os.environ.get(dial_env, "").strip() or None
+    return None
+
+
+def auth_headers(url: str, api_key: str) -> dict[str, str]:
+    """Build the auth header dict for ``url``.
+
+    DIAL expects ``Api-Key: <key>``; OpenAI / OpenRouter / generic
+    OpenAI-compatible endpoints expect ``Authorization: Bearer <key>``.
+    """
+    if is_dial_host(safe_url_hostname(url)):
+        return {"Api-Key": api_key}
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def app_label_headers(*, label_env: str = "DISTILL_APP_LABEL") -> dict[str, str]:
+    """Opt-in ``X-App-Label`` header for per-consumer gateway attribution.
+
+    The inference-governance gateway (dial-sandbox#506) keys cost attribution off
+    ``X-App-Label``. The header is inert metadata to endpoints that do not consume it, so it
+    is sent regardless of host. Off by default (empty env, zero behaviour change); set
+    ``$DISTILL_APP_LABEL`` (or pass ``label_env``) to enable.
+    """
+    label = os.environ.get(label_env, "").strip()
+    return {"X-App-Label": label} if label else {}
+
+
+def request_headers(
+    url: str,
+    api_key: str,
+    *,
+    label_env: str = "DISTILL_APP_LABEL",
+    content_type: str = "application/json",
+) -> dict[str, str]:
+    """The full header dict for one request: content-type, auth, and the opt-in app label."""
+    return {
+        "Content-Type": content_type,
+        **auth_headers(url, api_key),
+        **app_label_headers(label_env=label_env),
+    }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      FLEET_GOVERNANCE_ROOT: ${{ github.workspace }}/.fleet-governance
+      # Egress runtime is VENDORED in-repo (.fleet-governance-vendor) — no private-hub checkout, no
+      # GH_PAT. The vendored client is hostname-clean and SHA-256-pinned to the hub
+      # (tests/test_vendored_egress_pin.py). See governance-hub#75 / #78.
+      FLEET_GOVERNANCE_ROOT: ${{ github.workspace }}/.fleet-governance-vendor
     steps:
       - name: Reject PRs whose head branch is main
         if: github.event_name == 'pull_request'
@@ -36,23 +39,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Verify GH_PAT for governance-hub checkout
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          if [ -z "${GH_PAT:-}" ]; then
-            echo "::error::GH_PAT is not configured — cannot checkout private governance-hub runtime."
-            exit 1
-          fi
-
-      - name: Checkout governance-hub runtime
-        uses: actions/checkout@v6
-        with:
-          repository: agorokh/governance-hub
-          ref: main
-          path: .fleet-governance
-          token: ${{ secrets.GH_PAT }}
 
       - uses: actions/setup-python@v6
         with:

--- a/docs/10_Development/11_Repository_Structure.md
+++ b/docs/10_Development/11_Repository_Structure.md
@@ -19,6 +19,7 @@ These align with `scripts/check_agent_forbidden.py` for the unspecialized templa
 | `tests/` | Automated tests |
 | `scripts/` | Checked-in automation |
 | `tools/` | Optional Python tooling (e.g. `process_miner`, `repo_knowledge`); extras `[mining]` / `[knowledge]` |
+| `.fleet-governance-vendor/` | Vendored inference-egress runtime (`runtime/inference_egress/`), SHA-256-pinned byte-identical to governance-hub; CI points `FLEET_GOVERNANCE_ROOT` here so this PUBLIC repo needs no private-hub checkout / `GH_PAT` for egress ([governance-hub#75](https://github.com/agorokh/governance-hub/issues/75)) |
 
 When you add top-level directories (`apps/`, `data/`, etc.), update **both** this document and `ALLOWED_TOPLEVEL_DIRS` in `scripts/check_agent_forbidden.py`.
 

--- a/scripts/check_agent_forbidden.py
+++ b/scripts/check_agent_forbidden.py
@@ -34,6 +34,10 @@ ALLOWED_TOPLEVEL_DIRS = {
     # mirrors the canonical agent doc into .codex/skills/post-merge/SKILL.md
     # for Codex parity.
     ".codex",
+    # Vendored inference-egress runtime (governance-hub#75): runtime/inference_egress/ pinned
+    # byte-identical to the hub (tests/test_vendored_egress_pin.py). CI points
+    # FLEET_GOVERNANCE_ROOT here so this PUBLIC repo needs no private-hub checkout / GH_PAT.
+    ".fleet-governance-vendor",
 }
 
 # Tracked files at repository root (single path segment). Warnings only if not listed.

--- a/tests/test_process_miner/test_distill.py
+++ b/tests/test_process_miner/test_distill.py
@@ -134,9 +134,12 @@ def test_distill_api_key_scheme_less_openrouter_host(monkeypatch) -> None:
 
 def test_distill_api_key_dial_prefers_project_key(monkeypatch) -> None:
     monkeypatch.delenv("DISTILL_API_KEY", raising=False)
+    # Vendored egress client is hostname-clean (#78); declare the DIAL host via $DIAL_PROXY_HOST
+    # (placeholder host - no internal infra hostname in this PUBLIC repo).
+    monkeypatch.setenv("DIAL_PROXY_HOST", "dial.example.com")
     monkeypatch.setenv(
         "DISTILL_BASE_URL",
-        "https://ai-proxy.lab.epam.com/openai/deployments/gpt-4o/chat/completions",
+        "https://dial.example.com/openai/deployments/gpt-4o/chat/completions",
     )
     monkeypatch.setenv("DIAL_API_KEY_PROJECT", "dial-project-key")  # pragma: allowlist secret
     monkeypatch.setenv("DIAL_API_KEY", "dial-personal-key")  # pragma: allowlist secret
@@ -146,8 +149,9 @@ def test_distill_api_key_dial_prefers_project_key(monkeypatch) -> None:
 def test_distill_api_key_dial_falls_back_to_personal_key(monkeypatch) -> None:
     monkeypatch.delenv("DISTILL_API_KEY", raising=False)
     monkeypatch.setenv(
-        "DISTILL_BASE_URL", "https://ai-proxy.lab.epam.com/openai/deployments/gpt-4o"
-    )
+        "DIAL_PROXY_HOST", "dial.example.com"
+    )  # hostname-clean vendored client (#78)
+    monkeypatch.setenv("DISTILL_BASE_URL", "https://dial.example.com/openai/deployments/gpt-4o")
     monkeypatch.delenv("DIAL_API_KEY_PROJECT", raising=False)
     monkeypatch.setenv("DIAL_API_KEY", "dial-personal-key")  # pragma: allowlist secret
     assert distill_api_key() == "dial-personal-key"
@@ -550,10 +554,13 @@ def test_run_distillation_uses_canonical_dial_headers(monkeypatch) -> None:
         "tools.process_miner.distill.urllib.request.urlopen",
         capture_urlopen,
     )
+    monkeypatch.setenv(
+        "DIAL_PROXY_HOST", "dial.example.com"
+    )  # hostname-clean vendored client (#78)
     run_distillation(
         [{"title_key": "k"}],
         api_key="dial-api-key",  # pragma: allowlist secret
-        base_url="https://ai-proxy.lab.epam.com/openai/deployments/gpt-4o",
+        base_url="https://dial.example.com/openai/deployments/gpt-4o",
     )
     assert headers["api-key"] == "dial-api-key"
     assert "authorization" not in headers

--- a/tests/test_vendored_egress_pin.py
+++ b/tests/test_vendored_egress_pin.py
@@ -1,0 +1,85 @@
+"""Vendored inference-egress client pin (governance-hub#75 / #78).
+
+This PUBLIC repo cannot consume the PRIVATE governance-hub composite action the private governed
+repos use, and `tools/process_miner/distill.py` HARD-imports `inference_egress` at import time. So
+the canonical egress client is VENDORED into `.fleet-governance-vendor/runtime/inference_egress/`
+(referenced by CI via `FLEET_GOVERNANCE_ROOT`) instead of checked out with a per-repo `GH_PAT`.
+
+This pins the vendored files byte-identical to the hub canonical client — the pin IS the
+reference-not-vendor drift gate (mirroring the hub's `check_egress_conformance.py` byte-check and
+this repo's `test_public_governance_conformance.py` shim pin). The hub client was made
+hostname-clean in governance-hub#78 specifically so it is safe to vendor into a PUBLIC repo; these
+tests also guard that the PRIVATE sidecar (`dial_host.txt`, which carries the internal DIAL
+hostname) never leaks here and that no internal hostname token returns.
+
+PIN MAINTENANCE: update the CANONICAL_* hashes only when the hub
+`runtime/inference_egress/{client.py,__init__.py}` legitimately changes (re-vendor from
+governance-hub @ main, then update the pin). The values are PUBLIC file hashes, not credentials.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VENDOR_DIR = REPO_ROOT / ".fleet-governance-vendor" / "runtime" / "inference_egress"
+
+CANONICAL_CLIENT_SHA256 = (
+    "c116eedc744ae2a93334976dfbc7a885fa6e9d64cf46d6405222ddb9a9de5ff2"  # pragma: allowlist secret
+)
+CANONICAL_INIT_SHA256 = (
+    "caef2793afce8f3db96f15115ab87532ed5747cf5f26225159246c18e4df57d1"  # pragma: allowlist secret
+)
+PINS = {"client.py": CANONICAL_CLIENT_SHA256, "__init__.py": CANONICAL_INIT_SHA256}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_vendored_egress_files_present_and_pinned() -> None:
+    """Both vendored files exist and are byte-identical to the pinned hub canonical client."""
+    drift = []
+    for name, pin in PINS.items():
+        f = VENDOR_DIR / name
+        assert f.is_file(), f"vendored {name} missing at {f.relative_to(REPO_ROOT)}"
+        if _sha256(f) != pin:
+            drift.append(
+                f"{name}: {_sha256(f)[:16]} != pinned {pin[:16]} (drift from hub canonical)"
+            )
+    assert not drift, (
+        "vendored egress client drifted from the hub canonical client — re-vendor from "
+        "governance-hub @ main (or update the pin if the hub legitimately changed):\n  - "
+        + "\n  - ".join(drift)
+    )
+
+
+def test_no_extra_files_vendored() -> None:
+    """Only client.py + __init__.py are vendored. The PRIVATE hub sidecar `dial_host.txt` carries
+    the internal DIAL hostname and must NOT reach this PUBLIC repo (governance-hub#78); its absence
+    is also what keeps the vendored copy hostname-clean and the pins stable."""
+    assert VENDOR_DIR.is_dir(), f"vendor dir missing: {VENDOR_DIR.relative_to(REPO_ROOT)}"
+    present = sorted(p.name for p in VENDOR_DIR.iterdir() if p.is_file())
+    assert present == ["__init__.py", "client.py"], (
+        f"unexpected files in vendored egress dir: {present} — only client.py + __init__.py may be "
+        "vendored; dial_host.txt (internal hostname) must stay in the private hub"
+    )
+
+
+def test_vendored_client_is_real_and_hostname_clean() -> None:
+    """Load the vendored client.py standalone (no sys.path side effects) to confirm it is the real
+    egress client AND that, with no sidecar present, it bakes in no default DIAL host (a public
+    deployment configures `$DIAL_PROXY_HOST` if it ever needs DIAL)."""
+    spec = importlib.util.spec_from_file_location(
+        "_vendored_egress_client", VENDOR_DIR / "client.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    for sym in ("resolve_api_key", "auth_headers", "is_dial_host", "request_headers"):
+        assert hasattr(mod, sym), f"vendored client.py missing {sym}"
+    assert mod.DIAL_PROXY_HOST_MARKER == "", (
+        "vendored (public) copy must bake in no default DIAL host"
+    )


### PR DESCRIPTION
## What

Drop this PUBLIC spoke's per-repo `GH_PAT` for egress by **vendoring** the canonical
inference-egress client instead of checking out the private `governance-hub` runtime.

Implements **agorokh/governance-hub#75**. Built against the hostname-clean client from
**agorokh/governance-hub#78**.

## Why

`tools/process_miner/distill.py` hard-imports `inference_egress` at import time (CI's `make ci-fast`
→ `ci-test` → `test_distill.py`), so the `GH_PAT`-gated `governance-hub` checkout could not simply be
deleted. And this repo is PUBLIC, so it cannot reference the private hub's composite action.

## How

- **Vendor** `runtime/inference_egress/{client.py,__init__.py}` → `.fleet-governance-vendor/runtime/inference_egress/`,
  **SHA-256-pinned byte-identical** to the hub (`tests/test_vendored_egress_pin.py`). The pin IS the
  reference-not-vendor drift gate (mirrors the hub's `check_egress_conformance.py` byte-check and this
  repo's `test_public_governance_conformance.py` shim pin).
- **`ci.yml`**: point `FLEET_GOVERNANCE_ROOT` at the vendored dir; drop the `Verify GH_PAT` + `Checkout
  governance-hub runtime` steps. CI needs **no private-hub access and no GH_PAT** for egress.
- The vendored client is **hostname-clean** (governance-hub#78 moved the internal DIAL host marker into a
  private hub-only sidecar `dial_host.txt`, intentionally **not** vendored here). So no internal infra
  hostname is disclosed.
- **Scrubbed the pre-existing internal DIAL host** from the 3 distill DIAL tests — they now use a
  placeholder host (`dial.example.com`) configured via the `$DIAL_PROXY_HOST` override (the mechanism
  #78 added). This removes the only public occurrence of that hostname from this repo.

## Note for reviewers (incl. CodeRabbit / Bugbot)

- The vendored files are **intentionally byte-identical** to the hub canonical client — do not "fix" or
  reformat them; the SHA-256 pin enforces identity (update the pin only on a legitimate hub change).
- `dial_host.txt` is **intentionally absent** from the vendored dir (it carries the internal hostname and
  stays in the private hub). `test_no_extra_files_vendored` enforces that.
- The `dial.example.com` placeholder in `test_distill.py` is deliberate — DIAL is test-only here (the real
  miner egresses via OpenRouter), and the tests now verify DIAL routing without a real internal hostname.

## Verification (observed)

`make ci-fast` green with `FLEET_GOVERNANCE_ROOT` = the vendored dir and **no `~/.fleet-governance` / no
GH_PAT** (simulating a fresh clone with no private-hub access):

```
1239 passed, 71 skipped     # incl. the 3 DIAL tests + the new vendored-pin tests
bandit: No issues identified
ci-fast: OK                 # conventional, format, lint, test, security, secrets, policy, agent-proof, csp
```

Vendored hashes pinned: `client.py` = `c116eedc…de5ff2`, `__init__.py` = `caef2793…df57d1`.

## Acceptance (governance-hub#75)

- [x] `ac-copilot-trainer` no longer needs a per-repo `GH_PAT` secret for egress.
- [x] `make ci-fast` green on a fresh clone with no private-hub access.
- [x] Egress posture decided: vendored byte-identical + SHA-256 pin (self-contained, mirrors #138).
- [x] Approach ratified (Council on #75) before fan-out.
