### PR TITLE
feat(coaching): per-corner track reference envelope (GGV optimal + corpus best) (#286)

### DIFF
--- a/tests/test_track_reference.py
+++ b/tests/test_track_reference.py
@@ -1,0 +1,127 @@
+"""Tests for the per-corner track reference envelope (tools.ai_sidecar.track_reference)."""
+
+from __future__ import annotations
+
+import math
+
+from tools.ai_sidecar.lap_dynamics import LapTrace
+from tools.ai_sidecar.track_reference import (
+    add_corpus_lap,
+    build_references,
+    score_lap,
+)
+
+
+def _corner_lap(
+    *, v_apex: float = 25.0, v_straight: float = 55.0, brake_from: int = 25
+) -> LapTrace:
+    """A straight→single-corner→straight LapTrace (one clean apex) at a given apex speed."""
+    radius, ds, n_pre, n_arc, n_post = 30.0, 2.0, 40, 30, 40
+    n = n_pre + n_arc + n_post
+    kappa = [0.0] * n_pre + [1.0 / radius] * n_arc + [0.0] * n_post
+    theta, x, z = 0.0, 0.0, 0.0
+    xs, zs = [], []
+    for i in range(n):
+        xs.append(x)
+        zs.append(z)
+        theta += kappa[i] * ds
+        x += ds * math.cos(theta)
+        z += ds * math.sin(theta)
+    apex_i = n_pre + n_arc // 2
+    v = []
+    for i in range(n):
+        if i < brake_from:
+            v.append(v_straight)
+        elif i < apex_i:
+            v.append(
+                v_straight + (v_apex - v_straight) * (i - brake_from) / max(1, apex_i - brake_from)
+            )
+        elif i < n_pre + n_arc + 5:
+            v.append(
+                v_apex + (v_straight - v_apex) * (i - apex_i) / max(1, n_pre + n_arc + 5 - apex_i)
+            )
+        else:
+            v.append(v_straight)
+    brake = [0.8 if brake_from <= i < apex_i else 0.0 for i in range(n)]
+    throttle = [1.0 if i >= apex_i + 1 else 0.0 for i in range(n)]
+    steer = [0.4 if n_pre <= i < n_pre + n_arc else 0.0 for i in range(n)]
+    t_s = [0.0]
+    for i in range(1, n):
+        t_s.append(t_s[-1] + ds / max(0.5, 0.5 * (v[i] + v[i - 1])))
+    spline = [(ds * i) / (ds * (n - 1)) for i in range(n)]
+    return LapTrace(
+        spline=spline,
+        t_s=t_s,
+        v_ms=v,
+        brake=brake,
+        throttle=throttle,
+        steer=steer,
+        gear=[4] * n,
+        x=xs,
+        z=zs,
+    )
+
+
+def test_build_references_captures_optimal_apex():
+    optimal = _corner_lap(v_apex=30.0)  # the GGV-optimal line carries 30 m/s = 108 km/h at apex
+    refs = build_references(optimal)
+    assert len(refs) == 1
+    assert refs[0].optimal_apex_kmh == _approx_kmh(30.0)
+    # with no corpus yet, the realistic target IS the GGV optimum
+    assert refs[0].target_apex_kmh == refs[0].optimal_apex_kmh
+    assert refs[0].best_observed_apex_kmh is None
+
+
+def test_corpus_keeps_the_fastest_apex():
+    refs = build_references(_corner_lap(v_apex=30.0))
+    add_corpus_lap(refs, _corner_lap(v_apex=24.0))  # slow lap
+    add_corpus_lap(refs, _corner_lap(v_apex=28.0))  # faster lap
+    assert refs[0].best_observed_apex_kmh == _approx_kmh(28.0)
+    assert refs[0].n_corpus == 2
+    assert refs[0].target_apex_kmh == _approx_kmh(28.0)  # target is now the corpus best
+    assert refs[0].best_brake_point_spline is not None
+
+
+def test_partial_lap_does_not_reset_a_faster_best():
+    refs = build_references(_corner_lap(v_apex=30.0))
+    add_corpus_lap(refs, _corner_lap(v_apex=28.0))
+    best_before = refs[0].best_observed_apex_kmh
+    # a lap with NO samples in the corner window must not overwrite the best
+    empty = LapTrace(
+        [0.0, 0.001],
+        [0.0, 0.1],
+        [50.0, 50.0],
+        [0, 0],
+        [1, 1],
+        [0, 0],
+        [4, 4],
+        [0.0, 1.0],
+        [0.0, 0.0],
+    )
+    add_corpus_lap(refs, empty)
+    assert refs[0].best_observed_apex_kmh == best_before
+
+
+def test_score_lap_flags_apex_deficit_vs_target():
+    refs = build_references(_corner_lap(v_apex=30.0))
+    add_corpus_lap(refs, _corner_lap(v_apex=29.0))  # realistic best ~104 km/h
+    driven = _corner_lap(v_apex=23.0)  # ~6 km/h under target... actually ~22 km/h
+    scores = score_lap(refs, driven)
+    assert len(scores) == 1
+    s = scores[0]
+    assert s.deficit_to_target_kmh > 0
+    assert any("under the best lap" in f for f in s.findings)
+    assert "vs target" in s.headline
+
+
+def test_score_lap_on_target_no_finding():
+    refs = build_references(_corner_lap(v_apex=30.0))
+    add_corpus_lap(refs, _corner_lap(v_apex=30.0))
+    scores = score_lap(refs, _corner_lap(v_apex=30.0))
+    assert scores[0].deficit_to_target_kmh < 2.0
+    assert scores[0].findings == []
+    assert "on target" in scores[0].headline
+
+
+def _approx_kmh(v_ms: float) -> float:
+    return round(v_ms * 3.6, 1)

--- a/tests/test_track_reference.py
+++ b/tests/test_track_reference.py
@@ -104,8 +104,8 @@ def test_partial_lap_does_not_reset_a_faster_best():
 
 def test_score_lap_flags_apex_deficit_vs_target():
     refs = build_references(_corner_lap(v_apex=30.0))
-    add_corpus_lap(refs, _corner_lap(v_apex=29.0))  # realistic best ~104 km/h
-    driven = _corner_lap(v_apex=23.0)  # ~6 km/h under target... actually ~22 km/h
+    add_corpus_lap(refs, _corner_lap(v_apex=29.0))  # realistic best target ~104 km/h (29 m/s)
+    driven = _corner_lap(v_apex=23.0)  # ~83 km/h apex → ~22 km/h under the target
     scores = score_lap(refs, driven)
     assert len(scores) == 1
     s = scores[0]

--- a/tools/ai_sidecar/track_reference.py
+++ b/tools/ai_sidecar/track_reference.py
@@ -1,0 +1,154 @@
+"""Per-corner track reference envelope: GGV optimal + human-corpus best. Pure stdlib.
+
+The "track nuances" pillar. For each corner of a track it holds:
+  * the **GGV optimal** apex speed — the theoretical min-time target from the friction-circle QSS
+    profile (``ggv_profile.ggv_speed_profile_from_model``). A *ceiling*, not a guaranteed-achievable
+    number (the live car is TC-off traction-limited below it — see the #244 frontier diagnostics).
+  * the **corpus best** — the fastest apex speed + earliest sustainable brake point observed across
+    a set of human/AI laps. The realistic, demonstrated target.
+
+The coaching layer scores a driven corner against both ("apex 6 km/h under the best lap, 9 under the
+GGV optimum; brake ~4 m later"). Built by composing already-verified pieces — the GGV profile and
+``lap_dynamics`` corner segmentation — so nothing new is asserted about the physics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tools.ai_sidecar.lap_dynamics import LapTrace, segment_corners
+
+
+@dataclass
+class CornerReference:
+    """The optimal + best-observed envelope for one corner, keyed by its spline window."""
+
+    index: int
+    apex_spline: float
+    spline_lo: float
+    spline_hi: float
+    optimal_apex_kmh: float  # GGV QSS theoretical ceiling
+    best_observed_apex_kmh: float | None = None  # fastest corpus lap through this window
+    best_brake_point_spline: float | None = None  # earliest sustained brake of the best corpus lap
+    n_corpus: int = 0
+
+    @property
+    def target_apex_kmh(self) -> float:
+        """The realistic target: corpus best when known, else the GGV optimum."""
+        return (
+            self.best_observed_apex_kmh
+            if self.best_observed_apex_kmh is not None
+            else self.optimal_apex_kmh
+        )
+
+
+def _min_speed_kmh_in_window(lap: LapTrace, lo: float, hi: float) -> float | None:
+    """Slowest speed (km/h) of ``lap`` within the spline window [lo, hi], or None if no samples."""
+    vals = [lap.v_ms[i] for i in range(len(lap)) if lo <= lap.spline[i] <= hi]
+    return min(vals) * 3.6 if vals else None
+
+
+def _first_brake_spline(lap: LapTrace, lo: float, hi: float, thresh: float = 0.05) -> float | None:
+    """Spline of the first braking sample within [lo, hi] (the corpus lap's brake point)."""
+    for i in range(len(lap)):
+        if lo <= lap.spline[i] <= hi and lap.brake[i] > thresh:
+            return lap.spline[i]
+    return None
+
+
+def build_references(optimal_lap: LapTrace) -> list[CornerReference]:
+    """Build the GGV-optimal corner envelope from an optimal-line :class:`LapTrace`.
+
+    ``optimal_lap`` is a LapTrace whose ``v_ms`` is the GGV QSS profile over the racing line (build
+    it from ``ggv_speed_profile_from_model`` + the fast_lane geometry). Corner windows + apexes come
+    from the verified ``lap_dynamics.segment_corners``; the optimal apex speed is the profile min
+    in each window.
+    """
+    refs: list[CornerReference] = []
+    for idx, (entry_i, apex_i, exit_i) in enumerate(segment_corners(optimal_lap)):
+        refs.append(
+            CornerReference(
+                index=idx,
+                apex_spline=optimal_lap.spline[apex_i],
+                spline_lo=optimal_lap.spline[entry_i],
+                spline_hi=optimal_lap.spline[exit_i],
+                optimal_apex_kmh=round(optimal_lap.v_ms[apex_i] * 3.6, 1),
+            )
+        )
+    return refs
+
+
+def add_corpus_lap(references: list[CornerReference], lap: LapTrace) -> None:
+    """Fold one corpus lap into the references in place: keep the FASTEST apex per corner window.
+
+    A lap is only credited to a corner when it actually has samples in that window (a partial lap
+    doesn't reset a faster prior best).
+    """
+    for ref in references:
+        v = _min_speed_kmh_in_window(lap, ref.spline_lo, ref.spline_hi)
+        if v is None:
+            continue
+        ref.n_corpus += 1
+        if ref.best_observed_apex_kmh is None or v > ref.best_observed_apex_kmh:
+            ref.best_observed_apex_kmh = round(v, 1)
+            ref.best_brake_point_spline = _first_brake_spline(lap, ref.spline_lo, ref.spline_hi)
+
+
+@dataclass
+class CornerScore:
+    """How a driven corner compares to its reference envelope."""
+
+    index: int
+    apex_spline: float
+    driven_apex_kmh: float
+    target_apex_kmh: float
+    optimal_apex_kmh: float
+    deficit_to_target_kmh: float  # >0 = driver carried LESS than the realistic target
+    deficit_to_optimal_kmh: float
+    headline: str
+    findings: list[str] = field(default_factory=list)
+
+
+def score_lap(
+    references: list[CornerReference], lap: LapTrace, *, notable_kmh: float = 2.0
+) -> list[CornerScore]:
+    """Score each reference corner against a driven lap: apex-speed deficit vs target + optimum."""
+    scores: list[CornerScore] = []
+    for ref in references:
+        driven = _min_speed_kmh_in_window(lap, ref.spline_lo, ref.spline_hi)
+        if driven is None:
+            continue
+        target = ref.target_apex_kmh
+        d_target = round(target - driven, 1)
+        d_opt = round(ref.optimal_apex_kmh - driven, 1)
+        findings: list[str] = []
+        if d_target >= notable_kmh:
+            src = "best lap" if ref.best_observed_apex_kmh is not None else "GGV optimum"
+            findings.append(
+                f"apex {d_target:.0f} km/h under the {src} ({driven:.0f} vs {target:.0f}) — "
+                "carry more entry speed (if grip is available)."
+            )
+        if ref.best_observed_apex_kmh is not None and d_opt - d_target >= notable_kmh:
+            findings.append(
+                f"even the best lap is {d_opt - d_target:.0f} km/h under the GGV ceiling here — a "
+                "setup/grip ceiling, not just technique."
+            )
+        head = (
+            f"C{ref.index} (apex {ref.apex_spline:.2f}): on target."
+            if d_target < notable_kmh
+            else f"C{ref.index} (apex {ref.apex_spline:.2f}): -{d_target:.0f} km/h vs target."
+        )
+        scores.append(
+            CornerScore(
+                index=ref.index,
+                apex_spline=ref.apex_spline,
+                driven_apex_kmh=round(driven, 1),
+                target_apex_kmh=round(target, 1),
+                optimal_apex_kmh=ref.optimal_apex_kmh,
+                deficit_to_target_kmh=d_target,
+                deficit_to_optimal_kmh=d_opt,
+                headline=head,
+                findings=findings,
+            )
+        )
+    return scores

--- a/tools/ai_sidecar/track_reference.py
+++ b/tools/ai_sidecar/track_reference.py
@@ -48,10 +48,25 @@ def _min_speed_kmh_in_window(lap: LapTrace, lo: float, hi: float) -> float | Non
     return min(vals) * 3.6 if vals else None
 
 
-def _first_brake_spline(lap: LapTrace, lo: float, hi: float, thresh: float = 0.05) -> float | None:
-    """Spline of the first braking sample within [lo, hi] (the corpus lap's brake point)."""
-    for i in range(len(lap)):
-        if lo <= lap.spline[i] <= hi and lap.brake[i] > thresh:
+def _first_brake_spline(
+    lap: LapTrace, lo: float, hi: float, thresh: float = 0.05, min_run: int = 3
+) -> float | None:
+    """Spline of the first SUSTAINED braking onset within [lo, hi] (the corpus lap's brake point).
+
+    Requires ``min_run`` consecutive in-window samples above ``thresh`` so a single-frame blip is
+    not taken as the brake point — consistent with ``lap_dynamics`` treating a brake zone as
+    near-continuous rather than a lone sample.
+    """
+    n = len(lap)
+    for i in range(n):
+        if not (lo <= lap.spline[i] <= hi and lap.brake[i] > thresh):
+            continue
+        run = 1
+        j = i + 1
+        while j < n and lap.spline[j] <= hi and lap.brake[j] > thresh:
+            run += 1
+            j += 1
+        if run >= min_run:
             return lap.spline[i]
     return None
 


### PR DESCRIPTION
Closes #286. The north-star **track nuances** pillar — and pure composition of *already-verified* pieces (no new physics asserted): the GGV QSS optimal (`ggv_profile`) + corner segmentation (`lap_dynamics`).

## What it does
- **`build_references(optimal_lap)`** → per-corner `CornerReference` {apex spline-window, `optimal_apex_kmh` (GGV ceiling)}.
- **`add_corpus_lap(refs, lap)`** → folds human/AI laps in, keeping the **fastest** apex per corner + its brake point; a partial lap never resets a faster best.
- **`score_lap(refs, driven)`** → per-corner apex deficit vs the **realistic target** (corpus best, else GGV), and flags when *even the best lap* is under the GGV ceiling — i.e. a setup/grip limit, not technique.

Honest caveat baked in: the GGV optimum is a *theoretical ceiling* (the live car is TC-off traction-limited below it, per the #244 diagnostics), so the corpus best is the realistic target. 5 tests, ruff clean. Deliverable 6 of the frontier coaching program. 🤖 Generated with [Claude Code](https://claude.com/claude-code)