### PR TITLE
feat(coaching): wire the attribution brain into the live lap_complete path (#275)

### DIFF
--- a/tests/test_brain_wiring.py
+++ b/tests/test_brain_wiring.py
@@ -138,3 +138,29 @@ def test_brain_followup_rejects_unsafe_archive_path(tmp_path, monkeypatch):
 def test_brain_followup_disabled_when_feature_off(monkeypatch):
     monkeypatch.delenv(_ENABLE, raising=False)
     assert build_brain_followup(_corner_archive()) is None
+
+
+def test_brain_followup_rejects_traversal_archive_path(tmp_path, monkeypatch):
+    # codex #276: a path with `..` that RESOLVES outside journal/laps must be rejected, even though
+    # the raw string contains "/journal/laps/" + "lap_*.json".
+    monkeypatch.setenv(_ENABLE, "1")
+    (tmp_path / "evil").mkdir()
+    (tmp_path / "evil" / "lap_evil.json").write_text(
+        json.dumps(_corner_archive()), encoding="utf-8"
+    )
+    (tmp_path / "journal" / "laps").mkdir(parents=True)
+    traversal = tmp_path / "journal" / "laps" / ".." / ".." / "evil" / "lap_evil.json"
+    assert build_brain_followup({"archivePath": str(traversal)}) is None
+
+
+def test_brain_followup_uses_reference_for_time_loss(tmp_path, monkeypatch):
+    # codex #276: with a reference archive, delta-based rules fire (per-corner time_loss_s set).
+    monkeypatch.setenv(_ENABLE, "1")
+    laps = tmp_path / "journal" / "laps"
+    laps.mkdir(parents=True)
+    ref_file = laps / "lap_ref.json"
+    ref_file.write_text(json.dumps(_corner_archive(degrade=0.0)), encoding="utf-8")
+    student = _corner_archive(degrade=8.0) | {"referenceArchivePath": str(ref_file)}
+    out = build_brain_followup(student)
+    assert out is not None
+    assert any(c["time_loss_s"] is not None for c in out["cornerAnalysis"])

--- a/tests/test_brain_wiring.py
+++ b/tests/test_brain_wiring.py
@@ -1,0 +1,140 @@
+"""Tests for wiring the attribution brain into the live debrief path (#275).
+
+Covers coach_report.build_structured_debrief (the machine-readable brain output) and
+protocol.build_brain_followup (the non-blocking lap_complete follow-up that resolves the lap
+archive from an inline trace or a safe archivePath).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+from tools.ai_sidecar.coach_report import build_structured_debrief
+from tools.ai_sidecar.protocol import build_brain_followup
+
+_ENABLE = "AC_COPILOT_OLLAMA_ENABLE"
+
+
+def _corner_archive(*, degrade: float = 0.0) -> dict:
+    """A straight→corner→straight lap archive with a full trace (one clean apex)."""
+    radius, ds, n_pre, n_arc, n_post = 30.0, 2.0, 40, 30, 40
+    n = n_pre + n_arc + n_post
+    kappa = [0.0] * n_pre + [1.0 / radius] * n_arc + [0.0] * n_post
+    theta, x, z = 0.0, 0.0, 0.0
+    xs, zs = [], []
+    for i in range(n):
+        xs.append(x)
+        zs.append(z)
+        theta += kappa[i] * ds
+        x += ds * math.cos(theta)
+        z += ds * math.sin(theta)
+    apex_i = n_pre + n_arc // 2
+    v = []
+    for i in range(n):
+        if i < 25:
+            v.append(55.0)
+        elif i < apex_i:
+            v.append(55.0 + (25.0 - 55.0) * (i - 25) / max(1, apex_i - 25) - degrade)
+        elif i < n_pre + n_arc + 5:
+            v.append(25.0 + (55.0 - 25.0) * (i - apex_i) / max(1, n_pre + n_arc + 5 - apex_i))
+        else:
+            v.append(55.0)
+    brake = [0.8 if 25 <= i < apex_i else 0.0 for i in range(n)]
+    throttle = [1.0 if i >= apex_i + 1 else 0.0 for i in range(n)]
+    steer = [0.4 if n_pre <= i < n_pre + n_arc else 0.0 for i in range(n)]
+    t_ms = [0.0]
+    for i in range(1, n):
+        t_ms.append(t_ms[-1] + ds / max(0.5, 0.5 * (v[i] + v[i - 1])) * 1000.0)
+    total = ds * (n - 1)
+    spline = [(ds * i) / total for i in range(n)]
+    samples = [
+        [spline[i], v[i] * 3.6, t_ms[i], throttle[i], brake[i], steer[i], 4, xs[i], 0.0, zs[i]]
+        for i in range(n)
+    ]
+    return {
+        "event": "lap_complete",
+        "lap": 3,
+        "car": {"id": "ks_porsche_911_gt3_r_2016"},
+        "track": {"id": "magione", "lengthM": total},
+        "lap_obj": {"lap_ms": int(t_ms[-1]), "is_valid": True},
+        "setup": {"snapshot": {"FRONT_BIAS.VALUE": "66", "TRACTION_CONTROL.VALUE": "4"}},
+        "trace": {
+            "fields": [
+                "spline",
+                "speed",
+                "eMs",
+                "throttle",
+                "brake",
+                "steer",
+                "gear",
+                "px",
+                "py",
+                "pz",
+            ],
+            "samples": samples,
+        },
+    }
+
+
+# --- build_structured_debrief ----------------------------------------------
+def test_structured_debrief_has_corners_and_cause_classes():
+    out = build_structured_debrief(_corner_archive(), grip_ceiling_g=2.5)
+    assert out is not None
+    assert "Coaching debrief" in out["text"]
+    assert out["corners"]
+    c0 = out["corners"][0]
+    assert {"index", "headline", "attributions"} <= c0.keys()
+    for a in c0["attributions"]:
+        assert a["cause_class"] in ("setup", "technique", "grip", "setup+technique", "unknown")
+        assert 0.0 <= a["confidence"] <= 1.0
+        assert isinstance(a["advisory"], bool)
+    assert out["balance"]["verdict"]
+
+
+def test_structured_debrief_none_without_trace():
+    assert build_structured_debrief({"setup": {"snapshot": {}}}) is None
+
+
+# --- build_brain_followup ---------------------------------------------------
+def test_brain_followup_from_inline_trace(monkeypatch):
+    monkeypatch.setenv(_ENABLE, "1")
+    out = build_brain_followup(_corner_archive() | {"gripCeilingG": 2.5})
+    assert out is not None
+    assert out["event"] == "coaching_response"
+    assert out["debriefSource"] == "brain"
+    assert out["cornerAnalysis"]
+    assert "balance" in out
+
+
+def test_brain_followup_from_archive_path(tmp_path, monkeypatch):
+    monkeypatch.setenv(_ENABLE, "1")
+    laps = tmp_path / "journal" / "laps"
+    laps.mkdir(parents=True)
+    archive_file = laps / "lap_test123.json"
+    archive_file.write_text(json.dumps(_corner_archive()), encoding="utf-8")
+    out = build_brain_followup(
+        {"event": "lap_complete", "lap": 3, "archivePath": str(archive_file), "gripCeilingG": 2.5}
+    )
+    assert out is not None
+    assert out["debriefSource"] == "brain"
+
+
+def test_brain_followup_none_for_corner_table_only(monkeypatch):
+    monkeypatch.setenv(_ENABLE, "1")
+    # the live lap_complete payload (no trace, no archivePath) -> fall back to rules
+    inbound = {"event": "lap_complete", "lap": 3, "telemetry": {"corners": [{"label": "T1"}]}}
+    assert build_brain_followup(inbound) is None
+
+
+def test_brain_followup_rejects_unsafe_archive_path(tmp_path, monkeypatch):
+    monkeypatch.setenv(_ENABLE, "1")
+    # a real file, but not under journal/laps/lap_*.json -> rejected by the safe-path guard
+    bad = tmp_path / "passwd.json"
+    bad.write_text(json.dumps(_corner_archive()), encoding="utf-8")
+    assert build_brain_followup({"archivePath": str(bad)}) is None
+
+
+def test_brain_followup_disabled_when_feature_off(monkeypatch):
+    monkeypatch.delenv(_ENABLE, raising=False)
+    assert build_brain_followup(_corner_archive()) is None

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -17,6 +17,7 @@ import json
 from pathlib import Path
 
 from tools.ai_sidecar.corner_attribution import (
+    Attribution,
     BalanceFinding,
     CornerCoaching,
     analyze_balance,
@@ -76,6 +77,90 @@ def format_debrief(
 
 def _load_archive(path: str | Path) -> dict:
     return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _cause_class(attr: Attribution) -> str:
+    """Collapse an attribution to a single machine-readable cause class."""
+    if attr.key == "grip_limited":
+        return "grip"
+    has_setup = bool(attr.setup_causes)
+    has_tech = bool(attr.technique_causes)
+    if has_setup and has_tech:
+        return "setup+technique"
+    if has_setup:
+        return "setup"
+    if has_tech:
+        return "technique"
+    return "unknown"
+
+
+def build_structured_debrief(
+    lap_archive: dict,
+    *,
+    reference_archive: dict | None = None,
+    setup: CarSetup | None = None,
+    grip_ceiling_g: float | None = None,
+) -> dict | None:
+    """Run the coaching brain and return a JSON-serializable structured debrief.
+
+    Returns ``{text, corners[], balance, car_id, track_id}`` — the same analysis as
+    :func:`build_debrief` plus a machine-readable per-corner breakdown (cause_class, confidence,
+    advisory, coaching) for the sidecar / coach-handoff protocol. Returns ``None`` when the archive
+    has no usable trace (so callers fall back to the shallow rules debrief).
+    """
+    try:
+        lap = lap_trace_from_archive(lap_archive)
+    except ValueError:
+        return None
+    setup = setup or from_lap_archive(lap_archive)
+    ref = lap_trace_from_archive(reference_archive) if reference_archive else None
+    report = coach_lap(lap, setup, reference=ref, grip_ceiling_g=grip_ceiling_g)
+    sigs = corner_signatures(lap, segment_corners(lap))
+    deltas = compare_laps(lap, ref) if ref is not None else None
+    balance = analyze_balance(lap, sigs, deltas=deltas, grip_ceiling_g=grip_ceiling_g)
+    text = format_debrief(
+        report,
+        balance,
+        setup,
+        title=f"Coaching debrief — {lap.car_id or '?'} @ {lap.track_id or '?'}",
+    )
+    corners = [
+        {
+            "index": c.index,
+            "apex_spline": round(c.apex_spline, 4),
+            "min_speed_kmh": c.min_speed_kmh,
+            "time_loss_s": c.delta_s,
+            "headline": c.headline,
+            "attributions": [
+                {
+                    "key": a.key,
+                    "symptom": a.symptom,
+                    "phase": a.phase,
+                    "cause_class": _cause_class(a),
+                    "confidence": a.confidence,
+                    "advisory": a.advisory,
+                    "coaching": a.coaching,
+                    "setup_causes": a.setup_causes,
+                    "technique_causes": a.technique_causes,
+                }
+                for a in c.attributions
+            ],
+        }
+        for c in report
+    ]
+    return {
+        "text": text,
+        "car_id": lap.car_id,
+        "track_id": lap.track_id,
+        "balance": {
+            "verdict": balance.verdict,
+            "lever_class": balance.lever_class,
+            "coaching": balance.coaching,
+            "low_band_grip_used": balance.low_band_grip_used,
+            "high_band_grip_used": balance.high_band_grip_used,
+        },
+        "corners": corners,
+    }
 
 
 def build_debrief(

--- a/tools/ai_sidecar/protocol.py
+++ b/tools/ai_sidecar/protocol.py
@@ -36,34 +36,45 @@ EVENT_CORNER_ADVICE = "corner_advice"
 _MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
 
 
-def _resolve_lap_archive(inbound: dict[str, Any]) -> dict[str, Any] | None:
-    """Resolve a full lap-archive dict (with a trace) for the brain, or None.
+def _load_safe_archive_path(raw_path: Any) -> dict[str, Any] | None:
+    """Load a lap-archive dict from a path, or None — with traversal-safe validation.
 
-    Prefers an inline ``trace`` on the message; otherwise loads ``archivePath`` IF it is a safe
-    ``.../journal/laps/lap_*.json`` path that exists and parses. Never raises — returns None so the
-    caller falls back to the shallow rules debrief.
+    NORMALIZES the path first (``Path.resolve`` collapses ``..`` / symlinks) and only then checks it
+    is a ``.../journal/laps/lap_*.json`` path, so a traversal like
+    ``/x/journal/laps/../../etc/lap_evil.json`` is rejected on its resolved form. Size + existence
+    guarded. Never raises.
     """
-    trace = inbound.get("trace")
-    if isinstance(trace, dict) and isinstance(trace.get("samples"), list) and trace["samples"]:
-        return inbound
-    raw_path = inbound.get("archivePath")
     if not isinstance(raw_path, str) or not raw_path.strip():
         return None
     # Defer the import so protocol.py stays importable without the coaching extra installed.
     from tools.ai_sidecar.setup_optimizer import is_supported_lap_archive_path
 
-    if not is_supported_lap_archive_path(raw_path):
+    try:
+        resolved = Path(raw_path).resolve()
+    except (OSError, ValueError, RuntimeError):
+        return None
+    if not is_supported_lap_archive_path(str(resolved)):
         logger.debug("brain: archivePath rejected (not a journal/laps/lap_*.json): %r", raw_path)
         return None
     try:
-        p = Path(raw_path)
-        if not p.is_file() or p.stat().st_size > _MAX_ARCHIVE_BYTES:
+        if not resolved.is_file() or resolved.stat().st_size > _MAX_ARCHIVE_BYTES:
             return None
-        data = json.loads(p.read_text(encoding="utf-8"))
+        data = json.loads(resolved.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         logger.info("brain: could not load archivePath %r: %s", raw_path, exc)
         return None
     return data if isinstance(data, dict) else None
+
+
+def _resolve_lap_archive(inbound: dict[str, Any]) -> dict[str, Any] | None:
+    """Resolve a full lap-archive dict (with a trace) for the brain, or None.
+
+    Prefers an inline ``trace`` on the message; else loads a safe ``archivePath``. Never raises.
+    """
+    trace = inbound.get("trace")
+    if isinstance(trace, dict) and isinstance(trace.get("samples"), list) and trace["samples"]:
+        return inbound
+    return _load_safe_archive_path(inbound.get("archivePath"))
 
 
 def build_brain_followup(inbound: dict[str, Any]) -> dict[str, Any] | None:
@@ -82,10 +93,16 @@ def build_brain_followup(inbound: dict[str, Any]) -> dict[str, Any] | None:
         return None
     # optional per-car lateral grip ceiling (g) lets the brain separate grip-limited from technique
     grip_ceiling_g = _as_float(inbound.get("gripCeilingG"))
+    # optional reference lap (e.g. the driver's best): unlocks the delta-based rules (time lost per
+    # corner, "carried too little apex speed"). Without it the brain still emits grip/balance/exit/
+    # braking attributions, just no time-loss deltas.
+    reference = _load_safe_archive_path(inbound.get("referenceArchivePath"))
     try:
         from tools.ai_sidecar.coach_report import build_structured_debrief
 
-        structured = build_structured_debrief(archive, grip_ceiling_g=grip_ceiling_g)
+        structured = build_structured_debrief(
+            archive, reference_archive=reference, grip_ceiling_g=grip_ceiling_g
+        )
     except Exception as exc:  # the brain must never break the coaching socket
         logger.info("brain debrief raised: %s", exc)
         return None

--- a/tools/ai_sidecar/protocol.py
+++ b/tools/ai_sidecar/protocol.py
@@ -6,7 +6,9 @@ All frames are JSON objects. ``protocol`` is required on new messages; missing
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from tools.ai_sidecar.coaching.llm_coach import (
@@ -29,6 +31,77 @@ EVENT_COACHING_RESPONSE = "coaching_response"
 EVENT_ANALYSIS_ERROR = "analysis_error"
 EVENT_CORNER_QUERY = "corner_query"
 EVENT_CORNER_ADVICE = "corner_advice"
+
+#: A lap archive is at most a few MB; refuse to load anything larger from an archivePath.
+_MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
+
+
+def _resolve_lap_archive(inbound: dict[str, Any]) -> dict[str, Any] | None:
+    """Resolve a full lap-archive dict (with a trace) for the brain, or None.
+
+    Prefers an inline ``trace`` on the message; otherwise loads ``archivePath`` IF it is a safe
+    ``.../journal/laps/lap_*.json`` path that exists and parses. Never raises — returns None so the
+    caller falls back to the shallow rules debrief.
+    """
+    trace = inbound.get("trace")
+    if isinstance(trace, dict) and isinstance(trace.get("samples"), list) and trace["samples"]:
+        return inbound
+    raw_path = inbound.get("archivePath")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    # Defer the import so protocol.py stays importable without the coaching extra installed.
+    from tools.ai_sidecar.setup_optimizer import is_supported_lap_archive_path
+
+    if not is_supported_lap_archive_path(raw_path):
+        logger.debug("brain: archivePath rejected (not a journal/laps/lap_*.json): %r", raw_path)
+        return None
+    try:
+        p = Path(raw_path)
+        if not p.is_file() or p.stat().st_size > _MAX_ARCHIVE_BYTES:
+            return None
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.info("brain: could not load archivePath %r: %s", raw_path, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def build_brain_followup(inbound: dict[str, Any]) -> dict[str, Any] | None:
+    """Build a follow-up coaching_response from the full setup-vs-technique attribution brain.
+
+    Non-blocking follow-up (mirrors :func:`build_ollama_followup`): runs AFTER the immediate
+    rules-based ack, so it never blocks the <100ms path and tolerates the async archive write.
+    Resolves the lap archive (inline trace or safe ``archivePath``), runs the brain, and returns a
+    coaching_response carrying the rich text debrief + a machine-readable ``cornerAnalysis``.
+    Returns None on any failure or when no usable trace exists (the client keeps the rules debrief).
+    """
+    if not debrief_feature_enabled():
+        return None
+    archive = _resolve_lap_archive(inbound)
+    if archive is None:
+        return None
+    # optional per-car lateral grip ceiling (g) lets the brain separate grip-limited from technique
+    grip_ceiling_g = _as_float(inbound.get("gripCeilingG"))
+    try:
+        from tools.ai_sidecar.coach_report import build_structured_debrief
+
+        structured = build_structured_debrief(archive, grip_ceiling_g=grip_ceiling_g)
+    except Exception as exc:  # the brain must never break the coaching socket
+        logger.info("brain debrief raised: %s", exc)
+        return None
+    if not structured or not structured.get("corners"):
+        return None
+    return {
+        "protocol": PROTOCOL_VERSION,
+        "event": EVENT_COACHING_RESPONSE,
+        "lap": inbound.get("lap"),
+        "hints": [{"kind": "general", "text": "Setup-vs-technique debrief"}],
+        "debrief": structured["text"],
+        "debriefSource": "brain",
+        "cornerAnalysis": structured["corners"],
+        "balance": structured["balance"],
+    }
+
 
 _CORNER_LABEL_MAX_LEN = 64
 _CORNER_MAX_SPEED_ABS_KMH = 450.0

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -71,6 +71,7 @@ from tools.ai_sidecar.protocol import (
     EVENT_COACHING_RESPONSE,
     EVENT_CORNER_QUERY,
     PROTOCOL_VERSION,
+    build_brain_followup,
     build_ollama_followup,
     prepare_outbound_message,
 )
@@ -314,6 +315,25 @@ async def _send_ollama_followup(
         return
     if followup is None:
         observability.METRICS.record_ollama_followup_error()
+        return
+    await _safe_send(websocket, followup)
+
+
+async def _send_brain_followup(websocket: Any, inbound: dict[str, Any]) -> None:
+    """Run the setup-vs-technique attribution brain in a background task and send a follow-up.
+
+    Mirrors :func:`_send_ollama_followup`: runs AFTER the immediate rules ack, off the message loop
+    (the brain does disk I/O to load the lap archive + pure-Python analysis). Silently discards on
+    any error or when no usable trace is available.
+    """
+    try:
+        followup = await asyncio.to_thread(build_brain_followup, inbound)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.info("brain followup raised: %s", e)
+        return
+    if followup is None:
         return
     await _safe_send(websocket, followup)
 
@@ -972,6 +992,14 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
                     _background_tasks.add(bg_task)
                     pending_followups.add(bg_task)
                     bg_task.add_done_callback(_followup_done)
+
+                    # Also spawn the setup-vs-technique attribution brain (issue #275): a deeper,
+                    # archive-grounded follow-up that the rules ack + Ollama narration cannot
+                    # produce. Independent task so neither blocks the other.
+                    brain_task = asyncio.create_task(_send_brain_followup(websocket, data))
+                    _background_tasks.add(brain_task)
+                    pending_followups.add(brain_task)
+                    brain_task.add_done_callback(_followup_done)
     finally:
         _external_peers.discard(websocket)
         _external_peer_classes.pop(websocket, None)


### PR DESCRIPTION
Closes #275. The setup-vs-technique attribution brain (coach_lap / corner_attribution / analyze_balance) was **orphaned** — `server.py`/`protocol.py` only used the shallow `features` + `improvement_ranking` + Ollama, so live debriefs were min/apex-speed ranking, not the analysis the brain already produces. This connects it.

## Changes
- **`coach_report.build_structured_debrief`** — machine-readable `{text, corners[{cause_class, confidence, advisory, coaching, time_loss_s}], balance}` from the brain; `None` if the archive has no usable trace.
- **`protocol.build_brain_followup`** — resolves the lap archive (inline `trace`, or a **safe** `*/journal/laps/lap_*.json` `archivePath` with existence + 32 MB size guards) and runs the brain.
- **`server._send_brain_followup`** — spawned as a **non-blocking follow-up** on `lap_complete` (mirrors the Ollama follow-up), so it never blocks the <100 ms ack and tolerates the async archive write.

The brain now fires the moment a `lap_complete` carries a trace or `archivePath`, upgrading live debriefs to full setup-vs-technique + aero-vs-mechanical attribution with confidence + advisory flags.

## Verification
7 new tests (`test_brain_wiring.py`): structured debrief shape + cause classes; brain follow-up from inline trace; from a temp `journal/laps` archive; `None` for the corner-table-only live payload; unsafe-path rejection; feature-gate off. **96 sidecar/coaching tests green, ruff clean.**

Last-mile (have the Lua deliver `archivePath` to the sidecar each lap — the path is known only post-write via the existing `pumpLapArchiveNotifications`) is a small rig-verified follow-up; the brain logic + wiring are complete and offline-verified here.

Deliverable 2 of the frontier coaching program. 🤖 Generated with [Claude Code](https://claude.com/claude-code)