### PR TITLE
feat(coaching): activate archive-backed brain debriefs (#277)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-26T05:30:00Z
+last_updated: 2026-06-27T06:15:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-308-worktree-memory-gate-resolved-2026-06-25.md
   - AcCopilotTrainer/03_Investigations/pr-309-lap-archive-finalization.md
@@ -35,6 +35,36 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-27 LIVE RIG CONFIRMATION — #305 CLOSED)
+
+**Closed COMPLETED** ([#305](https://github.com/agorokh/ac-copilot-trainer/issues/305)) on AG_PC with
+AC + CSP running from the repo symlink. This was the post-PR #309 live proof for the final-lap archive
+bug.
+
+Observed run:
+- Launched AC through Content Manager `race/config` from the live `race.ini`: `ks_porsche_911_gt3_r_2016`
+  at `magione`; shared memory confirmed `LIVE` / not-in-pit and the HUD screenshot rendered.
+- Temporarily applied Magione Custom-AI permissions, drove two completed laps with the Custom-AI
+  controller, then restored stock `surfaces.ini` afterward.
+- Final target lap was **lap 2, valid PB, 81.841 s**, with no third completed lap before cleanup.
+- New archive:
+  `lap_20260627-055835_87fc4736_2_81841_6a3f668b9bbd.json` — **670,811 bytes / 655.1 KB**,
+  `trace.samples_count=2000`, `len(trace.samples)=2000`, 22 trace fields including
+  `wheelAngularSpeed_*` and `wheelSlip_*`. This is a full trace, not the former 923-byte stub.
+- CSP log also showed the defensive guard working: empty trace refused instead of written as a stub,
+  then `queued async write samples=2000` and wrote the final-lap archive.
+
+Evidence is local/ignored at `.scratch/issue305-live-20260626-225318/`:
+`drive.stdout.log`, `drive-visual.png`, `csp-archive-tail.log`, copied final archive JSON, and cleanup
+metadata. The public closeout comment is
+[#305#issuecomment-4815490402](https://github.com/agorokh/ac-copilot-trainer/issues/305#issuecomment-4815490402).
+
+Note: the session began while the active `feat/issue-277-live-brain-debrief` WIP branch already held
+source/test/docs changes for the brain-debrief delivery. The #305 rig-confirmation SAVE only added
+this vault handoff.
+
+---
 
 ## Resume here (2026-06-25 LATEST — #308 Tier-3 worktree memory-gate false-block CLOSED)
 

--- a/docs/10_Development/12_WS_Sidecar_Protocol.md
+++ b/docs/10_Development/12_WS_Sidecar_Protocol.md
@@ -22,6 +22,9 @@ Sent after each completed lap when `config.wsSidecarUrl` is set and the socket i
 | `lapTimeMs`     | int         | yes      | Previous lap time in ms              |
 | `coachingHints` | string[]    | no       | Rules-based hint strings (same lap)  |
 | `telemetry`     | object      | no       | Optional structured lap data for sidecar analysis (issue **#49**); see below |
+| `archivePath`   | string      | no       | Issue **#277**: archive-backed follow-up path, sent only after the async lap archive write completes |
+| `referenceArchivePath` | string | no    | Optional safe lap archive path for the driver's written PB/reference, enabling delta-based brain rules |
+| `brainOnly`     | bool        | no       | When `true`, the sidecar skips the generic immediate ack and only emits the archive-backed brain follow-up |
 
 \*Missing `protocol` on `lap_complete` is accepted with a server warning (legacy); new clients should always send `protocol: 1`.
 
@@ -49,6 +52,9 @@ Snake_case variants (`min_speed_kmh`, …) are also accepted.
 | `hints`    | array  | yes      | Up to 3 items: `{ "kind", "text" }` or plain strings |
 | `improvementRanking` | array | no | Issue **#49**: ordered corner-level suggestions vs best lap-with-corners reference (ignored by current Lua until **3b** consumes it) |
 | `debrief`  | string | no       | Issue **#46**: one or two paragraphs when `AC_COPILOT_OLLAMA_ENABLE=1` (local Ollama with **`AC_COPILOT_OLLAMA_DEBRIEF_TIMEOUT_SEC`** default 12s, then rules fallback); omitted when debrief feature is off. The sidecar builds outbound messages in a worker thread so slow Ollama does not block the WebSocket loop. |
+| `debriefSource` | string | no | `"ollama"` or `"brain"` for async follow-ups. Lua preserves the rich debrief text and treats `"brain"` as a structured tile source. |
+| `cornerAnalysis` | array | no | Issue **#277**: machine-readable setup-vs-technique corner tiles from the brain follow-up. |
+| `balance` | object | no | Issue **#277**: overall balance verdict/coaching, rendered as a secondary brain tile when space allows. |
 
 When received for the same `lap`, Lua **replaces** `state.coachingLines` with these hints (rules-based hints are overridden). If the hold timer had already expired (e.g. delayed sidecar), Lua **restarts** the hold so hints still display.
 

--- a/scripts/hook_session_start_memory_redirect.py
+++ b/scripts/hook_session_start_memory_redirect.py
@@ -93,9 +93,17 @@ def _slugify(path: Path) -> str:
     return abs_str.replace("/", "-")
 
 
+def _home_dir() -> Path:
+    """Return the hook home directory, honoring explicit test/session overrides."""
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
 def _auto_memory_dir(project_root: Path) -> Path:
     slug = _slugify(project_root)
-    return Path.home() / ".claude" / "projects" / slug / "memory"
+    return _home_dir() / ".claude" / "projects" / slug / "memory"
 
 
 def _marker_readme(project_root: Path) -> str:

--- a/scripts/merge_memory_contract.py
+++ b/scripts/merge_memory_contract.py
@@ -216,7 +216,7 @@ def _process(path: Path, *, root: Path, check: bool, diff: bool) -> tuple[bool, 
         original = path.read_text(encoding="utf-8")
     except OSError as e:
         return False, f"read error: {path}: {e}"
-    rel_target = str(path.relative_to(root))
+    rel_target = path.relative_to(root).as_posix()
     updated = _render(original, root=root, rel_target=rel_target)
     if updated == original:
         return False, None

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -410,6 +410,7 @@ local tires = tireMonitor.new()
 local pendingWsSidecarUrl = nil
 local pendingLapArchiveJobs = {}
 local pendingLapArchiveRecordPaths = {}
+local bestLapArchivePath = nil
 local LAP_ARCHIVE_ROWS_PER_FRAME = 64
 -- Per-step row budget used by the synchronous session-end drain (issue #305). Far above any
 -- real lap's downsampled trace (~2000 rows) so a single step finishes the whole job.
@@ -420,7 +421,18 @@ local LAP_ARCHIVE_FLUSH_ROWS = 1000000
 -- time; without this they would compile to globals and stay nil — issue #81).
 local state
 
-local function queueLapArchiveJob(archiveOpts)
+local function shallowCopy(tbl)
+  local out = {}
+  if type(tbl) ~= "table" then
+    return out
+  end
+  for k, v in pairs(tbl) do
+    out[k] = v
+  end
+  return out
+end
+
+local function queueLapArchiveJob(archiveOpts, notifyOpts)
   local job, err = lapArchive.createWriteJob(
     archiveOpts,
     lapArchive.clampArchiveCapMB(config.lapArchiveMaxMB)
@@ -430,6 +442,9 @@ local function queueLapArchiveJob(archiveOpts)
       ac.log("[COPILOT][ARCHIVE] queue failed: " .. tostring(err))
     end
     return
+  end
+  if type(notifyOpts) == "table" then
+    job._copilotNotify = notifyOpts
   end
   pendingLapArchiveJobs[#pendingLapArchiveJobs + 1] = job
   if ac and type(ac.log) == "function" then
@@ -452,7 +467,24 @@ local function pumpLapArchiveJobs(maxRows)
     end
   end
   if ok and type(pathOrErr) == "string" then
-    pendingLapArchiveRecordPaths[#pendingLapArchiveRecordPaths + 1] = pathOrErr
+    local notification = {
+      path = pathOrErr,
+      setupRecordSent = false,
+      archiveLapSent = false,
+    }
+    local notify = type(job._copilotNotify) == "table" and job._copilotNotify or nil
+    if notify and type(notify.archiveLapPayload) == "table" then
+      local payload = shallowCopy(notify.archiveLapPayload)
+      payload.archivePath = pathOrErr
+      if type(notify.referenceArchivePath) == "string" and notify.referenceArchivePath ~= "" then
+        payload.referenceArchivePath = notify.referenceArchivePath
+      end
+      notification.archiveLapPayload = payload
+    end
+    if notify and notify.isBestLapArchive == true then
+      bestLapArchivePath = pathOrErr
+    end
+    pendingLapArchiveRecordPaths[#pendingLapArchiveRecordPaths + 1] = notification
   end
 end
 
@@ -490,16 +522,40 @@ local function pumpLapArchiveNotifications()
     return
   end
   while #pendingLapArchiveRecordPaths > 0 do
-    local path = pendingLapArchiveRecordPaths[1]
-    local sent = false
-    pcall(function()
-      sent = wsBridge.sendSetupExperimentRecord(path) == true
-    end)
-    if sent then
+    local item = pendingLapArchiveRecordPaths[1]
+    if type(item) == "string" then
+      item = { path = item, setupRecordSent = false, archiveLapSent = true }
+      pendingLapArchiveRecordPaths[1] = item
+    end
+    local path = type(item) == "table" and item.path or nil
+    if type(path) ~= "string" or path == "" then
       table.remove(pendingLapArchiveRecordPaths, 1)
     else
-      -- Keep the path queued; handshake/reconnect can become ready on a later frame.
-      return
+      if not item.setupRecordSent then
+        local sent = false
+        pcall(function()
+          sent = wsBridge.sendSetupExperimentRecord(path) == true
+        end)
+        if sent then
+          item.setupRecordSent = true
+        else
+          -- Keep the path queued; handshake/reconnect can become ready on a later frame.
+          return
+        end
+      end
+      if type(item.archiveLapPayload) == "table" and not item.archiveLapSent then
+        local sent = false
+        pcall(function()
+          sent = wsBridge.sendJson(item.archiveLapPayload) == true
+        end)
+        if sent then
+          item.archiveLapSent = true
+        else
+          -- Avoid re-sending the setup record; retry only the archive-backed lap_complete later.
+          return
+        end
+      end
+      table.remove(pendingLapArchiveRecordPaths, 1)
     end
   end
 end
@@ -1427,6 +1483,7 @@ local function resetRuntimeAfterLeavingTrack()
   state.sidecarDebriefText = ""
   state.cornerAdvisories = {}
   state.lapInvalidatedThisLap = false
+  bestLapArchivePath = nil
   state.focusPracticeActive = false
   state.focusWorstThree = {}
   state.lastLapCornerFeats = {}
@@ -1460,6 +1517,7 @@ local function resetRollingDrivingState()
   state.sidecarDebriefText = ""
   state.cornerAdvisories = {}
   state.lapInvalidatedThisLap = false
+  bestLapArchivePath = nil
   state.lapsCompleted = 0
   state.focusWorstThree = {}
   state.lastLapCornerFeats = {}
@@ -2409,6 +2467,7 @@ function script.update(dt)
 
     -- PB flag must use pre-update `bestLapMs` (Cursor #78); archive runs after PB block mutates it.
     local isPbThisLap = lastMs > 0 and (state.bestLapMs == nil or lastMs <= state.bestLapMs)
+    local referenceArchivePathForBrain = bestLapArchivePath
 
     local prevBestBp = copyBpList(state.brakingPoints.best)
     local localBestChanged = false
@@ -2500,7 +2559,13 @@ function script.update(dt)
         -- (Codex + Cursor Bugbot #78 post-5f0ce39).
         corner_advice = wsBridge.cornerAdvisorySnapshotForLap((state.lapsCompleted or 0) - 1),
       }
-      queueLapArchiveJob(archiveOpts)
+      local archiveLapPayload = shallowCopy(lapPayload)
+      archiveLapPayload.brainOnly = true
+      queueLapArchiveJob(archiveOpts, {
+        archiveLapPayload = archiveLapPayload,
+        referenceArchivePath = referenceArchivePathForBrain,
+        isBestLapArchive = isPbThisLap,
+      })
     end
 
     state.lapInvalidatedThisLap = false

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1484,6 +1484,10 @@ local function resetRuntimeAfterLeavingTrack()
   state.cornerAdvisories = {}
   state.lapInvalidatedThisLap = false
   bestLapArchivePath = nil
+  -- Drop any archive-backed lap_complete follow-ups left unsent: they reference the prior
+  -- stint's archives and must not leak into the next session (drained best-effort above on
+  -- the session-end path). CodeRabbit #321.
+  pendingLapArchiveRecordPaths = {}
   state.focusPracticeActive = false
   state.focusWorstThree = {}
   state.lastLapCornerFeats = {}
@@ -1518,6 +1522,9 @@ local function resetRollingDrivingState()
   state.cornerAdvisories = {}
   state.lapInvalidatedThisLap = false
   bestLapArchivePath = nil
+  -- Rolling reset starts a disjoint session (new SESSION_UUID below); drop prior-stint
+  -- archive follow-ups so they cannot attach to the new session. CodeRabbit #321.
+  pendingLapArchiveRecordPaths = {}
   state.lapsCompleted = 0
   state.focusWorstThree = {}
   state.lastLapCornerFeats = {}
@@ -2097,6 +2104,11 @@ function script.update(dt)
       -- transition (a job can only be queued while driving), not on every idle menu frame;
       -- runs before resetRuntimeAfterLeavingTrack rebuilds runtime state.
       flushPendingLapArchiveJobs("session end (main menu)")
+      -- Drain the notifications flush just enqueued: update() returns a few lines below
+      -- before the per-frame pump runs again, and resetRuntimeAfterLeavingTrack (which
+      -- also calls wsBridge.reset) is imminent — so the last lap's archive-backed brain
+      -- follow-up gets its one send attempt here instead of being stranded. CodeRabbit #321.
+      pumpLapArchiveNotifications()
       if persistSnapshotCached() then
         -- Issue #47: training journal JSON under ScriptConfig (after persist, before state reset).
         local journalLaps = state.lapsCompleted or 0
@@ -2506,6 +2518,12 @@ function script.update(dt)
     state.postLapLines = buildPostLapLines(prevBestBp, state.brakingPoints.last, coastMs, sim)
     state.postLapUntil = ch.simSeconds(sim) + config.postLapHoldSeconds
 
+    -- Hoisted out of the `if lastMs > 0` block below: the deferred archive follow-up
+    -- (`shallowCopy(lapPayload)` further down) must see the populated table. In Lua 5.1 a
+    -- `local` declared inside that `if ... end` is out of scope by the archive block, so a
+    -- nested declaration would copy nil and strip the base `lap_complete` fields
+    -- (event/lap/lapTimeMs) — silently disabling the brain follow-up. CodeRabbit #321.
+    local lapPayload
     if lastMs > 0 then
       local hintsJson = {}
       if state.coachingLines then
@@ -2518,7 +2536,7 @@ function script.update(dt)
           end
         end
       end
-      local lapPayload = {
+      lapPayload = {
         protocol = wsBridge.PROTOCOL_VERSION,
         event = "lap_complete",
         lap = state.lapsCompleted,

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -414,6 +414,101 @@ local function normalizeSidecarHints(hints)
   return out
 end
 
+local function trimText(text, maxLen)
+  local s = tostring(text or "")
+  local n = tonumber(maxLen) or 220
+  if #s <= n then
+    return s
+  end
+  if n <= 3 then
+    return s:sub(1, n)
+  end
+  return s:sub(1, n - 3) .. "..."
+end
+
+local function brainKindForCause(causeClass)
+  local c = tostring(causeClass or "")
+  if c:find("technique", 1, true) then
+    return "line"
+  end
+  if c:find("setup", 1, true) then
+    return "brake"
+  end
+  if c:find("grip", 1, true) then
+    return "throttle"
+  end
+  return "general"
+end
+
+local function firstAttribution(corner)
+  local attrs = type(corner) == "table" and corner.attributions or nil
+  if type(attrs) ~= "table" then
+    return nil
+  end
+  local best = nil
+  local bestConf = -1
+  for i = 1, #attrs do
+    local a = attrs[i]
+    if type(a) == "table" then
+      local conf = tonumber(a.confidence) or 0
+      if not best or conf > bestConf then
+        best = a
+        bestConf = conf
+      end
+    end
+  end
+  return best
+end
+
+local function normalizeBrainHints(data, fallbackHints)
+  local out = {}
+  local corners = type(data) == "table" and data.cornerAnalysis or nil
+  if type(corners) == "table" then
+    for i = 1, #corners do
+      if #out >= 3 then
+        break
+      end
+      local corner = corners[i]
+      if type(corner) == "table" then
+        local attr = firstAttribution(corner)
+        local headline = type(corner.headline) == "string" and corner.headline or ""
+        if headline == "" then
+          headline = "Corner " .. tostring(corner.index or i)
+        end
+        local loss = tonumber(corner.time_loss_s)
+        local lossText = ""
+        if loss and loss > 0.05 then
+          lossText = string.format(" (+%.2fs)", loss)
+        end
+        local detail = ""
+        local kind = "general"
+        if attr then
+          kind = brainKindForCause(attr.cause_class)
+          if type(attr.coaching) == "string" and attr.coaching ~= "" then
+            detail = attr.coaching
+          elseif type(attr.symptom) == "string" and attr.symptom ~= "" then
+            detail = attr.symptom
+          end
+        end
+        local text = headline .. lossText
+        if detail ~= "" then
+          text = text .. ": " .. detail
+        end
+        out[#out + 1] = { kind = kind, text = trimText(text, 220) }
+      end
+    end
+  end
+  local balance = type(data) == "table" and data.balance or nil
+  if #out < 3 and type(balance) == "table" and type(balance.coaching) == "string"
+      and balance.coaching ~= "" then
+    out[#out + 1] = { kind = "positive", text = trimText("Balance: " .. balance.coaching, 220) }
+  end
+  if #out > 0 then
+    return out
+  end
+  return normalizeSidecarHints(fallbackHints)
+end
+
 local _wsDiagLogged = false
 local _wsDiagAttempts = 0
 --- Cap noisy per-frame WS recv logs (Bugbot); diagnostics reset on new socket.
@@ -640,7 +735,13 @@ function M.pollInbound(maxPerTick)
           if type(data.debrief) == "string" and data.debrief ~= "" then
             debrief = data.debrief
           end
-          if source == "ollama" then
+          if source == "brain" then
+            pendingCoaching = {
+              lap = lap,
+              hints = normalizeBrainHints(data, hints),
+              debrief = debrief,
+            }
+          elseif source == "ollama" then
             if pendingCoaching and pendingCoaching.lap == lap then
               -- Round 8: Ollama follow-up overwrites the rules debrief with
               -- the LLM version. Hints are preserved from the immediate

--- a/tests/test_ai_sidecar_protocol.py
+++ b/tests/test_ai_sidecar_protocol.py
@@ -296,6 +296,61 @@ def test_sidecar_websocket_lap_complete_roundtrip() -> None:
     asyncio.run(_go())
 
 
+def test_sidecar_brain_only_lap_complete_skips_generic_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websockets = pytest.importorskip("websockets", minversion="12")
+    from tools.ai_sidecar import server as srv
+    from tools.ai_sidecar.server import _handler
+
+    def _brain(inbound: dict) -> dict:
+        return {
+            "protocol": PROTOCOL_VERSION,
+            "event": EVENT_COACHING_RESPONSE,
+            "lap": inbound.get("lap"),
+            "hints": [{"kind": "general", "text": "brain"}],
+            "debrief": "archive-backed brain",
+            "debriefSource": "brain",
+            "cornerAnalysis": [{"index": 1, "headline": "T1", "attributions": []}],
+            "balance": {"coaching": "ok"},
+        }
+
+    monkeypatch.setattr(srv, "build_brain_followup", _brain)
+
+    async def _go() -> None:
+        async with websockets.serve(
+            lambda w: _handler(w, reply_coaching=True),
+            "127.0.0.1",
+            0,
+        ) as server:
+            port = server.sockets[0].getsockname()[1]
+            uri = f"ws://127.0.0.1:{port}"
+            async with websockets.connect(uri) as ws:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "protocol": PROTOCOL_VERSION,
+                            "event": "lap_complete",
+                            "lap": 7,
+                            "lapTimeMs": 95000,
+                            "archivePath": "journal/laps/lap_test.json",
+                            "brainOnly": True,
+                        },
+                        separators=(",", ":"),
+                    )
+                )
+                raw = await asyncio.wait_for(ws.recv(), timeout=5.0)
+                out = json.loads(raw)
+                assert out["event"] == EVENT_COACHING_RESPONSE
+                assert out["debriefSource"] == "brain"
+                assert out["debrief"] == "archive-backed brain"
+                assert out["hints"][0]["text"] == "brain"
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(ws.recv(), timeout=0.1)
+
+    asyncio.run(_go())
+
+
 def test_sidecar_non_object_json_gets_analysis_error() -> None:
     websockets = pytest.importorskip("websockets", minversion="12")
     from tools.ai_sidecar.server import _handler

--- a/tests/test_import_motec.py
+++ b/tests/test_import_motec.py
@@ -212,5 +212,6 @@ def test_default_output_dir_precedence(tmp_path: Path, monkeypatch: pytest.Monke
     )
 
     monkeypatch.delenv("AC_COPILOT_CSP_STATE_DIR")
+    monkeypatch.setattr("tools.import_motec._use_windows_ac_default", lambda: False)
     monkeypatch.chdir(tmp_path)
     assert default_output_dir(opts) == tmp_path / "journal" / "laps"

--- a/tests/test_lap_archive_source_structure.py
+++ b/tests/test_lap_archive_source_structure.py
@@ -100,3 +100,50 @@ def test_archive_write_notification_sends_brain_activation_lap_payload() -> None
     assert "local referenceArchivePathForBrain = bestLapArchivePath" in src
     assert "archiveLapPayload.brainOnly = true" in block
     assert "referenceArchivePath = referenceArchivePathForBrain" in block
+
+
+def test_deferred_archive_payload_copies_full_lap_complete_payload() -> None:
+    """#321 regression: the deferred archive-backed lap_complete must be a copy of the FULL
+    live ``lapPayload`` (protocol/event/lap/lapTimeMs), not a bare ``{brainOnly=true}`` table.
+
+    In Lua 5.1 a ``local`` declared inside the ``if lastMs > 0`` block is out of scope by the
+    archive block below, so ``shallowCopy(lapPayload)`` there would copy ``nil`` and silently
+    strip the base fields — leaving the sidecar's ``event == "lap_complete"`` gate unable to
+    fire the brain follow-up (the whole point of #321). The fix hoists ``lapPayload`` to an
+    outer-scope bare ``local``; this guard pins that shape so the bug cannot regress.
+    """
+    src = ENTRY.read_text(encoding="utf-8")
+
+    # Exactly one declaration, and it is a bare *hoisted* local — NOT `local lapPayload = {`,
+    # which would scope it inside the lap-boundary block and break the deferred copy.
+    decls = re.findall(r"\blocal lapPayload\b", src)
+    assert len(decls) == 1, "expected exactly one lapPayload local declaration"
+    assert re.search(r"\n[ \t]*local lapPayload[ \t]*\n", src) is not None, (
+        "lapPayload must be hoisted as a bare `local lapPayload` declaration above the "
+        "`if lastMs > 0` block (Lua block scope; #321)"
+    )
+    assert "local lapPayload = {" not in src, (
+        "lapPayload must not be re-declared inside the lap-boundary block — the deferred "
+        "archive copy would then see nil and drop the base lap_complete fields (#321)"
+    )
+
+    # The populated table is assigned to the hoisted local and carries the base lap_complete fields.
+    populated = re.search(r"\n[ \t]*lapPayload = \{(.*?)\n[ \t]*\}", src, flags=re.S)
+    assert populated is not None, "could not find the `lapPayload = { ... }` assignment"
+    payload_literal = populated.group(1)
+    for field in ('event = "lap_complete"', "lap = state.lapsCompleted", "lapTimeMs = lastMs"):
+        assert field in payload_literal, f"base lap_complete field missing from lapPayload: {field}"
+
+    # The deferred archive payload is a copy of that full payload (inheriting the base fields),
+    # then adds the brain-only marker — it must not be built from scratch.
+    archive_block = re.search(
+        r"-- Issue #77 Part C / #246: archive this lap.*?state\.lapInvalidatedThisLap = false",
+        src,
+        flags=re.S,
+    )
+    assert archive_block is not None
+    block = archive_block.group(0)
+    assert "local archiveLapPayload = shallowCopy(lapPayload)" in block, (
+        "deferred archive payload must shallowCopy the full lapPayload so it keeps the base "
+        "lap_complete fields (#321)"
+    )

--- a/tests/test_lap_archive_source_structure.py
+++ b/tests/test_lap_archive_source_structure.py
@@ -56,7 +56,7 @@ def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:
     )
     assert match is not None
     block = match.group(0)
-    assert "queueLapArchiveJob(archiveOpts)" in block
+    assert "queueLapArchiveJob(archiveOpts" in block
     assert "lapArchive.write" not in block
     assert "lapArchive.buildRecord" not in block
 
@@ -70,3 +70,33 @@ def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:
     assert ws_block.index("wsBridge.pollInbound(8)") < ws_block.index("pumpLapArchiveJobs()")
     assert ws_block.index("pumpLapArchiveJobs()") < ws_block.index("pumpLapArchiveNotifications()")
     assert "pendingLapArchiveRecordPaths" in src
+
+
+def test_archive_write_notification_sends_brain_activation_lap_payload() -> None:
+    """#277: the live brain needs the finalized archive path, which exists only after
+    the async archive job completes. The queue notification must attach that path to a
+    follow-up lap_complete payload and include the prior best archive as reference when
+    available, without turning the archive write back into synchronous lap-boundary I/O."""
+    src = ENTRY.read_text(encoding="utf-8")
+
+    pump = re.search(
+        r"local function pumpLapArchiveJobs.*?\nlocal function flushPendingLapArchiveJobs",
+        src,
+        flags=re.S,
+    )
+    assert pump is not None
+    pump_body = pump.group(0)
+    assert "payload.archivePath = pathOrErr" in pump_body
+    assert "payload.referenceArchivePath = notify.referenceArchivePath" in pump_body
+    assert "bestLapArchivePath = pathOrErr" in pump_body
+
+    archive_block = re.search(
+        r"-- Issue #77 Part C / #246: archive this lap.*?state\.lapInvalidatedThisLap = false",
+        src,
+        flags=re.S,
+    )
+    assert archive_block is not None
+    block = archive_block.group(0)
+    assert "local referenceArchivePathForBrain = bestLapArchivePath" in src
+    assert "archiveLapPayload.brainOnly = true" in block
+    assert "referenceArchivePath = referenceArchivePathForBrain" in block

--- a/tests/test_vendored_egress_pin.py
+++ b/tests/test_vendored_egress_pin.py
@@ -36,7 +36,10 @@ PINS = {"client.py": CANONICAL_CLIENT_SHA256, "__init__.py": CANONICAL_INIT_SHA2
 
 
 def _sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    # Pins are against the LF-normalized canonical files in governance-hub.
+    # Windows checkouts may materialize these text files as CRLF.
+    data = path.read_bytes().replace(b"\r\n", b"\n")
+    return hashlib.sha256(data).hexdigest()
 
 
 def test_vendored_egress_files_present_and_pinned() -> None:

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -243,6 +243,54 @@ def test_legacy_protocol_frame_does_not_unblock_v1_publish():
     assert rt.eval('require("ws_bridge").publishTopic("coaching.snapshot", {})') is True
 
 
+def test_brain_debrief_source_renders_corner_analysis_tiles():
+    rt = _runtime()
+    _open(rt)
+    _inject(
+        rt,
+        {
+            "protocol": 1,
+            "event": "coaching_response",
+            "lap": 2,
+            "hints": [{"kind": "general", "text": "Setup-vs-technique debrief"}],
+            "debrief": "full structured debrief",
+            "debriefSource": "brain",
+            "cornerAnalysis": [
+                {
+                    "index": 1,
+                    "headline": "T1 lost entry speed",
+                    "time_loss_s": 0.42,
+                    "attributions": [
+                        {
+                            "cause_class": "technique",
+                            "confidence": 0.72,
+                            "coaching": "Release brake more smoothly.",
+                        }
+                    ],
+                }
+            ],
+            "balance": {"coaching": "Car is balanced; chase technique first."},
+        },
+    )
+    rt.execute(
+        """
+        local h, d = require("ws_bridge").takeCoachingForLap(2)
+        _brain_hint_count = #h
+        _brain_hint_kind = h[1].kind
+        _brain_hint_text = h[1].text
+        _brain_debrief = d
+        """
+    )
+
+    assert int(rt.eval("_brain_hint_count")) == 2
+    assert rt.eval("_brain_hint_kind") == "line"
+    text = rt.eval("_brain_hint_text")
+    assert "T1 lost entry speed" in text
+    assert "+0.42s" in text
+    assert "Release brake more smoothly." in text
+    assert rt.eval("_brain_debrief") == "full structured debrief"
+
+
 def test_reconnect_via_onopen_rearms_handshake():
     # CodeRabbit Major on PR #171: with reconnect=true, CSP auto-reconnects by
     # firing onOpen WITHOUT calling tryOpen. The handshake gating must re-arm on

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -927,6 +927,19 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
                     hints,
                 )
 
+            # Archive-backed activation frames are emitted after Lua knows the final archive path.
+            # They should only run the brain, not the generic rules ack or Ollama narration.
+            if (
+                reply_coaching
+                and data.get("event") == "lap_complete"
+                and data.get("brainOnly") is True
+            ):
+                brain_task = asyncio.create_task(_send_brain_followup(websocket, data))
+                _background_tasks.add(brain_task)
+                pending_followups.add(brain_task)
+                brain_task.add_done_callback(_followup_done)
+                continue
+
             # corner_query runs compose_corner_hint (blocking HTTP to Ollama). Do not
             # stall the websocket message loop — process it in a background task.
             # corner_query does not read LapComparisonState — keep it out of

--- a/tools/import_motec/__init__.py
+++ b/tools/import_motec/__init__.py
@@ -484,6 +484,10 @@ def _record_for_lap(
     }
 
 
+def _use_windows_ac_default() -> bool:
+    return os.name == "nt"
+
+
 def default_output_dir(opts: ImportOptions) -> Path:
     env_laps = os.environ.get("AC_COPILOT_LAP_ARCHIVE_DIR")
     if env_laps:
@@ -495,7 +499,7 @@ def default_output_dir(opts: ImportOptions) -> Path:
     )
     if csp_state is not None:
         return csp_state / "ac_copilot_trainer" / "journal" / "laps"
-    if os.name == "nt":
+    if _use_windows_ac_default():
         docs = Path.home() / "Documents" / "Assetto Corsa"
         candidate = (
             docs


### PR DESCRIPTION
## Summary
- send a deferred `lap_complete` after async lap archive write completion with `archivePath`, optional `referenceArchivePath`, and `brainOnly=true`
- teach the sidecar to run only the archive-backed brain follow-up for those deferred frames, avoiding a duplicate generic ack
- render `debriefSource=brain` `cornerAnalysis`/`balance` as concrete Lua coaching tiles while keeping the full rich debrief text
- document the additive v1 protocol fields

## Verification
- `python -m pytest tests/test_lap_archive_source_structure.py tests/test_ws_bridge_hello_handshake.py tests/test_ai_sidecar_protocol.py tests/test_brain_wiring.py` -> 44 passed
- `python -m ruff format --check tests/test_ai_sidecar_protocol.py tests/test_lap_archive_source_structure.py tests/test_ws_bridge_hello_handshake.py tools/ai_sidecar/server.py` -> passed
- `python -m ruff check src tests tools scripts` -> passed
- `python -m bandit -r src -ll -ii` -> passed
- `PYTHON=python bash scripts/policy_tracked_files.sh` via Git Bash -> passed
- `bash scripts/check_policy_docs.sh` via Git Bash -> passed
- `python scripts/check_agent_forbidden.py` -> exited 0 (existing allowlist warnings for `.copier-answers.yml`, `doppler.yaml`)
- `python scripts/check_csp_api.py src` -> passed
- `python scripts/check_csp_ui_safety.py` -> passed

## Not Yet Verified
- `make ci-fast` could not run directly in this PowerShell environment because `make` is not installed.
- Full `pytest -q --cov=ac_copilot_trainer --cov=tools --cov-fail-under=80` is not a clean signal on this host: without `FLEET_GOVERNANCE_ROOT` it cannot import governance-hub `inference_egress`; with `FLEET_GOVERNANCE_ROOT=C:\Users\arsen\Projects\governance-hub`, 1315 tests passed, coverage was 86.67%, and 9 unrelated Windows/governance fixture tests failed.
- Rig completion remains pending: drive a lap in AC and confirm the brain `coaching_response` renders with the archive-backed `cornerAnalysis`/per-wheel attribution. This draft intentionally does not claim #277 complete until that observed run exists.

Refs #277