### PR TITLE
feat(coaching): surface trail-braking findings in the debrief + live response (#299)

### DIFF
--- a/tests/test_brain_wiring.py
+++ b/tests/test_brain_wiring.py
@@ -105,6 +105,9 @@ def test_brain_followup_from_inline_trace(monkeypatch):
     assert out["debriefSource"] == "brain"
     assert out["cornerAnalysis"]
     assert "balance" in out
+    # trail-braking findings are forwarded to live clients (#296/#299)
+    assert out.get("trailBraking")
+    assert "classification" in out["trailBraking"][0]
 
 
 def test_brain_followup_from_archive_path(tmp_path, monkeypatch):

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -192,3 +192,14 @@ def test_slower_reference_corners_are_not_published_as_targets():
     d = build_structured_debrief(fast, reference_archive=slow_ref, grip_ceiling_g=2.5)
     # every corner's "target" is below the driven speed -> all dropped -> block omitted
     assert d["corner_reference"] is None
+
+
+def test_trail_braking_block_in_structured_debrief():
+    # the trail-braking analyzer's per-corner read flows into the structured debrief + text (#296)
+    d = build_structured_debrief(_corner_archive(), grip_ceiling_g=2.5)
+    tb = d["trail_braking"]
+    assert tb is not None and tb  # the corner brakes, so it produces a finding
+    entry = tb[0]
+    assert "classification" in entry and "trail_overlap" in entry and "coaching" in entry
+    # the square-brake fixture is a non-"good" technique → surfaces in the text section
+    assert "Trail braking" in d["text"]

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -43,6 +43,7 @@ from tools.ai_sidecar.track_reference import (
     build_references,
     score_lap,
 )
+from tools.ai_sidecar.trail_brake import TrailBrakeFinding, analyze_trail_braking
 from tools.ai_sidecar.tyre_model import TyreReport, tyres_from_lap_archive
 
 
@@ -95,6 +96,7 @@ def format_debrief(
     tyres: TyreReport | None = None,
     conditions: ConditionsReport | None = None,
     corner_reference: list[CornerScore] | None = None,
+    trail_braking: list[TrailBrakeFinding] | None = None,
 ) -> str:
     """Render the full debrief as text."""
     out: list[str] = [f"=== {title} ==="]
@@ -156,6 +158,11 @@ def format_debrief(
             out.append("  " + s.headline)
             for fnd in s.findings[:1]:
                 out.append(f"      - {fnd}")
+    flagged = [f for f in (trail_braking or []) if f.classification != "good_trail_brake"]
+    if flagged:
+        out.append(f"\nTrail braking ({len(flagged)} corner(s) to work on):")
+        for f in flagged:
+            out.append(f"  T{f.corner + 1} ({f.classification}): {f.coaching}")
     return "\n".join(out)
 
 
@@ -259,6 +266,28 @@ def _corner_reference_struct(scores: list[CornerScore] | None) -> list[dict] | N
     ]
 
 
+def _trail_braking_struct(findings: list[TrailBrakeFinding] | None) -> list[dict] | None:
+    """JSON-serializable per-corner trail-braking block, or None when no corner braked.
+
+    Inferred from brake+steer overlap + decel (no direct load-transfer measurement) — a technique
+    read, not a proof of tyre state; the analyzer's docstring carries that caveat.
+    """
+    if not findings:
+        return None
+    return [
+        {
+            "corner": f.corner,
+            "apex_spline": round(f.apex_spline, 4),
+            "classification": f.classification,
+            "trail_overlap": f.trail_overlap,
+            "brake_off_rel": f.brake_off_rel,
+            "release_abruptness": f.release_abruptness,
+            "coaching": f.coaching,
+        }
+        for f in findings
+    ]
+
+
 def _analyze(
     lap_archive: dict,
     *,
@@ -286,6 +315,8 @@ def _analyze(
     if tyres is not None and not conditions.slick_model_valid:
         tyres = None
     corner_reference = _corner_reference_scores(ref, lap)
+    # trail-braking technique read, per corner (only corners that actually braked surface a finding)
+    trail_braking = [f for f in analyze_trail_braking(lap) if f.classification != "no_braking"]
     return {
         "lap": lap,
         "setup": setup,
@@ -294,6 +325,7 @@ def _analyze(
         "tyres": tyres,
         "conditions": conditions,
         "corner_reference": corner_reference,
+        "trail_braking": trail_braking,
     }
 
 
@@ -332,6 +364,7 @@ def build_structured_debrief(
         tyres=a["tyres"],
         conditions=a["conditions"],
         corner_reference=a["corner_reference"],
+        trail_braking=a["trail_braking"],
     )
     corners = [
         {
@@ -372,6 +405,7 @@ def build_structured_debrief(
         "tyres": _tyres_struct(a["tyres"]),
         "conditions": _conditions_struct(a["conditions"]),
         "corner_reference": _corner_reference_struct(a["corner_reference"]),
+        "trail_braking": _trail_braking_struct(a["trail_braking"]),
     }
 
 
@@ -398,6 +432,7 @@ def build_debrief(
         tyres=a["tyres"],
         conditions=a["conditions"],
         corner_reference=a["corner_reference"],
+        trail_braking=a["trail_braking"],
     )
 
 

--- a/tools/ai_sidecar/protocol.py
+++ b/tools/ai_sidecar/protocol.py
@@ -137,6 +137,8 @@ def build_brain_followup(inbound: dict[str, Any]) -> dict[str, Any] | None:
         response["conditions"] = structured["conditions"]
     if structured.get("corner_reference") is not None:
         response["cornerReference"] = structured["corner_reference"]
+    if structured.get("trail_braking") is not None:
+        response["trailBraking"] = structured["trail_braking"]
     return response
 
 


### PR DESCRIPTION
## What

Closes #299. Wires the trail-braking analyzer (`trail_brake.py`, #296) into the coaching **output** — mirroring the tyre/conditions/track integration in #291 — so its per-corner read actually reaches the debrief, the structured JSON, and the live `coaching_response`.

- `build_structured_debrief` → new `trail_braking` block (per-corner `classification` + `trail_overlap`/`brake_off_rel`/`release_abruptness` + coaching), text + structured. Only corners that braked produce a finding.
- `format_debrief` → a **"Trail braking (N corner(s) to work on)"** section listing the non-`good_trail_brake` corners.
- `protocol.build_brain_followup` → forwards it to live clients as `trailBraking`.

## Honesty

Carries the analyzer's caveat: inferred from brake+steer overlap + decel, **no direct load-transfer measurement**. No change to `trail_brake.py` itself.

## Verification

- `ruff format --check` ✅ · `ruff check` ✅ · `pytest` (coach_report + brain_wiring + trail_brake) → **29 passed**.
- **Operator-grade**: ran `build_debrief` on the real demo laps — the "Trail braking" section renders (T2/T4/T5 `abrupt_release` with coaching); structured `trail_braking[0]` carries `{classification, trail_overlap: 1.0, brake_off_rel: -0.27, ...}`.

With this, every north-star coaching capability is both built **and** wired into the coaching output. Only the rig-gated live activation (#277) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)