### PR TITLE
docs(vault): #327 CLOSED — vault-automerge already fixed (reconciliation)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-28T00:25:00Z
+last_updated: 2026-06-28T06:00:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-327-vault-automerge-already-resolved-2026-06-28.md
   - AcCopilotTrainer/03_Investigations/autonomous-drive-multitrack-generality-2026-06-27.md
   - AcCopilotTrainer/03_Investigations/issue-277-rig-verify-prepped-blocked-concurrency-2026-06-27.md
   - AcCopilotTrainer/03_Investigations/issue-308-worktree-memory-gate-resolved-2026-06-25.md
@@ -39,6 +40,16 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-06-28) — #327 CLOSED (no code): vault-automerge already fixed
+`/autonomous-deliver 327` reconciled the stale issue body against live state and **closed
+[#327](https://github.com/agorokh/ac-copilot-trainer/issues/327) COMPLETED with zero code**. Both
+symptoms were already gone: (1) the `guard-and-automerge` / `governance-hub`-not-found regression is a
+**duplicate of #329**, fixed by **PR #330** (fleet-bot app-token + checkout, present at `HEAD`); (2) the
+`build`/`ci-conventional` failure was a **branch-name artifact** of PR #326's `claude/...` branch, not a
+defect — every proper `vault/...` PR (#331/#332/#337) is green on both checks. Detail +
+live-evidence table: [[issue-327-vault-automerge-already-resolved-2026-06-28]]. **Lesson:** parallel
+autonomous sessions can file+fix the same root cause under different numbers — reconcile before re-doing.
 
 ## Delivered (2026-06-28) — PR #334 MERGED: Track Titan CoachingOracle
 [#334](https://github.com/agorokh/ac-copilot-trainer/pull/334) (issue #333) squash-merged to `main` as

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
@@ -2,7 +2,7 @@
 type: index
 status: active
 created: 2026-04-08
-updated: 2026-06-25
+updated: 2026-06-28
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
 ---
@@ -13,6 +13,7 @@ Technical deep-dives and root-cause analyses from development sessions.
 
 | Node | Summary |
 |------|---------|
+| [issue-327-vault-automerge-already-resolved-2026-06-28.md](issue-327-vault-automerge-already-resolved-2026-06-28.md) | #327 closed COMPLETED with **no code** — both symptoms already gone: `guard-and-automerge` regression = dup of #329, fixed by PR #330 (app-token); `build`/`ci-conventional` failure = `claude/...` branch-name artifact of PR #326, not a defect. Proper `vault/...` PRs (#331/#332/#337) green on both. Reconcile before re-doing CI-regression issues. |
 | [issue-308-worktree-memory-gate-resolved-2026-06-25.md](issue-308-worktree-memory-gate-resolved-2026-06-25.md) | #308 closed COMPLETED. Tier-3 worktree false-block was Part A (committed-manifest placeholder, fixed by #316) + a **transient substrate outage** — NOT the SSRF guard. The `untrusted port 8045` SSRF WARN is **cosmetic/by-design** on non-central hosts (grounding works via the registry Tailscale endpoint). Residual = cosmetic-WARN downgrade → governance-hub#111. |
 | [pr-309-lap-archive-finalization.md](pr-309-lap-archive-finalization.md) | Last lap's trace lost (≈923-byte stub) when not followed by another lap: session-end early-return skips the per-frame archive pump → abandoned `.tmp`. Fix: synchronous `flushPendingLapArchiveJobs` on driving→menu + empty-trace stub guard (#305 / PR #309; rig confirmation remains). |
 | [racing-driver-and-controller-2026-06-17.md](racing-driver-and-controller-2026-06-17.md) | Racing driver follows `fast_lane.ai`'s embedded speed profile (braking points/trail braking); gear bug fixed (limiter below shift point); the wall is STEERING (pure-pursuit cuts apexes → invalid laps); human-lap telemetry is the path (#241/#242/#244). |

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-327-vault-automerge-already-resolved-2026-06-28.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-327-vault-automerge-already-resolved-2026-06-28.md
@@ -1,0 +1,60 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-06-28
+updated: 2026-06-28
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/02_Investigations/post-merge-determinism-overhaul-2026-04.md
+  - AcCopilotTrainer/03_Investigations/_index.md
+---
+
+# Issue #327 — vault-automerge guard + build "broken": ALREADY RESOLVED (2026-06-28)
+
+[#327](https://github.com/agorokh/ac-copilot-trainer/issues/327) closed **COMPLETED** by
+`/autonomous-deliver 327` after reconciling the (stale) issue body against live state — **no code
+written**, because the fix had already landed. This is a clean Closing-reconciliation-gate outcome:
+the issue described a broken state that the evolved `main` no longer has.
+
+## What #327 claimed
+Two symptoms on vault-only PRs since #320:
+1. `guard-and-automerge` fails in ~3s: `Unable to resolve action 'agorokh/governance-hub', not found`.
+2. `build` fails on `make: *** [Makefile:8: ci-conventional] Error 1`.
+
+## Reconciliation (live evidence)
+**Symptom 1 = duplicate of #329, fixed by #330.**
+- `gh issue view 329` → `CLOSED 2026-06-27T23:07:07Z` (same governance-hub regression, filed by a
+  parallel autonomous session).
+- `gh pr view 330` → `MERGED 2026-06-27T23:07:06Z` — fix is the fleet-bot **app-token + checkout +
+  local-path `uses:`** pattern (a cross-repo `uses:` of a *private* action can't resolve with the
+  default `GITHUB_TOKEN`). Present at `HEAD` (`b88791b`) in `.github/workflows/vault-automerge.yml`.
+
+**Symptom 2 = branch-name artifact, not a defect.**
+- The `build` failure occurred **only on PR #326**, pushed from `claude/gifted-diffie-9dbb3a`.
+  `claude/` is not in `ALLOWED_BRANCH_PREFIXES` in `scripts/ci_policy.py`, so `ci-conventional`
+  correctly rejected it. (Locally reproducible: `make ci-conventional` on any `claude/...` worktree
+  branch fails the same way — a false positive, not the bug.)
+- Proper vault-SAVE PRs use `vault/...` (allowed) + `docs(vault): ...` titles (conventional-valid),
+  so they pass. **Do not** add `claude/` to the allowlist — that would weaken the policy. The real
+  rule: vault SAVE must ship on a `vault/...` branch (post-merge skill already does this; PR #326 was
+  a one-off where an autonomous session committed vault docs on its working `claude/` branch).
+
+## Live verification — observed, not inferred
+`gh pr view <N> --json headRefName,statusCheckRollup`:
+
+| PR | branch | build | guard-and-automerge |
+|----|--------|-------|---------------------|
+| #326 | `claude/gifted-diffie-9dbb3a` | FAILURE | FAILURE (pre-#330 + bad branch) |
+| #331 | `vault/post-merge-pr330` | SUCCESS | SUCCESS |
+| #332 | `vault/issue277-resolved` | SUCCESS | SUCCESS |
+| #337 | `vault/post-merge-pr334` | SUCCESS | SUCCESS (most recent; merged 2026-06-28T05:17Z) |
+
+The outcome #327 asked for — vault-only PRs auto-merge with green `build` + `guard-and-automerge` —
+is observed working on live `main`. The vault SAVE PR for *this* session is itself a fresh end-to-end
+proof of the same path.
+
+## Takeaway for future sessions
+Before re-attempting a CI-regression issue, reconcile against live state: a parallel autonomous
+session may have already filed+fixed the same root cause under a different number (here #329/#330).
+A `claude/...` branch failing `ci-conventional` locally is expected and is not the issue under test.


### PR DESCRIPTION
## Vault SAVE — `/autonomous-deliver 327`

Strictly `docs/01_Vault/**`. Records that **#327 was closed COMPLETED with no code**, after reconciling
the stale issue body against live state.

### What changed
- **New** `03_Investigations/issue-327-vault-automerge-already-resolved-2026-06-28.md` — reconciliation
  + live-evidence table.
- **Updated** `00_System/Next Session Handoff.md` — Delivered entry + `relates_to`.
- **Updated** `03_Investigations/_index.md` — index row.

### Why #327 needed no code
- **`guard-and-automerge`** (`Unable to resolve action 'agorokh/governance-hub'`) = duplicate of **#329**
  (CLOSED), fixed by **PR #330** (fleet-bot app-token + checkout of the private hub action; present at
  `HEAD`).
- **`build` / `ci-conventional`** failed **only on PR #326**, which was pushed from a `claude/…` branch
  (not an allowed prefix in `scripts/ci_policy.py`). Proper `vault/…` PRs (#331/#332/#337) pass both
  checks. No defect; adding `claude/` to the allowlist would weaken the policy.

This PR is itself a fresh end-to-end proof of the same auto-merge path #327 was about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
