### PR TITLE
feat(telemetry): persist per-wheel omega/slip + tyre core temp to lap trace (schema v2) (#266)

### DIFF
--- a/docs/10_Development/13_Lap_Archive_Export.md
+++ b/docs/10_Development/13_Lap_Archive_Export.md
@@ -42,24 +42,19 @@ archive trace. `lap_distance_m` is derived from `spline * track.lengthM` when
 track length is present; otherwise it is blank. Missing trace fields export as
 blank cells so downstream notebooks can distinguish "missing" from zero.
 
-The **per-wheel channels** (issue #266) carry, per corner FL/FR/RL/RR:
-`wheelAngularSpeed_*` (rad/s — the canonical longitudinal signal the analysis
-layer derives slip from, to attribute which axle locks / exit wheelspin),
-`wheelSlip_*` (AC `ndSlip`, secondary), and `tyreCoreTemp_*` (degC — feeds the
-tyre thermal model). Archives written before #266 lack these and export blank.
-The trace field set is a hard contract kept byte-identical between
-`lap_archive.lua::TRACE_FIELDS` and `reference_lap.py::TRACE_FIELDS`.
-
 ### Optional Tier-B per-wheel channels (#266)
 
-When present, the trace may also carry per-wheel channels named
-`wheelAngularSpeed_{fl,fr,rl,rr}` (rad/s) and `wheelSlip_{fl,fr,rl,rr}` (AC's
-combined Pacejka NDslip). These are **optional** — older laps omit them and the
-loader degrades gracefully. The setup-coaching engine
-(`tools/ai_sidecar/corner_attribution.py`) uses `wheelAngularSpeed` to compute
-true longitudinal slip per wheel, which upgrades brake-lockup and exit-wheelspin
-attributions from a *suspicion* to a *confirmed* axle-level verdict (which axle
-locks → brake bias; rear wheelspin → traction/TC/diff). Order is `[FL, FR, RL, RR]`.
+When present, the trace also carries per-wheel channels, order `[FL, FR, RL, RR]`:
+`wheelAngularSpeed_{fl,fr,rl,rr}` (rad/s — the canonical longitudinal signal),
+`wheelSlip_{fl,fr,rl,rr}` (AC's combined Pacejka NDslip, secondary), and
+`tyreCoreTemp_{fl,fr,rl,rr}` (degC — feeds the tyre thermal model). These are
+**optional**: archives written before #266 omit them and the loader / exporter degrade
+gracefully (they export as blank cells). The setup-coaching engine
+(`tools/ai_sidecar/corner_attribution.py`) derives true longitudinal slip per wheel from
+`wheelAngularSpeed`, which upgrades brake-lockup and exit-wheelspin attributions from a
+*suspicion* to a *confirmed* axle-level verdict (which axle locks → brake bias; rear
+wheelspin → traction/TC/diff). The trace field set is a hard contract kept byte-identical
+between `lap_archive.lua::TRACE_FIELDS` and `reference_lap.py::TRACE_FIELDS`.
 
 ## MoTeC-Shaped CSV
 

--- a/docs/10_Development/13_Lap_Archive_Export.md
+++ b/docs/10_Development/13_Lap_Archive_Export.md
@@ -31,13 +31,24 @@ Stable columns:
 source_file, lap_uuid, session_uuid, car_id, track_id, lap_n, lap_ms,
 is_valid, sample_index, time_s, elapsed_ms, spline, lap_distance_m,
 speed_kmh, brake, throttle, steering, gear,
-position_x_m, position_y_m, position_z_m
+position_x_m, position_y_m, position_z_m,
+wheelAngularSpeed_fl, wheelAngularSpeed_fr, wheelAngularSpeed_rl, wheelAngularSpeed_rr,
+wheelSlip_fl, wheelSlip_fr, wheelSlip_rl, wheelSlip_rr,
+tyreCoreTemp_fl, tyreCoreTemp_fr, tyreCoreTemp_rl, tyreCoreTemp_rr
 ```
 
 `brake`, `throttle`, and `steering` preserve the normalized CSP values from the
 archive trace. `lap_distance_m` is derived from `spline * track.lengthM` when
 track length is present; otherwise it is blank. Missing trace fields export as
 blank cells so downstream notebooks can distinguish "missing" from zero.
+
+The **per-wheel channels** (issue #266) carry, per corner FL/FR/RL/RR:
+`wheelAngularSpeed_*` (rad/s — the canonical longitudinal signal the analysis
+layer derives slip from, to attribute which axle locks / exit wheelspin),
+`wheelSlip_*` (AC `ndSlip`, secondary), and `tyreCoreTemp_*` (degC — feeds the
+tyre thermal model). Archives written before #266 lack these and export blank.
+The trace field set is a hard contract kept byte-identical between
+`lap_archive.lua::TRACE_FIELDS` and `reference_lap.py::TRACE_FIELDS`.
 
 ### Optional Tier-B per-wheel channels (#266)
 

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -53,9 +53,15 @@ function M.clampArchiveCapMB(raw)
   return math.floor(n + 0.5)
 end
 
--- Trace sample field order. `traceToColumns` builds rows by iterating this list (single source of truth).
+-- Trace sample field order. `traceToColumns` builds rows by iterating this list (single source of
+-- truth). MUST stay byte-identical to tools/ac_harness/reference_lap.py::TRACE_FIELDS (the Python
+-- generator + analysis loader read by name, and test_reference_lap asserts the two agree).
+-- Per-wheel channels (issue #266) are appended last; older archives lacking them export as blanks.
 local TRACE_FIELDS = {
   "spline", "speed", "eMs", "throttle", "brake", "steer", "gear", "px", "py", "pz",
+  "wheelAngularSpeed_fl", "wheelAngularSpeed_fr", "wheelAngularSpeed_rl", "wheelAngularSpeed_rr",
+  "wheelSlip_fl", "wheelSlip_fr", "wheelSlip_rl", "wheelSlip_rr",
+  "tyreCoreTemp_fl", "tyreCoreTemp_fr", "tyreCoreTemp_rl", "tyreCoreTemp_rr",
 }
 
 local function lapArchiveDir()

--- a/src/ac_copilot_trainer/modules/telemetry.lua
+++ b/src/ac_copilot_trainer/modules/telemetry.lua
@@ -1,6 +1,7 @@
 -- Rolling telemetry buffer plus per-lap trace (downsampled on finalize, max ~2000 samples).
 
 local ch = require("csp_helpers")
+local wheel_read = require("wheel_read")
 
 local M = {}
 
@@ -172,6 +173,12 @@ function Telemetry:update(dt, car, sim)
   if self.lapT0 ~= nil then
     local eMs = (t - self.lapT0) * 1000
     self.lapN = self.lapN + 1
+    -- Per-wheel channels (issue #266): angular speed is the canonical longitudinal signal the
+    -- analysis layer derives slip from (which axle locks / exit wheelspin); slip + tyre core temp
+    -- ride along for the tyre model. nil reads serialize as 0 via traceSampleToColumnRow; the
+    -- Python loader treats an all-zero omega column as "no live wheel data" so it never confirms a
+    -- false lockup when wheels are unreadable.
+    local w = wheel_read.readPerWheel(car)
     ---@type LapTraceSample
     local lp = {
       spline = car.splinePosition or 0,
@@ -184,6 +191,18 @@ function Telemetry:update(dt, car, sim)
       px = px,
       py = py,
       pz = pz,
+      wheelAngularSpeed_fl = w.omega.fl,
+      wheelAngularSpeed_fr = w.omega.fr,
+      wheelAngularSpeed_rl = w.omega.rl,
+      wheelAngularSpeed_rr = w.omega.rr,
+      wheelSlip_fl = w.slip.fl,
+      wheelSlip_fr = w.slip.fr,
+      wheelSlip_rl = w.slip.rl,
+      wheelSlip_rr = w.slip.rr,
+      tyreCoreTemp_fl = w.temp.fl,
+      tyreCoreTemp_fr = w.temp.fr,
+      tyreCoreTemp_rl = w.temp.rl,
+      tyreCoreTemp_rr = w.temp.rr,
     }
     self.lapBuf[self.lapN] = lp
     if self.lapN > MAX_LAP_RAW then

--- a/src/ac_copilot_trainer/modules/wheel_read.lua
+++ b/src/ac_copilot_trainer/modules/wheel_read.lua
@@ -1,0 +1,88 @@
+-- Shared per-wheel telemetry accessors (issue #266).
+--
+-- Single source of truth for reading `car.wheels` so telemetry.lua (trace capture) and
+-- tire_monitor.lua (live lockup/temp HUD) cannot drift on the finicky parts:
+--   * CSP `car.wheels` is **0-indexed** per `ac.Wheel`: FrontLeft=0, FrontRight=1, RearLeft=2,
+--     RearRight=3. A 1-based read shifts every corner and reads an out-of-bounds zero for RR
+--     (the `tire_temps.rr=0` regression in #180). Always iterate `for i=0,3`.
+--   * Every access is pcall-guarded: a schema-gated mock `car` (trace_replay) or a missing field
+--     raises, and we degrade to nil rather than throwing out of the hot update loop.
+--   * Non-finite reads (NaN / +-inf) are rejected to nil so they never serialize as invalid JSON
+--     downstream (a CSP field can be present-but-non-finite; NaN ~= itself, +-inf == math.huge).
+
+local M = {}
+
+-- 0-based CSP wheel index -> our FL/FR/RL/RR label.
+M.WHEEL_KEYS = { [0] = "fl", [1] = "fr", [2] = "rl", [3] = "rr" }
+
+--- Read a field from a table or userdata wheel object, pcall-guarded.
+function M.field(one, key)
+  local ok, v = pcall(function()
+    return one[key]
+  end)
+  if ok and v ~= nil then
+    return v
+  end
+  return nil
+end
+
+local function finite(n)
+  n = tonumber(n)
+  if n == nil or n ~= n or n == math.huge or n == -math.huge then
+    return nil
+  end
+  return n
+end
+
+--- Tyre core temperature (degC). Falls back across CSP field names; unwraps a `{average=}` table.
+function M.temp(one)
+  local t = M.field(one, "tyreCoreTemperature")
+    or M.field(one, "temperature")
+    or M.field(one, "tyreTemperature")
+  if type(t) == "table" and t.average ~= nil then
+    t = t.average
+  end
+  return finite(t)
+end
+
+--- Longitudinal slip ratio (signed; <0 = wheel slower than ground = locking). nil if unreadable.
+function M.slip(one)
+  return finite(M.field(one, "slipRatio") or M.field(one, "slip") or M.field(one, "ndSlip"))
+end
+
+--- Wheel angular speed (rad/s). The canonical longitudinal signal the analysis layer derives slip
+--- from (corner_attribution.corner_live_signals); nil if unreadable.
+function M.omega(one)
+  return finite(M.field(one, "angularSpeed") or M.field(one, "wheelAngularSpeed"))
+end
+
+--- Read all four wheels into {omega={fl,fr,rl,rr}, slip={...}, temp={...}} (each value number|nil).
+--- pcall-guards the `car.wheels` access and every per-wheel read.
+---@param car any
+---@return table
+function M.readPerWheel(car)
+  local out = { omega = {}, slip = {}, temp = {} }
+  if car == nil then
+    return out
+  end
+  local okW, wheels = pcall(function()
+    return car.wheels
+  end)
+  if not okW or wheels == nil then
+    return out
+  end
+  for i = 0, 3 do
+    local k = M.WHEEL_KEYS[i]
+    local oki, one = pcall(function()
+      return wheels[i]
+    end)
+    if oki and one ~= nil then
+      out.omega[k] = M.omega(one)
+      out.slip[k] = M.slip(one)
+      out.temp[k] = M.temp(one)
+    end
+  end
+  return out
+end
+
+return M

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -319,6 +319,18 @@ def test_corner_live_signals_empty_without_wheel_data():
     assert corner_live_signals(lap, sig) == {}
 
 
+def test_corner_live_signals_ignores_unread_zero_wheel():
+    # codex #274: one front wheel reads 0 (unread sentinel) while the car is NOT locking. The zero
+    # must be excluded, not treated as slip=-1 (a false front lock).
+    lap, sig = _wheel_lap(lock_axle=None, wheelspin=False)
+    assert lap.wheel_omega is not None
+    for k in range(sig.entry_i, sig.apex_i + 1):
+        if lap.brake[k] > 0.05:
+            lap.wheel_omega[k][0] = 0.0  # FL unread this frame
+    s = corner_live_signals(lap, sig)
+    assert s.get("lock_axle") is None  # the surviving FR (free-rolling) shows no lock
+
+
 def test_live_signals_feed_confirmed_braking_attribution():
     # computed live signals + a braking-phase time loss -> CONFIRMED front-axle verdict
     lap, sig = _wheel_lap(lock_axle="front", wheelspin=False)

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -153,6 +153,19 @@ def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.P
         "px",
         "py",
         "pz",
+        # per-wheel channels (issue #266)
+        "wheelAngularSpeed_fl",
+        "wheelAngularSpeed_fr",
+        "wheelAngularSpeed_rl",
+        "wheelAngularSpeed_rr",
+        "wheelSlip_fl",
+        "wheelSlip_fr",
+        "wheelSlip_rl",
+        "wheelSlip_rr",
+        "tyreCoreTemp_fl",
+        "tyreCoreTemp_fr",
+        "tyreCoreTemp_rl",
+        "tyreCoreTemp_rr",
     ]
     assert record["setup"]["hash"] == "hash1234"
     assert record["coaching"]["rules_hints"] == ["Brake earlier at T1"]

--- a/tests/test_lap_dynamics.py
+++ b/tests/test_lap_dynamics.py
@@ -217,6 +217,25 @@ def test_no_wheel_channels_means_no_wheel_data():
     assert lap.wheel_omega is None
 
 
+def test_all_zero_omega_columns_treated_as_no_wheel_data():
+    # #266: schema-v2 always WRITES the wheel columns; a real lap whose wheels were unreadable
+    # persists all zeros. A zero omega would compute slip = -1 (full lock) every sample and falsely
+    # confirm a lockup, so an all-zero column must be treated as "no live wheel data".
+    arch = _make_corner_archive()
+    cols = [
+        "wheelAngularSpeed_fl",
+        "wheelAngularSpeed_fr",
+        "wheelAngularSpeed_rl",
+        "wheelAngularSpeed_rr",
+    ]
+    arch["trace"]["fields"].extend(cols)
+    for row in arch["trace"]["samples"]:
+        row.extend([0.0, 0.0, 0.0, 0.0])
+    lap = lap_trace_from_archive(arch)
+    assert lap.has_wheel_data is False
+    assert lap.wheel_omega is None
+
+
 def test_spline_derived_from_positions_when_channel_missing():
     arch = _make_corner_archive()
     fi = arch["trace"]["fields"].index("spline")

--- a/tests/test_lua_trace_replay.py
+++ b/tests/test_lua_trace_replay.py
@@ -369,6 +369,19 @@ def test_synthesize_trace_scenarios_have_expected_shape(harness: TraceReplayHarn
         "px",
         "py",
         "pz",
+        # per-wheel channels (issue #266)
+        "wheelAngularSpeed_fl",
+        "wheelAngularSpeed_fr",
+        "wheelAngularSpeed_rl",
+        "wheelAngularSpeed_rr",
+        "wheelSlip_fl",
+        "wheelSlip_fr",
+        "wheelSlip_rl",
+        "wheelSlip_rr",
+        "tyreCoreTemp_fl",
+        "tyreCoreTemp_fr",
+        "tyreCoreTemp_rl",
+        "tyreCoreTemp_rr",
     }
     for scenario in available_scenarios():
         frames = synthesize_trace(scenario)

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -52,6 +52,10 @@ def test_validator_accepts_old_10_field_schema_v1_trace() -> None:
     record["trace"]["fields"] = keep
     record["trace"]["samples"] = [[row[i] for i in idxs] for row in record["trace"]["samples"]]
     validate_lap_archive_record(record)  # must not raise
+    # and conversion must degrade to 10-field frames, not IndexError on the missing wheel columns
+    frames = archive_trace_to_object_trace(record)
+    assert tuple(frames[0].keys()) == TRACE_FIELDS[:10]
+    assert "wheelAngularSpeed_fl" not in frames[0]
 
 
 def test_generated_archive_carries_per_wheel_channels() -> None:

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -42,6 +42,21 @@ def test_generated_reference_archive_matches_lap_archive_schema_v1() -> None:
     assert record["corners"][0]["entrySpeed"] == pytest.approx(BRAKE_ENTRY_SPEED_KMH)
 
 
+def test_generated_archive_carries_per_wheel_channels() -> None:
+    # #266: a generated reference archive must include the per-wheel columns with physically
+    # plausible synthetic values (free-rolling omega = v/radius, zero slip, warm tyres).
+    record = build_archive_record_from_scenario("brake_too_late")
+    fields = record["trace"]["fields"]
+    for name in ("wheelAngularSpeed_fl", "wheelSlip_rr", "tyreCoreTemp_fl"):
+        assert name in fields
+    frames = archive_trace_to_object_trace(record)
+    f0 = frames[0]
+    speed_ms = f0["speed"] / 3.6
+    assert f0["wheelAngularSpeed_fl"] == pytest.approx(speed_ms / 0.347, rel=1e-6)
+    assert f0["wheelSlip_fl"] == pytest.approx(0.0)
+    assert f0["tyreCoreTemp_rr"] == pytest.approx(80.0)
+
+
 def test_archive_trace_converts_to_live_best_lap_trace_shape() -> None:
     record = build_archive_record_from_scenario("brake_too_late")
     frames = archive_trace_to_object_trace(record)

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -42,6 +42,18 @@ def test_generated_reference_archive_matches_lap_archive_schema_v1() -> None:
     assert record["corners"][0]["entrySpeed"] == pytest.approx(BRAKE_ENTRY_SPEED_KMH)
 
 
+def test_validator_accepts_old_10_field_schema_v1_trace() -> None:
+    # codex #274: SCHEMA_VERSION is still 1 and old archives carry only the 10 required columns.
+    # The validator must still accept them (per-wheel channels are an optional extension).
+    record = build_archive_record_from_scenario("brake_too_late")
+    full = record["trace"]["fields"]
+    keep = list(full[:10])
+    idxs = list(range(10))
+    record["trace"]["fields"] = keep
+    record["trace"]["samples"] = [[row[i] for i in idxs] for row in record["trace"]["samples"]]
+    validate_lap_archive_record(record)  # must not raise
+
+
 def test_generated_archive_carries_per_wheel_channels() -> None:
     # #266: a generated reference archive must include the per-wheel columns with physically
     # plausible synthetic values (free-rolling omega = v/radius, zero slip, warm tyres).

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -312,8 +312,8 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
 def archive_trace_to_object_trace(record: Mapping[str, Any]) -> list[dict[str, float]]:
     """Convert archive column rows into the live trainer's ``bestLapTrace`` shape."""
     validate_lap_archive_record(record)
-    # Iterate the DECLARED fields, not TRACE_FIELDS: a pre-#266 archive declares only the 10 required
-    # columns, so indexing all 22 here would IndexError. Old records degrade to 10-field frames.
+    # Iterate the DECLARED fields, not TRACE_FIELDS: a pre-#266 archive declares only the 10
+    # required columns, so indexing all 22 would IndexError. Old records degrade to 10-field frames.
     fields = list(record["trace"]["fields"])
     rows = record["trace"]["samples"]
     frames: list[dict[str, float]] = []

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -288,16 +288,16 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
     if trace.get("samples_count") != len(samples):
         raise LapArchiveSchemaError("trace.samples_count must equal len(trace.samples)")
     last_elapsed = -math.inf
+    # Row width must match the DECLARED fields (10 pre-#266, 22 with per-wheel channels).
+    n_cols = len(fields)
     for row_index, row in enumerate(samples):
-        if not isinstance(row, list) or len(row) != len(TRACE_FIELDS):
-            raise LapArchiveSchemaError(
-                f"trace.samples[{row_index}] must have {len(TRACE_FIELDS)} columns"
-            )
+        if not isinstance(row, list) or len(row) != n_cols:
+            raise LapArchiveSchemaError(f"trace.samples[{row_index}] must have {n_cols} columns")
         for field_index, value in enumerate(row):
             parsed = _finite_float(value, f"trace.samples[{row_index}][{field_index}]")
-            if TRACE_FIELDS[field_index] == "spline" and (parsed < 0.0 or parsed > 1.0):
+            if fields[field_index] == "spline" and (parsed < 0.0 or parsed > 1.0):
                 raise LapArchiveSchemaError(f"trace.samples[{row_index}].spline must be in [0, 1]")
-            if TRACE_FIELDS[field_index] == "eMs":
+            if fields[field_index] == "eMs":
                 if parsed < last_elapsed:
                     raise LapArchiveSchemaError("trace eMs must be monotonic nondecreasing")
                 last_elapsed = parsed

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -273,8 +273,13 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
     if not isinstance(trace, Mapping):
         raise LapArchiveSchemaError("trace must be an object")
     fields = trace.get("fields")
-    if fields != list(TRACE_FIELDS):
-        raise LapArchiveSchemaError(f"trace.fields must be {list(TRACE_FIELDS)!r}")
+    # Accept the pre-#266 10-field trace AND the per-wheel-extended set: SCHEMA_VERSION is still 1
+    # and existing archives carry only the required columns. A valid trace is the required columns,
+    # optionally followed by the #266 per-wheel channels (exact, in order).
+    if fields not in (list(_REQUIRED_TRACE_FIELDS), list(TRACE_FIELDS)):
+        raise LapArchiveSchemaError(
+            f"trace.fields must be {list(_REQUIRED_TRACE_FIELDS)!r} or {list(TRACE_FIELDS)!r}"
+        )
     samples = trace.get("samples")
     if not isinstance(samples, list):
         raise LapArchiveSchemaError("trace.samples must be a list")

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -91,8 +91,11 @@ def _normalize_trace_frame(frame: Mapping[str, Any], index: int) -> dict[str, fl
     out: dict[str, float] = {}
     for field in TRACE_FIELDS:
         raw = frame.get(field)
+        # Optional per-wheel channels default to 0.0 whether absent OR explicitly null — both mean
+        # "no reading this frame", the desired graceful degradation. A REQUIRED field that is
+        # absent/None still falls through to _finite_float, which raises (a real schema violation).
         if raw is None and field not in _REQUIRED_TRACE_FIELDS:
-            out[field] = 0.0  # optional per-wheel channel absent on this frame
+            out[field] = 0.0
         else:
             out[field] = _finite_float(raw, f"trace[{index}].{field}")
     if out["spline"] < 0.0 or out["spline"] > 1.0:

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -36,6 +36,21 @@ TRACE_FIELDS: tuple[str, ...] = (
     "px",
     "py",
     "pz",
+    # Per-wheel channels (issue #266) — MUST stay identical to lap_archive.lua::TRACE_FIELDS.
+    # Order: FL, FR, RL, RR. angularSpeed (rad/s) is the canonical longitudinal slip source;
+    # slip (AC ndSlip) is secondary; tyre core temp (degC) feeds the tyre thermal model.
+    "wheelAngularSpeed_fl",
+    "wheelAngularSpeed_fr",
+    "wheelAngularSpeed_rl",
+    "wheelAngularSpeed_rr",
+    "wheelSlip_fl",
+    "wheelSlip_fr",
+    "wheelSlip_rl",
+    "wheelSlip_rr",
+    "tyreCoreTemp_fl",
+    "tyreCoreTemp_fr",
+    "tyreCoreTemp_rl",
+    "tyreCoreTemp_rr",
 )
 
 SCHEMA_VERSION = 1
@@ -67,10 +82,19 @@ def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+#: The original required trace columns. Fields beyond these (the per-wheel #266 channels) are
+#: OPTIONAL and default to 0.0 when a frame omits them, so hand-built / pre-#266 traces stay valid.
+_REQUIRED_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[:10]
+
+
 def _normalize_trace_frame(frame: Mapping[str, Any], index: int) -> dict[str, float]:
     out: dict[str, float] = {}
     for field in TRACE_FIELDS:
-        out[field] = _finite_float(frame.get(field), f"trace[{index}].{field}")
+        raw = frame.get(field)
+        if raw is None and field not in _REQUIRED_TRACE_FIELDS:
+            out[field] = 0.0  # optional per-wheel channel absent on this frame
+        else:
+            out[field] = _finite_float(raw, f"trace[{index}].{field}")
     if out["spline"] < 0.0 or out["spline"] > 1.0:
         raise LapArchiveSchemaError(f"trace[{index}].spline must be in [0, 1]")
     return out

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -312,10 +312,13 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
 def archive_trace_to_object_trace(record: Mapping[str, Any]) -> list[dict[str, float]]:
     """Convert archive column rows into the live trainer's ``bestLapTrace`` shape."""
     validate_lap_archive_record(record)
+    # Iterate the DECLARED fields, not TRACE_FIELDS: a pre-#266 archive declares only the 10 required
+    # columns, so indexing all 22 here would IndexError. Old records degrade to 10-field frames.
+    fields = list(record["trace"]["fields"])
     rows = record["trace"]["samples"]
     frames: list[dict[str, float]] = []
     for row in rows:
-        frame = {field: float(row[i]) for i, field in enumerate(TRACE_FIELDS)}
+        frame = {field: float(row[i]) for i, field in enumerate(fields)}
         frame["gear"] = int(frame["gear"])
         frames.append(frame)
     return frames

--- a/tools/ac_harness/trace_replay.py
+++ b/tools/ac_harness/trace_replay.py
@@ -273,6 +273,13 @@ CLEAN_LAP_FRAMES = 240
 DT_S = 0.05  # 20 Hz synthetic sampling
 
 
+# Synthetic per-wheel defaults: free-rolling wheels (omega = v / radius, zero slip) at a warm tyre
+# temperature. Keeps generated reference traces physically plausible and the per-wheel TRACE_FIELDS
+# populated (issue #266) without claiming a lockup/wheelspin the scenario didn't model.
+_SYNTH_WHEEL_RADIUS_M = 0.347
+_SYNTH_TYRE_TEMP_C = 80.0
+
+
 def _base_frame(
     *,
     spline: float,
@@ -286,6 +293,7 @@ def _base_frame(
     py: float = 0.0,
     pz: float = 0.0,
 ) -> TraceFrame:
+    omega = (speed / 3.6) / _SYNTH_WHEEL_RADIUS_M  # free-rolling (no slip)
     return {
         "spline": spline,
         "speed": speed,
@@ -297,6 +305,18 @@ def _base_frame(
         "px": px,
         "py": py,
         "pz": pz,
+        "wheelAngularSpeed_fl": omega,
+        "wheelAngularSpeed_fr": omega,
+        "wheelAngularSpeed_rl": omega,
+        "wheelAngularSpeed_rr": omega,
+        "wheelSlip_fl": 0.0,
+        "wheelSlip_fr": 0.0,
+        "wheelSlip_rl": 0.0,
+        "wheelSlip_rr": 0.0,
+        "tyreCoreTemp_fl": _SYNTH_TYRE_TEMP_C,
+        "tyreCoreTemp_fr": _SYNTH_TYRE_TEMP_C,
+        "tyreCoreTemp_rl": _SYNTH_TYRE_TEMP_C,
+        "tyreCoreTemp_rr": _SYNTH_TYRE_TEMP_C,
     }
 
 

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -426,14 +426,26 @@ def corner_live_signals(
     extra: dict[str, Any] = {"wheelAngularSpeed": True}
     if lap.wheel_slip is not None:
         extra["wheelSlip"] = True
+
+    def _axle_slip(om: list[float], a: int, b: int, v: float) -> float | None:
+        # A 0.0 omega among real readings is the "unread wheel" sentinel (telemetry serializes a nil
+        # read as 0), NOT a lock — a truly locked wheel at speed still has a small POSITIVE omega.
+        # Exclude unread wheels so one failed corner can't fake a lockup (codex partial-read guard).
+        vals = [_slip(om[i], wheel_radius_m, v) for i in (a, b) if om[i] > 0.0]
+        return min(vals) if vals else None
+
     # braking phase (turn-in..apex with brake on): which axle reaches lock first?
     front, rear = [], []
     for k in range(sig.entry_i, sig.apex_i + 1):
         if lap.brake[k] > brake_thresh:
             v, om = lap.v_ms[k], lap.wheel_omega[k]
-            front.append(min(_slip(om[0], wheel_radius_m, v), _slip(om[1], wheel_radius_m, v)))
-            rear.append(min(_slip(om[2], wheel_radius_m, v), _slip(om[3], wheel_radius_m, v)))
-    if front:
+            f = _axle_slip(om, 0, 1, v)
+            r = _axle_slip(om, 2, 3, v)
+            if f is not None:
+                front.append(f)
+            if r is not None:
+                rear.append(r)
+    if front and rear:
         fl, rl = min(front), min(rear)
         extra["front_lock"], extra["rear_lock"] = round(fl, 3), round(rl, 3)
         if min(fl, rl) <= lock_thresh:
@@ -445,7 +457,9 @@ def corner_live_signals(
     for k in range(sig.apex_i, sig.exit_i + 1):
         if lap.throttle[k] > throttle_thresh:
             v, om = lap.v_ms[k], lap.wheel_omega[k]
-            spins.append(max(_slip(om[2], wheel_radius_m, v), _slip(om[3], wheel_radius_m, v)))
+            rear_spin = [_slip(om[i], wheel_radius_m, v) for i in (2, 3) if om[i] > 0.0]
+            if rear_spin:
+                spins.append(max(rear_spin))
     if spins:
         rmax = max(spins)
         extra["rear_exit_slip"] = round(rmax, 3)

--- a/tools/ai_sidecar/lap_dynamics.py
+++ b/tools/ai_sidecar/lap_dynamics.py
@@ -89,20 +89,30 @@ _WHEELS = ("fl", "fr", "rl", "rr")
 
 
 def _wheel_cols(fields: list[str], samples: list, base: str, n: int) -> list[list[float]] | None:
-    """Read a 4-wheel channel (``<base>_fl/fr/rl/rr``) into N rows of [FL, FR, RL, RR], or None."""
+    """Read a 4-wheel channel (``<base>_fl/fr/rl/rr``) into N rows of [FL, FR, RL, RR], or None.
+
+    Returns None when the columns are absent OR present-but-all-zero. The all-zero guard matters
+    since #266 made these fields ALWAYS present in the trace: a real lap whose wheels were
+    unreadable persists zeros, and a zero ``wheelAngularSpeed`` would otherwise compute slip = -1
+    (full lock) at every sample and falsely "confirm" a lockup. All-zero => treat as no live data.
+    """
     idxs = [_idx(fields, f"{base}_{w}") for w in _WHEELS]
     if any(i is None for i in idxs):
         return None
     out: list[list[float]] = []
+    any_nonzero = False
     for row in samples:
         vals = []
         for i in idxs:
             try:
-                vals.append(float(row[i]))
+                v = float(row[i])
             except (TypeError, ValueError, IndexError):
-                vals.append(0.0)
+                v = 0.0
+            if v != 0.0:
+                any_nonzero = True
+            vals.append(v)
         out.append(vals)
-    return out if len(out) == n else out
+    return out if any_nonzero else None
 
 
 def lap_trace_from_archive(archive: dict[str, Any]) -> LapTrace:

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -42,6 +42,34 @@ CSV_COLUMNS: tuple[str, ...] = (
     "position_x_m",
     "position_y_m",
     "position_z_m",
+    # per-wheel channels (issue #266) — blank for pre-#266 archives that lack them
+    "wheelAngularSpeed_fl",
+    "wheelAngularSpeed_fr",
+    "wheelAngularSpeed_rl",
+    "wheelAngularSpeed_rr",
+    "wheelSlip_fl",
+    "wheelSlip_fr",
+    "wheelSlip_rl",
+    "wheelSlip_rr",
+    "tyreCoreTemp_fl",
+    "tyreCoreTemp_fr",
+    "tyreCoreTemp_rl",
+    "tyreCoreTemp_rr",
+)
+
+_PER_WHEEL_TRACE_FIELDS: tuple[str, ...] = (
+    "wheelAngularSpeed_fl",
+    "wheelAngularSpeed_fr",
+    "wheelAngularSpeed_rl",
+    "wheelAngularSpeed_rr",
+    "wheelSlip_fl",
+    "wheelSlip_fr",
+    "wheelSlip_rl",
+    "wheelSlip_rr",
+    "tyreCoreTemp_fl",
+    "tyreCoreTemp_fr",
+    "tyreCoreTemp_rl",
+    "tyreCoreTemp_rr",
 )
 
 _TRACE_TO_CSV: dict[str, str] = {
@@ -55,6 +83,8 @@ _TRACE_TO_CSV: dict[str, str] = {
     "px": "position_x_m",
     "py": "position_y_m",
     "pz": "position_z_m",
+    # per-wheel channels map to identically-named CSV columns
+    **{name: name for name in _PER_WHEEL_TRACE_FIELDS},
 }
 
 _MOTEC_CHANNELS: tuple[tuple[str, str, str], ...] = (


### PR DESCRIPTION
Closes #266. The producer-side capture that unblocks the whole frontier coaching program: the brain's Tier-B confirmation path (which axle locks under braking → brake bias; exit wheelspin → TC/diff) and the tyre thermal model are dead on real laps until per-wheel slip/omega + tyre core temps are in the archive. `tire_monitor.lua` + `racing_telemetry.py` already read these live; they were just dropped before archiving.

## Changes
- **`wheel_read.lua`** (new) — shared, pcall-guarded, 0-indexed (FL/FR/RL/RR) per-wheel accessor. Single source of truth so `telemetry.lua` (capture) and `tire_monitor.lua` (HUD) can't drift on the wheel-index bug the code comments document (the `tire_temps.rr=0` regression).
- **`telemetry.lua`** — write `wheelAngularSpeed_*` / `wheelSlip_*` / `tyreCoreTemp_*` per corner into the lap trace sample.
- **TRACE_FIELDS 10→22**, byte-identical in `lap_archive.lua` + `reference_lap.py` (hard schema contract).
- **`reference_lap` + `trace_replay`** — synthesize physically-plausible per-wheel defaults (free-rolling omega = v/radius, zero slip, warm tyres); per-wheel fields are optional in normalization so pre-#266 / hand-built traces stay valid.
- **`lap_dynamics`** — treat an all-zero omega column as 'no live wheel data', so a real lap with unreadable wheels never computes slip=-1 and falsely confirms a lockup (correctness guard).
- **`lap_archive_export` + export doc** — carry the new channels in the analysis CSV.

## Verification
New/updated tests cover: generated archive carries the per-wheel columns with synthetic values; the all-zero-omega guard; the widened schema across reference_lap / trace_replay / lap_archive_async / lua_trace_replay. **Zero new failures** — the 9 remaining suite failures are pre-existing Windows/governance-env issues, confirmed reproducing on origin/main. Rig-capture of a real lap is the live-verify follow-up (the consume side is already on main from #268).

Deliverable 1 of the frontier coaching program (foundation). 🤖 Generated with [Claude Code](https://claude.com/claude-code)