### PR TITLE
fix(voice): batch Piper baking + 48kHz default for on-rig bank smoke (#350)

### DIFF
--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -8,12 +8,16 @@ from __future__ import annotations
 
 import math
 import struct
+import subprocess
+import sys
 import wave
+from pathlib import Path
 
 import pytest
 
+from tools.ai_sidecar.voice import bake as bake_mod
 from tools.ai_sidecar.voice import vocabulary as vocab
-from tools.ai_sidecar.voice.bake import ToneBackend, bake_bank
+from tools.ai_sidecar.voice.bake import PiperBackend, ToneBackend, bake_bank
 from tools.ai_sidecar.voice.manifest import MANIFEST_FILENAME, Manifest, sha256_bytes
 
 
@@ -111,3 +115,151 @@ def test_bake_accepts_float32_external_backend(tmp_path) -> None:
         assert wf.getsampwidth() == 2
         raw = wf.readframes(wf.getnframes())
     assert max(abs(v[0]) for v in struct.iter_unpack("<h", raw)) > 1000
+
+
+class _BatchToneBackend:
+    voice_signature = "batch-tone-v1"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[tuple[str, Path]], int]] = []
+
+    def synthesize(self, text: str, out_path: Path, samplerate: int) -> None:
+        raise AssertionError("batch backend should not be called one clip at a time")
+
+    def synthesize_many(self, items: list[tuple[str, Path]], samplerate: int) -> None:
+        self.calls.append((list(items), samplerate))
+        tone = ToneBackend()
+        for text, target in items:
+            tone.synthesize(text, target, samplerate)
+
+
+def test_bake_uses_batch_backend_when_available(tmp_path) -> None:
+    backend = _BatchToneBackend()
+    manifest = bake_bank(tmp_path, backend)
+
+    assert len(backend.calls) == 1
+    assert len(backend.calls[0][0]) == len(vocab.vocabulary())
+    assert manifest.voice_signature == "batch-tone-v1"
+    assert manifest.validate(tmp_path).ok
+
+
+def test_cli_status_output_is_windows_codepage_safe(tmp_path, monkeypatch, capsys) -> None:
+    def fake_bake_bank(out_dir, backend, *, samplerate: int = 48000):
+        return Manifest(
+            version=1,
+            samplerate=samplerate,
+            voice_signature=backend.voice_signature,
+            vocabulary_hash=vocab.vocabulary_hash(),
+            clips={},
+        )
+
+    monkeypatch.setattr(bake_mod, "bake_bank", fake_bake_bank)
+
+    assert bake_mod.main(["--backend", "tone", "--out", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "->" in out
+    assert "→" not in out
+
+
+def _write_pcm16_wav(path: Path, *, samplerate: int, value: int, frames: int = 16) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(samplerate)
+        wf.writeframes(b"".join(struct.pack("<h", value) for _ in range(frames)))
+
+
+def _first_sample(path: Path) -> int:
+    with wave.open(str(path), "rb") as wf:
+        return struct.unpack("<h", wf.readframes(1))[0]
+
+
+def _piper_backend(tmp_path: Path) -> PiperBackend:
+    model = tmp_path / "voice.onnx"
+    model.write_bytes(b"stub-model")
+    return PiperBackend(model)
+
+
+def test_piper_batch_maps_clips_by_numeric_timestamp_order(tmp_path, monkeypatch) -> None:
+    """Generation-order recovery must use NUMERIC, not lexical, timestamp sort.
+
+    Piper names batch clips ``{monotonic_ns}.wav``; a lexical sort mis-orders across a digit-count
+    rollover (…9.wav vs …10.wav), silently writing the wrong audio under each stable clip_id while
+    the count guard still passes. Names 8/9/10 below sort numerically as 8<9<10 but lexically as
+    10<8<9, so the old code would scramble the mapping; the new numeric sort keeps it correct.
+    """
+    backend = _piper_backend(tmp_path)
+    out = tmp_path / "bank"
+    items = [
+        ("brake one", out / "clip_a.wav"),
+        ("turn two", out / "clip_b.wav"),
+        ("apex three", out / "clip_c.wav"),
+    ]
+    names = ["8", "9", "10"]  # generation order; numeric != lexical
+
+    def fake_run(cmd, *args, **kwargs):
+        assert "--input-file" in cmd, "batch path must use --input-file"
+        output_dir = Path(cmd[cmd.index("--output-dir") + 1])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for gen_index, name in enumerate(names):
+            # marker encodes generation order; clips are already at the target rate so the
+            # post-move _normalize_wav is a no-op and the marker survives byte-for-byte.
+            _write_pcm16_wav(
+                output_dir / f"{name}.wav", samplerate=48000, value=(gen_index + 1) * 1000
+            )
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(bake_mod.subprocess, "run", fake_run)
+    backend.synthesize_many(items, 48000)
+
+    # input order == generation order, so target[i] must hold marker (i+1)*1000
+    assert _first_sample(items[0][1]) == 1000
+    assert _first_sample(items[1][1]) == 2000
+    assert _first_sample(items[2][1]) == 3000
+
+
+def test_piper_batch_falls_back_to_per_clip_when_batch_fails(tmp_path, monkeypatch) -> None:
+    """A Piper build without the batch flags (e.g. MIT rhasspy/piper) must not break the bake.
+
+    The batch subprocess fails; synthesize_many must fall back to the per-clip ``--output_file``
+    path that every Piper build supports, producing every requested clip at the target rate.
+    """
+    backend = _piper_backend(tmp_path)
+    out = tmp_path / "bank"
+    items = [("brake one", out / "clip_a.wav"), ("turn two", out / "clip_b.wav")]
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if "--input-file" in cmd:
+            calls.append("batch")
+            raise subprocess.CalledProcessError(2, cmd)  # batch flags unsupported
+        # per-clip path: piper writes a WAV to --output_file. Bake the stub already at the target
+        # rate so _normalize_wav early-returns and the stdlib-only voice-bake suite runs without
+        # numpy (the `.[dev]` extra); the numpy resample path is covered by the tests above.
+        calls.append("per-clip")
+        out_path = Path(cmd[cmd.index("--output_file") + 1])
+        _write_pcm16_wav(out_path, samplerate=48000, value=500)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(bake_mod.subprocess, "run", fake_run)
+    backend.synthesize_many(items, 48000)
+
+    assert calls[0] == "batch"  # tried batch first
+    assert calls.count("per-clip") == 2  # then one per clip
+    for _text, target in items:
+        assert target.is_file()
+        with wave.open(str(target), "rb") as wf:
+            assert wf.getframerate() == 48000  # per-clip path produced clips at the target rate
+
+
+def test_normalize_wav_gives_clear_error_when_numpy_missing(tmp_path, monkeypatch) -> None:
+    """The 48 kHz bank default routes Piper output (commonly 22050 Hz) through _normalize_wav, which
+    needs numpy (a `voice` extra, not a base dep). Without numpy the bake must fail with an
+    actionable message, not a raw ModuleNotFoundError deep in the resample path.
+    """
+    fp = tmp_path / "native.wav"
+    _write_pcm16_wav(fp, samplerate=22050, value=500)  # rate mismatch -> resample path
+    monkeypatch.setitem(sys.modules, "numpy", None)  # simulate numpy not installed
+    with pytest.raises(RuntimeError, match="numpy"):
+        bake_mod._normalize_wav(fp, 48000)

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -17,7 +17,7 @@ Backends (pluggable via the :class:`VoiceBackend` protocol — wording always co
 
 CLI::
 
-    python -m tools.ai_sidecar.voice.bake --out <dir> --backend tone|piper|say [--samplerate 22050]
+    python -m tools.ai_sidecar.voice.bake --out <dir> --backend tone|piper|say [--samplerate 48000]
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import logging
 import math
+import shutil
 import struct
 import subprocess
 import sys
@@ -52,6 +53,12 @@ class VoiceBackend(Protocol):
     def voice_signature(self) -> str: ...
 
     def synthesize(self, text: str, out_path: Path, samplerate: int) -> None: ...
+
+
+class BatchVoiceBackend(VoiceBackend, Protocol):
+    """Backend that can render a whole phrase bank in one process."""
+
+    def synthesize_many(self, items: list[tuple[str, Path]], samplerate: int) -> None: ...
 
 
 # --------------------------------------------------------------------------------------------------
@@ -111,7 +118,17 @@ def _normalize_wav(path: Path, samplerate: int) -> None:
     if source_rate == samplerate and channels == 1 and sample_width == 2:
         return
 
-    import numpy as np
+    try:
+        import numpy as np
+    except ImportError as exc:
+        # numpy is an optional `voice` extra, not a base dep. With the 48 kHz bank default a Piper
+        # voice (commonly 22050 Hz) lands here, so surface an actionable message instead of a raw
+        # ModuleNotFoundError deep in the bake.
+        raise RuntimeError(
+            f"numpy is required to resample {path.name} ({source_rate} Hz -> {samplerate} Hz); "
+            "install it with `pip install -e '.[voice]'` (or `pip install numpy`), or bake with "
+            f"`--samplerate {source_rate}` to skip resampling."
+        ) from exc
 
     if sample_width == 2:
         audio = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
@@ -154,13 +171,81 @@ class PiperBackend:
         return f"piper:{self._model.stem}"
 
     def synthesize(self, text: str, out_path: Path, samplerate: int) -> None:
-        # piper reads text on stdin and writes a WAV at the model's native samplerate; we ask the
-        # caller to bake at that samplerate (Piper voices are commonly 22050 Hz).
+        # piper reads text on stdin and writes a WAV at the model's native samplerate, then we
+        # rewrite it to the bank samplerate so WASAPI devices that reject 22050 Hz can still
+        # play it.
         subprocess.run(  # noqa: S603 - fixed binary + our own text, no shell
             [self._bin, "--model", str(self._model), "--output_file", str(out_path)],
             input=text.encode("utf-8"),
             check=True,
         )
+        _normalize_wav(out_path, samplerate)
+
+    def synthesize_many(self, items: list[tuple[str, Path]], samplerate: int) -> None:
+        """Render a phrase bank in one Piper process, with a per-clip fallback.
+
+        Spawning Piper once per clip is prohibitively slow on Windows, so we try a single
+        batch process (piper1-gpl ``--input-file`` + ``--output-dir``). That batch path is
+        best-effort: if the installed Piper is the MIT ``rhasspy/piper`` build (which lacks
+        those flags), or the generated count/ordering cannot be trusted, or anything else
+        fails, we fall back to the per-clip :meth:`synthesize` path that every Piper build
+        supports. Slower but always correct -- never a silent mis-bake.
+        """
+        if not items:
+            return
+        try:
+            self._synthesize_many_batch(items, samplerate)
+        except (OSError, subprocess.SubprocessError, ValueError, RuntimeError) as exc:
+            _log.warning(
+                "voice: piper batch bake failed (%s); falling back to per-clip synthesis", exc
+            )
+            for text, target in items:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                self.synthesize(text, target, samplerate)
+
+    def _synthesize_many_batch(self, items: list[tuple[str, Path]], samplerate: int) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "phrases.txt"
+            output_dir = tmp_path / "clips"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            input_path.write_text(
+                "".join(f"{text}\n" for text, _target in items),
+                encoding="utf-8",
+            )
+            subprocess.run(  # noqa: S603 - fixed binary + our own text, no shell
+                [
+                    self._bin,
+                    "--model",
+                    str(self._model),
+                    "--input-file",
+                    str(input_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--output-dir-naming",
+                    "timestamp",
+                ],
+                check=True,
+                input=b"",  # close stdin: a flag-incompatible Piper errors out instead of hanging
+                timeout=600,
+            )
+            # piper1-gpl names each clip ``{time.monotonic_ns()}.wav`` in generation order, so a
+            # NUMERIC sort maps the generated clips back to input order. A LEXICAL sort would
+            # silently mis-order at a digit-count rollover (…9.wav vs …10.wav) and the count guard
+            # below — which checks cardinality, not correspondence — would not catch it. Any odd /
+            # non-numeric naming raises ValueError here and the caller falls back to per-clip.
+            generated = sorted(output_dir.glob("*.wav"), key=lambda p: int(p.stem))
+            if len(generated) != len(items):
+                raise RuntimeError(
+                    f"piper generated {len(generated)} clips for {len(items)} input phrases"
+                )
+            for source, (_text, target) in zip(generated, items, strict=True):
+                target.parent.mkdir(parents=True, exist_ok=True)
+                # shutil.move (not Path.replace): the temp dir and the bank output dir can be on
+                # different drives on a Windows rig (%TEMP% on C:, bank on D:), where os.replace
+                # raises a cross-device OSError.
+                shutil.move(str(source), str(target))
+                _normalize_wav(target, samplerate)
 
 
 class MacSayBackend:
@@ -203,7 +288,7 @@ class MacSayBackend:
 # --------------------------------------------------------------------------------------------------
 
 
-def bake_bank(out_dir: str | Path, backend: VoiceBackend, *, samplerate: int = 22050) -> Manifest:
+def bake_bank(out_dir: str | Path, backend: VoiceBackend, *, samplerate: int = 48000) -> Manifest:
     """Render every vocabulary phrase to ``out_dir/<clip_id>.wav`` and write ``manifest.json``.
 
     The manifest stamps the current :func:`vocabulary_hash` and the backend's
@@ -212,12 +297,18 @@ def bake_bank(out_dir: str | Path, backend: VoiceBackend, *, samplerate: int = 2
     """
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
+    phrases = list(iter_vocabulary())
+    targets = [(phrase, out / f"{phrase.clip_id}.wav") for phrase in phrases]
+    batch = getattr(backend, "synthesize_many", None)
+    if callable(batch):
+        batch([(phrase.text, target) for phrase, target in targets], samplerate)
+    else:
+        for phrase, target in targets:
+            backend.synthesize(phrase.text, target, samplerate)
+
     clips: dict[str, ClipEntry] = {}
-    count = 0
-    for phrase in iter_vocabulary():
-        fname = f"{phrase.clip_id}.wav"
-        fp = out / fname
-        backend.synthesize(phrase.text, fp, samplerate)
+    for phrase, fp in targets:
+        fname = fp.name
         _normalize_wav(fp, samplerate)
         data = fp.read_bytes()
         clips[phrase.clip_id] = ClipEntry(
@@ -229,7 +320,6 @@ def bake_bank(out_dir: str | Path, backend: VoiceBackend, *, samplerate: int = 2
             text=phrase.text,
             sha256=sha256_bytes(data),
         )
-        count += 1
     manifest = Manifest(
         version=MANIFEST_VERSION,
         samplerate=samplerate,
@@ -238,7 +328,7 @@ def bake_bank(out_dir: str | Path, backend: VoiceBackend, *, samplerate: int = 2
         clips=clips,
     )
     (out / MANIFEST_FILENAME).write_text(manifest.to_json(), encoding="utf-8")
-    _log.info("voice: baked %d clips with %s into %s", count, backend.voice_signature, out)
+    _log.info("voice: baked %d clips with %s into %s", len(clips), backend.voice_signature, out)
     return manifest
 
 
@@ -260,13 +350,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--backend", default="tone", choices=("tone", "piper", "say"), help="synthesis backend"
     )
-    parser.add_argument("--samplerate", type=int, default=22050)
+    parser.add_argument("--samplerate", type=int, default=48000)
     parser.add_argument("--piper-model", help="path to a Piper .onnx voice model (backend=piper)")
     parser.add_argument("--say-voice", default="Daniel", help="macOS voice name (backend=say)")
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
-    manifest = bake_bank(args.out, _build_backend(args), samplerate=args.samplerate)
-    print(f"baked {len(manifest.clips)} clips → {Path(args.out) / MANIFEST_FILENAME}")
+    try:
+        manifest = bake_bank(args.out, _build_backend(args), samplerate=args.samplerate)
+    except RuntimeError as exc:
+        # e.g. numpy missing on the resample path -> clean CLI error, not a deep traceback
+        raise SystemExit(str(exc)) from exc
+    print(f"baked {len(manifest.clips)} clips -> {Path(args.out) / MANIFEST_FILENAME}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Refs #350 (Part B — on-rig voice-cue smoke). **Rebased + re-scoped** onto current `main`.

Since this branch was first opened, **PR #363 (Game Point launcher) independently landed**
the same Windows-audio fixes this branch originally carried — and in a cleaner shape:

- `server.py` already has `--voice-backend/--voice-device/--voice-host-api/--voice-verbosity`
  CLI args + `AC_COPILOT_VOICE_*` env fallbacks + `VoiceConfig` + `VoiceCoach.from_bank(bank, config, backend=)`
  via a `VoiceRuntimeConfig` dataclass (plus extra pyttsx3 TTS). **PR #372's server.py changes were 100% subsumed — dropped.**
- `playback.py` already fixed the nonexistent-`rtmixer.done` bug via **duration/clock-based** completion
  (`_clock() >= _current_until`). PR #372's `action not in mixer.actions` membership variant was **dropped**
  (main's is shipped, tested, and version-independent — its own comment warns the cffi action pointer has no
  stable cross-version completion flag).
- `bake.py` already has `_normalize_wav` resampling. PR #372's duplicate stdlib `_ensure_wav_samplerate`
  was **dropped**; resampling stays centralized in `bake_bank` via `_normalize_wav` (handles mono down-mix + float32).

### What remains (the genuine net-new, `bake.py` only)

1. **Batch Piper baking** — `PiperBackend.synthesize_many` renders the whole phrase bank in **one** Piper
   process (`--input-file/--output-dir/--output-dir-naming timestamp`) instead of one spawn per clip.
   Per-clip spawn is prohibitively slow on Windows; `bake_bank` dispatches to it when the backend exposes it.
2. **Default bake samplerate `22050 -> 48000`** — so an operator-baked bank opens on WASAPI shared-mode
   endpoints without an explicit `--samplerate` flag (the bank is operator-baked via the CLI).
3. **Codepage-safe `->`** (not `→`) in CLI status output — prints under a non-UTF-8 Windows console codepage.

## Validation

- `ruff check` + `ruff format --check` on changed files — clean.
- Focused voice suite vs the rebased tree — **89 passed** (`test_voice_bake / _playback / _scheduler / _engine /
  _ai_sidecar_external / _realtime_observer`). New tests: batch-dispatch + codepage-safe output; main's
  resample/float32 tests retained.

## Reconciliation note

Direction (salvage to `bake.py`-only vs close-as-superseded; keep main's duration-based rtmixer completion)
was pressure-tested with the agent Council — unanimous: salvage the genuine bake-path net-new, keep main's
playback. Decided to salvage **in place** (preserve PR/CI/on-rig evidence) rather than churn a new PR.

## Remaining #350 acceptance (rig-gated, not this PR)

The final acceptance — **operator hears a spline-anchored cue while driving vs a faster reference** — is
on-rig and gated on the Windows rig being reachable. Tracked under #350; this PR makes the on-rig bank bake
fast + WASAPI-compatible so that smoke is practical.
