### PR TITLE
feat(coaching): surface trail-braking in coach-handoff + fold into attribution (#301)

### DIFF
--- a/tests/test_coach_handoff.py
+++ b/tests/test_coach_handoff.py
@@ -267,3 +267,66 @@ def test_end_to_end_from_build_structured_debrief():
     h = build_coach_handoff(structured, lap=1)
     assert h["v"] == COACH_HANDOFF_VERSION
     assert isinstance(h["corners"], list) and h["corners"]
+    # every handoff corner carries the (possibly None) trail_brake field
+    assert all("trail_brake" in c for c in h["corners"])
+
+
+# --- trail-braking joined onto the handoff corner (#301) ---------------------
+def test_trail_brake_joined_onto_handoff_corner():
+    corners = [
+        {
+            "index": 0,
+            "apex_spline": 0.3,
+            "time_loss_s": 0.2,
+            "headline": "C0",
+            "attributions": [_attr("braking_phase_loss", "setup+technique", advisory=True)],
+        }
+    ]
+    structured = _structured(corners)
+    structured["trail_braking"] = [
+        {
+            "corner": 0,
+            "apex_spline": 0.3,
+            "classification": "abrupt_release",
+            "trail_overlap": 0.5,
+            "brake_off_rel": -0.02,
+            "release_abruptness": 0.6,
+            "coaching": "bleed it off smoothly",
+        }
+    ]
+    tb = build_coach_handoff(structured, setup=SETUP)["corners"][0]["trail_brake"]
+    assert tb is not None
+    assert tb["classification"] == "abrupt_release"
+    assert tb["coaching"] == "bleed it off smoothly"
+    assert tb["trail_overlap"] == 0.5 and tb["release_abruptness"] == 0.6
+    assert "apex_spline" not in tb  # already on the handoff corner; not duplicated
+
+
+def test_handoff_trail_brake_is_none_when_unmatched_or_absent():
+    corners = [
+        {
+            "index": 0,
+            "apex_spline": 0.3,
+            "time_loss_s": 0.2,
+            "headline": "C0",
+            "attributions": [_attr("entry_speed_left", "technique")],
+        },
+        {"index": 1, "apex_spline": 0.6, "time_loss_s": 0.1, "headline": "C1", "attributions": []},
+    ]
+    structured = _structured(corners)
+    structured["trail_braking"] = [
+        {
+            "corner": 0,
+            "classification": "trails_too_deep",
+            "trail_overlap": 0.4,
+            "brake_off_rel": 0.2,
+            "release_abruptness": 0.1,
+            "coaching": "release earlier",
+        }
+    ]
+    h = build_coach_handoff(structured)
+    assert h["corners"][0]["trail_brake"]["classification"] == "trails_too_deep"
+    assert h["corners"][1]["trail_brake"] is None  # no finding for this corner
+    # a structured input with no trail_braking block at all -> all None
+    h2 = build_coach_handoff(_structured(corners))
+    assert all(c["trail_brake"] is None for c in h2["corners"])

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -456,3 +456,57 @@ def test_coach_lap_produces_per_corner_verdicts():
     assert isinstance(c0.attributions, list)
     # the synthetic apex (~90 km/h) at ~2.1 g vs 2.5 ceiling is near the limit -> grip-limited shows
     assert any(a.key == "grip_limited" for a in c0.attributions) or c0.min_speed_kmh > 0
+
+
+# --- trail-braking folded into the attribution layer (#301) ------------------
+def test_trail_brake_attribution_is_a_technique_verdict():
+    # an injected trail-brake deficit becomes a TECHNIQUE attribution (no live channel needed)
+    ctx = CornerContext(
+        sig=_sig(),
+        setup=SETUP,
+        extra={
+            "trail_brake": {"classification": "abrupt_release", "coaching": "bleed it off smoothly"}
+        },
+    )
+    tb = next(a for a in attribute_corner(ctx) if a.key == "trail_brake")
+    assert tb.advisory is False  # archive technique read — nothing live to confirm
+    assert tb.technique_causes and not tb.setup_causes  # -> cause_class "technique", no setup delta
+    assert tb.coaching == "bleed it off smoothly"  # forwards the classification's own coaching
+
+
+def test_trail_brake_no_attribution_without_injected_signal():
+    # attribute_corner called directly (no coach_lap injection) must not invent a trail_brake attr
+    assert not any(
+        a.key == "trail_brake" for a in attribute_corner(CornerContext(sig=_sig(), setup=SETUP))
+    )
+
+
+def test_good_trail_brake_does_not_attribute():
+    ctx = CornerContext(
+        sig=_sig(),
+        setup=SETUP,
+        extra={"trail_brake": {"classification": "good_trail_brake", "coaching": "textbook"}},
+    )
+    assert not any(a.key == "trail_brake" for a in attribute_corner(ctx))
+
+
+def test_trail_brake_never_displaces_a_setup_bearing_attribution():
+    # a corner that loses time braking AND trail-brakes poorly: braking_phase_loss stays PRIMARY
+    # (it carries the bias/setup hint); trail_brake only participates as a lower-ranked cue
+    ctx = CornerContext(
+        sig=_sig(peak_brake_g=1.1, brake_point_spline=0.40),
+        setup=SETUP,
+        delta=_delta(delta_s=0.3, min_speed_delta_kmh=0.0),  # no apex-speed deficit -> only braking
+        extra={"trail_brake": {"classification": "abrupt_release", "coaching": "bleed it off"}},
+    )
+    keys = [a.key for a in attribute_corner(ctx)]
+    assert "braking_phase_loss" in keys and "trail_brake" in keys
+    assert keys[0] == "braking_phase_loss"
+    assert keys.index("trail_brake") > keys.index("braking_phase_loss")
+
+
+def test_coach_lap_folds_in_trail_brake_attribution():
+    # the square-brake fixture trail-brakes poorly -> coach_lap injects a trail_brake attribution
+    lap = _corner_lap_trace()
+    report = coach_lap(lap, SETUP, grip_ceiling_g=2.5)
+    assert any(a.key == "trail_brake" for c in report for a in c.attributions)

--- a/tools/ai_sidecar/coach_handoff.py
+++ b/tools/ai_sidecar/coach_handoff.py
@@ -3,8 +3,15 @@
 Turns the brain's debrief (``coach_report.build_structured_debrief``) into a compact, versioned
 message a downstream consumer — an RL/agentic coach, the rig screen, or a logger — can act on
 without re-parsing prose. Per corner: ``{corner, time_loss_s, cause_class, confidence, advisory,
-coaching, suggested_setup_delta}``; per lap: total time lost, the top-focus corner, and the
-aero/mechanical balance verdict.
+coaching, suggested_setup_delta, trail_brake}``; per lap: total time lost, the top-focus corner,
+and the aero/mechanical balance verdict.
+
+The ``trail_brake`` field joins the structured debrief's separate ``trail_braking`` block (keyed by
+corner index) onto the matching handoff corner, so a downstream coach reads the trail-braking
+technique verdict inline with the per-corner cause instead of re-correlating two lists. It is
+``None`` for corners with no braking-into-entry phase. (The trail-brake read also participates in
+``cause_class`` directly, via the brain's ``trail_brake`` technique attribution — see
+``corner_attribution``.)
 
 The ``suggested_setup_delta`` is grounded in the verified setup knowledge + the attribution's own
 cause: a technique-class corner suggests NO setup change (it's a driver fix); a setup/grip-class
@@ -127,6 +134,23 @@ def _setup_delta(
     return None
 
 
+def _handoff_trail_brake(tb: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Compact per-corner trail-braking verdict for the handoff, or None when the corner has none.
+
+    Selects the actionable subset of one ``structured['trail_braking']`` entry. ``apex_spline`` is
+    already carried on the handoff corner, so it is not duplicated here.
+    """
+    if not isinstance(tb, dict):
+        return None
+    return {
+        "classification": tb.get("classification"),
+        "trail_overlap": tb.get("trail_overlap"),
+        "brake_off_rel": tb.get("brake_off_rel"),
+        "release_abruptness": tb.get("release_abruptness"),
+        "coaching": tb.get("coaching"),
+    }
+
+
 def build_coach_handoff(
     structured: dict[str, Any] | None, *, setup: CarSetup | None = None, lap: Any = None
 ) -> dict[str, Any]:
@@ -138,6 +162,12 @@ def build_coach_handoff(
     structured = structured or {}
     car_id = structured.get("car_id")
     corners_in = structured.get("corners") or []
+    # Index the separate trail-braking block by corner so it can be joined onto each handoff corner.
+    trail_by_idx = {
+        tb.get("corner"): tb
+        for tb in (structured.get("trail_braking") or [])
+        if isinstance(tb, dict)
+    }
     corners_out: list[dict[str, Any]] = []
     for c in corners_in:
         attrs = c.get("attributions") or []
@@ -160,6 +190,7 @@ def build_coach_handoff(
                 "symptom": top.get("symptom") if top else "on pace",
                 "coaching": top.get("coaching") if top else c.get("headline", ""),
                 "suggested_setup_delta": delta,
+                "trail_brake": _handoff_trail_brake(trail_by_idx.get(c.get("index"))),
             }
         )
     losers = [

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -31,6 +31,7 @@ from tools.ai_sidecar.lap_dynamics import (
 )
 from tools.ai_sidecar.setup_knowledge import AERO, MECHANICAL
 from tools.ai_sidecar.setup_model import CarSetup
+from tools.ai_sidecar.trail_brake import analyze_trail_braking
 
 
 # --- lap comparison: localize where time is lost ----------------------------
@@ -350,12 +351,33 @@ def coach_lap(
     sigs = corner_signatures(lap, corners)
     deltas = compare_laps(lap, reference, corners=corners) if reference is not None else []
     by_idx = {d.index: d for d in deltas}
+    # Trail-braking technique read (#301): computed once over the SAME segmentation as the
+    # signatures so the per-corner finding lines up with sig.index, then injected into each corner's
+    # ``extra`` so the trail_brake rule folds it into the attribution layer (cause_class reasoning)
+    # rather than only a parallel debrief block. ``no_braking`` corners get no finding.
+    trail_by_idx = {
+        f.corner: f for f in analyze_trail_braking(lap, corners) if f.classification != "no_braking"
+    }
     out: list[CornerCoaching] = []
     for sig in sigs:
         # explicit caller-supplied signals win; else auto-compute Tier-B signals from per-wheel data
         extra = (extra_by_corner or {}).get(sig.index)
         if extra is None:
             extra = corner_live_signals(lap, sig) if lap.has_wheel_data else {}
+        tb = trail_by_idx.get(sig.index)
+        if tb is not None and "trail_brake" not in extra:
+            # Copy (never mutate a caller-supplied extra dict); a caller that already set
+            # ``trail_brake`` wins, mirroring how explicit live signals take precedence above.
+            extra = {
+                **extra,
+                "trail_brake": {
+                    "classification": tb.classification,
+                    "coaching": tb.coaching,
+                    "trail_overlap": tb.trail_overlap,
+                    "brake_off_rel": tb.brake_off_rel,
+                    "release_abruptness": tb.release_abruptness,
+                },
+            }
         ctx = CornerContext(
             sig=sig,
             setup=setup,
@@ -622,6 +644,43 @@ def _exit_coaching(ctx: CornerContext) -> str:
     )
 
 
+# --- trail-braking technique (folds trail_brake.py into the attribution layer, #301) ----------
+#: Trail-brake deficit classification → attribution confidence. Kept deliberately LOW — below every
+#: other rule's firing floor yet above ``min_confidence`` (0.25) — so a trail-braking technique read
+#: PARTICIPATES in the cause_class reasoning as a supporting attribution but never DISPLACES a
+#: time-loss / setup-bearing attribution (braking_phase_loss, exit_traction, …) as the corner's
+#: primary cause. It becomes the primary cause only when no other rule fires (e.g. a clean lap with
+#: no reference). ``good_trail_brake`` / ``no_braking`` carry no deficit and never attribute.
+_TRAIL_BRAKE_CONFIDENCE = {
+    "abrupt_release": 0.29,
+    "brakes_early_then_coasts": 0.28,
+    "trails_too_deep": 0.28,
+    "straight_braking": 0.26,
+}
+
+
+def _r_trail_brake(ctx: CornerContext) -> float:
+    """Confidence for the trail-brake technique rule, from the injected ``extra['trail_brake']``.
+
+    Returns 0.0 (no attribution) when no trail-brake read was injected (e.g. ``attribute_corner``
+    called directly without ``coach_lap``) or the classification is non-deficit.
+    """
+    tb = ctx.extra.get("trail_brake")
+    if not isinstance(tb, dict):
+        return 0.0
+    return _TRAIL_BRAKE_CONFIDENCE.get(tb.get("classification"), 0.0)
+
+
+def _trail_brake_coaching(ctx: CornerContext) -> str:
+    tb = ctx.extra.get("trail_brake")
+    if isinstance(tb, dict) and tb.get("coaching"):
+        return str(tb["coaching"])
+    return (
+        "Trail the brake into the corner — bleed it off as the steering loads so the front stays "
+        "planted to the apex."
+    )
+
+
 RULES: list[DiagnosticRule] = [
     DiagnosticRule(
         key="grip_limited",
@@ -714,5 +773,22 @@ RULES: list[DiagnosticRule] = [
             "Sluggish turn-in (heading lags steer) — likely technique or front load, not "
             "necessarily toe. Confirm with live yaw-rate."
         ),
+    ),
+    DiagnosticRule(
+        key="trail_brake",
+        symptom="trail-braking technique",
+        phase="braking",
+        tier="A",
+        # Inferred from the archive brake+steer overlap + decel profile (trail_brake.py) — a
+        # technique read, so no live channel CONFIRMS it; advisory stays False like entry_speed.
+        channels_needed=(),
+        test=_r_trail_brake,
+        setup_causes=lambda c: [],  # technique-only → cause_class "technique", no setup delta
+        technique_causes=(
+            "Bleed the brake off progressively as steering loads up — keep the front tyres loaded "
+            "into the apex rather than braking straight then coasting, trailing past it, or "
+            "releasing in one step.",
+        ),
+        coaching=_trail_brake_coaching,
     ),
 ]


### PR DESCRIPTION
## What & why

Closes #301 — the two optional follow-ups to give the trail-braking signal (built in #296, surfaced in #299/#300) full reach. Both touch the AC sidecar coaching brain and are grouped because they're the two files #301 names.

### Part 1 — join `trail_braking` onto the coach-handoff corner (`coach_handoff.py`)
`build_coach_handoff` previously built per-corner verdicts from the structured corners' attributions but ignored the separate `structured["trail_braking"]` block. It now indexes that block by corner and joins a compact `trail_brake` field onto each handoff corner:

```json
"trail_brake": {"classification": "abrupt_release", "trail_overlap": 0.88,
                "brake_off_rel": -0.03, "release_abruptness": 0.8, "coaching": "..."}
```

`None` for corners with no braking-into-entry phase. `apex_spline` is already on the handoff corner, so it isn't duplicated.

### Part 2 — fold trail-braking into the attribution layer (`corner_attribution.py`)
Trail-braking now participates in `cause_class` reasoning instead of living only as a parallel block:
- `coach_lap` computes `analyze_trail_braking` over the **same** segmentation as the signatures and injects the per-corner read into `CornerContext.extra["trail_brake"]` (mirroring how `corner_live_signals` injects Tier-B signals; never mutates a caller-supplied `extra`).
- A new `DiagnosticRule(key="trail_brake")` turns a deficit classification (`abrupt_release` / `brakes_early_then_coasts` / `trails_too_deep` / `straight_braking`) into a **TECHNIQUE** attribution (`cause_class "technique"`, no suggested setup delta).

**"Never displaces" design:** the rule's confidence is deliberately low (0.26–0.29) — below every existing rule's firing floor (turn_in_lag 0.35, exit_traction ≥0.5, braking_phase_loss 0.4/0.7, entry_speed_left ≥0.5, grip_limited 0.6/1.0) yet above `min_confidence` (0.25). So trail-brake rides along as a supporting cue and is the primary cause only when nothing else fires (e.g. a clean lap with no reference). Existing corners' `cause_class` / `suggested_setup_delta` / `_headline` are unchanged.

## Compatibility
- **Additive only.** `COACH_HANDOFF_VERSION` unchanged (v1 consumers ignore unknown fields).
- The strict `coaching_response` golden (`test_harness_client.py::test_baseline_scenario_matches_golden`) is **unchanged**.
- `attribute_corner()` still no-ops for trail-brake when called directly without `coach_lap` injection.
- No circular import (`trail_brake` imports only `lap_dynamics`).

## Tests
New, plus full regression:
- `test_corner_attribution.py`: fires-as-technique, no-op-without-signal, good-classification-non-attribution, never-displaces-ranking, `coach_lap` injection.
- `test_coach_handoff.py`: trail_brake joined onto the corner, None when unmatched/absent, every corner carries the key.

## Verification
- `make ci-fast`: **OK** (full suite 1337 passed; ruff format+lint, bandit, policy, secrets, CSP all green).
- **End-to-end on the real pipeline**: confirmed the `trail_brake` attribution (`cause_class='technique'`) appears in `cornerAnalysis`, the handoff corner carries the joined `trail_brake` field, and the live `coaching_response` wire path (`build_brain_followup`) surfaces both the `trailBraking` block and the attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
