### PR TITLE
docs(vault): M-TT1 services crack post-merge handoff (#353) (#370)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-29T09:18:39Z
+last_updated: 2026-06-29T16:20:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/00_System/Project State.md
@@ -104,6 +104,15 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + final on-device proof) is the hot
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-29** — PR [#370](https://github.com/agorokh/ac-copilot-trainer/pull/370) **MERGED** at
+  `26e9a09` — **M-TT1 Track Titan services crack** ([#353](https://github.com/agorokh/ac-copilot-trainer/issues/353)):
+  `tools/tt_ingest/tt_services.py` (services client) + `coaching` CLI retaining per-lap raw
+  reference + advice evidence to the write-once lake. **Auth corrected**: services `/api/v2/*` /
+  `/dynamic-reference-laps/*` / `/advice/*` use the raw Cognito **access token** (not SigV4 — that
+  was the disproved hypothesis); verified live (accessToken→200, idToken→403). Per-corner coaching
+  oracle works E2E. Classification: additive `tools/`+tests+fixtures, no migrations/env/deps.
+  Resume → **M-TT2** (reference telemetry → `lap_archive` → M0 `--reference-archive`). Full state:
+  [`tt-services-sigv4-crack-2026-06-29`](../03_Investigations/tt-services-sigv4-crack-2026-06-29.md).
 - **2026-06-29** — PR [#365](https://github.com/agorokh/ac-copilot-trainer/pull/365) **MERGED** at
   `854f822` — **Game Point launcher supervisor** ([#363](https://github.com/agorokh/ac-copilot-trainer/issues/363)
   **CLOSED**): Windows launcher package/shortcut/settings, supervised sidecar start/status/logging,

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-29T09:18:39Z
+last_updated: 2026-06-29T16:20:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/tt-services-sigv4-crack-2026-06-29.md
   - AcCopilotTrainer/03_Investigations/issue-86-rig-screen-hotspot-autostart-2026-06-28.md
@@ -51,6 +51,35 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-06-29) — PR #370 MERGED: M-TT1 Track Titan services crack (#353)
+
+PR [#370](https://github.com/agorokh/ac-copilot-trainer/pull/370) merged to `main` as squash
+commit [`26e9a09`](https://github.com/agorokh/ac-copilot-trainer/commit/26e9a09eb943fca8bae3e65e80b79945ac5c421c)
+at 2026-06-29T16:15:20Z (milestone **M-TT1** of #353).
+
+**The crack (corrects the prior SigV4 hypothesis):** TT `services.tracktitan.io` `/api/v2/*`,
+`/dynamic-reference-laps/*`, `/advice/*` authenticate with the **raw Cognito access token** (no
+`Bearer`) — the same token vulcan uses; **no SigV4 / Identity-Pool flow needed**. The research
+node's 403s were the **idToken** on **old cached paths**. Verified live from our own mint path
+(accessToken→200, idToken→403) via CDP capture of the running renderer. Full detail +
+reusable method + the M-TT2 telemetry schema in [[tt-services-sigv4-crack-2026-06-29]].
+
+**Shipped:** `tools/tt_ingest/tt_services.py` (services client — pure builders/parsers, network
+no-cover) + `coaching` CLI that retains per-lap raw evidence (`last_session_lap{N}.json` +
+`coaching_lap{N}.json`: full raw `/last-session`, `dynamic-reference-laps`, and per-segment
+`/advice` responses) to the write-once lake, reindexed; sanitized fixtures + 55 unit tests.
+Reviewed by codex + qodo across 5 rounds (qodo's SigV4 finding rebutted with live evidence;
+Gemini at quota). Verified live E2E: `python -m tools.tt_ingest coaching` returned real
+per-corner diagnoses for the last session (Magione, Porsche 911 GT3 R — c3 "You messed up your
+exit", c4 "line too wide") and retained them to the lake.
+
+**Resume here → M-TT2:** reference-lap telemetry → `lap_archive` schema → M0 `--reference-archive`
+voice feed. Input schema is PINNED in [[tt-services-sigv4-crack-2026-06-29]]: TT telemetry point
+(`dist`→spline, `Kmh`→speed, `brak`→brake, `throt`→throttle, `steer`, `gear`, `X`/`Y`) maps to
+`TRACE_FIELDS` in `tools/ac_harness/reference_lap.py`. Then **M-TT3** (per-corner analysis →
+harness drive-to-reference curriculum). Arbitrary-lap/older-session coaching is also a deferred
+follow-up (needs per-lap telemetry endpoints; M-TT1 scopes to the last session's own lap).
 
 ## Delivered (2026-06-29) — PR #365 MERGED: Game Point launcher supervisor (#363 CLOSED)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/tt-services-sigv4-crack-2026-06-29.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/tt-services-sigv4-crack-2026-06-29.md
@@ -11,50 +11,52 @@ relates_to:
 issue: https://github.com/agorokh/ac-copilot-trainer/issues/353
 ---
 
-# M-TT1 services SigV4 crack — research (2026-06-29, BLOCKED on final path/key)
+# M-TT1 services crack — RESOLVED (2026-06-29): accessToken, not SigV4
 
-`/autonomous-deliver 353` (ultracode). After M-TT0 merged (PR #359), researched M-TT1 (the
-services API). The issue's stated blocker — "services sits behind Cognito Identity-Pool IAM
-(SigV4); idToken → 403" — is now **substantially cracked**. NOT yet end-to-end (no services 200),
-so no code shipped. Live-probed against the operator's real account.
+`/autonomous-deliver 353` (ultracode). M-TT1 shipped in **PR #370**. The earlier
+SigV4 / Identity-Pool hypothesis (this node's prior revision) was **WRONG** and is
+corrected here. Cracked + verified live via CDP capture of the running TT renderer.
 
-## CRACKED ✅ — the Cognito Identity-Pool → SigV4 auth flow works
-- `POST cognito-identity.us-east-1.amazonaws.com` `AWSCognitoIdentityService.GetId`
-  (IdentityPoolId `us-east-1:03459aca-683c-4cc1-b2af-86b86705dd67`, Logins
-  `{cognito-idp.us-east-1.amazonaws.com/us-east-1_fdm9kB5Wr: idToken}`) → **200**, IdentityId.
-- `GetCredentialsForIdentity` → **200**, temp creds `{AccessKeyId, SecretKey, SessionToken, Expiration}`.
-- Hand-rolled **SigV4** (stdlib hmac/hashlib; service `execute-api`, region us-east-1) is **accepted**
-  by API Gateway — no signature errors. Probe: `.scratch/tt_services_probe.py` (scratch, no secrets).
+## CORRECTED auth model (verified live, from our own mint path)
+- services `/api/v2/*`, `/dynamic-reference-laps/*`, `/advice/*` authenticate with the
+  **raw Cognito ACCESS token** in `Authorization` (NO `Bearer`) — the SAME token vulcan
+  uses (`tt_auth.mint_tokens` already returns it). **No SigV4 / Identity-Pool flow needed.**
+- Proof: `services last-session [accessToken] → 200`, `[idToken] → 403`; vulcan
+  `[accessToken] → 200`. uid `ed469389…` from the minted token matches the captured request.
+- Why the prior 403s: the research probed **old cached paths** (`data-analysis/{uid}%23{sk}`)
+  with the **idToken**. The live API is RESTful `/api/v2/…` and takes the access token.
+- The Cognito Identity-Pool `GetCredentialsForIdentity` calls the app also makes are for
+  analytics (Pinpoint), NOT these data routes.
 
-## PINNED ✅ — exact services path shapes (from the Electron HTTP cache, readable)
-TT is an **AWS Amplify** Next.js app (`app.tracktitan.io/_next/static/chunks/*.js`, CDN-fetchable,
-not bot-blocked — only the HTML route is 429). Paths grepped from `%APPDATA%/track-titan-ghost-application/{Cache,Code Cache}`:
-- `dynamic-reference-laps/sessions/{uid}/{sessionKey}/laps/{lap}`
-- `dynamic-reference-laps/context/{gameId}/{trackId}/{carId}`  (e.g. `.../assettoCorsa/ks_red_bull_ring/syn_mercedes_w09`)
-- `advice/sessions/{uid}/{sessionKey}/laps/{lap}/reference/{referenceId}/...`
-- `data-analysis/...` (fragmented to `data-analysis/20…` = sessionKey-first; full template not in the cached chunk set)
+## Method (reusable)
+Relaunch `TrackTitanDesktopApplication.exe --remote-debugging-port=9222`; attach CDP
+(`websockets`), `Network.enable`, drive the renderer (`Page.navigate` to /dashboard →
+click "Get Insights"), capture `Network.requestWillBeSent` + `getResponseBody`. 68+ real
+bodies captured to gitignored `.scratch/tt_capture/`. Scratch tooling: `.scratch/tt_cdp_*`,
+`tt_crack.py`, `tt_verify.py` (no secrets; redacted prints).
 
-## Auth model (observed status codes, correct paths)
-- **`data-analysis` ACCEPTS SigV4/IAM** → `404 {"message":"Not Found"}` (Lambda ran; wrong path/params,
-  OR session lacks computed analysis). This is the operator's PRIMARY want (per-corner diagnosis) and it
-  is **auth-cracked** — only the exact path remains.
-- **`dynamic-reference-laps` / `advice` / `context`** → `403 {"message":"Forbidden"}` under valid SigV4
-  on the correct path → the Identity-Pool IAM role likely lacks `execute-api:Invoke` on those routes (or
-  they need userPool/apiKey auth). No `da2-` AppSync apiKey literal exists in asar/cache/LocalStorage, so
-  it is NOT a simple embedded key; `services.tracktitan.io/{auth,api/content}` → 404 (not the issuer).
+## Live paths (envelope = `{success,status,data,message}`; dynamic-reference-laps is BARE)
+- `GET /api/v2/users/{uid}/sessions?page&hideLimited&limit`
+- `GET /api/v2/sessions/{uid}/last-session`  → session + referenceLap + **telemetry trace**
+- `GET /api/v2/sessions/{uid}/{sk}/laps/{lap}/reference`  (dynamicComparisonLap)
+- `GET /dynamic-reference-laps/sessions/{uid}/{sk}/laps/{lap}?segmentCount=N`
+- `GET /api/v2/sessions/{uid}/{sk}/reference/{refUid}/{refSk}/laps/{refLap}`
+- `GET /advice/sessions/{uid}/{sk}/laps/{lap}/reference/{refUid}/{refSk}/laps/theoreticalBestRef/segments/{n}`
+- `GET /api/v2/users/{uid}/analysis/progress/?gameId&trackId&carId`
 
-## BLOCKED — precise remaining work (next session)
-1. **Pin the exact `data-analysis` path** (unblocks the primary want via the already-working SigV4):
-   capture the running renderer's network (CDP — launch the TT app with `--remote-debugging-port`, read
-   `Network.requestWillBeSent` for the data-analysis GET), OR fetch the session-review page chunk (not in
-   the 77 cached chunk URLs) and read the fetch template. Then brute-confirm against a session known to
-   have analysis (cache lists `20260628051354/laps/5`, `20260620003604/laps/4`).
-2. **Resolve ref-laps/advice 403:** try the **userPool idToken** auth mode (Amplify `defaultAuthMode`
-   per-endpoint) vs IAM, or inspect the Identity-Pool role policy. The reference lap (M-TT2 input) comes
-   from `dynamic-reference-laps`.
-3. Then build `tt_services.py` (SigV4 signer already prototyped) + fixtures, and proceed to M-TT2
-   (reference → `lap_archive` → M0 `--voice-reference`) and M-TT3.
+Two references, kept distinct: **dynamic_reference** (community/other driver, e.g. "Dennis
+Bosman") vs **advice_reference** (operator's own `theoreticalBestRef`).
 
-Scratch tooling (gitignored, no secrets — values redacted on print): `.scratch/tt_services_probe.py`,
-`tt_chunk_scan.py`, `tt_chunk_context.py`, `tt_auth_endpoint_probe.py`. Guardrail scope (personal
-own-account use) per [[track-titan-coaching-oracle-strategy-2026-06-27]] applies.
+## M-TT2 input (telemetry trace, PINNED)
+`last-session.data.telemetry.telemetry.{user,reference}` = ~265-pt lists. Point keys:
+`dist`(spline 0-1), `distM`, `Kmh`(speed), `brak`, `throt`, `steer`, `ovSteer`, `unSteer`,
+`gear`, `lTime`(ms), `useGrip`, `X`,`Y`(track pos). Maps to `lap_archive` TRACE_FIELDS in
+`tools/ac_harness/reference_lap.py` (spline=dist, speed=Kmh, brake=brak, throttle=throt, …).
+
+## Shipped (PR #370)
+`tools/tt_ingest/tt_services.py` (client: builders+parsers pure, network no-cover) +
+`coaching` CLI (retains per-lap raw evidence `last_session_lap{N}.json` + `coaching_lap{N}.json`
+to the write-once lake, reindexed) + sanitized fixtures + tests. Live E2E verified
+(per-corner diagnoses, e.g. Magione Porsche 911 GT3 R: c3 "You messed up your exit").
+
+## NEXT: M-TT2 (reference telemetry → lap_archive → M0 --reference-archive), M-TT3 (per-corner → harness).


### PR DESCRIPTION
Post-merge vault SAVE for PR #370 (M-TT1). Corrects the services research node (accessToken auth, not SigV4 — verified live), records the CDP-capture method + the M-TT2 telemetry schema, and adds the #370 delivery + M-TT2 resume pointer to the handoff and Current Focus. Strictly docs/01_Vault/**.