### PR TITLE
docs(vault): post-merge handoff for PR #349

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-28T07:35:00Z
+last_updated: 2026-06-28T15:35:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -106,6 +106,15 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot p
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-28** — PR [#349](https://github.com/agorokh/ac-copilot-trainer/pull/349) **MERGED** at
+  `c477aee` — **live voice wiring** ([#341](https://github.com/agorokh/ac-copilot-trainer/issues/341)
+  M0 **CLOSED**): sidecar turns the live `telemetry_tick` stream into spoken cues — `coaching.cue` topic
+  + `voice` client-class + optional `spline`/`lap` validation; `server.py` `_publish_coaching_cues`
+  feeds the `RealtimeObserver` per tick → speaks via the in-process #340 `VoiceCoach` **and** publishes
+  `coaching.cue` to WS peers; `--voice-reference`/`--voice-bank` flags (audio deps lazy, OFF by default).
+  A parallel session hardened it (scheduler tie-break by rank→freshness + act-cue latency logging). 9
+  wiring tests + e2e round-trip; ci-fast green. **Remaining (rig-gated):** Lua `telemetry_tick`-with-`spline`
+  producer + on-rig audible smoke → [#350](https://github.com/agorokh/ac-copilot-trainer/issues/350).
 - **2026-06-28** — PR [#338](https://github.com/agorokh/ac-copilot-trainer/pull/338) **MERGED** at
   `f8d010e` — CoachingOracle **Qodo round-6 hardening** ([#333](https://github.com/agorokh/ac-copilot-trainer/issues/333)
   follow-up to #334): None-on-failure `get_coaching()`, spaced debrief OCR marker, nested-None coercion,

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-28T07:35:00Z
+last_updated: 2026-06-28T15:35:00Z
 relates_to:
   - AcCopilotTrainer/01_Decisions/voice-coach-architecture-2026-06-28.md
   - AcCopilotTrainer/03_Investigations/issue-327-vault-automerge-already-resolved-2026-06-28.md
@@ -45,7 +45,31 @@ relates_to:
 
 ## Resume here
 
-**[#341](https://github.com/agorokh/ac-copilot-trainer/issues/341) M0 voice-coaching thin slice** — wire live observer → voice cue (branch `feat/issue-341-m0-voice`). Voice output layer landed in [#343](https://github.com/agorokh/ac-copilot-trainer/pull/343); this is the realtime wiring pass.
+**[#350](https://github.com/agorokh/ac-copilot-trainer/issues/350) — voice coach LIVE-FIRE (rig-gated).** The
+off-sim engine (#340) and the sidecar live-wiring (#341, PR #349) are merged; what remains is a **Lua
+`telemetry_tick` producer that emits `spline`+speed** (none exists today — `git grep -rln telemetry_tick
+src/` is empty) so the observer actually fires live, plus the **on-rig audible smoke** (operator drives vs a
+faster reference, hears a spline-anchored cue). Bake a Piper bank (`python -m tools.ai_sidecar.voice.bake
+--backend piper`), launch the sidecar with `--voice-reference <archive> --voice-bank <dir>`, tap
+`coaching.cue`. This is the deferred verification for both #340 and #341.
+
+---
+
+## Delivered (2026-06-28) — PR #349 MERGED: live voice wiring (#341 M0 CLOSED)
+`/autonomous-deliver` continued from #340 into #341 Part A. [#349](https://github.com/agorokh/ac-copilot-trainer/pull/349)
+squash-merged to `main` as `c477aee`; **#341 CLOSED**. The sidecar now turns the live `telemetry_tick`
+stream into spoken cues: `external_protocol` adds `CLIENT_CLASS_VOICE`, the sidecar-originated
+`coaching.cue` topic, optional `spline`/`lap` validation, and `make_coaching_cue`; `server.py` gains
+optional `_observer`/`_voice_coach` state (OFF by default → byte-identical when unset) + `_publish_coaching_cues`
+(feeds the `RealtimeObserver` per tick → speaks via the in-process #340 `VoiceCoach` **and** publishes
+`coaching.cue` to WS peers) + `--voice-reference`/`--voice-bank` startup flags (audio deps lazy). A **parallel
+autonomous session** (running as `agorokh`) advanced this PR to green — adding a `process_pending` tie-break
+by `(rank, enqueued_at, batch_index)` (fixing a latent freshest-tie bug in #340 + act-cue advisory→dispatch
+latency logging vs the 150 ms budget), a test-isolation autouse fixture, and a `lapCount` case. 9 new wiring
+tests incl. an end-to-end `telemetry_tick → voice-client coaching.cue` round-trip; `make ci-fast` re-verified
+green locally on the merged head. **Reconciliation:** #341 closed COMPLETED but 2 ACs (Lua spline emit;
+rig smoke) were unmet → filed **#350** for the live producer + on-rig audible verification so the work isn't
+lost (cross-linked on #341). **Post-merge:** no classification flags.
 
 ---
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #349.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).