### PR TITLE
fix(process_miner): detect absolute paths cross-platform in normalize_path_list

### DIFF
--- a/tests/test_session_debrief_schema.py
+++ b/tests/test_session_debrief_schema.py
@@ -48,3 +48,22 @@ def test_normalize_path_list_dedupes_equivalent_paths() -> None:
 def test_normalize_path_list_normalizes_backslashes() -> None:
     paths = normalize_path_list([r"src\bar\baz.py"])
     assert paths == ["src/bar/baz.py"]
+
+
+def test_normalize_path_list_rejects_absolute_on_any_platform() -> None:
+    """Absolute paths are skipped regardless of host OS flavour.
+
+    Regression: ``WindowsPath('/etc/passwd').is_absolute()`` is ``False`` (no
+    drive), so a host-native ``is_absolute()`` check let POSIX-absolute paths
+    through the guard on Windows. The guard now tests both pure flavours.
+    """
+    assert normalize_path_list(["/etc/passwd"]) == []
+    assert normalize_path_list(["C:/Windows/System32/config"]) == []
+    # A mixed list drops only the absolute entry; the relative one survives.
+    assert normalize_path_list(["/etc/passwd", "src/app.py"]) == ["src/app.py"]
+
+
+def test_normalize_path_list_rejects_unc_path_without_repo_root() -> None:
+    """UNC-style absolute paths are skipped when no ``repo_root`` is supplied."""
+    assert normalize_path_list([r"\\server\share"]) == []
+    assert normalize_path_list([r"\\server\share\secret.txt"]) == []

--- a/tests/test_session_debrief_schema.py
+++ b/tests/test_session_debrief_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from tools.process_miner.session_debrief_schema import (
@@ -67,3 +68,21 @@ def test_normalize_path_list_rejects_unc_path_without_repo_root() -> None:
     """UNC-style absolute paths are skipped when no ``repo_root`` is supplied."""
     assert normalize_path_list([r"\\server\share"]) == []
     assert normalize_path_list([r"\\server\share\secret.txt"]) == []
+
+
+def test_normalize_path_list_foreign_absolute_with_repo_root_skipped() -> None:
+    """A path absolute on the OTHER OS flavour is skipped even *with* ``repo_root``.
+
+    Regression for the gemini-code-assist HIGH finding on PR #304. When
+    ``_is_absolute_any_platform`` is true but ``Path(...).is_absolute()`` is
+    ``False`` on the host, the path is not host-absolute, so ``resolve()`` anchors
+    it to the CWD. If ``repo_root`` is an ancestor of the CWD, the old code's
+    ``relative_to(repo_root)`` *succeeded* and admitted a cross-platform absolute
+    path as a contained relative path. The guard must skip it instead.
+    """
+    # Pick a path absolute on the *other* OS flavour than the host.
+    foreign = "/etc/passwd" if sys.platform.startswith("win") else "C:/Windows/System32"
+    # repo_root = the CWD's anchor — an ancestor of the CWD, the worst case where a
+    # pre-fix resolve()+relative_to() would have succeeded and admitted the path.
+    anchor = Path(Path.cwd().anchor)
+    assert normalize_path_list([foreign], repo_root=anchor) == []

--- a/tools/process_miner/session_debrief_schema.py
+++ b/tools/process_miner/session_debrief_schema.py
@@ -8,7 +8,7 @@ tolerate unknown keys and missing optional fields (best-effort ingest).
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, TypedDict
 
 # Bump when breaking or extending required semantics for consumers.
@@ -36,6 +36,19 @@ class SessionDebriefRecord(TypedDict, total=False):
     session_debrief_patterns: list[str] | str
 
 
+def _is_absolute_any_platform(s: str) -> bool:
+    """Whether ``s`` is absolute under POSIX *or* Windows path semantics.
+
+    ``Path.is_absolute()`` is host-specific: on Windows
+    ``WindowsPath('/etc/passwd').is_absolute()`` is ``False`` (no drive letter),
+    so a host-native check lets POSIX-style absolute paths slip through the
+    absolute-path / traversal guard. Testing both pure flavours catches a leading
+    ``/`` or ``\\``, drive letters (``C:/...``), and UNC prefixes
+    (``//server/share``) regardless of the host OS.
+    """
+    return PurePosixPath(s).is_absolute() or PureWindowsPath(s).is_absolute()
+
+
 def normalize_path_list(value: Any, *, repo_root: Path | None = None) -> list[str]:
     """Turn ``session_debrief_files`` env/record value into repo-relative posix paths."""
     raw: list[Any]
@@ -53,16 +66,19 @@ def normalize_path_list(value: Any, *, repo_root: Path | None = None) -> list[st
     for item in raw:
         if not isinstance(item, str) or not item.strip():
             continue
-        p = Path(item.strip().replace("\\", "/"))
-        if p.is_absolute():
+        # Normalize separators first so the absolute-path check below sees a
+        # single, OS-independent form (e.g. ``\\server\share`` -> ``//server/share``).
+        normalized = item.strip().replace("\\", "/")
+        if _is_absolute_any_platform(normalized):
             if root is None:
                 continue
             try:
-                rel = p.resolve().relative_to(root)
+                rel = Path(normalized).resolve().relative_to(root)
                 out.append(rel.as_posix())
             except ValueError:
                 continue
             continue
+        p = Path(normalized)
         if ".." in p.parts:
             continue
         posix = p.as_posix()

--- a/tools/process_miner/session_debrief_schema.py
+++ b/tools/process_miner/session_debrief_schema.py
@@ -70,7 +70,14 @@ def normalize_path_list(value: Any, *, repo_root: Path | None = None) -> list[st
         # single, OS-independent form (e.g. ``\\server\share`` -> ``//server/share``).
         normalized = item.strip().replace("\\", "/")
         if _is_absolute_any_platform(normalized):
-            if root is None:
+            # Only a *host-absolute* path can be meaningfully resolved and
+            # relativized against ``root``. A path that is absolute on the OTHER
+            # OS flavour (``C:/x`` on POSIX, ``/etc/x`` on Windows) is NOT
+            # host-absolute, so ``Path(normalized).resolve()`` would anchor it to
+            # the CWD and ``relative_to(root)`` could *admit* it as a contained
+            # relative path when the CWD lies under ``root``. Skip those outright
+            # (gemini-code-assist HIGH, PR #303/#304).
+            if root is None or not Path(normalized).is_absolute():
                 continue
             try:
                 rel = Path(normalized).resolve().relative_to(root)


### PR DESCRIPTION
## Summary

`normalize_path_list()` in `tools/process_miner/session_debrief_schema.py` guards against absolute paths (and `..` traversal) when no `repo_root` is supplied. The absolute-path detection used `pathlib.Path(...).is_absolute()`, which is **host-specific**:

- On Windows, `WindowsPath('/etc/passwd').is_absolute()` is `False` (no drive letter), so POSIX-style absolute paths slipped past the guard and were kept as if relative — defeating the absolute-path / path-traversal protection on Windows.

This made `tests/test_session_debrief_schema.py::test_normalize_path_list_absolute_without_repo_root_skipped` fail on Windows.

## Fix

Detect absoluteness cross-platform via a small helper:

```python
def _is_absolute_any_platform(s: str) -> bool:
    return PurePosixPath(s).is_absolute() or PureWindowsPath(s).is_absolute()
```

Separators are normalized first (`\` → `/`), so the check sees a single OS-independent form and catches a leading `/` or `\`, drive letters (`C:/...`), and UNC prefixes (`//server/share`) regardless of host OS. The repo-relative mapping, `..` traversal skip, dedupe, and backslash normalization are all preserved.

## Tests

Added regression tests asserting the guard rejects `/etc/passwd`, a Windows drive path, and `\server\share` on **any** platform (plus a mixed list where only the absolute entry is dropped).

```
python -m pytest tests/test_session_debrief_schema.py -q   # 10 passed
ruff format --check tools/process_miner/session_debrief_schema.py tests/test_session_debrief_schema.py  # clean
ruff check  tools/process_miner/session_debrief_schema.py tests/test_session_debrief_schema.py           # clean
```

Fixes #303