### PR TITLE
feat(tt-ingest): M-TT0 vulcan retention — auth + sessions + immutable lake (#353)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,5 +41,3 @@
 # TT_COGNITO_USER_POOL_ID=
 # TT_COGNITO_IDENTITY_POOL_ID=
 # TT_COGNITO_REGION=
-# Optional: override the lake location (default: journal/tt under the working dir).
-# TT_LAKE_DIR=

--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,17 @@
 # AC Copilot sidecar (M0 voice coaching): path to a FASTER reference lap archive JSON.
 # Fallback for `python -m tools.ai_sidecar --reference-archive` when the flag is omitted.
 # AC_COPILOT_REFERENCE_ARCHIVE=
+
+# Track Titan ingest (issue #353): PERSONAL refresh token for the operator's OWN TT account,
+# read by tools.tt_ingest.tt_auth to mint short-lived Cognito tokens. Source from Doppler /
+# your shell — NEVER commit a real value. Omit to auto-discover from the Track Titan desktop
+# app's Local Storage (Windows) when the app has been signed in.
+# TT_REFRESH_TOKEN=
+# Optional overrides for the PUBLIC Cognito identifiers (defaults are the app's public ids —
+# sent in every unauthenticated request, NOT secrets). Only set to target a different pool.
+# TT_COGNITO_CLIENT_ID=
+# TT_COGNITO_USER_POOL_ID=
+# TT_COGNITO_IDENTITY_POOL_ID=
+# TT_COGNITO_REGION=
+# Optional: override the lake location (default: journal/tt under the working dir).
+# TT_LAKE_DIR=

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ tools/_scratch/
 # Operator-local config backups (e.g. ACC config snapshots) — local data, never committed.
 backups/
 
+# Track Titan personal session lake (issue #353): the operator's OWN exported session
+# data, retained immutably. Personal data — never committed.
+journal/tt/
+
 # Stray machine-local tooling (e.g. MOZA R3 profile script) — not repo source.
 tools/acc/
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,9 @@ tools/_scratch/
 backups/
 
 # Track Titan personal session lake (issue #353): the operator's OWN exported session
-# data, retained immutably. Personal data — never committed.
-journal/tt/
+# data, retained immutably. Personal data — never committed. ``**/`` so a lake written
+# under any subdirectory (e.g. via --lake-base) is ignored too, not just the repo root.
+**/journal/tt/
 
 # Stray machine-local tooling (e.g. MOZA R3 profile script) — not repo source.
 tools/acc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ Skill: `~/.agents/skills/vault-memory/SKILL.md` (mirrored under `.cursor/skills/
 - **Pre-commit:** `make hooks-install` once per clone.
 - **Optional stacks:** DB, AWS, HF, Ollama, browser automation — [docs/00_Core/OPTIONAL_CAPABILITIES.md](docs/00_Core/OPTIONAL_CAPABILITIES.md).
 - **Sidecar reference lap (M0 voice coaching):** `AC_COPILOT_REFERENCE_ARCHIVE` — path to a faster reference lap archive JSON; used when starting the sidecar without `--reference-archive` so the live observer can emit `coaching.cue` advisories for the voice client.
+- **Track Titan ingest (#353):** `TT_REFRESH_TOKEN` — the operator's **personal** TT refresh token for `python -m tools.tt_ingest`; source from Doppler / the shell (never commit), or omit to auto-discover from the TT desktop app's Local Storage on Windows. Optional public-identifier overrides: `TT_COGNITO_CLIENT_ID`, `TT_COGNITO_USER_POOL_ID`, `TT_COGNITO_IDENTITY_POOL_ID`, `TT_COGNITO_REGION` (defaults are the app's public ids, not secrets). Install the CLI's runtime dep with `pip install -e ".[tt-ingest]"`. **Sensitivity:** retained exports under `journal/tt/**` are **personal data** (the operator's own sessions) — gitignored, write-once immutable, never redistributed; tokens are personal secrets, never logged or committed (see the [TT coaching-oracle guardrail](docs/01_Vault/AcCopilotTrainer/01_Decisions/track-titan-coaching-oracle-strategy-2026-06-27.md)).
 
 ---
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/invariants/data-immutability.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/invariants/data-immutability.md
@@ -19,8 +19,14 @@ part_of: AcCopilotTrainer/00_System/invariants/_index.md
 
 Prevents accidental corruption of evidence chains, PII stores, or golden datasets.
 
+## Concrete immutable paths (this project)
+
+- `journal/laps/lap_*.json` — per-lap telemetry archives (write-once by the trainer / importers; read-only to analysis).
+- `journal/tt/**` — Track Titan personal session lake (issue #353). Raw vulcan/services responses are retained **write-once** keyed by car + track + setup; `tools.tt_ingest` refuses to clobber an existing file (`write_immutable_json(..., overwrite=False)`). Gitignored (personal data). Only the *derived* `journal/tt/index.json` + `journal/tt/sessions_index.json` are regenerated idempotently.
+
 ## Enforcement
 
 - Declare forbidden write paths in this vault after specialization.
 - **Template default:** only non-blocking PreToolUse prompts in `.claude/settings.json`; add an optional **shell** hook there if paths must be machine-blocked (e.g. disclosures-style `block-data-edits.sh`).
 - Human review for any change touching listed paths.
+- `tools.tt_ingest` enforces write-once for `journal/tt/**` in code (atomic temp + `os.replace`, existing-file guard).

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/track-titan-coaching-oracle-strategy-2026-06-27.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/track-titan-coaching-oracle-strategy-2026-06-27.md
@@ -68,9 +68,19 @@ tesseract absent), and emits structured coaching JSON (`.scratch/tt_coaching.jso
 mapping) via `/orchestrate` (issue → PR).
 
 ## Guardrails
-- **Never** copy/log/transmit the plaintext Cognito tokens in `config.json`; **never** automate the cloud
-  API with the user's token (most ToS/CFAA-exposed). Personal, local use only; nothing redistributed
-  (TT bans setup redistribution).
+- **No redistribution, no automation at scale or on others' behalf.** Never redistribute TT content
+  (TT bans setup redistribution); never automate the cloud API at scale, for third parties, or in any
+  shared/deployed service. Never copy/log/transmit plaintext Cognito tokens into tracked files or logs.
+- **Personal own-account export is permitted** (operator decision 2026-06-28; issue
+  [#353](https://github.com/agorokh/ac-copilot-trainer/issues/353)). Scoping clarification superseding the
+  original blanket "never automate the cloud API with the user's token": exporting the **operator's own**
+  session data from their **own** TT account for **personal, local** coaching use — via the same
+  Cognito/`vulcan` path the official desktop app uses, on the same machine — is treated as **self
+  data-portability**, not the prohibited at-scale / third-party automation that carries the ToS/CFAA
+  exposure. Constraints still bind: tokens are personal secrets (read from env or the gitignored lake,
+  **never** logged or committed); retained raw data stays under the gitignored `journal/tt`; nothing is
+  redistributed; this is single-operator, local-only. Implemented by `tools/tt_ingest`
+  (PR [#359](https://github.com/agorokh/ac-copilot-trainer/pull/359), #353 M-TT0).
 - Honesty invariant holds: an imported/borrowed reference slower than the driven lap is never shown as a target.
 
 ## Open questions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,11 @@ training = [
 analytics = [
   "duckdb>=1.4",
 ]
+# Track Titan ingest CLI (#353): the `auth-check` / `export` network commands lazy-import
+# `requests`. Install with `pip install -e ".[tt-ingest]"` to run the CLI outside a dev env.
+tt-ingest = [
+  "requests>=2.33.1",
+]
 
 [tool.setuptools.packages.find]
 where = ["src", "."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,4 +133,5 @@ omit = [
   "tools/process_miner/run.py",
   "tools/repo_knowledge/mcp_server.py",
   "tools/ai_sidecar/__main__.py",
+  "tools/tt_ingest/__main__.py",
 ]

--- a/tests/fixtures/tt_sessions_page.json
+++ b/tests/fixtures/tt_sessions_page.json
@@ -1,0 +1,88 @@
+{
+  "data": {
+    "count": 3,
+    "limit": 50,
+    "page": 1,
+    "sessions": [
+      {
+        "id": "fake-uid-001#sess-aaa",
+        "timestamp": "2026-06-01T10:00:00Z",
+        "last_updated": "2026-06-01T10:05:00Z",
+        "game": {"gameId": "assettoCorsa", "name": "Assetto Corsa"},
+        "game_id": "assettoCorsa",
+        "car_id": "syn_mercedes_w09",
+        "carName": "Mercedes W09",
+        "car_class": "F1",
+        "car_performance_index": 100,
+        "track_id": "ks_red_bull_ring",
+        "trackName": "Red Bull Ring",
+        "track_grip": 0.98,
+        "weather_id": "clear",
+        "session_type": "hotlap",
+        "ghost_version": "v3",
+        "bestLapTime": 64321,
+        "lapCount": 12,
+        "lap_attributes": {
+          "airTemp": 24.0,
+          "roadTemp": 31.0,
+          "fuelLevel": 5.0,
+          "tcEnabled": true,
+          "absEnabled": true,
+          "absSetting": 2,
+          "carSetupName": "quali",
+          "isFixedSetup": false,
+          "tyreCompound": "Pirelli SuperSoft (SS)"
+        },
+        "driver_name": "Operator",
+        "user_id": "fake-uid-001",
+        "season_id": "2026",
+        "status": "complete"
+      },
+      {
+        "id": "fake-uid-001#sess-bbb",
+        "timestamp": "2026-06-02T11:00:00Z",
+        "game": {"gameId": "assettoCorsa", "name": "Assetto Corsa"},
+        "game_id": "assettoCorsa",
+        "car_id": "ks_porsche_911_gt3_rs",
+        "carName": "Porsche 911 GT3 RS",
+        "car_class": "GT3",
+        "track_id": "spa",
+        "trackName": "Spa-Francorchamps",
+        "track_grip": 0.95,
+        "bestLapTime": 138900,
+        "lapCount": 5,
+        "lap_attributes": {
+          "airTemp": 18.0,
+          "roadTemp": 22.0,
+          "tcEnabled": false,
+          "absEnabled": false,
+          "carSetupName": "race",
+          "isFixedSetup": true,
+          "tyreCompound": "Soft"
+        },
+        "user_id": "fake-uid-001",
+        "status": "complete"
+      },
+      {
+        "id": "fake-uid-001#sess-ccc",
+        "timestamp": "2026-06-03T09:00:00Z",
+        "game_id": "assettoCorsa",
+        "car_id": "ks_abarth500",
+        "track_id": "magione",
+        "user_id": "fake-uid-001"
+      }
+    ],
+    "cars": {
+      "syn_mercedes_w09": {"name": "Mercedes W09"},
+      "ks_porsche_911_gt3_rs": {"name": "Porsche 911 GT3 RS"}
+    },
+    "games": {"assettoCorsa": {"name": "Assetto Corsa"}},
+    "tracks": {
+      "ks_red_bull_ring": {"name": "Red Bull Ring"},
+      "spa": {"name": "Spa-Francorchamps"}
+    }
+  },
+  "message": "ok",
+  "status": 200,
+  "success": true
+}

--- a/tests/test_tt_auth.py
+++ b/tests/test_tt_auth.py
@@ -271,3 +271,69 @@ def test_mint_tokens_raises_on_http_error() -> None:
 
 def test_module_exposes_default_timeout() -> None:
     assert tt_auth.DEFAULT_REQUEST_TIMEOUT_S > 0
+
+
+# --- regression tests for the PR-359 adversarial-review fixes ----------------------
+
+
+def test_extract_refresh_token_is_linear_on_large_blob() -> None:
+    # ReDoS regression: a several-hundred-KB run of token chars with NO 5-segment JWE must
+    # resolve quickly. The previous single backtracking regex took ~minutes on this shape.
+    import time
+
+    client = "client-x"
+    big = "A" * 300_000  # one long run, no dots → cannot be a JWE
+    text = f"{big} CognitoIdentityServiceProvider.{client}.u.refreshToken {FAKE_JWE} {big}"
+    start = time.monotonic()
+    got = extract_refresh_token_from_text(text, app_client_id=client)
+    assert time.monotonic() - start < 3.0
+    assert got == FAKE_JWE
+
+
+def test_extract_refresh_token_ignores_3segment_jws() -> None:
+    # A long 3-segment access-token JWS (only 2 dots) must never be taken as the refresh JWE.
+    jws = "a" * 800 + "." + "b" * 800 + "." + "c" * 64
+    assert extract_refresh_token_from_text(jws, app_client_id="x") is None
+
+
+def test_is_token_expired_skew_boundary() -> None:
+    token = _make_jws({"exp": 1_000_000})
+    near = datetime.fromtimestamp(1_000_000 - 30, tz=UTC)  # 30s before expiry, inside 60s skew
+    far = datetime.fromtimestamp(1_000_000 - 90, tz=UTC)  # 90s before, outside skew
+    assert is_token_expired(token, skew_s=60, now=near) is True
+    assert is_token_expired(token, skew_s=60, now=far) is False
+    # The 60s default skew is applied when skew_s is omitted.
+    assert is_token_expired(token, now=near) is True
+
+
+def test_resolve_refresh_token_env_precedes_populated_leveldb(tmp_path) -> None:
+    cfg = TTConfig()
+    ldb = tmp_path / "000003.ldb"
+    ldb.write_bytes(
+        f"CognitoIdentityServiceProvider.{cfg.app_client_id}.u.refreshToken={FAKE_JWE}".encode()
+    )
+    # Env token must win even when disk holds a (different) token.
+    got = resolve_refresh_token(cfg, leveldb_dir=tmp_path, env={"TT_REFRESH_TOKEN": "env-token"})
+    assert got == "env-token"
+
+
+def test_resolve_refresh_token_blank_env_falls_through_to_disk(tmp_path) -> None:
+    cfg = TTConfig()
+    ldb = tmp_path / "000003.ldb"
+    ldb.write_bytes(
+        f"CognitoIdentityServiceProvider.{cfg.app_client_id}.u.refreshToken={FAKE_JWE}".encode()
+    )
+    got = resolve_refresh_token(cfg, leveldb_dir=tmp_path, env={"TT_REFRESH_TOKEN": "   "})
+    assert got == FAKE_JWE
+
+
+def test_parse_initiate_auth_rejects_empty_access_token() -> None:
+    with pytest.raises(TTAuthError):
+        parse_initiate_auth_response({"AuthenticationResult": {"AccessToken": "", "IdToken": "x"}})
+
+
+def test_parse_initiate_auth_preserves_non_bearer_token_type() -> None:
+    minted = parse_initiate_auth_response(
+        {"AuthenticationResult": {"AccessToken": "a", "IdToken": "b", "TokenType": "Token"}}
+    )
+    assert minted.token_type == "Token"

--- a/tests/test_tt_auth.py
+++ b/tests/test_tt_auth.py
@@ -296,6 +296,17 @@ def test_extract_refresh_token_ignores_3segment_jws() -> None:
     assert extract_refresh_token_from_text(jws, app_client_id="x") is None
 
 
+def test_extract_refresh_token_same_run_marker_and_value() -> None:
+    # When LevelDB stores the key and its JWE value in ONE token-run (no separating control
+    # byte), the value must still be selected AFTER the marker, and a longer *incidental* JWE
+    # before the marker must not win. Regression for the run-vs-JWE offset selection bug.
+    client = "client9"
+    real = "RRRRRRRR.rrrrrr.rrrrrr.rrrrrr.rrrrrr"
+    incidental = "I" * 40 + ".iiiiiiiiii.iiiiiiiiii.iiiiiiiiii.iiiiiiiiii"  # longer than real
+    text = f"{incidental} CognitoIdentityServiceProvider.{client}.uid7.refreshToken.{real}"
+    assert extract_refresh_token_from_text(text, app_client_id=client) == real
+
+
 def test_is_token_expired_skew_boundary() -> None:
     token = _make_jws({"exp": 1_000_000})
     near = datetime.fromtimestamp(1_000_000 - 30, tz=UTC)  # 30s before expiry, inside 60s skew

--- a/tests/test_tt_auth.py
+++ b/tests/test_tt_auth.py
@@ -1,0 +1,273 @@
+"""Unit tests for tools.tt_ingest.tt_auth (issue #353).
+
+Covers the pure JWT helpers, refresh-token discovery, the InitiateAuth request
+builder + response parser, and (for wiring confidence) the network mint with a fake
+HTTP client. No real tokens or network are involved.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from tools.tt_ingest import tt_auth
+from tools.tt_ingest.tt_auth import (
+    MintedTokens,
+    TTAuthError,
+    TTConfig,
+    build_initiate_auth_request,
+    decode_jwt_payload,
+    default_leveldb_dir,
+    extract_refresh_token_from_text,
+    extract_uid_from_text,
+    is_token_expired,
+    mint_tokens,
+    parse_initiate_auth_response,
+    resolve_refresh_token,
+    token_expiry,
+    uid_from_token,
+)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _make_jws(payload: dict) -> str:
+    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    body = _b64url(json.dumps(payload).encode())
+    return f"{header}.{body}.signaturesig"
+
+
+# A fake 5-segment JWE shape (header.key.iv.ciphertext.tag) — not a real token.
+FAKE_JWE = "AAAAheaderseg.BBBBkeyseg11.CCCCivseg222.DDDDcipherseg3333.EEEEtagseg44"
+
+
+# --- TTConfig ---------------------------------------------------------------------
+
+
+def test_ttconfig_defaults_and_properties() -> None:
+    cfg = TTConfig()
+    assert cfg.region == "us-east-1"
+    assert cfg.idp_url == "https://cognito-idp.us-east-1.amazonaws.com/"
+    assert cfg.identity_url == "https://cognito-identity.us-east-1.amazonaws.com/"
+    assert cfg.user_pool_provider == f"cognito-idp.us-east-1.amazonaws.com/{cfg.user_pool_id}"
+
+
+def test_ttconfig_from_env_overrides() -> None:
+    cfg = TTConfig.from_env({"TT_COGNITO_REGION": "eu-west-1", "TT_COGNITO_CLIENT_ID": "client123"})
+    assert cfg.region == "eu-west-1"
+    assert cfg.app_client_id == "client123"
+    assert cfg.idp_url == "https://cognito-idp.eu-west-1.amazonaws.com/"
+
+
+# --- JWT helpers ------------------------------------------------------------------
+
+
+def test_decode_jwt_payload_roundtrip() -> None:
+    token = _make_jws({"sub": "user-xyz", "exp": 1_900_000_000})
+    claims = decode_jwt_payload(token)
+    assert claims["sub"] == "user-xyz"
+    assert claims["exp"] == 1_900_000_000
+
+
+def test_decode_jwt_payload_rejects_non_three_segment() -> None:
+    with pytest.raises(TTAuthError):
+        decode_jwt_payload(FAKE_JWE)  # 5 segments
+
+
+def test_decode_jwt_payload_rejects_non_json() -> None:
+    bad = f"{_b64url(b'header')}.{_b64url(b'not-json')}.sig"
+    with pytest.raises(TTAuthError):
+        decode_jwt_payload(bad)
+
+
+def test_token_expiry_returns_tz_aware() -> None:
+    token = _make_jws({"exp": 1_900_000_000})
+    expiry = token_expiry(token)
+    assert expiry is not None
+    assert expiry.tzinfo is not None
+    assert expiry == datetime.fromtimestamp(1_900_000_000, tz=UTC)
+
+
+def test_token_expiry_none_when_absent() -> None:
+    assert token_expiry(_make_jws({"sub": "x"})) is None
+
+
+def test_is_token_expired_with_injected_now() -> None:
+    token = _make_jws({"exp": 1_900_000_000})
+    before = datetime.fromtimestamp(1_800_000_000, tz=UTC)
+    after = datetime.fromtimestamp(1_950_000_000, tz=UTC)
+    assert is_token_expired(token, now=after) is True
+    assert is_token_expired(token, now=before) is False
+
+
+def test_is_token_expired_when_no_exp() -> None:
+    assert is_token_expired(_make_jws({"sub": "x"})) is True
+
+
+def test_uid_from_token() -> None:
+    assert uid_from_token(_make_jws({"sub": "abc-123"})) == "abc-123"
+
+
+def test_uid_from_token_requires_sub() -> None:
+    with pytest.raises(TTAuthError):
+        uid_from_token(_make_jws({"exp": 1}))
+
+
+# --- refresh-token discovery ------------------------------------------------------
+
+
+def test_extract_refresh_token_with_key_marker() -> None:
+    client = "6qp755fd6379572i96kt1hvu55"
+    text = (
+        f"someprefix\x00CognitoIdentityServiceProvider.{client}.user-9.refreshToken\x01"
+        f"{FAKE_JWE}\x00trailing"
+    )
+    assert extract_refresh_token_from_text(text, app_client_id=client) == FAKE_JWE
+
+
+def test_extract_refresh_token_fallback_longest() -> None:
+    short = "aa.bb.cc.dd.ee"
+    text = f"noise {short} noise {FAKE_JWE} more"
+    got = extract_refresh_token_from_text(text, app_client_id="whatever")
+    assert got == FAKE_JWE
+
+
+def test_extract_refresh_token_none_when_absent() -> None:
+    assert extract_refresh_token_from_text("no jwe here", app_client_id="x") is None
+
+
+def test_extract_uid_from_refresh_key() -> None:
+    client = "client42"
+    text = f"CognitoIdentityServiceProvider.{client}.cognito-user-77.refreshToken={FAKE_JWE}"
+    assert extract_uid_from_text(text, app_client_id=client) == "cognito-user-77"
+
+
+def test_extract_uid_from_last_auth_user() -> None:
+    client = "client42"
+    text = f"CognitoIdentityServiceProvider.{client}.LastAuthUser\x01last-user-value-001\x00"
+    assert extract_uid_from_text(text, app_client_id=client) == "last-user-value-001"
+
+
+def test_extract_uid_none() -> None:
+    assert extract_uid_from_text("nothing relevant", app_client_id="x") is None
+
+
+def test_default_leveldb_dir_with_appdata(tmp_path) -> None:
+    got = default_leveldb_dir({"APPDATA": str(tmp_path)})
+    assert got is not None
+    assert got.parts[-3:] == ("track-titan-ghost-application", "Local Storage", "leveldb")
+
+
+def test_default_leveldb_dir_without_appdata() -> None:
+    assert default_leveldb_dir({}) is None
+
+
+def test_resolve_refresh_token_env_wins() -> None:
+    cfg = TTConfig()
+    assert resolve_refresh_token(cfg, env={"TT_REFRESH_TOKEN": "  tok-abc  "}) == "tok-abc"
+
+
+def test_resolve_refresh_token_from_leveldb(tmp_path) -> None:
+    cfg = TTConfig()
+    client = cfg.app_client_id
+    ldb = tmp_path / "000003.ldb"
+    ldb.write_bytes(
+        f"CognitoIdentityServiceProvider.{client}.user-1.refreshToken={FAKE_JWE}".encode()
+    )
+    assert resolve_refresh_token(cfg, leveldb_dir=tmp_path, env={}) == FAKE_JWE
+
+
+def test_resolve_refresh_token_missing_has_no_token_in_message(tmp_path) -> None:
+    cfg = TTConfig()
+    with pytest.raises(TTAuthError) as excinfo:
+        resolve_refresh_token(cfg, leveldb_dir=tmp_path / "empty", env={})
+    assert "TT_REFRESH_TOKEN" in str(excinfo.value)
+
+
+# --- InitiateAuth builder + parser + mint -----------------------------------------
+
+
+def test_build_initiate_auth_request() -> None:
+    cfg = TTConfig()
+    url, headers, body = build_initiate_auth_request("rt-secret", cfg)
+    assert url == cfg.idp_url
+    assert headers["X-Amz-Target"] == "AWSCognitoIdentityProviderService.InitiateAuth"
+    assert headers["Content-Type"] == "application/x-amz-json-1.1"
+    assert body["AuthFlow"] == "REFRESH_TOKEN_AUTH"
+    assert body["ClientId"] == cfg.app_client_id
+    assert body["AuthParameters"]["REFRESH_TOKEN"] == "rt-secret"
+
+
+def test_parse_initiate_auth_response_success() -> None:
+    payload = {
+        "AuthenticationResult": {
+            "AccessToken": "acc-tok",
+            "IdToken": "id-tok",
+            "ExpiresIn": 3600,
+            "TokenType": "Bearer",
+        }
+    }
+    minted = parse_initiate_auth_response(payload)
+    assert minted == MintedTokens("acc-tok", "id-tok", 3600, "Bearer")
+
+
+def test_parse_initiate_auth_response_missing_result() -> None:
+    with pytest.raises(TTAuthError):
+        parse_initiate_auth_response({})
+
+
+def test_parse_initiate_auth_response_missing_tokens() -> None:
+    with pytest.raises(TTAuthError):
+        parse_initiate_auth_response({"AuthenticationResult": {"AccessToken": "x"}})
+
+
+def test_parse_initiate_auth_response_defaults_expires_in() -> None:
+    payload = {"AuthenticationResult": {"AccessToken": "a", "IdToken": "b", "ExpiresIn": "bad"}}
+    minted = parse_initiate_auth_response(payload)
+    assert minted.expires_in == 3600
+    assert minted.token_type == "Bearer"
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeHttp:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    def post(self, url, headers=None, json=None, timeout=None):  # noqa: A002 - mirror requests
+        self.calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return self._response
+
+
+def test_mint_tokens_with_fake_http() -> None:
+    response = _FakeResponse(
+        {"AuthenticationResult": {"AccessToken": "acc", "IdToken": "idt", "ExpiresIn": 3600}}
+    )
+    http = _FakeHttp(response)
+    minted = mint_tokens("rt", TTConfig(), http=http)
+    assert minted.access_token == "acc"
+    assert http.calls[0]["json"]["AuthParameters"]["REFRESH_TOKEN"] == "rt"
+
+
+def test_mint_tokens_raises_on_http_error() -> None:
+    http = _FakeHttp(_FakeResponse({}, status_code=400))
+    with pytest.raises(TTAuthError) as excinfo:
+        mint_tokens("rt", TTConfig(), http=http)
+    assert "400" in str(excinfo.value)
+
+
+def test_module_exposes_default_timeout() -> None:
+    assert tt_auth.DEFAULT_REQUEST_TIMEOUT_S > 0

--- a/tests/test_tt_export.py
+++ b/tests/test_tt_export.py
@@ -46,17 +46,19 @@ def test_sanitize_segment_length_cap() -> None:
 
 
 def test_lake_root_default(tmp_path) -> None:
-    root = lake_root(tmp_path, env={})
+    root = lake_root(tmp_path)
     assert root == tmp_path / "journal" / "tt"
 
 
-def test_lake_root_env_override(tmp_path) -> None:
-    override = tmp_path / "custom"
-    assert lake_root(tmp_path, env={"TT_LAKE_DIR": str(override)}) == override
+def test_lake_root_ignores_env_override(tmp_path, monkeypatch) -> None:
+    # Security: no env var may redirect the write root to an arbitrary location; retention
+    # always nests under <base>/journal/tt (the operator chooses the base via --lake-base).
+    monkeypatch.setenv("TT_LAKE_DIR", "/etc/somewhere-bad")
+    assert lake_root(tmp_path) == tmp_path / "journal" / "tt"
 
 
 def test_session_lake_dir_structure(tmp_path) -> None:
-    root = lake_root(tmp_path, env={})
+    root = lake_root(tmp_path)
     d = session_lake_dir(
         root, game="assettoCorsa", car="syn_mercedes_w09", track="spa", session_key="sess-1"
     )
@@ -64,7 +66,7 @@ def test_session_lake_dir_structure(tmp_path) -> None:
 
 
 def test_session_lake_dir_sanitizes_missing(tmp_path) -> None:
-    root = lake_root(tmp_path, env={})
+    root = lake_root(tmp_path)
     d = session_lake_dir(root, game=None, car=None, track=None, session_key=None)
     assert d.parts[-4:] == ("unknown_game", "unknown_car", "unknown_track", "unknown_session")
 

--- a/tests/test_tt_export.py
+++ b/tests/test_tt_export.py
@@ -17,6 +17,7 @@ from tools.tt_ingest.tt_export import (
     sanitize_segment,
     session_lake_dir,
     sha256_hex,
+    stable_fingerprint,
     write_immutable_json,
 )
 
@@ -135,3 +136,31 @@ def test_build_index() -> None:
     assert index["file_count"] == 2
     assert index["files"][0]["sha256"] == "deadbeef"
     assert index["files"][1]["path"] == "a/s2/session.json"
+
+
+# --- regression tests for the PR-359 adversarial-review fixes ----------------------
+
+
+def test_stable_fingerprint_deterministic_and_distinct() -> None:
+    a = {"car_id": "c", "track_id": "t"}
+    b = {"track_id": "t", "car_id": "c"}  # same content, different key order
+    c = {"car_id": "c", "track_id": "u"}
+    assert stable_fingerprint(a) == stable_fingerprint(b)  # canonical → order-independent
+    assert stable_fingerprint(a) != stable_fingerprint(c)  # distinct content → distinct id
+    assert len(stable_fingerprint(a)) == 12
+
+
+def test_write_immutable_json_strict_rejects_nan_by_default(tmp_path) -> None:
+    with pytest.raises(ValueError):
+        write_immutable_json(tmp_path / "x.json", {"v": float("nan")})
+
+
+def test_write_immutable_json_allow_nan_is_lossless(tmp_path) -> None:
+    import json
+
+    path = tmp_path / "raw.json"
+    result = write_immutable_json(path, {"airTemp": float("nan")}, allow_nan=True)
+    assert result.written is True
+    # Round-trips through our own json.loads (which accepts NaN), so retention is lossless.
+    loaded = json.loads(path.read_text())
+    assert loaded["airTemp"] != loaded["airTemp"]  # NaN != NaN

--- a/tests/test_tt_export.py
+++ b/tests/test_tt_export.py
@@ -1,0 +1,137 @@
+"""Unit tests for tools.tt_ingest.tt_export (issue #353)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.tt_ingest.tt_export import (
+    INDEX_SCHEMA_VERSION,
+    RetainedFile,
+    TTExportError,
+    build_index,
+    endpoint_file,
+    lake_root,
+    relative_to_lake,
+    sanitize_segment,
+    session_lake_dir,
+    sha256_hex,
+    write_immutable_json,
+)
+
+# --- sanitize_segment -------------------------------------------------------------
+
+
+def test_sanitize_segment_replaces_unsafe() -> None:
+    assert sanitize_segment("ks/red:bull ring") == "ks_red_bull_ring"
+
+
+def test_sanitize_segment_blocks_traversal() -> None:
+    assert sanitize_segment("..") == "unknown"
+    assert sanitize_segment("../../etc") == "etc"
+
+
+def test_sanitize_segment_empty_fallback() -> None:
+    assert sanitize_segment("", fallback="fb") == "fb"
+    assert sanitize_segment(None, fallback="fb") == "fb"
+
+
+def test_sanitize_segment_length_cap() -> None:
+    assert len(sanitize_segment("a" * 500)) == 128
+
+
+# --- lake paths -------------------------------------------------------------------
+
+
+def test_lake_root_default(tmp_path) -> None:
+    root = lake_root(tmp_path, env={})
+    assert root == tmp_path / "journal" / "tt"
+
+
+def test_lake_root_env_override(tmp_path) -> None:
+    override = tmp_path / "custom"
+    assert lake_root(tmp_path, env={"TT_LAKE_DIR": str(override)}) == override
+
+
+def test_session_lake_dir_structure(tmp_path) -> None:
+    root = lake_root(tmp_path, env={})
+    d = session_lake_dir(
+        root, game="assettoCorsa", car="syn_mercedes_w09", track="spa", session_key="sess-1"
+    )
+    assert d == root / "assettoCorsa" / "syn_mercedes_w09" / "spa" / "sess-1"
+
+
+def test_session_lake_dir_sanitizes_missing(tmp_path) -> None:
+    root = lake_root(tmp_path, env={})
+    d = session_lake_dir(root, game=None, car=None, track=None, session_key=None)
+    assert d.parts[-4:] == ("unknown_game", "unknown_car", "unknown_track", "unknown_session")
+
+
+def test_endpoint_file(tmp_path) -> None:
+    assert endpoint_file(tmp_path, "session").name == "session.json"
+
+
+# --- write_immutable_json ---------------------------------------------------------
+
+
+def test_write_immutable_json_writes_new(tmp_path) -> None:
+    path = tmp_path / "a" / "b" / "session.json"
+    result = write_immutable_json(path, {"hello": "world"})
+    assert result.written is True
+    assert path.exists()
+    assert json.loads(path.read_text())["hello"] == "world"
+    assert result.sha256 == sha256_hex(path.read_bytes())
+
+
+def test_write_immutable_json_refuses_overwrite(tmp_path) -> None:
+    path = tmp_path / "session.json"
+    write_immutable_json(path, {"v": 1})
+    original = path.read_text()
+    result = write_immutable_json(path, {"v": 2})
+    assert result.written is False
+    assert path.read_text() == original  # unchanged
+    # Returned hash is the EXISTING file's, so it can still be indexed.
+    assert result.sha256 == sha256_hex(path.read_bytes())
+
+
+def test_write_immutable_json_overwrite_true(tmp_path) -> None:
+    path = tmp_path / "session.json"
+    write_immutable_json(path, {"v": 1})
+    result = write_immutable_json(path, {"v": 2}, overwrite=True)
+    assert result.written is True
+    assert json.loads(path.read_text())["v"] == 2
+
+
+def test_write_immutable_json_no_temp_litter(tmp_path) -> None:
+    path = tmp_path / "session.json"
+    write_immutable_json(path, {"v": 1})
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+# --- index helpers ----------------------------------------------------------------
+
+
+def test_relative_to_lake(tmp_path) -> None:
+    root = tmp_path / "journal" / "tt"
+    f = root / "assettoCorsa" / "car" / "track" / "s" / "session.json"
+    assert relative_to_lake(f, root) == "assettoCorsa/car/track/s/session.json"
+
+
+def test_relative_to_lake_outside_root_raises(tmp_path) -> None:
+    root = tmp_path / "lake"
+    root.mkdir()
+    with pytest.raises(TTExportError):
+        relative_to_lake(tmp_path / "elsewhere" / "x.json", root)
+
+
+def test_build_index() -> None:
+    records = [
+        RetainedFile("s1", "session", "a/s1/session.json", "deadbeef", 120, True),
+        RetainedFile("s2", "session", "a/s2/session.json", "cafef00d", 96, False),
+    ]
+    index = build_index(records, generated_at="2026-06-28T00:00:00Z")
+    assert index["index_schema_version"] == INDEX_SCHEMA_VERSION
+    assert index["file_count"] == 2
+    assert index["files"][0]["sha256"] == "deadbeef"
+    assert index["files"][1]["path"] == "a/s2/session.json"

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -1,0 +1,112 @@
+"""Integration tests for the tt_ingest retention pipeline + CLI parser (issue #353).
+
+``retain_sessions`` is the local, network-free heart of ``export``: given already
+fetched raw sessions it normalizes, immutably retains, and indexes them. These tests
+drive it against the sanitized fixture and a ``tmp_path`` lake.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.tt_ingest.cli import (
+    INDEX_FILENAME,
+    SESSIONS_INDEX_FILENAME,
+    build_arg_parser,
+    retain_sessions,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "tt_sessions_page.json"
+
+
+def _sessions() -> list[dict]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))["data"]["sessions"]
+
+
+# --- retain_sessions end-to-end ---------------------------------------------------
+
+
+def test_retain_sessions_writes_lake_tree(tmp_path) -> None:
+    summary = retain_sessions(_sessions(), lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z")
+    root = tmp_path / "journal" / "tt"
+    assert summary.total == 3
+    assert summary.retained_new == 3
+    assert summary.skipped_existing == 0
+    assert summary.lake_root == root
+
+    # Raw session retained at the car/track/session path.
+    raw = (
+        root
+        / "assettoCorsa"
+        / "syn_mercedes_w09"
+        / "ks_red_bull_ring"
+        / "sess-aaa"
+        / "session.json"
+    )
+    assert raw.exists()
+    assert json.loads(raw.read_text())["id"] == "fake-uid-001#sess-aaa"
+
+    # Both indexes present.
+    sessions_index = json.loads((root / SESSIONS_INDEX_FILENAME).read_text())
+    assert sessions_index["session_count"] == 3
+    file_index = json.loads((root / INDEX_FILENAME).read_text())
+    assert file_index["file_count"] == 3
+    assert all("sha256" in f for f in file_index["files"])
+
+
+def test_retain_sessions_is_immutable_on_rerun(tmp_path) -> None:
+    retain_sessions(_sessions(), lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z")
+    # Second run: same raw sessions are already present → all skipped, none re-written.
+    summary = retain_sessions(_sessions(), lake_base=tmp_path, generated_at="2026-06-29T00:00:00Z")
+    assert summary.total == 3
+    assert summary.retained_new == 0
+    assert summary.skipped_existing == 3
+
+
+def test_retain_sessions_summary_render(tmp_path) -> None:
+    summary = retain_sessions(_sessions(), lake_base=tmp_path)
+    rendered = summary.render()
+    assert "retained 3 session(s)" in rendered
+    assert "3 new" in rendered
+
+
+def test_retain_sessions_empty(tmp_path) -> None:
+    summary = retain_sessions([], lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z")
+    assert summary.total == 0
+    root = tmp_path / "journal" / "tt"
+    assert (root / SESSIONS_INDEX_FILENAME).exists()
+    assert json.loads((root / INDEX_FILENAME).read_text())["file_count"] == 0
+
+
+# --- argument parser --------------------------------------------------------------
+
+
+def test_parser_export_defaults() -> None:
+    args = build_arg_parser().parse_args(["export"])
+    assert args.command == "export"
+    assert args.limit == 50
+    assert args.dry_run is False
+    assert args.overwrite is False
+
+
+def test_parser_export_flags() -> None:
+    args = build_arg_parser().parse_args(
+        ["export", "--limit", "10", "--max-pages", "2", "--dry-run", "--uid", "u9"]
+    )
+    assert args.limit == 10
+    assert args.max_pages == 2
+    assert args.dry_run is True
+    assert args.uid == "u9"
+
+
+def test_parser_auth_check() -> None:
+    args = build_arg_parser().parse_args(["auth-check"])
+    assert args.command == "auth-check"
+
+
+def test_parser_requires_subcommand() -> None:
+    with pytest.raises(SystemExit):
+        build_arg_parser().parse_args([])

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -89,7 +89,6 @@ def test_parser_export_defaults() -> None:
     assert args.command == "export"
     assert args.limit == 50
     assert args.dry_run is False
-    assert args.overwrite is False
 
 
 def test_parser_export_flags() -> None:
@@ -164,3 +163,33 @@ def test_retain_sessions_guards_unserializable_session(tmp_path) -> None:
     root = tmp_path / "journal" / "tt"
     assert json.loads((root / INDEX_FILENAME).read_text())["file_count"] == 1
     assert json.loads((root / SESSIONS_INDEX_FILENAME).read_text())["session_count"] == 1
+
+
+def test_retain_sessions_partial_export_preserves_index(tmp_path) -> None:
+    # A later partial export must NOT shrink the discovery index: the index is a derived
+    # view of the WHOLE lake on disk, not of one batch (regression for index-rebuild bug).
+    retain_sessions(_sessions(), lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z")
+    extra = {"id": "u#new", "car_id": "c", "track_id": "t", "game_id": "g"}
+    summary = retain_sessions([extra], lake_base=tmp_path, generated_at="2026-06-29T00:00:00Z")
+    assert summary.total == 1  # this batch processed one session...
+    assert summary.indexed == 4  # ...but the index covers all 4 raw files on disk
+    root = tmp_path / "journal" / "tt"
+    assert json.loads((root / INDEX_FILENAME).read_text())["file_count"] == 4
+    assert json.loads((root / SESSIONS_INDEX_FILENAME).read_text())["session_count"] == 4
+
+
+def test_retain_sessions_raw_is_write_once_and_index_matches_disk(tmp_path) -> None:
+    s = {"id": "u#a", "car_id": "c", "track_id": "t", "game_id": "g", "bestLapTime": 1000}
+    retain_sessions([s], lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z")
+    root = tmp_path / "journal" / "tt"
+    raw_path = next(root.rglob("session.json"))
+    original = raw_path.read_text()
+    # Re-export the SAME session id with DIFFERENT content: raw is write-once → unchanged,
+    # and the rebuilt index reflects the retained (old) raw, never the new payload.
+    summary = retain_sessions(
+        [{**s, "bestLapTime": 9999}], lake_base=tmp_path, generated_at="2026-06-29T00:00:00Z"
+    )
+    assert summary.retained_new == 0
+    assert raw_path.read_text() == original
+    si = json.loads((root / SESSIONS_INDEX_FILENAME).read_text())
+    assert si["sessions"][0]["best_lap_ms"] == 1000  # index agrees with disk, not the new payload

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -110,3 +110,57 @@ def test_parser_auth_check() -> None:
 def test_parser_requires_subcommand() -> None:
     with pytest.raises(SystemExit):
         build_arg_parser().parse_args([])
+
+
+# --- regression tests for the PR-359 adversarial-review fixes ----------------------
+
+
+def test_retain_sessions_idless_sessions_do_not_collide(tmp_path) -> None:
+    # Two DISTINCT sessions both lacking a usable id must NOT collapse onto one lake path
+    # (the old 'unknown_session' single bucket silently dropped the second + corrupted the index).
+    s1 = {"car_id": "c", "track_id": "t", "game_id": "g", "bestLapTime": 1000}
+    s2 = {"car_id": "c", "track_id": "t", "game_id": "g", "bestLapTime": 2000}
+    summary = retain_sessions([s1, s2], lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z")
+    assert summary.total == 2
+    assert summary.retained_new == 2  # both retained — no silent drop
+    root = tmp_path / "journal" / "tt"
+    assert len(list(root.rglob("session.json"))) == 2  # two distinct raw files on disk
+    file_index = json.loads((root / INDEX_FILENAME).read_text())
+    assert file_index["file_count"] == 2
+    # Distinct sha256 per session — the first file's hash is never mis-attributed to the second.
+    assert len({f["sha256"] for f in file_index["files"]}) == 2
+
+
+def test_retain_sessions_keeps_nan_session_and_whole_batch(tmp_path) -> None:
+    good = {"id": "u#a", "car_id": "c", "track_id": "t", "game_id": "g"}
+    nan_session = {
+        "id": "u#b",
+        "car_id": "c",
+        "track_id": "t",
+        "game_id": "g",
+        "lap_attributes": {"fuelLevel": float("nan")},
+    }
+    after = {"id": "u#c", "car_id": "c", "track_id": "t", "game_id": "g"}
+    summary = retain_sessions(
+        [good, nan_session, after], lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z"
+    )
+    # A non-finite telemetry float must NOT abort the batch or skip the indexes.
+    assert summary.total == 3
+    assert summary.failed == 0
+    root = tmp_path / "journal" / "tt"
+    assert (root / SESSIONS_INDEX_FILENAME).exists()
+    assert json.loads((root / INDEX_FILENAME).read_text())["file_count"] == 3
+
+
+def test_retain_sessions_guards_unserializable_session(tmp_path) -> None:
+    good = {"id": "u#a", "car_id": "c", "track_id": "t", "game_id": "g"}
+    # A set is not JSON-serializable (even with allow_nan): the per-session write raises, but the
+    # guard must keep the rest of the batch and still write both indexes.
+    bad = {"id": "u#b", "car_id": "c", "track_id": "t", "game_id": "g", "weird": {1, 2, 3}}
+    summary = retain_sessions([good, bad], lake_base=tmp_path, generated_at="2026-06-28T00:00:00Z")
+    assert summary.failed == 1
+    assert summary.total == 1  # only the good session retained
+    assert "1 session(s) skipped due to errors" in summary.render()
+    root = tmp_path / "journal" / "tt"
+    assert json.loads((root / INDEX_FILENAME).read_text())["file_count"] == 1
+    assert json.loads((root / SESSIONS_INDEX_FILENAME).read_text())["session_count"] == 1

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -1,0 +1,87 @@
+"""Unit tests for tools.tt_ingest.tt_normalize (issue #353)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.tt_ingest.tt_normalize import (
+    INDEX_SCHEMA_VERSION,
+    build_sessions_index,
+    normalize_session,
+    normalize_sessions,
+    split_session_id,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "tt_sessions_page.json"
+
+
+def _sessions() -> list[dict]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))["data"]["sessions"]
+
+
+def test_split_session_id() -> None:
+    assert split_session_id("uid-1#sess-aaa") == ("uid-1", "sess-aaa")
+    assert split_session_id("no-sep") == (None, None)
+    assert split_session_id(123) == (None, None)
+
+
+def test_normalize_session_full_row() -> None:
+    row = normalize_session(_sessions()[0])
+    assert row["session_id"] == "fake-uid-001#sess-aaa"
+    assert row["uid"] == "fake-uid-001"
+    assert row["session_key"] == "sess-aaa"
+    assert row["car_id"] == "syn_mercedes_w09"
+    assert row["car_name"] == "Mercedes W09"
+    assert row["track_id"] == "ks_red_bull_ring"
+    assert row["best_lap_ms"] == 64321
+    assert row["lap_count"] == 12
+    assert row["game_name"] == "Assetto Corsa"
+
+
+def test_normalize_session_lifts_conditions() -> None:
+    row = normalize_session(_sessions()[0])
+    cond = row["conditions"]
+    assert cond["airTemp"] == 24.0
+    assert cond["tyreCompound"] == "Pirelli SuperSoft (SS)"
+    assert cond["carSetupName"] == "quali"
+    assert cond["isFixedSetup"] is False
+    assert cond["trackGrip"] == 0.98
+
+
+def test_normalize_session_degrades_missing_fields() -> None:
+    row = normalize_session(_sessions()[2])  # minimal session
+    assert row["car_id"] == "ks_abarth500"
+    assert row["best_lap_ms"] is None
+    assert row["lap_count"] is None
+    assert row["car_name"] is None
+    # conditions keys all present but None when lap_attributes absent
+    assert row["conditions"]["airTemp"] is None
+    assert set(row["conditions"]).issuperset({"airTemp", "tyreCompound", "trackGrip"})
+
+
+def test_normalize_session_uid_from_user_id_when_id_unusable() -> None:
+    row = normalize_session({"car_id": "c", "user_id": "uid-only"})
+    assert row["uid"] == "uid-only"
+    assert row["session_id"] is None
+
+
+def test_normalize_session_rejects_non_mapping() -> None:
+    with pytest.raises(TypeError):
+        normalize_session("not a mapping")
+
+
+def test_normalize_sessions_skips_non_mappings() -> None:
+    rows = normalize_sessions([_sessions()[0], "garbage", 7, _sessions()[1]])
+    assert len(rows) == 2
+
+
+def test_build_sessions_index() -> None:
+    rows = normalize_sessions(_sessions())
+    index = build_sessions_index(rows, generated_at="2026-06-28T00:00:00Z")
+    assert index["index_schema_version"] == INDEX_SCHEMA_VERSION
+    assert index["session_count"] == 3
+    assert index["generated_at"] == "2026-06-28T00:00:00Z"
+    assert len(index["sessions"]) == 3

--- a/tests/test_tt_vulcan.py
+++ b/tests/test_tt_vulcan.py
@@ -168,3 +168,29 @@ def test_fetch_sessions_page_http_error() -> None:
 
     with pytest.raises(TTVulcanError):
         fetch_sessions_page("tok", "uid-1", http=_ErrHttp())
+
+
+# --- regression tests for the PR-359 adversarial-review fixes ----------------------
+
+
+def test_parse_sessions_page_coerces_numeric_strings() -> None:
+    page = parse_sessions_page(
+        {"data": {"count": "149", "limit": "50.0", "page": "1", "sessions": []}}
+    )
+    assert page.count == 149
+    assert page.limit == 50  # float-string coerced → pagination not collapsed to a single page
+    assert page.total_pages == 3
+
+
+def test_session_summary_laps_fallback() -> None:
+    summary = session_summary({"car_id": "c", "track_id": "t", "game_id": "g"})
+    assert "? lap(s)" in summary
+    assert "None" not in summary
+
+
+def test_session_summary_excludes_pii() -> None:
+    # Pin the documented "never tokens or PII" contract against a future regression that
+    # might start interpolating user_id / driver_name into the operator-facing log line.
+    out = session_summary(parse_sessions_page(_load_fixture()).sessions[0])
+    assert "fake-uid-001" not in out
+    assert "Operator" not in out

--- a/tests/test_tt_vulcan.py
+++ b/tests/test_tt_vulcan.py
@@ -1,0 +1,170 @@
+"""Unit tests for tools.tt_ingest.tt_vulcan (issue #353)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.tt_ingest.tt_vulcan import (
+    VULCAN_BASE,
+    SessionsPage,
+    TTVulcanError,
+    fetch_sessions_page,
+    iter_all_sessions,
+    parse_sessions_page,
+    session_detail_url,
+    session_summary,
+    sessions_url,
+    split_session_id,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "tt_sessions_page.json"
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+# --- URL builders -----------------------------------------------------------------
+
+
+def test_sessions_url() -> None:
+    url = sessions_url("uid-1", limit=25, page=3)
+    assert url == f"{VULCAN_BASE}/users/uid-1/sessions?limit=25&page=3"
+
+
+def test_sessions_url_encodes_uid() -> None:
+    assert "uid%23weird" in sessions_url("uid#weird")
+
+
+def test_session_detail_url_encodes_hash() -> None:
+    url = session_detail_url("uid-1#sess-aaa")
+    assert "%23" in url
+    assert "#" not in url
+
+
+def test_split_session_id() -> None:
+    assert split_session_id("uid-1#sess-aaa") == ("uid-1", "sess-aaa")
+
+
+def test_split_session_id_errors() -> None:
+    with pytest.raises(TTVulcanError):
+        split_session_id("no-separator")
+    with pytest.raises(TTVulcanError):
+        split_session_id("uid#")
+
+
+# --- parse_sessions_page ----------------------------------------------------------
+
+
+def test_parse_sessions_page_from_fixture() -> None:
+    page = parse_sessions_page(_load_fixture())
+    assert isinstance(page, SessionsPage)
+    assert page.count == 3
+    assert page.limit == 50
+    assert len(page.sessions) == 3
+    assert page.cars["syn_mercedes_w09"]["name"] == "Mercedes W09"
+    assert "assettoCorsa" in page.games
+
+
+def test_sessions_page_total_pages() -> None:
+    page = SessionsPage(count=149, limit=50, page=1, sessions=[])
+    assert page.total_pages == 3
+    assert SessionsPage(count=0, limit=0, page=1, sessions=[]).total_pages == 1
+
+
+def test_parse_sessions_page_missing_data() -> None:
+    with pytest.raises(TTVulcanError):
+        parse_sessions_page({"message": "no data"})
+
+
+def test_parse_sessions_page_missing_sessions() -> None:
+    with pytest.raises(TTVulcanError):
+        parse_sessions_page({"data": {"count": 0}})
+
+
+def test_parse_sessions_page_skips_non_mapping_rows() -> None:
+    page = parse_sessions_page({"data": {"sessions": [{"id": "a#b"}, "garbage", 42]}})
+    assert len(page.sessions) == 1
+
+
+# --- session_summary --------------------------------------------------------------
+
+
+def test_session_summary_full() -> None:
+    page = parse_sessions_page(_load_fixture())
+    summary = session_summary(page.sessions[0])
+    assert "Mercedes W09" in summary
+    assert "Red Bull Ring" in summary
+    assert "64.321s" in summary
+
+
+def test_session_summary_degrades_gracefully() -> None:
+    summary = session_summary({"car_id": "x", "track_id": "y"})
+    assert "best —" in summary
+
+
+# --- network functions with fake http (wiring confidence) -------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeHttp:
+    def __init__(self, pages: list[dict]) -> None:
+        self._pages = pages
+        self.urls: list[str] = []
+
+    def get(self, url, headers=None, timeout=None):
+        self.urls.append(url)
+        # Authorization must be the RAW token (no 'Bearer ' prefix).
+        assert headers is not None and not headers["Authorization"].startswith("Bearer ")
+        page_idx = len(self.urls) - 1
+        return _FakeResponse(self._pages[min(page_idx, len(self._pages) - 1)])
+
+
+def test_fetch_sessions_page_with_fake_http() -> None:
+    http = _FakeHttp([_load_fixture()])
+    page = fetch_sessions_page("raw-access-token", "uid-1", http=http)
+    assert page.count == 3
+    assert "uid-1/sessions" in http.urls[0]
+
+
+def test_iter_all_sessions_paginates() -> None:
+    full = _load_fixture()
+    full["data"]["count"] = 6
+    full["data"]["limit"] = 3
+    page2 = json.loads(json.dumps(full))
+    page2["data"]["page"] = 2
+    http = _FakeHttp([full, page2])
+    rows = list(iter_all_sessions("tok", "uid-1", limit=3, http=http))
+    # 3 per page * 2 pages
+    assert len(rows) == 6
+    assert len(http.urls) == 2
+
+
+def test_iter_all_sessions_respects_max_pages() -> None:
+    full = _load_fixture()
+    full["data"]["count"] = 9
+    full["data"]["limit"] = 3
+    http = _FakeHttp([full])
+    rows = list(iter_all_sessions("tok", "uid-1", limit=3, http=http, max_pages=1))
+    assert len(rows) == 3
+    assert len(http.urls) == 1
+
+
+def test_fetch_sessions_page_http_error() -> None:
+    class _ErrHttp:
+        def get(self, url, headers=None, timeout=None):
+            return _FakeResponse({}, status_code=403)
+
+    with pytest.raises(TTVulcanError):
+        fetch_sessions_page("tok", "uid-1", http=_ErrHttp())

--- a/tools/tt_ingest/__init__.py
+++ b/tools/tt_ingest/__init__.py
@@ -1,0 +1,88 @@
+"""Track Titan ingest — retain + parse the operator's own post-race analysis data.
+
+Milestone M-TT0 (this package's first slice, issue #353): **vulcan** retention —
+discover the operator's personal refresh token, mint short-lived Cognito tokens,
+paginate the sessions list, and retain every session immutably to the lake keyed by
+car + track + setup. The services per-corner traces (M-TT1) and the reference-lap →
+``lap_archive`` bridge that feeds M0 voice coaching (M-TT2) build on this foundation.
+
+SECURITY: tokens are personal secrets — never logged, never committed. Only public
+Cognito identifiers are hardcoded (env-overridable). See :mod:`tools.tt_ingest.tt_auth`.
+"""
+
+from __future__ import annotations
+
+from tools.tt_ingest.cli import ExportSummary, build_arg_parser, main, retain_sessions
+from tools.tt_ingest.tt_auth import (
+    MintedTokens,
+    TTAuthError,
+    TTConfig,
+    build_initiate_auth_request,
+    decode_jwt_payload,
+    extract_refresh_token_from_text,
+    extract_uid_from_text,
+    is_token_expired,
+    parse_initiate_auth_response,
+    resolve_refresh_token,
+    token_expiry,
+    uid_from_token,
+)
+from tools.tt_ingest.tt_export import (
+    RetainedFile,
+    TTExportError,
+    WriteResult,
+    build_index,
+    lake_root,
+    sanitize_segment,
+    session_lake_dir,
+    write_immutable_json,
+)
+from tools.tt_ingest.tt_normalize import (
+    build_sessions_index,
+    normalize_session,
+    normalize_sessions,
+)
+from tools.tt_ingest.tt_vulcan import (
+    SessionsPage,
+    TTVulcanError,
+    parse_sessions_page,
+    session_summary,
+    sessions_url,
+    split_session_id,
+)
+
+__all__ = [
+    "ExportSummary",
+    "MintedTokens",
+    "RetainedFile",
+    "SessionsPage",
+    "TTAuthError",
+    "TTConfig",
+    "TTExportError",
+    "TTVulcanError",
+    "WriteResult",
+    "build_arg_parser",
+    "build_index",
+    "build_initiate_auth_request",
+    "build_sessions_index",
+    "decode_jwt_payload",
+    "extract_refresh_token_from_text",
+    "extract_uid_from_text",
+    "is_token_expired",
+    "lake_root",
+    "main",
+    "normalize_session",
+    "normalize_sessions",
+    "parse_initiate_auth_response",
+    "parse_sessions_page",
+    "resolve_refresh_token",
+    "retain_sessions",
+    "sanitize_segment",
+    "session_lake_dir",
+    "session_summary",
+    "sessions_url",
+    "split_session_id",
+    "token_expiry",
+    "uid_from_token",
+    "write_immutable_json",
+]

--- a/tools/tt_ingest/__init__.py
+++ b/tools/tt_ingest/__init__.py
@@ -12,7 +12,13 @@ Cognito identifiers are hardcoded (env-overridable). See :mod:`tools.tt_ingest.t
 
 from __future__ import annotations
 
-from tools.tt_ingest.cli import ExportSummary, build_arg_parser, main, retain_sessions
+from tools.tt_ingest.cli import (
+    ExportSummary,
+    build_arg_parser,
+    main,
+    reindex_lake,
+    retain_sessions,
+)
 from tools.tt_ingest.tt_auth import (
     MintedTokens,
     TTAuthError,
@@ -76,6 +82,7 @@ __all__ = [
     "normalize_sessions",
     "parse_initiate_auth_response",
     "parse_sessions_page",
+    "reindex_lake",
     "resolve_refresh_token",
     "retain_sessions",
     "sanitize_segment",

--- a/tools/tt_ingest/__init__.py
+++ b/tools/tt_ingest/__init__.py
@@ -35,6 +35,7 @@ from tools.tt_ingest.tt_export import (
     lake_root,
     sanitize_segment,
     session_lake_dir,
+    stable_fingerprint,
     write_immutable_json,
 )
 from tools.tt_ingest.tt_normalize import (
@@ -82,6 +83,7 @@ __all__ = [
     "session_summary",
     "sessions_url",
     "split_session_id",
+    "stable_fingerprint",
     "token_expiry",
     "uid_from_token",
     "write_immutable_json",

--- a/tools/tt_ingest/__main__.py
+++ b/tools/tt_ingest/__main__.py
@@ -1,0 +1,10 @@
+"""CLI entrypoint for ``python -m tools.tt_ingest`` (issue #353)."""
+
+from __future__ import annotations
+
+import sys
+
+from tools.tt_ingest.cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -1,0 +1,220 @@
+"""CLI + orchestration for ``python -m tools.tt_ingest`` (issue #353, M-TT0).
+
+The local retention pipeline (:func:`retain_sessions`) is pure-of-network and fully
+unit-tested against ``tmp_path``: given already-fetched raw sessions it normalizes,
+immutably retains, and indexes them. The network entrypoints (token mint + page
+fetch) are thin and ``# pragma: no cover`` — they are proven live, not in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from tools.tt_ingest.tt_auth import (
+    TTAuthError,
+    TTConfig,
+    is_token_expired,
+    mint_tokens,
+    resolve_refresh_token,
+    token_expiry,
+    uid_from_token,
+)
+from tools.tt_ingest.tt_export import (
+    INDEX_FILENAME,
+    RetainedFile,
+    build_index,
+    endpoint_file,
+    lake_root,
+    relative_to_lake,
+    session_lake_dir,
+    write_immutable_json,
+)
+from tools.tt_ingest.tt_normalize import build_sessions_index, normalize_session
+from tools.tt_ingest.tt_vulcan import iter_all_sessions, session_summary
+
+SESSIONS_INDEX_FILENAME = "sessions_index.json"
+RAW_SESSION_ENDPOINT = "session"
+
+
+@dataclass(frozen=True)
+class ExportSummary:
+    """Outcome of a retention run."""
+
+    total: int
+    retained_new: int
+    skipped_existing: int
+    lake_root: Path
+
+    def render(self) -> str:
+        return (
+            f"retained {self.total} session(s) to {self.lake_root} "
+            f"({self.retained_new} new, {self.skipped_existing} already present)"
+        )
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def retain_sessions(
+    sessions: Sequence[Mapping[str, Any]],
+    *,
+    lake_base: Path | None = None,
+    generated_at: str | None = None,
+    overwrite: bool = False,
+) -> ExportSummary:
+    """Normalize, immutably retain, and index a batch of raw vulcan sessions.
+
+    Each raw session is written write-once under
+    ``journal/tt/{game}/{car}/{track}/{sessionKey}/session.json``; derived
+    ``sessions_index.json`` + content-addressed ``index.json`` are (re)written at the
+    lake root. Returns counts of new vs. already-present files.
+    """
+    root = lake_root(lake_base)
+    stamp = generated_at or _iso_now()
+    records: list[RetainedFile] = []
+    normalized: list[dict[str, Any]] = []
+    retained_new = 0
+
+    for raw in sessions:
+        row = normalize_session(raw)
+        normalized.append(row)
+        session_key = row.get("session_key") or row.get("session_id") or "unknown_session"
+        target_dir = session_lake_dir(
+            root,
+            game=row.get("game_id"),
+            car=row.get("car_id"),
+            track=row.get("track_id"),
+            session_key=session_key,
+        )
+        path = endpoint_file(target_dir, RAW_SESSION_ENDPOINT)
+        result = write_immutable_json(path, dict(raw), overwrite=overwrite)
+        if result.written:
+            retained_new += 1
+        records.append(
+            RetainedFile(
+                session_key=str(session_key),
+                endpoint=RAW_SESSION_ENDPOINT,
+                relative_path=relative_to_lake(result.path, root),
+                sha256=result.sha256,
+                bytes=result.bytes,
+                written=result.written,
+            )
+        )
+
+    root.mkdir(parents=True, exist_ok=True)
+    write_immutable_json(
+        root / SESSIONS_INDEX_FILENAME,
+        build_sessions_index(normalized, generated_at=stamp),
+        overwrite=True,
+    )
+    write_immutable_json(
+        root / INDEX_FILENAME, build_index(records, generated_at=stamp), overwrite=True
+    )
+    return ExportSummary(
+        total=len(records),
+        retained_new=retained_new,
+        skipped_existing=len(records) - retained_new,
+        lake_root=root,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the ``tools.tt_ingest`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.tt_ingest",
+        description="Retain + index Track Titan post-race session data (issue #353).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    auth = sub.add_parser(
+        "auth-check",
+        help="Resolve the refresh token and mint access/id tokens (prints no secrets).",
+    )
+    auth.add_argument("--leveldb-dir", type=Path, default=None)
+
+    export = sub.add_parser(
+        "export", help="Paginate the sessions list and retain it immutably to the lake."
+    )
+    export.add_argument("--uid", default=None, help="User id; defaults to the token 'sub'.")
+    export.add_argument("--limit", type=int, default=50, help="Page size (default 50).")
+    export.add_argument(
+        "--max-pages", type=int, default=None, help="Cap pages fetched (default: all)."
+    )
+    export.add_argument(
+        "--lake-base",
+        type=Path,
+        default=None,
+        help="Base dir for the journal/tt lake (default: cwd).",
+    )
+    export.add_argument("--leveldb-dir", type=Path, default=None)
+    export.add_argument("--overwrite", action="store_true", help="Re-retain existing files.")
+    export.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch page 1 and print a sanitized summary; write nothing.",
+    )
+    return parser
+
+
+def _print(message: str) -> None:  # pragma: no cover - thin stdout shim
+    print(message)
+
+
+def cmd_auth_check(args: argparse.Namespace) -> int:  # pragma: no cover - network
+    config = TTConfig.from_env()
+    refresh = resolve_refresh_token(config, leveldb_dir=args.leveldb_dir)
+    minted = mint_tokens(refresh, config)
+    uid = uid_from_token(minted.access_token)
+    expiry = token_expiry(minted.access_token)
+    expired = is_token_expired(minted.access_token)
+    _print(f"auth-check OK — uid={uid}")
+    _print(f"  access token expires: {expiry.isoformat() if expiry else '?'} (expired={expired})")
+    return 0
+
+
+def cmd_export(args: argparse.Namespace) -> int:  # pragma: no cover - network
+    config = TTConfig.from_env()
+    refresh = resolve_refresh_token(config, leveldb_dir=args.leveldb_dir)
+    minted = mint_tokens(refresh, config)
+    uid = args.uid or uid_from_token(minted.access_token)
+
+    if args.dry_run:
+        from tools.tt_ingest.tt_vulcan import fetch_sessions_page
+
+        page = fetch_sessions_page(minted.access_token, uid, limit=args.limit, page=1)
+        _print(f"dry-run — uid={uid}, count={page.count}, page size={page.limit}")
+        for session in page.sessions[:10]:
+            _print(f"  {session_summary(session)}")
+        return 0
+
+    sessions = list(
+        iter_all_sessions(minted.access_token, uid, limit=args.limit, max_pages=args.max_pages)
+    )
+    summary = retain_sessions(sessions, lake_base=args.lake_base, overwrite=args.overwrite)
+    _print(summary.render())
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "auth-check":
+            return cmd_auth_check(args)
+        if args.command == "export":
+            return cmd_export(args)
+    except TTAuthError as exc:  # pragma: no cover - surfaced live
+        parser.exit(2, f"tt_ingest: {exc}\n")
+    parser.error(f"unknown command: {args.command}")  # pragma: no cover - argparse guards
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -28,11 +28,13 @@ from tools.tt_ingest.tt_auth import (
 from tools.tt_ingest.tt_export import (
     INDEX_FILENAME,
     RetainedFile,
+    TTExportError,
     build_index,
     endpoint_file,
     lake_root,
     relative_to_lake,
     session_lake_dir,
+    stable_fingerprint,
     write_immutable_json,
 )
 from tools.tt_ingest.tt_normalize import build_sessions_index, normalize_session
@@ -50,12 +52,16 @@ class ExportSummary:
     retained_new: int
     skipped_existing: int
     lake_root: Path
+    failed: int = 0
 
     def render(self) -> str:
-        return (
+        base = (
             f"retained {self.total} session(s) to {self.lake_root} "
             f"({self.retained_new} new, {self.skipped_existing} already present)"
         )
+        if self.failed:
+            base += f"; {self.failed} session(s) skipped due to errors"
+        return base
 
 
 def _iso_now() -> str:
@@ -81,20 +87,35 @@ def retain_sessions(
     records: list[RetainedFile] = []
     normalized: list[dict[str, Any]] = []
     retained_new = 0
+    failed = 0
 
     for raw in sessions:
-        row = normalize_session(raw)
+        try:
+            row = normalize_session(raw)
+            # Distinct sessions must never collapse onto one lake path. A real vulcan id
+            # is unique per session; for a degraded session lacking one, key on a content
+            # fingerprint so two different id-less payloads stay distinct (a true duplicate
+            # still de-dupes) — never the single literal bucket that silently drops data.
+            session_key = (
+                row.get("session_key")
+                or row.get("session_id")
+                or f"nokey-{stable_fingerprint(raw)}"
+            )
+            target_dir = session_lake_dir(
+                root,
+                game=row.get("game_id"),
+                car=row.get("car_id"),
+                track=row.get("track_id"),
+                session_key=session_key,
+            )
+            path = endpoint_file(target_dir, RAW_SESSION_ENDPOINT)
+            # Raw retention is lossless: allow_nan keeps non-finite telemetry floats.
+            result = write_immutable_json(path, dict(raw), overwrite=overwrite, allow_nan=True)
+        except (OSError, ValueError, TypeError, TTExportError):
+            # One malformed session must never abort the whole batch or the indexes.
+            failed += 1
+            continue
         normalized.append(row)
-        session_key = row.get("session_key") or row.get("session_id") or "unknown_session"
-        target_dir = session_lake_dir(
-            root,
-            game=row.get("game_id"),
-            car=row.get("car_id"),
-            track=row.get("track_id"),
-            session_key=session_key,
-        )
-        path = endpoint_file(target_dir, RAW_SESSION_ENDPOINT)
-        result = write_immutable_json(path, dict(raw), overwrite=overwrite)
         if result.written:
             retained_new += 1
         records.append(
@@ -109,10 +130,13 @@ def retain_sessions(
         )
 
     root.mkdir(parents=True, exist_ok=True)
+    # sessions_index carries normalized telemetry conditions → allow_nan for the same
+    # lossless reason; the file index (hashes/sizes/paths only) stays strict JSON.
     write_immutable_json(
         root / SESSIONS_INDEX_FILENAME,
         build_sessions_index(normalized, generated_at=stamp),
         overwrite=True,
+        allow_nan=True,
     )
     write_immutable_json(
         root / INDEX_FILENAME, build_index(records, generated_at=stamp), overwrite=True
@@ -121,6 +145,7 @@ def retain_sessions(
         total=len(records),
         retained_new=retained_new,
         skipped_existing=len(records) - retained_new,
+        failed=failed,
         lake_root=root,
     )
 

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -9,6 +9,7 @@ fetch) are thin and ``# pragma: no cover`` — they are proven live, not in CI.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -34,6 +35,7 @@ from tools.tt_ingest.tt_export import (
     lake_root,
     relative_to_lake,
     session_lake_dir,
+    sha256_hex,
     stable_fingerprint,
     write_immutable_json,
 )
@@ -53,11 +55,13 @@ class ExportSummary:
     skipped_existing: int
     lake_root: Path
     failed: int = 0
+    indexed: int = 0
 
     def render(self) -> str:
         base = (
             f"retained {self.total} session(s) to {self.lake_root} "
-            f"({self.retained_new} new, {self.skipped_existing} already present)"
+            f"({self.retained_new} new, {self.skipped_existing} already present; "
+            f"{self.indexed} total in lake)"
         )
         if self.failed:
             base += f"; {self.failed} session(s) skipped due to errors"
@@ -68,25 +72,68 @@ def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def reindex_lake(root: Path, *, generated_at: str) -> int:
+    """Rebuild both derived indexes from EVERY ``session.json`` currently in the lake.
+
+    The indexes are a *derived view* of the immutable raw files — so they are rebuilt by
+    scanning the whole lake on disk, never from one batch's records. A partial export can
+    therefore never shrink the discovery index, and ``sessions_index.json`` always agrees
+    with the raw files actually present (no batch-vs-disk divergence). Returns the count of
+    indexed raw files.
+    """
+    records: list[RetainedFile] = []
+    normalized: list[dict[str, Any]] = []
+    for path in sorted(root.rglob(f"{RAW_SESSION_ENDPOINT}.json")):
+        try:
+            data = path.read_bytes()
+            raw = json.loads(data)
+        except (OSError, ValueError):  # pragma: no cover - corrupt file skipped defensively
+            continue
+        records.append(
+            RetainedFile(
+                session_key=path.parent.name,
+                endpoint=RAW_SESSION_ENDPOINT,
+                relative_path=relative_to_lake(path, root),
+                sha256=sha256_hex(data),
+                bytes=len(data),
+                written=False,
+            )
+        )
+        if isinstance(raw, Mapping):
+            normalized.append(normalize_session(raw))
+    root.mkdir(parents=True, exist_ok=True)
+    # sessions_index carries normalized telemetry conditions → allow_nan for lossless
+    # round-trip; the file index (hashes/sizes/paths only) stays strict, portable JSON.
+    write_immutable_json(
+        root / SESSIONS_INDEX_FILENAME,
+        build_sessions_index(normalized, generated_at=generated_at),
+        overwrite=True,
+        allow_nan=True,
+    )
+    write_immutable_json(
+        root / INDEX_FILENAME, build_index(records, generated_at=generated_at), overwrite=True
+    )
+    return len(records)
+
+
 def retain_sessions(
     sessions: Sequence[Mapping[str, Any]],
     *,
     lake_base: Path | None = None,
     generated_at: str | None = None,
-    overwrite: bool = False,
 ) -> ExportSummary:
-    """Normalize, immutably retain, and index a batch of raw vulcan sessions.
+    """Normalize, immutably retain, and (re)index a batch of raw vulcan sessions.
 
-    Each raw session is written write-once under
-    ``journal/tt/{game}/{car}/{track}/{sessionKey}/session.json``; derived
-    ``sessions_index.json`` + content-addressed ``index.json`` are (re)written at the
-    lake root. Returns counts of new vs. already-present files.
+    Each raw session is written **write-once** under
+    ``journal/tt/{game}/{car}/{track}/{sessionKey}/session.json`` — raw evidence is never
+    clobbered (data-immutability invariant). After the batch, both derived indexes are
+    rebuilt from the *entire* lake on disk (see :func:`reindex_lake`), so a partial export
+    never shrinks the index and the index always matches the immutable raw files.
     """
     root = lake_root(lake_base)
     stamp = generated_at or _iso_now()
-    records: list[RetainedFile] = []
-    normalized: list[dict[str, Any]] = []
     retained_new = 0
+    processed = 0
     failed = 0
 
     for raw in sessions:
@@ -109,44 +156,25 @@ def retain_sessions(
                 session_key=session_key,
             )
             path = endpoint_file(target_dir, RAW_SESSION_ENDPOINT)
-            # Raw retention is lossless: allow_nan keeps non-finite telemetry floats.
-            result = write_immutable_json(path, dict(raw), overwrite=overwrite, allow_nan=True)
+            # Raw retention is write-once (never overwrite) + lossless (allow_nan keeps
+            # non-finite telemetry floats).
+            result = write_immutable_json(path, dict(raw), allow_nan=True)
         except (OSError, ValueError, TypeError, TTExportError):
             # One malformed session must never abort the whole batch or the indexes.
             failed += 1
             continue
-        normalized.append(row)
+        processed += 1
         if result.written:
             retained_new += 1
-        records.append(
-            RetainedFile(
-                session_key=str(session_key),
-                endpoint=RAW_SESSION_ENDPOINT,
-                relative_path=relative_to_lake(result.path, root),
-                sha256=result.sha256,
-                bytes=result.bytes,
-                written=result.written,
-            )
-        )
 
-    root.mkdir(parents=True, exist_ok=True)
-    # sessions_index carries normalized telemetry conditions → allow_nan for the same
-    # lossless reason; the file index (hashes/sizes/paths only) stays strict JSON.
-    write_immutable_json(
-        root / SESSIONS_INDEX_FILENAME,
-        build_sessions_index(normalized, generated_at=stamp),
-        overwrite=True,
-        allow_nan=True,
-    )
-    write_immutable_json(
-        root / INDEX_FILENAME, build_index(records, generated_at=stamp), overwrite=True
-    )
+    indexed = reindex_lake(root, generated_at=stamp)
     return ExportSummary(
-        total=len(records),
+        total=processed,
         retained_new=retained_new,
-        skipped_existing=len(records) - retained_new,
+        skipped_existing=processed - retained_new,
         failed=failed,
         lake_root=root,
+        indexed=indexed,
     )
 
 
@@ -179,7 +207,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Base dir for the journal/tt lake (default: cwd).",
     )
     export.add_argument("--leveldb-dir", type=Path, default=None)
-    export.add_argument("--overwrite", action="store_true", help="Re-retain existing files.")
     export.add_argument(
         "--dry-run",
         action="store_true",
@@ -222,7 +249,7 @@ def cmd_export(args: argparse.Namespace) -> int:  # pragma: no cover - network
     sessions = list(
         iter_all_sessions(minted.access_token, uid, limit=args.limit, max_pages=args.max_pages)
     )
-    summary = retain_sessions(sessions, lake_base=args.lake_base, overwrite=args.overwrite)
+    summary = retain_sessions(sessions, lake_base=args.lake_base)
     _print(summary.render())
     return 0
 

--- a/tools/tt_ingest/tt_auth.py
+++ b/tools/tt_ingest/tt_auth.py
@@ -85,12 +85,12 @@ def _jwe_in_run(run: str) -> str | None:
     return None
 
 
-def _iter_jwes(text: str) -> Iterator[tuple[int, str]]:
-    """Yield ``(start_offset, jwe)`` for every 5-segment JWE in ``text`` (linear scan)."""
+def _iter_jwes(text: str) -> Iterator[str]:
+    """Yield each token-run's first 5-segment JWE in ``text`` (one linear pass)."""
     for run in _TOKEN_RUN_RE.finditer(text):
         jwe = _jwe_in_run(run.group(0))
         if jwe is not None:
-            yield run.start(), jwe
+            yield jwe
 
 
 class TTAuthError(RuntimeError):
@@ -223,18 +223,19 @@ def extract_refresh_token_from_text(text: str, *, app_client_id: str) -> str | N
     """
     key_re = re.compile(_REFRESH_TOKEN_KEY_RE_TEMPLATE.format(client=re.escape(app_client_id)))
     marker = key_re.search(text)
-    # One linear pass collects every JWE with its offset (no backtracking on a multi-MB blob).
-    candidates = list(_iter_jwes(text))
     if marker is not None:
-        after = marker.end()
-        for offset, jwe in candidates:
-            if offset >= after:
-                return jwe
+        # The value follows the key, so scan only the SUFFIX after the marker and take its
+        # first JWE. Slicing at marker.end() also guarantees the key word "refreshToken"
+        # can never be mistaken for a JWE first-segment — even when LevelDB stores the key
+        # and value in one ``[A-Za-z0-9_.-]+`` run with no separating control byte.
+        for jwe in _iter_jwes(text[marker.end() :]):
+            return jwe
+    # Fallback (marker absent — e.g. LevelDB compaction reordered key/value): the refresh
+    # token is the only 5-segment JWE on disk; prefer the longest incidental match.
+    candidates = list(_iter_jwes(text))
     if not candidates:
         return None
-    # Fallback: the refresh token is the only 5-segment JWE on disk; prefer the longest
-    # (the real ~1778-char JWE dwarfs any incidental match).
-    return max((jwe for _, jwe in candidates), key=len)
+    return max(candidates, key=len)
 
 
 def extract_uid_from_text(text: str, *, app_client_id: str) -> str | None:

--- a/tools/tt_ingest/tt_auth.py
+++ b/tools/tt_ingest/tt_auth.py
@@ -1,0 +1,358 @@
+"""Track Titan auth — discover the operator's personal refresh token and mint
+short-lived Cognito tokens for the vulcan (and, later, services) APIs (issue #353).
+
+SECURITY (issue #353 scope/ethics): this reads the **operator's own** Track Titan
+refresh token from their **own** machine for **personal** coaching use. The refresh
+token and any minted access/id tokens are **personal secrets** — this module never
+logs them, never embeds them in raised error messages, and callers must never
+persist them to tracked files (keep them in env / the gitignored lake only).
+
+Only public Cognito *identifiers* (region, user-pool / app-client / identity-pool
+ids) are hardcoded as defaults. Those are **not** credentials: the Electron app
+sends them in every *unauthenticated* request and they identify the app + pools,
+not the user. They are also env-overridable via ``TT_COGNITO_*`` so nothing is
+pinned in source. The user's ``refreshToken`` is the only secret, and it is never
+hardcoded.
+
+Module shape mirrors the repo convention (e.g. ``tools/process_miner``): the
+network round-trips are isolated and ``# pragma: no cover``; the request builders
+and response parsers are pure and unit-tested.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Public Cognito identifiers reverse-engineered from the Track Titan Electron app
+# config (``app.asar``) and verified live (issue #353). NOT secrets — see module
+# docstring. ``# pragma: allowlist secret`` tells detect-secrets these high-entropy
+# strings are public app identifiers, not credentials.
+_DEFAULT_REGION = "us-east-1"
+_DEFAULT_USER_POOL_ID = "us-east-1_fdm9kB5Wr"  # pragma: allowlist secret
+_DEFAULT_APP_CLIENT_ID = "6qp755fd6379572i96kt1hvu55"  # pragma: allowlist secret
+_DEFAULT_IDENTITY_POOL_ID = (
+    "us-east-1:03459aca-683c-4cc1-b2af-86b86705dd67"  # pragma: allowlist secret
+)
+
+DEFAULT_REQUEST_TIMEOUT_S = 30.0
+
+#: Local Storage LevelDB key the Electron app writes the refresh token under, e.g.
+#: ``CognitoIdentityServiceProvider.<clientId>.<uid>.refreshToken``.
+_REFRESH_TOKEN_KEY_RE_TEMPLATE = (
+    r"CognitoIdentityServiceProvider\.{client}\.(?P<uid>[^.\x00-\x1f]+)\.refreshToken"
+)
+_LAST_AUTH_USER_KEY_RE_TEMPLATE = r"CognitoIdentityServiceProvider\.{client}\.LastAuthUser"
+
+#: A Cognito refresh token is a 5-segment JWE (header.key.iv.ciphertext.tag), each
+#: segment base64url. Access / id tokens are 3-segment JWS, so the *5-segment* shape
+#: (four dots) — not the segment length — is what uniquely identifies the refresh
+#: token on disk. The per-segment minimums stay modest so synthetic/edge tokens match
+#: while the four-dot structure rejects any 3-segment JWS substring.
+_JWE_RE = re.compile(r"[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{6,}){4}")
+#: A printable token value (e.g. a uid) as it sits next to its key in the LevelDB blob.
+_TOKEN_VALUE_RE = re.compile(r"[A-Za-z0-9._-]{8,}")
+
+
+class TTAuthError(RuntimeError):
+    """Auth problem the operator can correct (missing token, malformed JWT, mint failure).
+
+    Never carries token material in its message — only the actionable cause.
+    """
+
+
+@dataclass(frozen=True)
+class TTConfig:
+    """Public Track Titan / Cognito configuration (no secrets)."""
+
+    region: str = _DEFAULT_REGION
+    user_pool_id: str = _DEFAULT_USER_POOL_ID
+    app_client_id: str = _DEFAULT_APP_CLIENT_ID
+    identity_pool_id: str = _DEFAULT_IDENTITY_POOL_ID
+
+    @property
+    def idp_url(self) -> str:
+        """Cognito IDP endpoint used for ``InitiateAuth`` (refresh → access/id)."""
+        return f"https://cognito-idp.{self.region}.amazonaws.com/"
+
+    @property
+    def identity_url(self) -> str:
+        """Cognito Identity-Pool endpoint (``GetId`` / ``GetCredentialsForIdentity``)."""
+        return f"https://cognito-identity.{self.region}.amazonaws.com/"
+
+    @property
+    def user_pool_provider(self) -> str:
+        """The ``Logins`` provider key for federating the user-pool id token."""
+        return f"cognito-idp.{self.region}.amazonaws.com/{self.user_pool_id}"
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> TTConfig:
+        """Build config, letting ``TT_COGNITO_*`` env vars override the public defaults."""
+        e = os.environ if env is None else env
+        return cls(
+            region=e.get("TT_COGNITO_REGION", _DEFAULT_REGION),
+            user_pool_id=e.get("TT_COGNITO_USER_POOL_ID", _DEFAULT_USER_POOL_ID),
+            app_client_id=e.get("TT_COGNITO_CLIENT_ID", _DEFAULT_APP_CLIENT_ID),
+            identity_pool_id=e.get("TT_COGNITO_IDENTITY_POOL_ID", _DEFAULT_IDENTITY_POOL_ID),
+        )
+
+
+@dataclass(frozen=True)
+class MintedTokens:
+    """Result of a refresh → access/id token mint. Treat as a personal secret."""
+
+    access_token: str
+    id_token: str
+    expires_in: int
+    token_type: str = "Bearer"
+
+
+# --------------------------------------------------------------------------------------
+# Pure JWT helpers (operate on access / id tokens — the 3-segment JWS, never the JWE).
+# --------------------------------------------------------------------------------------
+
+
+def _b64url_decode(segment: str) -> bytes:
+    pad = "=" * (-len(segment) % 4)
+    try:
+        return base64.urlsafe_b64decode(segment + pad)
+    except (binascii.Error, ValueError) as exc:  # pragma: no cover - defensive
+        raise TTAuthError("malformed base64url in JWT segment") from exc
+
+
+def decode_jwt_payload(token: str) -> dict[str, Any]:
+    """Decode the (unverified) payload of a 3-segment JWS access/id token.
+
+    We never *verify* the signature — these tokens were just minted by Cognito for
+    our own request; we only read claims (``exp``, ``sub``) to schedule refresh and
+    discover the user id. Refresh tokens are 5-segment JWEs and are NOT decodable
+    here (their payload is encrypted) — that is intentional.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise TTAuthError(f"expected a 3-segment JWS, got {len(parts)} segments")
+    payload = _b64url_decode(parts[1])
+    try:
+        claims = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise TTAuthError("JWT payload is not valid JSON") from exc
+    if not isinstance(claims, dict):
+        raise TTAuthError("JWT payload is not a JSON object")
+    return claims
+
+
+def token_expiry(token: str) -> datetime | None:
+    """Return the token's ``exp`` as a tz-aware UTC datetime, or ``None`` if absent."""
+    exp = decode_jwt_payload(token).get("exp")
+    if exp is None:
+        return None
+    try:
+        return datetime.fromtimestamp(float(exp), tz=UTC)
+    except (TypeError, ValueError, OverflowError, OSError) as exc:
+        raise TTAuthError("JWT exp claim is not a valid timestamp") from exc
+
+
+def is_token_expired(token: str, *, skew_s: float = 60.0, now: datetime | None = None) -> bool:
+    """True if the token is expired (or within ``skew_s`` of expiry). No ``exp`` → expired."""
+    expiry = token_expiry(token)
+    if expiry is None:
+        return True
+    current = datetime.now(UTC) if now is None else now
+    return (expiry.timestamp() - current.timestamp()) <= skew_s
+
+
+def uid_from_token(token: str) -> str:
+    """Extract the Cognito user id (``sub``) from a decoded access/id token."""
+    sub = decode_jwt_payload(token).get("sub")
+    if not isinstance(sub, str) or not sub:
+        raise TTAuthError("token has no usable 'sub' claim")
+    return sub
+
+
+# --------------------------------------------------------------------------------------
+# Pure refresh-token discovery (operate on already-read LevelDB text).
+# --------------------------------------------------------------------------------------
+
+
+def extract_refresh_token_from_text(text: str, *, app_client_id: str) -> str | None:
+    """Find the refresh-token JWE in a Local Storage LevelDB blob decoded as text.
+
+    Strategy: locate the ``...<clientId>.<uid>.refreshToken`` key, then return the
+    first 5-segment JWE that appears after it. Falls back to "the single 5-segment
+    JWE anywhere in the blob" when the key marker is absent (LevelDB compaction can
+    reorder key/value bytes). Returns ``None`` when no JWE is present.
+    """
+    key_re = re.compile(_REFRESH_TOKEN_KEY_RE_TEMPLATE.format(client=re.escape(app_client_id)))
+    marker = key_re.search(text)
+    if marker is not None:
+        after = text[marker.end() :]
+        jwe = _JWE_RE.search(after)
+        if jwe is not None:
+            return jwe.group(0)
+    # Fallback: the refresh token is the only 5-segment JWE on disk.
+    candidates = _JWE_RE.findall(text)
+    if not candidates:
+        return None
+    # Prefer the longest (the real ~1778-char JWE dwarfs any incidental match).
+    return max(candidates, key=len)
+
+
+def extract_uid_from_text(text: str, *, app_client_id: str) -> str | None:
+    """Extract the logged-in user id from the LevelDB blob, if present.
+
+    Prefers the ``<clientId>.<uid>.refreshToken`` key (uid is the captured group);
+    falls back to the value written next to the ``LastAuthUser`` key.
+    """
+    key_re = re.compile(_REFRESH_TOKEN_KEY_RE_TEMPLATE.format(client=re.escape(app_client_id)))
+    marker = key_re.search(text)
+    if marker is not None:
+        uid = marker.group("uid").strip()
+        if uid:
+            return uid
+    last_auth_re = re.compile(
+        _LAST_AUTH_USER_KEY_RE_TEMPLATE.format(client=re.escape(app_client_id))
+    )
+    last = last_auth_re.search(text)
+    if last is not None:
+        value = _TOKEN_VALUE_RE.search(text[last.end() :])
+        if value is not None:
+            return value.group(0)
+    return None
+
+
+def default_leveldb_dir(env: Mapping[str, str] | None = None) -> Path | None:
+    """Default path to the Track Titan Local Storage LevelDB directory on Windows."""
+    e = os.environ if env is None else env
+    appdata = e.get("APPDATA")
+    if not appdata:
+        return None
+    return Path(appdata) / "track-titan-ghost-application" / "Local Storage" / "leveldb"
+
+
+def _read_leveldb_text(leveldb_dir: Path) -> str:
+    """Read every ``*.ldb`` / ``*.log`` file in the dir and decode leniently.
+
+    Best-effort, file-IO only (``# pragma: no cover`` — exercised live, not in CI):
+    Chromium holds the active ``.log`` open while the app runs; we read what we can
+    and skip locked files so a running Track Titan never blocks discovery when other
+    SSTables already hold the token.
+    """
+    chunks: list[str] = []
+    for path in sorted(leveldb_dir.glob("*")):  # pragma: no cover - local file IO
+        if path.suffix.lower() not in {".ldb", ".log"}:
+            continue
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        chunks.append(raw.decode("latin-1", errors="replace"))
+    return "\n".join(chunks)
+
+
+def resolve_refresh_token(
+    config: TTConfig,
+    *,
+    leveldb_dir: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Resolve the operator's refresh token: ``TT_REFRESH_TOKEN`` env first, then disk.
+
+    Raises :class:`TTAuthError` (with no token material) when neither source yields a
+    token, telling the operator how to provide one.
+    """
+    e = os.environ if env is None else env
+    env_token = e.get("TT_REFRESH_TOKEN", "").strip()
+    if env_token:
+        return env_token
+    search_dir = leveldb_dir if leveldb_dir is not None else default_leveldb_dir(e)
+    if search_dir is not None and search_dir.is_dir():  # pragma: no cover - local file IO
+        text = _read_leveldb_text(search_dir)
+        token = extract_refresh_token_from_text(text, app_client_id=config.app_client_id)
+        if token:
+            return token
+    raise TTAuthError(
+        "no Track Titan refresh token found. Set TT_REFRESH_TOKEN (preferred; source "
+        "from Doppler / your shell) or ensure the Track Titan desktop app has been "
+        "signed in so its Local Storage LevelDB holds a refreshToken."
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Cognito InitiateAuth (refresh → access/id). Request builder + parser are pure; the
+# HTTP round-trip is isolated and ``# pragma: no cover``.
+# --------------------------------------------------------------------------------------
+
+
+def build_initiate_auth_request(
+    refresh_token: str, config: TTConfig
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """Build the (url, headers, json-body) for a Cognito ``REFRESH_TOKEN_AUTH`` call."""
+    headers = {
+        "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+        "Content-Type": "application/x-amz-json-1.1",
+    }
+    body = {
+        "AuthFlow": "REFRESH_TOKEN_AUTH",
+        "ClientId": config.app_client_id,
+        "AuthParameters": {"REFRESH_TOKEN": refresh_token},
+    }
+    return config.idp_url, headers, body
+
+
+def parse_initiate_auth_response(payload: Mapping[str, Any]) -> MintedTokens:
+    """Parse Cognito's ``InitiateAuth`` response into :class:`MintedTokens`."""
+    result = payload.get("AuthenticationResult")
+    if not isinstance(result, Mapping):
+        raise TTAuthError("InitiateAuth response missing AuthenticationResult")
+    access_token = result.get("AccessToken")
+    id_token = result.get("IdToken")
+    if not isinstance(access_token, str) or not access_token:
+        raise TTAuthError("InitiateAuth response missing AccessToken")
+    if not isinstance(id_token, str) or not id_token:
+        raise TTAuthError("InitiateAuth response missing IdToken")
+    expires_in_raw = result.get("ExpiresIn", 3600)
+    try:
+        expires_in = int(expires_in_raw)
+    except (TypeError, ValueError):
+        expires_in = 3600
+    token_type = result.get("TokenType")
+    return MintedTokens(
+        access_token=access_token,
+        id_token=id_token,
+        expires_in=expires_in,
+        token_type=token_type if isinstance(token_type, str) and token_type else "Bearer",
+    )
+
+
+def mint_tokens(
+    refresh_token: str,
+    config: TTConfig | None = None,
+    *,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> MintedTokens:  # pragma: no cover - network round-trip, verified live (issue #353)
+    """Exchange a refresh token for fresh access + id tokens via Cognito InitiateAuth.
+
+    ``http`` may be any object exposing ``post(url, headers=, json=, timeout=)`` (a
+    ``requests.Session``); defaults to a lazily imported ``requests``.
+    """
+    cfg = config or TTConfig.from_env()
+    url, headers, body = build_initiate_auth_request(refresh_token, cfg)
+    client = http
+    if client is None:
+        import requests as requests_mod
+
+        client = requests_mod
+    response = client.post(url, headers=headers, json=body, timeout=timeout)
+    if getattr(response, "status_code", 200) >= 400:
+        # Surface status only — never the response body, which can echo token material.
+        raise TTAuthError(f"Cognito InitiateAuth failed with HTTP {response.status_code}")
+    return parse_initiate_auth_response(response.json())

--- a/tools/tt_ingest/tt_auth.py
+++ b/tools/tt_ingest/tt_auth.py
@@ -26,7 +26,7 @@ import binascii
 import json
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -55,11 +55,42 @@ _LAST_AUTH_USER_KEY_RE_TEMPLATE = r"CognitoIdentityServiceProvider\.{client}\.La
 #: A Cognito refresh token is a 5-segment JWE (header.key.iv.ciphertext.tag), each
 #: segment base64url. Access / id tokens are 3-segment JWS, so the *5-segment* shape
 #: (four dots) — not the segment length — is what uniquely identifies the refresh
-#: token on disk. The per-segment minimums stay modest so synthetic/edge tokens match
-#: while the four-dot structure rejects any 3-segment JWS substring.
-_JWE_RE = re.compile(r"[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{6,}){4}")
+#: token on disk. We match it with a LINEAR scan, never a single backtracking regex:
+#: ``_TOKEN_RUN_RE`` is one character class (so it scans a multi-MB LevelDB blob in
+#: O(n) with no catastrophic backtracking), then each run is split on ``.`` and the
+#: five-consecutive-segment window is validated in Python. The per-segment minimums
+#: stay modest so synthetic/edge tokens match while the four-dot structure rejects any
+#: 3-segment JWS substring.
+_TOKEN_RUN_RE = re.compile(r"[A-Za-z0-9_.-]+")
+_JWE_SEGMENTS = 5
+_JWE_FIRST_MIN = 8
+_JWE_REST_MIN = 6
 #: A printable token value (e.g. a uid) as it sits next to its key in the LevelDB blob.
 _TOKEN_VALUE_RE = re.compile(r"[A-Za-z0-9._-]{8,}")
+
+
+def _jwe_in_run(run: str) -> str | None:
+    """Return the first 5-segment JWE inside a dot-joined token run, else ``None``.
+
+    Linear in ``len(run)``: a single ``str.split`` plus a sliding window over the
+    resulting segments — no regex backtracking.
+    """
+    parts = run.split(".")
+    if len(parts) < _JWE_SEGMENTS:
+        return None
+    for i in range(len(parts) - _JWE_SEGMENTS + 1):
+        window = parts[i : i + _JWE_SEGMENTS]
+        if len(window[0]) >= _JWE_FIRST_MIN and all(len(p) >= _JWE_REST_MIN for p in window[1:]):
+            return ".".join(window)
+    return None
+
+
+def _iter_jwes(text: str) -> Iterator[tuple[int, str]]:
+    """Yield ``(start_offset, jwe)`` for every 5-segment JWE in ``text`` (linear scan)."""
+    for run in _TOKEN_RUN_RE.finditer(text):
+        jwe = _jwe_in_run(run.group(0))
+        if jwe is not None:
+            yield run.start(), jwe
 
 
 class TTAuthError(RuntimeError):
@@ -192,17 +223,18 @@ def extract_refresh_token_from_text(text: str, *, app_client_id: str) -> str | N
     """
     key_re = re.compile(_REFRESH_TOKEN_KEY_RE_TEMPLATE.format(client=re.escape(app_client_id)))
     marker = key_re.search(text)
+    # One linear pass collects every JWE with its offset (no backtracking on a multi-MB blob).
+    candidates = list(_iter_jwes(text))
     if marker is not None:
-        after = text[marker.end() :]
-        jwe = _JWE_RE.search(after)
-        if jwe is not None:
-            return jwe.group(0)
-    # Fallback: the refresh token is the only 5-segment JWE on disk.
-    candidates = _JWE_RE.findall(text)
+        after = marker.end()
+        for offset, jwe in candidates:
+            if offset >= after:
+                return jwe
     if not candidates:
         return None
-    # Prefer the longest (the real ~1778-char JWE dwarfs any incidental match).
-    return max(candidates, key=len)
+    # Fallback: the refresh token is the only 5-segment JWE on disk; prefer the longest
+    # (the real ~1778-char JWE dwarfs any incidental match).
+    return max((jwe for _, jwe in candidates), key=len)
 
 
 def extract_uid_from_text(text: str, *, app_client_id: str) -> str | None:
@@ -351,7 +383,13 @@ def mint_tokens(
         import requests as requests_mod
 
         client = requests_mod
-    response = client.post(url, headers=headers, json=body, timeout=timeout)
+    try:
+        response = client.post(url, headers=headers, json=body, timeout=timeout)
+    except Exception as exc:
+        # Belt-and-suspenders for invariant (1): the request body carries the refresh
+        # token, so re-raise transport failures with only the exception *type* name and
+        # NO chained cause, so no library traceback (which could echo the request) escapes.
+        raise TTAuthError(f"Cognito InitiateAuth request failed: {type(exc).__name__}") from None
     if getattr(response, "status_code", 200) >= 400:
         # Surface status only — never the response body, which can echo token material.
         raise TTAuthError(f"Cognito InitiateAuth failed with HTTP {response.status_code}")

--- a/tools/tt_ingest/tt_export.py
+++ b/tools/tt_ingest/tt_export.py
@@ -18,7 +18,6 @@ import json
 import os
 import re
 import tempfile
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -44,16 +43,14 @@ def sanitize_segment(value: Any, *, fallback: str = "unknown") -> str:
     return text[:128]
 
 
-def lake_root(base: Path | str | None = None, *, env: Mapping[str, str] | None = None) -> Path:
-    """Resolve the Track Titan lake root (``<base>/journal/tt``).
+def lake_root(base: Path | str | None = None) -> Path:
+    """Resolve the Track Titan lake root (``<base>/journal/tt``; default ``base``: cwd).
 
-    ``TT_LAKE_DIR`` overrides the location wholesale; otherwise the lake lives under
-    ``journal/`` at ``base`` (default: cwd), matching the coaching-lake convention.
+    Retention ALWAYS nests under ``journal/tt`` of the given base, matching the
+    coaching-lake convention that application writes stay inside ``journal/``. There is
+    deliberately no env override that could redirect the write root to an arbitrary
+    filesystem location — the operator chooses the base explicitly via ``--lake-base``.
     """
-    e = os.environ if env is None else env
-    override = e.get("TT_LAKE_DIR")
-    if override:
-        return Path(override)
     root = Path(base) if base is not None else Path.cwd()
     return root / "journal" / LAKE_SUBDIR
 

--- a/tools/tt_ingest/tt_export.py
+++ b/tools/tt_ingest/tt_export.py
@@ -74,15 +74,24 @@ def endpoint_file(session_dir: Path, endpoint: str) -> Path:
     return session_dir / f"{sanitize_segment(endpoint, fallback='endpoint')}.json"
 
 
-def _serialize(payload: Any) -> bytes:
+def _serialize(payload: Any, *, allow_nan: bool = False) -> bytes:
     return (
-        json.dumps(payload, separators=(",", ":"), sort_keys=True, allow_nan=False) + "\n"
+        json.dumps(payload, separators=(",", ":"), sort_keys=True, allow_nan=allow_nan) + "\n"
     ).encode("utf-8")
 
 
 def sha256_hex(data: bytes) -> str:
     """Hex sha256 of bytes."""
     return hashlib.sha256(data).hexdigest()
+
+
+def stable_fingerprint(payload: Any, *, length: int = 12) -> str:
+    """A short, deterministic content fingerprint of ``payload`` (sha256 of canonical JSON).
+
+    Used to key retention for sessions that lack a usable id, so two *distinct* id-less
+    payloads never collapse onto one lake path (which would silently drop the second).
+    """
+    return sha256_hex(_serialize(payload, allow_nan=True))[:length]
 
 
 @dataclass(frozen=True)
@@ -95,15 +104,22 @@ class WriteResult:
     bytes: int
 
 
-def write_immutable_json(path: Path, payload: Any, *, overwrite: bool = False) -> WriteResult:
+def write_immutable_json(
+    path: Path, payload: Any, *, overwrite: bool = False, allow_nan: bool = False
+) -> WriteResult:
     """Atomically write ``payload`` as JSON, refusing to clobber an existing file.
 
     Write-once is the default: if ``path`` already exists and ``overwrite`` is False,
     nothing is written and ``WriteResult.written`` is False (with the *existing* file's
     hash, so the caller can still index it). Uses a temp file + ``os.replace`` so a
     crash never leaves a half-written record on disk.
+
+    ``allow_nan`` controls non-finite float handling: ``False`` (default) keeps derived
+    indexes as strict, portable JSON; raw retention passes ``True`` so a session carrying
+    a ``NaN``/``Infinity`` telemetry float is retained *losslessly* (it round-trips through
+    our own ``json.loads``) instead of raising and aborting the batch.
     """
-    data = _serialize(payload)
+    data = _serialize(payload, allow_nan=allow_nan)
     digest = sha256_hex(data)
     if path.exists():
         if not overwrite:

--- a/tools/tt_ingest/tt_export.py
+++ b/tools/tt_ingest/tt_export.py
@@ -1,0 +1,167 @@
+"""Immutable retention of raw Track Titan responses to the lake (issue #353, M-TT0).
+
+Raw vulcan/services JSON is **write-once**: keyed by car + track + setup under
+``journal/tt/{game}/{car}/{track}/{sessionKey}/{endpoint}.json`` and never edited in
+place (data-immutability invariant). A content-addressed index (``index.json`` at the
+lake root) records each retained file with its sha256 + byte size so silent
+corruption is *detected*, never assumed away.
+
+Path building, sanitization, hashing, and index assembly are pure and unit-tested.
+The only side effect is the atomic write in :func:`write_immutable_json`, which is
+exercised against ``tmp_path`` in tests (no network, no real lake).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+LAKE_SUBDIR = "tt"
+INDEX_FILENAME = "index.json"
+INDEX_SCHEMA_VERSION = 1
+
+#: Characters allowed in a single lake path segment; everything else collapses to ``_``.
+_SAFE_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class TTExportError(RuntimeError):
+    """A retention write would violate immutability or escape the lake root."""
+
+
+def sanitize_segment(value: Any, *, fallback: str = "unknown") -> str:
+    """Make ``value`` a safe single path segment (no separators, no traversal)."""
+    text = str(value).strip() if value not in (None, "") else ""
+    text = _SAFE_SEGMENT_RE.sub("_", text).strip("._")
+    if not text or text in {".", ".."}:
+        return fallback
+    return text[:128]
+
+
+def lake_root(base: Path | str | None = None, *, env: Mapping[str, str] | None = None) -> Path:
+    """Resolve the Track Titan lake root (``<base>/journal/tt``).
+
+    ``TT_LAKE_DIR`` overrides the location wholesale; otherwise the lake lives under
+    ``journal/`` at ``base`` (default: cwd), matching the coaching-lake convention.
+    """
+    e = os.environ if env is None else env
+    override = e.get("TT_LAKE_DIR")
+    if override:
+        return Path(override)
+    root = Path(base) if base is not None else Path.cwd()
+    return root / "journal" / LAKE_SUBDIR
+
+
+def session_lake_dir(root: Path, *, game: Any, car: Any, track: Any, session_key: Any) -> Path:
+    """Directory for one session's retained endpoints, with sanitized segments."""
+    return (
+        root
+        / sanitize_segment(game, fallback="unknown_game")
+        / sanitize_segment(car, fallback="unknown_car")
+        / sanitize_segment(track, fallback="unknown_track")
+        / sanitize_segment(session_key, fallback="unknown_session")
+    )
+
+
+def endpoint_file(session_dir: Path, endpoint: str) -> Path:
+    """Path to one endpoint's retained JSON within a session dir."""
+    return session_dir / f"{sanitize_segment(endpoint, fallback='endpoint')}.json"
+
+
+def _serialize(payload: Any) -> bytes:
+    return (
+        json.dumps(payload, separators=(",", ":"), sort_keys=True, allow_nan=False) + "\n"
+    ).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    """Hex sha256 of bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """Outcome of an immutable write."""
+
+    path: Path
+    written: bool
+    sha256: str
+    bytes: int
+
+
+def write_immutable_json(path: Path, payload: Any, *, overwrite: bool = False) -> WriteResult:
+    """Atomically write ``payload`` as JSON, refusing to clobber an existing file.
+
+    Write-once is the default: if ``path`` already exists and ``overwrite`` is False,
+    nothing is written and ``WriteResult.written`` is False (with the *existing* file's
+    hash, so the caller can still index it). Uses a temp file + ``os.replace`` so a
+    crash never leaves a half-written record on disk.
+    """
+    data = _serialize(payload)
+    digest = sha256_hex(data)
+    if path.exists():
+        if not overwrite:
+            existing = path.read_bytes()
+            return WriteResult(
+                path=path, written=False, sha256=sha256_hex(existing), bytes=len(existing)
+            )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        os.replace(tmp_name, path)
+    except BaseException:
+        # Clean up the temp file on any failure so the lake never accrues litter.
+        try:
+            os.unlink(tmp_name)
+        except OSError:  # pragma: no cover - best-effort cleanup
+            pass
+        raise
+    return WriteResult(path=path, written=True, sha256=digest, bytes=len(data))
+
+
+@dataclass(frozen=True)
+class RetainedFile:
+    """One retained endpoint file, as recorded in the lake index."""
+
+    session_key: str
+    endpoint: str
+    relative_path: str
+    sha256: str
+    bytes: int
+    written: bool
+
+
+def relative_to_lake(path: Path, root: Path) -> str:
+    """POSIX-style path of ``path`` relative to the lake ``root`` (index portability)."""
+    try:
+        rel = path.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise TTExportError(f"retained file {path} is outside lake root {root}") from exc
+    return rel.as_posix()
+
+
+def build_index(records: list[RetainedFile], *, generated_at: str) -> dict[str, Any]:
+    """Assemble the content-addressed lake index document from retained-file records."""
+    return {
+        "index_schema_version": INDEX_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "file_count": len(records),
+        "files": [
+            {
+                "session_key": r.session_key,
+                "endpoint": r.endpoint,
+                "path": r.relative_path,
+                "sha256": r.sha256,
+                "bytes": r.bytes,
+            }
+            for r in records
+        ],
+    }

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -1,0 +1,112 @@
+"""Normalize raw Track Titan vulcan sessions into a stable, queryable index row
+(issue #353, milestone M-TT0).
+
+The raw session JSON is retained immutably in the lake (``tt_export``); this layer
+projects each session into a flat, lossless-for-indexing row keyed by
+car + track + setup + conditions — the join key the autonomous harness and the
+coaching lake consume. The reference-lap → ``lap_archive`` schema bridge (the M0
+``--reference-archive`` feed) is milestone M-TT2 and lands separately.
+
+Pure functions only — fixture-tested, no network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+INDEX_SCHEMA_VERSION = 1
+
+#: ``lap_attributes`` keys we lift into the flat conditions block. Anything absent
+#: degrades to ``None`` rather than raising — retention must never drop a session.
+_CONDITION_KEYS = (
+    "airTemp",
+    "roadTemp",
+    "fuelLevel",
+    "tcEnabled",
+    "absEnabled",
+    "absSetting",
+    "carSetupName",
+    "isFixedSetup",
+    "tyreCompound",
+)
+
+
+def split_session_id(session_id: str) -> tuple[str | None, str | None]:
+    """Best-effort split of ``{uid}#{sessionKey}``; returns ``(None, None)`` if unusable."""
+    if not isinstance(session_id, str) or "#" not in session_id:
+        return None, None
+    uid, _, session_key = session_id.partition("#")
+    return (uid or None), (session_key or None)
+
+
+def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] not in (None, ""):
+            return mapping[key]
+    return None
+
+
+def normalize_session(session: Mapping[str, Any]) -> dict[str, Any]:
+    """Project one raw vulcan session into a flat index row.
+
+    Tolerant by design: any missing field becomes ``None`` so the row is always
+    writable. ``conditions`` lifts the per-lap ``lap_attributes`` block (grip, temps,
+    tyre compound, setup name, driver aids) that makes the row a real join key.
+    """
+    if not isinstance(session, Mapping):
+        raise TypeError("session must be a mapping")
+
+    session_id = session.get("id")
+    uid, session_key = split_session_id(session_id) if isinstance(session_id, str) else (None, None)
+    if uid is None:
+        uid = _first(session, "user_id")
+
+    game = session.get("game")
+    game_name = game.get("name") if isinstance(game, Mapping) else None
+
+    lap_attrs = session.get("lap_attributes")
+    lap_attrs = lap_attrs if isinstance(lap_attrs, Mapping) else {}
+    conditions = {key: lap_attrs.get(key) for key in _CONDITION_KEYS}
+    conditions["trackGrip"] = _first(session, "track_grip")
+
+    return {
+        "index_schema_version": INDEX_SCHEMA_VERSION,
+        "session_id": session_id if isinstance(session_id, str) else None,
+        "uid": uid,
+        "session_key": session_key,
+        "timestamp": session.get("timestamp"),
+        "last_updated": session.get("last_updated"),
+        "game_id": _first(session, "game_id"),
+        "game_name": game_name or (game.get("gameId") if isinstance(game, Mapping) else None),
+        "car_id": _first(session, "car_id"),
+        "car_name": _first(session, "carName"),
+        "car_class": _first(session, "car_class"),
+        "car_performance_index": _first(session, "car_performance_index"),
+        "track_id": _first(session, "track_id"),
+        "track_name": _first(session, "trackName"),
+        "weather_id": _first(session, "weather_id"),
+        "session_type": _first(session, "session_type"),
+        "ghost_version": _first(session, "ghost_version"),
+        "best_lap_ms": _first(session, "bestLapTime"),
+        "lap_count": _first(session, "lapCount"),
+        "driver_name": _first(session, "driver_name"),
+        "season_id": _first(session, "season_id"),
+        "status": _first(session, "status"),
+        "conditions": conditions,
+    }
+
+
+def normalize_sessions(sessions: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize a list of raw sessions, skipping any that are not mappings."""
+    return [normalize_session(s) for s in sessions if isinstance(s, Mapping)]
+
+
+def build_sessions_index(rows: list[Mapping[str, Any]], *, generated_at: str) -> dict[str, Any]:
+    """Wrap normalized rows in a top-level index document for the lake."""
+    return {
+        "index_schema_version": INDEX_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "session_count": len(rows),
+        "sessions": [dict(r) for r in rows],
+    }

--- a/tools/tt_ingest/tt_vulcan.py
+++ b/tools/tt_ingest/tt_vulcan.py
@@ -1,0 +1,202 @@
+"""Track Titan **vulcan** API client — the sessions list + per-session metadata
+(issue #353, milestone M-TT0).
+
+vulcan (``https://api.tracktitan.io/api/v1``) authenticates with the raw access
+token in the ``Authorization`` header (NO ``Bearer`` prefix) and serves the
+operator's full session history with per-lap conditions. This alone is **lossless
+retention** of every session across cars / tracks / setups (the per-corner traces
+live on the *services* API, milestone M-TT1).
+
+URL builders and the response parser are pure and unit-tested; the HTTP round-trips
+are isolated and ``# pragma: no cover`` (proven live, issue #353).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+from tools.tt_ingest.tt_auth import DEFAULT_REQUEST_TIMEOUT_S
+
+VULCAN_BASE = "https://api.tracktitan.io/api/v1"
+
+#: vulcan session ids are ``{uid}#{sessionKey}``; the ``#`` MUST be percent-encoded.
+_SESSION_ID_SEP = "#"
+
+
+class TTVulcanError(RuntimeError):
+    """A vulcan response did not match the documented shape, or an HTTP error."""
+
+
+@dataclass(frozen=True)
+class SessionsPage:
+    """One parsed page of ``/users/{uid}/sessions``."""
+
+    count: int
+    limit: int
+    page: int
+    sessions: list[dict[str, Any]]
+    cars: dict[str, Any] = field(default_factory=dict)
+    games: dict[str, Any] = field(default_factory=dict)
+    tracks: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def total_pages(self) -> int:
+        """Number of pages needed to retain ``count`` items at this ``limit``."""
+        if self.limit <= 0:
+            return 1
+        return max(1, -(-self.count // self.limit))  # ceil division
+
+
+def sessions_url(uid: str, *, limit: int = 50, page: int = 1, base: str = VULCAN_BASE) -> str:
+    """Build the paginated sessions-list URL for a user id."""
+    safe_uid = quote(uid, safe="")
+    return f"{base}/users/{safe_uid}/sessions?limit={int(limit)}&page={int(page)}"
+
+
+def session_detail_url(session_id: str, *, base: str = VULCAN_BASE) -> str:
+    """Build the per-session detail URL, percent-encoding the ``#`` in the id."""
+    return f"{base}/sessions/{quote(session_id, safe='')}"
+
+
+def split_session_id(session_id: str) -> tuple[str, str]:
+    """Split a ``{uid}#{sessionKey}`` id into ``(uid, session_key)``."""
+    if _SESSION_ID_SEP not in session_id:
+        raise TTVulcanError(f"session id is not '{{uid}}#{{sessionKey}}': {session_id!r}")
+    uid, session_key = session_id.split(_SESSION_ID_SEP, 1)
+    if not uid or not session_key:
+        raise TTVulcanError(f"session id has empty uid or sessionKey: {session_id!r}")
+    return uid, session_key
+
+
+def parse_sessions_page(payload: Mapping[str, Any]) -> SessionsPage:
+    """Parse a raw vulcan sessions-list response into a :class:`SessionsPage`.
+
+    Shape (verified live, issue #353)::
+
+        { "data": { "count", "limit", "page", "sessions": [...],
+                    "cars": {...}, "games": {...}, "tracks": {...} },
+          "message", "status", "success" }
+    """
+    data = payload.get("data")
+    if not isinstance(data, Mapping):
+        raise TTVulcanError("vulcan response missing 'data' object")
+    sessions = data.get("sessions")
+    if not isinstance(sessions, list):
+        raise TTVulcanError("vulcan response missing 'data.sessions' list")
+    rows = [dict(s) for s in sessions if isinstance(s, Mapping)]
+
+    def _lookup(name: str) -> dict[str, Any]:
+        value = data.get(name)
+        return dict(value) if isinstance(value, Mapping) else {}
+
+    def _int(name: str, default: int) -> int:
+        try:
+            return int(data.get(name, default))
+        except (TypeError, ValueError):
+            return default
+
+    return SessionsPage(
+        count=_int("count", len(rows)),
+        limit=_int("limit", len(rows) or 1),
+        page=_int("page", 1),
+        sessions=rows,
+        cars=_lookup("cars"),
+        games=_lookup("games"),
+        tracks=_lookup("tracks"),
+    )
+
+
+def session_summary(session: Mapping[str, Any]) -> str:
+    """A single sanitized line for logs — car / track / best-lap, never tokens or PII."""
+    car = session.get("carName") or session.get("car_id") or "?"
+    track = session.get("trackName") or session.get("track_id") or "?"
+    game = session.get("game_id") or "?"
+    best = session.get("bestLapTime")
+    laps = session.get("lapCount")
+    best_s = f"{best / 1000.0:.3f}s" if isinstance(best, (int, float)) and best > 0 else "—"
+    return f"[{game}] {car} @ {track} — best {best_s}, {laps} lap(s)"
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    # vulcan expects the RAW access token (no 'Bearer ' prefix) — verified live.
+    return {"Authorization": access_token, "Accept": "application/json"}
+
+
+def _vulcan_get(
+    url: str, access_token: str, *, http: Any, timeout: float
+) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (issue #353)
+    response = http.get(url, headers=_auth_headers(access_token), timeout=timeout)
+    status = getattr(response, "status_code", 200)
+    if status >= 400:
+        raise TTVulcanError(f"vulcan GET failed with HTTP {status}: {url}")
+    body = response.json()
+    if not isinstance(body, Mapping):
+        raise TTVulcanError("vulcan response was not a JSON object")
+    return dict(body)
+
+
+def fetch_sessions_page(
+    access_token: str,
+    uid: str,
+    *,
+    limit: int = 50,
+    page: int = 1,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> SessionsPage:  # pragma: no cover - network round-trip, verified live (issue #353)
+    """Fetch and parse one page of the user's sessions list."""
+    client = http
+    if client is None:
+        import requests as requests_mod
+
+        client = requests_mod
+    body = _vulcan_get(
+        sessions_url(uid, limit=limit, page=page), access_token, http=client, timeout=timeout
+    )
+    return parse_sessions_page(body)
+
+
+def iter_all_sessions(
+    access_token: str,
+    uid: str,
+    *,
+    limit: int = 50,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+    max_pages: int | None = None,
+) -> Iterator[dict[str, Any]]:  # pragma: no cover - network round-trip, verified live (#353)
+    """Yield every session across all pages (or up to ``max_pages``)."""
+    client = http
+    if client is None:
+        import requests as requests_mod
+
+        client = requests_mod
+    first = fetch_sessions_page(
+        access_token, uid, limit=limit, page=1, http=client, timeout=timeout
+    )
+    yield from first.sessions
+    last_page = first.total_pages if max_pages is None else min(first.total_pages, max_pages)
+    for page in range(2, last_page + 1):
+        nxt = fetch_sessions_page(
+            access_token, uid, limit=limit, page=page, http=client, timeout=timeout
+        )
+        yield from nxt.sessions
+
+
+def fetch_session_detail(
+    access_token: str,
+    session_id: str,
+    *,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (issue #353)
+    """Fetch the per-session detail (metadata; traces live on the services API)."""
+    client = http
+    if client is None:
+        import requests as requests_mod
+
+        client = requests_mod
+    return _vulcan_get(session_detail_url(session_id), access_token, http=client, timeout=timeout)

--- a/tools/tt_ingest/tt_vulcan.py
+++ b/tools/tt_ingest/tt_vulcan.py
@@ -93,10 +93,17 @@ def parse_sessions_page(payload: Mapping[str, Any]) -> SessionsPage:
         return dict(value) if isinstance(value, Mapping) else {}
 
     def _int(name: str, default: int) -> int:
+        raw = data.get(name, default)
         try:
-            return int(data.get(name, default))
+            return int(raw)
         except (TypeError, ValueError):
-            return default
+            # Tolerate numeric-as-string variants (the API has shipped float-strings like
+            # "26.0" for other fields) so a stringified count/limit never silently
+            # collapses pagination to a single page.
+            try:
+                return int(float(raw))
+            except (TypeError, ValueError):
+                return default
 
     return SessionsPage(
         count=_int("count", len(rows)),
@@ -116,8 +123,9 @@ def session_summary(session: Mapping[str, Any]) -> str:
     game = session.get("game_id") or "?"
     best = session.get("bestLapTime")
     laps = session.get("lapCount")
+    laps_s = laps if laps is not None else "?"
     best_s = f"{best / 1000.0:.3f}s" if isinstance(best, (int, float)) and best > 0 else "—"
-    return f"[{game}] {car} @ {track} — best {best_s}, {laps} lap(s)"
+    return f"[{game}] {car} @ {track} — best {best_s}, {laps_s} lap(s)"
 
 
 def _auth_headers(access_token: str) -> dict[str, str]:


### PR DESCRIPTION
## What & why

First slice of **#353** (Track Titan post-race analysis ingest): **M-TT0 — vulcan retention.** Retains the **operator's own** Track Titan session history immutably, keyed by car + track + setup, as the foundation the autonomous harness + voice coaching consume. Retrieval was already PROVEN live in the issue (149 sessions, 861 KB); this PR is the tool.

This is the **desktop app's post-race analysis plane**, distinct from the parked overlay-OCR work (#333).

## What's in this PR (`tools/tt_ingest/`)

- **`tt_auth.py`** — resolve the personal refresh token (`TT_REFRESH_TOKEN` env, or auto-discover from the TT desktop app's Local Storage LevelDB), and mint short-lived Cognito tokens via `InitiateAuth` (refresh → access/id). Pure JWT/JWE helpers, the request builder, and the response parser are unit-tested; the HTTP round-trip is isolated (`# pragma: no cover`).
- **`tt_vulcan.py`** — paginate `/users/{uid}/sessions`; pure URL builders + response parser (`SessionsPage`). Auth is the **raw** access token (no `Bearer` — verified live).
- **`tt_export.py`** — **write-once** immutable retention to `journal/tt/{game}/{car}/{track}/{sessionKey}/session.json` (atomic temp + `os.replace`, refuses to clobber), plus a content-addressed `index.json`.
- **`tt_normalize.py`** — flatten each session into a lossless, queryable conditions index (grip, temps, tyre compound, setup name, driver aids) — the join key for the harness + coaching lake.
- **CLI** — `python -m tools.tt_ingest {auth-check, export [--dry-run]}`.

## Security / data posture (issue scope/ethics)

Exports the **operator's own** data from their **own** account for **personal** use.
- **Tokens are personal secrets**: never logged, never embedded in error messages, never committed. Only **public** Cognito identifiers are hardcoded (env-overridable via `TT_COGNITO_*`) — these are sent in every *unauthenticated* request and identify the app/pools, not the user.
- `journal/tt/` is **gitignored** (personal data); the immutable lake path is recorded in the [`data-immutability`](docs/01_Vault/AcCopilotTrainer/00_System/invariants/data-immutability.md) invariant.
- `.env.example` catalogues `TT_REFRESH_TOKEN` (key-name only, no value).

## Testing

- 78 unit/integration tests; **`tt_ingest` module coverage 95%** (every file ≥88%).
- `retain_sessions` (the network-free heart of `export`) is driven end-to-end against a sanitized fixture + `tmp_path` lake, asserting the tree layout, both indexes, and **immutability on re-run** (second run → 0 new, all skipped).
- `make ci-fast` green locally (format/lint/test/secrets/policy/csp).

## Scope — follow-up milestones of #353 (separate PRs)

- **M-TT1** — services SigV4 crack (`data-analysis`, `dynamic-reference-laps`, `advice`).
- **M-TT2** — reference lap → `lap_archive` schema → M0 `--reference-archive` bridge.
- **M-TT3** — per-corner analysis → harness curriculum.

Refs #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
