### PR TITLE
feat(coaching): structured coach-handoff protocol — versioned per-corner verdict (#289)

### DIFF
--- a/tests/test_coach_handoff.py
+++ b/tests/test_coach_handoff.py
@@ -44,23 +44,59 @@ def test_envelope_is_versioned_and_well_formed_even_when_empty():
 
 
 def test_braking_loss_suggests_front_bias_rearward_for_911():
+    # real brain output for braking is "setup+technique" (both causes present) — use the real value
     corners = [
         {
             "index": 0,
             "apex_spline": 0.3,
             "time_loss_s": 0.4,
             "headline": "C0",
-            "attributions": [_attr("braking_phase_loss", "setup", advisory=True)],
+            "attributions": [_attr("braking_phase_loss", "setup+technique", advisory=True)],
         }
     ]
     h = build_coach_handoff(_structured(corners), setup=SETUP)
     c = h["corners"][0]
-    assert c["cause_class"] == "setup"
+    assert c["cause_class"] == "setup+technique"  # mixed class forwarded verbatim (v1 enum)
     d = c["suggested_setup_delta"]
     assert d["section"] == "FRONT_BIAS"
-    assert d["direction"] == "decrease"  # 66% > 58% -> rearward
+    assert d["direction"] == "decrease"  # suspected + 911 + 66% > 58% -> rearward
     assert "50-56" in d["rationale"]
     assert c["advisory"] is True
+
+
+def test_braking_bias_decrease_is_gated_to_the_911():
+    # a non-911 car with the same high bias must NOT get the 911-specific rearward advice
+    corners = [
+        {
+            "index": 0,
+            "apex_spline": 0.3,
+            "time_loss_s": 0.4,
+            "headline": "C0",
+            "attributions": [_attr("braking_phase_loss", "setup+technique", advisory=True)],
+        }
+    ]
+    h = build_coach_handoff(_structured(corners, car="ferrari_488_gt3"), setup=SETUP)
+    d = h["corners"][0]["suggested_setup_delta"]
+    assert d["section"] == "FRONT_BIAS"
+    assert d["direction"] == "investigate"  # not "decrease" — car-specific target
+    assert "50-56" not in d["rationale"]
+
+
+def test_confirmed_braking_defers_to_the_brain_not_the_bias_number():
+    # advisory=False -> per-wheel slip confirmed the axle; do NOT guess "decrease" from bias alone
+    corners = [
+        {
+            "index": 0,
+            "apex_spline": 0.3,
+            "time_loss_s": 0.4,
+            "headline": "C0",
+            "attributions": [_attr("braking_phase_loss", "setup+technique", advisory=False)],
+        }
+    ]
+    h = build_coach_handoff(_structured(corners), setup=SETUP)  # 911, bias 66 > 58
+    d = h["corners"][0]["suggested_setup_delta"]
+    assert d["direction"] == "investigate"  # respects the confirmed diagnosis
+    assert "FORWARD" in d["rationale"] or "follow" in d["rationale"].lower()
 
 
 def test_technique_corner_suggests_no_setup_change():
@@ -129,6 +165,7 @@ def test_braking_loss_without_setup_is_investigate():
         },
     ]
     # no CarSetup supplied -> can't read bias -> "investigate", not a specific direction
+    corners[0]["attributions"][0]["advisory"] = True  # suspected, but no bias data
     d = build_coach_handoff(_structured(corners))["corners"][0]["suggested_setup_delta"]
     assert d["section"] == "FRONT_BIAS"
     assert d["direction"] == "investigate"

--- a/tests/test_coach_handoff.py
+++ b/tests/test_coach_handoff.py
@@ -1,0 +1,183 @@
+"""Tests for the structured coach-handoff protocol (tools.ai_sidecar.coach_handoff)."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.coach_handoff import COACH_HANDOFF_VERSION, build_coach_handoff
+from tools.ai_sidecar.setup_model import from_snapshot
+
+
+def _attr(key, cause_class, **kw):
+    base = {
+        "key": key,
+        "symptom": kw.get("symptom", key),
+        "phase": kw.get("phase", "entry"),
+        "cause_class": cause_class,
+        "confidence": kw.get("confidence", 0.8),
+        "advisory": kw.get("advisory", False),
+        "coaching": kw.get("coaching", "do the thing"),
+        "setup_causes": kw.get("setup_causes", []),
+        "technique_causes": kw.get("technique_causes", []),
+    }
+    return base
+
+
+def _structured(corners, *, car="ks_porsche_911_gt3_r_2016", track="magione"):
+    return {
+        "text": "debrief",
+        "car_id": car,
+        "track_id": track,
+        "balance": {"verdict": "mechanical_all_speed", "lever_class": "mechanical"},
+        "corners": corners,
+    }
+
+
+SETUP = from_snapshot({"FRONT_BIAS.VALUE": "66", "DIFF_POWER.VALUE": "45", "TYRES.VALUE": "1"})
+
+
+def test_envelope_is_versioned_and_well_formed_even_when_empty():
+    h = build_coach_handoff(None, lap=3)
+    assert h["v"] == COACH_HANDOFF_VERSION
+    assert h["lap"] == 3
+    assert h["corners"] == []
+    assert h["total_time_lost_s"] is None
+    assert h["top_focus_corner"] is None
+
+
+def test_braking_loss_suggests_front_bias_rearward_for_911():
+    corners = [
+        {
+            "index": 0,
+            "apex_spline": 0.3,
+            "time_loss_s": 0.4,
+            "headline": "C0",
+            "attributions": [_attr("braking_phase_loss", "setup", advisory=True)],
+        }
+    ]
+    h = build_coach_handoff(_structured(corners), setup=SETUP)
+    c = h["corners"][0]
+    assert c["cause_class"] == "setup"
+    d = c["suggested_setup_delta"]
+    assert d["section"] == "FRONT_BIAS"
+    assert d["direction"] == "decrease"  # 66% > 58% -> rearward
+    assert "50-56" in d["rationale"]
+    assert c["advisory"] is True
+
+
+def test_technique_corner_suggests_no_setup_change():
+    corners = [
+        {
+            "index": 1,
+            "apex_spline": 0.5,
+            "time_loss_s": 0.2,
+            "headline": "C1",
+            "attributions": [_attr("entry_speed_left", "technique")],
+        }
+    ]
+    h = build_coach_handoff(_structured(corners), setup=SETUP)
+    assert h["corners"][0]["suggested_setup_delta"] is None
+
+
+def test_grip_limited_suggests_grip_levers():
+    corners = [
+        {
+            "index": 2,
+            "apex_spline": 0.7,
+            "time_loss_s": 0.1,
+            "headline": "C2",
+            "attributions": [_attr("grip_limited", "grip")],
+        }
+    ]
+    d = build_coach_handoff(_structured(corners), setup=SETUP)["corners"][0][
+        "suggested_setup_delta"
+    ]
+    assert d["direction"] == "increase_grip"
+    assert "TYRES" in d["section"] or "WING" in d["section"]
+
+
+def test_lap_summary_picks_biggest_time_loss():
+    corners = [
+        {
+            "index": 0,
+            "apex_spline": 0.1,
+            "time_loss_s": 0.15,
+            "headline": "C0",
+            "attributions": [_attr("entry_speed_left", "technique")],
+        },
+        {
+            "index": 1,
+            "apex_spline": 0.4,
+            "time_loss_s": 0.55,
+            "headline": "C1",
+            "attributions": [_attr("braking_phase_loss", "setup")],
+        },
+        {"index": 2, "apex_spline": 0.8, "time_loss_s": 0.0, "headline": "C2", "attributions": []},
+    ]
+    h = build_coach_handoff(_structured(corners), setup=SETUP, lap=5)
+    assert h["top_focus_corner"] == 1  # biggest loser
+    assert h["total_time_lost_s"] == 0.7  # 0.15 + 0.55 (the 0.0 corner excluded)
+    assert h["corners"][2]["cause_class"] == "none"  # no attributions -> on pace
+
+
+def test_braking_loss_without_setup_is_investigate():
+    corners = [
+        {
+            "index": 0,
+            "apex_spline": 0.3,
+            "time_loss_s": 0.4,
+            "headline": "C0",
+            "attributions": [_attr("braking_phase_loss", "setup")],
+        },
+    ]
+    # no CarSetup supplied -> can't read bias -> "investigate", not a specific direction
+    d = build_coach_handoff(_structured(corners))["corners"][0]["suggested_setup_delta"]
+    assert d["section"] == "FRONT_BIAS"
+    assert d["direction"] == "investigate"
+
+
+def test_end_to_end_from_build_structured_debrief():
+    # integration: the real brain output flows into the handoff envelope
+    import math
+
+    from tools.ai_sidecar.coach_report import build_structured_debrief
+
+    n = 110
+    kappa = [0.0] * 40 + [1 / 30] * 30 + [0.0] * 40
+    theta = x = z = 0.0
+    xs, zs = [], []
+    for i in range(n):
+        xs.append(x)
+        zs.append(z)
+        theta += kappa[i] * 2.0
+        x += 2.0 * math.cos(theta)
+        z += 2.0 * math.sin(theta)
+    v = [55.0 if i < 25 or i > 75 else 25.0 for i in range(n)]
+    t_ms, t = [0.0], 0.0
+    for i in range(1, n):
+        t += 2.0 / max(0.5, 0.5 * (v[i] + v[i - 1]))
+        t_ms.append(t * 1000)
+    fields = ["spline", "speed", "eMs", "throttle", "brake", "steer", "gear", "px", "py", "pz"]
+    samples = [
+        [
+            i / (n - 1),
+            v[i] * 3.6,
+            t_ms[i],
+            1.0 if i > 55 else 0.0,
+            0.8 if 25 <= i < 55 else 0.0,
+            0.4 if 40 <= i < 70 else 0.0,
+            4,
+            xs[i],
+            0.0,
+            zs[i],
+        ]
+        for i in range(n)
+    ]
+    archive = {
+        "car": {"id": "x"},
+        "track": {"id": "magione"},
+        "setup": {"snapshot": {"FRONT_BIAS.VALUE": "66"}},
+        "trace": {"fields": fields, "samples": samples},
+    }
+    structured = build_structured_debrief(archive, grip_ceiling_g=2.5)
+    h = build_coach_handoff(structured, lap=1)
+    assert h["v"] == COACH_HANDOFF_VERSION
+    assert isinstance(h["corners"], list) and h["corners"]

--- a/tests/test_coach_handoff.py
+++ b/tests/test_coach_handoff.py
@@ -99,6 +99,43 @@ def test_confirmed_braking_defers_to_the_brain_not_the_bias_number():
     assert "FORWARD" in d["rationale"] or "follow" in d["rationale"].lower()
 
 
+def test_suspected_exit_traction_suggests_diff_power_context():
+    corners = [
+        {
+            "index": 4,
+            "apex_spline": 0.6,
+            "time_loss_s": 0.3,
+            "headline": "C4",
+            "attributions": [_attr("exit_traction", "setup+technique", advisory=True)],
+        }
+    ]
+    d = build_coach_handoff(_structured(corners), setup=SETUP)["corners"][0][
+        "suggested_setup_delta"
+    ]
+    assert d["section"] == "DIFF_POWER"
+    assert d["direction"] == "context"
+
+
+def test_confirmed_exit_traction_defers_to_brain():
+    # advisory=False -> per-wheel slip resolved it; don't push DIFF_POWER/TC blind (could be
+    # "late to power" technique, not wheelspin)
+    corners = [
+        {
+            "index": 4,
+            "apex_spline": 0.6,
+            "time_loss_s": 0.3,
+            "headline": "C4",
+            "attributions": [_attr("exit_traction", "setup+technique", advisory=False)],
+        }
+    ]
+    d = build_coach_handoff(_structured(corners), setup=SETUP)["corners"][0][
+        "suggested_setup_delta"
+    ]
+    assert d["section"] == "DIFF_POWER"
+    assert d["direction"] == "investigate"  # deferred, not a blind "context" push
+    assert "wheelspin" in d["rationale"].lower()
+
+
 def test_technique_corner_suggests_no_setup_change():
     corners = [
         {

--- a/tests/test_coach_handoff.py
+++ b/tests/test_coach_handoff.py
@@ -41,6 +41,7 @@ def test_envelope_is_versioned_and_well_formed_even_when_empty():
     assert h["corners"] == []
     assert h["total_time_lost_s"] is None
     assert h["top_focus_corner"] is None
+    assert h["balance"] is None  # nothing to forward from an empty/None structured input
 
 
 def test_braking_loss_suggests_front_bias_rearward_for_911():
@@ -62,6 +63,17 @@ def test_braking_loss_suggests_front_bias_rearward_for_911():
     assert d["direction"] == "decrease"  # suspected + 911 + 66% > 58% -> rearward
     assert "50-56" in d["rationale"]
     assert c["advisory"] is True
+    # the delta self-describes its uncertainty (a suspicion, not a confirmed verdict)
+    assert d["advisory"] is True
+    assert d["confidence"] == 0.8
+    # per-corner pass-through + lap-level fields are forwarded intact
+    assert c["confidence"] == 0.8
+    assert c["symptom"] == "braking_phase_loss"
+    assert c["coaching"] == "do the thing"
+    assert c["apex_spline"] == 0.3
+    assert h["car_id"] == "ks_porsche_911_gt3_r_2016"
+    assert h["track_id"] == "magione"
+    assert h["balance"] == {"verdict": "mechanical_all_speed", "lever_class": "mechanical"}
 
 
 def test_braking_bias_decrease_is_gated_to_the_911():

--- a/tools/ai_sidecar/coach_handoff.py
+++ b/tools/ai_sidecar/coach_handoff.py
@@ -97,12 +97,24 @@ def _setup_delta(
             "and live per-wheel slip confirms which axle locks.",
         }
     if key == "exit_traction":
+        if not bool(attr.get("advisory")):
+            # confirmed by per-wheel slip: the brain knows whether it was wheelspin (diff/TC
+            # relevant) or simply late to power (technique) — defer, don't push a setup lever blind.
+            return {
+                "section": "DIFF_POWER",
+                "direction": "investigate",
+                "from": setup.diff_power if setup else None,
+                "rationale": "the brain confirmed exit traction from live per-wheel slip — follow "
+                "its corner coaching; only touch DIFF_POWER/TC if it was actually wheelspin, not "
+                "if the loss was getting to power late (technique).",
+            }
         return {
             "section": "DIFF_POWER",
             "direction": "context",
             "from": setup.diff_power if setup else None,
-            "rationale": "lead with throttle technique + DIFF_POWER (on-throttle lock); lower TC "
-            "if it is cutting power — needs live RPM/slip to tell a cut from over-throttle.",
+            "rationale": "suspected exit traction — lead with throttle technique + DIFF_POWER "
+            "(on-throttle lock); lower TC if it is cutting power — needs live RPM/slip to tell a "
+            "cut from over-throttle.",
         }
     if key == "grip_limited":
         return {

--- a/tools/ai_sidecar/coach_handoff.py
+++ b/tools/ai_sidecar/coach_handoff.py
@@ -142,6 +142,13 @@ def build_coach_handoff(
     for c in corners_in:
         attrs = c.get("attributions") or []
         top = attrs[0] if attrs else None
+        delta = _setup_delta(top, setup, car_id) if top else None
+        if delta is not None and top is not None:
+            # Stamp the uncertainty onto the delta object itself so a consumer that branches on
+            # `direction` (without re-parsing the prose rationale) still sees that a suspected
+            # (advisory) directive is a hypothesis, not a confirmed verdict (review #289).
+            delta.setdefault("advisory", bool(top.get("advisory")))
+            delta.setdefault("confidence", top.get("confidence", 0.0))
         corners_out.append(
             {
                 "corner": c.get("index"),
@@ -152,7 +159,7 @@ def build_coach_handoff(
                 "advisory": bool(top.get("advisory")) if top else False,
                 "symptom": top.get("symptom") if top else "on pace",
                 "coaching": top.get("coaching") if top else c.get("headline", ""),
-                "suggested_setup_delta": _setup_delta(top, setup, car_id) if top else None,
+                "suggested_setup_delta": delta,
             }
         )
     losers = [

--- a/tools/ai_sidecar/coach_handoff.py
+++ b/tools/ai_sidecar/coach_handoff.py
@@ -10,7 +10,18 @@ The ``suggested_setup_delta`` is grounded in the verified setup knowledge + the 
 cause: a technique-class corner suggests NO setup change (it's a driver fix); a setup/grip-class
 corner names the lever + direction (e.g. front-biased braking → ``FRONT_BIAS`` rearward), always
 carrying the honest "needs live per-wheel slip to confirm the axle" caveat where the archive can
-only suspect. Pure stdlib.
+only suspect.
+
+``cause_class`` is forwarded verbatim from the brain's attribution and is one of
+:data:`CAUSE_CLASSES`. Note the **mixed** ``"setup+technique"`` value: several common rules
+(braking, exit-traction) legitimately have both setup and technique causes, so a v1 consumer MUST
+handle it (do not assume the bare ``setup|technique|grip`` trio).
+
+The braking-bias direction is **car-** and **confidence-gated** (codex/copilot #290): the
+rear-engine-911 "bias rearward toward ~50-56%" recommendation fires only for that car AND only while
+the diagnosis is still *suspected* (``advisory``). Once per-wheel slip confirms the locking axle
+the brain already knows the direction (rear-lock wants bias forward, the opposite), so the handoff
+defers to the brain's coaching instead of guessing from the bias number. Pure stdlib.
 """
 
 from __future__ import annotations
@@ -21,36 +32,69 @@ from tools.ai_sidecar.setup_model import CarSetup
 
 COACH_HANDOFF_VERSION = 1
 
+#: The complete set of ``cause_class`` values a v1 consumer may receive (forwarded verbatim from
+#: ``coach_report._cause_class``). ``"setup+technique"`` is a real, common value — handle it.
+CAUSE_CLASSES = ("setup", "technique", "setup+technique", "grip", "none", "unknown")
+
 #: 911 GT3 R (rear-engine) wants lower front brake bias than a typical GT3 — flag above this.
 _FRONT_BIAS_HIGH_PCT = 58.0
 _TIME_LOSS_EPS_S = 0.03  # a corner counts as "losing time" above this
 
 
-def _setup_delta(attr: dict[str, Any], setup: CarSetup | None) -> dict[str, Any] | None:
+def _is_rear_engine_911(car_id: str | None) -> bool:
+    """True for the rear-engine Porsche 911 GT3 family (the car the bias-rearward rule fits)."""
+    if not car_id:
+        return False
+    cid = car_id.lower()
+    return "911" in cid and "gt3" in cid
+
+
+def _setup_delta(
+    attr: dict[str, Any], setup: CarSetup | None, car_id: str | None = None
+) -> dict[str, Any] | None:
     """Derive a structured, grounded setup-change suggestion from one attribution, or None.
 
     Technique-class causes return None (the fix is the driver, not the car). Setup/grip causes name
     the AC section + direction, with the verified caveats (per-wheel slip to confirm an axle, etc.).
+    The braking-bias direction is gated by car (rear-engine 911 only) and by confidence (suspected
+    only) so the machine-readable advice never contradicts a confirmed per-wheel diagnosis.
     """
     key = attr.get("key")
     if key in ("entry_speed_left", "turn_in_lag"):
         return None  # technique-first — no setup delta
     if key == "braking_phase_loss":
         bias = setup.brake_bias_pct if setup else None
-        if bias is not None and bias > _FRONT_BIAS_HIGH_PCT:
+        car = car_id or (setup.car_id if setup else None)
+        suspected = bool(attr.get("advisory"))  # confirmed (per-wheel) → defer to the brain
+        if (
+            suspected
+            and _is_rear_engine_911(car)
+            and bias is not None
+            and bias > _FRONT_BIAS_HIGH_PCT
+        ):
             return {
                 "section": "FRONT_BIAS",
                 "direction": "decrease",
                 "from": bias,
-                "rationale": "front-biased braking; a rear-engine GT3 R usually wants ~50-56% — "
-                "confirm which axle locks with live per-wheel slip before committing.",
+                "rationale": "suspected front-biased braking on a rear-engine 911 GT3 R (usually "
+                "wants ~50-56%) — confirm which axle locks with live per-wheel slip before "
+                "committing.",
+            }
+        if not suspected:
+            return {
+                "section": "FRONT_BIAS",
+                "direction": "investigate",
+                "from": bias,
+                "rationale": "the brain confirmed the locking axle from live per-wheel slip; "
+                "follow its corner coaching (rear lock wants bias FORWARD, front lock rearward) "
+                "and do not move bias off the bias number alone.",
             }
         return {
             "section": "FRONT_BIAS",
             "direction": "investigate",
             "from": bias,
-            "rationale": "investigate brake bias + modulation; live per-wheel slip confirms "
-            "the axle.",
+            "rationale": "investigate brake bias + modulation; the right target is car-specific, "
+            "and live per-wheel slip confirms which axle locks.",
         }
     if key == "exit_traction":
         return {
@@ -80,6 +124,7 @@ def build_coach_handoff(
     consumer always gets a well-formed, versioned message.
     """
     structured = structured or {}
+    car_id = structured.get("car_id")
     corners_in = structured.get("corners") or []
     corners_out: list[dict[str, Any]] = []
     for c in corners_in:
@@ -95,7 +140,7 @@ def build_coach_handoff(
                 "advisory": bool(top.get("advisory")) if top else False,
                 "symptom": top.get("symptom") if top else "on pace",
                 "coaching": top.get("coaching") if top else c.get("headline", ""),
-                "suggested_setup_delta": _setup_delta(top, setup) if top else None,
+                "suggested_setup_delta": _setup_delta(top, setup, car_id) if top else None,
             }
         )
     losers = [

--- a/tools/ai_sidecar/coach_handoff.py
+++ b/tools/ai_sidecar/coach_handoff.py
@@ -1,0 +1,116 @@
+"""Structured coach-handoff protocol: a versioned, machine-readable per-corner verdict.
+
+Turns the brain's debrief (``coach_report.build_structured_debrief``) into a compact, versioned
+message a downstream consumer — an RL/agentic coach, the rig screen, or a logger — can act on
+without re-parsing prose. Per corner: ``{corner, time_loss_s, cause_class, confidence, advisory,
+coaching, suggested_setup_delta}``; per lap: total time lost, the top-focus corner, and the
+aero/mechanical balance verdict.
+
+The ``suggested_setup_delta`` is grounded in the verified setup knowledge + the attribution's own
+cause: a technique-class corner suggests NO setup change (it's a driver fix); a setup/grip-class
+corner names the lever + direction (e.g. front-biased braking → ``FRONT_BIAS`` rearward), always
+carrying the honest "needs live per-wheel slip to confirm the axle" caveat where the archive can
+only suspect. Pure stdlib.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.ai_sidecar.setup_model import CarSetup
+
+COACH_HANDOFF_VERSION = 1
+
+#: 911 GT3 R (rear-engine) wants lower front brake bias than a typical GT3 — flag above this.
+_FRONT_BIAS_HIGH_PCT = 58.0
+_TIME_LOSS_EPS_S = 0.03  # a corner counts as "losing time" above this
+
+
+def _setup_delta(attr: dict[str, Any], setup: CarSetup | None) -> dict[str, Any] | None:
+    """Derive a structured, grounded setup-change suggestion from one attribution, or None.
+
+    Technique-class causes return None (the fix is the driver, not the car). Setup/grip causes name
+    the AC section + direction, with the verified caveats (per-wheel slip to confirm an axle, etc.).
+    """
+    key = attr.get("key")
+    if key in ("entry_speed_left", "turn_in_lag"):
+        return None  # technique-first — no setup delta
+    if key == "braking_phase_loss":
+        bias = setup.brake_bias_pct if setup else None
+        if bias is not None and bias > _FRONT_BIAS_HIGH_PCT:
+            return {
+                "section": "FRONT_BIAS",
+                "direction": "decrease",
+                "from": bias,
+                "rationale": "front-biased braking; a rear-engine GT3 R usually wants ~50-56% — "
+                "confirm which axle locks with live per-wheel slip before committing.",
+            }
+        return {
+            "section": "FRONT_BIAS",
+            "direction": "investigate",
+            "from": bias,
+            "rationale": "investigate brake bias + modulation; live per-wheel slip confirms "
+            "the axle.",
+        }
+    if key == "exit_traction":
+        return {
+            "section": "DIFF_POWER",
+            "direction": "context",
+            "from": setup.diff_power if setup else None,
+            "rationale": "lead with throttle technique + DIFF_POWER (on-throttle lock); lower TC "
+            "if it is cutting power — needs live RPM/slip to tell a cut from over-throttle.",
+        }
+    if key == "grip_limited":
+        return {
+            "section": "TYRES/PRESSURE/WING",
+            "direction": "increase_grip",
+            "from": setup.compound_index if setup else None,
+            "rationale": "at the grip limit — pressures toward the hot window, a softer compound, "
+            "or more wing; confirm with live hot-pressure + core-temp.",
+        }
+    return None
+
+
+def build_coach_handoff(
+    structured: dict[str, Any] | None, *, setup: CarSetup | None = None, lap: Any = None
+) -> dict[str, Any]:
+    """Build the versioned coach-handoff message from a ``build_structured_debrief`` result.
+
+    Returns the envelope even when ``structured`` is None/empty (an empty corner list), so a
+    consumer always gets a well-formed, versioned message.
+    """
+    structured = structured or {}
+    corners_in = structured.get("corners") or []
+    corners_out: list[dict[str, Any]] = []
+    for c in corners_in:
+        attrs = c.get("attributions") or []
+        top = attrs[0] if attrs else None
+        corners_out.append(
+            {
+                "corner": c.get("index"),
+                "apex_spline": c.get("apex_spline"),
+                "time_loss_s": c.get("time_loss_s"),
+                "cause_class": top.get("cause_class") if top else "none",
+                "confidence": top.get("confidence", 0.0) if top else 0.0,
+                "advisory": bool(top.get("advisory")) if top else False,
+                "symptom": top.get("symptom") if top else "on pace",
+                "coaching": top.get("coaching") if top else c.get("headline", ""),
+                "suggested_setup_delta": _setup_delta(top, setup) if top else None,
+            }
+        )
+    losers = [
+        c
+        for c in corners_out
+        if isinstance(c["time_loss_s"], (int, float)) and c["time_loss_s"] > _TIME_LOSS_EPS_S
+    ]
+    top_focus = max(losers, key=lambda c: c["time_loss_s"]) if losers else None
+    return {
+        "v": COACH_HANDOFF_VERSION,
+        "lap": lap,
+        "car_id": structured.get("car_id"),
+        "track_id": structured.get("track_id"),
+        "total_time_lost_s": round(sum(c["time_loss_s"] for c in losers), 3) if losers else None,
+        "top_focus_corner": top_focus["corner"] if top_focus else None,
+        "balance": structured.get("balance"),
+        "corners": corners_out,
+    }


### PR DESCRIPTION
## What

Closes #289. Adds `tools/ai_sidecar/coach_handoff.py` — the **structured coach-handoff protocol**: turns the brain's debrief (`coach_report.build_structured_debrief`) into a compact, versioned, machine-readable message a downstream consumer (an RL/agentic coach, the rig screen, a logger) can act on **without re-parsing prose**.

This is deliverable 7 of the frontier-coaching program — the clean seam between the offline analysis brain and a future real-time/agentic coach (north star: an AI that coaches a human in real time, better than human at mechanics/tyres/technique).

## The envelope

`build_coach_handoff(structured, *, setup=None, lap=None)` returns:

```
{v, lap, car_id, track_id, total_time_lost_s, top_focus_corner, balance,
 corners: [{corner, apex_spline, time_loss_s, cause_class, confidence,
            advisory, symptom, coaching, suggested_setup_delta}]}
```

- **`suggested_setup_delta` is cause-grounded**, not a blanket suggestion:
  - technique-class corner (`entry_speed_left`, `turn_in_lag`) → **None** (driver fix, no setup change)
  - `braking_phase_loss` on a >58% front-biased 911 GT3 R → **FRONT_BIAS rearward** (else `investigate` when bias unknown)
  - `exit_traction` → **DIFF_POWER / TC** context
  - `grip_limited` → **tyres / pressure / wing**
- Every delta carries the honest **"needs live per-wheel slip / hot-pressure to confirm"** caveat where the archive can only *suspect* the axle — consistent with the Tier-A (archive) vs Tier-B (live) honesty split already in the brain.
- Always returns a well-formed, versioned envelope even for `None`/empty input.

## Verification

- `ruff format --check` ✅ · `ruff check` ✅ · `pytest tests/test_coach_handoff.py` → **7 passed**
- Includes an **end-to-end** test that drives a real `build_structured_debrief` output into the handoff envelope (not just hand-built dicts).
- Pure stdlib; no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)