### PR TITLE
chore(qodo): switch push_commands to /agentic_review

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -26,7 +26,7 @@
 # Enable review on subsequent pushes, not just PR open.
 # Each push costs 1 credit from the 30/month free budget.
 handle_push_trigger = true
-push_commands = ["/review"]
+push_commands = ["/agentic_review"]
 
 [pr_reviewer]
 extra_instructions = """


### PR DESCRIPTION
Propagate template-repo#435: Qodo auto push-review /review -> /agentic_review (was summary-only, burned a credit per push). Review-bot sunset; resolve-pr skill already triggers /agentic_review fleet-wide.