### PR TITLE
docs(vault): post-merge handoff for PR #325 (auto_drive composed loop + flat-out racing)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-19T19:45:00Z
+last_updated: 2026-06-27T22:15:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -43,6 +43,21 @@ CLOSED** on the rig this session: timestamped tap of the script-frame `coaching.
 showed max gap **255 ms** (at S/F: 217 ms / 255 ms, not ~2 s); archives still land off-frame, laps
 `valid=True`. The ~2 s render freeze is gone. Evidence:
 [#246#issuecomment-4754133099](https://github.com/agorokh/ac-copilot-trainer/issues/246#issuecomment-4754133099).
+
+**Active focus update (2026-06-27) — #324 / PR [#325](https://github.com/agorokh/ac-copilot-trainer/pull/325) MERGED (`0fb721f`), generality + flat-out LIVE-VERIFIED:**
+Operator pushback ("the composed run wasn't racing — stuck in 1st gear") drove the fix. New
+`tools/ac_harness/auto_drive.py` is the genuinely-composed one-command L2 loop (launch → carcsw
+hijack w/ retry → autonomous drive in a thread → WS producer assert), **parametrized by
+car/track/preset**, with **sim-death anti-false-green** (Car0 packet stagnation). Three driver modes:
+`cruise` (LapDriver), `racing` (AI-line pace), **`ggv`** (flat-out friction-circle min-time).
+**Generality proven beyond Magione/Porsche**: Imola + Audi R8 LMS (full lap + reference coaching),
+Mugello + Corvette C7R, and **Spa + BMW Z4 GT3 flat-out top gear 6 / 211 km/h** with reference
+coaching (`T2 · target entry 241 km/h`). Load-bearing fix: the generic GGV's `k_aero_lat` MUST be 0
+(an aero-lateral term spins the GT3 out — a multi-agent verification workflow caught it against the
+#259 plant fit). Honest residual: flat-out on Stanley still loses a few corners; the clean ~83 s line
+needs curvature-ff + per-car `ff_c1/c2` calibration (#244). #154 stays OPEN (children #277/#278/#305 +
+Part-G KPI residual). Full state:
+[`autonomous-drive-multitrack-generality-2026-06-27`](../03_Investigations/autonomous-drive-multitrack-generality-2026-06-27.md).
 
 **Infra (2026-05-20):** PR [#111](https://github.com/agorokh/ac-copilot-trainer/pull/111) closed the [#108](https://github.com/agorokh/ac-copilot-trainer/issues/108) agent-surface campaign (closeout doc only; five agent SHA alignments deferred). PR [#109](https://github.com/agorokh/ac-copilot-trainer/pull/109) memory-contract cursor rule fix remains on `main`.
 
@@ -91,6 +106,13 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-27** — PR [#325](https://github.com/agorokh/ac-copilot-trainer/pull/325) **MERGED** at
+  `0fb721f` — `tools/ac_harness/auto_drive.py`: one-command composed L2 loop (launch → hijack → drive
+  → WS assert), driver modes cruise/racing/**ggv flat-out**, sim-death anti-false-green, `max_gear_used`;
+  closes [#324](https://github.com/agorokh/ac-copilot-trainer/issues/324). Live-verified non-Magione /
+  non-Porsche: Imola+Audi R8 LMS (full lap + reference coaching), Mugello+Corvette C7R, Spa+BMW Z4 GT3
+  **flat-out 6th gear / 211 km/h** with reference coaching. 21 off-sim tests; no post-merge flags.
+  #154 stays OPEN.
 - **2026-06-19** — PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248) **MERGED** at
   `88249bf` — Stanley steering + `RacingDriver.from_human_profile` ([#244](https://github.com/agorokh/ac-copilot-trainer/issues/244)).
   **LIVE-VERIFIED on `AG_PC`**: 3 AC VALID laps via carcsw (best 106.8 s, 207.6 km/h, gears 1–6),

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-27T20:40:00Z
+last_updated: 2026-06-27T22:15:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/autonomous-drive-multitrack-generality-2026-06-27.md
   - AcCopilotTrainer/03_Investigations/issue-277-rig-verify-prepped-blocked-concurrency-2026-06-27.md
   - AcCopilotTrainer/03_Investigations/issue-308-worktree-memory-gate-resolved-2026-06-25.md
   - AcCopilotTrainer/03_Investigations/pr-309-lap-archive-finalization.md
@@ -36,6 +37,34 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-27 LATE — EPIC #154 auto_drive composed loop + flat-out racing MERGED)
+
+**`/autonomous-deliver 154` on AG_PC (this session, `flamboyant-poincare-b469d9`).** Shipped PR
+[#325](https://github.com/agorokh/ac-copilot-trainer/pull/325) (`0fb721f`, closes
+[#324](https://github.com/agorokh/ac-copilot-trainer/issues/324)): new `tools/ac_harness/auto_drive.py`
+— the genuinely-composed one-command L2 loop (launch → carcsw hijack w/ retry → autonomous drive in a
+thread → WS producer assert), **parametrized by car/track/preset**, with **sim-death anti-false-green**
+(Car0 packet stagnation). Driver modes: `cruise` (LapDriver) / `racing` (AI-line) / **`ggv`
+(flat-out friction-circle min-time)**. 21 off-sim tests; post-merge classification clean.
+
+**Operator question answered LIVE (generality beyond Magione/Porsche, racing not theater):**
+- **Imola + Audi R8 LMS** — autonomous **full lap** (5200 m), trainer registered the lap + reference coaching.
+- **Mugello + Corvette C7R** — 2.5 km autonomous; coaching `current_speed_kmh` matched the AI-driven car.
+- **Spa + BMW Z4 GT3** — `ggv` **flat-out top gear 6 / 211 km/h**, reference coaching (`T2 · target entry 241 km/h`).
+- The first composed run "wasn't racing" (1st gear, 49 km/h) → now shifts 1→6 and sends straights.
+
+**Load-bearing finding:** the generic GGV's `k_aero_lat` MUST be 0 — an aero-lateral grip term spins the
+GT3 out (matches the #259 red-team; a multi-agent verification workflow caught it pre-ship). Verified
+plant fit lives in `auto_drive.generic_gt3_ggv()`.
+
+**What remains (Part-G residual; #154 stays OPEN):** clean flat-out line (~83 s) needs curvature-ff
+steering with per-car `ff_c1/c2` calibration from a human CSV (#244); the formal false-green-rate <5%
+KPI; and #154 children #277/#278/#305. AC rig was crash-prone this session (4 fresh-launch crashes — the
+sim-death guard caught all, reporting honest FAIL). Full write-up:
+[[autonomous-drive-multitrack-generality-2026-06-27]].
+
+---
 
 ## Resume here (2026-06-27 EVENING — #277 brain-debrief rig-verify PREPPED, paused on rig contention)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/autonomous-drive-multitrack-generality-2026-06-27.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/autonomous-drive-multitrack-generality-2026-06-27.md
@@ -1,0 +1,91 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-06-27
+updated: 2026-06-27
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/154
+relates_to:
+  - AcCopilotTrainer/01_Decisions/autonomous-self-test-harness.md
+  - AcCopilotTrainer/03_Investigations/autonomous-drive-live-verified-2026-06-16.md
+  - AcCopilotTrainer/03_Investigations/csp-custom-ai-mmap-interface-2026-06-16.md
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+---
+
+# Autonomous drive — multi-track / multi-car generality LIVE-VERIFIED (EPIC #154 Part G, 2026-06-27)
+
+**Question (operator):** does the autonomous self-test setup actually work on a *different track
+and different cars*, or is it "overly orchestrated theater"? Prior L2 verification was **Magione +
+Porsche 911 GT3 R only**.
+
+**Answer: it generalizes — not theater.** Verified live on the rig (`AG_PC`), no human at the wheel,
+on two new combos plus a third drive:
+
+| Combo | Track | Car | Result |
+|---|---|---|---|
+| 1 | **Imola** | **ks_audi_r8_lms** | carcsw **full lap** (5200 m, 0 recoveries, `drove=true`); trainer registered the lap (HUD `Best/Last/Record 9:13.874`, tyre widget `Laps: 2`); 1173+ `coaching.snapshot`; HUD screenshot inspected — coaching `CURRENT 49 KMH` == carcsw telemetry |
+| 2 | **Mugello** | **ks_corvette_c7r** | carcsw 2.5 km @ ~65 km/h; 703 `coaching.snapshot` + 357 `tire_temps`; `coaching.snapshot.current_speed_kmh=64.81` == carcsw telemetry; HUD screenshot inspected |
+
+`load_ai_line` parses imola/mugello/monza/spa/ks_laguna_seca `fast_lane.ai` cleanly — the racing-line
+loader is track-agnostic. `lap_driver` (conservative pure-pursuit, ~50–65 km/h cap) drove all combos
+with the default tune. The trainer reads `ac.getCar(0)` and coaches whatever drives car 0.
+
+## New findings (folded into PR #325 / #324)
+
+1. **`surfaces.ini` permission is NOT required to hijack car 0.** The carcsw hijack landed on Imola
+   and Mugello with **only the global `extension/config/new_behaviour.ini [CUSTOM_AI] ENABLED=1`** —
+   **no** per-track `[_EXTRA_PERMISSIONS] ALLOW_CUSTOM_AI_MANIPULATION=1` edit. The Magione
+   `surfaces.ini` edit recorded in [[csp-custom-ai-mmap-interface-2026-06-16]] was for a *different*
+   experiment (extended-physics / AI-line manipulation); it is **not** on the player-car hijack path.
+   Correction to the documented recipe.
+2. **Early-LIVE hijack race.** CSP only creates the `Car0` read section once its Custom-AI subsystem
+   is watching. Creating `CarControls0` too soon after `AC_STATUS`→LIVE silently no-ops (live: hijack
+   FAILED at `gfx=13`; SUCCEEDED at `gfx=26907` once settled). Mitigation: settle after LIVE, retry
+   the hijack, relaunch on failure.
+3. **Sim-death false-green.** When `acs.exe` crashes mid-drive the Car0 mmap freezes and
+   `read_car_data()` returns the last frame forever — a parked car read as "still driving" (observed:
+   Mugello AC crash at drive-t≈125 s, scratch loop spun on stale `dist=2487m`). Mitigation: detect
+   Car0 `packet_id` stagnation and stop. (AC mid-session crashes remain a flaky rig reality.)
+
+## Composition gap closed
+
+`self_test.py` (#236) asserts the WS producer contract but **never drives** — the only
+motion-requiring check (`--wait-lap`) was wired to nothing that produces motion. New
+`tools/ac_harness/auto_drive.py` (PR #325, closes #324) composes **launch → wait LIVE+settle →
+carcsw hijack (retry/relaunch) → autonomous `lap_driver` drive (background thread) → tap sidecar WS
++ assert → teardown**, parametrized by car/track/preset. Pure injectable orchestration → 11 off-sim
+tests; rig wiring `pragma: no cover`.
+
+Reusable rig recipe: tokenless loopback sidecar (`python -m tools.ai_sidecar --host 127.0.0.1
+--port 8765`); per-combo `.cmpreset` is just JSON with `CarId`/`TrackId` (template from
+`autodrive_magione.cmpreset`); CM-URL launch survives the elevated-shell split (#233).
+
+## Flat-out (`--driver ggv`) — full GT3 send, live-verified
+
+Operator pushback: the first composed run used the cruise `LapDriver` (1st gear, 49 km/h) — "not
+racing." Fixes, in order:
+1. **`--driver racing`** (default) → `RacingDriver` on the AI line's embedded speed profile: shifts
+   1→3, ~130 km/h on Spa, full reference coaching (`T3 ON PACE`, `TARGET ENTRY 253 KMH`). But the
+   stock AI lines are moderate-speed (Imola maxes 93 km/h), so it's not flat-out.
+2. **`--driver ggv`** → flat-out: a generic-GT3 friction-circle min-time profile
+   (`ggv_speed_profile_from_model`) driven verbatim by `RacingDriver.from_ggv_profile`.
+   **Live-verified Spa + BMW Z4 GT3: top gear 6, max 211 km/h, all gears 1→6**, with reference
+   coaching at speed (`T2 · TARGET ENTRY 241 KMH · CURRENT 182 · braking point 25 m`). HUD
+   screenshot inspected: 6th gear / 182 km/h on Kemmel.
+
+**Critical GGV correction (#259 red-team, re-confirmed live this session):** the generic GGV's
+**`k_aero_lat` MUST be 0**. A first-pass `k_aero_lat=0.00007` made the profile carry too much corner
+speed and the GT3 **spun out** (live: hit 5th/165 km/h then spun to neutral). The live-fitted plant
+(`mu_lat_g=1.5, k_aero_lat=0, brake=0.955+0.0214·v_ms, ellipse_n=1.55`) — the Stanley+GGV config
+that ran clean 95.3s at Magione — holds the line. Steering stays Stanley + `ax_feedforward=False`
+(the verified-stable config); the faster curvature-ff/ax-ff pace (83.5s) needs runtime `ff_c1/c2`
+calibration from a human CSV + per-track `ff_sign` — separate scope. At flat-out on Spa the
+geometric controller still loses a few corners and recovers (honest: not yet the clean 83s line).
+
+`max_gear_used` was added to `DriveStats`/report so a crawl-in-1st run now visibly FAILs the racing
+intent. The verified GGV plant is encoded in `auto_drive.generic_gt3_ggv()`.
+
+## Remaining (Part-G optional formal gate)
+Determinism-lock preset + CSP precondition assert, and the false-green-rate <5% KPI shadow report.
+The sim-death guard here is a concrete anti-false-green step toward that KPI. Deliver if the formal
+KPI is wanted; else descope per the #154 Closure Criterion.


### PR DESCRIPTION
Post-merge vault SAVE for #325 (#154 Part G). Adds the multi-track/multi-car generality + flat-out investigation node, updates Next Session Handoff resume block and Current Focus. Vault-only (diff strictly under docs/01_Vault/**).