### PR TITLE
docs(vault): M-TT2 de-risk finding — /last-session telemetry is per-segment (#353)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-29T16:20:00Z
+last_updated: 2026-06-29T16:30:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/tt-services-sigv4-crack-2026-06-29.md
   - AcCopilotTrainer/03_Investigations/issue-86-rig-screen-hotspot-autostart-2026-06-28.md
@@ -75,11 +75,17 @@ per-corner diagnoses for the last session (Magione, Porsche 911 GT3 R — c3 "Yo
 exit", c4 "line too wide") and retained them to the lake.
 
 **Resume here → M-TT2:** reference-lap telemetry → `lap_archive` schema → M0 `--reference-archive`
-voice feed. Input schema is PINNED in [[tt-services-sigv4-crack-2026-06-29]]: TT telemetry point
-(`dist`→spline, `Kmh`→speed, `brak`→brake, `throt`→throttle, `steer`, `gear`, `X`/`Y`) maps to
-`TRACE_FIELDS` in `tools/ac_harness/reference_lap.py`. Then **M-TT3** (per-corner analysis →
-harness drive-to-reference curriculum). Arbitrary-lap/older-session coaching is also a deferred
-follow-up (needs per-lap telemetry endpoints; M-TT1 scopes to the last session's own lap).
+voice feed. Point schema PINNED + the frame→`TRACE_FIELDS` mapping is **de-risk-PROVEN** against
+real data (`.scratch/tt_mtt2_smoke.py` builds a valid `lap_archive` from the TT reference frames;
+`Kmh`→`speed` units confirmed km/h). **BUT a real blocker surfaced (and is now documented in
+[[tt-services-sigv4-crack-2026-06-29]]): `/last-session` carries only ONE SEGMENT's telemetry
+window (~9% of the lap: measured `dist` 0.265→0.359, derived lap_ms≈29s vs the true ~71s reference).**
+So M-TT2's FIRST step is a **live capture** of the FULL reference telemetry (stitch all 7 segment
+windows by scrubbing the renderer per-segment via CDP, or find a full-lap telemetry endpoint) —
+do it while TT is open — THEN normalise + ship the `reference` CLI + M0 bridge. M-TT2 is NOT a
+single-call add. Then **M-TT3** (per-corner analysis → harness drive-to-reference curriculum).
+Arbitrary-lap/older-session coaching is also a deferred follow-up (M-TT1 scopes to the last
+session's own lap).
 
 ## Delivered (2026-06-29) — PR #365 MERGED: Game Point launcher supervisor (#363 CLOSED)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/tt-services-sigv4-crack-2026-06-29.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/tt-services-sigv4-crack-2026-06-29.md
@@ -47,11 +47,26 @@ bodies captured to gitignored `.scratch/tt_capture/`. Scratch tooling: `.scratch
 Two references, kept distinct: **dynamic_reference** (community/other driver, e.g. "Dennis
 Bosman") vs **advice_reference** (operator's own `theoreticalBestRef`).
 
-## M-TT2 input (telemetry trace, PINNED)
-`last-session.data.telemetry.telemetry.{user,reference}` = ~265-pt lists. Point keys:
-`dist`(spline 0-1), `distM`, `Kmh`(speed), `brak`, `throt`, `steer`, `ovSteer`, `unSteer`,
-`gear`, `lTime`(ms), `useGrip`, `X`,`Y`(track pos). Maps to `lap_archive` TRACE_FIELDS in
-`tools/ac_harness/reference_lap.py` (spline=dist, speed=Kmh, brake=brak, throttle=throt, …).
+## M-TT2 input (telemetry trace) — point schema PINNED, full-lap SOURCE still open
+Point keys (`last-session.data.telemetry.telemetry.{user,reference}`): `dist`(spline 0-1),
+`distM`(often null), `Kmh`(speed, **km/h — matches our `lap_archive` `speed`**, confirmed
+`realtime_observer.py:19`), `brak`, `throt`, `steer`, `ovSteer`, `unSteer`, `gear`, `lTime`(ms),
+`useGrip`, `X`,`Y`(**normalised track pos 0-1, NOT world metres** — so they are not directly our
+`px/py/pz`; voice coaching uses spline/speed/brake, not px/py geometry). Maps to `lap_archive`
+TRACE_FIELDS in `tools/ac_harness/reference_lap.py` (spline=dist, speed=Kmh, brake=brak,
+throttle=throt, steer, gear). **De-risk PROVEN** (`.scratch/tt_mtt2_smoke.py`): these frames
+build a schema-v1 `lap_archive` record via `build_archive_record` (speeds 55.9–161.3 km/h, valid).
+
+**⚠️ BLOCKER for M-TT2 — `/last-session` carries only ONE SEGMENT's telemetry window, not the
+full lap.** Measured: the `reference` trace is 256 pts spanning `dist` **0.265→0.359** (~9% of
+the lap), `lTime` 20420→29147 ms — i.e. the corner the renderer is currently scrubbed to. Derived
+`lap_ms`≈29.1 s ≠ the real reference lap time (~71.0 s). So a single `/last-session` call yields a
+**9%-of-a-lap** reference. **Next session (M-TT2) must first capture the FULL reference telemetry**
+— either stitch all 7 segment windows (scrub the renderer per segment via CDP, concatenate by
+`dist`) or find a full-lap telemetry endpoint — THEN normalise to `lap_archive`. Do this while TT
+is open (live capture). Only after the full-lap trace is correct should the normalizer + `reference`
+CLI + M0 `--reference-archive` bridge land. (M-TT2 is NOT a single-call add — this is the trap M-TT1
+de-risking caught.)
 
 ## Shipped (PR #370)
 `tools/tt_ingest/tt_services.py` (client: builders+parsers pure, network no-cover) +


### PR DESCRIPTION
Records the M-TT2 de-risk result: the /last-session reference telemetry trace covers only one segment window (~9% of the lap), so M-TT2 must first capture the FULL reference telemetry (stitch segments via CDP). Corrects the prior 'full-lap PINNED' note. Strictly docs/01_Vault/**.