### PR TITLE
docs(vault): post-merge handoff for PR #365

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-28T15:35:00Z
+last_updated: 2026-06-29T09:18:39Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -21,7 +21,7 @@ relates_to:
 
 **Active focus (2026-06-17):** EPIC [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) — **Part F harness daemon shipped** ([#228](https://github.com/agorokh/ac-copilot-trainer/issues/228)/PR #229) and its on-rig launch gap fixed ([#232](https://github.com/agorokh/ac-copilot-trainer/issues/232) **CLOSED** / PR [#233](https://github.com/agorokh/ac-copilot-trainer/pull/233) **MERGED** `c556dfe`): the daemon now launches AC **de-elevated via Content Manager** (`--launch-mode cm`), live-verified hands-off on `AG_PC`. The autonomous self-test is now **one command** ([#235](https://github.com/agorokh/ac-copilot-trainer/issues/235) **CLOSED** / PR [#236](https://github.com/agorokh/ac-copilot-trainer/pull/236) **MERGED** `d051096`): `python -m tools.ac_harness.self_test` drives the daemon hands-off and asserts the live coaching pipeline — **LIVE PASS** (`coaching.snapshot=335, tire_temps=168, connection=34`, no human at the wheel). The vision-oracle **"eyes"** also landed ([#238](https://github.com/agorokh/ac-copilot-trainer/issues/238) **CLOSED** / PR [#239](https://github.com/agorokh/ac-copilot-trainer/pull/239) **MERGED** `3e677c7`): `tools.ac_harness.hud_capture` (stdlib ctypes GDI, no new dep) captures the live AC HUD hands-off with a render-liveness check — **LIVE-VERIFIED** (in-cockpit at Spa, HUD text legible). [#188](https://github.com/agorokh/ac-copilot-trainer/issues/188)/[#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) **CLOSED**. **The autonomous self-test now has launch + pipeline-assert + eyes, all hands-off + live-verified.**
 
-**Active focus (2026-06-19) — HANDOFF, see [#244](https://github.com/agorokh/ac-copilot-trainer/issues/244):** Part G **racing driver** **MERGED** ([#241](https://github.com/agorokh/ac-copilot-trainer/issues/241) / PR [#242](https://github.com/agorokh/ac-copilot-trainer/pull/242) `372156a`): follows `fast_lane.ai`'s embedded speed profile with braking points/trail braking; **gear bug fixed** (was stuck in 1st — limiter below shift point) → now shifts 1→4, **146 km/h** (was 52). `tools/ac_harness/racing_telemetry.py` records human laps. **The wall is STEERING** (pure-pursuit cuts apexes → corners crawl, lap INVALID → no `lap`/`delta` telemetry). **Next:** record 5–10 human GT3 laps → build a path-tracking steering controller from real corner speeds/braking points. Full state: [`racing-driver-and-controller-2026-06-17`](../03_Investigations/racing-driver-and-controller-2026-06-17.md). Parallel hot path: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) Parts E–F.
+**Active focus (2026-06-19) — HANDOFF, see [#244](https://github.com/agorokh/ac-copilot-trainer/issues/244):** Part G **racing driver** **MERGED** ([#241](https://github.com/agorokh/ac-copilot-trainer/issues/241) / PR [#242](https://github.com/agorokh/ac-copilot-trainer/pull/242) `372156a`): follows `fast_lane.ai`'s embedded speed profile with braking points/trail braking; **gear bug fixed** (was stuck in 1st — limiter below shift point) → now shifts 1→4, **146 km/h** (was 52). `tools/ac_harness/racing_telemetry.py` records human laps. **The wall is STEERING** (pure-pursuit cuts apexes → corners crawl, lap INVALID → no `lap`/`delta` telemetry). **Next:** record 5–10 human GT3 laps → build a path-tracking steering controller from real corner speeds/braking points. Full state: [`racing-driver-and-controller-2026-06-17`](../03_Investigations/racing-driver-and-controller-2026-06-17.md). Parallel hot path: Stream A rig screen EPIC [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86) after PR [#365](https://github.com/agorokh/ac-copilot-trainer/pull/365) is final polish/proof: font conversion outputs, persistence/backpressure/debug-screen polish if still desired, and final on-device smoke.
 
 **Active focus update (2026-06-19 LATER) — #244 / PR [#248](https://github.com/agorokh/ac-copilot-trainer/pull/248) MERGED + LIVE-VERIFIED on the rig:**
 Ran `/autonomous-deliver 244` **on `AG_PC` itself** (prior Mac→rig blocker moot). The merged Stanley
@@ -71,12 +71,10 @@ PR #83 (WS + Lua bridge) **MERGED 2026-04-22** at `caa8a9ad` — still the found
 
 **Outstanding housekeeping:** Issue [#81](https://github.com/agorokh/ac-copilot-trainer/issues/81) may still be OPEN from before PR #83 — close with `gh issue close 81` when confirmed duplicate.
 
-**Next (EPIC #86 remainder, new PRs):**
+**Next (EPIC #86 remainder after PR #365):**
 
-- **Part E** — Setup Exchange (`se_proxy.py`, SPIFFS LRU) per issue.
-- **Part F** — SPIFFS persistence, telemetry backpressure, debug screen, token runbook.
-- **Part A4** — `lv_font_conv` for bundled faces (screens still default to built-in Montserrat until converted).
-- **Polish / bugs** — `start_sidecar.bat` external-bind + token; PT BB chip refresh landed in PR [#100](https://github.com/agorokh/ac-copilot-trainer/pull/100) (optional on-device smoke).
+- **Delivered by PR #365** — Game Point launcher, Setup Exchange screen/proxy/install path, Pocket Technician spinner controls, and environment-only sidecar token/voice routing.
+- **Still open on #86** — Part A4 `lv_font_conv` outputs; SPIFFS/persistence/backpressure/debug-screen polish if still desired; final device smoke artifact covering launcher → AC Copilot live hints → Pocket Technician setup load → Setup Exchange browse/download/install.
 
 **Live-dev:** Hotspot + sidecar path per `[glossary/rig-network.md](../glossary/rig-network.md)`. Firmware: `python -m platformio run -e jc3248w535` under `firmware/screen/` (CI does not build firmware).
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-29T07:17:00Z
+last_updated: 2026-06-29T09:18:39Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/tt-services-sigv4-crack-2026-06-29.md
   - AcCopilotTrainer/03_Investigations/issue-86-rig-screen-hotspot-autostart-2026-06-28.md
@@ -52,6 +52,43 @@ relates_to:
 
 # Next session handoff
 
+## Delivered (2026-06-29) — PR #365 MERGED: Game Point launcher supervisor (#363 CLOSED)
+
+PR [#365](https://github.com/agorokh/ac-copilot-trainer/pull/365) merged to
+`main` as squash commit
+[`854f822`](https://github.com/agorokh/ac-copilot-trainer/commit/854f822bdd868397e99bfd56c08ade2f87277139)
+at 2026-06-29T09:15:25Z and closed
+[#363](https://github.com/agorokh/ac-copilot-trainer/issues/363).
+
+Delivered: Windows Game Point launcher package (`python -m tools.rig_launcher`),
+Desktop shortcut installer/build path, per-user launcher settings, supervised
+sidecar start/status/logging, environment-only sidecar token/voice routing,
+Setup Exchange proxy/install path, rig-screen Setup Exchange screen, Pocket
+Technician spinner list/set protocol, and Game Point launcher docs.
+Review-resolution and install notes live in
+[[pr-365-game-point-launcher-2026-06-29]].
+
+Verification before merge: local `make ci-fast PYTHON=.venv/bin/python` passed on
+current head `27e7dbd` (`1753 passed, 75 skipped`, coverage 84.93%); GitHub
+`build`, `pip-audit`, `Canonical docs exist`, and `conformance` passed on the
+same head; `scripts/ci_resolve_gate.py agorokh/ac-copilot-trainer 365` reported
+`No substantive findings hanging`; GraphQL `reviewThreads` returned 60 threads,
+`hasNext=false`, `unresolved_total=0`; no current-SHA self-hosted reviewer body
+was present after the required cooldown.
+
+Post-merge classification: `.env.example` changed, so review/update operator
+environment on the rig as needed; `pyproject.toml` changed, so refresh the local
+dev install with `pip install -e '.[dev]'` or the equivalent lockfile workflow.
+No migrations were detected or run.
+
+Honest remaining #86 scope: [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86)
+is still OPEN as the broader rig-screen epic. After #361 and #365, its remaining
+closure gates are not the Game Point code path itself; they are LVGL font
+conversion outputs, SPIFFS/persistence/backpressure/debug-screen polish if still
+desired, and final on-device smoke evidence
+`launcher -> AC Copilot live hints -> Pocket Technician setup load -> Setup Exchange browse/download/install`.
+Packaged-launcher proof should be rerun on the Windows rig when available.
+
 ## Claude Design UI package for launcher + rig screens (2026-06-29)
 
 Created `docs/10_Development/15_Claude_Design_UI_Package.md` as the handoff
@@ -67,7 +104,7 @@ driver-facing launcher work discovers the UI contract. Tier-3 MCP was not
 exposed in this Codex session; the package was grounded from the vault and live
 source files listed inside the package.
 
-## Game Point #363 / PR #365 (2026-06-29)
+## Game Point #363 / PR #365 (2026-06-29) — pre-merge handoff
 
 PR [#365](https://github.com/agorokh/ac-copilot-trainer/pull/365) delivers the
 Game Point launcher supervisor and Pocket Technician spinner completion for
@@ -86,7 +123,7 @@ exact path/params still to pin — the operator's primary want is auth-cracked).
 the running TT app, or fetch the session-review page chunk) → build `tt_services.py` → M-TT2 (reference
 → `lap_archive` → M0 `--voice-reference`) → M-TT3. Personal-use guardrail scope applies.
 
-## Resume here (2026-06-28 evening) - #86 rig screen connectivity restored; PR #361 active
+## Historical (2026-06-28 evening) — #86 rig screen connectivity restored; PR #361 merged
 
 User reported the #86 rig screen was powered on but not connecting. Live cause:
 PC was on a home 5 GHz Wi-Fi network, Mobile Hotspot was not presenting the
@@ -98,7 +135,9 @@ sidecar `/health` OK with an established hotspot-gateway-to-screen socket, and
 protocol counters moving (`state.snapshot`, `state.subscribe`, `corner_query`,
 setup experiment frames).
 
-Branch **`fix/issue-86-rig-sidecar-autostart`** patches the recurring gap:
+PR [#361](https://github.com/agorokh/ac-copilot-trainer/pull/361) merged as
+[`210c2a1`](https://github.com/agorokh/ac-copilot-trainer/commit/210c2a14f9e3e4993c22aa22ec56767922375296).
+It patched the recurring gap:
 `start_sidecar.bat` now stays loopback-only by default, but if
 `AC_COPILOT_SIDECAR_TOKEN` is set it launches with `--external-bind 0.0.0.0`
 (or `AC_COPILOT_SIDECAR_EXTERNAL_BIND`) and keeps the token in the process
@@ -126,7 +165,7 @@ changed files pass targeted `ruff format --check`.
 Detail: [[issue-86-rig-screen-hotspot-autostart-2026-06-28]]. Successor issue
 [#363](https://github.com/agorokh/ac-copilot-trainer/issues/363) now owns the
 broader human-playable Game Point launcher, Pocket Technician completion, and
-Setup Exchange completion scope.
+Setup Exchange completion scope; #363 closed with PR #365.
 
 ## Resume here (2026-06-28) — Track Titan #353 M-TT1 next, then #345 P0 capture
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/pr-365-game-point-launcher-2026-06-29.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/pr-365-game-point-launcher-2026-06-29.md
@@ -54,5 +54,9 @@ the sidecar until the official signed `/session` handshake is ported. Use
 
 ## Follow-ups
 
-- Part C (Setup Exchange) and Part D (full rig smoke video) remain open on #363.
+- #363 is closed by PR #365. Remaining rig-screen epic gates stay on
+  [#86](https://github.com/agorokh/ac-copilot-trainer/issues/86): LVGL font
+  conversion outputs, SPIFFS/persistence/backpressure/debug-screen polish if
+  still desired, and final on-device smoke evidence
+  `launcher -> AC Copilot live hints -> Pocket Technician setup load -> Setup Exchange browse/download/install`.
 - Re-run packaged-launcher rig proof after merge when the Windows rig is available.


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #365.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).