### PR TITLE
docs(vault): pitfall — EPIC body delivery-drift (re-rake trap)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-22T23:45:00Z
+last_updated: 2026-06-23T00:30:00Z
 relates_to:
   - AcCopilotTrainer/01_Decisions/realtime-coaching-architecture-2026-06-22.md
   - AcCopilotTrainer/03_Investigations/frontier-controller-ggv-2026-06-19.md
@@ -32,6 +32,21 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Housekeeping addendum — backlog steward sweep (2026-06-22)
+
+`/backlog-steward` reconciled all 8 open issues against merged delivery (read-only; substrate
+`ac_copilot` returned empty → Tier-2 + code grounding). Verdicts: **5 live, 2 partially-delivered,
+0 stale/drifted**. Ledger: `.scratch/backlog-steward/ledger.json`. Two actions shipped:
+- **#154 EPIC body reconciled** (Parts A–G checked off w/ PR evidence; L2-achieved milestone #196
+  recorded; scope narrowed to open children #277/#278/#305 + a Part-G KPI residual) — see the
+  reconciliation comment on the issue.
+- **New pitfall node** [`pitfalls/epic-body-delivery-drift.md`](../pitfalls/epic-body-delivery-drift.md)
+  — captures the "long-lived EPIC body never reconciled → re-rake" pattern; candidate for upstream
+  propagation to the template-repo hub.
+
+Recommended next pick-ups (off-rig first): **#303** (Windows path-guard, CI-able on Mac) → **#305**
+(flying-lap 0 KB trace, highest-impact bug) → **#277** (close the live loop, rig-gated).
 
 ## Resume here (2026-06-22 LIVE-VERIFIED — coaching pipeline RUN IN-GAME on real schema-v2 telemetry)
 

--- a/docs/01_Vault/AcCopilotTrainer/pitfalls/_index.md
+++ b/docs/01_Vault/AcCopilotTrainer/pitfalls/_index.md
@@ -2,10 +2,11 @@
 type: index
 status: active
 created: 2026-04-10
-updated: 2026-04-10
+updated: 2026-06-22
 relates_to:
   - AcCopilotTrainer/00_System/invariants/_index.md
   - AcCopilotTrainer/01_Decisions/shift-left-issue-creation.md
+  - AcCopilotTrainer/pitfalls/epic-body-delivery-drift.md
 ---
 
 # Pitfalls (index)
@@ -25,3 +26,13 @@ Recurring implementation mistakes mined from fleet-wide PR review comments (sema
 | [vault-path-integrity.md](vault-path-integrity.md) | reliability | 6 | 73 | 2 |
 | [secret-credential-handling.md](secret-credential-handling.md) | security | 4 | 41 | 3 |
 | [redundant-code-drift.md](redundant-code-drift.md) | maintainability | 4 | 36 | 3 |
+
+## Project-curated (not fleet-mined)
+
+Pitfalls observed locally (e.g. during `/backlog-steward` runs) rather than mined from the
+fleet PR corpus — so they carry no cluster/comment counts. The issue-writer only injects nodes
+with `scope_paths`; process pitfalls below deliberately omit them.
+
+| Node | Severity | Source |
+|------|----------|--------|
+| [epic-body-delivery-drift.md](epic-body-delivery-drift.md) | maintainability | `/backlog-steward` sweep 2026-06-22 (canonical: #154) |

--- a/docs/01_Vault/AcCopilotTrainer/pitfalls/epic-body-delivery-drift.md
+++ b/docs/01_Vault/AcCopilotTrainer/pitfalls/epic-body-delivery-drift.md
@@ -1,0 +1,74 @@
+---
+type: pitfall
+status: active
+created: 2026-06-22
+updated: 2026-06-22
+severity: maintainability
+origin: human-curated
+domains: [process, backlog]
+relates_to:
+  - AcCopilotTrainer/pitfalls/redundant-code-drift.md
+  - AcCopilotTrainer/pitfalls/_index.md
+  - AcCopilotTrainer/02_Investigations/process-miner-corpus-analysis-2026-04.md
+  - AcCopilotTrainer/00_System/invariants/_index.md
+---
+
+# EPIC body delivery-drift (the re-rake trap)
+
+**Project-curated** (not fleet-mined — no cluster/comment metadata). Surfaced by a
+`/backlog-steward` intent-vs-delivery sweep on 2026-06-22.
+
+> Deliberately carries **no `scope_paths`** — this is a process pitfall about *issue/EPIC
+> tracking*, not a code-path mistake, so the issue-writer must **not** inject it into every
+> code issue. It is meant to be read during backlog grooming / steward runs.
+
+## Pattern
+
+A long-lived `[EPIC]` issue with labeled Parts (A–G…) keeps its **original body** while Part
+after Part ships under separate PRs. The body still reads as all-future work; the merged
+delivery lives only in PR titles, the vault handoff, and the code. Re-reading the EPIC weeks
+later, an agent (or the operator) takes the body at face value and **re-attempts work that
+already shipped in a different shape** — *stepping on a rake.* The cost is highest precisely on
+the EPICs that succeeded fastest, because those accumulated the most undocumented delivery.
+
+The tell: the EPIC's `updated_at` moves (label tweaks, comments) but the **body's
+delivered/remaining split never moves**. Age is not the signal — *un-reconciled delivery* is.
+
+## Canonical damage
+
+- **`ac-copilot-trainer#154`** — "[EPIC] Autonomous self-test harness". Parts A–G all shipped
+  across ~12 PRs (#157, #158, #173/#182/#185, #191/#201/#209/#221/#226, #176/#229/#233,
+  #236/#239/#242 + the #244 racing-controller sub-program) and **L2 was live-verified** in
+  PR #196 (agent drove a no-human lap; trainer coached it in real time). The body still framed
+  every Part as future work until reconciled by `/backlog-steward` on 2026-06-22. Contrast
+  **`#86`** (rig-screen EPIC), which carried a "Delivered / No Longer Active" section from the
+  start and never drifted — the working antidote.
+
+## Preventive rule
+
+1. **Reconcile the EPIC body at each Part merge**, not at the end. The merging PR (or the
+   `/post-merge` step) should check off the delivered Part in the EPIC body with its PR number,
+   the same turn it lands. A one-line edit beats a months-late audit.
+2. **Every EPIC keeps a `## Delivered / No Longer Active` section** with PR evidence, and a
+   `## Current Scope After Reconciliation` that lists only what is genuinely open (prefer links
+   to child issues over re-stated scope). Model it on `#86`.
+3. **Before re-picking up any EPIC or its child, run `/backlog-steward`** (or at minimum diff
+   the body against merged PRs). The steward's reconciliation ledger
+   (`.scratch/backlog-steward/ledger.json`) exists to make this cheap on the next pass.
+4. **The verdict, not the merge, owns the status.** A merged Part-PR that only partially
+   delivers must be recorded as `partially-delivered`, not silently checked off — otherwise the
+   body lies in the other direction.
+
+## Detection
+
+- `/backlog-steward` flags an EPIC as `partially-delivered` when ≥2 merged PRs name its Parts
+  but the body shows no delivered section — exactly how `#154` was caught.
+- Cheap manual check: `gh pr list --state merged --search "<epic-#> in:title,body"` vs the
+  EPIC's checkbox state.
+
+## Upstream candidate
+
+EPIC-body delivery-drift is **domain-agnostic** — it applies to any repo that runs large
+labeled-Part EPICs. Per the upstream-template-sync rule (`.claude/rules/workflow.md`), this is
+a candidate to propagate into the **template-repo hub** `pitfalls/` so the whole fleet's
+issue-writer and steward can surface it. Operator decision; not auto-propagated.


### PR DESCRIPTION
## What

Adds a **project-curated vault pitfall node** capturing a recurring drift pattern surfaced by the `/backlog-steward` sweep on 2026-06-22: a long-lived `[EPIC]` keeps its original body while Parts ship under separate PRs, so the body reads as all-future work and re-reading it re-attempts work that already shipped — *stepping on a rake*.

- New: [`docs/01_Vault/AcCopilotTrainer/pitfalls/epic-body-delivery-drift.md`](https://github.com/agorokh/ac-copilot-trainer/blob/vault/backlog-steward-epic-drift-pitfall/docs/01_Vault/AcCopilotTrainer/pitfalls/epic-body-delivery-drift.md)
- Updated: `pitfalls/_index.md` (new "Project-curated (not fleet-mined)" subsection + row; `updated` bumped)
- Updated: `00_System/Next Session Handoff.md` (steward-sweep addendum)

**Canonical damage:** [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) — Parts A–G shipped across ~12 PRs and L2 was live-verified in #196, but the EPIC body framed everything as future work until reconciled this sweep. Antidote model: #86, which carried a "Delivered" section from the start.

## Notes for review

- **Vault-only diff** (strictly under `docs/01_Vault/**`) → eligible for `vault-automerge.yml` auto-merge.
- The node deliberately carries **no `scope_paths`** so the issue-writer does **not** inject this process pitfall into every code issue; it's meant to be read during grooming / steward runs.
- It's a **human-curated** node (not fleet-mined), kept out of the mined cluster/comment table.
- **Upstream candidate:** EPIC-body delivery-drift is domain-agnostic — a candidate to propagate into the template-repo hub `pitfalls/` (operator decision; flagged in the node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)