### PR TITLE
docs(vault): post-merge handoff — real-time coaching path (3 deliverables merged)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-20T04:00:00Z
+last_updated: 2026-06-22T22:05:00Z
 relates_to:
+  - AcCopilotTrainer/01_Decisions/realtime-coaching-architecture-2026-06-22.md
   - AcCopilotTrainer/03_Investigations/frontier-controller-ggv-2026-06-19.md
   - AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
   - AcCopilotTrainer/00_System/Current Focus.md
@@ -32,7 +33,53 @@ relates_to:
 
 # Next session handoff
 
-## Resume here (2026-06-22 — FRONTIER COACHING PROGRAM: 6 deliverables shipped; real-time path is next)
+## Resume here (2026-06-22 LATER — REAL-TIME COACHING PATH: 3 more deliverables MERGED; only the RIG step (#277) remains)
+
+**The offline real-time-coaching upgrade is DONE — all three offline-buildable pieces merged this run**
+(each through multi-bot review **+ a 12-agent adversarial pre-merge workflow**; every real finding fixed-forward):
+
+- **#289 / PR #290 MERGED — structured coach-handoff protocol** (`tools/ai_sidecar/coach_handoff.py`):
+  versioned per-corner verdict envelope `{v, lap, car_id, track_id, total_time_lost_s,
+  top_focus_corner, balance, corners[corner, time_loss_s, cause_class, confidence, advisory, symptom,
+  coaching, suggested_setup_delta]}` for a downstream RL/agentic coach. `suggested_setup_delta` is
+  cause- AND car- AND confidence-gated: technique corners → no change; braking/exit deltas fire only
+  while SUSPECTED and defer to the confirmed per-wheel verdict; 911-bias advice gated to the
+  rear-engine 911. Full `cause_class` enum documented (incl. `setup+technique`); the delta
+  self-describes its `advisory`/`confidence`.
+- **#291 / PR #292 MERGED — tyre/conditions/track-reference integrated into the debrief**
+  (`coach_report.py` + `protocol.py`): `build_structured_debrief` now emits `tyres`/`conditions`/
+  `corner_reference` (text + JSON), forwarded to live clients by `build_brain_followup`
+  (`tyres`/`conditions`/`cornerReference`). Honest by construction — tyre block suppressed in the wet
+  (slick model invalid); conditions surfaced from temps alone; a slower reference is never published
+  as a target; reference labeled corpus-best, never a fabricated GGV optimum; inline lap_complete
+  lap-number normalized into `lap.lap_n` for tyre warm-up classification.
+- **#293 / PR #294 MERGED — real-time observer core** (`tools/ai_sidecar/realtime_observer.py`):
+  `RealtimeObserver` streams live frames → grounded `late_brake` + `apex_deficit` advisories vs the
+  per-corner reference. Lap detection matches in-sim `delta.lua` (true wrap vs pit/teleport vs
+  **deferred-lapCount**); trail-brake-aware (no false "brake!" when the driver braked early); brake
+  eval spans **upstream** of turn-in; honest corpus-vs-GGV source label; 1-based turn labels.
+  Pure-stdlib, replay-tested; verified on real demo laps. Live wiring is **#277** (rig-gated).
+
+**Discipline that held (again):** every output honest about its data limits — confirmed-axle
+deference, GGV-vs-corpus labeling, wet-tyre suppression, lap-count gating. ~20 bot threads across 4–6
+rounds per PR, **plus** a 12-agent adversarial workflow that caught the GGV-vs-corpus mislabel the bots
+missed. Filed a spawn-task chip for a real Windows path-guard bug in `tools/process_miner/`
+(`normalize_path_list` uses `Path.is_absolute()`, which misses `/etc/passwd` on Windows).
+
+**THE remaining north-star step — [#277](https://github.com/agorokh/ac-copilot-trainer/issues/277) (RIG):**
+wire `RealtimeObserver` into the sidecar's live `telemetry_tick` stream (the observer already
+normalizes that payload shape; the high-rate contract must add `spline`), deliver `archivePath` on
+lap_complete, render `debriefSource==brain` + the live advisories in `ws_bridge.lua`, and drive a real
+lap to confirm the in-the-ear coach end-to-end. THE in-the-ear coach.
+
+**Housekeeping:** local `main` still carries one stray prior-session chore (`b620a06`,
+`.cursor/hooks.json` untrack) not on `origin` — branch all work from `origin/main`; a post-merge
+steward should reconcile it. The process-miner is still mining bot BOILERPLATE into
+`.claude/rules/learned/local/*.md` (noise filter needed).
+
+---
+
+## Prior (2026-06-22 — FRONTIER COACHING PROGRAM: 6 deliverables shipped; real-time path is next)
 
 **Five offline pillars MERGED + a 6th in PR. Remaining: the real-time path (the north star).**
 Shipped this run (each through full multi-bot review, every real finding fixed):

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/realtime-coaching-architecture-2026-06-22.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/realtime-coaching-architecture-2026-06-22.md
@@ -1,0 +1,60 @@
+---
+type: decision
+status: active
+memory_tier: canonical
+created: 2026-06-22
+updated: 2026-06-22
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/03_Investigations/setup-aware-coaching-2026-06-20.md
+  - AcCopilotTrainer/03_Investigations/tyre-thermal-knowledge-2026-06-21.md
+  - AcCopilotTrainer/03_Investigations/conditions-grip-knowledge-2026-06-21.md
+  - AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
+---
+
+# Real-time coaching architecture (offline core shipped 2026-06-22)
+
+The seam from the offline analysis **brain** to a future **real-time / agentic coach**. Three layers,
+all pure-stdlib under `tools/ai_sidecar/`, each honest about its data limits (the project invariant:
+never claim more than the data proves).
+
+## The pipeline
+
+```
+setup_model + lap_dynamics + corner_attribution   (the brain, #264/#268/#275)
+            │  tyre_model · conditions_model · track_reference  (#280/#282/#286)
+            ▼
+coach_report.build_structured_debrief  → {text, balance, corners[], tyres, conditions, corner_reference}   (#291)
+            │
+            ├── protocol.build_brain_followup → live coaching_response (debrief + cornerAnalysis +
+            │       tyres/conditions/cornerReference), non-blocking on lap_complete                 (#291)
+            │
+            └── coach_handoff.build_coach_handoff → versioned per-corner verdict envelope for an
+                    RL/agentic coach (cause_class, confidence, advisory, suggested_setup_delta)     (#289)
+
+realtime_observer.RealtimeObserver  ← streaming live telemetry frames (offline-buildable core)      (#293)
+            → grounded per-corner advisories: late_brake (act) + apex_deficit (info)
+```
+
+## Honesty guardrails (the part that matters)
+
+- **suggested_setup_delta** (coach_handoff) is cause- AND car- AND confidence-gated. A *technique*
+  corner suggests no setup change. Braking/exit deltas fire only while SUSPECTED (advisory); once
+  per-wheel slip CONFIRMS the axle, the handoff defers to the brain's verdict (a confirmed rear-lock
+  wants bias FORWARD — the opposite of the suspected-front-bias heuristic). The 911-specific
+  bias-rearward range is gated to the rear-engine 911 GT3 family.
+- **Tyre block** is the slick compound-window thermal model → suppressed in the wet (conditions report
+  `slick_model_valid == False`); conditions surfaced from temps alone; no fabricated °C→grip%.
+- **Reference target** is the corpus best (demonstrated), never a fabricated GGV theoretical optimum
+  from a driven lap. The observer labels `source` as `corpus_best` vs `ggv_optimum` from provenance.
+  A reference that is *slower* than the driven lap is never published as a pace target.
+- **Observer lap detection** mirrors in-sim `delta.lua`: a backward spline jump is graded only on real
+  lap-completion evidence (a lapCount advance, deferred a frame if it lags; or a wrap-shaped jump when
+  no counter is supplied). A pit/teleport near the line never produces a spurious end-of-lap advisory.
+
+## What's deferred
+
+Live wiring is **[#277](https://github.com/agorokh/ac-copilot-trainer/issues/277)** (rig-gated): feed
+`RealtimeObserver` from the sidecar's `telemetry_tick` stream (the observer already normalizes that
+payload; the high-rate contract must add `spline`), deliver `archivePath` on lap_complete, render
+`debriefSource==brain` + advisories in `ws_bridge.lua`, and confirm the in-the-ear coach on a real lap.


### PR DESCRIPTION
Post-merge vault SAVE after the real-time-coaching offline core landed: **#290** (coach-handoff protocol), **#292** (tyre/conditions/track integration + live forwarding), **#294** (real-time observer core) all merged.

- Updates `Next Session Handoff.md` with the resume block (3 deliverables merged; only the rig-gated **#277** live activation remains).
- Adds `01_Decisions/realtime-coaching-architecture-2026-06-22.md` — a small linked node capturing the brain→debrief→handoff→observer seam and its honesty guardrails.

Diff is strictly under `docs/01_Vault/**`. Auto-merge via the `vault-only` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)