### PR TITLE
feat(coaching): tyre thermal model — window/warm-up/degradation/imbalance + hot-pressure (#280)

### DIFF
--- a/tests/test_tyre_model.py
+++ b/tests/test_tyre_model.py
@@ -39,7 +39,8 @@ def test_overheat_flagged():
 
 
 def test_critical_triggers_backoff():
-    r = analyze_tyres(_core(CRITICAL_C + 3, 100, 100, 100), laps_since_start=8)
+    # CRITICAL_C is the soft limit (115); pin compound=soft so the threshold matches.
+    r = analyze_tyres(_core(CRITICAL_C + 3, 100, 100, 100), compound="soft", laps_since_start=8)
     assert r.status["fl"] == "critical"
     assert "CRITICAL" in r.headline()
     assert any(f.key == "critical" and f.severity == "act" for f in r.findings)
@@ -49,6 +50,29 @@ def test_unknown_compound_falls_back_to_slick():
     r = analyze_tyres(_core(90, 90, 90, 90))
     assert r.compound == "slick"
     assert r.window == COMPOUND_WINDOWS["slick"]
+
+
+def test_critical_is_compound_dependent():
+    # 120°C is critical for SOFT (limit 115) but only overheat for HARD (limit 135) — codex #281.
+    soft = analyze_tyres(_core(120, 100, 100, 100), compound="soft", laps_since_start=6)
+    hard = analyze_tyres(_core(120, 100, 100, 100), compound="hard", laps_since_start=6)
+    assert soft.status["fl"] == "critical"
+    assert hard.status["fl"] == "overheat"
+    assert not any(f.key == "critical" for f in hard.findings)
+
+
+def test_degradation_onset_finding_in_window():
+    # medium window 75-105; 104°C is in-window but past the 103°C degradation band (codex #281).
+    r = analyze_tyres(_core(104, 104, 100, 100), compound="medium", laps_since_start=6)
+    assert r.status["fl"] == "in_window"
+    assert any(f.key == "degradation_onset" for f in r.findings)
+
+
+def test_warming_tyre_in_off_window_headline():
+    # a late lap where tyres are below window (warming status) but not flagged "warming" rising —
+    # the headline must still say off-window, not "in window" (codex #281).
+    r = analyze_tyres(_core(60, 60, 58, 58), compound="medium", laps_since_start=8)
+    assert "in window" not in r.headline().lower()
 
 
 # --- imbalance --------------------------------------------------------------
@@ -125,14 +149,16 @@ def _archive_with_temps(temps_per_wheel: dict[str, float]) -> dict:
         for i in range(5)
     ]
     return {
+        # AC setup INI uses side-corner order: LF/RF/LR/RR (NOT FL/FR/...).
         "setup": {
             "snapshot": {
-                "PRESSURE_FL.VALUE": "27.5",
-                "PRESSURE_FR.VALUE": "27.5",
-                "PRESSURE_RL.VALUE": "26.5",
+                "PRESSURE_LF.VALUE": "27.5",
+                "PRESSURE_RF.VALUE": "27.5",
+                "PRESSURE_LR.VALUE": "26.5",
                 "PRESSURE_RR.VALUE": "26.5",
             }
         },
+        "lap": {"lap_n": 5},
         "trace": {"fields": fields, "samples": samples},
     }
 

--- a/tests/test_tyre_model.py
+++ b/tests/test_tyre_model.py
@@ -1,0 +1,155 @@
+"""Tests for the tyre thermal model (tools.ai_sidecar.tyre_model)."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.tyre_model import (
+    COMPOUND_WINDOWS,
+    CRITICAL_C,
+    analyze_tyres,
+    tyres_from_lap_archive,
+)
+
+
+def _core(fl, fr, rl, rr):
+    return {"fl": fl, "fr": fr, "rl": rl, "rr": rr}
+
+
+# --- window status ----------------------------------------------------------
+def test_in_window_balanced():
+    r = analyze_tyres(_core(90, 90, 88, 88), compound="medium", laps_since_start=5)
+    assert all(s == "in_window" for s in r.status.values())
+    assert not r.warming
+    assert "in window" in r.headline().lower()
+    assert any(f.key == "balanced" for f in r.findings)
+
+
+def test_cold_tyres_flagged_and_warming():
+    r = analyze_tyres(_core(30, 32, 28, 29), compound="medium", laps_since_start=1)
+    assert all(s == "cold" for s in r.status.values())
+    assert r.warming
+    assert any(f.key == "cold" for f in r.findings)
+
+
+def test_overheat_flagged():
+    r = analyze_tyres(_core(112, 110, 95, 96), compound="medium", laps_since_start=6)
+    assert r.status["fl"] == "overheat"
+    f = next(f for f in r.findings if f.key == "overheat")
+    assert f.severity == "act"
+    assert f.core_only is True
+
+
+def test_critical_triggers_backoff():
+    r = analyze_tyres(_core(CRITICAL_C + 3, 100, 100, 100), laps_since_start=8)
+    assert r.status["fl"] == "critical"
+    assert "CRITICAL" in r.headline()
+    assert any(f.key == "critical" and f.severity == "act" for f in r.findings)
+
+
+def test_unknown_compound_falls_back_to_slick():
+    r = analyze_tyres(_core(90, 90, 90, 90))
+    assert r.compound == "slick"
+    assert r.window == COMPOUND_WINDOWS["slick"]
+
+
+# --- imbalance --------------------------------------------------------------
+def test_axle_imbalance_hypothesis():
+    # fronts 12C hotter than rears -> front-axle finding (ranked hypothesis, not verdict)
+    r = analyze_tyres(_core(100, 100, 86, 86), compound="medium", laps_since_start=5)
+    f = next(f for f in r.findings if f.key == "axle_imbalance")
+    assert "front" in f.summary
+    assert f.confidence in ("medium", "low")
+    assert "hypothes" in f.coaching.lower() or "check" in f.coaching.lower()
+
+
+def test_side_imbalance_notes_track_confound():
+    r = analyze_tyres(_core(100, 88, 99, 87), compound="medium", laps_since_start=5)
+    f = next(f for f in r.findings if f.key == "side_imbalance")
+    assert "confound" in f.coaching.lower()
+    assert f.severity == "info"  # not actionable without a reference lap
+
+
+def test_single_wheel_outlier():
+    r = analyze_tyres(_core(110, 90, 90, 90), compound="hard", laps_since_start=5)
+    assert any(f.key == "wheel_outlier" for f in r.findings)
+
+
+# --- hot pressure estimate --------------------------------------------------
+def test_hot_pressure_modelled_and_flagged_high():
+    # cold 30 psi + hot core ~95C -> modelled hot well above the 26-29 window
+    r = analyze_tyres(
+        _core(95, 95, 95, 95),
+        cold_pressure=_core(30.0, 30.0, 30.0, 30.0),
+        compound="medium",
+        laps_since_start=5,
+    )
+    assert r.hot_pressure_est["fl"] > 29.0
+    f = next(f for f in r.findings if f.key == "hot_pressure_high")
+    assert f.core_only is False  # hot pressure is modelled, not measured
+    assert "modelled" in f.coaching.lower()
+
+
+def test_no_pressure_means_no_hot_estimate():
+    r = analyze_tyres(_core(90, 90, 90, 90), compound="medium", laps_since_start=5)
+    assert r.hot_pressure_est == {}
+
+
+# --- warm-up from previous lap ---------------------------------------------
+def test_rising_fast_marks_warming_even_late():
+    prev = _core(60, 60, 58, 58)
+    r = analyze_tyres(_core(66, 66, 64, 64), compound="medium", prev_core=prev, laps_since_start=5)
+    # mean core below window AND rising > 2C/lap -> warming
+    assert r.warming
+
+
+# --- archive integration ----------------------------------------------------
+def _archive_with_temps(temps_per_wheel: dict[str, float]) -> dict:
+    fields = [
+        "spline",
+        "speed",
+        "eMs",
+        "tyreCoreTemp_fl",
+        "tyreCoreTemp_fr",
+        "tyreCoreTemp_rl",
+        "tyreCoreTemp_rr",
+    ]
+    samples = [
+        [
+            i / 4,
+            100.0,
+            i * 100.0,
+            temps_per_wheel["fl"],
+            temps_per_wheel["fr"],
+            temps_per_wheel["rl"],
+            temps_per_wheel["rr"],
+        ]
+        for i in range(5)
+    ]
+    return {
+        "setup": {
+            "snapshot": {
+                "PRESSURE_FL.VALUE": "27.5",
+                "PRESSURE_FR.VALUE": "27.5",
+                "PRESSURE_RL.VALUE": "26.5",
+                "PRESSURE_RR.VALUE": "26.5",
+            }
+        },
+        "trace": {"fields": fields, "samples": samples},
+    }
+
+
+def test_tyres_from_lap_archive_averages_core_and_reads_pressure():
+    r = tyres_from_lap_archive(_archive_with_temps(_core(92, 92, 88, 88)))
+    assert r is not None
+    assert r.core["fl"] == 92.0
+    assert r.hot_pressure_est  # cold pressures were read from the setup snapshot
+
+
+def test_tyres_from_lap_archive_none_without_temp_channels():
+    archive = {"trace": {"fields": ["spline", "speed", "eMs"], "samples": [[0, 1, 2], [0.5, 1, 3]]}}
+    assert tyres_from_lap_archive(archive) is None
+
+
+def test_archive_zero_temps_are_unread_sentinel():
+    # all-zero core (unread) -> no usable wheel data -> None (mirrors #266 all-zero guard)
+    r = tyres_from_lap_archive(_archive_with_temps(_core(0.0, 0.0, 0.0, 0.0)))
+    assert r is None

--- a/tests/test_tyre_model.py
+++ b/tests/test_tyre_model.py
@@ -62,10 +62,40 @@ def test_critical_is_compound_dependent():
 
 
 def test_degradation_onset_finding_in_window():
-    # medium window 75-105; 104°C is in-window but past the 103°C degradation band (codex #281).
+    # medium window 75-105; 104°C is in-window but in the top-3°C roll-off band (codex #281).
     r = analyze_tyres(_core(104, 104, 100, 100), compound="medium", laps_since_start=6)
     assert r.status["fl"] == "in_window"
     assert any(f.key == "degradation_onset" for f in r.findings)
+
+
+def test_degradation_onset_is_compound_aware():
+    # 104°C is degrading for MEDIUM (window top 105) but NOT for HARD (window top 110) — codex #281.
+    med = analyze_tyres(_core(104, 104, 100, 100), compound="medium", laps_since_start=6)
+    hard = analyze_tyres(_core(104, 104, 100, 100), compound="hard", laps_since_start=6)
+    assert any(f.key == "degradation_onset" for f in med.findings)
+    assert not any(f.key == "degradation_onset" for f in hard.findings)
+
+
+def test_headline_precedence_overheat_over_warming():
+    # one overheat wheel + others cold: headline says overheating (not warming), listing ONLY FL.
+    r = analyze_tyres(_core(112, 60, 60, 60), compound="medium", laps_since_start=8)
+    h = r.headline()
+    assert "overheating" in h.lower()
+    assert "FL" in h and "FR" not in h
+
+
+def test_archive_rejects_nonfinite_temps_and_lap_n():
+    # a NaN sample must be ignored (not poison the mean); NaN lap_n must not crash — codex #281.
+    fields = ["spline", "tyreCoreTemp_fl", "tyreCoreTemp_fr", "tyreCoreTemp_rl", "tyreCoreTemp_rr"]
+    samples = [
+        [0.0, 90.0, 90.0, 88.0, 88.0],
+        [0.5, float("nan"), 91.0, 89.0, 89.0],
+        [1.0, 92.0, 92.0, 90.0, 90.0],
+    ]
+    archive = {"lap": {"lap_n": float("nan")}, "trace": {"fields": fields, "samples": samples}}
+    r = tyres_from_lap_archive(archive)
+    assert r is not None
+    assert r.core["fl"] == 91.0  # mean of 90 and 92 (the NaN row skipped)
 
 
 def test_warming_tyre_in_off_window_headline():

--- a/tools/ai_sidecar/tyre_model.py
+++ b/tools/ai_sidecar/tyre_model.py
@@ -1,0 +1,356 @@
+"""Tyre thermal model: optimal window, warm-up, degradation, imbalance, hot-pressure estimate.
+
+Consumes per-wheel CORE temperature (CSP ``tyreCoreTemperature``, persisted by #266) + cold pressure
+(setup) and produces a pro-engineer tyre read. Pure stdlib.
+
+Grounded in adversarially-verified research (see
+``docs/01_Vault/AcCopilotTrainer/03_Investigations/tyre-thermal-knowledge-2026-06-21.md``). The
+red-team corrections are encoded here and must NOT be "simplified" away:
+
+* **Core is a BULK average** — no edge/surface temp, so window/onset/blistering calls are
+  inferences, never definitive. We report a degradation-onset *band*, not a blistering diagnosis.
+* **Pressure↔core coupling is gas-law** ~+1 psi / 10 °C (≈0.013 psi/°C·psi). Hot pressure here is
+  **modelled** from cold + coupling, never measured (CSP is read-only for live pressure).
+* **Thermal overheat and mechanical wear both raise core temp** — core alone cannot separate them.
+* **Left-right (and weakly front-rear) asymmetry is confounded by track corner-direction bias** — a
+  balance finding is a ranked HYPOTHESIS pending a reference-lap comparison, not a verdict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+_WHEELS = ("fl", "fr", "rl", "rr")
+
+# --- verified parameters (°C core, bulk-average) ---------------------------
+#: Optimal core-temp window per compound key. "slick" is the generic fallback when compound is
+#: unknown (compound identity is NOT in the telemetry feed — see module docstring).
+COMPOUND_WINDOWS: dict[str, tuple[float, float]] = {
+    "soft": (70.0, 100.0),
+    "medium": (75.0, 105.0),
+    "hard": (80.0, 110.0),
+    "wet": (55.0, 80.0),
+    "slick": (75.0, 105.0),  # generic slick fallback (medium-ish)
+}
+GRIP_ONSET_C = 40.0  # below ~35-45: too cold to make meaningful grip
+DEG_WARN_C = 103.0  # 100-105 degradation-onset band (grip roll-off region)
+CRITICAL_C = 115.0  # >115 soft / ~130-140 hard: thermal-risk back-off trigger
+
+# pressure↔core coupling (ideal gas, constant V): ~+1 psi per 10 °C at GT3 pressures
+PRESSURE_PSI_PER_DEGC = 0.12
+HOT_PRESSURE_WINDOW = (26.0, 29.0)  # GT3 target HOT psi
+_COLD_CORE_REF_C = 25.0  # nominal cold-tyre core for the hot-pressure delta estimate
+
+# imbalance thresholds (°C)
+AXLE_IMBALANCE_C = 10.0  # |front_avg - rear_avg| beyond natural ~4-8
+SIDE_IMBALANCE_C = 7.0  # |left_avg - right_avg| (heavily track-direction confounded)
+WHEEL_OUTLIER_C = 15.0  # a single corner this far from its pair-mate
+BALANCED_SPREAD_C = 5.0  # all four within this = thermally balanced
+
+# warm-up
+WARMUP_RISE_C_PER_LAP = 2.0  # core rising faster than this early = still warming
+
+
+@dataclass(frozen=True)
+class TyreFinding:
+    """One tyre observation: what it is, how confident, and what to do (honest about data)."""
+
+    key: str
+    summary: str
+    severity: str  # "info" | "caution" | "act"
+    core_only: bool  # True = computable from core temp alone; False = needs richer channels
+    coaching: str
+    confidence: str  # "high" | "medium" | "low"
+
+
+@dataclass
+class TyreReport:
+    """Per-wheel + whole-car tyre-thermal read for one lap."""
+
+    compound: str
+    window: tuple[float, float]
+    core: dict[str, float]  # fl/fr/rl/rr core temp (°C)
+    status: dict[str, str]  # per-wheel: cold|warming|in_window|overheat|critical
+    mean_core: float
+    front_minus_rear: float | None
+    left_minus_right: float | None
+    spread: float
+    hot_pressure_est: dict[str, float]  # modelled psi per wheel (estimate)
+    warming: bool
+    findings: list[TyreFinding] = field(default_factory=list)
+
+    def headline(self) -> str:
+        bad = [w for w, s in self.status.items() if s in ("overheat", "critical", "cold")]
+        if any(self.status[w] == "critical" for w in self.status):
+            return (
+                f"TYRES CRITICAL: {', '.join(w.upper() for w in bad)} over-temp — back off / box."
+            )
+        if self.warming:
+            return f"Tyres warming (mean core {self.mean_core:.0f}°C) — build heat before pushing."
+        if bad:
+            return f"Tyres off-window: {', '.join(w.upper() for w in bad)} ({self.compound})."
+        return f"Tyres in window ({self.compound}, mean core {self.mean_core:.0f}°C)."
+
+
+def _status_for(core: float, window: tuple[float, float]) -> str:
+    lo, hi = window
+    if core >= CRITICAL_C:
+        return "critical"
+    if core > hi:
+        return "overheat"
+    if core < GRIP_ONSET_C:
+        return "cold"
+    if core < lo:
+        return "warming"
+    return "in_window"
+
+
+def _hot_pressure_est(cold_psi: float, core: float) -> float:
+    """Modelled hot pressure: cold + gas-law coupling over the core rise from a nominal cold ref."""
+    return round(cold_psi + PRESSURE_PSI_PER_DEGC * (core - _COLD_CORE_REF_C), 2)
+
+
+def _mean(vals: list[float]) -> float:
+    return sum(vals) / len(vals) if vals else 0.0
+
+
+def analyze_tyres(
+    core: dict[str, float],
+    cold_pressure: dict[str, float] | None = None,
+    *,
+    compound: str | None = None,
+    prev_core: dict[str, float] | None = None,
+    laps_since_start: int | None = None,
+) -> TyreReport:
+    """Analyze a lap's per-wheel core temps (+ optional cold pressures, compound, previous lap).
+
+    ``core``/``cold_pressure`` are ``{fl,fr,rl,rr: value}`` (missing wheels tolerated). ``compound``
+    is one of COMPOUND_WINDOWS keys; unknown → generic ``slick``. ``prev_core`` +
+    ``laps_since_start`` drive warm-up vs steady classification. Returns a :class:`TyreReport`.
+    """
+    comp = (compound or "slick").lower()
+    window = COMPOUND_WINDOWS.get(comp, COMPOUND_WINDOWS["slick"])
+    core = {w: float(core[w]) for w in _WHEELS if w in core and core[w] is not None}
+    status = {w: _status_for(core[w], window) for w in core}
+    present = list(core.values())
+    mean_core = round(_mean(present), 1)
+    spread = round(max(present) - min(present), 1) if present else 0.0
+
+    front = [core[w] for w in ("fl", "fr") if w in core]
+    rear = [core[w] for w in ("rl", "rr") if w in core]
+    left = [core[w] for w in ("fl", "rl") if w in core]
+    right = [core[w] for w in ("fr", "rr") if w in core]
+    fmr = round(_mean(front) - _mean(rear), 1) if front and rear else None
+    lmr = round(_mean(left) - _mean(right), 1) if left and right else None
+
+    hot_est: dict[str, float] = {}
+    if cold_pressure:
+        for w in core:
+            cp = cold_pressure.get(w)
+            if cp is not None:
+                hot_est[w] = _hot_pressure_est(float(cp), core[w])
+
+    # warm-up: cold/below-window mean AND (rising fast OR within first 2 laps)
+    rising_fast = False
+    if prev_core:
+        rises = [core[w] - prev_core[w] for w in core if w in prev_core]
+        rising_fast = bool(rises) and _mean(rises) > WARMUP_RISE_C_PER_LAP
+    early = laps_since_start is not None and laps_since_start <= 2
+    warming = (
+        bool(present)
+        and mean_core < window[0]
+        and (rising_fast or early or laps_since_start is None)
+    )
+
+    findings = _build_findings(core, status, window, comp, mean_core, fmr, lmr, spread, hot_est)
+    return TyreReport(
+        compound=comp,
+        window=window,
+        core=core,
+        status=status,
+        mean_core=mean_core,
+        front_minus_rear=fmr,
+        left_minus_right=lmr,
+        spread=spread,
+        hot_pressure_est=hot_est,
+        warming=warming,
+        findings=findings,
+    )
+
+
+def _build_findings(
+    core: dict[str, float],
+    status: dict[str, str],
+    window: tuple[float, float],
+    comp: str,
+    mean_core: float,
+    fmr: float | None,
+    lmr: float | None,
+    spread: float,
+    hot_est: dict[str, float],
+) -> list[TyreFinding]:
+    out: list[TyreFinding] = []
+    crit = [w for w, s in status.items() if s == "critical"]
+    over = [w for w, s in status.items() if s == "overheat"]
+    cold = [w for w, s in status.items() if s in ("cold", "warming")]
+    if crit:
+        out.append(
+            TyreFinding(
+                "critical",
+                f"{', '.join(w.upper() for w in crit)} core ≥ {CRITICAL_C:.0f}°C",
+                "act",
+                True,
+                "Thermal-risk band — back off significantly or box. (A risk trigger, not a "
+                "blistering diagnosis: core is a bulk average.)",
+                "low",
+            )
+        )
+    if over:
+        out.append(
+            TyreFinding(
+                "overheat",
+                f"{', '.join(w.upper() for w in over)} above the {comp} window "
+                f"(> {window[1]:.0f}°C)",
+                "act",
+                True,
+                "Reduce thermal load: ease exit throttle, smoother brake/steer; if it persists, "
+                "raise cold pressure or pick a harder compound.",
+                "medium",
+            )
+        )
+    if cold:
+        out.append(
+            TyreFinding(
+                "cold",
+                f"{', '.join(w.upper() for w in cold)} below the {comp} window "
+                f"(< {window[0]:.0f}°C)",
+                "caution",
+                True,
+                "Still building heat — one or two more laps, or load the tyre harder; surface temp "
+                "(the true grip layer) is not measurable, so this is approximate.",
+                "low",
+            )
+        )
+    if fmr is not None and abs(fmr) > AXLE_IMBALANCE_C:
+        hotter = "front" if fmr > 0 else "rear"
+        out.append(
+            TyreFinding(
+                "axle_imbalance",
+                f"{hotter} axle hotter by {abs(fmr):.0f}°C",
+                "caution",
+                True,
+                f"Check the cold-pressure split first; then a {hotter}-bias hypothesis (brake "
+                "bias / ARB / camber). Ranked hypotheses, not a verdict.",
+                "medium",
+            )
+        )
+    if lmr is not None and abs(lmr) > SIDE_IMBALANCE_C:
+        out.append(
+            TyreFinding(
+                "side_imbalance",
+                f"left-right core differs by {abs(lmr):.0f}°C",
+                "info",
+                True,
+                "HIGH confound: a track with directional corners produces this naturally. Only "
+                "actionable vs a reference lap / known-symmetric circuit.",
+                "low",
+            )
+        )
+    # single-wheel outlier vs its axle pair-mate
+    for a, b in (("fl", "fr"), ("fr", "fl"), ("rl", "rr"), ("rr", "rl")):
+        if a in core and b in core and core[a] - core[b] > WHEEL_OUTLIER_C:
+            out.append(
+                TyreFinding(
+                    "wheel_outlier",
+                    f"{a.upper()} ≫ {b.upper()} by {core[a] - core[b]:.0f}°C",
+                    "caution",
+                    True,
+                    f"Check {a.upper()} cold pressure + camber vs its pair-mate; one corner is "
+                    "loading/heating asymmetrically.",
+                    "low",
+                )
+            )
+    if hot_est:
+        high = [w for w, p in hot_est.items() if p > HOT_PRESSURE_WINDOW[1]]
+        low = [w for w, p in hot_est.items() if p < HOT_PRESSURE_WINDOW[0]]
+        if high:
+            out.append(
+                TyreFinding(
+                    "hot_pressure_high",
+                    f"modelled hot pressure high on {', '.join(w.upper() for w in high)} "
+                    f"(> {HOT_PRESSURE_WINDOW[1]:.0f} psi)",
+                    "caution",
+                    False,
+                    "Drop cold pressure ~0.5 psi to bring hot pressure into the 26-29 window. "
+                    "NOTE: hot pressure is MODELLED from cold + gas-law, not measured.",
+                    "low",
+                )
+            )
+        if low:
+            out.append(
+                TyreFinding(
+                    "hot_pressure_low",
+                    f"modelled hot pressure low on {', '.join(w.upper() for w in low)} "
+                    f"(< {HOT_PRESSURE_WINDOW[0]:.0f} psi)",
+                    "caution",
+                    False,
+                    "Raise cold pressure ~0.5 psi. Modelled estimate, not measured.",
+                    "low",
+                )
+            )
+    if not out and spread <= BALANCED_SPREAD_C and mean_core >= window[0]:
+        out.append(
+            TyreFinding(
+                "balanced",
+                f"all four within {BALANCED_SPREAD_C:.0f}°C, in window",
+                "info",
+                True,
+                "Thermally balanced — no tyre tuning needed; focus on pace/consistency.",
+                "medium",
+            )
+        )
+    return out
+
+
+def tyres_from_lap_archive(archive: dict) -> TyreReport | None:
+    """Build a :class:`TyreReport` from a lap archive's per-wheel ``tyreCoreTemp_*`` trace columns.
+
+    Averages each wheel's core temp over the lap (the trace carries per-sample core temps, #266).
+    Returns None if the archive has no per-wheel temp channels. Compound/cold-pressure are read from
+    the setup snapshot when present (compound index → unknown name, so falls back to generic slick).
+    """
+    trace = archive.get("trace") if isinstance(archive, dict) else None
+    if not isinstance(trace, dict):
+        return None
+    fields = trace.get("fields")
+    samples = trace.get("samples")
+    if not isinstance(fields, list) or not isinstance(samples, list) or not samples:
+        return None
+    idx = {w: fields.index(f"tyreCoreTemp_{w}") for w in _WHEELS if f"tyreCoreTemp_{w}" in fields}
+    if not idx:
+        return None
+    sums = {w: 0.0 for w in idx}
+    counts = {w: 0 for w in idx}
+    for row in samples:
+        for w, i in idx.items():
+            try:
+                v = float(row[i])
+            except (TypeError, ValueError, IndexError):
+                continue
+            if v != 0.0:  # 0 = unread sentinel (see #266 all-zero guard)
+                sums[w] += v
+                counts[w] += 1
+    core = {w: round(sums[w] / counts[w], 1) for w in idx if counts[w] > 0}
+    if not core:
+        return None
+    setup = archive.get("setup") if isinstance(archive.get("setup"), dict) else {}
+    snap = setup.get("snapshot") if isinstance(setup.get("snapshot"), dict) else {}
+    cold = {}
+    for w in _WHEELS:
+        key = f"PRESSURE_{w.upper()}.VALUE"
+        if key in snap:
+            try:
+                cold[w] = float(snap[key])
+            except (TypeError, ValueError):
+                pass
+    return analyze_tyres(core, cold or None)

--- a/tools/ai_sidecar/tyre_model.py
+++ b/tools/ai_sidecar/tyre_model.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 _WHEELS = ("fl", "fr", "rl", "rr")
+#: Our front-corner wheel key (fl) → AC setup INI's side-corner key (LF). AC uses LF/RF/LR/RR.
+_AC_CORNER = {"fl": "LF", "fr": "RF", "rl": "LR", "rr": "RR"}
 
 # --- verified parameters (°C core, bulk-average) ---------------------------
 #: Optimal core-temp window per compound key. "slick" is the generic fallback when compound is
@@ -33,8 +35,17 @@ COMPOUND_WINDOWS: dict[str, tuple[float, float]] = {
     "slick": (75.0, 105.0),  # generic slick fallback (medium-ish)
 }
 GRIP_ONSET_C = 40.0  # below ~35-45: too cold to make meaningful grip
-DEG_WARN_C = 103.0  # 100-105 degradation-onset band (grip roll-off region)
-CRITICAL_C = 115.0  # >115 soft / ~130-140 hard: thermal-risk back-off trigger
+DEG_WARN_C = 103.0  # 100-105 degradation-onset band (grip roll-off region; soft/medium)
+#: Critical (thermal-risk back-off) core temp is COMPOUND-DEPENDENT: soft fails ~115°C, hard not
+#: until ~130-140°C. Using one 115°C limit would false-flag a hard tyre that is still fine.
+COMPOUND_CRITICAL_C: dict[str, float] = {
+    "soft": 115.0,
+    "medium": 125.0,
+    "hard": 135.0,
+    "wet": 100.0,
+    "slick": 120.0,
+}
+CRITICAL_C = COMPOUND_CRITICAL_C["soft"]  # back-compat default (most conservative)
 
 # pressure↔core coupling (ideal gas, constant V): ~+1 psi per 10 °C at GT3 pressures
 PRESSURE_PSI_PER_DEGC = 0.12
@@ -80,7 +91,9 @@ class TyreReport:
     findings: list[TyreFinding] = field(default_factory=list)
 
     def headline(self) -> str:
-        bad = [w for w, s in self.status.items() if s in ("overheat", "critical", "cold")]
+        bad = [
+            w for w, s in self.status.items() if s in ("overheat", "critical", "cold", "warming")
+        ]
         if any(self.status[w] == "critical" for w in self.status):
             return (
                 f"TYRES CRITICAL: {', '.join(w.upper() for w in bad)} over-temp — back off / box."
@@ -92,9 +105,9 @@ class TyreReport:
         return f"Tyres in window ({self.compound}, mean core {self.mean_core:.0f}°C)."
 
 
-def _status_for(core: float, window: tuple[float, float]) -> str:
+def _status_for(core: float, window: tuple[float, float], critical_c: float) -> str:
     lo, hi = window
-    if core >= CRITICAL_C:
+    if core >= critical_c:
         return "critical"
     if core > hi:
         return "overheat"
@@ -130,8 +143,9 @@ def analyze_tyres(
     """
     comp = (compound or "slick").lower()
     window = COMPOUND_WINDOWS.get(comp, COMPOUND_WINDOWS["slick"])
+    critical_c = COMPOUND_CRITICAL_C.get(comp, COMPOUND_CRITICAL_C["slick"])
     core = {w: float(core[w]) for w in _WHEELS if w in core and core[w] is not None}
-    status = {w: _status_for(core[w], window) for w in core}
+    status = {w: _status_for(core[w], window, critical_c) for w in core}
     present = list(core.values())
     mean_core = round(_mean(present), 1)
     spread = round(max(present) - min(present), 1) if present else 0.0
@@ -162,7 +176,9 @@ def analyze_tyres(
         and (rising_fast or early or laps_since_start is None)
     )
 
-    findings = _build_findings(core, status, window, comp, mean_core, fmr, lmr, spread, hot_est)
+    findings = _build_findings(
+        core, status, window, comp, critical_c, mean_core, fmr, lmr, spread, hot_est
+    )
     return TyreReport(
         compound=comp,
         window=window,
@@ -183,6 +199,7 @@ def _build_findings(
     status: dict[str, str],
     window: tuple[float, float],
     comp: str,
+    critical_c: float,
     mean_core: float,
     fmr: float | None,
     lmr: float | None,
@@ -193,15 +210,30 @@ def _build_findings(
     crit = [w for w, s in status.items() if s == "critical"]
     over = [w for w, s in status.items() if s == "overheat"]
     cold = [w for w, s in status.items() if s in ("cold", "warming")]
+    # degradation-onset band: in-window but past DEG_WARN (grip roll-off region, not yet overheat)
+    degrading = [w for w, s in status.items() if s == "in_window" and core[w] >= DEG_WARN_C]
     if crit:
         out.append(
             TyreFinding(
                 "critical",
-                f"{', '.join(w.upper() for w in crit)} core ≥ {CRITICAL_C:.0f}°C",
+                f"{', '.join(w.upper() for w in crit)} core ≥ {critical_c:.0f}°C ({comp} limit)",
                 "act",
                 True,
                 "Thermal-risk band — back off significantly or box. (A risk trigger, not a "
                 "blistering diagnosis: core is a bulk average.)",
+                "low",
+            )
+        )
+    if degrading and not over and not crit:
+        out.append(
+            TyreFinding(
+                "degradation_onset",
+                f"{', '.join(w.upper() for w in degrading)} in the {DEG_WARN_C:.0f}°C+ "
+                "degradation-onset band (top of the window)",
+                "caution",
+                True,
+                "Grip roll-off region — ease thermal load (smoother inputs) to hold the window; "
+                "watch for a lap-time creep over the next laps.",
                 "low",
             )
         )
@@ -347,10 +379,14 @@ def tyres_from_lap_archive(archive: dict) -> TyreReport | None:
     snap = setup.get("snapshot") if isinstance(setup.get("snapshot"), dict) else {}
     cold = {}
     for w in _WHEELS:
-        key = f"PRESSURE_{w.upper()}.VALUE"
+        # AC setup INI uses side-corner keys PRESSURE_LF/RF/LR/RR — wheel 'fl' maps to 'LF'.
+        key = f"PRESSURE_{_AC_CORNER[w]}.VALUE"
         if key in snap:
             try:
                 cold[w] = float(snap[key])
             except (TypeError, ValueError):
                 pass
-    return analyze_tyres(core, cold or None)
+    lap = archive.get("lap") if isinstance(archive.get("lap"), dict) else {}
+    lap_n = lap.get("lap_n")
+    laps_since = int(lap_n) if isinstance(lap_n, (int, float)) else None
+    return analyze_tyres(core, cold or None, laps_since_start=laps_since)

--- a/tools/ai_sidecar/tyre_model.py
+++ b/tools/ai_sidecar/tyre_model.py
@@ -19,6 +19,7 @@ red-team corrections are encoded here and must NOT be "simplified" away:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 _WHEELS = ("fl", "fr", "rl", "rr")
 #: Our front-corner wheel key (fl) → AC setup INI's side-corner key (LF). AC uses LF/RF/LR/RR.
@@ -35,7 +36,7 @@ COMPOUND_WINDOWS: dict[str, tuple[float, float]] = {
     "slick": (75.0, 105.0),  # generic slick fallback (medium-ish)
 }
 GRIP_ONSET_C = 40.0  # below ~35-45: too cold to make meaningful grip
-DEG_WARN_C = 103.0  # 100-105 degradation-onset band (grip roll-off region; soft/medium)
+DEG_MARGIN_C = 3.0  # degradation-onset = top this-many °C of the compound window (grip roll-off)
 #: Critical (thermal-risk back-off) core temp is COMPOUND-DEPENDENT: soft fails ~115°C, hard not
 #: until ~130-140°C. Using one 115°C limit would false-flag a hard tyre that is still fine.
 COMPOUND_CRITICAL_C: dict[str, float] = {
@@ -91,17 +92,19 @@ class TyreReport:
     findings: list[TyreFinding] = field(default_factory=list)
 
     def headline(self) -> str:
-        bad = [
-            w for w, s in self.status.items() if s in ("overheat", "critical", "cold", "warming")
-        ]
-        if any(self.status[w] == "critical" for w in self.status):
-            return (
-                f"TYRES CRITICAL: {', '.join(w.upper() for w in bad)} over-temp — back off / box."
-            )
+        # precedence: critical > overheat > warming > cold > in-window, each listing only ITS wheels
+        crit = [w for w, s in self.status.items() if s == "critical"]
+        over = [w for w, s in self.status.items() if s == "overheat"]
+        coldish = [w for w, s in self.status.items() if s in ("cold", "warming")]
+        if crit:
+            names = ", ".join(w.upper() for w in crit)
+            return f"TYRES CRITICAL: {names} over-temp — back off / box."
+        if over:
+            return f"Tyres overheating: {', '.join(w.upper() for w in over)} ({self.compound})."
         if self.warming:
             return f"Tyres warming (mean core {self.mean_core:.0f}°C) — build heat before pushing."
-        if bad:
-            return f"Tyres off-window: {', '.join(w.upper() for w in bad)} ({self.compound})."
+        if coldish:
+            return f"Tyres off-window (cold): {', '.join(w.upper() for w in coldish)}."
         return f"Tyres in window ({self.compound}, mean core {self.mean_core:.0f}°C)."
 
 
@@ -121,6 +124,15 @@ def _status_for(core: float, window: tuple[float, float], critical_c: float) -> 
 def _hot_pressure_est(cold_psi: float, core: float) -> float:
     """Modelled hot pressure: cold + gas-law coupling over the core rise from a nominal cold ref."""
     return round(cold_psi + PRESSURE_PSI_PER_DEGC * (core - _COLD_CORE_REF_C), 2)
+
+
+def _num(value: Any) -> float | None:
+    """Parse to a finite float, else None (rejects NaN/±inf so int() never crashes downstream)."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f and f not in (float("inf"), float("-inf")) else None
 
 
 def _mean(vals: list[float]) -> float:
@@ -210,8 +222,10 @@ def _build_findings(
     crit = [w for w, s in status.items() if s == "critical"]
     over = [w for w, s in status.items() if s == "overheat"]
     cold = [w for w, s in status.items() if s in ("cold", "warming")]
-    # degradation-onset band: in-window but past DEG_WARN (grip roll-off region, not yet overheat)
-    degrading = [w for w, s in status.items() if s == "in_window" and core[w] >= DEG_WARN_C]
+    # degradation-onset band: COMPOUND-AWARE — the top DEG_MARGIN_C of THIS compound's window
+    # (a hard tyre at 103°C is mid-window, not degrading; only ~107-110 is its roll-off region).
+    deg_floor = window[1] - DEG_MARGIN_C
+    degrading = [w for w, s in status.items() if s == "in_window" and core[w] >= deg_floor]
     if crit:
         out.append(
             TyreFinding(
@@ -228,8 +242,8 @@ def _build_findings(
         out.append(
             TyreFinding(
                 "degradation_onset",
-                f"{', '.join(w.upper() for w in degrading)} in the {DEG_WARN_C:.0f}°C+ "
-                "degradation-onset band (top of the window)",
+                f"{', '.join(w.upper() for w in degrading)} in the top {DEG_MARGIN_C:.0f}°C of "
+                f"the {comp} window (≥ {deg_floor:.0f}°C grip roll-off region)",
                 "caution",
                 True,
                 "Grip roll-off region — ease thermal load (smoother inputs) to hold the window; "
@@ -369,7 +383,8 @@ def tyres_from_lap_archive(archive: dict) -> TyreReport | None:
                 v = float(row[i])
             except (TypeError, ValueError, IndexError):
                 continue
-            if v != 0.0:  # 0 = unread sentinel (see #266 all-zero guard)
+            # reject NaN/±inf (float() accepts them) + the 0.0 unread sentinel (#266 all-zero guard)
+            if v == v and v not in (float("inf"), float("-inf")) and v != 0.0:
                 sums[w] += v
                 counts[w] += 1
     core = {w: round(sums[w] / counts[w], 1) for w in idx if counts[w] > 0}
@@ -387,6 +402,6 @@ def tyres_from_lap_archive(archive: dict) -> TyreReport | None:
             except (TypeError, ValueError):
                 pass
     lap = archive.get("lap") if isinstance(archive.get("lap"), dict) else {}
-    lap_n = lap.get("lap_n")
-    laps_since = int(lap_n) if isinstance(lap_n, (int, float)) else None
+    lap_num = _num(lap.get("lap_n"))  # _num rejects NaN/±inf so int() below never crashes
+    laps_since = int(lap_num) if lap_num is not None else None
     return analyze_tyres(core, cold or None, laps_since_start=laps_since)


### PR DESCRIPTION
Closes #280. The north-star **tyres** pillar: `tyre_model.py` turns per-wheel core temp (#266) + cold pressure (setup) into a pro-engineer tyre read.

## What it produces
- per-wheel **optimal-window status** (cold/warming/in_window/overheat/critical), compound-aware (soft/medium/hard/wet; unknown → generic slick);
- **warm-up vs steady** classification (from previous-lap rise + lap count);
- **overheat / critical** back-off flags;
- per-wheel / axle / side **thermal imbalance** — causes as *ranked hypotheses* (check cold pressure/camber first), with the left-right track-direction confound explicitly noted;
- a **modelled hot pressure** (cold + gas-law ~+1 psi/10 °C) flagged vs the 26-29 psi window.

## Grounded + honest
Encodes the [adversarially-verified tyre-thermal knowledge](../blob/main/docs/01_Vault/AcCopilotTrainer/03_Investigations/tyre-thermal-knowledge-2026-06-21.md) — including the red-team's gas-law correction (killed an impossible 0.35-0.55 psi/°C coupling) — and its honest limits baked into every finding: core is a **bulk average** (no surface/band temp → window calls are inferences), hot pressure is **modelled not measured**, and thermal-overheat vs mechanical-wear are **inseparable** from core alone. Findings carry `core_only` (true = computable now) + confidence.

14 tests, ruff clean. Integration into the live debrief (a tyre section in build_structured_debrief) is a thin follow-up. Deliverable 4 of the frontier coaching program. 🤖 Generated with [Claude Code](https://claude.com/claude-code)