### PR TITLE
refactor(sidecar): de-duplicate spline/lap validation in _validate_telemetry_tick (#357)

### DIFF
--- a/tests/test_voice_wiring.py
+++ b/tests/test_voice_wiring.py
@@ -138,6 +138,10 @@ def test_telemetry_tick_accepts_optional_spline_and_lap() -> None:
     assert ep.validate_inbound(_telemetry_tick(spline=0.0, lap=3)) is None
     assert ep.validate_inbound(_telemetry_tick(completedLaps=5)) is None
     assert ep.validate_inbound(_telemetry_tick(lapCount=5)) is None
+    # snake_case lap spellings validate too — locks the union after the #357 de-duplication so the
+    # snake variants the first (removed) block enforced are not silently dropped.
+    assert ep.validate_inbound(_telemetry_tick(lap_count=5)) is None
+    assert ep.validate_inbound(_telemetry_tick(completed_laps=5)) is None
     # still valid with neither (existing producers unaffected)
     assert ep.validate_inbound(_telemetry_tick()) is None
 
@@ -149,6 +153,11 @@ def test_telemetry_tick_rejects_bad_spline_and_lap() -> None:
         ep.validate_inbound(_telemetry_tick(spline="x")) or ""
     )
     assert "lap must be >= 0" in (ep.validate_inbound(_telemetry_tick(lap=-1)) or "")
+    # snake_case lap spellings are still range-checked after the #357 de-duplication.
+    assert "lap_count must be >= 0" in (ep.validate_inbound(_telemetry_tick(lap_count=-1)) or "")
+    assert "completed_laps must be >= 0" in (
+        ep.validate_inbound(_telemetry_tick(completed_laps=-1)) or ""
+    )
 
 
 def test_make_coaching_cue_frame_shape() -> None:

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -327,12 +327,15 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
     err = _validate_optional_number(payload, "slip")
     if err is not None:
         return err
-    # M0 (#341): the live RealtimeObserver needs track position (spline 0..1); the lap counter
-    # disambiguates a true start/finish wrap from a pit/teleport. Both optional + back-compatible.
+    # M0 (#341): the live RealtimeObserver needs `spline` (0..1) to locate corners + detect lap
+    # wraps; the lap counter separates a real start/finish wrap from a pit/teleport. All optional +
+    # back-compatible (producers may omit them); when present they must be sane (`spline` 0..1, lap
+    # counters non-negative). Both snake_case and camelCase lap spellings are accepted (the Lua
+    # producer emits `lap`). #357: consolidated from two duplicate blocks (merge debris).
     err = _validate_optional_number(payload, "spline", min_value=0, max_value=1)
     if err is not None:
         return err
-    for lap_key in ("lap", "lap_count", "completed_laps"):
+    for lap_key in ("lap", "lap_count", "completed_laps", "lapCount", "completedLaps"):
         err = _validate_optional_number(payload, lap_key, min_value=0)
         if err is not None:
             return err
@@ -343,16 +346,6 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
     for key in ("abs_active", "brake_lock", "wheel_lock"):
         if key in payload and not isinstance(payload[key], bool):
             return f"{key} must be a boolean"
-    # Issue #341: optional position fields the RealtimeObserver needs to locate corners and detect
-    # lap wraps. Optional so existing producers (which omit them) keep validating; when present they
-    # must be sane — `spline` is the normalized 0..1 track position, lap counters are non-negative.
-    err = _validate_optional_number(payload, "spline", min_value=0, max_value=1)
-    if err is not None:
-        return err
-    for lap_key in ("lap", "lapCount", "completedLaps", "lap_count"):
-        err = _validate_optional_number(payload, lap_key, min_value=0)
-        if err is not None:
-            return err
     return None
 
 


### PR DESCRIPTION
## What & why

The M0 `#341`/`#342`/`#349` merge collision left **two near-identical** spline+lap validation blocks
in `_validate_telemetry_tick` (`external_protocol.py:332-338` and `:349-355`): the `spline` check was
duplicated and the lap-key tuples overlapped (snake vs camelCase). Harmless (both blocks pass/fail
identically for any real frame) but redundant on every ~20 Hz `telemetry_tick` and confusing
dead-duplicate code in a validation function.

## Change

Consolidated to **one** block — a single `spline` (0..1) check + one loop over the **union** of all
lap-key spellings: `("lap", "lap_count", "completed_laps", "lapCount", "completedLaps")`.
**Behavior-preserving**: every key either original block enforced is still enforced; `spline` is
checked once instead of twice.

Added `tests/test_voice_wiring.py` assertions locking the snake_case variants (`lap_count`,
`completed_laps`) — accept-valid + reject-negative — so the union is not silently narrowed by a future
edit.

## Verification (Python 3.11, CI-faithful)

- `make ci-fast` → **OK**.
- Full suite: **1513 passed, 0 failed**.
- `tests/test_voice_wiring.py` + `tests/test_external_protocol_m0.py` + `tests/test_ai_sidecar_external.py` green.

Closes #357.
