### PR TITLE
feat(ci): GH_PAT → fleet-automation-bot App token (gh#76)

### DIFF
--- a/.github/workflows/cross-repo-mining.yml
+++ b/.github/workflows/cross-repo-mining.yml
@@ -72,6 +72,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Mint GitHub App token (PR creation)
+        # Short-lived installation token from fleet-automation-bot; replaces the
+        # static GH_PAT (projected per-repo from Doppler). governance-hub#76.
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FLEET_BOT_APP_ID }}
+          private-key: ${{ secrets.FLEET_BOT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
@@ -93,7 +101,7 @@ jobs:
 
       - name: Verify GH_PAT is configured
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          GH_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           if [ -z "${GH_PAT:-}" ]; then
             echo "::error::GH_PAT is not configured — cannot open a PR with the default token (blocked by repo policy)."
@@ -103,7 +111,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore(mining): cross-repo learned rules (process-miner)"
           branch: process-miner/learned-rules-${{ github.run_id }}
           delete-branch: true

--- a/.github/workflows/process-miner.yml
+++ b/.github/workflows/process-miner.yml
@@ -21,6 +21,14 @@ jobs:
   mine:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App token (PR creation)
+        # Short-lived installation token from fleet-automation-bot; replaces the
+        # static GH_PAT (projected per-repo from Doppler). governance-hub#76.
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FLEET_BOT_APP_ID }}
+          private-key: ${{ secrets.FLEET_BOT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
@@ -62,7 +70,7 @@ jobs:
 
       - name: Open PR with learned rules
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -28,10 +28,18 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App token (PR creation)
+        # Short-lived installation token from fleet-automation-bot; replaces the
+        # static GH_PAT (projected per-repo from Doppler). governance-hub#76.
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FLEET_BOT_APP_ID }}
+          private-key: ${{ secrets.FLEET_BOT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-python@v6
         with:
@@ -72,7 +80,7 @@ jobs:
 
       - name: Create sync PR
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VCS_REF: ${{ steps.ref.outputs.ref }}
         shell: bash
         run: |


### PR DESCRIPTION
Swap `secrets.GH_PAT` → a short-lived GitHub App installation token (the
`fleet-automation-bot` app, via `actions/create-github-app-token@v3`) in the
PR-creating workflows, so the static per-repo `GH_PAT` secret can be purged.

- Token is ephemeral (minted per run, ~1h), fine-grained; secrets
  `FLEET_BOT_APP_ID` / `FLEET_BOT_APP_PRIVATE_KEY` are projected from Doppler by
  `workstation-ops/scripts/sync_gh_pat_secrets.sh`.
- A mint step is added as the first step of each job that opened PRs.
- The App-token path was proven end-to-end (a real PR opened by the app in a
  runner) via the workstation-ops self-test.

Part of the governance-hub#76 fleet cutover (council-ratified: in-Actions App
token, not the #818 daemon, for these low-volume crons).