### PR TITLE
refactor(ci): vault-automerge -> governance-hub composite action caller (#863)

### DIFF
--- a/.github/workflows/vault-automerge.yml
+++ b/.github/workflows/vault-automerge.yml
@@ -1,11 +1,12 @@
 name: Vault auto-merge
 
-# Validates that a vault-only PR (label `vault-only`) touches *only* paths under
-# `docs/01_Vault/**`, then enables GitHub auto-merge. Branch protection still
-# applies — if required reviews/checks block the bot, a human must merge.
-#
-# This decouples the post-merge-steward agent from `git push origin main`:
-# the agent opens a labeled PR, this workflow guards scope and ships it.
+# Thin caller. The vault-only scope guard (`docs/01_Vault/**` only) + `gh pr merge --auto`
+# logic -- including the #506 confirmation-race handling and the #855 `allow_auto_merge`-off
+# benign-downgrade -- lives ONCE in the governance-hub `vault-automerge` composite action
+# (agent-factory#863, gov-hub#122/#123), instead of a per-repo vendored copy. This repo keeps
+# only the trigger, the `vault-only` label gate, and permissions; the action operates on the PR
+# via `gh` (no checkout) and re-arms auto-merge only when scope passes (the gov-hub#123
+# disarm-first fix). SHA-pinned (reference-not-vendor; roll new versions canary -> fleet).
 
 on:
   pull_request:
@@ -17,66 +18,12 @@ permissions:
 
 jobs:
   guard-and-automerge:
-    if: contains(github.event.pull_request.labels.*.name, 'vault-only')
+    if: contains(github.event.pull_request.labels.*.name, 'vault-only') && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: Validate vault-only scope
-        id: scope
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          files="$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)"
-          if [[ -z "$files" ]]; then
-            echo "::error::PR has no file changes"
-            exit 1
-          fi
-          out_of_scope="$(echo "$files" | grep -Ev '^docs/01_Vault/' || true)"
-          if [[ -n "$out_of_scope" ]]; then
-            echo "::error::vault-only PR contains out-of-scope files:"
-            echo "$out_of_scope"
-            comment_path="$(mktemp)"
-            {
-              printf '%s\n\n' 'Auto-merge declined: `vault-only` PR must touch only `docs/01_Vault/**`. Out-of-scope files:'
-              printf '%s\n' '```'
-              printf '%s\n' "$out_of_scope"
-              printf '%s\n' '```'
-            } >"$comment_path"
-            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$comment_path"
-            rm -f "$comment_path"
-            exit 1
-          fi
-          echo "All changes within docs/01_Vault/ — scope OK."
-
-      - name: Enable auto-merge (squash)
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          auto_log="$(mktemp)"
-          if ! gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --auto --delete-branch 2>&1 | tee "$auto_log"; then
-            # Benign race: GitHub is already squash-merging this PR (or it just
-            # merged). `mergePullRequest` returns "Merge already in progress" /
-            # "already merged" — the PR lands fine, so this is success, not a red check.
-            if grep -qiE '(merge already in progress|already in progress|already( been)? merged)' "$auto_log"; then
-              echo "::notice::Squash merge already in progress (or PR already merged); GitHub will complete it. Treating as success."
-              rm -f "$auto_log"
-              exit 0
-            fi
-            if grep -qiE '(not enabled|disabled|protected|required)' "$auto_log"; then
-              echo "::warning::Auto-merge could not be enabled (likely branch protection / required reviews missing). A human must merge."
-              gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
-                "Vault scope validated, but auto-merge could not be enabled by the bot. Branch protection / required reviews may be the cause. A human with merge rights should land this PR."
-              rm -f "$auto_log"
-              exit 0
-            fi
-            rm -f "$auto_log"
-            echo "::error::Failed to enable auto-merge"
-            exit 1
-          fi
-          rm -f "$auto_log"
+      - uses: agorokh/governance-hub/.github/actions/vault-automerge@0939d4724bd1e89515d4abd89d676c750580b028
+        with:
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.pull_request.number }}
+          repo: ${{ github.repository }}


### PR DESCRIPTION
Fleet fan-out of agorokh/agent-factory#863 (Council-signed-off, drift-audited).

Replaces this repo's vendored `.github/workflows/vault-automerge.yml` with a thin caller of the canonical governance-hub `vault-automerge` composite action (gov-hub#122/#123), SHA-pinned to the rename-aware `0939d472`. The vault-only scope guard + `gh pr merge --auto` logic -- with the #506 confirmation-race handling, the #855 `allow_auto_merge`-off benign downgrade, and the gov-hub#123 disarm-prior-auto-merge fix -- now lives once in the hub instead of a vendored copy here.

This repo keeps only the `pull_request` trigger, the `vault-only` label gate, and `permissions`. Behaviour is preserved (and upgraded to the latest hub logic). Proven on the agent-factory pilot (a real vault PR auto-merged through the hub action).

Rollback: revert this commit (the vendored workflow is restored from git history).
