### PR TITLE
docs(vault): post-merge handoff for PR #365

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -84,7 +84,7 @@ Integration ADR landed 2026-04-21 as `[screen-and-csp-apps-integration.md](../01
 
 Surface map of both apps lives in `[csp-app-pocket-tech-setup-exchange-2026-04-21](../03_Investigations/csp-app-pocket-tech-setup-exchange-2026-04-21.md)`.
 
-**Next:** `setup.list` / `setup.load` shipped with PR #91; remaining B-stream work is spinner tiles / `setup_control.lua` if still desired, plus Setup Exchange (Part E).
+**Next:** `setup.list` / `setup.load` shipped with PR #91; spinner controls and Setup Exchange screen/proxy/install shipped with PR #365. Remaining B-stream work is optional `setup_control.lua` / UI polish if still desired, plus the #86 final on-device smoke artifact.
 
 ## Stream C — Physical rig integration EPIC #59
 
@@ -100,10 +100,16 @@ Now **MERGED 2026-04-14**. Ollama corner coaching pipeline (`corner_query` / `co
 
 ## Priority call
 
-Stream A (rig screen Phase-2 LVGL + Figma UI + setup spinner tiles) is the hot path — user designed the visuals, firmware Phase 1 is end-to-end working, next tangible win is "tap a tile on the screen, see the setup change in-game." Stream B integration is folded into Stream A's protocol work.
+Stream A (rig screen Phase-2 LVGL + Figma UI + final on-device proof) is the hot path — the Game Point/Pocket Technician/Setup Exchange code path is now merged, so the next tangible win is a clean physical-rig smoke artifact across launcher → live hints → setup load → Setup Exchange install. Stream B integration is folded into Stream A's protocol work.
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-29** — PR [#365](https://github.com/agorokh/ac-copilot-trainer/pull/365) **MERGED** at
+  `854f822` — **Game Point launcher supervisor** ([#363](https://github.com/agorokh/ac-copilot-trainer/issues/363)
+  **CLOSED**): Windows launcher package/shortcut/settings, supervised sidecar start/status/logging,
+  environment-only sidecar token/voice routing, Pocket Technician spinner controls, Setup Exchange
+  proxy/install path + rig-screen browse/download/install UI, and Game Point docs. Classification:
+  `.env.example` and `pyproject.toml` changed; no migrations.
 - **2026-06-28** — PR [#348](https://github.com/agorokh/ac-copilot-trainer/pull/348) **MERGED** at
   `226bc97` — **Coaching lakehouse DuckDB** ([#344](https://github.com/agorokh/ac-copilot-trainer/issues/344) P1):
   embedded DuckDB star schema in `tools/coaching_lake` rebuilt from lap-archives.

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -104,14 +104,6 @@ driver-facing launcher work discovers the UI contract. Tier-3 MCP was not
 exposed in this Codex session; the package was grounded from the vault and live
 source files listed inside the package.
 
-## Game Point #363 / PR #365 (2026-06-29) — pre-merge handoff
-
-PR [#365](https://github.com/agorokh/ac-copilot-trainer/pull/365) delivers the
-Game Point launcher supervisor and Pocket Technician spinner completion for
-[#363](https://github.com/agorokh/ac-copilot-trainer/issues/363). Install
-evidence, review-resolution history, and follow-ups:
-[[pr-365-game-point-launcher-2026-06-29]].
-
 ## Track Titan #353 (parallel track) — M-TT0 shipped; M-TT1 services auth CRACKED, path-pinning remains
 
 PR [#359](https://github.com/agorokh/ac-copilot-trainer/pull/359) (M-TT0 vulcan retention) MERGED.

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/pr-365-game-point-launcher-2026-06-29.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/pr-365-game-point-launcher-2026-06-29.md
@@ -1,6 +1,6 @@
 ---
 type: investigation
-status: active
+status: completed
 created: 2026-06-29
 updated: 2026-06-29
 relates_to:
@@ -18,6 +18,10 @@ visible user launch path and extension contract for Game Point
 ([#363](https://github.com/agorokh/ac-copilot-trainer/issues/363)): Windows
 shortcut installer, per-user settings, Pocket Technician spinner protocol, and
 launcher-sidecar supervision.
+
+Merged 2026-06-29T09:15:25Z as squash commit
+[`854f822`](https://github.com/agorokh/ac-copilot-trainer/commit/854f822bdd868397e99bfd56c08ade2f87277139);
+[#363](https://github.com/agorokh/ac-copilot-trainer/issues/363) is closed.
 
 ## Install verification (rig)
 
@@ -60,3 +64,6 @@ the sidecar until the official signed `/session` handshake is ported. Use
   still desired, and final on-device smoke evidence
   `launcher -> AC Copilot live hints -> Pocket Technician setup load -> Setup Exchange browse/download/install`.
 - Re-run packaged-launcher rig proof after merge when the Windows rig is available.
+- Post-merge classifier flagged `.env.example` and `pyproject.toml`: review rig
+  environment defaults and refresh the local dev install (`pip install -e '.[dev]'`
+  or equivalent lockfile workflow). No migrations were detected or run.


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #365.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).