### PR TITLE
chore(governance): refresh hub shim digest

### DIFF
--- a/scripts/hook_detect_git_commit.py
+++ b/scripts/hook_detect_git_commit.py
@@ -10,6 +10,15 @@ import sys
 from pathlib import Path
 
 
+def _is_relative_to(path: Path, base: Path) -> bool:
+    """Python 3.9-compatible containment check."""
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
 def _canonical_impl_path() -> Path | None:
     """Resolve the hub's ``hook_protect_main_impl.py`` from a trusted location.
 
@@ -22,10 +31,20 @@ def _canonical_impl_path() -> Path | None:
         bases.append(Path(env_root).expanduser())
     bases.append(Path.home() / ".fleet-governance")
     for base in bases:
+        if not base.is_absolute():
+            continue
+        try:
+            resolved_base = base.resolve()
+        except (OSError, RuntimeError):
+            continue
         for sub in ("hooks", "scripts"):
             p = base / sub / "hook_protect_main_impl.py"
-            if p.is_file():
-                return p
+            try:
+                resolved = p.resolve()
+            except (OSError, RuntimeError):
+                continue
+            if _is_relative_to(resolved, resolved_base) and resolved.is_file():
+                return resolved
     return None
 
 

--- a/scripts/hook_memory_gate.py
+++ b/scripts/hook_memory_gate.py
@@ -72,6 +72,15 @@ _RECOVERY_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _is_relative_to(path: Path, base: Path) -> bool:
+    """Python 3.9-compatible containment check."""
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
 def _canonical(name: str) -> Path | None:
     """Resolve the canonical hook from a TRUSTED, configured location only."""
     here = Path(__file__).resolve()
@@ -81,10 +90,24 @@ def _canonical(name: str) -> Path | None:
         bases.append(Path(env_root).expanduser())
     bases.append(Path.home() / ".fleet-governance")
     for base in bases:
+        if not base.is_absolute():
+            continue
+        try:
+            resolved_base = base.resolve()
+        except (OSError, RuntimeError):
+            continue
         for sub in ("hooks", "scripts"):  # hub layout, then legacy layout
             p = base / sub / name
-            if p.is_file() and p.resolve() != here:
-                return p
+            try:
+                resolved = p.resolve()
+            except (OSError, RuntimeError):
+                continue
+            if (
+                _is_relative_to(resolved, resolved_base)
+                and resolved.is_file()
+                and resolved != here
+            ):
+                return resolved
     return None
 
 

--- a/scripts/hook_memory_manifest.py
+++ b/scripts/hook_memory_manifest.py
@@ -847,6 +847,11 @@ def resolve_memory_endpoints(
                 if not _is_loopback_host(parsed[1]):
                     registry_hosts.add(parsed[1])
 
+    # SSRF guard (#7) WARN is DEFERRED (gh#111): if the manifest names a loopback
+    # endpoint on an untrusted port we reject it below, but only surface that as a
+    # WARN once we know nothing else resolved for this workspace. Captured here,
+    # emitted after have_real_substrate is computed.
+    rejected_untrusted_loopback_port: int | None = None
     if isinstance(manifest_workspace, dict):
         # Only attach the manifest endpoint when the row is actually THIS
         # workspace and is an online (lightrag) substrate — never a mismatched
@@ -880,10 +885,10 @@ def resolve_memory_endpoints(
                     if mf_port in allowed_loopback_ports:
                         raw.append((40, "manifest", *parsed))
                     else:
-                        sys.stderr.write(
-                            "WARN  hook_memory_manifest: ignoring manifest loopback endpoint on "
-                            f"untrusted port {mf_port} (not registry-known); SSRF guard (#7)\n"
-                        )
+                        # Rejected (security #7 — unchanged). DEFER the WARN: it is only
+                        # worth surfacing if no accepted endpoint resolves for this
+                        # workspace; emitted below, gated on have_real_substrate (gh#111).
+                        rejected_untrusted_loopback_port = mf_port
                 else:
                     # Non-loopback: validated later by the registry/bridge allowlist + HTTPS.
                     raw.append((40, "manifest", *parsed))
@@ -926,6 +931,18 @@ def resolve_memory_endpoints(
         _accepted(scheme, host) and port not in _PLACEHOLDER_PORTS
         for (_pri, _src, scheme, host, port) in raw
     )
+    # SSRF guard (#7), deferred WARN (gh#111): a manifest loopback endpoint on an
+    # untrusted port was rejected above. Surface it ONLY when it actually mattered —
+    # i.e. no accepted (registry/bridge) endpoint resolved for this workspace. When a
+    # real substrate is already reachable, ignoring the repo-named loopback is a
+    # harmless, security-correct skip, and the WARN is pure noise that reads like a
+    # grounding failure on every non-central host.
+    if rejected_untrusted_loopback_port is not None and not have_real_substrate:
+        sys.stderr.write(
+            "WARN  hook_memory_manifest: ignoring manifest loopback endpoint on "
+            f"untrusted port {rejected_untrusted_loopback_port} (not registry-known); "
+            "SSRF guard (#7)\n"
+        )
     # A loopback fallback is only meaningful when the workspace config actually
     # points at loopback (central host). Synthesizing 127.0.0.1:<port> for a
     # remote-only substrate can hit an unrelated local service reusing the port

--- a/scripts/hook_memory_query_stamp.py
+++ b/scripts/hook_memory_query_stamp.py
@@ -72,6 +72,15 @@ _RECOVERY_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _is_relative_to(path: Path, base: Path) -> bool:
+    """Python 3.9-compatible containment check."""
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
 def _canonical(name: str) -> Path | None:
     """Resolve the canonical hook from a TRUSTED, configured location only."""
     here = Path(__file__).resolve()
@@ -81,10 +90,24 @@ def _canonical(name: str) -> Path | None:
         bases.append(Path(env_root).expanduser())
     bases.append(Path.home() / ".fleet-governance")
     for base in bases:
+        if not base.is_absolute():
+            continue
+        try:
+            resolved_base = base.resolve()
+        except (OSError, RuntimeError):
+            continue
         for sub in ("hooks", "scripts"):  # hub layout, then legacy layout
             p = base / sub / name
-            if p.is_file() and p.resolve() != here:
-                return p
+            try:
+                resolved = p.resolve()
+            except (OSError, RuntimeError):
+                continue
+            if (
+                _is_relative_to(resolved, resolved_base)
+                and resolved.is_file()
+                and resolved != here
+            ):
+                return resolved
     return None
 
 

--- a/scripts/hook_protect_main_impl.py
+++ b/scripts/hook_protect_main_impl.py
@@ -72,6 +72,15 @@ _RECOVERY_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _is_relative_to(path: Path, base: Path) -> bool:
+    """Python 3.9-compatible containment check."""
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
 def _canonical(name: str) -> Path | None:
     """Resolve the canonical hook from a TRUSTED, configured location only."""
     here = Path(__file__).resolve()
@@ -81,10 +90,24 @@ def _canonical(name: str) -> Path | None:
         bases.append(Path(env_root).expanduser())
     bases.append(Path.home() / ".fleet-governance")
     for base in bases:
+        if not base.is_absolute():
+            continue
+        try:
+            resolved_base = base.resolve()
+        except (OSError, RuntimeError):
+            continue
         for sub in ("hooks", "scripts"):  # hub layout, then legacy layout
             p = base / sub / name
-            if p.is_file() and p.resolve() != here:
-                return p
+            try:
+                resolved = p.resolve()
+            except (OSError, RuntimeError):
+                continue
+            if (
+                _is_relative_to(resolved, resolved_base)
+                and resolved.is_file()
+                and resolved != here
+            ):
+                return resolved
     return None
 
 

--- a/scripts/hook_session_start_memory_prefetch.py
+++ b/scripts/hook_session_start_memory_prefetch.py
@@ -72,6 +72,15 @@ _RECOVERY_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _is_relative_to(path: Path, base: Path) -> bool:
+    """Python 3.9-compatible containment check."""
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
 def _canonical(name: str) -> Path | None:
     """Resolve the canonical hook from a TRUSTED, configured location only."""
     here = Path(__file__).resolve()
@@ -81,10 +90,24 @@ def _canonical(name: str) -> Path | None:
         bases.append(Path(env_root).expanduser())
     bases.append(Path.home() / ".fleet-governance")
     for base in bases:
+        if not base.is_absolute():
+            continue
+        try:
+            resolved_base = base.resolve()
+        except (OSError, RuntimeError):
+            continue
         for sub in ("hooks", "scripts"):  # hub layout, then legacy layout
             p = base / sub / name
-            if p.is_file() and p.resolve() != here:
-                return p
+            try:
+                resolved = p.resolve()
+            except (OSError, RuntimeError):
+                continue
+            if (
+                _is_relative_to(resolved, resolved_base)
+                and resolved.is_file()
+                and resolved != here
+            ):
+                return resolved
     return None
 
 

--- a/tests/test_hook_scripts.py
+++ b/tests/test_hook_scripts.py
@@ -81,6 +81,17 @@ def _load_protect_impl():
     return mod
 
 
+def _load_detect_git_commit():
+    spec = importlib.util.spec_from_file_location(
+        "hook_detect_git_commit",
+        SCRIPTS / "hook_detect_git_commit.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
 @_SKIP_PROTECT_SHIM
 def test_shell_command_segments_are_independent_lists() -> None:
     """Regression: flush must not append the same list object that is then cleared."""
@@ -196,6 +207,61 @@ def test_hook_detect_git_commit_script() -> None:
         check=False,
     )
     assert r3.returncode == 0
+
+
+def test_hook_detect_git_commit_rejects_relative_env_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub = tmp_path / "hub"
+    (hub / "hooks").mkdir(parents=True)
+    (hub / "hooks" / "hook_protect_main_impl.py").write_text("OK = True\n", encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("FLEET_GOVERNANCE_ROOT", "hub")
+
+    det = _load_detect_git_commit()
+    assert det._canonical_impl_path() is None
+
+
+def test_hook_detect_git_commit_allows_symlink_inside_hub(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub = tmp_path / "hub"
+    real_hooks = hub / "real_hooks"
+    real_hooks.mkdir(parents=True)
+    target = real_hooks / "hook_protect_main_impl.py"
+    target.write_text("OK = True\n", encoding="utf-8")
+    (hub / "hooks").symlink_to(real_hooks)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("FLEET_GOVERNANCE_ROOT", str(hub))
+
+    det = _load_detect_git_commit()
+    assert det._canonical_impl_path() == target.resolve()
+
+
+def test_hook_detect_git_commit_rejects_symlink_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hub = tmp_path / "hub"
+    (hub / "hooks").mkdir(parents=True)
+    outside = tmp_path / "outside" / "hook_protect_main_impl.py"
+    outside.parent.mkdir()
+    outside.write_text("OK = True\n", encoding="utf-8")
+    (hub / "hooks" / "hook_protect_main_impl.py").symlink_to(outside)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("FLEET_GOVERNANCE_ROOT", str(hub))
+
+    det = _load_detect_git_commit()
+    assert det._canonical_impl_path() is None
 
 
 def _git_init_on(tmp_path: Path, branch: str) -> Path:

--- a/tests/test_public_governance_conformance.py
+++ b/tests/test_public_governance_conformance.py
@@ -32,7 +32,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 CANONICAL_SHIM_SHA256 = (
-    "d28fab569a94f943c5c0c49178d9fd4cadcfa37550222cabf7cc2fa40f92d71c"  # pragma: allowlist secret
+    "9a794b498f2f75b55e2f4752b98fdbd94a9fd61980f4ba4a95cde5b8f4ed8da7"  # pragma: allowlist secret
 )
 GOVERNED_SHIMS = (
     "hook_session_start_memory_prefetch.py",


### PR DESCRIPTION
## Summary
- refresh tracked governance shim copies after agorokh/governance-hub#117 hardened canonical hub resolution
- update the public canonical shim hash pin to `9a794b498f2f75b55e2f4752b98fdbd94a9fd61980f4ba4a95cde5b8f4ed8da7`
- sync `scripts/hook_memory_manifest.py` with the hub helper because this public repo actively tests and loads it
- replaces the earlier `codex/govhub-117-reshim` PR because this repo's branch policy requires a conventional branch prefix

## Verification
- hard governance conformance sweep passed for this spoke after the refresh
- `python3 -m pytest tests/test_public_governance_conformance.py tests/test_hook_memory_manifest.py tests/test_memory_endpoint_resolver.py -q` -> 58 passed
- `git diff --check`

Refs agorokh/governance-hub#117
