### PR TITLE
feat(harness): one-command autonomous self-test — carcsw drive + assert, any car/track (#154 Part G)

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -20,6 +20,7 @@ from tools.ac_harness.auto_drive import (
     _build_driver,
     _config_from_args,
     default_ac_root,
+    generic_gt3_ggv,
     resolve_fast_lane,
     run_auto_drive,
 )
@@ -266,6 +267,25 @@ def test_build_driver_racing_is_default_and_shifts_gears():
 def test_build_driver_racing_requires_speed_profile():
     with pytest.raises(ValueError, match="speed_profile"):
         _build_driver(_cfg(driver="racing"), _LINE, None)
+
+
+def test_build_driver_ggv_builds_min_time_racingdriver():
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    # GGV computes its own min-time profile from the line curvature (no speed_profile needed).
+    d = _build_driver(_cfg(driver="ggv", racing_max_speed_kmh=200.0, ggv_scale=0.9), _LINE, None)
+    assert isinstance(d, RacingDriver)
+    assert d.max_gear >= 6  # top gears available for flat-out straights
+
+
+def test_generic_gt3_ggv_is_realistic():
+    from tools.ac_harness.ggv_profile import GGVModel
+
+    g = generic_gt3_ggv()
+    assert isinstance(g, GGVModel)
+    assert 1.0 < g.mu_lat_g < 2.0  # realistic GT3 mechanical lateral grip
+    assert 0.8 < g.brake_b0_g < 2.5  # low-speed braking g (rises with speed via brake_b1)
+    assert g.k_aero_lat == 0.0  # aero-lateral term MUST be 0 (#259: spins the GT3 out live)
 
 
 def test_build_driver_rejects_unknown_driver():

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1,0 +1,239 @@
+"""Off-sim tests for the composed autonomous drive+assert loop (EPIC #154 Part G).
+
+The four legs (launch / hijack / drive / tap) are injected as fakes so the orchestration —
+ordering, the stop-event teardown, the drove-gates-success rule, and the failure-stage
+reporting — is verified with no Assetto Corsa, no Windows, and no real sidecar.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from tools.ac_harness.auto_drive import (
+    AutoDriveConfig,
+    DriveStats,
+    resolve_fast_lane,
+    run_auto_drive,
+)
+
+
+def _cfg(**kw) -> AutoDriveConfig:
+    base = dict(cm_preset="preset.cmpreset", track_id="imola", tap_seconds=0.0)
+    base.update(kw)
+    return AutoDriveConfig(**base)  # type: ignore[arg-type]
+
+
+def _snap(topic: str) -> dict:
+    return {"type": "state.snapshot", "topic": topic, "v": 1, "payload": {}}
+
+
+CONTINUOUS = [_snap("connection"), _snap("tire_temps"), _snap("coaching.snapshot")]
+
+
+class FakeController:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def write_controls(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+        pass
+
+    def read_car_data(self):  # noqa: ANN201
+        return {
+            "position": (0.0, 0.0, 0.0),
+            "look": (1.0, 0.0, 0.0),
+            "speed_kmh": 50.0,
+            "rpm": 4000.0,
+            "gear": 2,
+            "packet_id": 1,
+        }
+
+    def teleport_to_pits(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _drive_returning(stats: DriveStats, record: dict):
+    def _drive(controller, config, stop: threading.Event) -> DriveStats:
+        record["stop_set"] = stop.wait(timeout=2.0)
+        record["controller"] = controller
+        return stats
+
+    return _drive
+
+
+def _tap_returning(frames: list[dict]):
+    async def _tap(url, *, seconds, wait_for_lap):  # noqa: ANN001
+        return frames
+
+    return _tap
+
+
+def _ok_launch(config) -> tuple[bool, str]:  # noqa: ANN001
+    return True, "live"
+
+
+def test_launch_failure_short_circuits():
+    record: dict = {}
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=lambda c: (False, "no LIVE"),
+            hijack=lambda c: pytest.fail("hijack must not run after launch failure"),
+            drive=_drive_returning(DriveStats(drove=True), record),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.ok is False
+    assert report.stage == "launch"
+    assert report.error == "no LIVE"
+    assert report.hijacked is False
+
+
+def test_hijack_failure_reports_stage_hijack():
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: None,
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.ok is False
+    assert report.stage == "hijack"
+    assert report.launched is True
+    assert report.hijacked is False
+
+
+def test_happy_path_window_mode_passes_and_tears_down():
+    record: dict = {}
+    ctrl = FakeController()
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: ctrl,
+            drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.ok is True
+    assert report.stage == "done"
+    assert report.sequence_ok is True
+    assert report.drive is not None and report.drive.drove is True
+    # Orchestrator must always stop the drive and release the controller.
+    assert record["stop_set"] is True
+    assert ctrl.closed is True
+
+
+def test_pipeline_failure_when_continuous_topic_missing():
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning([_snap("connection"), _snap("tire_temps")]),  # no coaching.snapshot
+        )
+    )
+    assert report.ok is False
+    assert report.sequence_ok is False
+
+
+def test_wait_lap_requires_a_lap_frame():
+    # wait_lap but no lap frame -> require_lap fails the sequence.
+    no_lap = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert no_lap.ok is False
+    # lap frame present -> passes.
+    with_lap = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning([*CONTINUOUS, _snap("session"), _snap("lap")]),
+        )
+    )
+    assert with_lap.ok is True
+
+
+def test_drove_false_gates_overall_success_even_if_pipeline_ok():
+    # Sim died mid-drive: pipeline frames present but the drive did not actually move the car.
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=False, sim_dead=True, reason="acs died"), {}),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.sequence_ok is True
+    assert report.ok is False  # drove=False must veto success
+    assert report.drive is not None and report.drive.sim_dead is True
+
+
+def test_tap_exception_marks_pipeline_stage_and_still_tears_down():
+    record: dict = {}
+    ctrl = FakeController()
+
+    async def _boom(url, *, seconds, wait_for_lap):  # noqa: ANN001
+        raise RuntimeError("sidecar exploded")
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: ctrl,
+            drive=_drive_returning(DriveStats(drove=True), record),
+            tap=_boom,
+        )
+    )
+    assert report.ok is False
+    assert report.stage == "pipeline"
+    assert report.error is not None and "sidecar exploded" in report.error
+    assert record["stop_set"] is True  # teardown still ran
+    assert ctrl.closed is True
+
+
+def test_skip_launch_does_not_call_launch():
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(skip_launch=True),
+            launch=lambda c: pytest.fail("launch must be skipped"),
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.ok is True
+    assert report.launched is False
+
+
+def test_resolve_fast_lane_direct_layout_and_missing(tmp_path):
+    root = tmp_path
+    direct = root / "content" / "tracks" / "imola" / "ai"
+    direct.mkdir(parents=True)
+    (direct / "fast_lane.ai").write_bytes(b"x")
+    assert resolve_fast_lane(root, "imola") == direct / "fast_lane.ai"
+
+    layout = root / "content" / "tracks" / "monza" / "layout_gp" / "ai"
+    layout.mkdir(parents=True)
+    (layout / "fast_lane.ai").write_bytes(b"x")
+    assert resolve_fast_lane(root, "monza") == layout / "fast_lane.ai"
+
+    with pytest.raises(FileNotFoundError):
+        resolve_fast_lane(root, "nonexistent")

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -14,7 +14,11 @@ import pytest
 
 from tools.ac_harness.auto_drive import (
     AutoDriveConfig,
+    AutoDriveReport,
     DriveStats,
+    _build_arg_parser,
+    _config_from_args,
+    default_ac_root,
     resolve_fast_lane,
     run_auto_drive,
 )
@@ -237,3 +241,55 @@ def test_resolve_fast_lane_direct_layout_and_missing(tmp_path):
 
     with pytest.raises(FileNotFoundError):
         resolve_fast_lane(root, "nonexistent")
+
+
+def test_cli_args_map_to_config():
+    args = _build_arg_parser().parse_args(
+        [
+            "--cm-preset",
+            "p.cmpreset",
+            "--track",
+            "spa",
+            "--wait-lap",
+            "--strict",
+            "--skip-launch",
+            "--drive-seconds",
+            "120",
+            "--target-speed",
+            "70",
+            "--min-corner",
+            "40",
+            "--tap-seconds",
+            "15",
+        ]
+    )
+    cfg = _config_from_args(args)
+    assert str(cfg.cm_preset) == "p.cmpreset"
+    assert cfg.track_id == "spa"
+    assert cfg.wait_lap is True
+    assert cfg.strict is True
+    assert cfg.skip_launch is True
+    assert cfg.drive_seconds == 120
+    assert cfg.target_speed_kmh == 70
+    assert cfg.min_corner_speed_kmh == 40
+    assert cfg.tap_seconds == 15
+    # --ac-root omitted -> default factory used.
+    assert cfg.ac_root == default_ac_root()
+
+
+def test_report_summary_renders_all_sections():
+    report = AutoDriveReport(
+        ok=True,
+        stage="done",
+        launched=True,
+        hijacked=True,
+        drive=DriveStats(drove=True, laps=1, total_distance_m=5200.0, max_speed_kmh=63.0),
+        sequence_ok=True,
+        counts={"coaching.snapshot": 300, "connection": 30},
+        notes=["delta: not in window"],
+    )
+    text = report.summary()
+    assert "PASS" in text
+    assert "drove=True" in text
+    assert "coaching.snapshot=300" in text
+    assert "delta: not in window" in text

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -249,6 +249,69 @@ def test_resolve_fast_lane_direct_layout_and_missing(tmp_path):
         resolve_fast_lane(root, "nonexistent")
 
 
+def test_resolve_fast_lane_explicit_layout(tmp_path):
+    root = tmp_path
+    lay = root / "content" / "tracks" / "monza" / "layout_gp" / "ai"
+    lay.mkdir(parents=True)
+    (lay / "fast_lane.ai").write_bytes(b"x")
+    assert resolve_fast_lane(root, "monza", "layout_gp") == lay / "fast_lane.ai"
+    with pytest.raises(FileNotFoundError):
+        resolve_fast_lane(root, "monza", "no_such_layout")
+
+
+def test_sim_dead_vetoes_success_even_when_drove_true():
+    # sim_dead can be set AFTER the car passed the distance/speed thresholds — must still FAIL.
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(
+                DriveStats(drove=True, total_distance_m=900.0, sim_dead=True), {}
+            ),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.sequence_ok is True
+    assert report.ok is False  # sim_dead vetoes despite drove=True
+
+
+def test_drive_exception_closes_controller_and_reports_drive_stage():
+    ctrl = FakeController()
+
+    def _boom_drive(controller, config, stop):  # noqa: ANN001
+        raise RuntimeError("drive blew up")
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: ctrl,
+            drive=_boom_drive,
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.ok is False
+    assert report.stage == "drive"
+    assert report.error is not None and "drive blew up" in report.error
+    assert ctrl.closed is True  # controller released despite the drive thread crashing
+
+
+def test_skip_launch_hijack_failure_reports_launched_false():
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(skip_launch=True),
+            launch=lambda c: pytest.fail("launch must be skipped"),
+            hijack=lambda c: None,
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.ok is False
+    assert report.stage == "hijack"
+    assert report.launched is False  # skip_launch -> launched stays False on hijack failure
+
+
 def test_build_driver_racing_is_default_and_shifts_gears():
     from tools.ac_harness.lap_driver import LapDriver
     from tools.ac_harness.racing_driver import RacingDriver

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -17,11 +17,16 @@ from tools.ac_harness.auto_drive import (
     AutoDriveReport,
     DriveStats,
     _build_arg_parser,
+    _build_driver,
     _config_from_args,
     default_ac_root,
     resolve_fast_lane,
     run_auto_drive,
 )
+
+# A tiny closed square line + a per-point speed profile, for driver-construction tests.
+_LINE = [(0.0, 0.0, 0.0), (50.0, 0.0, 0.0), (50.0, 0.0, 50.0), (0.0, 0.0, 50.0)]
+_PROFILE = [40.0, 40.0, 40.0, 40.0]  # m/s targets
 
 
 def _cfg(**kw) -> AutoDriveConfig:
@@ -241,6 +246,39 @@ def test_resolve_fast_lane_direct_layout_and_missing(tmp_path):
 
     with pytest.raises(FileNotFoundError):
         resolve_fast_lane(root, "nonexistent")
+
+
+def test_build_driver_racing_is_default_and_shifts_gears():
+    from tools.ac_harness.lap_driver import LapDriver
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    # Default config -> racing.
+    assert _cfg().driver == "racing"
+    racing = _build_driver(_cfg(pace=1.0, racing_max_speed_kmh=240.0), _LINE, _PROFILE)
+    assert isinstance(racing, RacingDriver)
+    # RacingDriver can shift well past 1st gear; LapDriver is capped at 3 (AC enc) = 2nd.
+    assert racing.max_gear >= 6
+
+    cruise = _build_driver(_cfg(driver="cruise"), _LINE, _PROFILE)
+    assert isinstance(cruise, LapDriver)
+
+
+def test_build_driver_racing_requires_speed_profile():
+    with pytest.raises(ValueError, match="speed_profile"):
+        _build_driver(_cfg(driver="racing"), _LINE, None)
+
+
+def test_build_driver_rejects_unknown_driver():
+    with pytest.raises(ValueError, match="unknown driver"):
+        _build_driver(_cfg(driver="bogus"), _LINE, _PROFILE)
+
+
+def test_racing_driver_step_upshifts_at_high_rpm():
+    # Direct evidence the racing controller commands an upshift out of 1st when revving + moving.
+    racing = _build_driver(_cfg(pace=1.0, racing_max_speed_kmh=240.0), _LINE, _PROFILE)
+    racing.phase = "LAP"  # skip OUT phase so longitudinal/gear logic runs
+    frame = racing.step((25.0, 0.0, 0.0), (1.0, 0.0, 0.0), 120.0, 7500.0, 3, now=10.0)
+    assert frame.gear_up is True  # rpm 7500 > rpm_up, gear 3 (2nd) < max -> upshift
 
 
 def test_cli_args_map_to_config():

--- a/tools/ac_harness/__init__.py
+++ b/tools/ac_harness/__init__.py
@@ -18,6 +18,13 @@ from tools.ac_harness.ai_line import (
     StanleySteering,
     load_ai_line,
 )
+from tools.ac_harness.auto_drive import (
+    AutoDriveConfig,
+    AutoDriveReport,
+    DriveStats,
+    resolve_fast_lane,
+    run_auto_drive,
+)
 from tools.ac_harness.custom_ai import (
     CarControls,
     CarData,
@@ -112,4 +119,10 @@ __all__ = [
     "PurePursuit",
     "StanleySteering",
     "load_ai_line",
+    # Composed autonomous drive+assert loop (EPIC #154 Part G --drive).
+    "AutoDriveConfig",
+    "AutoDriveReport",
+    "DriveStats",
+    "resolve_fast_lane",
+    "run_auto_drive",
 ]

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -10,7 +10,7 @@ modules into the loop the EPIC claimed** —
     CM-URL launch (entry_launcher)            -> AC on track, non-elevated
     wait LIVE + settle                        -> CSP ready to accept the Custom-AI hijack
     carcsw hijack of car 0 (custom_ai)        -> retry / relaunch on the early-LIVE race
-    autonomous drive (lap_driver + ai_line)   -> a real lap of ANY track, no human, in a thread
+    autonomous drive (racing_driver + ai_line) -> RACES any track: shifts gears, carries pace
     tap the sidecar WS (sequence_probe)        -> assert the live coaching producer contract
     teardown
 
@@ -70,10 +70,16 @@ class AutoDriveConfig:
     ac_root: Path = field(default_factory=default_ac_root)
     cm_exe: Path | None = None
     sidecar_url: str = "ws://127.0.0.1:8765"
-    # Drive.
+    # Drive. ``driver="racing"`` (default) follows fast_lane.ai's embedded speed profile with real
+    # braking points + gear shifting (RacingDriver) — the car actually races (shifts through gears,
+    # carries pace). ``driver="cruise"`` is the conservative ~50 km/h, 1st-gear lane-keeper
+    # (LapDriver) for a guaranteed-clean slow lap when pace is not the point.
+    driver: str = "racing"
     drive_seconds: float = 300.0
-    target_speed_kmh: float = 55.0
-    min_corner_speed_kmh: float = 30.0
+    pace: float = 0.9  # racing: fraction of the AI line's speed profile to target
+    racing_max_speed_kmh: float = 240.0  # racing: cap (above any GT speed; lets it use top gears)
+    target_speed_kmh: float = 55.0  # cruise only
+    min_corner_speed_kmh: float = 30.0  # cruise only
     # Assertion.
     tap_seconds: float = 30.0
     wait_lap: bool = False
@@ -95,6 +101,7 @@ class DriveStats:
     drove: bool = False
     laps: int = 0
     max_speed_kmh: float = 0.0
+    max_gear_used: int = 0  # highest AC gear seen (encoding 2=1st); >2 proves real shifting
     total_distance_m: float = 0.0
     samples: int = 0
     sim_dead: bool = False
@@ -122,8 +129,8 @@ class AutoDriveReport:
             d = self.drive
             lines.append(
                 f"  drive: drove={d.drove} laps={d.laps} max_speed={d.max_speed_kmh:.1f}km/h "
-                f"dist={d.total_distance_m:.0f}m sim_dead={d.sim_dead}"
-                + (f" reason={d.reason}" if d.reason else "")
+                f"top_gear={max(d.max_gear_used - 1, 0)} dist={d.total_distance_m:.0f}m "
+                f"sim_dead={d.sim_dead}" + (f" reason={d.reason}" if d.reason else "")
             )
         if self.sequence_ok is not None:
             lines.append(f"  pipeline: {'ok' if self.sequence_ok else 'FAILED'}")
@@ -313,24 +320,55 @@ def rig_hijack(config: AutoDriveConfig) -> Controller | None:  # pragma: no cove
     return None
 
 
+def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list | None = None):
+    """Construct the drive controller for ``config.driver`` (pure; CI-testable).
+
+    ``racing`` → :class:`racing_driver.RacingDriver` following the AI line's embedded speed profile
+    (real braking points + gear shifting + pace) — the car actually races. ``cruise`` →
+    :class:`lap_driver.LapDriver`, the conservative ~50 km/h 1st-gear lane-keeper. Both expose the
+    same ``step()``/``on_recovery()`` contract, so the rig drive loop is driver-agnostic.
+    """
+    from tools.ac_harness.lap_driver import LapDriver
+
+    if config.driver == "cruise":
+        return LapDriver(
+            fast_line,
+            target_speed_kmh=config.target_speed_kmh,
+            min_corner_speed_kmh=config.min_corner_speed_kmh,
+        )
+    if config.driver == "racing":
+        from tools.ac_harness.racing_driver import RacingDriver
+
+        if speed_profile is None:
+            raise ValueError("racing driver requires a speed_profile from the track's fast_lane.ai")
+        return RacingDriver(
+            fast_line,
+            speed_profile,
+            pace=config.pace,
+            max_speed_kmh=config.racing_max_speed_kmh,
+        )
+    raise ValueError(f"unknown driver {config.driver!r} (expected 'racing' or 'cruise')")
+
+
 def rig_drive(  # pragma: no cover - rig-only
     controller: Controller, config: AutoDriveConfig, stop: threading.Event
 ) -> DriveStats:
-    """Drive ``lap_driver`` over the track's fast_lane.ai until ``stop`` or sim-death.
+    """Drive the selected controller over the track's fast_lane.ai until ``stop`` or sim-death.
 
-    Mirrors :meth:`lap_driver.LapDriver.run` but adds the sim-death guard: a frozen Car0
-    ``packet_id`` for ``sim_dead_seconds`` means ``acs.exe`` died, so we stop instead of spinning
-    on stale telemetry and reporting a false drive.
+    ``config.driver`` picks RacingDriver (default — shifts gears, carries pace) or the cruise
+    LapDriver. Adds the sim-death guard: a frozen Car0 ``packet_id`` for ``sim_dead_seconds`` means
+    ``acs.exe`` died, so we stop instead of spinning on stale telemetry and reporting a false drive.
     """
     from tools.ac_harness.ai_line import _horizontal, load_ai_line
-    from tools.ac_harness.lap_driver import LapDriver
 
-    line = load_ai_line(resolve_fast_lane(config.ac_root, config.track_id))
-    driver = LapDriver(
-        line,
-        target_speed_kmh=config.target_speed_kmh,
-        min_corner_speed_kmh=config.min_corner_speed_kmh,
-    )
+    fast_path = resolve_fast_lane(config.ac_root, config.track_id)
+    line = load_ai_line(fast_path)
+    speed_profile = None
+    if config.driver == "racing":
+        from tools.ac_harness.racing_driver import load_speed_profile
+
+        speed_profile = load_speed_profile(fast_path)
+    driver = _build_driver(config, line, speed_profile)
     stats = DriveStats()
     prev_plane: tuple[float, float] | None = None
     last_pkt: int | None = None
@@ -376,6 +414,7 @@ def rig_drive(  # pragma: no cover - rig-only
             )
             stats.samples += 1
             stats.max_speed_kmh = max(stats.max_speed_kmh, cd["speed_kmh"])
+            stats.max_gear_used = max(stats.max_gear_used, int(cd["gear"]))
             plane = _horizontal(cd["position"])
             if prev_plane is not None:
                 d = ((plane[0] - prev_plane[0]) ** 2 + (plane[1] - prev_plane[1]) ** 2) ** 0.5
@@ -405,9 +444,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--ac-root", type=Path, default=None, help="AC content root (Steam install)")
     p.add_argument("--cm-exe", type=Path, default=None, help="Content Manager.exe path")
     p.add_argument("--sidecar-url", default="ws://127.0.0.1:8765")
+    p.add_argument(
+        "--driver",
+        choices=("racing", "cruise"),
+        default="racing",
+        help="racing = shift gears + carry pace (default); cruise = slow 1st-gear lane-keeper",
+    )
+    p.add_argument("--pace", type=float, default=0.9, help="racing: fraction of AI-line speed")
+    p.add_argument("--max-speed", type=float, default=240.0, help="racing: speed cap (km/h)")
     p.add_argument("--drive-seconds", type=float, default=300.0)
-    p.add_argument("--target-speed", type=float, default=55.0)
-    p.add_argument("--min-corner", type=float, default=30.0)
+    p.add_argument("--target-speed", type=float, default=55.0, help="cruise target speed (km/h)")
+    p.add_argument("--min-corner", type=float, default=30.0, help="cruise min corner speed (km/h)")
     p.add_argument("--tap-seconds", type=float, default=30.0)
     p.add_argument("--wait-lap", action="store_true", help="assert a completed lap (real motion)")
     p.add_argument("--strict", action="store_true", help="require session+lap, enforce ordering")
@@ -421,6 +468,9 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         track_id=args.track,
         cm_exe=args.cm_exe,
         sidecar_url=args.sidecar_url,
+        driver=args.driver,
+        pace=args.pace,
+        racing_max_speed_kmh=args.max_speed,
         drive_seconds=args.drive_seconds,
         target_speed_kmh=args.target_speed,
         min_corner_speed_kmh=args.min_corner,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1,0 +1,454 @@
+"""One-command **autonomous** self-test (EPIC #154 Part G — the ``--drive`` composition).
+
+``self_test.py`` (#236) asserts the live WS producer contract but does **not** itself drive the
+car — its own docstring calls the carcsw lap "an optional follow-up step". So the only assertion
+that needs real motion (``--wait-lap``) was never wired to anything that produces motion, and the
+"hands-off L2" loop was only ever exercised by a human at the wheel or a throwaway ``.scratch``
+script (Magione + Porsche only). This module closes that gap: it **composes the shipped harness
+modules into the loop the EPIC claimed** —
+
+    CM-URL launch (entry_launcher)            -> AC on track, non-elevated
+    wait LIVE + settle                        -> CSP ready to accept the Custom-AI hijack
+    carcsw hijack of car 0 (custom_ai)        -> retry / relaunch on the early-LIVE race
+    autonomous drive (lap_driver + ai_line)   -> a real lap of ANY track, no human, in a thread
+    tap the sidecar WS (sequence_probe)        -> assert the live coaching producer contract
+    teardown
+
+— **parametrized by car/track/preset**, so the same command drives any combo (the anti-overfit
+property the EPIC needed and Magione-only verification never showed).
+
+Two pieces of hard-won rig robustness are baked in (live-found 2026-06-27 on Imola/Mugello):
+
+* **Hijack retry/relaunch.** CSP only creates the ``Car<N>`` read section once its Custom-AI
+  subsystem is watching; creating ``CarControls0`` too soon after ``AC_STATUS`` flips LIVE loses
+  the race and the hijack silently no-ops. We settle, retry the hijack, and relaunch on failure.
+* **Sim-death detection (anti-false-green).** When ``acs.exe`` crashes the Car0 mmap freezes and
+  ``read_car_data()`` returns the last frame forever — a parked car reported as "still driving".
+  The drive loop watches the Car0 ``packet_id`` and stops on stagnation rather than spinning on
+  stale data and reporting a false success.
+
+Design split mirrors the rest of ``ac_harness``: :func:`run_auto_drive` is **pure orchestration**
+with injectable ``launch`` / ``hijack`` / ``drive`` / ``tap`` seams, unit-tested off-sim with fakes
+(no AC, no Windows); the rig wiring (:func:`rig_launch`, :func:`rig_hijack`, :func:`rig_drive`) is
+``pragma: no cover`` and validated on the rig.
+
+Run on the rig (loopback to a sidecar started by the daemon or by hand)::
+
+    python -m tools.ac_harness.auto_drive \
+        --cm-preset "<.cmpreset>" --track imola --wait-lap --drive-seconds 360
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import threading
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from tools.ac_harness.sequence_probe import evaluate_sequence, tap_frames
+
+
+def default_ac_root() -> Path:
+    """Default Steam Assetto Corsa content root (override with ``--ac-root``).
+
+    Mirrors the hardcoded path :mod:`tools.ac_harness.daemon` already uses for ``acs.exe`` so
+    programmatic and CLI callers agree; a non-standard Steam library is handled via ``--ac-root``.
+    """
+    return Path(r"C:\Program Files (x86)\Steam\steamapps\common\assettocorsa")
+
+
+@dataclass
+class AutoDriveConfig:
+    """Inputs for one autonomous drive+assert run, parametrized by car/track/preset."""
+
+    cm_preset: Path
+    track_id: str
+    ac_root: Path = field(default_factory=default_ac_root)
+    cm_exe: Path | None = None
+    sidecar_url: str = "ws://127.0.0.1:8765"
+    # Drive.
+    drive_seconds: float = 300.0
+    target_speed_kmh: float = 55.0
+    min_corner_speed_kmh: float = 30.0
+    # Assertion.
+    tap_seconds: float = 30.0
+    wait_lap: bool = False
+    strict: bool = False
+    # Launch / hijack robustness (the early-LIVE race).
+    max_launches: int = 3
+    attempt_timeout: float = 75.0
+    settle_seconds: float = 5.0
+    hijack_timeout: float = 25.0
+    # Sim-death guard.
+    sim_dead_seconds: float = 4.0
+    skip_launch: bool = False
+
+
+@dataclass
+class DriveStats:
+    """Outcome of the autonomous drive leg."""
+
+    drove: bool = False
+    laps: int = 0
+    max_speed_kmh: float = 0.0
+    total_distance_m: float = 0.0
+    samples: int = 0
+    sim_dead: bool = False
+    reason: str = ""
+
+
+@dataclass
+class AutoDriveReport:
+    """Structured result of one composed autonomous self-test run."""
+
+    ok: bool
+    stage: str  # launch | hijack | pipeline | done
+    launched: bool = False
+    hijacked: bool = False
+    drive: DriveStats | None = None
+    sequence_ok: bool | None = None
+    counts: dict[str, int] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    def summary(self) -> str:
+        lines = [f"auto-drive: {'PASS' if self.ok else 'FAIL'} (stage={self.stage})"]
+        lines.append(f"  launched: {self.launched}  hijacked: {self.hijacked}")
+        if self.drive is not None:
+            d = self.drive
+            lines.append(
+                f"  drive: drove={d.drove} laps={d.laps} max_speed={d.max_speed_kmh:.1f}km/h "
+                f"dist={d.total_distance_m:.0f}m sim_dead={d.sim_dead}"
+                + (f" reason={d.reason}" if d.reason else "")
+            )
+        if self.sequence_ok is not None:
+            lines.append(f"  pipeline: {'ok' if self.sequence_ok else 'FAILED'}")
+            if self.counts:
+                lines.append(
+                    "  frames: " + ", ".join(f"{k}={v}" for k, v in sorted(self.counts.items()))
+                )
+            for note in self.notes:
+                lines.append(f"  note: {note}")
+        if self.error:
+            lines.append(f"  error: {self.error}")
+        return "\n".join(lines)
+
+
+class Controller(Protocol):
+    """The subset of :class:`custom_ai.CustomAIController` the drive loop needs (test seam)."""
+
+    def write_controls(self, gas: float, brake: float, steer: float, **kwargs: Any) -> None: ...
+    def read_car_data(self) -> dict[str, object] | None: ...
+    def teleport_to_pits(self) -> None: ...
+    def close(self) -> None: ...
+
+
+LaunchFn = Callable[[AutoDriveConfig], "tuple[bool, str]"]
+HijackFn = Callable[[AutoDriveConfig], "Controller | None"]
+DriveFn = Callable[[Controller, AutoDriveConfig, threading.Event], DriveStats]
+TapFn = Callable[..., Awaitable[list[dict]]]
+
+
+async def run_auto_drive(
+    config: AutoDriveConfig,
+    *,
+    launch: LaunchFn,
+    hijack: HijackFn,
+    drive: DriveFn,
+    tap: TapFn = tap_frames,
+) -> AutoDriveReport:
+    """Compose launch → hijack → (background drive) → WS assert → teardown into one report.
+
+    The four legs are injectable so the orchestration is unit-testable with fakes — no AC, no
+    Windows, no real sidecar. On the rig the defaults (:func:`rig_launch`, :func:`rig_hijack`,
+    :func:`rig_drive`, :func:`tap_frames`) wire it to the live game.
+    """
+    if not config.skip_launch:
+        ok, reason = launch(config)
+        if not ok:
+            return AutoDriveReport(ok=False, stage="launch", error=reason)
+
+    controller = hijack(config)
+    if controller is None:
+        return AutoDriveReport(
+            ok=False, stage="hijack", launched=True, error="CSP did not accept the carcsw hijack"
+        )
+
+    stop = threading.Event()
+    drive_task = asyncio.create_task(asyncio.to_thread(drive, controller, config, stop))
+    try:
+        frames = await tap(
+            config.sidecar_url, seconds=config.tap_seconds, wait_for_lap=config.wait_lap
+        )
+        result = evaluate_sequence(
+            frames, strict_lifecycle=config.strict, require_lap=config.wait_lap
+        )
+        seq_ok: bool | None = result.ok
+        counts = dict(result.counts)
+        notes = list(result.notes)
+        tap_error: str | None = None
+    except Exception as exc:  # noqa: BLE001 - surface any tap/eval failure as a FAIL report
+        seq_ok, counts, notes, tap_error = None, {}, [], f"{type(exc).__name__}: {exc}"
+    finally:
+        stop.set()
+        stats = await drive_task
+        controller.close()
+
+    ok = bool(seq_ok) and stats.drove and tap_error is None
+    return AutoDriveReport(
+        ok=ok,
+        stage="done" if tap_error is None else "pipeline",
+        launched=not config.skip_launch,
+        hijacked=True,
+        drive=stats,
+        sequence_ok=seq_ok,
+        counts=counts,
+        notes=notes,
+        error=tap_error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Track racing-line resolution (pure).
+# ---------------------------------------------------------------------------
+def resolve_fast_lane(ac_root: Path, track_id: str) -> Path:
+    """Return ``<ac_root>/content/tracks/<track>/ai/fast_lane.ai`` (root or first layout subdir).
+
+    Raises :class:`FileNotFoundError` if no fast_lane.ai exists for the track.
+    """
+    root = ac_root / "content" / "tracks" / track_id
+    direct = root / "ai" / "fast_lane.ai"
+    if direct.exists():
+        return direct
+    for layout in sorted(root.glob("*/ai/fast_lane.ai")):
+        return layout
+    raise FileNotFoundError(f"no fast_lane.ai for track {track_id!r} under {root}")
+
+
+# ---------------------------------------------------------------------------
+# Rig wiring (Windows/AC only; not exercised by CI — validated on the rig).
+# ---------------------------------------------------------------------------
+def rig_launch(config: AutoDriveConfig) -> tuple[bool, str]:  # pragma: no cover - rig-only
+    """Launch AC via the de-elevated Content-Manager URL and wait for the sim to go LIVE.
+
+    Unlike the daemon's strict ``driving`` gate (which needs the car already moving — a
+    chicken-and-egg for an autonomous launch), this waits only for LIVE + advancing physics, then
+    the hijack+drive supplies the motion. Relaunches on the menu-skip race up to ``max_launches``.
+    """
+    from tools.ac_harness.entry_launcher import ContentManagerActuator
+
+    actuator = ContentManagerActuator(preset=config.cm_preset, cm_exe=config.cm_exe)
+    actuator.normalize_prior_state()
+    for attempt in range(1, config.max_launches + 1):
+        actuator.launch() if attempt == 1 else actuator.relaunch()
+        if _wait_live(config.attempt_timeout):
+            time.sleep(config.settle_seconds)  # let CSP arm Custom-AI before the hijack
+            return True, f"LIVE after {attempt} launch attempt(s)"
+    return False, f"sim never reached LIVE after {config.max_launches} attempt(s)"
+
+
+def _wait_live(timeout: float) -> bool:  # pragma: no cover - rig-only
+    """Poll AC shared memory until status is LIVE with advancing physics."""
+    from tools.ac_harness.shared_memory import (
+        AcGameStatus,
+        SharedMemoryReader,
+        SharedMemoryUnavailable,
+    )
+
+    deadline = time.monotonic() + timeout
+    reader: SharedMemoryReader | None = None
+    last_pkt: int | None = None
+    last_change: float | None = None
+    advancing_reads = 0
+    try:
+        while time.monotonic() < deadline:
+            now = time.monotonic()
+            if reader is None:
+                try:
+                    reader = SharedMemoryReader()
+                except SharedMemoryUnavailable:
+                    time.sleep(0.2)
+                    continue
+            try:
+                g = reader.read_graphics()
+                p = reader.read_physics()
+            except SharedMemoryUnavailable:
+                reader.close()
+                reader = None
+                time.sleep(0.2)
+                continue
+            if p is not None:
+                if last_pkt is None or p.packet_id != last_pkt:
+                    last_pkt = p.packet_id
+                    last_change = now
+            advancing = last_change is not None and (now - last_change) <= 0.25
+            if g.status == AcGameStatus.LIVE and advancing:
+                advancing_reads += 1
+                if advancing_reads >= 5:
+                    return True
+            else:
+                advancing_reads = 0
+            time.sleep(0.05)
+    finally:
+        if reader is not None:
+            reader.close()
+    return False
+
+
+def rig_hijack(config: AutoDriveConfig) -> Controller | None:  # pragma: no cover - rig-only
+    """Create the CarControls0 section and wait for CSP to create Car0 (the hijack landing)."""
+    from tools.ac_harness.custom_ai import CustomAIController
+
+    ctrl = CustomAIController(0)
+    deadline = time.monotonic() + config.hijack_timeout
+    while time.monotonic() < deadline:
+        if ctrl.read_car_data() is not None:
+            return ctrl
+        time.sleep(0.1)
+    ctrl.close()
+    return None
+
+
+def rig_drive(  # pragma: no cover - rig-only
+    controller: Controller, config: AutoDriveConfig, stop: threading.Event
+) -> DriveStats:
+    """Drive ``lap_driver`` over the track's fast_lane.ai until ``stop`` or sim-death.
+
+    Mirrors :meth:`lap_driver.LapDriver.run` but adds the sim-death guard: a frozen Car0
+    ``packet_id`` for ``sim_dead_seconds`` means ``acs.exe`` died, so we stop instead of spinning
+    on stale telemetry and reporting a false drive.
+    """
+    from tools.ac_harness.ai_line import _horizontal, load_ai_line
+    from tools.ac_harness.lap_driver import LapDriver
+
+    line = load_ai_line(resolve_fast_lane(config.ac_root, config.track_id))
+    driver = LapDriver(
+        line,
+        target_speed_kmh=config.target_speed_kmh,
+        min_corner_speed_kmh=config.min_corner_speed_kmh,
+    )
+    stats = DriveStats()
+    prev_plane: tuple[float, float] | None = None
+    last_pkt: int | None = None
+    last_pkt_change = time.monotonic()
+    t0 = time.monotonic()
+    try:
+        while not stop.is_set() and time.monotonic() - t0 < config.drive_seconds:
+            cd = controller.read_car_data()
+            if not cd:
+                time.sleep(0.02)
+                continue
+            pkt = cd.get("packet_id")
+            if last_pkt is None or pkt != last_pkt:
+                last_pkt = pkt  # type: ignore[assignment]
+                last_pkt_change = time.monotonic()
+            elif time.monotonic() - last_pkt_change > config.sim_dead_seconds:
+                stats.sim_dead = True
+                stats.reason = "Car0 packet_id stagnant (acs.exe died)"
+                break
+            frame = driver.step(
+                cd["position"],
+                cd["look"],
+                cd["speed_kmh"],
+                cd["rpm"],
+                cd["gear"],
+                time.monotonic() - t0,
+            )
+            if frame.needs_recovery:
+                for _ in range(5):
+                    controller.teleport_to_pits()
+                    time.sleep(0.1)
+                time.sleep(0.8)
+                driver.on_recovery()
+                continue
+            controller.write_controls(
+                frame.gas,
+                frame.brake,
+                frame.steer,
+                gear_up=frame.gear_up,
+                gear_dn=frame.gear_dn,
+                autoclutch_on_start=True,
+                autoclutch_on_change=True,
+            )
+            stats.samples += 1
+            stats.max_speed_kmh = max(stats.max_speed_kmh, cd["speed_kmh"])
+            plane = _horizontal(cd["position"])
+            if prev_plane is not None:
+                d = ((plane[0] - prev_plane[0]) ** 2 + (plane[1] - prev_plane[1]) ** 2) ** 0.5
+                if d < 50:  # ignore teleport jumps
+                    stats.total_distance_m += d
+            prev_plane = plane
+            if frame.lap_completed:
+                stats.laps += 1
+            time.sleep(0.012)
+    finally:
+        for _ in range(20):
+            try:
+                controller.write_controls(0.0, 0.6, 0.0)
+            except Exception:  # noqa: BLE001 - sim may already be gone
+                break
+            time.sleep(0.03)
+    stats.drove = stats.total_distance_m > 200 and stats.max_speed_kmh > 25
+    return stats
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Composed autonomous self-test (#154 Part G): drive any car/track + assert"
+    )
+    p.add_argument("--cm-preset", required=True, type=Path, help="Quick Drive .cmpreset")
+    p.add_argument("--track", required=True, help="AC track id (for the fast_lane.ai racing line)")
+    p.add_argument("--ac-root", type=Path, default=None, help="AC content root (Steam install)")
+    p.add_argument("--cm-exe", type=Path, default=None, help="Content Manager.exe path")
+    p.add_argument("--sidecar-url", default="ws://127.0.0.1:8765")
+    p.add_argument("--drive-seconds", type=float, default=300.0)
+    p.add_argument("--target-speed", type=float, default=55.0)
+    p.add_argument("--min-corner", type=float, default=30.0)
+    p.add_argument("--tap-seconds", type=float, default=30.0)
+    p.add_argument("--wait-lap", action="store_true", help="assert a completed lap (real motion)")
+    p.add_argument("--strict", action="store_true", help="require session+lap, enforce ordering")
+    p.add_argument("--skip-launch", action="store_true", help="AC already LIVE; only hijack+drive")
+    return p
+
+
+def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
+    kwargs: dict[str, Any] = dict(
+        cm_preset=args.cm_preset,
+        track_id=args.track,
+        cm_exe=args.cm_exe,
+        sidecar_url=args.sidecar_url,
+        drive_seconds=args.drive_seconds,
+        target_speed_kmh=args.target_speed,
+        min_corner_speed_kmh=args.min_corner,
+        tap_seconds=args.tap_seconds,
+        wait_lap=args.wait_lap,
+        strict=args.strict,
+        skip_launch=args.skip_launch,
+    )
+    if args.ac_root is not None:
+        kwargs["ac_root"] = args.ac_root
+    return AutoDriveConfig(**kwargs)
+
+
+def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only CLI wiring
+    args = _build_arg_parser().parse_args(argv)
+    config = _config_from_args(args)
+    report = asyncio.run(
+        run_auto_drive(config, launch=rig_launch, hijack=rig_hijack, drive=rig_drive)
+    )
+    print(report.summary())
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - rig-only CLI wiring
+    import sys
+    from pathlib import Path as _Path
+
+    _repo_root = str(_Path(__file__).resolve().parents[2])
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
+    raise SystemExit(_main())

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -67,6 +67,7 @@ class AutoDriveConfig:
 
     cm_preset: Path
     track_id: str
+    track_layout: str | None = None  # set for multi-layout tracks to match the launched layout
     ac_root: Path = field(default_factory=default_ac_root)
     cm_exe: Path | None = None
     sidecar_url: str = "ws://127.0.0.1:8765"
@@ -92,6 +93,7 @@ class AutoDriveConfig:
     attempt_timeout: float = 75.0
     settle_seconds: float = 5.0
     hijack_timeout: float = 25.0
+    hijack_attempts: int = 3  # recreate CarControls0 N times — beats the early-LIVE hijack race
     # Sim-death guard.
     sim_dead_seconds: float = 4.0
     skip_launch: bool = False
@@ -185,11 +187,20 @@ async def run_auto_drive(
     controller = hijack(config)
     if controller is None:
         return AutoDriveReport(
-            ok=False, stage="hijack", launched=True, error="CSP did not accept the carcsw hijack"
+            ok=False,
+            stage="hijack",
+            launched=not config.skip_launch,
+            error="CSP did not accept the carcsw hijack",
         )
 
     stop = threading.Event()
     drive_task = asyncio.create_task(asyncio.to_thread(drive, controller, config, stop))
+    stats = DriveStats(reason="drive did not run")
+    seq_ok: bool | None = None
+    counts: dict[str, int] = {}
+    notes: list[str] = []
+    error: str | None = None
+    stage = "done"
     try:
         frames = await tap(
             config.sidecar_url, seconds=config.tap_seconds, wait_for_lap=config.wait_lap
@@ -197,45 +208,66 @@ async def run_auto_drive(
         result = evaluate_sequence(
             frames, strict_lifecycle=config.strict, require_lap=config.wait_lap
         )
-        seq_ok: bool | None = result.ok
+        seq_ok = result.ok
         counts = dict(result.counts)
         notes = list(result.notes)
-        tap_error: str | None = None
     except Exception as exc:  # noqa: BLE001 - surface any tap/eval failure as a FAIL report
-        seq_ok, counts, notes, tap_error = None, {}, [], f"{type(exc).__name__}: {exc}"
+        stage, error = "pipeline", f"{type(exc).__name__}: {exc}"
     finally:
         stop.set()
-        stats = await drive_task
-        controller.close()
+        # Always stop the drive AND release the controller — even if the drive thread raised, the
+        # control mmap (the carcsw hijack) must be released, or it leaks and keeps holding the car.
+        try:
+            stats = await drive_task
+        except Exception as exc:  # noqa: BLE001 - drive thread crashed; record, don't leak
+            stage = "drive"
+            error = error or f"drive: {type(exc).__name__}: {exc}"
+        finally:
+            controller.close()
 
-    ok = bool(seq_ok) and stats.drove and tap_error is None
+    # Success needs a clean pipeline AND a real drive that did not die mid-run: sim_dead can be set
+    # after the car already passed the distance/speed thresholds (drove=True), so veto on it too.
+    ok = bool(seq_ok) and stats.drove and not stats.sim_dead and error is None
     return AutoDriveReport(
         ok=ok,
-        stage="done" if tap_error is None else "pipeline",
+        stage=stage,
         launched=not config.skip_launch,
         hijacked=True,
         drive=stats,
         sequence_ok=seq_ok,
         counts=counts,
         notes=notes,
-        error=tap_error,
+        error=error,
     )
 
 
 # ---------------------------------------------------------------------------
 # Track racing-line resolution (pure).
 # ---------------------------------------------------------------------------
-def resolve_fast_lane(ac_root: Path, track_id: str) -> Path:
-    """Return ``<ac_root>/content/tracks/<track>/ai/fast_lane.ai`` (root or first layout subdir).
+def resolve_fast_lane(ac_root: Path, track_id: str, layout: str | None = None) -> Path:
+    """Return the ``fast_lane.ai`` for ``track_id`` (optionally a specific ``layout``).
 
-    Raises :class:`FileNotFoundError` if no fast_lane.ai exists for the track.
+    A multi-layout track (e.g. Monza GP vs Junior) has one ``ai/fast_lane.ai`` per layout, and
+    ``track_id`` alone does not say which layout the CM preset launched. Pass ``layout`` to select
+    ``<track>/<layout>/ai/fast_lane.ai`` so the driven line matches the launched layout. Without it,
+    a root-level ``ai/fast_lane.ai`` is used, else the first layout subdir is picked **and the
+    ambiguity is the caller's to resolve** — set ``--track-layout`` for multi-layout tracks.
+
+    Raises :class:`FileNotFoundError` if no matching fast_lane.ai exists.
     """
     root = ac_root / "content" / "tracks" / track_id
+    if layout:
+        chosen = root / layout / "ai" / "fast_lane.ai"
+        if chosen.exists():
+            return chosen
+        raise FileNotFoundError(
+            f"no fast_lane.ai for track {track_id!r} layout {layout!r}: {chosen}"
+        )
     direct = root / "ai" / "fast_lane.ai"
     if direct.exists():
         return direct
-    for layout in sorted(root.glob("*/ai/fast_lane.ai")):
-        return layout
+    for found in sorted(root.glob("*/ai/fast_lane.ai")):
+        return found
     raise FileNotFoundError(f"no fast_lane.ai for track {track_id!r} under {root}")
 
 
@@ -310,16 +342,25 @@ def _wait_live(timeout: float) -> bool:  # pragma: no cover - rig-only
 
 
 def rig_hijack(config: AutoDriveConfig) -> Controller | None:  # pragma: no cover - rig-only
-    """Create the CarControls0 section and wait for CSP to create Car0 (the hijack landing)."""
+    """Create CarControls0 and wait for CSP to create Car0 (the hijack landing), with retry.
+
+    The early-LIVE race: CSP only creates Car0 once its Custom-AI subsystem is watching, and the
+    act that triggers it is *creating* the CarControls0 section — so a creation that lands too early
+    silently no-ops. We split ``hijack_timeout`` across ``hijack_attempts`` and **recreate** the
+    section each attempt (close + new ``CustomAIController``) so a later creation re-triggers CSP.
+    """
     from tools.ac_harness.custom_ai import CustomAIController
 
-    ctrl = CustomAIController(0)
-    deadline = time.monotonic() + config.hijack_timeout
-    while time.monotonic() < deadline:
-        if ctrl.read_car_data() is not None:
-            return ctrl
-        time.sleep(0.1)
-    ctrl.close()
+    attempts = max(1, config.hijack_attempts)
+    per_attempt = config.hijack_timeout / attempts
+    for _ in range(attempts):
+        ctrl = CustomAIController(0)
+        deadline = time.monotonic() + per_attempt
+        while time.monotonic() < deadline:
+            if ctrl.read_car_data() is not None:
+                return ctrl
+            time.sleep(0.1)
+        ctrl.close()  # recreate the section next attempt to re-trigger the hijack
     return None
 
 
@@ -406,7 +447,7 @@ def rig_drive(  # pragma: no cover - rig-only
     """
     from tools.ac_harness.ai_line import _horizontal, load_ai_line
 
-    fast_path = resolve_fast_lane(config.ac_root, config.track_id)
+    fast_path = resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
     line = load_ai_line(fast_path)
     speed_profile = None
     if config.driver == "racing":
@@ -486,6 +527,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--cm-preset", required=True, type=Path, help="Quick Drive .cmpreset")
     p.add_argument("--track", required=True, help="AC track id (for the fast_lane.ai racing line)")
+    p.add_argument(
+        "--track-layout",
+        default=None,
+        help="layout subdir for multi-layout tracks (e.g. layout_gp)",
+    )
     p.add_argument("--ac-root", type=Path, default=None, help="AC content root (Steam install)")
     p.add_argument("--cm-exe", type=Path, default=None, help="Content Manager.exe path")
     p.add_argument("--sidecar-url", default="ws://127.0.0.1:8765")
@@ -513,6 +559,7 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
     kwargs: dict[str, Any] = dict(
         cm_preset=args.cm_preset,
         track_id=args.track,
+        track_layout=args.track_layout,
         cm_exe=args.cm_exe,
         sidecar_url=args.sidecar_url,
         driver=args.driver,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -10,7 +10,7 @@ modules into the loop the EPIC claimed** —
     CM-URL launch (entry_launcher)            -> AC on track, non-elevated
     wait LIVE + settle                        -> CSP ready to accept the Custom-AI hijack
     carcsw hijack of car 0 (custom_ai)        -> retry / relaunch on the early-LIVE race
-    autonomous drive (racing_driver + ai_line) -> RACES any track: shifts gears, carries pace
+    autonomous drive (racing_driver / ggv)     -> RACES any track: shifts gears, flat-out min-time
     tap the sidecar WS (sequence_probe)        -> assert the live coaching producer contract
     teardown
 
@@ -35,7 +35,7 @@ with injectable ``launch`` / ``hijack`` / ``drive`` / ``tap`` seams, unit-tested
 Run on the rig (loopback to a sidecar started by the daemon or by hand)::
 
     python -m tools.ac_harness.auto_drive \
-        --cm-preset "<.cmpreset>" --track imola --wait-lap --drive-seconds 360
+        --cm-preset "<.cmpreset>" --track spa --driver ggv --drive-seconds 360   # flat-out
 """
 
 from __future__ import annotations
@@ -77,7 +77,10 @@ class AutoDriveConfig:
     driver: str = "racing"
     drive_seconds: float = 300.0
     pace: float = 0.9  # racing: fraction of the AI line's speed profile to target
-    racing_max_speed_kmh: float = 240.0  # racing: cap (above any GT speed; lets it use top gears)
+    racing_max_speed_kmh: float = (
+        240.0  # racing/ggv: cap (above any GT speed; lets it use top gears)
+    )
+    ggv_scale: float = 0.9  # ggv: safety margin on the min-time profile (flat-out * scale)
     target_speed_kmh: float = 55.0  # cruise only
     min_corner_speed_kmh: float = 30.0  # cruise only
     # Assertion.
@@ -320,13 +323,46 @@ def rig_hijack(config: AutoDriveConfig) -> Controller | None:  # pragma: no cove
     return None
 
 
+def generic_gt3_ggv():
+    """The live-VERIFIED GT3 friction-circle (GGVModel), telemetry-free at call time.
+
+    These are the values empirically fit from human GT3 laps for EPIC #154's frontier controller
+    (#259, ``frontier-controller-ggv``) — the config that drove **clean AC-valid flying laps** at
+    Magione (Stanley + this GGV = 95.3 s, ~216 km/h, zero teleports). They are car-representative
+    for a GT3, so the QSS min-time profile sends straights flat-out and brakes on the friction
+    circle, **without spinning**.
+
+    The load-bearing correction (red-team #259, live-disproven aero-lateral): ``k_aero_lat`` MUST be
+    0. Any aero-lateral grip term makes the profile carry too much speed into corners and the live
+    GT3 spins out (k>=0.0003 → 96 s with teleports; even k=0.0001 spun). Braking grip RISES with
+    speed instead (aero): ``ax_brake = 0.955 + 0.0214*v_ms`` g (~1.0 g @40, ~2.2 g @180 km/h) — the
+    fixed ``brake_g=1.4`` it replaced braked far too early at speed.
+    """
+    from tools.ac_harness.ggv_profile import GGVModel
+
+    return GGVModel(
+        mu_lat_g=1.5,
+        k_aero_lat=0.0,  # MUST be 0 — an aero-lateral term spins the GT3 out at speed (#259)
+        brake_b0_g=0.955,
+        brake_b1=0.0214,  # braking rises with speed (aero): ~1.0 g @40, ~2.2 g @180 km/h
+        drive_b0_g=1.1,
+        drive_b1=-0.0117,
+        drive_min_g=0.35,
+        ellipse_n=1.55,
+        ay_cap_g=1.8,
+        ax_brake_cap_g=3.4,
+    )
+
+
 def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list | None = None):
     """Construct the drive controller for ``config.driver`` (pure; CI-testable).
 
-    ``racing`` → :class:`racing_driver.RacingDriver` following the AI line's embedded speed profile
-    (real braking points + gear shifting + pace) — the car actually races. ``cruise`` →
-    :class:`lap_driver.LapDriver`, the conservative ~50 km/h 1st-gear lane-keeper. Both expose the
-    same ``step()``/``on_recovery()`` contract, so the rig drive loop is driver-agnostic.
+    ``ggv`` → flat-out: a generic-GT3 friction-circle min-time profile (``ggv_profile``) driven
+    verbatim by :class:`racing_driver.RacingDriver` (``from_ggv_profile``) — sends straights in the
+    top gears, brakes on the friction circle. ``racing`` → :class:`racing_driver.RacingDriver`
+    following the AI line's embedded speed profile (gear shifting + pace, but only as fast as the
+    stock AI line). ``cruise`` → :class:`lap_driver.LapDriver`, the ~50 km/h 1st-gear lane-keeper.
+    All three expose the same ``step()``/``on_recovery()`` contract, so the rig loop is agnostic.
     """
     from tools.ac_harness.lap_driver import LapDriver
 
@@ -347,7 +383,16 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
             pace=config.pace,
             max_speed_kmh=config.racing_max_speed_kmh,
         )
-    raise ValueError(f"unknown driver {config.driver!r} (expected 'racing' or 'cruise')")
+    if config.driver == "ggv":
+        from tools.ac_harness.ggv_profile import ggv_speed_profile_from_model
+        from tools.ac_harness.racing_driver import RacingDriver
+
+        v_target, _summ = ggv_speed_profile_from_model(
+            fast_line, generic_gt3_ggv(), v_top_kmh=config.racing_max_speed_kmh
+        )
+        v_target = [v * config.ggv_scale for v in v_target]
+        return RacingDriver.from_ggv_profile(fast_line, v_target)
+    raise ValueError(f"unknown driver {config.driver!r} (expected 'ggv', 'racing', or 'cruise')")
 
 
 def rig_drive(  # pragma: no cover - rig-only
@@ -446,12 +491,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--sidecar-url", default="ws://127.0.0.1:8765")
     p.add_argument(
         "--driver",
-        choices=("racing", "cruise"),
+        choices=("ggv", "racing", "cruise"),
         default="racing",
-        help="racing = shift gears + carry pace (default); cruise = slow 1st-gear lane-keeper",
+        help="ggv = flat-out min-time (top gears, 200+); racing = AI-line pace (default); "
+        "cruise = slow 1st-gear lane-keeper",
     )
     p.add_argument("--pace", type=float, default=0.9, help="racing: fraction of AI-line speed")
-    p.add_argument("--max-speed", type=float, default=240.0, help="racing: speed cap (km/h)")
+    p.add_argument("--ggv-scale", type=float, default=0.9, help="ggv: safety margin on min-time")
+    p.add_argument("--max-speed", type=float, default=240.0, help="racing/ggv: speed cap (km/h)")
     p.add_argument("--drive-seconds", type=float, default=300.0)
     p.add_argument("--target-speed", type=float, default=55.0, help="cruise target speed (km/h)")
     p.add_argument("--min-corner", type=float, default=30.0, help="cruise min corner speed (km/h)")
@@ -470,6 +517,7 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         sidecar_url=args.sidecar_url,
         driver=args.driver,
         pace=args.pace,
+        ggv_scale=args.ggv_scale,
         racing_max_speed_kmh=args.max_speed,
         drive_seconds=args.drive_seconds,
         target_speed_kmh=args.target_speed,


### PR DESCRIPTION
## Why

`self_test.py` (#236) asserts the live WS producer contract but **never drives the car** —
its own docstring calls the carcsw lap "an optional follow-up step". So the EPIC's
"one-command hands-off L2" had a real composition gap: the only assertion that needs real
motion (`--wait-lap`) was wired to nothing that produces motion, and the loop was only ever
live-verified on **Magione + Porsche 911 GT3 R**. The operator asked whether the autonomous
test setup actually works on *a different track and different cars* — "or is it just overly
orchestrated theater."

## What

`tools/ac_harness/auto_drive.py` — composes the **shipped** harness modules into the loop the
EPIC claimed, parametrized by **car/track/preset**:

```
CM-URL launch (entry_launcher)          -> AC on track, non-elevated
wait LIVE + settle                      -> CSP ready to accept the Custom-AI hijack
carcsw hijack of car 0 (custom_ai)      -> retry / relaunch on the early-LIVE race
autonomous drive (lap_driver + ai_line) -> a real lap of ANY track, no human, in a thread
tap the sidecar WS (sequence_probe)     -> assert the live coaching producer contract
teardown
```

`run_auto_drive` is **pure orchestration** with injectable `launch`/`hijack`/`drive`/`tap`
seams → 9 off-sim unit tests (no AC, no Windows); the rig wiring is `pragma: no cover`.

Two robustness findings from this session's live runs are baked in:
- **Hijack retry/relaunch** — CSP only creates `Car0` once its Custom-AI subsystem is watching;
  hijacking too soon after `AC_STATUS`→LIVE loses the race (observed live: `gfx=13` fail vs
  `gfx=26907` success after settling).
- **Sim-death detection (anti-false-green)** — a crashed `acs.exe` freezes the Car0 mmap and
  `read_car_data()` returns the last frame forever; watch Car0 `packet_id` stagnation and stop,
  instead of reporting a parked car as "still driving".

## Live generality evidence (rig AG_PC, 2026-06-27) — answering "working or theater?"

| Combo | Track | Car | Result |
|---|---|---|---|
| 1 | **Imola** | **Audi R8 LMS** | autonomous **full lap** (5200 m, 0 recoveries); trainer registered the lap (HUD `Best/Last/Record 9:13.874`, `Laps: 2`); 1173+ `coaching.snapshot` frames; HUD screenshot inspected (`CURRENT 49 KMH` matches carcsw telemetry) |
| 2 | **Mugello** | **Corvette C7R** | autonomous 2.5 km @ ~65 km/h; 703 `coaching.snapshot` + 357 `tire_temps`; `coaching.snapshot.current_speed_kmh=64.81` matches carcsw telemetry; HUD screenshot inspected |

Both combos: hijack of car 0 landed with **only the global `[CUSTOM_AI] ENABLED=1`** — no
per-track `surfaces.ini ALLOW_CUSTOM_AI_MANIPULATION` edit needed (corrects the documented
recipe). Verdict: the autonomous self-test setup **generalizes** beyond Magione/Porsche.

## Test
- `tests/test_ac_harness_auto_drive.py` — 9 tests (launch/hijack failure stages, happy path +
  teardown, missing-topic fail, `--wait-lap` requires a lap, drove-gates-success, tap-exception
  teardown, skip-launch, `resolve_fast_lane`).
- Full `tools/ac_harness` suite green locally (123 passed).

Part of #154. Closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)