### PR TITLE
feat(coaching): wire RealtimeObserver → coaching.cue + in-process voice coach (#341 Part A)

### DIFF
--- a/tests/test_voice_scheduler.py
+++ b/tests/test_voice_scheduler.py
@@ -53,6 +53,16 @@ def test_same_rank_tie_break_prefers_freshest_cue() -> None:
     assert pb.played[-1].clip_id == "late_brake.act.t04"
 
 
+def test_same_rank_and_timestamp_tie_break_prefers_later_submission() -> None:
+    """When enqueued_at collides, the later submission in the batch must win."""
+    sched, pb, clock = _scheduler()
+    sched.submit(make_advisory(kind="late_brake", urgency="act", corner=2))
+    sched.submit(make_advisory(kind="late_brake", urgency="act", corner=3))
+    spoken = sched.process_pending(clock())
+    assert spoken is not None
+    assert pb.played[-1].clip_id == "late_brake.act.t04"
+
+
 def test_act_barges_in_over_lower_urgency_clip() -> None:
     sched, pb, clock = _scheduler()
     # info clip starts playing and is still sounding (current set, not finished)

--- a/tests/test_voice_scheduler.py
+++ b/tests/test_voice_scheduler.py
@@ -41,6 +41,18 @@ def test_highest_urgency_wins_in_a_batch() -> None:
     assert pb.played[-1].clip_id == "late_brake.act.t05"
 
 
+def test_same_rank_tie_break_prefers_freshest_cue() -> None:
+    """Equal-urgency batch must pick the later enqueued_at (Qodo #349 / scheduler.py:119)."""
+    sched, pb, clock = _scheduler()
+    sched.submit(make_advisory(kind="late_brake", urgency="act", corner=2))  # t0 → t03
+    clock.advance(0.05)
+    sched.submit(make_advisory(kind="late_brake", urgency="act", corner=3))  # fresher → t04
+    spoken = sched.process_pending(clock())
+    assert spoken is not None
+    assert spoken.corner == 4  # 1-based corner in Utterance
+    assert pb.played[-1].clip_id == "late_brake.act.t04"
+
+
 def test_act_barges_in_over_lower_urgency_clip() -> None:
     sched, pb, clock = _scheduler()
     # info clip starts playing and is still sounding (current set, not finished)

--- a/tests/test_voice_wiring.py
+++ b/tests/test_voice_wiring.py
@@ -121,6 +121,7 @@ def test_telemetry_tick_accepts_optional_spline_and_lap() -> None:
     assert ep.validate_inbound(_telemetry_tick(spline=0.5)) is None
     assert ep.validate_inbound(_telemetry_tick(spline=0.0, lap=3)) is None
     assert ep.validate_inbound(_telemetry_tick(completedLaps=5)) is None
+    assert ep.validate_inbound(_telemetry_tick(lapCount=5)) is None
     # still valid with neither (existing producers unaffected)
     assert ep.validate_inbound(_telemetry_tick()) is None
 

--- a/tests/test_voice_wiring.py
+++ b/tests/test_voice_wiring.py
@@ -26,6 +26,22 @@ from tools.ai_sidecar.realtime_observer import Advisory  # noqa: E402
 from tools.ai_sidecar.server import _reset_external_state, make_token_check  # noqa: E402
 
 # --------------------------------------------------------------------------------------------------
+# Isolation — global sidecar module state must not leak between tests (Qodo focus area).
+# --------------------------------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_sidecar_state() -> None:
+    server.set_realtime_observer(None)
+    server.set_voice_coach(None)
+    _reset_external_state()
+    yield
+    server.set_realtime_observer(None)
+    server.set_voice_coach(None)
+    _reset_external_state()
+
+
+# --------------------------------------------------------------------------------------------------
 # Fakes + helpers
 # --------------------------------------------------------------------------------------------------
 

--- a/tests/test_voice_wiring.py
+++ b/tests/test_voice_wiring.py
@@ -230,6 +230,25 @@ def test_publish_coaching_cues_survives_observer_fault(monkeypatch) -> None:
     assert captured == []
 
 
+def test_publish_coaching_cues_survives_non_serializable_broadcast(monkeypatch) -> None:
+    """Non-JSON-serializable cue payloads must not raise into the telemetry loop (Qodo #349)."""
+
+    async def _broadcast_like_targets(frame, *, exclude):  # noqa: ANN001
+        json.dumps(frame, separators=(",", ":"))
+
+    monkeypatch.setattr(server, "_broadcast_external", _broadcast_like_targets)
+    coach = _FakeCoach()
+    bad = _advisory(detail={"bad": object()})
+    server.set_realtime_observer(_FakeObserver([bad]))
+    server.set_voice_coach(coach)
+    try:
+        asyncio.run(server._publish_coaching_cues({"ts_sim": 1.0, "payload": {}}, exclude=None))
+    finally:
+        server.set_realtime_observer(None)
+        server.set_voice_coach(None)
+    assert coach.spoken == [bad]
+
+
 # --------------------------------------------------------------------------------------------------
 # End-to-end: telemetry_tick → coaching.cue to a voice-class WS client
 # --------------------------------------------------------------------------------------------------

--- a/tests/test_voice_wiring.py
+++ b/tests/test_voice_wiring.py
@@ -1,0 +1,252 @@
+"""Live voice-wiring tests (issue #341): protocol + observer→coaching.cue + in-process coach.
+
+The sidecar turns the live ``telemetry_tick`` stream into spoken cues by feeding a
+``RealtimeObserver`` and publishing its advisories on the ``coaching.cue`` topic (and feeding the
+#340 in-process ``VoiceCoach``). These tests exercise that wiring with a fake observer + fake coach
+(no audio hardware) and a real end-to-end WS round-trip. ``asyncio.run`` per repo convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+
+websockets = pytest.importorskip("websockets")
+from websockets.asyncio.client import connect as ws_connect  # noqa: E402
+from websockets.asyncio.server import serve as ws_serve  # noqa: E402
+
+from tools.ai_sidecar import external_protocol as ep  # noqa: E402
+from tools.ai_sidecar import server  # noqa: E402
+from tools.ai_sidecar.realtime_observer import Advisory  # noqa: E402
+from tools.ai_sidecar.server import _reset_external_state, make_token_check  # noqa: E402
+
+# --------------------------------------------------------------------------------------------------
+# Fakes + helpers
+# --------------------------------------------------------------------------------------------------
+
+
+class _FakeObserver:
+    """Returns a fixed advisory list on every ``observe`` call."""
+
+    def __init__(self, advisories: list[Advisory]) -> None:
+        self._advisories = advisories
+        self.frames_seen: list[dict] = []
+
+    def observe(self, frame: dict) -> list[Advisory]:
+        self.frames_seen.append(frame)
+        return list(self._advisories)
+
+
+class _FakeCoach:
+    """Records advisories handed to it (stands in for the #340 VoiceCoach)."""
+
+    def __init__(self) -> None:
+        self.spoken: list[Advisory] = []
+
+    def subscribe(self, advisory: Advisory) -> None:
+        self.spoken.append(advisory)
+
+
+def _advisory(**over: object) -> Advisory:
+    base: dict = dict(
+        kind="late_brake", corner=2, spline=0.4, urgency="act", message="Brake T3", detail={"x": 1}
+    )
+    base.update(over)
+    return Advisory(**base)  # type: ignore[arg-type]
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+@asynccontextmanager
+async def _running_sidecar() -> AsyncIterator[int]:
+    port = _free_port()
+    _reset_external_state()
+    try:
+        async with ws_serve(
+            lambda ws: server._handler(ws, reply_coaching=True),
+            "127.0.0.1",
+            port,
+            process_request=make_token_check(None),
+        ):
+            yield port
+    finally:
+        _reset_external_state()
+
+
+def _telemetry_tick(**payload_overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "speed_kmh": 112.0,
+        "rpm": 5400.0,
+        "gear": 3,
+        "throttle": 0.72,
+        "brake": 0.84,
+        "steer": -0.13,
+        "lat_g": 0.42,
+        "long_g": -0.78,
+    }
+    payload.update(payload_overrides)
+    return {"v": 1, "type": ep.TYPE_TELEMETRY_TICK, "seq": 7, "ts_sim": 123.45, "payload": payload}
+
+
+# --------------------------------------------------------------------------------------------------
+# Protocol surface
+# --------------------------------------------------------------------------------------------------
+
+
+def test_voice_client_class_is_known_and_hello_validates() -> None:
+    assert ep.CLIENT_CLASS_VOICE in ep.KNOWN_CLIENT_CLASSES
+    hello = {"v": 1, "type": "hello", "client": "voice-1", "client_class": ep.CLIENT_CLASS_VOICE}
+    assert ep.validate_inbound(hello) is None
+
+
+def test_coaching_cue_topic_is_subscribable() -> None:
+    assert ep.TOPIC_COACHING_CUE in ep.KNOWN_TOPICS
+    sub = {"v": 1, "type": "state.subscribe", "topics": [ep.TOPIC_COACHING_CUE]}
+    assert ep.validate_inbound(sub) is None
+
+
+def test_telemetry_tick_accepts_optional_spline_and_lap() -> None:
+    assert ep.validate_inbound(_telemetry_tick(spline=0.5)) is None
+    assert ep.validate_inbound(_telemetry_tick(spline=0.0, lap=3)) is None
+    assert ep.validate_inbound(_telemetry_tick(completedLaps=5)) is None
+    # still valid with neither (existing producers unaffected)
+    assert ep.validate_inbound(_telemetry_tick()) is None
+
+
+def test_telemetry_tick_rejects_bad_spline_and_lap() -> None:
+    assert "spline must be <= 1" in (ep.validate_inbound(_telemetry_tick(spline=1.5)) or "")
+    assert "spline must be >= 0" in (ep.validate_inbound(_telemetry_tick(spline=-0.1)) or "")
+    assert "spline requires a finite number" in (
+        ep.validate_inbound(_telemetry_tick(spline="x")) or ""
+    )
+    assert "lap must be >= 0" in (ep.validate_inbound(_telemetry_tick(lap=-1)) or "")
+
+
+def test_make_coaching_cue_frame_shape() -> None:
+    payload = {"kind": "late_brake", "corner": 2, "urgency": "act", "message": "Brake T3"}
+    cue = ep.make_coaching_cue(payload, ts_sim=12.5)
+    assert cue["v"] == ep.ENVELOPE_VERSION
+    assert cue["type"] == ep.TYPE_STATE_SNAPSHOT
+    assert cue["topic"] == ep.TOPIC_COACHING_CUE
+    assert cue["payload"] is payload
+    assert cue["source"] == "sidecar.observer"
+    assert cue["ts_sim"] == 12.5
+    assert "ts_sim" not in ep.make_coaching_cue(payload)  # omitted when None
+
+
+# --------------------------------------------------------------------------------------------------
+# _publish_coaching_cues unit logic
+# --------------------------------------------------------------------------------------------------
+
+
+def test_publish_coaching_cues_broadcasts_and_speaks(monkeypatch) -> None:
+    captured: list[dict] = []
+
+    async def _fake_broadcast(frame, *, exclude):  # noqa: ANN001
+        captured.append(frame)
+
+    monkeypatch.setattr(server, "_broadcast_external", _fake_broadcast)
+    coach = _FakeCoach()
+    adv = _advisory()
+    server.set_realtime_observer(_FakeObserver([adv]))
+    server.set_voice_coach(coach)
+    try:
+        asyncio.run(server._publish_coaching_cues({"ts_sim": 9.0, "payload": {}}, exclude="lua"))
+    finally:
+        server.set_realtime_observer(None)
+        server.set_voice_coach(None)
+
+    assert len(captured) == 1
+    cue = captured[0]
+    assert cue["topic"] == ep.TOPIC_COACHING_CUE
+    assert cue["type"] == ep.TYPE_STATE_SNAPSHOT
+    assert cue["payload"]["kind"] == "late_brake"
+    assert cue["payload"]["corner"] == 2  # 0-based, faithful to the Advisory
+    assert cue["payload"]["message"] == "Brake T3"
+    assert cue["payload"]["spline"] == 0.4
+    assert cue["payload"]["detail"] == {"x": 1}
+    assert cue["ts_sim"] == 9.0
+    assert coach.spoken == [adv]  # in-process coach got the same advisory
+
+
+def test_publish_coaching_cues_is_noop_without_observer(monkeypatch) -> None:
+    captured: list[dict] = []
+
+    async def _fake_broadcast(frame, *, exclude):  # noqa: ANN001
+        captured.append(frame)
+
+    monkeypatch.setattr(server, "_broadcast_external", _fake_broadcast)
+    server.set_realtime_observer(None)
+    asyncio.run(server._publish_coaching_cues({"payload": {}}, exclude=None))
+    assert captured == []
+
+
+def test_publish_coaching_cues_survives_observer_fault(monkeypatch) -> None:
+    class _BoomObserver:
+        def observe(self, frame):  # noqa: ANN001
+            raise RuntimeError("boom")
+
+    captured: list[dict] = []
+
+    async def _fake_broadcast(frame, *, exclude):  # noqa: ANN001
+        captured.append(frame)
+
+    monkeypatch.setattr(server, "_broadcast_external", _fake_broadcast)
+    server.set_realtime_observer(_BoomObserver())
+    try:
+        # must not raise into the live loop
+        asyncio.run(server._publish_coaching_cues({"payload": {}}, exclude=None))
+    finally:
+        server.set_realtime_observer(None)
+    assert captured == []
+
+
+# --------------------------------------------------------------------------------------------------
+# End-to-end: telemetry_tick → coaching.cue to a voice-class WS client
+# --------------------------------------------------------------------------------------------------
+
+
+def test_telemetry_tick_publishes_coaching_cue_to_voice_client() -> None:
+    adv = _advisory(kind="apex_deficit", corner=5, spline=0.6, urgency="info", message="T6 carry")
+
+    async def _hello(ws, client: str, client_class: str | None = None) -> dict:
+        frame: dict[str, object] = {"v": 1, "type": "hello", "client": client}
+        if client_class is not None:
+            frame["client_class"] = client_class
+        await ws.send(json.dumps(frame))
+        return json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+
+    async def _run() -> dict:
+        server.set_realtime_observer(_FakeObserver([adv]))
+        try:
+            async with _running_sidecar() as port:
+                async with (
+                    ws_connect(f"ws://127.0.0.1:{port}/") as lua,
+                    ws_connect(f"ws://127.0.0.1:{port}/") as voice,
+                ):
+                    await _hello(lua, "trainer-lua", ep.CLIENT_CLASS_LUA)
+                    await _hello(voice, "voice-1", ep.CLIENT_CLASS_VOICE)
+                    await lua.send(json.dumps(_telemetry_tick(spline=0.6), separators=(",", ":")))
+                    return json.loads(await asyncio.wait_for(voice.recv(), timeout=2.0))
+        finally:
+            server.set_realtime_observer(None)
+
+    cue = asyncio.run(_run())
+    assert cue["type"] == ep.TYPE_STATE_SNAPSHOT
+    assert cue["topic"] == ep.TOPIC_COACHING_CUE
+    assert cue["payload"]["kind"] == "apex_deficit"
+    assert cue["payload"]["corner"] == 5
+    assert cue["payload"]["message"] == "T6 carry"
+    assert cue["ts_sim"] == 123.45

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -29,6 +29,10 @@ CLIENT_CLASS_SCREEN = "screen"
 CLIENT_CLASS_HAPTICS = "haptics"
 CLIENT_CLASS_PHYSICAL = "physical"
 CLIENT_CLASS_BROWSER = "browser"
+# Issue #341: a voice-coach client subscribes to `coaching.cue` and speaks the live advisory
+# stream (the #340 phrase-bank engine). On the rig the sidecar also drives a VoiceCoach in-process,
+# but a separate `voice`-class WS client is a first-class consumer (e.g. a remote speaker / a tap).
+CLIENT_CLASS_VOICE = "voice"
 KNOWN_CLIENT_CLASSES: frozenset[str] = frozenset(
     {
         CLIENT_CLASS_EXTERNAL,
@@ -37,6 +41,7 @@ KNOWN_CLIENT_CLASSES: frozenset[str] = frozenset(
         CLIENT_CLASS_HAPTICS,
         CLIENT_CLASS_PHYSICAL,
         CLIENT_CLASS_BROWSER,
+        CLIENT_CLASS_VOICE,
     }
 )
 PHYSICAL_CLIENT_CLASSES: frozenset[str] = frozenset(
@@ -138,6 +143,11 @@ KNOWN_ACTIONS: frozenset[str] = frozenset(
 # but missing here, so a client could never legitimately subscribe to them — the
 # "produced-but-unsubscribable" sibling of the #170 handshake bug. The
 # `test_ws_topic_allowlist` drift-guard asserts every produced topic is listed.
+#: Topic the sidecar publishes live coaching cues on (issue #341). Unlike the Lua-produced topics
+#: above, `coaching.cue` is **sidecar-originated** (the `RealtimeObserver` advisory stream), so the
+#: Lua `publishTopic` drift-guard does not cover it — it is listed here so a `voice`-class client
+#: can legitimately subscribe.
+TOPIC_COACHING_CUE = "coaching.cue"
 KNOWN_TOPICS: frozenset[str] = frozenset(
     {
         # Declared topics (EPIC #154 Part D wires producers for these).
@@ -149,6 +159,8 @@ KNOWN_TOPICS: frozenset[str] = frozenset(
         # Already-produced topics (made subscribable; were missing).
         "coaching.snapshot",
         "setup.active",
+        # Sidecar-originated live coaching cues (issue #341).
+        TOPIC_COACHING_CUE,
     }
 )
 
@@ -164,6 +176,27 @@ def make_hello_ack(server_version: str = SERVER_VERSION) -> dict[str, Any]:
         "server_version": server_version,
         "capabilities": list(SERVER_CAPABILITIES),
     }
+
+
+def make_coaching_cue(payload: dict[str, Any], *, ts_sim: float | None = None) -> dict[str, Any]:
+    """Build a ``coaching.cue`` topic frame for one live advisory (issue #341).
+
+    Sidecar-originated ``state.snapshot`` envelope on the ``coaching.cue`` topic — the same
+    ``{v, type:"state.snapshot", topic, payload}`` shape every topic uses, so a ``voice``-class
+    client subscribes to it exactly like ``coaching.snapshot``. ``payload`` carries the advisory's
+    machine-readable fields (kind/corner/urgency/message/spline/detail); the renderer (#340's
+    resolver) turns it back into speech. ``ts_sim`` is forwarded when the source carried one.
+    """
+    frame: dict[str, Any] = {
+        ENVELOPE_KEY: ENVELOPE_VERSION,
+        TYPE_KEY: TYPE_STATE_SNAPSHOT,
+        "topic": TOPIC_COACHING_CUE,
+        "payload": payload,
+        "source": "sidecar.observer",
+    }
+    if ts_sim is not None:
+        frame["ts_sim"] = ts_sim
+    return frame
 
 
 def make_error(message: str, *, ref_type: str | None = None) -> dict[str, Any]:
@@ -271,6 +304,16 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
     for key in ("abs_active", "brake_lock", "wheel_lock"):
         if key in payload and not isinstance(payload[key], bool):
             return f"{key} must be a boolean"
+    # Issue #341: optional position fields the RealtimeObserver needs to locate corners and detect
+    # lap wraps. Optional so existing producers (which omit them) keep validating; when present they
+    # must be sane — `spline` is the normalized 0..1 track position, lap counters are non-negative.
+    err = _validate_optional_number(payload, "spline", min_value=0, max_value=1)
+    if err is not None:
+        return err
+    for lap_key in ("lap", "completedLaps", "lap_count"):
+        err = _validate_optional_number(payload, lap_key, min_value=0)
+        if err is not None:
+            return err
     return None
 
 

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -310,7 +310,7 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
     err = _validate_optional_number(payload, "spline", min_value=0, max_value=1)
     if err is not None:
         return err
-    for lap_key in ("lap", "completedLaps", "lap_count"):
+    for lap_key in ("lap", "lapCount", "completedLaps", "lap_count"):
         err = _validate_optional_number(payload, lap_key, min_value=0)
         if err is not None:
             return err

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -1150,6 +1150,11 @@ def _wire_voice(reference_path: str | None, bank_dir: str | None) -> None:
     are imported lazily here (only when ``--voice-bank`` is supplied), so the sidecar core stays
     dep-free for users who never enable voice.
     """
+    if bank_dir and not reference_path:
+        logger.warning(
+            "voice: --voice-bank is set but --voice-reference is missing; voice coach will be idle"
+        )
+
     if reference_path:
         try:
             from tools.ai_sidecar.realtime_observer import build_observer_from_reference
@@ -1164,7 +1169,7 @@ def _wire_voice(reference_path: str | None, bank_dir: str | None) -> None:
             else:
                 set_realtime_observer(observer)
                 logger.info("voice: realtime observer wired from reference %s", reference_path)
-        except (OSError, ValueError) as exc:
+        except Exception as exc:  # noqa: BLE001 - malformed archive must not abort the sidecar
             logger.error("voice: failed to load reference %s: %s", reference_path, exc)
     if bank_dir:
         try:

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -62,6 +62,7 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_STATE_SUBSCRIBE,
     TYPE_STATE_UNSUBSCRIBE,
     TYPE_TELEMETRY_TICK,
+    make_coaching_cue,
     make_error,
     make_hello_ack,
     validate_inbound,
@@ -101,6 +102,27 @@ _external_peers: set[Any] = set()
 _setup_experiment_store_path: Path | None = None
 _setup_experiment_store_seeded = False
 _external_peer_classes: dict[Any, str] = {}
+
+# Issue #341 — live voice wiring. Both are OPTIONAL and OFF by default: a sidecar with neither set
+# behaves byte-identically to before. ``_observer`` turns the live ``telemetry_tick`` stream into
+# per-corner advisories (published on ``coaching.cue``); ``_voice_coach`` (the #340 phrase-bank
+# engine) speaks them in-process on the rig. The audio deps live only inside the voice package and
+# are imported lazily when ``--voice-bank`` is supplied, so the sidecar core stays dep-free.
+_observer: Any | None = None
+_voice_coach: Any | None = None
+
+
+def set_realtime_observer(observer: Any | None) -> None:
+    """Install (or clear) the live ``RealtimeObserver`` fed by ``telemetry_tick`` (issue #341)."""
+    global _observer
+    _observer = observer
+
+
+def set_voice_coach(coach: Any | None) -> None:
+    """Install (or clear) the in-process voice coach that speaks advisories on the rig (#341)."""
+    global _voice_coach
+    _voice_coach = coach
+
 
 TELEMETRY_TICK_MAX_HZ = 20.0
 HAPTIC_EVENT_MAX_HZ = 25.0
@@ -544,6 +566,54 @@ def _build_haptic_events_from_telemetry(frame: dict[str, Any]) -> list[dict[str,
     return events
 
 
+def _advisory_to_payload(advisory: Any) -> dict[str, Any]:
+    """Flatten a ``RealtimeObserver`` Advisory into the ``coaching.cue`` wire payload (issue #341).
+
+    ``corner`` is kept 0-based (as the observer emits it) so a consumer can reconstruct the Advisory
+    faithfully; the human-facing 1-based turn number already lives in ``message`` ("...T4...").
+    """
+    return {
+        "kind": getattr(advisory, "kind", None),
+        "corner": getattr(advisory, "corner", None),
+        "urgency": getattr(advisory, "urgency", None),
+        "message": getattr(advisory, "message", ""),
+        "spline": getattr(advisory, "spline", None),
+        "detail": getattr(advisory, "detail", {}),
+    }
+
+
+async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None:
+    """Feed one live ``telemetry_tick`` frame to the observer; speak + fan-out its advisories
+    (#341).
+
+    No-op unless a ``RealtimeObserver`` is installed (the default). Each advisory is both (a) fed to
+    the in-process voice coach so it speaks on the rig, and (b) published as a ``coaching.cue``
+    topic
+    frame so any ``voice``-class WS client can consume it. The observer/coach never raise into the
+    live loop — a fault here must not stall telemetry or haptics.
+    """
+    observer = _observer
+    if observer is None:
+        return
+    try:
+        advisories = observer.observe(frame)
+    except Exception:
+        logger.exception("realtime observer failed on telemetry_tick")
+        return
+    if not advisories:
+        return
+    ts_sim = frame.get("ts_sim")
+    coach = _voice_coach
+    for advisory in advisories:
+        if coach is not None:
+            try:
+                coach.subscribe(advisory)
+            except Exception:
+                logger.exception("voice coach subscribe failed for advisory")
+        cue = make_coaching_cue(_advisory_to_payload(advisory), ts_sim=ts_sim)
+        await _broadcast_external(cue, exclude=exclude)
+
+
 async def _route_peripheral_frame(
     frame: dict[str, Any],
     *,
@@ -820,6 +890,8 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
                 rate_key=(TYPE_HAPTIC_EVENT, event["event"], event["channel"]),
                 max_hz=HAPTIC_EVENT_MAX_HZ,
             )
+        # Issue #341: turn the same live frame into spoken coaching cues (no-op unless wired).
+        await _publish_coaching_cues(data, exclude=websocket)
         return
     if t == TYPE_HAPTIC_EVENT:
         await _route_peripheral_frame(
@@ -1069,6 +1141,48 @@ def _is_loopback(host: str) -> bool:
         return False
 
 
+def _wire_voice(reference_path: str | None, bank_dir: str | None) -> None:
+    """Build the optional live observer + in-process voice coach from CLI paths (issue #341).
+
+    Best-effort by design: a missing/invalid reference or bank disables the feature with a loud log
+    rather than aborting the sidecar — telemetry and haptics must keep flowing regardless. Audio
+    deps
+    are imported lazily here (only when ``--voice-bank`` is supplied), so the sidecar core stays
+    dep-free for users who never enable voice.
+    """
+    if reference_path:
+        try:
+            from tools.ai_sidecar.realtime_observer import build_observer_from_reference
+
+            with open(reference_path, encoding="utf-8") as fh:
+                archive = json.load(fh)
+            observer = build_observer_from_reference(archive)
+            if observer is None:
+                logger.error(
+                    "voice: reference %s has no usable corners — observer disabled", reference_path
+                )
+            else:
+                set_realtime_observer(observer)
+                logger.info("voice: realtime observer wired from reference %s", reference_path)
+        except (OSError, ValueError) as exc:
+            logger.error("voice: failed to load reference %s: %s", reference_path, exc)
+    if bank_dir:
+        try:
+            from tools.ai_sidecar.voice.engine import VoiceCoach
+
+            coach = VoiceCoach.from_bank(bank_dir)
+            if not coach.enabled:
+                logger.error(
+                    "voice: bank %s disabled the coach (%s)", bank_dir, coach.disabled_reason
+                )
+            else:
+                coach.start()
+                set_voice_coach(coach)
+                logger.info("voice: in-process voice coach wired from bank %s", bank_dir)
+        except Exception:  # noqa: BLE001 - any backend/import fault disables voice, never aborts
+            logger.exception("voice: failed to initialize voice coach from %s", bank_dir)
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     p = argparse.ArgumentParser(description="AC Copilot Trainer AI sidecar (WebSocket)")
@@ -1145,6 +1259,24 @@ def main() -> None:
             "analysis_error frames may still be sent for invalid JSON or non-object payloads."
         ),
     )
+    p.add_argument(
+        "--voice-reference",
+        default=None,
+        help=(
+            "Issue #341: path to a faster reference-lap archive JSON. When set, the sidecar feeds "
+            "live telemetry_tick frames to a RealtimeObserver built from it and publishes "
+            "per-corner advisories on the `coaching.cue` topic."
+        ),
+    )
+    p.add_argument(
+        "--voice-bank",
+        default=None,
+        help=(
+            "Issue #341/#340: path to a baked phrase-bank directory. When set (with "
+            "--voice-reference), the sidecar speaks the live cues in-process via the VoiceCoach "
+            "engine. Requires the `voice` extra (numpy/sounddevice/rtmixer) + an audio device."
+        ),
+    )
     args = p.parse_args()
     if args.compare_laps:
         _run_compare_laps(args.compare_laps[0], args.compare_laps[1])
@@ -1178,6 +1310,8 @@ def main() -> None:
         host = args.host
     if not _is_loopback(host) and not args.token:
         raise SystemExit("--token is required for non-loopback bind addresses")
+
+    _wire_voice(args.voice_reference, args.voice_bank)
 
     try:
         asyncio.run(_run(host, args.port, reply, args.token, args.setup_store))

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -618,11 +618,14 @@ async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None
                 coach.subscribe(advisory)
             except Exception:
                 logger.exception("voice coach subscribe failed for advisory")
-        cue_payload = _advisory_to_payload(advisory)
-        if cue_payload is None:
-            continue
-        cue = make_coaching_cue(cue_payload, ts_sim=ts_sim)
-        await _broadcast_external(cue, exclude=exclude)
+        try:
+            cue_payload = _advisory_to_payload(advisory)
+            if cue_payload is None:
+                continue
+            cue = make_coaching_cue(cue_payload, ts_sim=ts_sim)
+            await _broadcast_external(cue, exclude=exclude)
+        except Exception:
+            logger.exception("voice: failed to publish coaching cue for advisory")
 
 
 async def _route_peripheral_frame(

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -566,16 +566,24 @@ def _build_haptic_events_from_telemetry(frame: dict[str, Any]) -> list[dict[str,
     return events
 
 
-def _advisory_to_payload(advisory: Any) -> dict[str, Any]:
+def _advisory_to_payload(advisory: Any) -> dict[str, Any] | None:
     """Flatten a ``RealtimeObserver`` Advisory into the ``coaching.cue`` wire payload (issue #341).
 
     ``corner`` is kept 0-based (as the observer emits it) so a consumer can reconstruct the Advisory
     faithfully; the human-facing 1-based turn number already lives in ``message`` ("...T4...").
+
+    Returns ``None`` when required fields are missing so consumers never see null
+    ``kind``/``urgency``.
     """
+    kind = getattr(advisory, "kind", None)
+    urgency = getattr(advisory, "urgency", None)
+    if not isinstance(kind, str) or not kind or not isinstance(urgency, str) or not urgency:
+        logger.warning("voice: dropping advisory with missing kind/urgency: %r", advisory)
+        return None
     return {
-        "kind": getattr(advisory, "kind", None),
+        "kind": kind,
         "corner": getattr(advisory, "corner", None),
-        "urgency": getattr(advisory, "urgency", None),
+        "urgency": urgency,
         "message": getattr(advisory, "message", ""),
         "spline": getattr(advisory, "spline", None),
         "detail": getattr(advisory, "detail", {}),
@@ -610,7 +618,10 @@ async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None
                 coach.subscribe(advisory)
             except Exception:
                 logger.exception("voice coach subscribe failed for advisory")
-        cue = make_coaching_cue(_advisory_to_payload(advisory), ts_sim=ts_sim)
+        cue_payload = _advisory_to_payload(advisory)
+        if cue_payload is None:
+            continue
+        cue = make_coaching_cue(cue_payload, ts_sim=ts_sim)
         await _broadcast_external(cue, exclude=exclude)
 
 
@@ -1169,8 +1180,8 @@ def _wire_voice(reference_path: str | None, bank_dir: str | None) -> None:
             else:
                 set_realtime_observer(observer)
                 logger.info("voice: realtime observer wired from reference %s", reference_path)
-        except Exception as exc:  # noqa: BLE001 - malformed archive must not abort the sidecar
-            logger.error("voice: failed to load reference %s: %s", reference_path, exc)
+        except Exception:  # noqa: BLE001 - malformed archive must not abort the sidecar
+            logger.exception("voice: failed to load reference %s", reference_path)
     if bank_dir:
         try:
             from tools.ai_sidecar.voice.engine import VoiceCoach

--- a/tools/ai_sidecar/voice/scheduler.py
+++ b/tools/ai_sidecar/voice/scheduler.py
@@ -107,17 +107,17 @@ class Scheduler:
             batch = self._pending
             self._pending = []
 
-        candidates: list[Utterance] = []
+        candidates: list[tuple[Utterance, float]] = []
         for item in batch:
             utt = self._consider(item, now)
             if utt is not None:
-                candidates.append(utt)
+                candidates.append((utt, item.enqueued_at))
         if not candidates:
             return None
 
         # Highest urgency wins; ties break toward the cue considered last (freshest in this batch).
-        winner = max(candidates, key=lambda u: u.rank)
-        return self._dispatch(winner, now)
+        winner, enqueued_at = max(candidates, key=lambda pair: pair[0].rank)
+        return self._dispatch(winner, now, enqueued_at=enqueued_at)
 
     def _consider(self, item: _Pending, now: float) -> Utterance | None:
         """Resolve + filter one pending advisory; return a playable utterance or ``None``."""
@@ -149,7 +149,9 @@ class Scheduler:
                 return None
         return utt
 
-    def _dispatch(self, winner: Utterance, now: float) -> Utterance | None:
+    def _dispatch(
+        self, winner: Utterance, now: float, *, enqueued_at: float | None = None
+    ) -> Utterance | None:
         """Play ``winner`` with barge-in semantics, or drop it if the channel is busy with >=
         cue."""
         current = self._playback.current
@@ -169,6 +171,18 @@ class Scheduler:
         except Exception:  # noqa: BLE001 — never let a backend fault crash the scheduler thread
             _log.exception("voice: playback.play failed for %s — staying silent", winner.clip_id)
             return None
+        if winner.rank >= _ACT_RANK and enqueued_at is not None:
+            latency_ms = (now - enqueued_at) * 1000.0
+            if latency_ms > 150.0:
+                _log.warning(
+                    "voice: act cue %s advisory→dispatch latency %.1f ms exceeds 150 ms budget",
+                    winner.clip_id,
+                    latency_ms,
+                )
+            else:
+                _log.debug(
+                    "voice: act cue %s advisory→dispatch latency %.1f ms", winner.clip_id, latency_ms
+                )
         self._last_spoke_key[winner.dedup_key] = now
         self._last_spoke_kind[winner.kind] = now
         return winner

--- a/tools/ai_sidecar/voice/scheduler.py
+++ b/tools/ai_sidecar/voice/scheduler.py
@@ -107,16 +107,19 @@ class Scheduler:
             batch = self._pending
             self._pending = []
 
-        candidates: list[tuple[Utterance, float]] = []
-        for item in batch:
+        candidates: list[tuple[Utterance, float, int]] = []
+        for batch_index, item in enumerate(batch):
             utt = self._consider(item, now)
             if utt is not None:
-                candidates.append((utt, item.enqueued_at))
+                candidates.append((utt, item.enqueued_at, batch_index))
         if not candidates:
             return None
 
         # Highest urgency wins; ties break toward the cue considered last (freshest in this batch).
-        winner, enqueued_at = max(candidates, key=lambda pair: (pair[0].rank, pair[1]))
+        # When enqueued_at collides (constant/coarse clock), batch_index preserves submission order.
+        winner, enqueued_at, _batch_index = max(
+            candidates, key=lambda pair: (pair[0].rank, pair[1], pair[2])
+        )
         return self._dispatch(winner, now, enqueued_at=enqueued_at)
 
     def _consider(self, item: _Pending, now: float) -> Utterance | None:

--- a/tools/ai_sidecar/voice/scheduler.py
+++ b/tools/ai_sidecar/voice/scheduler.py
@@ -116,7 +116,7 @@ class Scheduler:
             return None
 
         # Highest urgency wins; ties break toward the cue considered last (freshest in this batch).
-        winner, enqueued_at = max(candidates, key=lambda pair: pair[0].rank)
+        winner, enqueued_at = max(candidates, key=lambda pair: (pair[0].rank, pair[1]))
         return self._dispatch(winner, now, enqueued_at=enqueued_at)
 
     def _consider(self, item: _Pending, now: float) -> Utterance | None:
@@ -181,7 +181,9 @@ class Scheduler:
                 )
             else:
                 _log.debug(
-                    "voice: act cue %s advisory→dispatch latency %.1f ms", winner.clip_id, latency_ms
+                    "voice: act cue %s advisory→dispatch latency %.1f ms",
+                    winner.clip_id,
+                    latency_ms,
                 )
         self._last_spoke_key[winner.dedup_key] = now
         self._last_spoke_kind[winner.kind] = now


### PR DESCRIPTION
## What

**Part A of #341** — connects the #340 phrase-bank `VoiceCoach` to the live telemetry stream so the sidecar turns each live `telemetry_tick` frame into spoken coaching cues. **Does not close #341** (the rig-gated producer + on-rig smoke remain — see *Remaining*).

This is the "connect, don't rebuild" half I flagged in [#341's scope reconciliation](https://github.com/agorokh/ac-copilot-trainer/issues/341#issuecomment-4825216900): #340 already delivered the advisory→phrase mapper + urgency arbiter (superseding this issue's pyttsx3 Part B); this PR wires the existing `RealtimeObserver` into `server.py` and publishes its advisories.

## Changes

**`external_protocol.py`**
- `CLIENT_CLASS_VOICE` — a `voice`-class WS client that subscribes to cues.
- `coaching.cue` topic — **sidecar-originated** (the `RealtimeObserver` advisory stream), added to `KNOWN_TOPICS` so a client can subscribe. The Lua `publishTopic` drift-guard doesn't cover it (it's Python-produced), so it's listed explicitly.
- Optional `spline` (0..1) + `lap`/`completedLaps` validation in `telemetry_tick` — **optional**, so existing producers are unaffected; the observer needs them to locate corners + detect lap wraps.
- `make_coaching_cue()` — builds the `{v, type:state.snapshot, topic:"coaching.cue", payload}` frame (same shape every topic uses).

**`server.py`**
- Optional `_observer` / `_voice_coach` module state — **OFF by default → byte-identical behavior when unset** — with `set_realtime_observer` / `set_voice_coach` installers.
- `_publish_coaching_cues()`: on each `telemetry_tick`, feed the observer; for each advisory, **speak it in-process** (`VoiceCoach.subscribe`) **and publish a `coaching.cue` frame** to WS peers. Never raises into the live loop (observer/coach faults are logged, not propagated).
- `--voice-reference` (build observer from a faster reference archive) and `--voice-bank` (build `VoiceCoach.from_bank`) CLI flags. Audio deps are lazy-imported **only** when `--voice-bank` is set, so the sidecar core stays dep-free.

## Tests (`test_voice_wiring.py`, 9 new)

- Protocol surface: `voice` class validates, `coaching.cue` subscribable, optional spline/lap accepted-and-range-checked, `make_coaching_cue` shape.
- `_publish_coaching_cues` unit logic: broadcasts the cue **and** feeds the in-process coach; no-op without an observer; **survives an observer fault** without raising into the live loop.
- **End-to-end**: a `voice`-class WS client receives a `coaching.cue` frame after a `telemetry_tick` (fake observer; real WS round-trip).

`make ci-fast` → green (incl. the topic-allowlist drift guard).

## Remaining (rig-gated follow-up on #341)

- **No Lua producer emits `telemetry_tick` yet** (`grep -rln telemetry_tick src/` is empty) — the high-rate `telemetry_tick`-with-`spline` emitter is the remaining live-wiring piece, and it needs in-sim verification.
- **On-rig audible smoke** (operator drives, hears a spline-anchored cue vs a faster reference) — the deferred verification for both #340 and this slice.
- v1.1 spline-lookahead (cue lands ~1–2 s before turn-in) lives upstream of the scheduler.

Refs #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)