### PR TITLE
fix(ci): resolve private governance-hub vault-automerge action via fleet-bot token (#329)

### DIFF
--- a/.github/workflows/vault-automerge.yml
+++ b/.github/workflows/vault-automerge.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: agorokh/governance-hub
-          ref: 0939d4724bd1e89515d4abd89d676c750580b028
+          ref: 0939d4724bd1e89515d4abd89d676c750580b028  # pragma: allowlist secret (git SHA, not a secret)
           token: ${{ steps.app-token.outputs.token }}
           path: .governance-hub
       - uses: ./.governance-hub/.github/actions/vault-automerge

--- a/.github/workflows/vault-automerge.yml
+++ b/.github/workflows/vault-automerge.yml
@@ -22,7 +22,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: agorokh/governance-hub/.github/actions/vault-automerge@0939d4724bd1e89515d4abd89d676c750580b028
+      # The composite action lives in the PRIVATE governance-hub repo. A cross-repo `uses:` of a
+      # private action does NOT resolve with the default GITHUB_TOKEN ("Unable to resolve action
+      # agorokh/governance-hub, not found" — issue #329), so mint the fleet-bot app token, check the
+      # action out at its pinned SHA, and run it via a local path. Reference-not-vendor is preserved:
+      # the logic still lives ONCE in the hub at this SHA; we only change HOW it is fetched.
+      - name: Mint fleet-bot token (read governance-hub)
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FLEET_BOT_APP_ID }}
+          private-key: ${{ secrets.FLEET_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: governance-hub
+      - name: Check out the pinned governance-hub vault-automerge action
+        uses: actions/checkout@v7
+        with:
+          repository: agorokh/governance-hub
+          ref: 0939d4724bd1e89515d4abd89d676c750580b028
+          token: ${{ steps.app-token.outputs.token }}
+          path: .governance-hub
+      - uses: ./.governance-hub/.github/actions/vault-automerge
         with:
           github-token: ${{ github.token }}
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem
Every `vault-only` PR's **guard-and-automerge** check fails in ~3s — `Unable to resolve action agorokh/governance-hub, not found` — so auto-merge never arms and post-merge handoff PRs stall (#329; PR #328 had to be merged by hand).

Root cause: the #863 refactor points the guard at `agorokh/governance-hub/.github/actions/vault-automerge@<sha>`, a **private** repo. A cross-repo `uses:` of a private action does not resolve with the default `GITHUB_TOKEN`. The hub's access is already `access_level=user` and the action exists at the pinned SHA — still insufficient for a personal-account cross-repo private action (a re-run with that setting still failed identically).

## Fix
Mirror the fleet's existing cross-repo auth pattern (`cross-repo-mining` / `process-miner` / `template-sync` all use `actions/create-github-app-token@v3` + `FLEET_BOT_APP_*`): mint the fleet-bot token, `actions/checkout` the governance-hub action **at its pinned SHA** to a local path, and run it via `./.governance-hub/...`. **Reference-not-vendor preserved** — the guard logic still lives once in the hub at the same SHA; only the fetch mechanism changes.

## Verification
This is a code PR (not `vault-only`), so the guard does not run here. It is exercised end-to-end by the **post-merge vault PR for this change** — if that vault PR's guard goes green and auto-merges, the fix is confirmed live.

## Fleet note
The #863 refactor is fleet-wide → every child repo has the same broken guard. Propose this app-token wrapper upstream in agent-factory / governance-hub.

Closes #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)