### PR TITLE
fix(sidecar): green main — repair M0 voice-wiring tests + reset observer feed-peer (#354)

### DIFF
--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 
-import pytest
-
 import tools.ai_sidecar.server as server
 from tests.test_realtime_observer import _corner_archive
 from tools.ai_sidecar.external_protocol import TOPIC_COACHING_CUE, TYPE_STATE_SNAPSHOT
@@ -51,13 +49,13 @@ def _reset_feed(monkeypatch):
 
 
 async def _run_publish_cues(frame, *, exclude):
-    await server._publish_observer_cues(frame, exclude=exclude)
+    await server._publish_coaching_cues(frame, exclude=exclude)
     pending = list(server._background_tasks)
     if pending:
         await asyncio.gather(*pending)
 
 
-def test_publish_observer_cues_broadcasts_coaching_cue(monkeypatch):
+def test_publish_coaching_cues_broadcasts_coaching_cue(monkeypatch):
     _reset_feed(monkeypatch)
     observer = _FakeObserver([_adv()])
     monkeypatch.setattr(server, "_observer", observer)
@@ -76,7 +74,7 @@ def test_publish_observer_cues_broadcasts_coaching_cue(monkeypatch):
     assert cue_frame["payload"]["corner"] == 3
 
 
-def test_publish_observer_cues_fans_out_each_advisory(monkeypatch):
+def test_publish_coaching_cues_fans_out_each_advisory(monkeypatch):
     # one frame -> two advisories -> two coaching.cue frames, each carrying the same exclude.
     _reset_feed(monkeypatch)
     a = _adv(kind="late_brake", corner=3)
@@ -92,7 +90,7 @@ def test_publish_observer_cues_fans_out_each_advisory(monkeypatch):
     assert sent[0][1] == "wsX" and sent[1][1] == "wsX"
 
 
-def test_publish_observer_cues_noop_without_observer(monkeypatch):
+def test_publish_coaching_cues_noop_without_observer(monkeypatch):
     _reset_feed(monkeypatch)
     monkeypatch.setattr(server, "_observer", None)
     sent = _capture_broadcast(monkeypatch)
@@ -100,7 +98,7 @@ def test_publish_observer_cues_noop_without_observer(monkeypatch):
     assert sent == []
 
 
-def test_publish_observer_cues_swallows_observer_error(monkeypatch):
+def test_publish_coaching_cues_swallows_observer_error(monkeypatch):
     _reset_feed(monkeypatch)
 
     class _Boom:
@@ -117,7 +115,7 @@ def test_publish_observer_cues_swallows_observer_error(monkeypatch):
     assert sent == []
 
 
-def test_publish_observer_cues_ignores_second_producer(monkeypatch):
+def test_publish_coaching_cues_ignores_second_producer(monkeypatch):
     # single-producer guard: a second concurrent producer is NOT fed to the single-stream observer.
     _reset_feed(monkeypatch)
     observer = _FakeObserver([_adv()])
@@ -144,27 +142,37 @@ def test_release_observer_feed_frees_owner_only(monkeypatch):
     assert server._observer_feed_peer == "owner2"
 
 
-def test_load_observer_builds_from_archive(tmp_path, monkeypatch):
+def test_wire_voice_builds_and_installs_observer_from_reference(tmp_path, monkeypatch):
+    # Happy path of the real loader (#354 — replaces the removed _load_observer happy-path test):
+    # a corner-bearing reference archive is read, built, and installed via set_realtime_observer.
+    # This drives the file-read -> build -> install seam that the dead _load_observer test used to.
     monkeypatch.setattr(server, "_observer", None)
     ref = tmp_path / "ref.json"
     ref.write_text(json.dumps(_corner_archive()), encoding="utf-8")
-    server._load_observer(str(ref))
+    server._wire_voice(str(ref), None)
     assert server._observer is not None
 
 
-def test_load_observer_unsegmentable_archive_raises(tmp_path, monkeypatch):
-    monkeypatch.setattr(server, "_observer", object())
-    monkeypatch.setattr(server, "build_observer_from_reference", lambda archive: None)
-    ref = tmp_path / "straight.json"
-    ref.write_text(json.dumps(_corner_archive()), encoding="utf-8")
-    with pytest.raises(SystemExit, match="did not yield a usable observer"):
-        server._load_observer(str(ref))
+def test_wire_voice_no_corners_reference_disables_observer(tmp_path, monkeypatch):
+    # build_observer_from_reference returns None for a reference with no usable corners; _wire_voice
+    # logs and leaves the observer UNINSTALLED (best-effort), never raising. The sentinel makes the
+    # negative-install non-vacuous: a pre-existing observer is left untouched, not cleared/replaced.
+    sentinel = object()
+    monkeypatch.setattr(server, "_observer", sentinel)
+    ref = tmp_path / "no_corners.json"
+    ref.write_text(json.dumps({}), encoding="utf-8")
+    server._wire_voice(str(ref), None)
+    assert server._observer is sentinel
 
 
-def test_load_observer_missing_file_raises(monkeypatch):
-    monkeypatch.setattr(server, "_observer", object())
-    with pytest.raises(SystemExit, match="reference archive unusable"):
-        server._load_observer("does-not-exist-9f3a.json")
+def test_wire_voice_missing_reference_is_best_effort(monkeypatch):
+    # A missing/unreadable reference must NOT abort the sidecar — telemetry + haptics keep flowing
+    # (#341 best-effort; the earlier fail-fast _load_observer/SystemExit contract was abandoned).
+    # The sentinel proves _wire_voice neither raises nor disturbs the existing observer.
+    sentinel = object()
+    monkeypatch.setattr(server, "_observer", sentinel)
+    server._wire_voice("does-not-exist-9f3a.json", None)
+    assert server._observer is sentinel
 
 
 class _FakeWS:
@@ -192,7 +200,7 @@ def _full_tick_payload():
     }
 
 
-def test_publish_observer_cues_rate_limited_at_20hz(monkeypatch):
+def test_publish_coaching_cues_rate_limited_at_20hz(monkeypatch):
     _reset_feed(monkeypatch)
     observer = _FakeObserver([_adv()])
     monkeypatch.setattr(server, "_observer", observer)

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -123,7 +123,7 @@ _observer_feed_warned = False
 # per-corner advisories (published on ``coaching.cue``); ``_voice_coach`` (the #340 phrase-bank
 # engine) speaks them in-process on the rig. The audio deps live only inside the voice package and
 # are imported lazily when ``--voice-bank`` is supplied, so the sidecar core stays dep-free.
-_observer: Any | None = None
+# (``_observer`` is declared once above with its RealtimeObserver type; not re-declared here.)
 _voice_coach: Any | None = None
 
 
@@ -218,9 +218,16 @@ _peripheral_rate_limiter = _RateLimiter()
 
 
 def _reset_external_state() -> None:
+    global _observer_feed_peer, _observer_feed_warned
     _external_peers.clear()
     _external_peer_classes.clear()
     _peripheral_rate_limiter.reset()
+    # The single-producer observer feed is external-peer state: a full reset (server (re)start or
+    # teardown) leaves no producer owning the feed, so the next telemetry producer can claim it.
+    # Without this, a stale owner persists and the next producer is silently rejected by the guard
+    # in _publish_coaching_cues — which also leaked across tests sharing this reset (#354).
+    _observer_feed_peer = None
+    _observer_feed_warned = False
 
 
 def _get_ollama_followup_sem() -> asyncio.Semaphore:


### PR DESCRIPTION
## What & why

`origin/main` is **red**: the post-merge `build` check on the M0 merge commit failed.

```
gh api repos/agorokh/ac-copilot-trainer/commits/84b5698/check-runs → build: failure
```

Root cause is a **two-PR merge collision** (#342 × #349), confirmed from the CI log:

- **PR #349** (`c477aee`) shipped the sidecar fan-out as **`_publish_coaching_cues`** + `_wire_voice` (best-effort reference loading).
- **PR #342** (`84b5698`, long-running branch) added `tests/test_server_observer_wiring.py` written against that branch's *older* API: **`_publish_observer_cues`**, **`_load_observer`**, `build_observer_from_reference` as a `server` attribute.

Each was green alone; the merge left the test referencing symbols that no longer exist:

```
build  E  AttributeError: module 'tools.ai_sidecar.server' has no attribute '_publish_observer_cues'
build  E  AttributeError: module 'tools.ai_sidecar.server' has no attribute '_load_observer'
build  E  AttributeError: ... has no attribute 'build_observer_from_reference'
build  E  AssertionError: assert [] == [Advisory(...)]      # feed-peer leak (below)
build  E  TimeoutError                                       # feed-peer leak (below)
```

Two distinct defects:

1. **Dead-symbol test** — `_publish_observer_cues` (→ `_publish_coaching_cues`) and the `_load_observer`/`SystemExit` fail-fast contract that was **abandoned** for `_wire_voice`'s best-effort log-and-continue.
2. **Isolation leak** — `_reset_external_state()` reset external peers + the rate-limiter but **not** the single-producer globals `_observer_feed_peer`/`_observer_feed_warned`. `test_voice_wiring.py`'s autouse fixture calls `_reset_external_state()`, so an earlier test left `_observer_feed_peer` set and a later producer (different object) was rejected by the single-producer guard in `_publish_coaching_cues` → no `coaching.cue` → assertion empty / `voice.recv()` timeout. The same `AssertionError` reproduces on the **Linux CI runner**, so this is the real cause, not a local artifact.

## Changes

- **`tools/ai_sidecar/server.py`** — `_reset_external_state()` now also clears `_observer_feed_peer`/`_observer_feed_warned`. This is correct production semantics: a full external-state reset (server (re)start or teardown, lines 1186/1206) leaves no producer owning the single-stream feed, so the next telemetry producer can claim it; without it a stale owner persists and the next producer is silently rejected. Also removed a duplicate `_observer` module-global declaration (merge debris; the typed `_observer: RealtimeObserver | None` declaration above is kept).
- **`tests/test_server_observer_wiring.py`** — point the publish tests at `_publish_coaching_cues`; replace the 3 stale `_load_observer` `SystemExit` tests with one best-effort `_wire_voice` test (a missing reference must not abort the sidecar). The `build_observer_from_reference` builder (incl. the no-corners → `None` case) is already covered by `tests/test_realtime_observer.py`.

## Verification (observed, Python 3.11 — CI-faithful)

- `make ci-fast` → **OK** (format, lint, full test, security, policy, CSP API/UI).
- Full suite: **1511 passed, 77 skipped, 0 failed** (was 11 failed on `main`).
- `tests/test_server_observer_wiring.py` + `tests/test_voice_wiring.py` pass in full-suite order — the isolation dependency is gone.
- No references to the removed symbols remain (`git grep`).

Closes #354. Unblocks the end-to-end verification of #350 (the Lua `telemetry_tick` producer follow-up; producer landed in PR #342, only the rig-gated on-rig audible smoke remains).
