### PR TITLE
docs(vault): #277 CLOSED — brain debrief live-verified on the rig

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-27T22:15:00Z
+last_updated: 2026-06-28T00:25:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/autonomous-drive-multitrack-generality-2026-06-27.md
   - AcCopilotTrainer/03_Investigations/issue-277-rig-verify-prepped-blocked-concurrency-2026-06-27.md
@@ -37,6 +37,34 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Resume here (2026-06-27 — #277 CLOSED: brain debrief LIVE-VERIFIED on the rig)
+
+**`/autonomous-deliver 277` — DONE.** [#277](https://github.com/agorokh/ac-copilot-trainer/issues/277)
+**CLOSED**: the archive-backed brain debrief (#321) is live-verified end-to-end on AG_PC. Autonomous
+carcsw/Stanley drive of **`ks_audi_r8_lms` @ magione** (3 valid laps, best 1:46.9, 207.8 km/h) →
+**5 live `debriefSource:"brain"` `coaching_response` frames** captured on the WS wire
+(sidecar→`ws_bridge.lua`), each a 5-corner `cornerAnalysis` with **CONFIRMED per-wheel attribution**
+(e.g. "Rear wheelspin on exit (confirmed) — raise TC / open diff", "No wheelspin (confirmed)") plus
+`trailBraking`/`tyres`/`balance`. `build_brain_followup` on the real archive reproduces it offline.
+Detail + learnings: [[issue-277-rig-verify-prepped-blocked-concurrency-2026-06-27]].
+
+**Key learnings (durable):**
+- Brain debrief is gated by **`AC_COPILOT_OLLAMA_ENABLE`** (deterministic brain, but shares the Ollama
+  flag). `start_sidecar.bat` sets it `=1` by default → the CSP-auto-launched sidecar enables it; a
+  sidecar started with it `=0` silently disables the brain debrief (`build_brain_followup` → None).
+- **carcsw hijack is incompatible with extended-physics cars**: `911 GT3 R 2016` triggers CSP
+  "extended physics for car" → no `Car0` mmap → hijack fails. Use a non-extended car (`ks_audi_r8_lms`).
+  **No `surfaces.ini` custom-AI edit is needed** (stock + AC-install `new_behaviour.ini [CUSTOM_AI]
+  ENABLED=1` suffices; the `WAV_PITCH=extended-0` edit actively BREAKS the hijack).
+- Launch reliably via `ContentManagerActuator` (`Content Manager.exe acmanager://…`), **not**
+  `explorer.exe` (opens CM without applying the preset).
+- **Residual (separable → EPIC #154 Part-G):** the HUD coaching-summary *tile* gates on an AC-**valid**
+  lap; the autonomous Stanley line clips curbs → AC-invalid → tile placeholder. The brain frame is
+  delivered live regardless; on-screen tile pixels confirm on a clean valid (human) lap.
+
+**Rig left:** surfaces stock, `new_behaviour.ini` restored; AC + a brain-enabled sidecar left running.
+The "PREPPED/paused" block below is superseded by this.
 
 ## Resume here (2026-06-27 LATE — CI: vault-automerge guard fixed (#329 / PR #330))
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-277-rig-verify-prepped-blocked-concurrency-2026-06-27.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-277-rig-verify-prepped-blocked-concurrency-2026-06-27.md
@@ -12,7 +12,28 @@ relates_to:
   - AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
 ---
 
-# #277 live brain-debrief rig-verify — PREPPED, paused on rig contention (2026-06-27 eve)
+# #277 live brain-debrief rig-verify — RESOLVED (#277 CLOSED 2026-06-27)
+
+> **RESOLVED 2026-06-27 (later same day):** live-verified end-to-end on AG_PC + **#277 CLOSED**.
+> Autonomous carcsw/Stanley drive of `ks_audi_r8_lms` @ magione (3 valid laps) produced **5 live
+> `debriefSource:"brain"` coaching_response frames** on the WS wire, each a 5-corner `cornerAnalysis`
+> with CONFIRMED per-wheel attribution ("Rear wheelspin on exit (confirmed)", "No wheelspin
+> (confirmed)") + trailBraking/tyres/balance; `build_brain_followup` reproduces it offline on the real
+> archive. **Root cause of the earlier no-fire:** the brain debrief is gated by
+> `AC_COPILOT_OLLAMA_ENABLE` (deterministic brain, shares the Ollama flag; the capture harness had set
+> it `=0` — `start_sidecar.bat` defaults it `=1`, so normal operation is enabled). **carcsw gotcha:**
+> the `911 GT3 R 2016` is an extended-physics car → CSP "extended physics for car" → no `Car0` mmap →
+> hijack fails; use `ks_audi_r8_lms` (non-extended) on **stock** surfaces (the `WAV_PITCH=extended-0` /
+> `_EXTRA_PERMISSIONS` edit actively BREAKS the hijack; AC-install `new_behaviour.ini [CUSTOM_AI]
+> ENABLED=1` is the only enable needed). Launch via `ContentManagerActuator`, not `explorer.exe`.
+> **Residual (→ EPIC #154 Part-G):** the HUD coaching-summary tile gates on an AC-valid lap (autonomous
+> laps clip curbs → invalid) → on-screen tile pixels confirm on a clean valid lap. Evidence:
+> `.scratch/issue277-cap-frames2.jsonl`, `issue277_brain_{live,offline}.json`, `issue277_hud_brain_*.png`.
+> Closeout: [#277#issuecomment-4823317786](https://github.com/agorokh/ac-copilot-trainer/issues/277#issuecomment-4823317786).
+
+The original (now-superseded) prepped/paused write-up follows.
+
+## Prepped + paused (earlier 2026-06-27 eve)
 
 `/autonomous-deliver 277` on **AG_PC**. The #277 *code* shipped in **PR #321** (merged `8d9eb97`);
 the only remaining acceptance is the **rig-verify** (drive a lap → confirm the live


### PR DESCRIPTION
## Summary
Vault SAVE recording the live rig verification + closure of #277 (`/autonomous-deliver 277` on AG_PC).

- #277 **CLOSED**: archive-backed brain debrief (#321) live-verified end-to-end — 5 `debriefSource:"brain"` `coaching_response` frames captured on the WS wire driving `ks_audi_r8_lms` @ magione (3 valid laps), each with **CONFIRMED per-wheel attribution**.
- Durable learnings recorded in the handoff + investigation node: `AC_COPILOT_OLLAMA_ENABLE` gates the brain debrief (default-on via `start_sidecar.bat`); carcsw cannot hijack extended-physics cars (911 GT3 R) — use a non-extended car on **stock** surfaces; launch via `ContentManagerActuator`.
- Residual (on-screen valid-lap tile display) tracked under EPIC #154 Part-G.

Diff strictly under `docs/01_Vault/**` (vault-only auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)