### PR TITLE
feat(tt-ingest): M-TT1 services crack — per-corner reference + advice (#353)

### DIFF
--- a/tests/fixtures/tt_services_advice.json
+++ b/tests/fixtures/tt_services_advice.json
@@ -1,0 +1,72 @@
+{
+  "success": true,
+  "status": 200,
+  "data": {
+    "showOutput": true,
+    "stories": [
+      {
+        "timeLoss": 0.001,
+        "timeLoss_mistake_all": 0.0,
+        "timeLoss_mistake_rest": 0.0,
+        "timeLoss_mistake_this": 0.0,
+        "timeLoss_mistake_next": 0.0,
+        "diagnosis": "You made a mistake as you slowed down",
+        "consequence": "Look at your braking and steering technique to understand why this cost you 0.001s through the corner",
+        "diagnosisKey": "coaching.diagnosis.rotation_insufficient",
+        "consequenceKey": "coaching.consequence.rotation_insufficient",
+        "vars": {
+          "timeLoss": 0.001,
+          "highlightKey": "coaching.highlight.corner",
+          "nthOrdinal": null,
+          "segment": null,
+          "impactSegment": null
+        },
+        "highlight": [
+          0.04054021880233441,
+          0.07350374622656264
+        ],
+        "phase_mistake": "nfta",
+        "phase_dists_norm": [
+          0.04054021880233441,
+          0.07350374622656264
+        ],
+        "mistake_list_filtered": [],
+        "time_loss_shown": 0.001,
+        "info": {
+          "mistake_key": null
+        }
+      }
+    ],
+    "phases": [
+      {
+        "number": 0,
+        "name": "userNFTA_p1",
+        "type": "nfta",
+        "start_dist": 0.04054735600948334,
+        "end_dist": 0.07346820458769798
+      },
+      {
+        "number": 1,
+        "name": "userNFTA_p2",
+        "type": "nfta",
+        "start_dist": 0.07346820458769798,
+        "end_dist": 0.10638905316591263
+      },
+      {
+        "number": 2,
+        "name": "userIPA",
+        "type": "ipa",
+        "start_dist": 0.10638905316591263,
+        "end_dist": 0.12960994243621826
+      },
+      {
+        "number": 3,
+        "name": "userFTE_p1",
+        "type": "fte",
+        "start_dist": 0.12960994243621826,
+        "end_dist": 0.14883123338222504
+      }
+    ]
+  },
+  "message": "Cached Advice retrieved successfully."
+}

--- a/tests/fixtures/tt_services_dynamic_reference.json
+++ b/tests/fixtures/tt_services_dynamic_reference.json
@@ -1,0 +1,50 @@
+{
+  "session": "ref-uid-002#20220611194228",
+  "fastest": null,
+  "fastest_effective": null,
+  "prospects_seen": 0,
+  "lap": {
+    "game_version": null,
+    "season_name": null,
+    "is_in_pit": false,
+    "session_id": "ref-uid-002#20220611194228",
+    "season_id": null,
+    "car_performance_index": null,
+    "leaderboard_block": false,
+    "has_processed": true,
+    "segments": [
+      {
+        "segment_time": 11281.8,
+        "segment_number": 1
+      },
+      {
+        "segment_time": 9126.7,
+        "segment_number": 2
+      },
+      {
+        "segment_time": 8765.1,
+        "segment_number": 3
+      },
+      {
+        "segment_time": 13807.5,
+        "segment_number": 4
+      }
+    ],
+    "user_id": "ref-uid-002",
+    "has_sufficient_data": true,
+    "weather": null,
+    "name": "dynamicComparisonLap",
+    "session_key": "20220611194228",
+    "lap_time": "71035",
+    "attributes": null,
+    "session_type": "race",
+    "lap_number": 4,
+    "car_class": null,
+    "is_invalid": false,
+    "timestamp": 1654976550000,
+    "username": "Reference Driver",
+    "user_groups": null
+  },
+  "user_lap_time": 80303.0,
+  "is_cache_hit": true
+}

--- a/tests/fixtures/tt_services_lap_reference.json
+++ b/tests/fixtures/tt_services_lap_reference.json
@@ -1,0 +1,47 @@
+{
+  "success": true,
+  "status": 200,
+  "data": {
+    "game_version": null,
+    "season_name": null,
+    "is_in_pit": false,
+    "session_id": "ref-uid-002#20220611194228",
+    "season_id": null,
+    "car_performance_index": null,
+    "leaderboard_block": false,
+    "has_processed": true,
+    "segments": [
+      {
+        "segment_time": 11281.8,
+        "segment_number": 1
+      },
+      {
+        "segment_time": 9126.7,
+        "segment_number": 2
+      },
+      {
+        "segment_time": 8765.1,
+        "segment_number": 3
+      },
+      {
+        "segment_time": 13807.5,
+        "segment_number": 4
+      }
+    ],
+    "user_id": "ref-uid-002",
+    "has_sufficient_data": true,
+    "weather": null,
+    "name": "dynamicComparisonLap",
+    "session_key": "20220611194228",
+    "lap_time": "71035",
+    "attributes": null,
+    "session_type": "race",
+    "lap_number": 4,
+    "car_class": null,
+    "is_invalid": false,
+    "timestamp": 1654976550000,
+    "username": "Reference Driver",
+    "user_groups": null
+  },
+  "message": "Cached Dynamic Reference Lap fetched successfully"
+}

--- a/tests/fixtures/tt_services_last_session.json
+++ b/tests/fixtures/tt_services_last_session.json
@@ -1,0 +1,316 @@
+{
+  "success": true,
+  "status": 200,
+  "data": {
+    "session": {
+      "id": "fake-uid-001#20260629005756",
+      "user_id": "fake-uid-001",
+      "car": "ks_porsche_911_gt3_r_2016",
+      "driver_name": "operator",
+      "game_id": "assettoCorsa",
+      "track_id": "magione",
+      "weather_id": null,
+      "session_type": "race",
+      "track_grip": null,
+      "game_version": "1",
+      "ghost_version": "2.1.37",
+      "timestamp": "2026-06-29T00:57:56.000Z",
+      "last_updated": "2026-06-29T01:06:21.499Z",
+      "is_blocked": false,
+      "car_performance_index": null,
+      "car_class": null,
+      "season_id": null,
+      "leaderboard_block": false,
+      "attributes": {
+        "airTemp": "26.0",
+        "roadTemp": "37.0",
+        "fuelLevel": 24.836441614284116,
+        "tcEnabled": true,
+        "absEnabled": true,
+        "absSetting": "1.0",
+        "carSetupName": null,
+        "isFixedSetup": null,
+        "tyreCompound": "Slick Medium (M)",
+        "old_ghost_version": false,
+        "playerCarPowerAdjust": null,
+        "playerCarWeightPenalty": null,
+        "tractionControlSetting": null
+      },
+      "limited_status": null,
+      "ghost_version_number": 2001037,
+      "session_id": "fake-uid-001#20260629005756",
+      "lap_number": 5,
+      "lap_time": "80303",
+      "is_invalid": false,
+      "has_processed": true,
+      "is_in_pit": false,
+      "has_sufficient_data": true,
+      "has_pov": null,
+      "segments": {
+        "1": {
+          "segment_time": 12327.8,
+          "has_sufficient_data": true
+        },
+        "2": {
+          "segment_time": 10170.8,
+          "has_sufficient_data": true
+        },
+        "3": {
+          "segment_time": 10815.7,
+          "has_sufficient_data": true
+        },
+        "4": {
+          "segment_time": 14834.7,
+          "has_sufficient_data": true
+        },
+        "5": {
+          "segment_time": 10118.2,
+          "has_sufficient_data": true
+        },
+        "6": {
+          "segment_time": 6221,
+          "has_sufficient_data": true
+        },
+        "7": {
+          "segment_time": 15814.8,
+          "has_sufficient_data": true
+        }
+      },
+      "etl_version": "1.0.210",
+      "lapCount": "5"
+    },
+    "referenceLap": {
+      "game_version": null,
+      "season_name": null,
+      "is_in_pit": false,
+      "session_id": "ref-uid-002#20220611194228",
+      "season_id": null,
+      "car_performance_index": null,
+      "leaderboard_block": false,
+      "has_processed": true,
+      "segments": [
+        {
+          "segment_time": 11281.8,
+          "segment_number": 1
+        },
+        {
+          "segment_time": 9126.7,
+          "segment_number": 2
+        },
+        {
+          "segment_time": 8765.1,
+          "segment_number": 3
+        },
+        {
+          "segment_time": 13807.5,
+          "segment_number": 4
+        }
+      ],
+      "user_id": "ref-uid-002",
+      "has_sufficient_data": true,
+      "weather": null,
+      "name": "dynamicComparisonLap",
+      "session_key": "20220611194228",
+      "lap_time": "71035",
+      "attributes": null,
+      "session_type": "race",
+      "lap_number": 4,
+      "car_class": null,
+      "is_invalid": false,
+      "timestamp": 1654976550000,
+      "username": "Reference Driver",
+      "user_groups": null
+    },
+    "telemetry": {
+      "telemetry": {
+        "user": [
+          {
+            "dist": 0.265,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 142.77418,
+            "lTime": 22499,
+            "ovSteer": 0,
+            "steer": 0.1504,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 257.88217,
+            "Y": -22.75985,
+            "distM": null
+          },
+          {
+            "dist": 0.26502,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 142.79489,
+            "lTime": 22500,
+            "ovSteer": 0,
+            "steer": 0.13395,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 257.93661,
+            "Y": -22.77325,
+            "distM": null
+          },
+          {
+            "dist": 0.26604,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 143.88756,
+            "lTime": 22563,
+            "ovSteer": 0,
+            "steer": -0.40185,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 260.39194,
+            "Y": -23.37434,
+            "distM": null
+          },
+          {
+            "dist": 0.26673,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 144.61549,
+            "lTime": 22605,
+            "ovSteer": 0,
+            "steer": -0.75905,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 262.02737,
+            "Y": -23.77105,
+            "distM": null
+          }
+        ],
+        "reference": [
+          {
+            "dist": 0.265,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 149.53914,
+            "lTime": 20420,
+            "ovSteer": 0,
+            "steer": 0.36,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 258.18731,
+            "Y": -22.50241,
+            "distM": null
+          },
+          {
+            "dist": 0.26502,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 149.56046,
+            "lTime": 20421.7586,
+            "ovSteer": 0,
+            "steer": 0.36,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 258.2414693,
+            "Y": -22.5160159,
+            "distM": null
+          },
+          {
+            "dist": 0.26604,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 150.6091,
+            "lTime": 20481.94563,
+            "ovSteer": 0,
+            "steer": 0.25767,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 260.6759008,
+            "Y": -23.1286101,
+            "distM": null
+          },
+          {
+            "dist": 0.26673,
+            "brak": 0,
+            "gear": 3,
+            "Kmh": 151.32525,
+            "lTime": 20522.04395,
+            "ovSteer": 0,
+            "steer": 0.396,
+            "throt": 1,
+            "unSteer": 0,
+            "useGrip": 0,
+            "X": 262.3072557,
+            "Y": -23.5403095,
+            "distM": null
+          }
+        ]
+      },
+      "diffToRef": [
+        {
+          "dist": 0.265,
+          "value": 0
+        },
+        {
+          "dist": 0.26502,
+          "value": -0.0007586000000010245,
+          "keyMomentStart": true
+        },
+        {
+          "dist": 0.26604,
+          "value": 0.0020543700000016543
+        },
+        {
+          "dist": 0.26673,
+          "value": 0.003956050000000687
+        }
+      ],
+      "format": {
+        "user": "jsonzip",
+        "reference": "jsonzip"
+      }
+    },
+    "segment": 3,
+    "game": {
+      "gameId": "assettoCorsa",
+      "name": "Assetto Corsa",
+      "image": {
+        "id": 6,
+        "alt": "Assetto Corsa",
+        "url": "/api/media/file/943e7ee99e82185b22b6176eea5a9548ae595d30-1024x1024.webp",
+        "width": 1024,
+        "height": 1024
+      },
+      "fullImage": null,
+      "supportedPlatforms": null,
+      "mobileSupported": false,
+      "supported": true
+    },
+    "track": {
+      "trackId": "magione",
+      "name": "Magione",
+      "image": {
+        "id": 3520,
+        "alt": "Magione",
+        "url": "/api/media/file/a1251fabd03440504de4743e64293f2c6f4b3723-1920x1080.webp",
+        "width": 1920,
+        "height": 1080
+      },
+      "trackLength": null
+    },
+    "car": {
+      "carId": "ks_porsche_911_gt3_r_2016",
+      "name": "Porsche 911 GT3 R 2016",
+      "image": {
+        "id": 1332,
+        "alt": "Porsche 911 GT3 R 2016",
+        "url": "/api/media/file/dc2524e04b0d3f0c8f597a8c0006010aa5b03864-2500x1238.png",
+        "width": 2500,
+        "height": 1238
+      }
+    }
+  },
+  "message": "Last session successfully returned"
+}

--- a/tests/fixtures/tt_services_sessions.json
+++ b/tests/fixtures/tt_services_sessions.json
@@ -1,0 +1,387 @@
+{
+  "success": true,
+  "status": 200,
+  "data": {
+    "sessions": [
+      {
+        "id": "fake-uid-001#20260629005756",
+        "user_id": "fake-uid-001",
+        "car": {
+          "carId": "ks_porsche_911_gt3_r_2016",
+          "name": "Porsche 911 GT3 R 2016",
+          "image": {
+            "id": 1332,
+            "alt": "Porsche 911 GT3 R 2016",
+            "url": "/api/media/file/dc2524e04b0d3f0c8f597a8c0006010aa5b03864-2500x1238.png",
+            "width": 2500,
+            "height": 1238
+          }
+        },
+        "driver_name": "operator",
+        "game_id": "assettoCorsa",
+        "track_id": "magione",
+        "weather_id": null,
+        "session_type": "race",
+        "track_grip": null,
+        "game_version": "1",
+        "ghost_version": "2.1.37",
+        "timestamp": "2026-06-29T00:57:56.000Z",
+        "last_updated": "2026-06-29T01:06:21.375Z",
+        "is_blocked": false,
+        "car_performance_index": null,
+        "car_class": null,
+        "season_id": null,
+        "leaderboard_block": false,
+        "attributes": {
+          "has_sent_session_analysed_notification": true
+        },
+        "limited_status": null,
+        "ghost_version_number": 2001037,
+        "status": "PROCESSED",
+        "lap_attributes": {
+          "airTemp": "26.0",
+          "roadTemp": "37.0",
+          "fuelLevel": 29.458195677177166,
+          "tcEnabled": true,
+          "absEnabled": true,
+          "absSetting": "1.0",
+          "carSetupName": null,
+          "isFixedSetup": null,
+          "tyreCompound": "Slick Medium (M)",
+          "old_ghost_version": false,
+          "playerCarPowerAdjust": null,
+          "playerCarWeightPenalty": null,
+          "tractionControlSetting": null
+        },
+        "lapCount": 5,
+        "bestLapTime": 80303,
+        "carName": "Porsche 911 GT3 R 2016",
+        "trackName": "Magione",
+        "session_type_supported": true,
+        "track_not_supported": false,
+        "track_supported": true,
+        "car_id": "ks_porsche_911_gt3_r_2016",
+        "track": {
+          "trackId": "magione",
+          "name": "Magione",
+          "image": {
+            "id": 3520,
+            "alt": "Magione",
+            "url": "/api/media/file/a1251fabd03440504de4743e64293f2c6f4b3723-1920x1080.webp",
+            "width": 1920,
+            "height": 1080
+          },
+          "trackLength": null
+        },
+        "game": {
+          "gameId": "assettoCorsa",
+          "name": "Assetto Corsa",
+          "image": {
+            "id": 6,
+            "alt": "Assetto Corsa",
+            "url": "/api/media/file/943e7ee99e82185b22b6176eea5a9548ae595d30-1024x1024.webp",
+            "width": 1024,
+            "height": 1024
+          },
+          "fullImage": null,
+          "supportedPlatforms": null,
+          "mobileSupported": false,
+          "supported": true
+        }
+      },
+      {
+        "id": "fake-uid-001#20260628051354",
+        "user_id": "fake-uid-001",
+        "car": {
+          "carId": "syn_mercedes_w09",
+          "name": "SYN MERCEDES W09",
+          "image": {
+            "id": 1303,
+            "alt": "Mercedes W09 - SYN",
+            "url": "/api/media/file/274eb4cdb2acc45adc66fba194bde18c470d7628-1814x989.png",
+            "width": 1814,
+            "height": 989
+          }
+        },
+        "driver_name": "operator",
+        "game_id": "assettoCorsa",
+        "track_id": "ks_red_bull_ring",
+        "weather_id": null,
+        "session_type": "race",
+        "track_grip": null,
+        "game_version": "1",
+        "ghost_version": "2.1.37",
+        "timestamp": "2026-06-28T05:13:54.000Z",
+        "last_updated": "2026-06-28T05:24:53.220Z",
+        "is_blocked": false,
+        "car_performance_index": null,
+        "car_class": null,
+        "season_id": null,
+        "leaderboard_block": false,
+        "attributes": {
+          "has_sent_session_analysed_notification": true
+        },
+        "limited_status": null,
+        "ghost_version_number": 2001037,
+        "status": "PROCESSED",
+        "lap_attributes": {
+          "airTemp": "26.0",
+          "roadTemp": "37.0",
+          "fuelLevel": 49.15855060126273,
+          "tcEnabled": false,
+          "absEnabled": false,
+          "absSetting": "0.0",
+          "carSetupName": null,
+          "isFixedSetup": null,
+          "tyreCompound": "Pirelli SuperSoft (SS)",
+          "old_ghost_version": false,
+          "playerCarPowerAdjust": null,
+          "playerCarWeightPenalty": null,
+          "tractionControlSetting": null
+        },
+        "lapCount": 5,
+        "bestLapTime": 83737,
+        "carName": "Mercedes W09 - SYN",
+        "trackName": "Red Bull Ring",
+        "session_type_supported": true,
+        "track_not_supported": false,
+        "track_supported": true,
+        "car_id": "syn_mercedes_w09",
+        "track": {
+          "trackId": "ks_red_bull_ring",
+          "name": "Red Bull Ring",
+          "image": {
+            "id": 1664,
+            "alt": "Red Bull Ring - F1 - 2025 (FN)",
+            "url": "/api/media/file/65520effc4f924b84ee3f02e050b0c96b42b1ee1-8000x4500.png",
+            "width": 8000,
+            "height": 4500
+          },
+          "trackLength": null
+        },
+        "game": {
+          "gameId": "assettoCorsa",
+          "name": "Assetto Corsa",
+          "image": {
+            "id": 6,
+            "alt": "Assetto Corsa",
+            "url": "/api/media/file/943e7ee99e82185b22b6176eea5a9548ae595d30-1024x1024.webp",
+            "width": 1024,
+            "height": 1024
+          },
+          "fullImage": null,
+          "supportedPlatforms": null,
+          "mobileSupported": false,
+          "supported": true
+        }
+      }
+    ],
+    "page": 1,
+    "limit": 10,
+    "count": 150,
+    "cars": {
+      "success": true,
+      "status": 200,
+      "data": {
+        "cars": [
+          {
+            "carId": "bmw_m2_competition_coupé_2020",
+            "name": "BMW M2 Competition Coupé",
+            "image": {
+              "id": 1470,
+              "alt": "BMW M2 Competition Coupé",
+              "url": "/api/media/file/9562e244d670cc7002649d002088a8b241c5c2b4-653x276.png",
+              "width": 653,
+              "height": 276
+            }
+          },
+          {
+            "carId": "jaguar_etype_1961",
+            "name": "Jaguar E-type",
+            "image": {
+              "id": 1471,
+              "alt": "Jaguar E-type",
+              "url": "/api/media/file/4971065c7dc3c52211b24249ccaf18b50a333bd3-720x320.png",
+              "width": 720,
+              "height": 320
+            }
+          },
+          {
+            "carId": "porsche_911_gt2_rs_2012",
+            "name": "Porsche 911 GT2 RS (2012)",
+            "image": {
+              "id": 1472,
+              "alt": "Porsche 911 GT2 RS (2012)",
+              "url": "/api/media/file/ce445105aa0440cb45d982f1df91514a0bec92fd-720x320.png",
+              "width": 720,
+              "height": 320
+            }
+          },
+          {
+            "carId": "jaguar_xj220_1993",
+            "name": "Jaguar XJ220",
+            "image": {
+              "id": 1473,
+              "alt": "Jaguar XJ220",
+              "url": "/api/media/file/6dffd3b75704f0cac0dc5cb43a47761ed6cb054a-720x320.png",
+              "width": 720,
+              "height": 320
+            }
+          }
+        ]
+      },
+      "message": "Cached cars fetched successfully"
+    },
+    "tracks": {
+      "success": true,
+      "status": 200,
+      "data": {
+        "tracks": [
+          {
+            "trackId": "Mexico",
+            "name": "Mexico ",
+            "image": {
+              "id": 2783,
+              "alt": "Mexico (2021 - ACU) - F1 2024",
+              "url": "/api/media/file/5b9ce3876b9c9da305363bc7cd71c27642758062-1920x1080.png",
+              "width": 1920,
+              "height": 1080
+            },
+            "trackLength": null
+          },
+          {
+            "trackId": "acu_mexico_2021_layout_f1_2023",
+            "name": "Mexico (2021 - ACU) - F1 2023",
+            "image": {
+              "id": 2783,
+              "alt": "Mexico (2021 - ACU) - F1 2024",
+              "url": "/api/media/file/5b9ce3876b9c9da305363bc7cd71c27642758062-1920x1080.png",
+              "width": 1920,
+              "height": 1080
+            },
+            "trackLength": null
+          },
+          {
+            "trackId": "acu_mexico_osrw",
+            "name": "Mexico (OSRW)",
+            "image": {
+              "id": 2783,
+              "alt": "Mexico (2021 - ACU) - F1 2024",
+              "url": "/api/media/file/5b9ce3876b9c9da305363bc7cd71c27642758062-1920x1080.png",
+              "width": 1920,
+              "height": 1080
+            },
+            "trackLength": null
+          },
+          {
+            "trackId": "acu_mexico_2021_layout_f1_2022",
+            "name": "Mexico (2021 - ACU) - F1 2022",
+            "image": {
+              "id": 2783,
+              "alt": "Mexico (2021 - ACU) - F1 2024",
+              "url": "/api/media/file/5b9ce3876b9c9da305363bc7cd71c27642758062-1920x1080.png",
+              "width": 1920,
+              "height": 1080
+            },
+            "trackLength": null
+          }
+        ]
+      },
+      "message": "Track retrieved"
+    },
+    "games": {
+      "success": true,
+      "status": 200,
+      "data": {
+        "games": [
+          {
+            "gameId": "assettoCorsaEvo",
+            "name": "Assetto Corsa EVO",
+            "image": {
+              "id": 2,
+              "alt": "Assetto Corsa EVO",
+              "url": "/api/media/file/66e5c8e8b816101ffb7ef35dda849c80d3b352ec-1227x1236.png",
+              "width": 1227,
+              "height": 1236
+            },
+            "fullImage": {
+              "id": 3,
+              "alt": "Assetto Corsa EVO full",
+              "url": "/api/media/file/0196c165c222d381ad832d8ecd17416bbb1d3b3a-1407x471.png",
+              "width": 1407,
+              "height": 471
+            },
+            "supportedPlatforms": null,
+            "mobileSupported": false,
+            "supported": true
+          },
+          {
+            "gameId": "F12024",
+            "name": "F1 24",
+            "image": {
+              "id": 8,
+              "alt": "F1 24",
+              "url": "/api/media/file/13d12c56d4ce0a0340399d05d422b5f2a99e6e15-2048x2048.jpg",
+              "width": 2048,
+              "height": 2048
+            },
+            "fullImage": {
+              "id": 9,
+              "alt": "F1 24 full",
+              "url": "/api/media/file/daeb47bccaf74b2148379ed0b624b83eecf65e39-640x100.png",
+              "width": 640,
+              "height": 100
+            },
+            "supportedPlatforms": null,
+            "mobileSupported": false,
+            "supported": true
+          },
+          {
+            "gameId": "assettoCorsaCompetizione",
+            "name": "Assetto Corsa Competizione",
+            "image": {
+              "id": 15,
+              "alt": "Assetto Corsa Competizione",
+              "url": "/api/media/file/90917c5104bccbe7892cd47536eef4b9a81f3c76-1024x1024.webp",
+              "width": 1024,
+              "height": 1024
+            },
+            "fullImage": {
+              "id": 16,
+              "alt": "Assetto Corsa Competizione full",
+              "url": "/api/media/file/4facecec0f08a567af7c0d6112487698deb8da13-1510x480.png",
+              "width": 1510,
+              "height": 480
+            },
+            "supportedPlatforms": null,
+            "mobileSupported": false,
+            "supported": true
+          },
+          {
+            "gameId": "iRacing",
+            "name": "iRacing",
+            "image": {
+              "id": 17,
+              "alt": "iRacing",
+              "url": "/api/media/file/9526e57541ca97fc776fc1b645d185216d7cdb7f-500x500.png",
+              "width": 500,
+              "height": 500
+            },
+            "fullImage": {
+              "id": 18,
+              "alt": "iRacing full",
+              "url": "/api/media/file/276f080ed284dafc0af43143277cd4a8d515f5fc-655x121.svg",
+              "width": 655,
+              "height": 121
+            },
+            "supportedPlatforms": null,
+            "mobileSupported": false,
+            "supported": true
+          }
+        ]
+      },
+      "message": "Supported Games fetched successfully"
+    }
+  },
+  "message": "Sessions fetched successfully"
+}

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -172,6 +172,49 @@ def test_retain_coaching_summary_render(tmp_path) -> None:
     assert "1 actionable" in rendered
 
 
+def test_retain_coaching_preserves_full_payload(tmp_path) -> None:
+    # The FULL services payload (session + referenceLap + telemetry) must be retained as
+    # last_session.json so the lake reconstructs what the endpoint returned (M-TT2 input).
+    full = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
+    retain_coaching(_last_session(), _bundle(), last_session_payload=full, lake_base=tmp_path)
+    root = tmp_path / "journal" / "tt"
+    session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
+    retained = json.loads((session_dir / f"{LAST_SESSION_ENDPOINT}.json").read_text())
+    assert retained.get("success") is True  # envelope preserved, not the stripped session
+    assert "referenceLap" in retained["data"]  # reference evidence kept for M-TT2
+
+
+def test_retain_coaching_indexes_endpoint_files(tmp_path) -> None:
+    summary = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
+    root = tmp_path / "journal" / "tt"
+    file_index = json.loads((root / INDEX_FILENAME).read_text())
+    endpoints = {f["endpoint"] for f in file_index["files"]}
+    assert {LAST_SESSION_ENDPOINT, COACHING_ENDPOINT} <= endpoints
+    assert summary.indexed == file_index["file_count"] >= 2
+
+
+def test_retain_coaching_keys_on_given_session(tmp_path) -> None:
+    # The lake key comes from the GIVEN session, so coaching for an OLD session lands under
+    # that session's dir (PR #370 review fix — not the latest session's).
+    old = {
+        "session_id": "u#20240101120000",
+        "game_id": "assettoCorsa",
+        "car": "ks_audi_r8_lms",
+        "track_id": "monza",
+        "lap_number": 3,
+    }
+    retain_coaching(old, _bundle(), lake_base=tmp_path)
+    root = tmp_path / "journal" / "tt"
+    assert (
+        root
+        / "assettoCorsa"
+        / "ks_audi_r8_lms"
+        / "monza"
+        / "20240101120000"
+        / f"{COACHING_ENDPOINT}.json"
+    ).exists()
+
+
 def test_parser_requires_subcommand() -> None:
     with pytest.raises(SystemExit):
         build_arg_parser().parse_args([])

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -13,11 +13,11 @@ from pathlib import Path
 import pytest
 
 from tools.tt_ingest.cli import (
-    COACHING_ENDPOINT,
     INDEX_FILENAME,
     LAST_SESSION_ENDPOINT,
     SESSIONS_INDEX_FILENAME,
     build_arg_parser,
+    coaching_endpoint,
     retain_coaching,
     retain_sessions,
 )
@@ -129,16 +129,12 @@ def test_parser_coaching_defaults() -> None:
     args = build_arg_parser().parse_args(["coaching"])
     assert args.command == "coaching"
     assert args.segment_count == 7
-    assert args.session_key is None
     assert args.lap is None
     assert args.dry_run is False
 
 
 def test_parser_coaching_flags() -> None:
-    args = build_arg_parser().parse_args(
-        ["coaching", "--session-key", "20260629005756", "--lap", "5", "--segment-count", "3"]
-    )
-    assert args.session_key == "20260629005756"
+    args = build_arg_parser().parse_args(["coaching", "--lap", "5", "--segment-count", "3"])
     assert args.lap == 5
     assert args.segment_count == 3
 
@@ -147,26 +143,38 @@ def test_parser_coaching_flags() -> None:
 
 
 def test_retain_coaching_writes_lake(tmp_path) -> None:
-    summary = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
+    summary = retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path)
     root = tmp_path / "journal" / "tt"
     session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
     assert (session_dir / f"{LAST_SESSION_ENDPOINT}.json").exists()
-    coaching = json.loads((session_dir / f"{COACHING_ENDPOINT}.json").read_text())
+    coaching = json.loads((session_dir / f"{coaching_endpoint(5)}.json").read_text())
     assert coaching["reference_lap"]["username"] == "Reference Driver"
     assert summary.segments == 2
     assert summary.actionable == 1  # only the 0.12s loss is actionable; the 0.0 is not
-    assert set(summary.written) == {LAST_SESSION_ENDPOINT, COACHING_ENDPOINT}
+    assert set(summary.written) == {LAST_SESSION_ENDPOINT, coaching_endpoint(5)}
+
+
+def test_retain_coaching_per_lap_files_do_not_collide(tmp_path) -> None:
+    # Two laps of the SAME session retain to distinct coaching_lap{N}.json files — the
+    # write-once lake never blocks the second lap (PR #370 review fix).
+    retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path)
+    summary = retain_coaching(_last_session(), _bundle(), lap=6, lake_base=tmp_path)
+    root = tmp_path / "journal" / "tt"
+    session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
+    assert (session_dir / f"{coaching_endpoint(5)}.json").exists()
+    assert (session_dir / f"{coaching_endpoint(6)}.json").exists()
+    assert coaching_endpoint(6) in summary.written  # lap 6 was newly written, not blocked
 
 
 def test_retain_coaching_is_write_once(tmp_path) -> None:
-    retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
-    again = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
+    retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path)
+    again = retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path)
     assert again.written == []  # both endpoints already present → nothing re-written
     assert "nothing new" in again.render()
 
 
 def test_retain_coaching_summary_render(tmp_path) -> None:
-    rendered = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path).render()
+    rendered = retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path).render()
     assert "session 20260629005756" in rendered
     assert "2 segment(s)" in rendered
     assert "1 actionable" in rendered
@@ -176,7 +184,9 @@ def test_retain_coaching_preserves_full_payload(tmp_path) -> None:
     # The FULL services payload (session + referenceLap + telemetry) must be retained as
     # last_session.json so the lake reconstructs what the endpoint returned (M-TT2 input).
     full = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
-    retain_coaching(_last_session(), _bundle(), last_session_payload=full, lake_base=tmp_path)
+    retain_coaching(
+        _last_session(), _bundle(), lap=5, last_session_payload=full, lake_base=tmp_path
+    )
     root = tmp_path / "journal" / "tt"
     session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
     retained = json.loads((session_dir / f"{LAST_SESSION_ENDPOINT}.json").read_text())
@@ -185,25 +195,25 @@ def test_retain_coaching_preserves_full_payload(tmp_path) -> None:
 
 
 def test_retain_coaching_indexes_endpoint_files(tmp_path) -> None:
-    summary = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
+    summary = retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path)
     root = tmp_path / "journal" / "tt"
     file_index = json.loads((root / INDEX_FILENAME).read_text())
     endpoints = {f["endpoint"] for f in file_index["files"]}
-    assert {LAST_SESSION_ENDPOINT, COACHING_ENDPOINT} <= endpoints
+    assert {LAST_SESSION_ENDPOINT, coaching_endpoint(5)} <= endpoints
     assert summary.indexed == file_index["file_count"] >= 2
 
 
 def test_retain_coaching_keys_on_given_session(tmp_path) -> None:
-    # The lake key comes from the GIVEN session, so coaching for an OLD session lands under
-    # that session's dir (PR #370 review fix — not the latest session's).
+    # The lake key comes from the GIVEN session (game/car/track/session_key); a car object
+    # (sessions-list shape) is unwrapped to its string id, never a dict-repr (#353 review).
     old = {
         "session_id": "u#20240101120000",
         "game_id": "assettoCorsa",
-        "car": "ks_audi_r8_lms",
+        "car": {"car_id": "ks_audi_r8_lms", "name": "Audi R8 LMS"},
         "track_id": "monza",
         "lap_number": 3,
     }
-    retain_coaching(old, _bundle(), lake_base=tmp_path)
+    retain_coaching(old, _bundle(), lap=3, lake_base=tmp_path)
     root = tmp_path / "journal" / "tt"
     assert (
         root
@@ -211,7 +221,7 @@ def test_retain_coaching_keys_on_given_session(tmp_path) -> None:
         / "ks_audi_r8_lms"
         / "monza"
         / "20240101120000"
-        / f"{COACHING_ENDPOINT}.json"
+        / f"{coaching_endpoint(3)}.json"
     ).exists()
 
 

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -129,14 +129,13 @@ def test_parser_coaching_defaults() -> None:
     args = build_arg_parser().parse_args(["coaching"])
     assert args.command == "coaching"
     assert args.segment_count == 7
-    assert args.lap is None
     assert args.dry_run is False
 
 
 def test_parser_coaching_flags() -> None:
-    args = build_arg_parser().parse_args(["coaching", "--lap", "5", "--segment-count", "3"])
-    assert args.lap == 5
+    args = build_arg_parser().parse_args(["coaching", "--segment-count", "3", "--uid", "u9"])
     assert args.segment_count == 3
+    assert args.uid == "u9"
 
 
 # --- retain_coaching (M-TT1) ------------------------------------------------------

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -13,17 +13,36 @@ from pathlib import Path
 import pytest
 
 from tools.tt_ingest.cli import (
+    COACHING_ENDPOINT,
     INDEX_FILENAME,
+    LAST_SESSION_ENDPOINT,
     SESSIONS_INDEX_FILENAME,
     build_arg_parser,
+    retain_coaching,
     retain_sessions,
 )
 
 FIXTURE = Path(__file__).parent / "fixtures" / "tt_sessions_page.json"
+LAST_SESSION_FIXTURE = Path(__file__).parent / "fixtures" / "tt_services_last_session.json"
 
 
 def _sessions() -> list[dict]:
     return json.loads(FIXTURE.read_text(encoding="utf-8"))["data"]["sessions"]
+
+
+def _last_session() -> dict:
+    return json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))["data"]["session"]
+
+
+def _bundle() -> dict:
+    return {
+        "reference_lap": {"username": "Reference Driver", "lap_time": "71035"},
+        "reference_id": ["ref-uid-002", "20220611194228"],
+        "segments": [
+            {"segment": 1, "stories": [{"diagnosis": "Brake later", "time_loss": 0.12}]},
+            {"segment": 2, "stories": [{"diagnosis": "Good corner", "time_loss": 0.0}]},
+        ],
+    }
 
 
 # --- retain_sessions end-to-end ---------------------------------------------------
@@ -104,6 +123,53 @@ def test_parser_export_flags() -> None:
 def test_parser_auth_check() -> None:
     args = build_arg_parser().parse_args(["auth-check"])
     assert args.command == "auth-check"
+
+
+def test_parser_coaching_defaults() -> None:
+    args = build_arg_parser().parse_args(["coaching"])
+    assert args.command == "coaching"
+    assert args.segment_count == 7
+    assert args.session_key is None
+    assert args.lap is None
+    assert args.dry_run is False
+
+
+def test_parser_coaching_flags() -> None:
+    args = build_arg_parser().parse_args(
+        ["coaching", "--session-key", "20260629005756", "--lap", "5", "--segment-count", "3"]
+    )
+    assert args.session_key == "20260629005756"
+    assert args.lap == 5
+    assert args.segment_count == 3
+
+
+# --- retain_coaching (M-TT1) ------------------------------------------------------
+
+
+def test_retain_coaching_writes_lake(tmp_path) -> None:
+    summary = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
+    root = tmp_path / "journal" / "tt"
+    session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
+    assert (session_dir / f"{LAST_SESSION_ENDPOINT}.json").exists()
+    coaching = json.loads((session_dir / f"{COACHING_ENDPOINT}.json").read_text())
+    assert coaching["reference_lap"]["username"] == "Reference Driver"
+    assert summary.segments == 2
+    assert summary.actionable == 1  # only the 0.12s loss is actionable; the 0.0 is not
+    assert set(summary.written) == {LAST_SESSION_ENDPOINT, COACHING_ENDPOINT}
+
+
+def test_retain_coaching_is_write_once(tmp_path) -> None:
+    retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
+    again = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path)
+    assert again.written == []  # both endpoints already present → nothing re-written
+    assert "nothing new" in again.render()
+
+
+def test_retain_coaching_summary_render(tmp_path) -> None:
+    rendered = retain_coaching(_last_session(), _bundle(), lake_base=tmp_path).render()
+    assert "session 20260629005756" in rendered
+    assert "2 segment(s)" in rendered
+    assert "1 actionable" in rendered
 
 
 def test_parser_requires_subcommand() -> None:

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -14,10 +14,10 @@ import pytest
 
 from tools.tt_ingest.cli import (
     INDEX_FILENAME,
-    LAST_SESSION_ENDPOINT,
     SESSIONS_INDEX_FILENAME,
     build_arg_parser,
     coaching_endpoint,
+    last_session_endpoint,
     retain_coaching,
     retain_sessions,
 )
@@ -145,23 +145,25 @@ def test_retain_coaching_writes_lake(tmp_path) -> None:
     summary = retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path)
     root = tmp_path / "journal" / "tt"
     session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
-    assert (session_dir / f"{LAST_SESSION_ENDPOINT}.json").exists()
+    assert (session_dir / f"{last_session_endpoint(5)}.json").exists()
     coaching = json.loads((session_dir / f"{coaching_endpoint(5)}.json").read_text())
     assert coaching["reference_lap"]["username"] == "Reference Driver"
     assert summary.segments == 2
     assert summary.actionable == 1  # only the 0.12s loss is actionable; the 0.0 is not
-    assert set(summary.written) == {LAST_SESSION_ENDPOINT, coaching_endpoint(5)}
+    assert set(summary.written) == {last_session_endpoint(5), coaching_endpoint(5)}
 
 
 def test_retain_coaching_per_lap_files_do_not_collide(tmp_path) -> None:
-    # Two laps of the SAME session retain to distinct coaching_lap{N}.json files — the
-    # write-once lake never blocks the second lap (PR #370 review fix).
+    # Two laps of the SAME session retain to distinct lap-keyed files — the write-once lake
+    # never blocks the second lap, and each lap's last-session evidence stays coherent with
+    # its coaching (PR #370 review fix).
     retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path)
     summary = retain_coaching(_last_session(), _bundle(), lap=6, lake_base=tmp_path)
     root = tmp_path / "journal" / "tt"
     session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
-    assert (session_dir / f"{coaching_endpoint(5)}.json").exists()
-    assert (session_dir / f"{coaching_endpoint(6)}.json").exists()
+    for lap in (5, 6):
+        assert (session_dir / f"{coaching_endpoint(lap)}.json").exists()
+        assert (session_dir / f"{last_session_endpoint(lap)}.json").exists()
     assert coaching_endpoint(6) in summary.written  # lap 6 was newly written, not blocked
 
 
@@ -188,7 +190,7 @@ def test_retain_coaching_preserves_full_payload(tmp_path) -> None:
     )
     root = tmp_path / "journal" / "tt"
     session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
-    retained = json.loads((session_dir / f"{LAST_SESSION_ENDPOINT}.json").read_text())
+    retained = json.loads((session_dir / f"{last_session_endpoint(5)}.json").read_text())
     assert retained.get("success") is True  # envelope preserved, not the stripped session
     assert "referenceLap" in retained["data"]  # reference evidence kept for M-TT2
 
@@ -198,7 +200,7 @@ def test_retain_coaching_indexes_endpoint_files(tmp_path) -> None:
     root = tmp_path / "journal" / "tt"
     file_index = json.loads((root / INDEX_FILENAME).read_text())
     endpoints = {f["endpoint"] for f in file_index["files"]}
-    assert {LAST_SESSION_ENDPOINT, coaching_endpoint(5)} <= endpoints
+    assert {last_session_endpoint(5), coaching_endpoint(5)} <= endpoints
     assert summary.indexed == file_index["file_count"] >= 2
 
 

--- a/tests/test_tt_services.py
+++ b/tests/test_tt_services.py
@@ -1,0 +1,248 @@
+"""Unit tests for tools.tt_ingest.tt_services (issue #353, M-TT1).
+
+Fixtures are SANITIZED captures from the live services API (CDP capture, 2026-06-29):
+the operator's uid + reference-driver identity are replaced with stable fakes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.tt_ingest.tt_services import (
+    SERVICES_BASE,
+    THEORETICAL_BEST_REF,
+    CoachingStory,
+    TTServicesError,
+    advice_segment_url,
+    analysis_progress_url,
+    dynamic_reference_lap_url,
+    fetch_advice_segment,
+    fetch_dynamic_reference_lap,
+    fetch_last_session,
+    is_enveloped,
+    lap_reference_url,
+    last_session_url,
+    parse_advice,
+    parse_last_session,
+    parse_reference_lap,
+    reference_identity,
+    reference_lap_segments,
+    reference_lap_url,
+    services_sessions_url,
+    unwrap_envelope,
+)
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIX / name).read_text(encoding="utf-8"))
+
+
+# --- URL builders -----------------------------------------------------------------
+
+
+def test_services_sessions_url() -> None:
+    url = services_sessions_url("uid-1", page=2, limit=10, hide_limited=True)
+    assert url == f"{SERVICES_BASE}/api/v2/users/uid-1/sessions?page=2&hideLimited=true&limit=10"
+
+
+def test_last_session_url() -> None:
+    assert last_session_url("uid-1") == f"{SERVICES_BASE}/api/v2/sessions/uid-1/last-session"
+
+
+def test_lap_reference_url() -> None:
+    url = lap_reference_url("uid-1", "20260629005756", 5)
+    assert url == f"{SERVICES_BASE}/api/v2/sessions/uid-1/20260629005756/laps/5/reference"
+
+
+def test_dynamic_reference_lap_url_default_segment_count() -> None:
+    url = dynamic_reference_lap_url("uid-1", "sk-9", 4)
+    assert url == (
+        f"{SERVICES_BASE}/dynamic-reference-laps/sessions/uid-1/sk-9/laps/4?segmentCount=7"
+    )
+
+
+def test_reference_lap_url() -> None:
+    url = reference_lap_url("u", "s", "refu", "refs", "theoreticalBestRef")
+    assert url == (
+        f"{SERVICES_BASE}/api/v2/sessions/u/s/reference/refu/refs/laps/theoreticalBestRef"
+    )
+
+
+def test_advice_segment_url_defaults_to_theoretical_best() -> None:
+    url = advice_segment_url("u", "s", 5, "refu", "refs", 1)
+    assert THEORETICAL_BEST_REF in url
+    assert url.endswith("/segments/1")
+    assert "/advice/sessions/u/s/laps/5/reference/refu/refs/laps/" in url
+
+
+def test_analysis_progress_url_encodes_query() -> None:
+    url = analysis_progress_url("u", game_id="assettoCorsa", track_id="magione", car_id="a/b")
+    assert "gameId=assettoCorsa" in url and "trackId=magione" in url
+    assert "carId=a%2Fb" in url  # the '/' in the car id is encoded, not a path break
+
+
+def test_url_builders_encode_segments() -> None:
+    # A uid containing '#'/'/' must never break out of its path segment.
+    assert "%23" in last_session_url("uid#weird")
+    assert "uid%2Fevil" in last_session_url("uid/evil")
+
+
+# --- envelope ---------------------------------------------------------------------
+
+
+def test_is_enveloped() -> None:
+    assert is_enveloped({"success": True, "data": {}})
+    assert not is_enveloped({"session": "x", "lap": {}})
+
+
+def test_unwrap_envelope_enveloped() -> None:
+    assert unwrap_envelope({"success": True, "data": {"k": 1}, "status": 200}) == {"k": 1}
+
+
+def test_unwrap_envelope_bare_returns_self() -> None:
+    bare = {"session": "x", "lap": {"lap_time": "1"}}
+    assert unwrap_envelope(bare) is bare
+
+
+def test_unwrap_envelope_failure_raises() -> None:
+    with pytest.raises(TTServicesError):
+        unwrap_envelope({"success": False, "data": None, "status": 500})
+
+
+def test_unwrap_envelope_non_mapping_raises() -> None:
+    with pytest.raises(TTServicesError):
+        unwrap_envelope([1, 2, 3])  # type: ignore[arg-type]
+
+
+# --- parse_advice -----------------------------------------------------------------
+
+
+def test_parse_advice_from_fixture() -> None:
+    stories = parse_advice(_load("tt_services_advice.json"))
+    assert len(stories) == 1
+    s = stories[0]
+    assert isinstance(s, CoachingStory)
+    assert s.diagnosis_key == "coaching.diagnosis.rotation_insufficient"
+    assert s.diagnosis.startswith("You made a mistake")
+    assert s.highlight is not None and len(s.highlight) == 2
+    assert s.is_actionable  # timeLoss 0.001 > 0
+
+
+def test_parse_advice_handles_no_stories() -> None:
+    assert parse_advice({"success": True, "status": 200, "data": {"stories": None}}) == []
+
+
+def test_coaching_story_not_actionable_when_zero_loss() -> None:
+    assert not CoachingStory("d", "c", "dk", "ck", 0.0, "nfta", (0.0, 0.1)).is_actionable
+    assert not CoachingStory("d", "c", "dk", "ck", None, None, None).is_actionable
+
+
+# --- reference lap ----------------------------------------------------------------
+
+
+def test_parse_reference_lap_bare_dynamic() -> None:
+    lap = parse_reference_lap(_load("tt_services_dynamic_reference.json"))
+    assert lap["name"] == "dynamicComparisonLap"
+    assert lap["lap_time"] == "71035"
+
+
+def test_parse_reference_lap_enveloped() -> None:
+    lap = parse_reference_lap(_load("tt_services_lap_reference.json"))
+    assert lap["name"] == "dynamicComparisonLap"
+
+
+def test_reference_identity() -> None:
+    lap = parse_reference_lap(_load("tt_services_dynamic_reference.json"))
+    ref_uid, ref_sk = reference_identity(lap)
+    assert ref_uid == "ref-uid-002"
+    assert ref_sk == "20220611194228"
+
+
+def test_reference_identity_missing_raises() -> None:
+    with pytest.raises(TTServicesError):
+        reference_identity({"user_id": "", "session_key": "x"})
+
+
+def test_reference_lap_segments_sorted() -> None:
+    lap = parse_reference_lap(_load("tt_services_dynamic_reference.json"))
+    segs = reference_lap_segments(lap)
+    assert [n for n, _ in segs] == sorted(n for n, _ in segs)
+    assert segs[0] == (1, 11281.8)
+
+
+# --- last session -----------------------------------------------------------------
+
+
+def test_parse_last_session() -> None:
+    out = parse_last_session(_load("tt_services_last_session.json"))
+    assert out["session"]["game_id"] == "assettoCorsa"
+    assert out["session"]["track_id"] == "magione"
+    assert out["session"]["lap_number"] == 5
+    assert out["reference_lap"] is not None
+
+
+def test_parse_last_session_missing_session_raises() -> None:
+    with pytest.raises(TTServicesError):
+        parse_last_session({"success": True, "status": 200, "data": {"foo": 1}})
+
+
+# --- network wiring with fake http ------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttp:
+    def __init__(self, payload) -> None:
+        self._payload = payload
+        self.urls: list[str] = []
+        self.headers: list[dict] = []
+
+    def get(self, url, headers=None, timeout=None):
+        self.urls.append(url)
+        self.headers.append(headers or {})
+        # services authenticates with the RAW access token (no 'Bearer ' prefix).
+        assert headers is not None and not headers["Authorization"].startswith("Bearer ")
+        return _FakeResponse(self._payload)
+
+
+def test_fetch_last_session_wiring() -> None:
+    http = _FakeHttp(_load("tt_services_last_session.json"))
+    out = fetch_last_session("raw-access-token", "uid-1", http=http)
+    assert out["session"]["track_id"] == "magione"
+    assert "uid-1/last-session" in http.urls[0]
+    assert http.headers[0]["Authorization"] == "raw-access-token"
+
+
+def test_fetch_dynamic_reference_lap_wiring() -> None:
+    http = _FakeHttp(_load("tt_services_dynamic_reference.json"))
+    body = fetch_dynamic_reference_lap("tok", "uid-1", "sk-1", 4, segment_count=7, http=http)
+    assert body["lap"]["name"] == "dynamicComparisonLap"
+    assert "segmentCount=7" in http.urls[0]
+
+
+def test_fetch_advice_segment_wiring() -> None:
+    http = _FakeHttp(_load("tt_services_advice.json"))
+    stories = fetch_advice_segment("tok", "u", "s", 5, "refu", "refs", 1, http=http)
+    assert stories[0].diagnosis_key == "coaching.diagnosis.rotation_insufficient"
+    assert "/segments/1" in http.urls[0]
+
+
+def test_services_get_raises_on_http_error() -> None:
+    class _ErrHttp:
+        def get(self, url, headers=None, timeout=None):
+            return _FakeResponse({}, status_code=403)
+
+    with pytest.raises(TTServicesError):
+        fetch_last_session("tok", "uid-1", http=_ErrHttp())

--- a/tests/test_tt_services.py
+++ b/tests/test_tt_services.py
@@ -22,16 +22,19 @@ from tools.tt_ingest.tt_services import (
     fetch_advice_segment,
     fetch_dynamic_reference_lap,
     fetch_last_session,
+    find_session,
     is_enveloped,
     lap_reference_url,
     last_session_url,
     parse_advice,
     parse_last_session,
     parse_reference_lap,
+    parse_services_sessions,
     reference_identity,
     reference_lap_segments,
     reference_lap_url,
     services_sessions_url,
+    session_key_of,
     unwrap_envelope,
 )
 
@@ -246,3 +249,71 @@ def test_services_get_raises_on_http_error() -> None:
 
     with pytest.raises(TTServicesError):
         fetch_last_session("tok", "uid-1", http=_ErrHttp())
+
+
+# --- services sessions list (parse + find) ----------------------------------------
+
+
+def test_parse_services_sessions_from_fixture() -> None:
+    rows = parse_services_sessions(_load("tt_services_sessions.json"))
+    assert len(rows) == 2
+    assert all(isinstance(r, dict) for r in rows)
+    assert rows[0].get("game_id")
+
+
+def test_parse_services_sessions_bare_list() -> None:
+    rows = parse_services_sessions(
+        {"success": True, "status": 200, "data": [{"id": "u#a"}, "junk", {"id": "u#b"}]}
+    )
+    assert [r["id"] for r in rows] == ["u#a", "u#b"]
+
+
+def test_parse_services_sessions_missing_raises() -> None:
+    with pytest.raises(TTServicesError):
+        parse_services_sessions({"success": True, "status": 200, "data": {"count": 0}})
+
+
+def test_session_key_of() -> None:
+    assert session_key_of({"id": "uid-1#20260629005756"}) == "20260629005756"
+    assert session_key_of({"session_id": "u#sk-2"}) == "sk-2"
+    assert session_key_of({"session_key": "sk-3"}) == "sk-3"
+    assert session_key_of({"id": "no-separator"}) is None
+
+
+def test_find_session() -> None:
+    rows = parse_services_sessions(_load("tt_services_sessions.json"))
+    key = session_key_of(rows[0])
+    found = find_session(rows, key)
+    assert found is not None and session_key_of(found) == key
+    assert find_session(rows, "does-not-exist") is None
+
+
+def test_fetch_session_coaching_bundle_separates_references() -> None:
+    # Build advice URLs against the operator's OWN theoreticalBestRef (observed renderer
+    # behaviour) while recording the dynamic reference's identity distinctly — so the bundle
+    # never mislabels the advice source (PR #370 review fix).
+    from tools.tt_ingest.tt_services import fetch_session_coaching
+
+    class _SeqHttp:
+        """Returns the dynamic-reference payload first, then advice for each segment."""
+
+        def __init__(self) -> None:
+            self.urls: list[str] = []
+            self._dyn = _load("tt_services_dynamic_reference.json")
+            self._advice = _load("tt_services_advice.json")
+
+        def get(self, url, headers=None, timeout=None):
+            self.urls.append(url)
+            payload = self._dyn if "dynamic-reference-laps" in url else self._advice
+            return _FakeResponse(payload)
+
+    http = _SeqHttp()
+    bundle = fetch_session_coaching("tok", "own-uid", "own-sk", 5, segment_count=2, http=http)
+    # dynamic_reference is the OTHER driver from the dynamic-reference-laps payload...
+    assert bundle["dynamic_reference"] == ["ref-uid-002", "20220611194228"]
+    # ...while advice was requested against the operator's OWN session + theoreticalBestRef.
+    assert bundle["advice_reference"] == ["own-uid", "own-sk", THEORETICAL_BEST_REF]
+    advice_urls = [u for u in http.urls if "/advice/" in u]
+    assert advice_urls and all(
+        "own-uid/own-sk" in u and THEORETICAL_BEST_REF in u for u in advice_urls
+    )

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -47,9 +47,7 @@ from tools.tt_ingest.tt_normalize import (
 from tools.tt_ingest.tt_services import (
     TTServicesError,
     fetch_last_session_raw,
-    fetch_services_sessions,
     fetch_session_coaching,
-    find_session,
     parse_last_session,
 )
 from tools.tt_ingest.tt_vulcan import iter_all_sessions, session_summary
@@ -57,7 +55,15 @@ from tools.tt_ingest.tt_vulcan import iter_all_sessions, session_summary
 SESSIONS_INDEX_FILENAME = "sessions_index.json"
 RAW_SESSION_ENDPOINT = "session"
 LAST_SESSION_ENDPOINT = "last_session"
-COACHING_ENDPOINT = "coaching"
+#: Coaching is retained one file PER LAP (``coaching_lap{N}.json``) so a multi-lap session
+#: never collides on the write-once lake (a single ``coaching.json`` would block later laps).
+COACHING_ENDPOINT_PREFIX = "coaching_lap"
+COACHING_ENDPOINT_GLOB = f"{COACHING_ENDPOINT_PREFIX}*.json"
+
+
+def coaching_endpoint(lap: Any) -> str:
+    """Endpoint (file stem) for a lap's coaching bundle: ``coaching_lap{lap}``."""
+    return f"{COACHING_ENDPOINT_PREFIX}{lap}"
 
 
 @dataclass(frozen=True)
@@ -86,10 +92,14 @@ def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-# Endpoint files the content-addressed file index records (sessions_index is built from
-# RAW_SESSION_ENDPOINT only — it normalizes vulcan sessions; the coaching endpoints are
-# services data, indexed for discovery/integrity but not normalized into sessions_index).
-INDEXED_ENDPOINTS = (RAW_SESSION_ENDPOINT, LAST_SESSION_ENDPOINT, COACHING_ENDPOINT)
+# File-index globs (sessions_index is built from RAW_SESSION_ENDPOINT only — it normalizes
+# vulcan sessions; the M-TT1 services endpoints are indexed for discovery/integrity but not
+# normalized). Coaching is per-lap, so it is matched by glob, not a fixed name.
+INDEXED_ENDPOINT_GLOBS = (
+    f"{RAW_SESSION_ENDPOINT}.json",
+    f"{LAST_SESSION_ENDPOINT}.json",
+    COACHING_ENDPOINT_GLOB,
+)
 
 
 def reindex_lake(root: Path, *, generated_at: str) -> int:
@@ -100,18 +110,23 @@ def reindex_lake(root: Path, *, generated_at: str) -> int:
     therefore never shrink the discovery index, and ``sessions_index.json`` always agrees
     with the raw files actually present (no batch-vs-disk divergence). The content-addressed
     file index covers vulcan ``session.json`` **and** the M-TT1 services endpoints
-    (``last_session.json`` / ``coaching.json``); ``sessions_index.json`` is built from
+    (``last_session.json`` / ``coaching_lap{N}.json``); ``sessions_index.json`` is built from
     ``session.json`` only (it normalizes vulcan sessions). Returns the count of indexed files.
     """
     records: list[RetainedFile] = []
     normalized: list[dict[str, Any]] = []
-    for endpoint in INDEXED_ENDPOINTS:
-        for path in sorted(root.rglob(f"{endpoint}.json")):
+    seen: set[Path] = set()
+    for pattern in INDEXED_ENDPOINT_GLOBS:
+        for path in sorted(root.rglob(pattern)):
+            if path in seen:
+                continue
+            seen.add(path)
             try:
                 data = path.read_bytes()
                 raw = json.loads(data)
             except (OSError, ValueError):  # pragma: no cover - corrupt file skipped defensively
                 continue
+            endpoint = path.stem  # e.g. "session", "last_session", "coaching_lap5"
             records.append(
                 RetainedFile(
                     session_key=path.parent.name,
@@ -220,17 +235,34 @@ class CoachingSummary:
         )
 
 
+def _car_segment(session: Mapping[str, Any]) -> Any:
+    """Resolve a STRING car id for the lake path.
+
+    The last-session ``session`` stores ``car`` as a string id; other surfaces may carry a
+    string ``car_id`` or a ``car`` object. Prefer a string id and unwrap an object so the
+    lake path is ``…/{car_id}/…``, never a dict-repr (#353 review).
+    """
+    for value in (session.get("car_id"), session.get("car")):
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, Mapping):
+            inner = value.get("car_id") or value.get("id")
+            if isinstance(inner, str) and inner:
+                return inner
+    return None
+
+
 def _session_lake_key(session: Mapping[str, Any]) -> dict[str, Any]:
     """Resolve the (game, car, track, session_key) lake key for a services session.
 
-    The services session uses ``car`` (vulcan uses ``car_id``); the session key is the
-    second half of the ``{uid}#{sessionKey}`` id (services has no standalone field).
+    The session key is the second half of the ``{uid}#{sessionKey}`` id (services has no
+    standalone field). The car id is resolved to a string via :func:`_car_segment`.
     """
     raw_id = session.get("session_id") or session.get("id") or ""
     _, session_key = split_session_id(raw_id)
     return {
         "game": session.get("game_id"),
-        "car": session.get("car") or session.get("car_id"),
+        "car": _car_segment(session),
         "track": session.get("track_id"),
         "session_key": session_key or f"nokey-{stable_fingerprint(dict(session))}",
     }
@@ -251,16 +283,18 @@ def retain_coaching(
     session: Mapping[str, Any],
     bundle: Mapping[str, Any],
     *,
+    lap: Any,
     last_session_payload: Mapping[str, Any] | None = None,
     lake_base: Path | None = None,
     generated_at: str | None = None,
 ) -> CoachingSummary:
-    """Immutably retain a session's last-session payload + coaching bundle, then reindex.
+    """Immutably retain a session's last-session payload + per-lap coaching bundle, then reindex.
 
     Pure of network: given already-fetched payloads, writes ``last_session.json`` and
-    ``coaching.json`` **write-once** under ``journal/tt/{game}/{car}/{track}/{sk}/`` keyed
-    by the **given** ``session`` (so ``coaching --session-key OLD`` lands under OLD, not the
-    latest). ``last_session_payload`` is the FULL raw services response (session +
+    ``coaching_lap{lap}.json`` **write-once** under ``journal/tt/{game}/{car}/{track}/{sk}/``
+    keyed by the given ``session``. The coaching file is **per-lap** so retaining a second
+    lap of the same session never collides with the first on the write-once lake (#353
+    review). ``last_session_payload`` is the FULL raw services response (session +
     referenceLap + telemetry) — preserved so the lake reconstructs exactly what the endpoint
     returned (the M-TT2 reference-lap input); it defaults to ``session`` when not supplied.
     After writing, the lake indexes are rebuilt from disk (:func:`reindex_lake`) so the new
@@ -277,7 +311,7 @@ def retain_coaching(
     written: list[str] = []
     for endpoint, payload in (
         (LAST_SESSION_ENDPOINT, last_payload),
-        (COACHING_ENDPOINT, dict(bundle)),
+        (coaching_endpoint(lap), dict(bundle)),
     ):
         result = write_immutable_json(endpoint_file(target_dir, endpoint), payload, allow_nan=True)
         if result.written:
@@ -330,16 +364,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
     coaching = sub.add_parser(
         "coaching",
-        help="Fetch + retain per-corner reference & advice for a session (services API, M-TT1).",
+        help="Fetch + retain per-corner reference & advice for the last session (services, M-TT1).",
     )
     coaching.add_argument("--uid", default=None, help="User id; defaults to the token 'sub'.")
     coaching.add_argument(
-        "--session-key",
+        "--lap",
+        type=int,
         default=None,
-        help="Session key (YYYYMMDDHHMMSS); defaults to the most recent session.",
-    )
-    coaching.add_argument(
-        "--lap", type=int, default=None, help="Lap number; defaults to the last session's lap."
+        help="Lap number of the last session; defaults to that session's lap.",
     )
     coaching.add_argument(
         "--segment-count", type=int, default=7, help="Corners (segments) to pull (default 7)."
@@ -399,29 +431,19 @@ def cmd_coaching(args: argparse.Namespace) -> int:  # pragma: no cover - network
     minted = mint_tokens(refresh, config)
     uid = args.uid or uid_from_token(minted.access_token)
 
-    # Resolve the target session. Default: the current last session (full payload incl.
-    # telemetry). With --session-key for an OLDER session, look it up in the services
-    # sessions list so retention is keyed to the REQUESTED session, not the latest.
+    # M-TT1 scope: coach the LAST session. The /last-session endpoint gives the full raw
+    # payload (session + referenceLap + telemetry) keyed correctly to the lake; --lap selects
+    # which lap of that session to coach (default: the session's own lap). Coaching for an
+    # ARBITRARY older session needs per-session telemetry endpoints not in M-TT1 scope — see
+    # the M-TT2+ follow-up — so it is intentionally not wired here (a sessions-list row is not
+    # a /last-session payload and must not masquerade as one in the lake).
     raw_last = fetch_last_session_raw(minted.access_token, uid)
-    last_session = parse_last_session(raw_last)["session"]
-    last_key = _session_lake_key(last_session)["session_key"]
-    session_key = args.session_key or last_key
-
-    if session_key == last_key:
-        target_session: Mapping[str, Any] = last_session
-        last_payload: Mapping[str, Any] = raw_last  # full services evidence (telemetry)
-    else:
-        sessions = fetch_services_sessions(minted.access_token, uid, limit=50)
-        found = find_session(sessions, session_key)
-        if found is None:
-            _print(f"coaching: session_key {session_key} not found in the sessions list")
-            return 1
-        target_session = found
-        last_payload = found  # metadata for the requested (non-last) session
-
-    lap = args.lap if args.lap is not None else target_session.get("lap_number")
+    session = parse_last_session(raw_last)["session"]
+    key = _session_lake_key(session)
+    session_key = key["session_key"]
+    lap = args.lap if args.lap is not None else session.get("lap_number")
     if not session_key or lap is None:
-        _print("coaching: could not resolve a session_key/lap (no recent session?)")
+        _print("coaching: could not resolve the last session's key/lap (no recent session?)")
         return 1
 
     bundle = fetch_session_coaching(
@@ -438,7 +460,7 @@ def cmd_coaching(args: argparse.Namespace) -> int:  # pragma: no cover - network
         return 0
 
     summary = retain_coaching(
-        target_session, bundle, last_session_payload=last_payload, lake_base=args.lake_base
+        session, bundle, lap=lap, last_session_payload=raw_last, lake_base=args.lake_base
     )
     _print(summary.render())
     return 0

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -39,11 +39,22 @@ from tools.tt_ingest.tt_export import (
     stable_fingerprint,
     write_immutable_json,
 )
-from tools.tt_ingest.tt_normalize import build_sessions_index, normalize_session
+from tools.tt_ingest.tt_normalize import (
+    build_sessions_index,
+    normalize_session,
+    split_session_id,
+)
+from tools.tt_ingest.tt_services import (
+    TTServicesError,
+    fetch_last_session,
+    fetch_session_coaching,
+)
 from tools.tt_ingest.tt_vulcan import iter_all_sessions, session_summary
 
 SESSIONS_INDEX_FILENAME = "sessions_index.json"
 RAW_SESSION_ENDPOINT = "session"
+LAST_SESSION_ENDPOINT = "last_session"
+COACHING_ENDPOINT = "coaching"
 
 
 @dataclass(frozen=True)
@@ -178,6 +189,87 @@ def retain_sessions(
     )
 
 
+@dataclass(frozen=True)
+class CoachingSummary:
+    """Outcome of retaining one session's coaching bundle (M-TT1)."""
+
+    session_key: str
+    segments: int
+    actionable: int
+    written: list[str]
+    lake_root: Path
+
+    def render(self) -> str:
+        return (
+            f"retained coaching for session {self.session_key} "
+            f"({self.segments} segment(s), {self.actionable} actionable) to {self.lake_root} "
+            f"[{', '.join(self.written) or 'nothing new'}]"
+        )
+
+
+def _session_lake_key(session: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve the (game, car, track, session_key) lake key for a services session.
+
+    The services session uses ``car`` (vulcan uses ``car_id``); the session key is the
+    second half of the ``{uid}#{sessionKey}`` id (services has no standalone field).
+    """
+    raw_id = session.get("session_id") or session.get("id") or ""
+    _, session_key = split_session_id(raw_id)
+    return {
+        "game": session.get("game_id"),
+        "car": session.get("car") or session.get("car_id"),
+        "track": session.get("track_id"),
+        "session_key": session_key or f"nokey-{stable_fingerprint(dict(session))}",
+    }
+
+
+def _count_actionable(bundle: Mapping[str, Any]) -> int:
+    """Count corner stories carrying a real (>0) time loss across the bundle."""
+    total = 0
+    for seg in bundle.get("segments", []) or []:
+        for story in seg.get("stories", []) or []:
+            loss = story.get("time_loss")
+            if isinstance(loss, (int, float)) and loss > 0:
+                total += 1
+    return total
+
+
+def retain_coaching(
+    session: Mapping[str, Any],
+    bundle: Mapping[str, Any],
+    *,
+    lake_base: Path | None = None,
+    generated_at: str | None = None,
+) -> CoachingSummary:
+    """Immutably retain a session's last-session metadata + coaching bundle.
+
+    Pure of network: given already-fetched payloads, writes ``last_session.json`` and
+    ``coaching.json`` **write-once** under ``journal/tt/{game}/{car}/{track}/{sk}/`` —
+    the per-corner reference + advice the M0 voice loop (M-TT2) will consume. ``allow_nan``
+    keeps non-finite telemetry floats lossless, matching raw session retention.
+    """
+    root = lake_root(lake_base)
+    key = _session_lake_key(session)
+    target_dir = session_lake_dir(
+        root, game=key["game"], car=key["car"], track=key["track"], session_key=key["session_key"]
+    )
+    written: list[str] = []
+    for endpoint, payload in (
+        (LAST_SESSION_ENDPOINT, dict(session)),
+        (COACHING_ENDPOINT, dict(bundle)),
+    ):
+        result = write_immutable_json(endpoint_file(target_dir, endpoint), payload, allow_nan=True)
+        if result.written:
+            written.append(endpoint)
+    return CoachingSummary(
+        session_key=key["session_key"],
+        segments=len(bundle.get("segments", []) or []),
+        actionable=_count_actionable(bundle),
+        written=written,
+        lake_root=root,
+    )
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     """Build the ``tools.tt_ingest`` argument parser."""
     parser = argparse.ArgumentParser(
@@ -211,6 +303,30 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help="Fetch page 1 and print a sanitized summary; write nothing.",
+    )
+
+    coaching = sub.add_parser(
+        "coaching",
+        help="Fetch + retain per-corner reference & advice for a session (services API, M-TT1).",
+    )
+    coaching.add_argument("--uid", default=None, help="User id; defaults to the token 'sub'.")
+    coaching.add_argument(
+        "--session-key",
+        default=None,
+        help="Session key (YYYYMMDDHHMMSS); defaults to the most recent session.",
+    )
+    coaching.add_argument(
+        "--lap", type=int, default=None, help="Lap number; defaults to the last session's lap."
+    )
+    coaching.add_argument(
+        "--segment-count", type=int, default=7, help="Corners (segments) to pull (default 7)."
+    )
+    coaching.add_argument("--lake-base", type=Path, default=None)
+    coaching.add_argument("--leveldb-dir", type=Path, default=None)
+    coaching.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved session + a sanitized advice summary; write nothing.",
     )
     return parser
 
@@ -254,6 +370,40 @@ def cmd_export(args: argparse.Namespace) -> int:  # pragma: no cover - network
     return 0
 
 
+def cmd_coaching(args: argparse.Namespace) -> int:  # pragma: no cover - network
+    config = TTConfig.from_env()
+    refresh = resolve_refresh_token(config, leveldb_dir=args.leveldb_dir)
+    minted = mint_tokens(refresh, config)
+    uid = args.uid or uid_from_token(minted.access_token)
+
+    # Resolve the target session/lap from the last session unless explicitly given.
+    last = fetch_last_session(minted.access_token, uid)
+    session = last["session"]
+    key = _session_lake_key(session)
+    session_key = args.session_key or key["session_key"]
+    lap = args.lap if args.lap is not None else session.get("lap_number")
+    if not session_key or lap is None:
+        _print("coaching: could not resolve a session_key/lap (no recent session?)")
+        return 1
+
+    bundle = fetch_session_coaching(
+        minted.access_token, uid, session_key, lap, segment_count=args.segment_count
+    )
+
+    if args.dry_run:
+        _print(f"dry-run — uid={uid}, session={session_key}, lap={lap}")
+        _print(f"  reference: {bundle['reference_lap'].get('username', '?')}")
+        for seg in bundle["segments"]:
+            stories = seg.get("stories", [])
+            head = stories[0]["diagnosis"] if stories else "(no advice)"
+            _print(f"  corner {seg['segment']}: {head}")
+        return 0
+
+    summary = retain_coaching(session, bundle, lake_base=args.lake_base)
+    _print(summary.render())
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
@@ -262,7 +412,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             return cmd_auth_check(args)
         if args.command == "export":
             return cmd_export(args)
-    except TTAuthError as exc:  # pragma: no cover - surfaced live
+        if args.command == "coaching":
+            return cmd_coaching(args)
+    except (TTAuthError, TTServicesError) as exc:  # pragma: no cover - surfaced live
         parser.exit(2, f"tt_ingest: {exc}\n")
     parser.error(f"unknown command: {args.command}")  # pragma: no cover - argparse guards
     return 2

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -368,12 +368,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     coaching.add_argument("--uid", default=None, help="User id; defaults to the token 'sub'.")
     coaching.add_argument(
-        "--lap",
-        type=int,
-        default=None,
-        help="Lap number of the last session; defaults to that session's lap.",
-    )
-    coaching.add_argument(
         "--segment-count", type=int, default=7, help="Corners (segments) to pull (default 7)."
     )
     coaching.add_argument("--lake-base", type=Path, default=None)
@@ -431,17 +425,17 @@ def cmd_coaching(args: argparse.Namespace) -> int:  # pragma: no cover - network
     minted = mint_tokens(refresh, config)
     uid = args.uid or uid_from_token(minted.access_token)
 
-    # M-TT1 scope: coach the LAST session. The /last-session endpoint gives the full raw
-    # payload (session + referenceLap + telemetry) keyed correctly to the lake; --lap selects
-    # which lap of that session to coach (default: the session's own lap). Coaching for an
-    # ARBITRARY older session needs per-session telemetry endpoints not in M-TT1 scope — see
-    # the M-TT2+ follow-up — so it is intentionally not wired here (a sessions-list row is not
-    # a /last-session payload and must not masquerade as one in the lake).
+    # M-TT1 scope: coach the LAST session's own lap. The /last-session endpoint returns the
+    # full raw payload (session + referenceLap + telemetry) for exactly that lap, so the
+    # retained last_session.json is COHERENT lap-specific evidence next to coaching_lap{N}.json.
+    # Coaching an arbitrary lap (or older session) needs per-lap telemetry endpoints not in
+    # M-TT1 scope — see the M-TT2+ follow-up — so it is intentionally not offered here (a
+    # mismatched lap would pair lap-N coaching with the wrong lap's raw evidence).
     raw_last = fetch_last_session_raw(minted.access_token, uid)
     session = parse_last_session(raw_last)["session"]
     key = _session_lake_key(session)
     session_key = key["session_key"]
-    lap = args.lap if args.lap is not None else session.get("lap_number")
+    lap = session.get("lap_number")
     if not session_key or lap is None:
         _print("coaching: could not resolve the last session's key/lap (no recent session?)")
         return 1

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -54,11 +54,20 @@ from tools.tt_ingest.tt_vulcan import iter_all_sessions, session_summary
 
 SESSIONS_INDEX_FILENAME = "sessions_index.json"
 RAW_SESSION_ENDPOINT = "session"
-LAST_SESSION_ENDPOINT = "last_session"
-#: Coaching is retained one file PER LAP (``coaching_lap{N}.json``) so a multi-lap session
-#: never collides on the write-once lake (a single ``coaching.json`` would block later laps).
+# Both the raw /last-session payload AND the coaching bundle are retained one file PER LAP
+# (``last_session_lap{N}.json`` / ``coaching_lap{N}.json``). The /last-session telemetry is
+# lap-specific, so lap-keying it keeps each lap's raw evidence COHERENT with its coaching even
+# when the same session later gains another lap (a single write-once ``last_session.json``
+# would otherwise go stale against a newer lap's bundle).
+LAST_SESSION_ENDPOINT_PREFIX = "last_session_lap"
+LAST_SESSION_ENDPOINT_GLOB = f"{LAST_SESSION_ENDPOINT_PREFIX}*.json"
 COACHING_ENDPOINT_PREFIX = "coaching_lap"
 COACHING_ENDPOINT_GLOB = f"{COACHING_ENDPOINT_PREFIX}*.json"
+
+
+def last_session_endpoint(lap: Any) -> str:
+    """Endpoint (file stem) for a lap's raw /last-session payload: ``last_session_lap{lap}``."""
+    return f"{LAST_SESSION_ENDPOINT_PREFIX}{lap}"
 
 
 def coaching_endpoint(lap: Any) -> str:
@@ -97,7 +106,7 @@ def _iso_now() -> str:
 # normalized). Coaching is per-lap, so it is matched by glob, not a fixed name.
 INDEXED_ENDPOINT_GLOBS = (
     f"{RAW_SESSION_ENDPOINT}.json",
-    f"{LAST_SESSION_ENDPOINT}.json",
+    LAST_SESSION_ENDPOINT_GLOB,
     COACHING_ENDPOINT_GLOB,
 )
 
@@ -290,13 +299,14 @@ def retain_coaching(
 ) -> CoachingSummary:
     """Immutably retain a session's last-session payload + per-lap coaching bundle, then reindex.
 
-    Pure of network: given already-fetched payloads, writes ``last_session.json`` and
+    Pure of network: given already-fetched payloads, writes ``last_session_lap{lap}.json`` and
     ``coaching_lap{lap}.json`` **write-once** under ``journal/tt/{game}/{car}/{track}/{sk}/``
-    keyed by the given ``session``. The coaching file is **per-lap** so retaining a second
-    lap of the same session never collides with the first on the write-once lake (#353
-    review). ``last_session_payload`` is the FULL raw services response (session +
-    referenceLap + telemetry) — preserved so the lake reconstructs exactly what the endpoint
-    returned (the M-TT2 reference-lap input); it defaults to ``session`` when not supplied.
+    keyed by the given ``session``. BOTH files are **per-lap**: the /last-session telemetry is
+    lap-specific, so lap-keying it keeps each lap's raw evidence coherent with its coaching even
+    when the same session later gains another lap (#353 review). ``last_session_payload`` is the
+    FULL raw services response (session + referenceLap + telemetry) — preserved so the lake
+    reconstructs exactly what the endpoint returned (the M-TT2 reference-lap input); it defaults
+    to ``session`` when not supplied.
     After writing, the lake indexes are rebuilt from disk (:func:`reindex_lake`) so the new
     services endpoints are discoverable and integrity-checkable. ``allow_nan`` keeps
     non-finite telemetry floats lossless, matching raw session retention.
@@ -310,7 +320,7 @@ def retain_coaching(
     last_payload = dict(last_session_payload) if last_session_payload is not None else dict(session)
     written: list[str] = []
     for endpoint, payload in (
-        (LAST_SESSION_ENDPOINT, last_payload),
+        (last_session_endpoint(lap), last_payload),
         (coaching_endpoint(lap), dict(bundle)),
     ):
         result = write_immutable_json(endpoint_file(target_dir, endpoint), payload, allow_nan=True)

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -46,8 +46,11 @@ from tools.tt_ingest.tt_normalize import (
 )
 from tools.tt_ingest.tt_services import (
     TTServicesError,
-    fetch_last_session,
+    fetch_last_session_raw,
+    fetch_services_sessions,
     fetch_session_coaching,
+    find_session,
+    parse_last_session,
 )
 from tools.tt_ingest.tt_vulcan import iter_all_sessions, session_summary
 
@@ -83,35 +86,44 @@ def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+# Endpoint files the content-addressed file index records (sessions_index is built from
+# RAW_SESSION_ENDPOINT only — it normalizes vulcan sessions; the coaching endpoints are
+# services data, indexed for discovery/integrity but not normalized into sessions_index).
+INDEXED_ENDPOINTS = (RAW_SESSION_ENDPOINT, LAST_SESSION_ENDPOINT, COACHING_ENDPOINT)
+
+
 def reindex_lake(root: Path, *, generated_at: str) -> int:
-    """Rebuild both derived indexes from EVERY ``session.json`` currently in the lake.
+    """Rebuild both derived indexes from EVERY retained endpoint file in the lake.
 
     The indexes are a *derived view* of the immutable raw files — so they are rebuilt by
     scanning the whole lake on disk, never from one batch's records. A partial export can
     therefore never shrink the discovery index, and ``sessions_index.json`` always agrees
-    with the raw files actually present (no batch-vs-disk divergence). Returns the count of
-    indexed raw files.
+    with the raw files actually present (no batch-vs-disk divergence). The content-addressed
+    file index covers vulcan ``session.json`` **and** the M-TT1 services endpoints
+    (``last_session.json`` / ``coaching.json``); ``sessions_index.json`` is built from
+    ``session.json`` only (it normalizes vulcan sessions). Returns the count of indexed files.
     """
     records: list[RetainedFile] = []
     normalized: list[dict[str, Any]] = []
-    for path in sorted(root.rglob(f"{RAW_SESSION_ENDPOINT}.json")):
-        try:
-            data = path.read_bytes()
-            raw = json.loads(data)
-        except (OSError, ValueError):  # pragma: no cover - corrupt file skipped defensively
-            continue
-        records.append(
-            RetainedFile(
-                session_key=path.parent.name,
-                endpoint=RAW_SESSION_ENDPOINT,
-                relative_path=relative_to_lake(path, root),
-                sha256=sha256_hex(data),
-                bytes=len(data),
-                written=False,
+    for endpoint in INDEXED_ENDPOINTS:
+        for path in sorted(root.rglob(f"{endpoint}.json")):
+            try:
+                data = path.read_bytes()
+                raw = json.loads(data)
+            except (OSError, ValueError):  # pragma: no cover - corrupt file skipped defensively
+                continue
+            records.append(
+                RetainedFile(
+                    session_key=path.parent.name,
+                    endpoint=endpoint,
+                    relative_path=relative_to_lake(path, root),
+                    sha256=sha256_hex(data),
+                    bytes=len(data),
+                    written=False,
+                )
             )
-        )
-        if isinstance(raw, Mapping):
-            normalized.append(normalize_session(raw))
+            if endpoint == RAW_SESSION_ENDPOINT and isinstance(raw, Mapping):
+                normalized.append(normalize_session(raw))
     root.mkdir(parents=True, exist_ok=True)
     # sessions_index carries normalized telemetry conditions → allow_nan for lossless
     # round-trip; the file index (hashes/sizes/paths only) stays strict, portable JSON.
@@ -198,12 +210,13 @@ class CoachingSummary:
     actionable: int
     written: list[str]
     lake_root: Path
+    indexed: int = 0
 
     def render(self) -> str:
         return (
             f"retained coaching for session {self.session_key} "
             f"({self.segments} segment(s), {self.actionable} actionable) to {self.lake_root} "
-            f"[{', '.join(self.written) or 'nothing new'}]"
+            f"[{', '.join(self.written) or 'nothing new'}; {self.indexed} file(s) indexed]"
         )
 
 
@@ -238,35 +251,45 @@ def retain_coaching(
     session: Mapping[str, Any],
     bundle: Mapping[str, Any],
     *,
+    last_session_payload: Mapping[str, Any] | None = None,
     lake_base: Path | None = None,
     generated_at: str | None = None,
 ) -> CoachingSummary:
-    """Immutably retain a session's last-session metadata + coaching bundle.
+    """Immutably retain a session's last-session payload + coaching bundle, then reindex.
 
     Pure of network: given already-fetched payloads, writes ``last_session.json`` and
-    ``coaching.json`` **write-once** under ``journal/tt/{game}/{car}/{track}/{sk}/`` —
-    the per-corner reference + advice the M0 voice loop (M-TT2) will consume. ``allow_nan``
-    keeps non-finite telemetry floats lossless, matching raw session retention.
+    ``coaching.json`` **write-once** under ``journal/tt/{game}/{car}/{track}/{sk}/`` keyed
+    by the **given** ``session`` (so ``coaching --session-key OLD`` lands under OLD, not the
+    latest). ``last_session_payload`` is the FULL raw services response (session +
+    referenceLap + telemetry) — preserved so the lake reconstructs exactly what the endpoint
+    returned (the M-TT2 reference-lap input); it defaults to ``session`` when not supplied.
+    After writing, the lake indexes are rebuilt from disk (:func:`reindex_lake`) so the new
+    services endpoints are discoverable and integrity-checkable. ``allow_nan`` keeps
+    non-finite telemetry floats lossless, matching raw session retention.
     """
     root = lake_root(lake_base)
+    stamp = generated_at or _iso_now()
     key = _session_lake_key(session)
     target_dir = session_lake_dir(
         root, game=key["game"], car=key["car"], track=key["track"], session_key=key["session_key"]
     )
+    last_payload = dict(last_session_payload) if last_session_payload is not None else dict(session)
     written: list[str] = []
     for endpoint, payload in (
-        (LAST_SESSION_ENDPOINT, dict(session)),
+        (LAST_SESSION_ENDPOINT, last_payload),
         (COACHING_ENDPOINT, dict(bundle)),
     ):
         result = write_immutable_json(endpoint_file(target_dir, endpoint), payload, allow_nan=True)
         if result.written:
             written.append(endpoint)
+    indexed = reindex_lake(root, generated_at=stamp)
     return CoachingSummary(
         session_key=key["session_key"],
         segments=len(bundle.get("segments", []) or []),
         actionable=_count_actionable(bundle),
         written=written,
         lake_root=root,
+        indexed=indexed,
     )
 
 
@@ -376,12 +399,27 @@ def cmd_coaching(args: argparse.Namespace) -> int:  # pragma: no cover - network
     minted = mint_tokens(refresh, config)
     uid = args.uid or uid_from_token(minted.access_token)
 
-    # Resolve the target session/lap from the last session unless explicitly given.
-    last = fetch_last_session(minted.access_token, uid)
-    session = last["session"]
-    key = _session_lake_key(session)
-    session_key = args.session_key or key["session_key"]
-    lap = args.lap if args.lap is not None else session.get("lap_number")
+    # Resolve the target session. Default: the current last session (full payload incl.
+    # telemetry). With --session-key for an OLDER session, look it up in the services
+    # sessions list so retention is keyed to the REQUESTED session, not the latest.
+    raw_last = fetch_last_session_raw(minted.access_token, uid)
+    last_session = parse_last_session(raw_last)["session"]
+    last_key = _session_lake_key(last_session)["session_key"]
+    session_key = args.session_key or last_key
+
+    if session_key == last_key:
+        target_session: Mapping[str, Any] = last_session
+        last_payload: Mapping[str, Any] = raw_last  # full services evidence (telemetry)
+    else:
+        sessions = fetch_services_sessions(minted.access_token, uid, limit=50)
+        found = find_session(sessions, session_key)
+        if found is None:
+            _print(f"coaching: session_key {session_key} not found in the sessions list")
+            return 1
+        target_session = found
+        last_payload = found  # metadata for the requested (non-last) session
+
+    lap = args.lap if args.lap is not None else target_session.get("lap_number")
     if not session_key or lap is None:
         _print("coaching: could not resolve a session_key/lap (no recent session?)")
         return 1
@@ -392,14 +430,16 @@ def cmd_coaching(args: argparse.Namespace) -> int:  # pragma: no cover - network
 
     if args.dry_run:
         _print(f"dry-run — uid={uid}, session={session_key}, lap={lap}")
-        _print(f"  reference: {bundle['reference_lap'].get('username', '?')}")
+        _print(f"  dynamic reference: {bundle['reference_lap'].get('username', '?')}")
         for seg in bundle["segments"]:
             stories = seg.get("stories", [])
             head = stories[0]["diagnosis"] if stories else "(no advice)"
             _print(f"  corner {seg['segment']}: {head}")
         return 0
 
-    summary = retain_coaching(session, bundle, lake_base=args.lake_base)
+    summary = retain_coaching(
+        target_session, bundle, last_session_payload=last_payload, lake_base=args.lake_base
+    )
     _print(summary.render())
     return 0
 

--- a/tools/tt_ingest/tt_services.py
+++ b/tools/tt_ingest/tt_services.py
@@ -302,6 +302,42 @@ def parse_last_session(payload: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def parse_services_sessions(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return the session rows from a services ``/users/{uid}/sessions`` response.
+
+    Enveloped (``data.sessions``); tolerates a bare ``data`` list. Skips non-mapping rows.
+    """
+    data = unwrap_envelope(payload)
+    rows: Any = None
+    if isinstance(data, Mapping):
+        rows = data.get("sessions")
+    elif isinstance(data, list):
+        rows = data
+    if not isinstance(rows, list):
+        raise TTServicesError("services sessions response missing 'data.sessions' list")
+    return [dict(s) for s in rows if isinstance(s, Mapping)]
+
+
+def session_key_of(session: Mapping[str, Any]) -> str | None:
+    """Extract the bare session key from a services session row.
+
+    The services id is ``{uid}#{sessionKey}``; fall back to an explicit ``session_key``.
+    """
+    raw_id = session.get("id") or session.get("session_id") or ""
+    if isinstance(raw_id, str) and "#" in raw_id:
+        return raw_id.split("#", 1)[1] or None
+    sk = session.get("session_key")
+    return sk if isinstance(sk, str) and sk else None
+
+
+def find_session(sessions: list[Mapping[str, Any]], session_key: str) -> dict[str, Any] | None:
+    """Return the session row whose key matches ``session_key``, else ``None``."""
+    for s in sessions:
+        if session_key_of(s) == session_key:
+            return dict(s)
+    return None
+
+
 # ----------------------------------------------------------------------------------
 # Network round-trips — thin, isolated, ``# pragma: no cover`` (verified live, #353).
 # ----------------------------------------------------------------------------------
@@ -334,6 +370,24 @@ def _client(http: Any | None) -> Any:  # pragma: no cover - trivial import shim
     return requests_mod
 
 
+def fetch_last_session_raw(
+    access_token: str,
+    uid: str,
+    *,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (#353)
+    """Fetch the FULL raw last-session payload (session + referenceLap + telemetry).
+
+    Retention uses this so the immutable lake preserves the complete services evidence
+    (incl. the reference telemetry trace M-TT2 needs) rather than a stripped projection.
+    """
+    body = _services_get(last_session_url(uid), access_token, http=_client(http), timeout=timeout)
+    if not isinstance(body, Mapping):
+        raise TTServicesError("last-session response was not an object")
+    return dict(body)
+
+
 def fetch_last_session(
     access_token: str,
     uid: str,
@@ -344,6 +398,23 @@ def fetch_last_session(
     """Fetch + parse the user's last session (session + reference lap)."""
     body = _services_get(last_session_url(uid), access_token, http=_client(http), timeout=timeout)
     return parse_last_session(body)
+
+
+def fetch_services_sessions(
+    access_token: str,
+    uid: str,
+    *,
+    page: int = 1,
+    limit: int = 20,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> list[dict[str, Any]]:  # pragma: no cover - network round-trip, verified live (#353)
+    """Fetch + parse one page of the services-view sessions list."""
+    url = services_sessions_url(uid, page=page, limit=limit)
+    body = _services_get(url, access_token, http=_client(http), timeout=timeout)
+    if not isinstance(body, Mapping):
+        raise TTServicesError("services sessions response was not an object")
+    return parse_services_sessions(body)
 
 
 def fetch_dynamic_reference_lap(
@@ -394,16 +465,28 @@ def fetch_session_coaching(
     lap: Any,
     *,
     segment_count: int = DEFAULT_SEGMENT_COUNT,
-    ref_lap: Any = THEORETICAL_BEST_REF,
+    advice_ref_uid: str | None = None,
+    advice_ref_session_key: str | None = None,
+    advice_ref_lap: Any = THEORETICAL_BEST_REF,
     http: Any | None = None,
     timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
 ) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (#353)
     """Pull the full per-corner coaching bundle for one lap.
 
-    Returns ``{"reference_lap": {...}, "segments": [{segment, stories: [...]}]}``.
-    The reference lap's identity (uid + session key) drives the advice requests; the
-    advice itself compares the lap against the operator's ``theoreticalBestRef`` by
-    default (matching the renderer's own behaviour).
+    Returns ``{"reference_lap", "dynamic_reference", "advice_reference", "segments"}``.
+
+    There are **two distinct references**, which must not be conflated (#353 review):
+
+    * ``dynamic_reference`` — the comparison lap returned by ``dynamic-reference-laps``
+      (a faster/community driver, e.g. another user's session). Its identity is
+      ``[ref_uid, ref_session_key]`` and it drives the racing-line/segment comparison.
+    * ``advice_reference`` — what the per-corner ``/advice`` is computed against. The
+      renderer compares the operator's lap against their **own** ``theoreticalBestRef``
+      by default (verified live), so advice defaults to ``(uid, session_key,
+      theoreticalBestRef)``. Override via ``advice_ref_*`` to diff against another lap.
+
+    Recording both separately means the bundle's reference identity always matches the
+    data it labels (the prior single ``reference_id`` mislabelled the advice source).
     """
     client = _client(http)
     raw_ref = _services_get(
@@ -413,22 +496,33 @@ def fetch_session_coaching(
         timeout=timeout,
     )
     reference_lap = parse_reference_lap(raw_ref)
-    ref_uid, ref_sk = reference_identity(reference_lap)
+    try:
+        dyn_uid, dyn_sk = reference_identity(reference_lap)
+    except TTServicesError:
+        dyn_uid, dyn_sk = None, None
+    a_uid = advice_ref_uid or uid
+    a_sk = advice_ref_session_key or session_key
     segments: list[dict[str, Any]] = []
-    for seg_num, _ in reference_lap_segments(reference_lap) or [
-        (i, 0.0) for i in range(1, segment_count + 1)
-    ]:
+    seg_nums = [n for n, _ in reference_lap_segments(reference_lap)] or list(
+        range(1, segment_count + 1)
+    )
+    for seg_num in seg_nums:
         stories = fetch_advice_segment(
             access_token,
             uid,
             session_key,
             lap,
-            uid,  # advice references the operator's OWN session for theoreticalBestRef
-            session_key,
+            a_uid,
+            a_sk,
             seg_num,
-            ref_lap=ref_lap,
+            ref_lap=advice_ref_lap,
             http=client,
             timeout=timeout,
         )
         segments.append({"segment": seg_num, "stories": [s.__dict__ for s in stories]})
-    return {"reference_lap": reference_lap, "reference_id": [ref_uid, ref_sk], "segments": segments}
+    return {
+        "reference_lap": reference_lap,
+        "dynamic_reference": [dyn_uid, dyn_sk],
+        "advice_reference": [a_uid, a_sk, advice_ref_lap],
+        "segments": segments,
+    }

--- a/tools/tt_ingest/tt_services.py
+++ b/tools/tt_ingest/tt_services.py
@@ -471,31 +471,31 @@ def fetch_session_coaching(
     http: Any | None = None,
     timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
 ) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (#353)
-    """Pull the full per-corner coaching bundle for one lap.
+    """Pull the full per-corner coaching bundle for one lap, preserving RAW evidence.
 
-    Returns ``{"reference_lap", "dynamic_reference", "advice_reference", "segments"}``.
+    The lake is write-once **raw services evidence**, so the bundle keeps the unmodified
+    endpoint responses (``dynamic_reference_raw`` and each segment's ``advice_raw``) — the
+    parsed views (``reference_lap``, per-segment ``stories``) are convenience on top, never
+    a replacement (#353 review: don't drop ``vars``/``user_lap_time``/``is_cache_hit`` etc).
 
     There are **two distinct references**, which must not be conflated (#353 review):
 
-    * ``dynamic_reference`` — the comparison lap returned by ``dynamic-reference-laps``
-      (a faster/community driver, e.g. another user's session). Its identity is
-      ``[ref_uid, ref_session_key]`` and it drives the racing-line/segment comparison.
-    * ``advice_reference`` — what the per-corner ``/advice`` is computed against. The
-      renderer compares the operator's lap against their **own** ``theoreticalBestRef``
-      by default (verified live), so advice defaults to ``(uid, session_key,
-      theoreticalBestRef)``. Override via ``advice_ref_*`` to diff against another lap.
-
-    Recording both separately means the bundle's reference identity always matches the
-    data it labels (the prior single ``reference_id`` mislabelled the advice source).
+    * ``dynamic_reference`` — the comparison lap from ``dynamic-reference-laps`` (a
+      faster/community driver). Identity ``[ref_uid, ref_session_key]``; drives the
+      racing-line/segment comparison.
+    * ``advice_reference`` — what ``/advice`` is computed against. The renderer compares the
+      operator's lap against their **own** ``theoreticalBestRef`` by default (verified live),
+      so advice defaults to ``(uid, session_key, theoreticalBestRef)``. Override via
+      ``advice_ref_*``.
     """
     client = _client(http)
-    raw_ref = _services_get(
+    dynamic_reference_raw = _services_get(
         dynamic_reference_lap_url(uid, session_key, lap, segment_count=segment_count),
         access_token,
         http=client,
         timeout=timeout,
     )
-    reference_lap = parse_reference_lap(raw_ref)
+    reference_lap = parse_reference_lap(dynamic_reference_raw)
     try:
         dyn_uid, dyn_sk = reference_identity(reference_lap)
     except TTServicesError:
@@ -507,21 +507,23 @@ def fetch_session_coaching(
         range(1, segment_count + 1)
     )
     for seg_num in seg_nums:
-        stories = fetch_advice_segment(
+        advice_raw = _services_get(
+            advice_segment_url(uid, session_key, lap, a_uid, a_sk, seg_num, ref_lap=advice_ref_lap),
             access_token,
-            uid,
-            session_key,
-            lap,
-            a_uid,
-            a_sk,
-            seg_num,
-            ref_lap=advice_ref_lap,
             http=client,
             timeout=timeout,
         )
-        segments.append({"segment": seg_num, "stories": [s.__dict__ for s in stories]})
+        stories = parse_advice(advice_raw) if isinstance(advice_raw, Mapping) else []
+        segments.append(
+            {
+                "segment": seg_num,
+                "advice_raw": advice_raw,  # write-once raw /advice evidence
+                "stories": [s.__dict__ for s in stories],  # parsed convenience view
+            }
+        )
     return {
-        "reference_lap": reference_lap,
+        "dynamic_reference_raw": dynamic_reference_raw,  # write-once raw /dynamic-reference-laps
+        "reference_lap": reference_lap,  # parsed convenience view
         "dynamic_reference": [dyn_uid, dyn_sk],
         "advice_reference": [a_uid, a_sk, advice_ref_lap],
         "segments": segments,

--- a/tools/tt_ingest/tt_services.py
+++ b/tools/tt_ingest/tt_services.py
@@ -1,0 +1,434 @@
+"""Track Titan **services** API client — the turn-by-turn coaching plane
+(issue #353, milestone M-TT1).
+
+The services API (``https://services.tracktitan.io``) serves the rich post-race
+analysis the operator wants: per-corner reference laps, the personalised /
+community reference, and natural-language coaching **advice** per corner. The
+desktop app's renderer was captured live (CDP) to pin both the auth model and the
+exact paths — see ``track-titan-services-auth-2026-06-29`` in the vault.
+
+Auth model (VERIFIED LIVE, issue #353): every services route authenticates with
+the **raw Cognito access token** in the ``Authorization`` header (NO ``Bearer``
+prefix) — the *same* access token vulcan uses (:func:`tools.tt_ingest.tt_auth.mint_tokens`
+already returns it). The M-TT1 research checkpoint's "needs SigV4 / Identity-Pool
+IAM" was a red herring: it had probed *old* cached path shapes (``data-analysis/…``)
+with the **id** token, which 403s. The current API is RESTful ``/api/v2/…`` and the
+access token is accepted (200). The Cognito Identity-Pool ``GetCredentialsForIdentity``
+calls the app also makes are for analytics, not these data routes.
+
+Two response shapes:
+  * **Enveloped** (``/api/v2/*`` and ``/advice/*``): ``{success, status, data, message}``.
+  * **Bare** (``/dynamic-reference-laps/*``): the object itself (``{session, lap, …}``).
+:func:`unwrap_envelope` normalises both.
+
+URL builders + parsers are pure and unit-tested against sanitized fixtures; the
+HTTP round-trips are isolated and ``# pragma: no cover`` (proven live, issue #353).
+
+SECURITY (issue #353 scope/ethics): personal own-account coaching data. The access
+token is a personal secret — this module never logs it, never embeds it in error
+messages, and callers must keep it in env / the gitignored lake only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+from tools.tt_ingest.tt_auth import DEFAULT_REQUEST_TIMEOUT_S
+
+SERVICES_BASE = "https://services.tracktitan.io"
+
+#: The reference-lap identifier the app uses for the personalised theoretical best.
+THEORETICAL_BEST_REF = "theoreticalBestRef"
+#: Default number of segments (corners) the renderer requests per reference lap.
+DEFAULT_SEGMENT_COUNT = 7
+
+
+class TTServicesError(RuntimeError):
+    """A services response did not match the documented shape, or an HTTP error.
+
+    Never carries token material — only the actionable cause + sanitized URL path.
+    """
+
+
+# ----------------------------------------------------------------------------------
+# Pure URL builders. Every path segment is percent-encoded so an id containing a
+# ``#``/``/`` can never break out of its segment (the vulcan id form is
+# ``{uid}#{sessionKey}``; services takes uid and sessionKey as SEPARATE segments).
+# ----------------------------------------------------------------------------------
+
+
+def _seg(value: Any) -> str:
+    """Percent-encode one path segment (encode everything, incl. ``/`` and ``#``)."""
+    return quote(str(value), safe="")
+
+
+def services_sessions_url(
+    uid: str,
+    *,
+    page: int = 1,
+    limit: int = 5,
+    hide_limited: bool = False,
+    base: str = SERVICES_BASE,
+) -> str:
+    """The services view of a user's sessions list (richer than vulcan's)."""
+    hl = "true" if hide_limited else "false"
+    return (
+        f"{base}/api/v2/users/{_seg(uid)}/sessions"
+        f"?page={int(page)}&hideLimited={hl}&limit={int(limit)}"
+    )
+
+
+def last_session_url(uid: str, *, base: str = SERVICES_BASE) -> str:
+    """The user's most recent session + its reference lap."""
+    return f"{base}/api/v2/sessions/{_seg(uid)}/last-session"
+
+
+def lap_reference_url(uid: str, session_key: str, lap: Any, *, base: str = SERVICES_BASE) -> str:
+    """The reference (``dynamicComparisonLap``) for one lap of a session."""
+    return f"{base}/api/v2/sessions/{_seg(uid)}/{_seg(session_key)}/laps/{_seg(lap)}/reference"
+
+
+def dynamic_reference_lap_url(
+    uid: str,
+    session_key: str,
+    lap: Any,
+    *,
+    segment_count: int = DEFAULT_SEGMENT_COUNT,
+    base: str = SERVICES_BASE,
+) -> str:
+    """The dynamic reference lap (per-corner segments) for one lap. **Bare** response."""
+    return (
+        f"{base}/dynamic-reference-laps/sessions/{_seg(uid)}/{_seg(session_key)}"
+        f"/laps/{_seg(lap)}?segmentCount={int(segment_count)}"
+    )
+
+
+def reference_lap_url(
+    uid: str,
+    session_key: str,
+    ref_uid: str,
+    ref_session_key: str,
+    ref_lap: Any,
+    *,
+    base: str = SERVICES_BASE,
+) -> str:
+    """A specific reference lap (another user/session, or the user's theoretical best)."""
+    return (
+        f"{base}/api/v2/sessions/{_seg(uid)}/{_seg(session_key)}"
+        f"/reference/{_seg(ref_uid)}/{_seg(ref_session_key)}/laps/{_seg(ref_lap)}"
+    )
+
+
+def advice_segment_url(
+    uid: str,
+    session_key: str,
+    lap: Any,
+    ref_uid: str,
+    ref_session_key: str,
+    segment: Any,
+    *,
+    ref_lap: Any = THEORETICAL_BEST_REF,
+    base: str = SERVICES_BASE,
+) -> str:
+    """Natural-language coaching advice for one corner (segment) vs a reference lap."""
+    return (
+        f"{base}/advice/sessions/{_seg(uid)}/{_seg(session_key)}/laps/{_seg(lap)}"
+        f"/reference/{_seg(ref_uid)}/{_seg(ref_session_key)}/laps/{_seg(ref_lap)}"
+        f"/segments/{_seg(segment)}"
+    )
+
+
+def analysis_progress_url(
+    uid: str,
+    *,
+    game_id: str,
+    track_id: str,
+    car_id: str,
+    base: str = SERVICES_BASE,
+) -> str:
+    """Per car/track analysis-progress summary."""
+    return (
+        f"{base}/api/v2/users/{_seg(uid)}/analysis/progress/"
+        f"?gameId={_seg(game_id)}&trackId={_seg(track_id)}&carId={_seg(car_id)}"
+    )
+
+
+# ----------------------------------------------------------------------------------
+# Pure parsers / envelope handling.
+# ----------------------------------------------------------------------------------
+
+
+def is_enveloped(payload: Mapping[str, Any]) -> bool:
+    """True for the ``{success, status, data, message}`` envelope (vs a bare object)."""
+    return "success" in payload and "data" in payload
+
+
+def unwrap_envelope(payload: Mapping[str, Any]) -> Any:
+    """Return ``data`` for an enveloped response, or the payload itself when bare.
+
+    Raises :class:`TTServicesError` if the envelope reports failure, so a
+    ``{"success": false}`` body never silently parses as empty data.
+    """
+    if not isinstance(payload, Mapping):
+        raise TTServicesError("services response was not a JSON object")
+    if is_enveloped(payload):
+        if not payload.get("success", False):
+            status = payload.get("status")
+            raise TTServicesError(f"services response reported failure (status={status})")
+        return payload.get("data")
+    return payload
+
+
+@dataclass(frozen=True)
+class CoachingStory:
+    """One natural-language coaching insight for a corner (from ``/advice``)."""
+
+    diagnosis: str
+    consequence: str
+    diagnosis_key: str
+    consequence_key: str
+    time_loss: float | None
+    phase_mistake: str | None
+    highlight: tuple[float, float] | None
+
+    @property
+    def is_actionable(self) -> bool:
+        """True when there is a real, non-trivial time loss to coach on."""
+        return self.time_loss is not None and self.time_loss > 0.0
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _highlight(raw: Any) -> tuple[float, float] | None:
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        a, b = _as_float(raw[0]), _as_float(raw[1])
+        if a is not None and b is not None:
+            return (a, b)
+    return None
+
+
+def parse_advice(payload: Mapping[str, Any]) -> list[CoachingStory]:
+    """Extract the coaching stories from an ``/advice`` response."""
+    data = unwrap_envelope(payload)
+    if not isinstance(data, Mapping):
+        raise TTServicesError("advice response missing 'data' object")
+    stories = data.get("stories")
+    if not isinstance(stories, list):
+        return []
+    out: list[CoachingStory] = []
+    for s in stories:
+        if not isinstance(s, Mapping):
+            continue
+        out.append(
+            CoachingStory(
+                diagnosis=str(s.get("diagnosis", "")),
+                consequence=str(s.get("consequence", "")),
+                diagnosis_key=str(s.get("diagnosisKey", "")),
+                consequence_key=str(s.get("consequenceKey", "")),
+                time_loss=_as_float(s.get("timeLoss")),
+                phase_mistake=s.get("phase_mistake")
+                if isinstance(s.get("phase_mistake"), str)
+                else None,
+                highlight=_highlight(s.get("highlight")),
+            )
+        )
+    return out
+
+
+def parse_reference_lap(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the reference lap object from either response shape.
+
+    ``/api/v2/.../laps/{lap}/reference`` → enveloped, the lap IS ``data``.
+    ``/dynamic-reference-laps/...`` → bare ``{session, lap: {...}, ...}`` — the lap
+    is the nested ``lap`` object.
+    """
+    data = unwrap_envelope(payload)
+    if isinstance(data, Mapping) and isinstance(data.get("lap"), Mapping):
+        # Bare dynamic-reference-laps shape.
+        return dict(data["lap"])
+    if isinstance(data, Mapping):
+        return dict(data)
+    raise TTServicesError("reference-lap response missing lap object")
+
+
+def reference_identity(reference_lap: Mapping[str, Any]) -> tuple[str, str]:
+    """Pull ``(ref_uid, ref_session_key)`` from a parsed reference lap.
+
+    Needed to build the advice URL, which references the lap by uid + session key.
+    """
+    uid = reference_lap.get("user_id")
+    session_key = reference_lap.get("session_key")
+    if not isinstance(uid, str) or not uid or not isinstance(session_key, str) or not session_key:
+        raise TTServicesError("reference lap has no usable user_id / session_key")
+    return uid, session_key
+
+
+def reference_lap_segments(reference_lap: Mapping[str, Any]) -> list[tuple[int, float]]:
+    """Return ``[(segment_number, segment_time_ms), …]`` sorted by segment number."""
+    segs = reference_lap.get("segments")
+    if not isinstance(segs, list):
+        return []
+    out: list[tuple[int, float]] = []
+    for s in segs:
+        if not isinstance(s, Mapping):
+            continue
+        num = s.get("segment_number")
+        t = _as_float(s.get("segment_time"))
+        if isinstance(num, int) and t is not None:
+            out.append((num, t))
+    return sorted(out, key=lambda x: x[0])
+
+
+def parse_last_session(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return ``{"session": {...}, "reference_lap": {...} | None}`` from last-session."""
+    data = unwrap_envelope(payload)
+    if not isinstance(data, Mapping):
+        raise TTServicesError("last-session response missing 'data' object")
+    session = data.get("session")
+    if not isinstance(session, Mapping):
+        raise TTServicesError("last-session response missing 'data.session'")
+    ref = data.get("referenceLap")
+    return {
+        "session": dict(session),
+        "reference_lap": dict(ref) if isinstance(ref, Mapping) else None,
+    }
+
+
+# ----------------------------------------------------------------------------------
+# Network round-trips — thin, isolated, ``# pragma: no cover`` (verified live, #353).
+# ----------------------------------------------------------------------------------
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    # services expects the RAW access token (no 'Bearer ' prefix) — verified live #353.
+    return {"Authorization": access_token, "Accept": "application/json"}
+
+
+def _services_get(
+    url: str, access_token: str, *, http: Any, timeout: float
+) -> Any:  # pragma: no cover - network round-trip, verified live (issue #353)
+    response = http.get(url, headers=_auth_headers(access_token), timeout=timeout)
+    status = getattr(response, "status_code", 200)
+    if status >= 400:
+        # Surface the path (not the query, which is safe here) but never the token.
+        raise TTServicesError(f"services GET failed with HTTP {status}: {url.split('?')[0]}")
+    body = response.json()
+    if not isinstance(body, (Mapping, list)):
+        raise TTServicesError("services response was not a JSON object/array")
+    return body
+
+
+def _client(http: Any | None) -> Any:  # pragma: no cover - trivial import shim
+    if http is not None:
+        return http
+    import requests as requests_mod
+
+    return requests_mod
+
+
+def fetch_last_session(
+    access_token: str,
+    uid: str,
+    *,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (#353)
+    """Fetch + parse the user's last session (session + reference lap)."""
+    body = _services_get(last_session_url(uid), access_token, http=_client(http), timeout=timeout)
+    return parse_last_session(body)
+
+
+def fetch_dynamic_reference_lap(
+    access_token: str,
+    uid: str,
+    session_key: str,
+    lap: Any,
+    *,
+    segment_count: int = DEFAULT_SEGMENT_COUNT,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (#353)
+    """Fetch the raw (bare) dynamic-reference-lap payload for a lap."""
+    url = dynamic_reference_lap_url(uid, session_key, lap, segment_count=segment_count)
+    body = _services_get(url, access_token, http=_client(http), timeout=timeout)
+    if not isinstance(body, Mapping):
+        raise TTServicesError("dynamic-reference-lap response was not an object")
+    return dict(body)
+
+
+def fetch_advice_segment(
+    access_token: str,
+    uid: str,
+    session_key: str,
+    lap: Any,
+    ref_uid: str,
+    ref_session_key: str,
+    segment: Any,
+    *,
+    ref_lap: Any = THEORETICAL_BEST_REF,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> list[CoachingStory]:  # pragma: no cover - network round-trip, verified live (#353)
+    """Fetch + parse coaching advice for one corner (segment)."""
+    url = advice_segment_url(
+        uid, session_key, lap, ref_uid, ref_session_key, segment, ref_lap=ref_lap
+    )
+    body = _services_get(url, access_token, http=_client(http), timeout=timeout)
+    if not isinstance(body, Mapping):
+        raise TTServicesError("advice response was not an object")
+    return parse_advice(body)
+
+
+def fetch_session_coaching(
+    access_token: str,
+    uid: str,
+    session_key: str,
+    lap: Any,
+    *,
+    segment_count: int = DEFAULT_SEGMENT_COUNT,
+    ref_lap: Any = THEORETICAL_BEST_REF,
+    http: Any | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> dict[str, Any]:  # pragma: no cover - network round-trip, verified live (#353)
+    """Pull the full per-corner coaching bundle for one lap.
+
+    Returns ``{"reference_lap": {...}, "segments": [{segment, stories: [...]}]}``.
+    The reference lap's identity (uid + session key) drives the advice requests; the
+    advice itself compares the lap against the operator's ``theoreticalBestRef`` by
+    default (matching the renderer's own behaviour).
+    """
+    client = _client(http)
+    raw_ref = _services_get(
+        dynamic_reference_lap_url(uid, session_key, lap, segment_count=segment_count),
+        access_token,
+        http=client,
+        timeout=timeout,
+    )
+    reference_lap = parse_reference_lap(raw_ref)
+    ref_uid, ref_sk = reference_identity(reference_lap)
+    segments: list[dict[str, Any]] = []
+    for seg_num, _ in reference_lap_segments(reference_lap) or [
+        (i, 0.0) for i in range(1, segment_count + 1)
+    ]:
+        stories = fetch_advice_segment(
+            access_token,
+            uid,
+            session_key,
+            lap,
+            uid,  # advice references the operator's OWN session for theoreticalBestRef
+            session_key,
+            seg_num,
+            ref_lap=ref_lap,
+            http=client,
+            timeout=timeout,
+        )
+        segments.append({"segment": seg_num, "stories": [s.__dict__ for s in stories]})
+    return {"reference_lap": reference_lap, "reference_id": [ref_uid, ref_sk], "segments": segments}


### PR DESCRIPTION
## M-TT1 — Track Titan **services** API crack (issue #353)

Milestone **M-TT1** of #353: pull the turn-by-turn coaching plane (per-corner
reference laps + natural-language advice) the operator wants for the autonomous
harness + voice coaching loop.

### The crack (corrects the M-TT1 research checkpoint)

A **live CDP capture** of the running Track Titan desktop renderer (own account,
own machine) pinned the real auth model and paths — and corrected the research
node's SigV4 / Identity-Pool hypothesis:

| Research checkpoint (#364) said | Reality (verified live) |
|---|---|
| services behind Cognito **Identity-Pool IAM (SigV4)** | services `/api/v2/*`, `/dynamic-reference-laps/*`, `/advice/*` take the **raw Cognito access token** in `Authorization` (no `Bearer`) — the *same* token vulcan uses |
| `idToken → 403` means "auth insufficient" | `idToken → 403`, **`accessToken → 200`**. The 403s were the wrong token + old cached path shapes (`data-analysis/{uid}%23{sk}`) |
| paths need pinning from the JS bundle | live paths captured: `/api/v2/sessions/{uid}/{sk}/laps/{lap}/reference`, `/dynamic-reference-laps/sessions/{uid}/{sk}/laps/{lap}?segmentCount=N`, `/advice/sessions/{uid}/{sk}/laps/{lap}/reference/{refUid}/{refSk}/laps/theoreticalBestRef/segments/{n}` |

So **no SigV4 / Identity-Pool flow is needed** for the data — `tt_auth.mint_tokens()`
already returns the access token. (The Cognito-Identity `GetCredentialsForIdentity`
calls the app also makes are for analytics, not these routes.)

**Verified end-to-end from our own mint path** (not inference):
- `accessToken → 200 success=True`, `idToken → 403`, uid matches the captured request.
- `python -m tools.tt_ingest coaching --dry-run` against the live API returned the real
  per-corner diagnoses for the last session (Magione, Porsche 911 GT3 R): e.g. corner 3
  *"You messed up your exit"*, corner 4 *"Your line on entry was too wide"*.
- A real retention run wrote `coaching.json` + `last_session.json` to the lake.

### What's in this PR

- **`tools/tt_ingest/tt_services.py`** — pure URL builders + envelope/parsers for the
  services view of sessions, `last-session`, lap reference, `dynamic-reference-laps`,
  `advice` (per-corner `CoachingStory`), plus a `fetch_session_coaching` bundle. Network
  round-trips isolated and `# pragma: no cover` (proven live, not in CI). Handles both the
  enveloped (`{success,status,data,message}`) and bare (`dynamic-reference-laps`) shapes.
- **`coaching` CLI subcommand** — `python -m tools.tt_ingest coaching [--session-key K --lap N]`
  fetches + immutably retains the per-corner reference + advice bundle to the lake
  (write-once, `allow_nan` for telemetry floats), with `--dry-run`.
- **Sanitized fixtures** captured live (uid + reference-driver identity scrubbed) and
  **unit tests** (URL builders, envelope, parsers, network wiring asserting the
  raw-access-token header, retention).

### Scope / ethics
Personal own-account coaching data. The access token is a personal secret — never logged,
never in error messages, raw captures kept in gitignored `.scratch/` only. Fixtures are
scrubbed.

### Next (separate PRs)
- **M-TT2** — reference-lap telemetry → `lap_archive` schema → M0 `--reference-archive` voice feed.
- **M-TT3** — per-corner analysis → harness drive-to-reference curriculum.

Vault research node + handoff are updated via the `vault-only` flow post-merge.

Closes the M-TT1 milestone of #353.
