### PR TITLE
docs(vault): record #308 resolution + correct stale substrate-DOWN note

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-23T13:45:00Z
+last_updated: 2026-06-26T05:30:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-308-worktree-memory-gate-resolved-2026-06-25.md
   - AcCopilotTrainer/03_Investigations/pr-309-lap-archive-finalization.md
   - AcCopilotTrainer/01_Decisions/realtime-coaching-architecture-2026-06-22.md
   - AcCopilotTrainer/03_Investigations/frontier-controller-ggv-2026-06-19.md
@@ -34,6 +35,31 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-25 LATEST — #308 Tier-3 worktree memory-gate false-block CLOSED)
+
+**Closed COMPLETED** ([#308](https://github.com/agorokh/ac-copilot-trainer/issues/308)) — autonomous
+triage, no source change. Both acceptance criteria verified by running the **real** SessionStart
+prefetch from inside a linked git worktree (operator-grade, observed):
+
+- **Part A** (gitignored overlay non-propagation → `example_kb_workspace` block): already fixed by
+  [PR #316](https://github.com/agorokh/ac-copilot-trainer/pull/316). Prefetch in a linked worktree
+  resolves `workspace: ac_copilot`, **no** `.last_memory_query.missing` block marker.
+- **Part B** (prefetch SSRF guard on `:8045`): **functional criterion met** — prefetch exits 0,
+  substrate answers, `prefetch_ok: true` stamp written. The `untrusted port 8045` SSRF WARN is
+  **cosmetic / by-design** on a non-central host (grounding succeeds via the registry's non-loopback
+  Tailscale endpoint; the manifest loopback is correctly rejected). The original "permanent SSRF
+  block" was a **transient substrate outage**, not the guard.
+- **Residual** (genuinely upstream — governance-hub owns the resolver; this repo carries only shims):
+  cosmetic-WARN downgrade filed as
+  [governance-hub#111](https://github.com/agorokh/governance-hub/issues/111).
+- Detail: [issue-308-worktree-memory-gate-resolved-2026-06-25.md](../03_Investigations/issue-308-worktree-memory-gate-resolved-2026-06-25.md).
+
+**CORRECTION to the older note below:** the earlier *"Tier-3 `ac_copilot` substrate remains DOWN"* is
+now **stale** — the substrate is **UP** as of 2026-06-25 (`verify_server_health reachable=true`; the
+prefetch grounds with a real answer).
+
+---
 
 ## Resume here (2026-06-23 LATEST — #278 lupa per-wheel test fidelity SHIPPED via PR #315)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
@@ -2,7 +2,7 @@
 type: index
 status: active
 created: 2026-04-08
-updated: 2026-06-23
+updated: 2026-06-25
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
 ---
@@ -13,6 +13,7 @@ Technical deep-dives and root-cause analyses from development sessions.
 
 | Node | Summary |
 |------|---------|
+| [issue-308-worktree-memory-gate-resolved-2026-06-25.md](issue-308-worktree-memory-gate-resolved-2026-06-25.md) | #308 closed COMPLETED. Tier-3 worktree false-block was Part A (committed-manifest placeholder, fixed by #316) + a **transient substrate outage** — NOT the SSRF guard. The `untrusted port 8045` SSRF WARN is **cosmetic/by-design** on non-central hosts (grounding works via the registry Tailscale endpoint). Residual = cosmetic-WARN downgrade → governance-hub#111. |
 | [pr-309-lap-archive-finalization.md](pr-309-lap-archive-finalization.md) | Last lap's trace lost (≈923-byte stub) when not followed by another lap: session-end early-return skips the per-frame archive pump → abandoned `.tmp`. Fix: synchronous `flushPendingLapArchiveJobs` on driving→menu + empty-trace stub guard (#305 / PR #309; rig confirmation remains). |
 | [racing-driver-and-controller-2026-06-17.md](racing-driver-and-controller-2026-06-17.md) | Racing driver follows `fast_lane.ai`'s embedded speed profile (braking points/trail braking); gear bug fixed (limiter below shift point); the wall is STEERING (pure-pursuit cuts apexes → invalid laps); human-lap telemetry is the path (#241/#242/#244). |
 | [cm-url-deelevated-launch-2026-06-16.md](cm-url-deelevated-launch-2026-06-16.md) | De-elevated `acmanager://race/quick` launch (CM-IPC forward) gets AC on track non-elevated from the elevated agent shell — the hands-off L2 keystone (#232/#233). |

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-308-worktree-memory-gate-resolved-2026-06-25.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-308-worktree-memory-gate-resolved-2026-06-25.md
@@ -1,0 +1,59 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-06-25
+updated: 2026-06-25
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/00_System/invariants/memory-three-tiers.md
+  - AcCopilotTrainer/03_Investigations/_index.md
+---
+
+# Issue #308 — Tier-3 worktree memory-gate false-block: RESOLVED (2026-06-25)
+
+[#308](https://github.com/agorokh/ac-copilot-trainer/issues/308) closed COMPLETED. Both acceptance
+criteria verified by running the **real** SessionStart prefetch from inside a linked git worktree —
+not by reading a diff.
+
+## TL;DR for future sessions (do not re-investigate)
+
+- The **SSRF WARN** `ignoring manifest loopback endpoint on untrusted port 8045 (not registry-known);
+  SSRF guard (#7)` is **COSMETIC and BY DESIGN on a non-central host.** It is **not** a grounding
+  failure. The prefetch still grounds — it reaches the substrate via the fleet registry's
+  **non-loopback Tailscale HTTPS** endpoint (`https://100.71.123.90:8045`, registry-named → passes
+  the allowlist), and correctly rejects the manifest's repo-controlled `http://localhost:8045`.
+- If a linked-worktree session *looks* blocked, check whether the **substrate is actually reachable**
+  (`verify_server_health`) before suspecting the SSRF guard — a transient outage is the usual cause.
+
+## Part A — gitignored overlay non-propagation → fixed by #316
+
+[PR #316](https://github.com/agorokh/ac-copilot-trainer/pull/316) (closes #314) pins
+`tier3_workspace_id: ac_copilot` in the **committed** `ops/memory_manifest.yml` (tracked → present in
+every worktree; the gitignored `ops/memory_manifest.local.yml` overlay is no longer needed). Verified:
+prefetch in a linked worktree resolves `workspace: ac_copilot` (not `example_kb_workspace`), no
+`.scratch/.last_memory_query.missing` block marker.
+
+## Part B — prefetch SSRF guard on `:8045` → functional criterion met
+
+Root-cause reframe: the original *"substrate unreachable → permanent SSRF block"* reading conflated a
+**transient substrate outage** (502 at filing time; now up) with the **cosmetic SSRF WARN**. The SSRF
+guard was never the grounding blocker. Real prefetch run from the linked worktree:
+
+```
+exit 0 · workspace: ac_copilot · result: <real grounded substrate answer>
+stamp: .scratch/.last_memory_query → prefetch_ok: true · no block marker
+stderr: WARN ... untrusted port 8045 (SSRF guard #7)   ← cosmetic, by design on non-central host
+```
+
+`resolve_memory_endpoints()` (governance-hub `hooks/hook_memory_manifest.py`) accepts a *loopback*
+manifest endpoint only on a registry-known loopback port; on a non-central host the registry names
+the workspace only at its Tailscale endpoint, so `localhost:8045` is correctly rejected. On the
+central host (`mac-mini-dev`) the loopback IS registry-known → no WARN there.
+
+## Residual (genuinely separable, upstream — filed)
+
+The prefetch + SSRF resolver are **owned by the governance-hub**; this repo carries only thin shims.
+The only thing left is downgrading the cosmetic WARN when an accepted registry endpoint already
+resolved. Filed with a concrete proposed fix + acceptance criteria:
+**[agorokh/governance-hub#111](https://github.com/agorokh/governance-hub/issues/111)**.


### PR DESCRIPTION
Vault-only SAVE for the autonomous-deliver session that closed **#308** (Tier-3 worktree memory-gate false-block).

## What changed (strictly `docs/01_Vault/**`)
- **New investigation node** `issue-308-worktree-memory-gate-resolved-2026-06-25.md` — root-cause reframe: Part A fixed by #316; Part B was a transient substrate outage, not the SSRF guard; the `untrusted port 8045` WARN is cosmetic/by-design on non-central hosts.
- **Investigations `_index.md`** — registers the node; bumps `updated`.
- **Next Session Handoff.md** — new "Resume here" block for #308 closure; **corrects the stale "substrate remains DOWN" note** (substrate is UP, prefetch grounds).

## Verification (operator-grade, observed)
Ran the real `scripts/hook_session_start_memory_prefetch.py` from inside a linked worktree → `exit 0`, `workspace: ac_copilot`, real grounded substrate answer, `prefetch_ok: true` stamp, **no** `.last_memory_query.missing` block marker.

Residual (genuinely upstream) filed as **agorokh/governance-hub#111**. Closes the loop on #308; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)