### PR TITLE
fix(coaching): finalize the last lap's trace on session end (#305)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2031,13 +2031,14 @@ function script.update(dt)
   end
 
   if sim.isInMainMenu then
-    -- Issue #305: the session has ended (or we are back at the menu). update() returns a
-    -- few lines below on every menu frame, so the per-frame archive pump further down never
-    -- runs again — drain any job queued for the last lap NOW so its full trace is written
-    -- instead of being abandoned as a partial `.tmp` stub. Must run before the early return
-    -- (and before resetRuntimeAfterLeavingTrack rebuilds runtime state).
-    flushPendingLapArchiveJobs("session end (main menu)")
     if state.wasDriving then
+      -- Issue #305: we just left the track. update() returns a few lines below on every menu
+      -- frame, so the per-frame archive pump further down never runs again — drain any job
+      -- queued for the last lap NOW so its full trace is written instead of being abandoned as
+      -- a partial `.tmp` stub. Gated by `wasDriving` so it runs once on the driving→menu
+      -- transition (a job can only be queued while driving), not on every idle menu frame;
+      -- runs before resetRuntimeAfterLeavingTrack rebuilds runtime state.
+      flushPendingLapArchiveJobs("session end (main menu)")
       if persistSnapshotCached() then
         -- Issue #47: training journal JSON under ScriptConfig (after persist, before state reset).
         local journalLaps = state.lapsCompleted or 0

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -411,6 +411,9 @@ local pendingWsSidecarUrl = nil
 local pendingLapArchiveJobs = {}
 local pendingLapArchiveRecordPaths = {}
 local LAP_ARCHIVE_ROWS_PER_FRAME = 64
+-- Per-step row budget used by the synchronous session-end drain (issue #305). Far above any
+-- real lap's downsampled trace (~2000 rows) so a single step finishes the whole job.
+local LAP_ARCHIVE_FLUSH_ROWS = 1000000
 
 -- Forward-declare so closures registered with wsBridge below capture the
 -- main state table as an upvalue (Lua resolves locals lexically at compile
@@ -435,10 +438,10 @@ local function queueLapArchiveJob(archiveOpts)
   end
 end
 
-local function pumpLapArchiveJobs()
+local function pumpLapArchiveJobs(maxRows)
   local job = pendingLapArchiveJobs[1]
   if not job then return end
-  local done, ok, pathOrErr = job:step(LAP_ARCHIVE_ROWS_PER_FRAME)
+  local done, ok, pathOrErr = job:step(maxRows or LAP_ARCHIVE_ROWS_PER_FRAME)
   if not done then return end
   table.remove(pendingLapArchiveJobs, 1)
   if ac and type(ac.log) == "function" then
@@ -450,6 +453,35 @@ local function pumpLapArchiveJobs()
   end
   if ok and type(pathOrErr) == "string" then
     pendingLapArchiveRecordPaths[#pendingLapArchiveRecordPaths + 1] = pathOrErr
+  end
+end
+
+--- Synchronously force EVERY pending archive job to completion (issue #305).
+--- The per-frame `pumpLapArchiveJobs` only advances the queue while `script.update`
+--- reaches its body. When a session ends (back to the main menu) update() returns
+--- early — before the per-frame pump — so a job queued for the LAST lap driven (the
+--- common "hot lap, then pit / stop" case) would otherwise be abandoned mid-stream as
+--- a partial `.tmp` and its trace lost. Drain it here instead, before that early return.
+--- `LAP_ARCHIVE_FLUSH_ROWS` finishes each front job in a single step; a hard iteration
+--- cap guarantees this can never spin even if a job's step path ever misbehaves.
+local function flushPendingLapArchiveJobs(reason)
+  if #pendingLapArchiveJobs == 0 then
+    return
+  end
+  if ac and type(ac.log) == "function" then
+    ac.log("[COPILOT][ARCHIVE] flushing " .. tostring(#pendingLapArchiveJobs)
+      .. " pending job(s) on " .. tostring(reason or "session end"))
+  end
+  local guard = 0
+  while #pendingLapArchiveJobs > 0 and guard < 4096 do
+    guard = guard + 1
+    local before = #pendingLapArchiveJobs
+    pumpLapArchiveJobs(LAP_ARCHIVE_FLUSH_ROWS)
+    if #pendingLapArchiveJobs == before then
+      -- A step with the flush budget always reaches `done`, so the front job is removed
+      -- above; this guard only fires if that contract ever breaks — drop it rather than spin.
+      table.remove(pendingLapArchiveJobs, 1)
+    end
   end
 end
 
@@ -1999,6 +2031,12 @@ function script.update(dt)
   end
 
   if sim.isInMainMenu then
+    -- Issue #305: the session has ended (or we are back at the menu). update() returns a
+    -- few lines below on every menu frame, so the per-frame archive pump further down never
+    -- runs again — drain any job queued for the last lap NOW so its full trace is written
+    -- instead of being abandoned as a partial `.tmp` stub. Must run before the early return
+    -- (and before resetRuntimeAfterLeavingTrack rebuilds runtime state).
+    flushPendingLapArchiveJobs("session end (main menu)")
     if state.wasDriving then
       if persistSnapshotCached() then
         -- Issue #47: training journal JSON under ScriptConfig (after persist, before state reset).

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -475,6 +475,14 @@ function M.createWriteJob(opts, capMB)
     return nil, "invalid archive record options"
   end
 
+  -- Issue #305: never stage a traceless archive. A completed in-game lap always has
+  -- trace rows; 0 rows means the trace was lost upstream (finalized after a reset, or a
+  -- lap that was never recorded). Writing the envelope-only ~900-byte stub the coaching
+  -- pipeline cannot use is worse than skipping — refuse so the caller logs and moves on.
+  if samplesCount <= 0 then
+    return nil, "refusing to archive lap with empty trace (0 rows)"
+  end
+
   capMB = M.clampArchiveCapMB(capMB)
   local path = archivePathForRecord(rec)
   local job = {

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -193,7 +193,8 @@ def test_create_write_job_refuses_empty_trace(tmp_path: pathlib.Path) -> None:
     )
     assert rt.globals()["_job"] is None, "createWriteJob must refuse an empty-trace lap"
     err = rt.globals()["_err"]
-    assert isinstance(err, str) and "empty trace" in err, f"unexpected err: {err!r}"
+    assert isinstance(err, str), f"err must be a string reason, got: {err!r}"
+    assert "empty trace" in err, f"unexpected err: {err!r}"
     assert not list(tmp_path.rglob("lap_*.json")), "no stub .json may be written"
     assert not list(tmp_path.rglob("*.tmp")), "no .tmp may be staged"
 

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import pathlib
-import re
 from typing import Any
 
 import pytest
@@ -13,7 +12,6 @@ lupa = pytest.importorskip("lupa", reason="lupa Lua runtime not installed (pip i
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
-ENTRY = REPO / "src" / "ac_copilot_trainer" / "ac_copilot_trainer.lua"
 
 
 def _lua_to_py(value: Any) -> Any:
@@ -172,29 +170,170 @@ def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.P
     assert record["coaching"]["corner_advice_used"]["T1"] == "Trail brake to apex"
 
 
-def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:
-    # This is an intentional source-structure regression test: if the lap
-    # boundary or WS pump sections are refactored, update these regex anchors
-    # with the implementation so the architectural guard remains meaningful.
-    src = ENTRY.read_text(encoding="utf-8")
-    match = re.search(
-        r"-- Issue #77 Part C / #246: archive this lap.*?state\.lapInvalidatedThisLap = false",
-        src,
-        flags=re.S,
+def test_create_write_job_refuses_empty_trace(tmp_path: pathlib.Path) -> None:
+    """#305 stub guard: a lap with no trace rows must NOT produce an archive at all —
+    not the envelope-only ~900-byte stub the coaching pipeline cannot use. The writer
+    refuses and the caller (queueLapArchiveJob) logs + skips. No .json, no .tmp."""
+    rt = _runtime(tmp_path)
+    rt.execute(
+        """
+        _opts = {
+          session_uuid = "session-empty",
+          car = { id = "ks_porsche_911_gt3_r_2016" },
+          sim = { trackName = "magione", trackLengthM = 2507 },
+          lap_n = 5,
+          lap_ms = 82550,
+          is_pb = true,
+          is_valid = true,
+          trace = {},  -- no samples
+        }
+        local lapArchive = require("lap_archive")
+        _job, _err = lapArchive.createWriteJob(_opts, 50)
+        """
     )
-    assert match is not None
-    block = match.group(0)
-    assert "queueLapArchiveJob(archiveOpts)" in block
-    assert "lapArchive.write" not in block
-    assert "lapArchive.buildRecord" not in block
+    assert rt.globals()["_job"] is None, "createWriteJob must refuse an empty-trace lap"
+    err = rt.globals()["_err"]
+    assert isinstance(err, str) and "empty trace" in err, f"unexpected err: {err!r}"
+    assert not list(tmp_path.rglob("lap_*.json")), "no stub .json may be written"
+    assert not list(tmp_path.rglob("*.tmp")), "no .tmp may be staged"
 
-    ws_match = re.search(
-        r"wsBridge\.tick\(ch\.simSeconds\(sim\)\).*?-- Issue #180 Part D step 2",
-        src,
-        flags=re.S,
+
+def test_pending_job_flushes_to_full_archive_in_one_step(tmp_path: pathlib.Path) -> None:
+    """#305 drain primitive: a job only partially pumped (the few frames before a session
+    ends) must complete to a FULL archive when force-drained in a single large step, never
+    left as a .tmp stub. This is exactly what flushPendingLapArchiveJobs relies on."""
+    rt = _runtime(tmp_path)
+    rt.execute(
+        """
+        local trace = {}
+        for i = 1, 200 do
+          trace[i] = {
+            spline = (i - 1) / 199, speed = 100, eMs = (i - 1) * 10,
+            throttle = 1, brake = 0, steer = 0, gear = 4, px = i, py = 0, pz = i,
+          }
+        end
+        _opts = {
+          session_uuid = "session-flush",
+          car = { id = "ks_porsche_911_gt3_r_2016" },
+          sim = { trackName = "magione", trackLengthM = 2507 },
+          lap_n = 7, lap_ms = 82550, is_pb = true, is_valid = true, trace = trace,
+        }
+        local lapArchive = require("lap_archive")
+        _job = assert(lapArchive.createWriteJob(_opts, 50))
+        """
     )
-    assert ws_match is not None
-    ws_block = ws_match.group(0)
-    assert ws_block.index("wsBridge.pollInbound(8)") < ws_block.index("pumpLapArchiveJobs()")
-    assert ws_block.index("pumpLapArchiveJobs()") < ws_block.index("pumpLapArchiveNotifications()")
-    assert "pendingLapArchiveRecordPaths" in src
+    # Reproduce the abandoned state: one per-frame step (64 rows) — not done, .tmp staged.
+    first = _step(rt, 64)
+    assert first["done"] is False
+    assert list(tmp_path.rglob("*.tmp")), "a partial pump should stage a .tmp"
+    assert not list(tmp_path.rglob("lap_*.json"))
+    # The drain: a single huge-budget step must finish the WHOLE job into a full .json.
+    final = _step(rt, 1_000_000)
+    assert final["done"] is True
+    assert final["ok"] is True
+    archive_path = pathlib.Path(final["res"])
+    assert archive_path.is_file()
+    assert not archive_path.with_name(archive_path.name + ".tmp").exists()
+    record = json.loads(archive_path.read_text(encoding="utf-8"))
+    assert record["lap"]["lap_n"] == 7
+    assert record["trace"]["samples_count"] == 200
+    assert len(record["trace"]["samples"]) == 200, "drain must write the full trace, not a stub"
+
+
+def test_flush_drains_whole_queue_to_full_archives(tmp_path: pathlib.Path) -> None:
+    """#305 drain ORCHESTRATION: model the entry's pending-job queue + the synchronous
+    flush helper (flushPendingLapArchiveJobs) and drive REAL createWriteJob jobs through
+    it. The source-side helper is a file-local in the 2300-line CSP entry and can't be
+    required directly (its call-site wiring is guarded by test_lap_archive_source_structure),
+    so this mirrors its exact logic — LAP_ARCHIVE_FLUSH_ROWS=1000000, the guard cap, and the
+    before==after fallback pop — and asserts the queue-level behavior end to end:
+      (a) a partially pumped job (a few per-frame rows) completes to a FULL .json, .tmp gone;
+      (b) several queued jobs all drain;
+      (c) an empty queue is a no-op.
+    """
+    rt = _runtime(tmp_path)
+    rt.execute(
+        """
+        -- Faithful mirror of the entry's queue primitives (issue #305). Kept in lockstep
+        -- with ac_copilot_trainer.lua via test_lap_archive_source_structure.
+        local lapArchive = require("lap_archive")
+        local LAP_ARCHIVE_ROWS_PER_FRAME = 64
+        local LAP_ARCHIVE_FLUSH_ROWS = 1000000
+        _pending = {}
+        _written = {}
+
+        function _enqueue(lap_n, n_rows)
+          local trace = {}
+          for i = 1, n_rows do
+            trace[i] = { spline = (i - 1) / math.max(1, n_rows - 1), speed = 100,
+              eMs = (i - 1) * 10, throttle = 1, brake = 0, steer = 0, gear = 4,
+              px = i, py = 0, pz = i }
+          end
+          local job = assert(lapArchive.createWriteJob({
+            session_uuid = "s", car = { id = "x" },
+            sim = { trackName = "magione", trackLengthM = 2507 },
+            lap_n = lap_n, lap_ms = 80000 + lap_n, is_pb = false, is_valid = true,
+            trace = trace,
+          }, 50))
+          _pending[#_pending + 1] = job
+        end
+
+        function _pump(maxRows)  -- mirror of pumpLapArchiveJobs
+          local job = _pending[1]
+          if not job then return end
+          local done, ok, pathOrErr = job:step(maxRows or LAP_ARCHIVE_ROWS_PER_FRAME)
+          if not done then return end
+          table.remove(_pending, 1)
+          if ok and type(pathOrErr) == "string" then
+            _written[#_written + 1] = pathOrErr
+          end
+        end
+
+        function _flush()  -- mirror of flushPendingLapArchiveJobs
+          if #_pending == 0 then return end
+          local guard = 0
+          while #_pending > 0 and guard < 4096 do
+            guard = guard + 1
+            local before = #_pending
+            _pump(LAP_ARCHIVE_FLUSH_ROWS)
+            if #_pending == before then
+              table.remove(_pending, 1)
+            end
+          end
+        end
+
+        function _queue_len() return #_pending end
+        function _written_len() return #_written end
+        """
+    )
+
+    # (c) empty queue: flush is a harmless no-op.
+    rt.execute("_flush()")
+    assert rt.eval("_queue_len()") == 0
+    assert rt.eval("_written_len()") == 0
+
+    # (a) one job, partially pumped (the few frames before a session ends), then drained.
+    rt.execute("_enqueue(7, 200)")
+    rt.execute("_pump(64)")  # one per-frame step: stages a .tmp, not done
+    assert rt.eval("_queue_len()") == 1
+    assert list(tmp_path.rglob("*.tmp")), "a partial pump should stage a .tmp"
+    assert not list(tmp_path.rglob("lap_*.json"))
+
+    rt.execute("_flush()")
+    assert rt.eval("_queue_len()") == 0, "flush must drain the queue"
+    assert not list(tmp_path.rglob("*.tmp")), "no leftover .tmp after flush"
+    archives = list(tmp_path.rglob("lap_*.json"))
+    assert len(archives) == 1
+    record = json.loads(archives[0].read_text(encoding="utf-8"))
+    assert record["lap"]["lap_n"] == 7
+    assert record["trace"]["samples_count"] == 200
+    assert len(record["trace"]["samples"]) == 200, "drain must write the full trace, not a stub"
+
+    # (b) multiple queued jobs: the loop drains all of them in one flush.
+    rt.execute("_enqueue(8, 120)")
+    rt.execute("_enqueue(9, 80)")
+    assert rt.eval("_queue_len()") == 2
+    rt.execute("_flush()")
+    assert rt.eval("_queue_len()") == 0, "flush must drain ALL queued jobs, not just the first"
+    assert not list(tmp_path.rglob("*.tmp"))
+    assert len(list(tmp_path.rglob("lap_*.json"))) == 3  # lap 7 + lap 8 + lap 9

--- a/tests/test_lap_archive_source_structure.py
+++ b/tests/test_lap_archive_source_structure.py
@@ -1,0 +1,72 @@
+"""Source-structure (architectural) guards for the lap-archive pump/flush wiring.
+
+These are pure ``read_text()`` + ``re`` assertions over ``ac_copilot_trainer.lua`` —
+they do NOT need the lupa Lua runtime, so (unlike the behavioral tests in
+``test_lap_archive_async.py``) they must run even on a box without lupa installed.
+Keeping them in their own module avoids the module-level ``importorskip("lupa")``
+silently disabling the regression net for the archive wiring (#305 review finding).
+
+If the lap boundary, WS pump, or session-end branch is refactored, update the
+anchors here so the guard stays meaningful rather than deleting it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+ENTRY = REPO / "src" / "ac_copilot_trainer" / "ac_copilot_trainer.lua"
+
+
+def test_session_end_flushes_pending_lap_archive() -> None:
+    """#305: the main-menu (session-end) branch of script.update must drain pending
+    archive jobs before its early return, so the last lap driven is never abandoned as
+    a partial .tmp. The drain must run BEFORE the session-end work (writeSessionEnd /
+    resetRuntimeAfterLeavingTrack), which is what gives it a queue to drain."""
+    src = ENTRY.read_text(encoding="utf-8")
+
+    # The synchronous drain helper exists and operates on the pending-job queue.
+    flush_def = re.search(r"local function flushPendingLapArchiveJobs.*?\nend\n", src, flags=re.S)
+    assert flush_def is not None, "flushPendingLapArchiveJobs helper missing"
+    assert "pendingLapArchiveJobs" in flush_def.group(0)
+
+    # Pin the exact update() session-end branch via a marker unique to it
+    # (sessionJournal.writeSessionEnd is only called there), then take the LAST
+    # `if sim.isInMainMenu then` before that marker — that is the branch start. This
+    # captures the precise branch body with no fixed-width window to grow brittle.
+    anchor = src.index("sessionJournal.writeSessionEnd")
+    menu_kw = src.rindex("if sim.isInMainMenu then", 0, anchor)
+    branch_body = src[menu_kw:anchor]
+    assert "flushPendingLapArchiveJobs(" in branch_body, (
+        "session-end branch must drain pending lap-archive jobs before its session-end "
+        "work (issue #305)"
+    )
+
+
+def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:
+    # This is an intentional source-structure regression test: if the lap
+    # boundary or WS pump sections are refactored, update these regex anchors
+    # with the implementation so the architectural guard remains meaningful.
+    src = ENTRY.read_text(encoding="utf-8")
+    match = re.search(
+        r"-- Issue #77 Part C / #246: archive this lap.*?state\.lapInvalidatedThisLap = false",
+        src,
+        flags=re.S,
+    )
+    assert match is not None
+    block = match.group(0)
+    assert "queueLapArchiveJob(archiveOpts)" in block
+    assert "lapArchive.write" not in block
+    assert "lapArchive.buildRecord" not in block
+
+    ws_match = re.search(
+        r"wsBridge\.tick\(ch\.simSeconds\(sim\)\).*?-- Issue #180 Part D step 2",
+        src,
+        flags=re.S,
+    )
+    assert ws_match is not None
+    ws_block = ws_match.group(0)
+    assert ws_block.index("wsBridge.pollInbound(8)") < ws_block.index("pumpLapArchiveJobs()")
+    assert ws_block.index("pumpLapArchiveJobs()") < ws_block.index("pumpLapArchiveNotifications()")
+    assert "pendingLapArchiveRecordPaths" in src


### PR DESCRIPTION
## Problem

Addresses #305. A clean **flying lap's trace archive is lost** (left as a ~923-byte / 0KB stub) when that lap is **not followed by another completed lap** — the common "do a hot lap, then pit / stop" pattern, and exactly what happens when an automated capture run ends. The trainer HUD times the lap correctly (e.g. `Best/Last 1:22.55`), so detection works; only the trace persistence is lost. The outlap (followed by the flying lap) always writes a full ~655 KB trace.

## Root cause

The per-lap archive job is **queued at the S/F crossing that completes a lap** (`queueLapArchiveJob`, `ac_copilot_trainer.lua`) and pumped a few rows per frame by `pumpLapArchiveJobs()`. When the session ends, `script.update()` enters the `if sim.isInMainMenu then` branch and **`return`s before ever reaching the per-frame pump** — so the *last* lap's job is abandoned mid-stream as a partial `.tmp` and never renamed to `.json`. The outlap survived only because ~82 s of flying-lap frames pumped it to completion. `resetRuntimeAfterLeavingTrack` never drains the queue.

(This is purely the Lua capture/flush path — the offline coaching pipeline is verified working on full-trace archives.)

## Fix

1. **`ac_copilot_trainer.lua` — `flushPendingLapArchiveJobs()`**: a synchronous drain that force-completes every pending job (`pumpLapArchiveJobs` now takes an optional row budget; the flush uses `LAP_ARCHIVE_FLUSH_ROWS = 1_000_000` so one step finishes a job; a 4096-iteration cap + a `before == after` fallback make a spin impossible). **Wired into the session-end (main-menu) branch before its early return**, ahead of the session-end work.
2. **`lap_archive.lua` — stub guard**: `createWriteJob` refuses an empty trace (`samplesCount <= 0`) so a traceless ~900-byte stub the coaching pipeline cannot use is never staged.

This delivers the issue's ask: *flush on session-end* + *guard so a valid completed lap always produces a full trace*. (Car-stationary *on track* is already covered — `update()` keeps running there, so the per-frame pump finishes the job; the only starvation point is the menu early-return.)

## Test plan (offline)

- `tests/test_lap_archive_async.py` (behavioral, lupa): empty-trace **refusal** (no `.json`/`.tmp`), partially-pumped job **drained to a full archive in one step**, and **multi-job flush orchestration** (drains all jobs, empty-queue no-op).
- `tests/test_lap_archive_source_structure.py` (lupa-independent): the session-end branch **calls the drain before its session-end work**, and the lap-boundary/WS-pump ordering guard.
- Proved the stub-guard test **fails on pre-fix `origin/main`** (`createWriteJob({trace={}})` returns a job pre-fix).
- Full suite: **1334 passed, 75 skipped**; `make ci-fast` green (ruff format/lint, bandit, CSP-API, CSP-UI-safety, policy, secrets, conventional).
- Pre-merge **adversarial review** (5 lenses × skeptic verification): 19 raw → 3 confirmed, all test-hygiene — addressed in this PR. No correctness/Lua/regression finding survived verification.

## Remaining (rig-gated, not in this PR)

The true end-to-end confirmation — drive a lap, pit/stop, confirm a full `lap_*.json` (not a stub) — needs the physical rig (AG_PC + AC); I ran this from macOS so it could not be live-verified here. Recipe for the next rig session: drive ≥1 flying lap, return to the menu / end the session, then check `…/journal/laps/` for a full-trace `lap_*.json` for that lap. Keeping #305 open until that live check passes.
