### PR TITLE
feat(coaching): conditions→grip model — trackGripLevel normalization + regime gating (#282)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/conditions-grip-knowledge-2026-06-21.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/conditions-grip-knowledge-2026-06-21.md
@@ -1,0 +1,36 @@
+---
+type: investigation
+status: active
+created: 2026-06-21
+updated: 2026-06-21
+memory_tier: canonical
+relates_to:
+  - AcCopilotTrainer/03_Investigations/tyre-thermal-knowledge-2026-06-21.md
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/282
+---
+
+# Verified conditions→grip knowledge (for conditions_model.py)
+
+Adversarially-verified research (4 lenses → red-team that corrected several over-claims). Inputs:
+lap-archive `conditions{trackGripLevel, ambientTempC, trackTempC, weatherType}`. The corrections are
+**load-bearing** — they make the model conservative on purpose:
+
+- **`trackGripLevel` is the ONLY authoritative, persisted, cross-session-comparable scalar.**
+  Normalize on it ALONE; fresh stock session ~0.95-0.96, rubbers UP toward ~1.0 (rubber-in is the
+  main driver; base AC does NOT auto-drop it from temp/rain). Cross-band normalization is
+  **APPROXIMATE** (scalar→laptime is nonlinear/car-specific) — prefer comparing laps in the same band.
+- **AC exposes NO reliable track-temp→grip percentage.** Any `-x%/°C` figure is fabricated; the real
+  curve is per-compound, mod-dependent, on *tyre* temp (not track temp), not in the API. Temperature
+  is **qualitative/directional only** (cold → slower warm-up, grip-limited laps 1-2; hot → switches
+  on fast, overheats sooner). No grip-multiplier number, ever.
+- **Wet/snow ⇒ the slick temp/grip model is INVALID** — gate it off; coach compound + water
+  management; never "build heat aggressively" (wets run cooler).
+- **`trackTempC` / `weatherType` are nullable**; `weatherType` enum isn't standardized across base
+  AC/CSP/Sol → match defensively (lowercase substring); null weather = "unknown", not "dry".
+- `trackGripLevel` > 1.0 just means session config set grip above reference — NOT "polished track →
+  lockup" (that mechanism is fabricated). Sane band ~0.70-1.05 → outside = investigate config/data.
+
+Encoded in `tools/ai_sidecar/conditions_model.py` (regime gating + grip-band classification +
+approximate trackGripLevel normalizer + qualitative temp coaching, all findings carrying an
+`approximate` flag). Full research: session task `ww78qo452`. Deliverable 5 of the program (#282).

--- a/tests/test_conditions_model.py
+++ b/tests/test_conditions_model.py
@@ -98,6 +98,22 @@ def test_reference_temp_note_gated_by_regime():
     assert not any(f.key == "track_temp_vs_reference" for f in r.findings)
 
 
+def test_bool_grip_is_rejected_not_treated_as_1():
+    # copilot #283: float(True)==1.0 would misclassify a malformed field — bools must be rejected.
+    r = analyze_conditions(_cond(grip=True))
+    assert r.grip_level is None
+
+
+def test_temp_note_independent_of_grip_sanity():
+    # codex #283: an out-of-range grip scalar must NOT suppress the (grip-independent) temp note.
+    r = analyze_conditions(
+        _cond(grip=0.5, track=20.0, weather="dry"),
+        reference_conditions=_cond(grip=0.99, track=34.0, weather="dry"),
+    )
+    assert r.grip_level_delta is None  # grip out of range -> no grip delta
+    assert any(f.key == "track_temp_vs_reference" for f in r.findings)  # temp note still fires
+
+
 def test_grip_vs_reference_is_labeled_approximate():
     r = analyze_conditions(_cond(grip=0.94), reference_conditions=_cond(grip=0.99))
     assert r.grip_level_delta is not None and r.grip_level_delta < 0

--- a/tests/test_conditions_model.py
+++ b/tests/test_conditions_model.py
@@ -65,6 +65,16 @@ def test_normalizer_is_track_grip_clamped():
     assert analyze_conditions(_cond(grip=2.0)).normalizer() == 1.05  # clamped to sane ceiling
 
 
+def test_grip_delta_skipped_across_mismatched_regimes():
+    # codex #283: dry current vs WET reference — a trackGripLevel delta is meaningless, so skip it.
+    r = analyze_conditions(
+        _cond(grip=0.97, weather="dry"),
+        reference_conditions=_cond(grip=0.90, weather="rain"),
+    )
+    assert r.grip_level_delta is None
+    assert not any(f.key == "grip_vs_reference" for f in r.findings)
+
+
 def test_grip_vs_reference_is_labeled_approximate():
     r = analyze_conditions(_cond(grip=0.94), reference_conditions=_cond(grip=0.99))
     assert r.grip_level_delta is not None and r.grip_level_delta < 0

--- a/tests/test_conditions_model.py
+++ b/tests/test_conditions_model.py
@@ -1,0 +1,112 @@
+"""Tests for the conditions→grip model (tools.ai_sidecar.conditions_model)."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.conditions_model import (
+    analyze_conditions,
+    conditions_from_lap_archive,
+)
+
+
+def _cond(grip=0.98, track=30.0, ambient=22.0, weather="dry"):
+    return {
+        "trackGripLevel": grip,
+        "trackTempC": track,
+        "ambientTempC": ambient,
+        "weatherType": weather,
+    }
+
+
+# --- regime gating ----------------------------------------------------------
+def test_wet_regime_disables_slick_model():
+    r = analyze_conditions(_cond(weather="light_rain", track=18.0))
+    assert r.regime == "wet"
+    assert r.slick_model_valid is False
+    f = next(f for f in r.findings if f.key == "wet_regime")
+    assert "do not" in f.coaching.lower() and "build heat" in f.coaching.lower()
+    # cold-track slick advice must NOT fire in the wet
+    assert not any(f.key == "cold_track" for f in r.findings)
+
+
+def test_dry_regime_detected_defensively():
+    assert analyze_conditions(_cond(weather="Clear")).regime == "dry"
+    assert analyze_conditions(_cond(weather="overcast")).regime == "dry"
+    assert analyze_conditions(_cond(weather="Heavy Rain")).regime == "wet"
+
+
+def test_null_weather_is_unknown_not_dry():
+    r = analyze_conditions(_cond(weather=None))
+    assert r.regime == "unknown"
+    assert r.slick_model_valid is True  # unknown is treated as not-wet for slick logic
+
+
+# --- trackGripLevel bands ---------------------------------------------------
+def test_green_track_flagged():
+    r = analyze_conditions(_cond(grip=0.90))
+    assert r.grip_band == "green"
+    assert any(f.key == "green_track" for f in r.findings)
+
+
+def test_rubbered_track_is_reference_quality():
+    r = analyze_conditions(_cond(grip=0.99))
+    assert r.grip_band == "rubbered"
+    assert any(f.key == "rubbered_track" for f in r.findings)
+
+
+def test_grip_out_of_sane_range_flags_investigate():
+    r = analyze_conditions(_cond(grip=0.5))
+    assert any(f.key == "grip_out_of_range" and f.approximate for f in r.findings)
+
+
+# --- normalization (approximate) -------------------------------------------
+def test_normalizer_is_track_grip_clamped():
+    assert analyze_conditions(_cond(grip=0.97)).normalizer() == 0.97
+    assert analyze_conditions(_cond(grip=None)).normalizer() == 1.0  # unknown -> neutral
+    assert analyze_conditions(_cond(grip=2.0)).normalizer() == 1.05  # clamped to sane ceiling
+
+
+def test_grip_vs_reference_is_labeled_approximate():
+    r = analyze_conditions(_cond(grip=0.94), reference_conditions=_cond(grip=0.99))
+    assert r.grip_level_delta is not None and r.grip_level_delta < 0
+    f = next(f for f in r.findings if f.key == "grip_vs_reference")
+    assert f.approximate is True
+    assert "approximate" in f.coaching.lower()
+
+
+# --- temperature is QUALITATIVE only ----------------------------------------
+def test_cold_track_is_qualitative_no_grip_number():
+    r = analyze_conditions(_cond(track=15.0))
+    f = next(f for f in r.findings if f.key == "cold_track")
+    assert f.approximate is True
+    # no fabricated grip percentage anywhere in the coaching
+    assert "%" not in f.coaching
+
+
+def test_null_track_temp_guarded():
+    r = analyze_conditions(_cond(track=None))
+    assert r.track_temp_c is None
+    assert any(f.key == "no_track_temp" for f in r.findings)
+    assert not any(f.key in ("cold_track", "hot_track") for f in r.findings)
+
+
+def test_track_temp_vs_reference_direction_only():
+    r = analyze_conditions(_cond(track=20.0), reference_conditions=_cond(track=32.0))
+    f = next(f for f in r.findings if f.key == "track_temp_vs_reference")
+    assert "colder" in f.summary
+    assert "%" not in f.coaching  # direction only, no quantified grip change
+
+
+# --- archive integration ----------------------------------------------------
+def test_conditions_from_lap_archive():
+    archive = {"conditions": _cond(grip=0.96, track=28.0)}
+    ref = {"conditions": _cond(grip=0.99, track=34.0)}
+    r = conditions_from_lap_archive(archive, reference_archive=ref)
+    assert r.regime == "dry"
+    assert r.grip_level == 0.96
+    assert r.grip_level_delta is not None
+
+
+def test_conditions_from_archive_missing_block():
+    r = conditions_from_lap_archive({"lap": {}})
+    assert r.regime == "unknown"
+    assert r.grip_level is None

--- a/tests/test_conditions_model.py
+++ b/tests/test_conditions_model.py
@@ -75,6 +75,29 @@ def test_grip_delta_skipped_across_mismatched_regimes():
     assert not any(f.key == "grip_vs_reference" for f in r.findings)
 
 
+def test_wet_to_wet_grip_delta_suppressed():
+    # codex #283: trackGripLevel comparison doesn't transfer in the wet, even wet-vs-wet.
+    r = analyze_conditions(
+        _cond(grip=0.95, weather="rain"), reference_conditions=_cond(grip=0.92, weather="rain")
+    )
+    assert r.grip_level_delta is None
+
+
+def test_out_of_range_grip_skips_delta():
+    # codex #283: if either grip scalar is outside the sane band, the delta is unreliable -> skip.
+    r = analyze_conditions(_cond(grip=0.5), reference_conditions=_cond(grip=0.99))
+    assert r.grip_level_delta is None
+
+
+def test_reference_temp_note_gated_by_regime():
+    # codex #283: a dry-current vs WET-reference track-temp comparison must not fire.
+    r = analyze_conditions(
+        _cond(track=20.0, weather="dry"),
+        reference_conditions=_cond(track=34.0, weather="rain"),
+    )
+    assert not any(f.key == "track_temp_vs_reference" for f in r.findings)
+
+
 def test_grip_vs_reference_is_labeled_approximate():
     r = analyze_conditions(_cond(grip=0.94), reference_conditions=_cond(grip=0.99))
     assert r.grip_level_delta is not None and r.grip_level_delta < 0

--- a/tools/ai_sidecar/conditions_model.py
+++ b/tools/ai_sidecar/conditions_model.py
@@ -108,6 +108,8 @@ def _grip_band(grip: float | None) -> str:
 
 
 def _num(value: Any) -> float | None:
+    if isinstance(value, bool):  # float(True)==1.0 would silently misclassify a malformed field
+        return None
     try:
         f = float(value)
     except (TypeError, ValueError):
@@ -138,14 +140,16 @@ def analyze_conditions(
     ref_grip = _num(ref.get("trackGripLevel"))
     ref_track_t = _num(ref.get("trackTempC"))
     ref_regime = _regime(ref.get("weatherType"))
-    # A reference comparison is only meaningful when current + reference are the SAME, DRY regime
-    # (wet trackGripLevel/temp don't transfer) and both grip scalars are in the sane band. Otherwise
-    # both the grip delta AND the reference-temperature note are apples-to-oranges (codex #283).
-    comparable_ref = (
-        regime != "wet" and ref_regime == regime and _sane_grip(grip) and _sane_grip(ref_grip)
+    # Reference comparisons are only meaningful DRY-to-DRY (wet/unknown conditions don't transfer).
+    same_dry = regime == "dry" and ref_regime == "dry"
+    # The grip delta ADDITIONALLY needs both scalars in the sane band; the track-temperature note
+    # is independent of grip validity, so it gates on regime only (codex/copilot #283).
+    grip_delta = (
+        round(grip - ref_grip, 4)
+        if same_dry and _sane_grip(grip) and _sane_grip(ref_grip)
+        else None
     )
-    grip_delta = round(grip - ref_grip, 4) if comparable_ref else None
-    ref_track_for_note = ref_track_t if comparable_ref else None
+    ref_track_for_note = ref_track_t if same_dry else None
 
     findings = _build_findings(
         regime, grip, band, track_t, ambient_t, weather, grip_delta, ref_grip, ref_track_for_note
@@ -224,11 +228,11 @@ def _build_findings(
 
     # cross-session grip normalization — APPROXIMATE, trackGripLevel only
     if grip_delta is not None and abs(grip_delta) >= 0.005:
-        hotter = "higher" if grip_delta > 0 else "lower"
+        grip_dir = "higher" if grip_delta > 0 else "lower"
         out.append(
             ConditionsFinding(
                 "grip_vs_reference",
-                f"track grip {hotter} than reference by {abs(grip_delta):.3f}",
+                f"track grip {grip_dir} than reference by {abs(grip_delta):.3f}",
                 f"Part of the laptime gap is track grip ({ref_grip:.3f} → {grip:.3f}), not you — "
                 "this normalization is APPROXIMATE; ideally compare laps in the same grip band.",
                 "medium",

--- a/tools/ai_sidecar/conditions_model.py
+++ b/tools/ai_sidecar/conditions_model.py
@@ -1,0 +1,285 @@
+"""Track/weather conditions → grip model for cross-session-comparable coaching. Pure stdlib.
+
+Consumes a lap archive's ``conditions`` block (``trackGripLevel``, ``ambientTempC``, ``trackTempC``,
+``weatherType``) and produces a regime + a coarse grip normalizer + honest coaching about how
+conditions, not the driver, explain part of a lap delta.
+
+Grounded in adversarially-verified research (the red-team's corrections are LOAD-BEARING — do not
+re-introduce the precision they removed):
+
+* **``trackGripLevel`` is the ONLY authoritative, persisted, cross-session-comparable scalar.**
+  Normalize on it ALONE; the scalar→laptime mapping is nonlinear/car-specific, so any cross-band
+  comparison is **approximate** — prefer comparing laps in the *same* grip band.
+* **AC exposes NO reliable track-temp→grip percentage.** Grip-vs-temp is per-compound,
+  mod-dependent, defined on *tyre* temp (not track temp), and not in the API. So temperature here
+  is **qualitative** ("colder → slower warm-up, grip-limited early"), NEVER a grip multiplier.
+* **Wet/snow ⇒ the slick model is INVALID** — gate it off; coach compound + water management, never
+  "build heat aggressively".
+* ``trackTempC`` / ``weatherType`` are **nullable** — guard; null weather = "unknown", not "dry".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# weatherType is NOT standardized across base AC / CSP / Sol — match defensively (lowercase substr).
+_WET_TOKENS = ("damp", "rain", "wet", "snow", "storm", "shower")
+_DRY_TOKENS = ("dry", "clear", "sun", "cloud", "overcast", "fair", "mist")
+
+# trackGripLevel bands (AC native scalar; fresh stock session ~0.95-0.96, rubbers UP toward ~1.0).
+GREEN_BELOW = 0.93  # green/dusty/low-rubber — grip is the dominant limit, will build
+RUBBERED_AT = 0.985  # at/above ~ rubbered-in plateau
+SANE_GRIP = (0.70, 1.05)  # outside → "investigate config/data", not a physics claim
+
+# qualitative track-temp bands for a DRY slick (directional only; NO grip-% attached)
+TRACK_TEMP_COLD_C = 20.0
+TRACK_TEMP_HOT_C = 45.0
+TEMP_DELTA_NOTABLE_C = 6.0  # reference-vs-current track-temp gap worth a coaching note
+
+
+@dataclass(frozen=True)
+class ConditionsFinding:
+    key: str
+    summary: str
+    coaching: str
+    confidence: str  # high | medium | low
+    approximate: bool = False  # True when the statement is a coarse/qualitative inference
+
+
+@dataclass
+class ConditionsReport:
+    regime: str  # "dry" | "wet" | "unknown"
+    grip_level: float | None
+    grip_band: str  # green | building | rubbered | boosted | unknown
+    track_temp_c: float | None
+    ambient_temp_c: float | None
+    weather: str | None
+    grip_level_delta: float | None  # vs reference (approximate normalizer signal)
+    findings: list[ConditionsFinding] = field(default_factory=list)
+
+    @property
+    def slick_model_valid(self) -> bool:
+        """Slick temp/grip heuristics only apply in a dry (or unknown-but-not-wet) regime."""
+        return self.regime != "wet"
+
+    def normalizer(self) -> float:
+        """Coarse, APPROXIMATE grip normalizer (= trackGripLevel, clamped). 1.0 when unknown.
+
+        Use only to scale deltas between laps of the SAME regime, and always label the result
+        approximate — the scalar→laptime mapping is nonlinear and car/track-specific.
+        """
+        if self.grip_level is None:
+            return 1.0
+        return max(SANE_GRIP[0], min(SANE_GRIP[1], self.grip_level))
+
+    def headline(self) -> str:
+        if self.regime == "wet":
+            return f"WET/{(self.weather or 'rain')} — slick model off; coach compound + water."
+        g = (
+            f"track grip {self.grip_level:.3f} ({self.grip_band})"
+            if self.grip_level is not None
+            else "track grip unknown"
+        )
+        return f"Conditions: {self.regime}, {g}."
+
+
+def _regime(weather: Any) -> str:
+    if not isinstance(weather, str) or not weather.strip():
+        return "unknown"
+    w = weather.strip().lower()
+    if any(t in w for t in _WET_TOKENS):
+        return "wet"
+    if any(t in w for t in _DRY_TOKENS):
+        return "dry"
+    return "unknown"
+
+
+def _grip_band(grip: float | None) -> str:
+    if grip is None:
+        return "unknown"
+    if grip > 1.02:
+        return "boosted"
+    if grip >= RUBBERED_AT:
+        return "rubbered"
+    if grip < GREEN_BELOW:
+        return "green"
+    return "building"
+
+
+def _num(value: Any) -> float | None:
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f and abs(f) != float("inf") else None
+
+
+def analyze_conditions(
+    conditions: dict[str, Any] | None,
+    *,
+    reference_conditions: dict[str, Any] | None = None,
+) -> ConditionsReport:
+    """Build a :class:`ConditionsReport` from a ``conditions`` block (+ optional reference)."""
+    conditions = conditions or {}
+    grip = _num(conditions.get("trackGripLevel"))
+    track_t = _num(conditions.get("trackTempC"))
+    ambient_t = _num(conditions.get("ambientTempC"))
+    weather = conditions.get("weatherType")
+    regime = _regime(weather)
+    band = _grip_band(grip)
+
+    ref = reference_conditions or {}
+    ref_grip = _num(ref.get("trackGripLevel"))
+    ref_track_t = _num(ref.get("trackTempC"))
+    grip_delta = round(grip - ref_grip, 4) if grip is not None and ref_grip is not None else None
+
+    findings = _build_findings(
+        regime, grip, band, track_t, ambient_t, weather, grip_delta, ref_grip, ref_track_t
+    )
+    return ConditionsReport(
+        regime=regime,
+        grip_level=grip,
+        grip_band=band,
+        track_temp_c=track_t,
+        ambient_temp_c=ambient_t,
+        weather=weather if isinstance(weather, str) else None,
+        grip_level_delta=grip_delta,
+        findings=findings,
+    )
+
+
+def _build_findings(
+    regime, grip, band, track_t, ambient_t, weather, grip_delta, ref_grip, ref_track_t
+) -> list[ConditionsFinding]:
+    out: list[ConditionsFinding] = []
+    if regime == "wet":
+        out.append(
+            ConditionsFinding(
+                "wet_regime",
+                f"wet/snow regime ({weather})",
+                "Slick temp/grip model is OFF — pace is limited by the surface + compound, not "
+                "your technique or 'cold tyres'. Run an inter/wet, brake earlier, no "
+                "trail-braking, smooth throttle. Do NOT build heat aggressively (wets run cooler).",
+                "high",
+            )
+        )
+        return out  # in the wet, the slick-temp findings below do not apply
+
+    if grip is None:
+        out.append(
+            ConditionsFinding(
+                "no_grip_data",
+                "trackGripLevel missing",
+                "No track-grip data this lap — cannot normalize across sessions; compare only "
+                "within the same session.",
+                "low",
+                approximate=True,
+            )
+        )
+    else:
+        if not (SANE_GRIP[0] <= grip <= SANE_GRIP[1]):
+            out.append(
+                ConditionsFinding(
+                    "grip_out_of_range",
+                    f"trackGripLevel {grip:.3f} outside {SANE_GRIP}",
+                    "Unusual grip scalar — investigate session config / data, not a physics claim.",
+                    "low",
+                    approximate=True,
+                )
+            )
+        elif band == "green":
+            out.append(
+                ConditionsFinding(
+                    "green_track",
+                    f"low-rubber track (grip {grip:.3f})",
+                    "Track is green/low-rubber — that's the dominant limit now; grip builds over "
+                    "the session as rubber goes down. Don't over-correct setup on a green track.",
+                    "medium",
+                )
+            )
+        elif band == "rubbered":
+            out.append(
+                ConditionsFinding(
+                    "rubbered_track",
+                    f"rubbered-in (grip {grip:.3f})",
+                    "Track is rubbered-in and stable — a good reference session; deltas here "
+                    "reflect you + setup, not track state.",
+                    "medium",
+                )
+            )
+
+    # cross-session grip normalization — APPROXIMATE, trackGripLevel only
+    if grip_delta is not None and abs(grip_delta) >= 0.005:
+        hotter = "higher" if grip_delta > 0 else "lower"
+        out.append(
+            ConditionsFinding(
+                "grip_vs_reference",
+                f"track grip {hotter} than reference by {abs(grip_delta):.3f}",
+                f"Part of the laptime gap is track grip ({ref_grip:.3f} → {grip:.3f}), not you — "
+                "this normalization is APPROXIMATE; ideally compare laps in the same grip band.",
+                "medium",
+                approximate=True,
+            )
+        )
+
+    # qualitative track-temp coaching (NO grip-% — AC exposes none)
+    if track_t is None:
+        out.append(
+            ConditionsFinding(
+                "no_track_temp",
+                "trackTempC missing",
+                "No track-temp data — using the grip meter only; not inferring a temp effect.",
+                "low",
+                approximate=True,
+            )
+        )
+    else:
+        if track_t < TRACK_TEMP_COLD_C:
+            out.append(
+                ConditionsFinding(
+                    "cold_track",
+                    f"track {track_t:.0f}°C (cold for slicks)",
+                    "Cold track — tyres take extra laps to switch on; laps 1-2 feel grip-limited. "
+                    "Qualitative (AC exposes no track-temp→grip number); warm up before pushing.",
+                    "low",
+                    approximate=True,
+                )
+            )
+        elif track_t > TRACK_TEMP_HOT_C:
+            out.append(
+                ConditionsFinding(
+                    "hot_track",
+                    f"track {track_t:.0f}°C (hot)",
+                    "Hot track — tyres switch on fast but overheat sooner; manage thermal load "
+                    "with smoother inputs. Qualitative direction only.",
+                    "low",
+                    approximate=True,
+                )
+            )
+        if ref_track_t is not None and abs(track_t - ref_track_t) >= TEMP_DELTA_NOTABLE_C:
+            cooler = "colder" if track_t < ref_track_t else "hotter"
+            out.append(
+                ConditionsFinding(
+                    "track_temp_vs_reference",
+                    f"track {abs(track_t - ref_track_t):.0f}°C {cooler} than reference",
+                    f"Track is {cooler} than your reference lap — expect a different tyre warm-up/"
+                    "thermal balance; treat early-lap grip differences as conditions, not you. "
+                    "Direction only, not a quantified grip change.",
+                    "low",
+                    approximate=True,
+                )
+            )
+    return out
+
+
+def conditions_from_lap_archive(
+    archive: dict, *, reference_archive: dict | None = None
+) -> ConditionsReport:
+    """Build a :class:`ConditionsReport` from a lap archive's conditions (+ optional reference)."""
+    cond = archive.get("conditions") if isinstance(archive, dict) else None
+    ref = reference_archive.get("conditions") if isinstance(reference_archive, dict) else None
+    return analyze_conditions(
+        cond if isinstance(cond, dict) else None,
+        reference_conditions=ref if isinstance(ref, dict) else None,
+    )

--- a/tools/ai_sidecar/conditions_model.py
+++ b/tools/ai_sidecar/conditions_model.py
@@ -115,6 +115,11 @@ def _num(value: Any) -> float | None:
     return f if f == f and abs(f) != float("inf") else None
 
 
+def _sane_grip(grip: float | None) -> bool:
+    """True when a trackGripLevel is present and within the sane band (else not comparable)."""
+    return grip is not None and SANE_GRIP[0] <= grip <= SANE_GRIP[1]
+
+
 def analyze_conditions(
     conditions: dict[str, Any] | None,
     *,
@@ -132,18 +137,18 @@ def analyze_conditions(
     ref = reference_conditions or {}
     ref_grip = _num(ref.get("trackGripLevel"))
     ref_track_t = _num(ref.get("trackTempC"))
-    # Cross-regime comparison is apples-to-oranges (a dry lap vs a WET reference): trackGripLevel
-    # doesn't explain the gap. Only emit a grip delta when current + reference are the SAME regime.
     ref_regime = _regime(ref.get("weatherType"))
-    same_regime = regime == ref_regime
-    grip_delta = (
-        round(grip - ref_grip, 4)
-        if grip is not None and ref_grip is not None and same_regime
-        else None
+    # A reference comparison is only meaningful when current + reference are the SAME, DRY regime
+    # (wet trackGripLevel/temp don't transfer) and both grip scalars are in the sane band. Otherwise
+    # both the grip delta AND the reference-temperature note are apples-to-oranges (codex #283).
+    comparable_ref = (
+        regime != "wet" and ref_regime == regime and _sane_grip(grip) and _sane_grip(ref_grip)
     )
+    grip_delta = round(grip - ref_grip, 4) if comparable_ref else None
+    ref_track_for_note = ref_track_t if comparable_ref else None
 
     findings = _build_findings(
-        regime, grip, band, track_t, ambient_t, weather, grip_delta, ref_grip, ref_track_t
+        regime, grip, band, track_t, ambient_t, weather, grip_delta, ref_grip, ref_track_for_note
     )
     return ConditionsReport(
         regime=regime,

--- a/tools/ai_sidecar/conditions_model.py
+++ b/tools/ai_sidecar/conditions_model.py
@@ -132,7 +132,15 @@ def analyze_conditions(
     ref = reference_conditions or {}
     ref_grip = _num(ref.get("trackGripLevel"))
     ref_track_t = _num(ref.get("trackTempC"))
-    grip_delta = round(grip - ref_grip, 4) if grip is not None and ref_grip is not None else None
+    # Cross-regime comparison is apples-to-oranges (a dry lap vs a WET reference): trackGripLevel
+    # doesn't explain the gap. Only emit a grip delta when current + reference are the SAME regime.
+    ref_regime = _regime(ref.get("weatherType"))
+    same_regime = regime == ref_regime
+    grip_delta = (
+        round(grip - ref_grip, 4)
+        if grip is not None and ref_grip is not None and same_regime
+        else None
+    )
 
     findings = _build_findings(
         regime, grip, band, track_t, ambient_t, weather, grip_delta, ref_grip, ref_track_t


### PR DESCRIPTION
Closes #282. The north-star **conditions** pillar — and a study in *not inventing physics*. The adversarially-verified research forced a conservative model:

- **`trackGripLevel` is the only authoritative cross-session scalar** → normalize on it alone, labeled **approximate**; prefer comparing laps in the same grip band. Bands: green/building/rubbered/boosted.
- **AC exposes no reliable track-temp→grip %** → temperature is **qualitative/directional only** (cold → slower warm-up, grip-limited laps 1-2; hot → overheats sooner). The red-team killed fabricated `-x%/°C` figures; there is **no grip-multiplier number** anywhere.
- **Wet/snow → slick model OFF** (gate it; coach compound + water, never 'build heat').
- Nullable `trackTempC`/`weatherType` guarded; defensive (lowercase-substring) weather matching; null = 'unknown', not 'dry'.

Every finding carries an `approximate` flag so the coach never overstates a conditions inference. 13 tests, ruff clean. Knowledge node banked in the vault. Deliverable 5 of the frontier coaching program. 🤖 Generated with [Claude Code](https://claude.com/claude-code)