### PR TITLE
fix: align weekly miner policy

### DIFF
--- a/.github/workflows/process-miner.yml
+++ b/.github/workflows/process-miner.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::GH_PAT is not configured for this repo — cannot open a PR (default GITHUB_TOKEN is blocked by policy)."
+            echo "::error::GH_TOKEN is not available from the fleet GitHub App token step -- cannot open a PR (default GITHUB_TOKEN is blocked by policy). Check FLEET_BOT_APP_ID/FLEET_BOT_APP_PRIVATE_KEY secrets and app permissions."
             exit 1
           fi
           BRANCH="chore/miner-weekly-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"

--- a/.github/workflows/process-miner.yml
+++ b/.github/workflows/process-miner.yml
@@ -77,7 +77,7 @@ jobs:
             echo "::error::GH_PAT is not configured for this repo — cannot open a PR (default GITHUB_TOKEN is blocked by policy)."
             exit 1
           fi
-          BRANCH="miner/weekly-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
+          BRANCH="chore/miner-weekly-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
           git checkout -b "$BRANCH"
           git add .claude/rules/learned .cursor/rules/learned reports/process_miner AGENTS.md || true
           if git diff --cached --quiet; then

--- a/scripts/ci_policy.py
+++ b/scripts/ci_policy.py
@@ -37,6 +37,9 @@ ALLOWED_BRANCH_PREFIXES: tuple[str, ...] = (
     "renovate/",
     "sanitize/",  # urgent privacy/metadata scrub branches (e.g. PR #113)
     "vault/",  # vault-only post-merge handoff branches
+    # Existing weekly process-miner PRs used `miner/weekly-*`; keep them
+    # mergeable while the producer moves to `chore/miner-weekly-*`.
+    "miner/",
 )
 
 # Conventional commit style for PR titles (type, optional scope, optional !, colon, message).

--- a/scripts/ci_policy.py
+++ b/scripts/ci_policy.py
@@ -39,7 +39,7 @@ ALLOWED_BRANCH_PREFIXES: tuple[str, ...] = (
     "vault/",  # vault-only post-merge handoff branches
     # Existing weekly process-miner PRs used `miner/weekly-*`; keep them
     # mergeable while the producer moves to `chore/miner-weekly-*`.
-    "miner/",
+    "miner/weekly-",
 )
 
 # Conventional commit style for PR titles (type, optional scope, optional !, colon, message).

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -47,6 +47,7 @@ def test_validate_branch_accepts_allowed(ci_policy_mod, branch: str) -> None:
         ("main", "must not be 'main'"),
         ("wrong-branch", "must start with one of"),
         ("feature/foo", "must start with one of"),
+        ("miner/not-weekly", "must start with one of"),
         ("", "must not be empty"),
     ],
 )

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -34,7 +34,7 @@ def ci_policy_mod():
         "cursor/feat_issue-1_x",
         "renovate/configure",
         "vault/post-merge-pr176",
-        "miner/weekly-20260622-27948235804",
+        "miner/weekly-legacy",
     ],
 )
 def test_validate_branch_accepts_allowed(ci_policy_mod, branch: str) -> None:

--- a/tests/test_ci_policy.py
+++ b/tests/test_ci_policy.py
@@ -34,6 +34,7 @@ def ci_policy_mod():
         "cursor/feat_issue-1_x",
         "renovate/configure",
         "vault/post-merge-pr176",
+        "miner/weekly-20260622-27948235804",
     ],
 )
 def test_validate_branch_accepts_allowed(ci_policy_mod, branch: str) -> None:


### PR DESCRIPTION
Refs agorokh/template-repo#370.

## Summary
- switch weekly process-miner branches from miner/weekly-* to chore/miner-weekly-*
- temporarily allow miner/ so the current weekly miner PR can re-run against fixed base policy
- add a ci_policy regression case for the current miner branch

## Verification
- python3 -m pytest tests/test_ci_policy.py
- PATH=.venv/bin:$PATH make ci-fast