### PR TITLE
fix(launcher): rtmixer fallback + adopt healthy sidecar + clean port-in-use exit (#383)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,10 @@
 # AC_COPILOT_VOICE_BANK=
 # Optional phrase-bank runtime routing. Use a named output so voice does not land
 # on the haptic USB DAC; DirectSound accepts common Piper 22050 Hz banks.
-# AC_COPILOT_VOICE_BACKEND=rtmixer
+# Backend is `sounddevice` (the always-installable floor) or `rtmixer` (lower latency,
+# opt-in via `pip install -e ".[voice-rtmixer]"`; #383). The engine falls back to
+# sounddevice when rtmixer is not importable, so either value is safe.
+# AC_COPILOT_VOICE_BACKEND=sounddevice
 # AC_COPILOT_VOICE_DEVICE=
 # AC_COPILOT_VOICE_HOST_API=
 # AC_COPILOT_VOICE_VERBOSITY=low

--- a/docs/10_Development/14_Game_Point_Launcher.md
+++ b/docs/10_Development/14_Game_Point_Launcher.md
@@ -24,6 +24,28 @@ The shortcut points at `dist\AC-Copilot-Game-Point.exe` and uses the repository
 root as the working directory. The exe remains a local build artifact and is not
 committed.
 
+### Audio backend (rtmixer is opt-in)
+
+`pip install -e ".[launcher]"` is **always installable on a clean Windows rig**:
+its sidecar voice floor is `numpy` + `sounddevice`, which ship bundled-PortAudio
+wheels. The lower-latency `rtmixer` backend is **not** part of the default
+`launcher` / `voice` extras (issue #383) — it has no prebuilt Windows wheels and
+needs a C/PortAudio build toolchain, so bundling it made the documented install
+path hard-fail on the rig.
+
+The voice engine auto-falls back to the `sounddevice` backend when `rtmixer` is
+not importable (PR #387), so voice playback works with the floor alone. To opt
+into the lower-latency backend **where a C/PortAudio toolchain can build it**,
+add the best-effort extra:
+
+```powershell
+pip install -e ".[launcher,voice-rtmixer]"
+```
+
+`voice-rtmixer` self-references the `voice` extra, so `pip install -e ".[voice-rtmixer]"`
+also installs the `numpy` + `sounddevice` floor. Select the backend at runtime
+with `AC_COPILOT_VOICE_BACKEND` (`rtmixer` or `sounddevice`).
+
 ## UI design handoff
 
 Before changing launcher screens, rig screen UI, or cross-surface status

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,23 @@ coaching = [
 ]
 # Issue #340: in-the-ear phrase-bank playback (lazy-imported in voice/playback.py).
 # Install on the rig to render/play clips: pip install -e ".[voice]".
+# numpy + sounddevice are the always-installable floor (bundled-PortAudio wheels that install
+# cleanly on a clean Windows box). The lower-latency rtmixer backend is opt-in via the
+# `voice-rtmixer` extra (#383) because it has no prebuilt Windows wheels; the voice engine
+# auto-falls back to the sounddevice backend when rtmixer is not importable (PR #387), so this
+# extra alone is enough to render and play clips.
 voice = [
     "numpy>=2.4.4",
     "sounddevice>=0.5.1",
+]
+# Issue #383: OPT-IN, best-effort low-latency playback. rtmixer is the GIL-free C/PortAudio
+# backend (`RtMixerPlayback`) but ships NO prebuilt Windows wheels and needs a C/PortAudio build
+# toolchain, so it frequently HARD-FAILS `pip install` on a clean Windows rig. It is kept out of
+# the default `voice`/`launcher` extras so those stay installable everywhere; install it only
+# where pip can build it: `pip install -e ".[voice-rtmixer]"`. Pulls in the `voice` floor so this
+# extra is sufficient on its own.
+voice-rtmixer = [
+    "ac-copilot-trainer[voice]",
     "rtmixer>=0.1.7",
 ]
 # M0 (#341): Windows pyttsx3 voice client — no native audio stack required.
@@ -66,12 +80,15 @@ voice-client = [
 ]
 # Game Point launcher packaging (#363). Runtime code stays stdlib-only; this
 # extra is needed to build the Windows .exe artifact and bundle sidecar runtime deps.
+# Keep this extra ALWAYS-INSTALLABLE on a clean Windows rig: the sidecar voice floor here is
+# numpy + sounddevice (bundled-PortAudio wheels). rtmixer is deliberately NOT bundled (#383) —
+# it has no prebuilt Windows wheels and would hard-fail `pip install -e ".[launcher]"`; add the
+# lower-latency backend opt-in and best-effort via `.[voice-rtmixer]` where a C toolchain exists.
 launcher = [
   "pyinstaller>=6.15.0",
   "websockets>=16.0",
   "numpy>=2.4.4",
   "sounddevice>=0.5.1",
-  "rtmixer>=0.1.7",
   "pyttsx3>=2.90",
 ]
 # Issue #368: OFFLINE neural-voice bake (recommended Kokoro-82M backend, Apache-2.0). Used only by

--- a/tests/test_ai_sidecar.py
+++ b/tests/test_ai_sidecar.py
@@ -1,5 +1,6 @@
 """Package smoke tests for optional AI WebSocket sidecar (issue #9 Part B)."""
 
+import asyncio
 import importlib
 
 import pytest
@@ -12,3 +13,48 @@ def test_ai_sidecar_subpackage_importable() -> None:
 def test_ai_sidecar_server_importable_when_websockets_installed() -> None:
     pytest.importorskip("websockets")
     importlib.import_module("tools.ai_sidecar.server")
+
+
+def test_run_exits_cleanly_when_port_already_in_use(monkeypatch) -> None:
+    """Port-in-use must raise SystemExit(str), not an unhandled OSError traceback.
+
+    A frozen ``--noconsole`` launcher turns an unhandled exception into a Windows
+    "Unhandled exception in script" dialog; a ``SystemExit`` string just logs the reason and
+    exits non-zero. Reproduces WinError 10048 from the rig log.
+    """
+    websockets = pytest.importorskip("websockets")
+    server = importlib.import_module("tools.ai_sidecar.server")
+
+    class _BoomServe:
+        async def __aenter__(self):
+            err = OSError("only one usage of each socket address is normally permitted")
+            err.errno = server._WSAEADDRINUSE
+            raise err
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    monkeypatch.setattr(websockets, "serve", lambda *a, **k: _BoomServe())
+
+    with pytest.raises(SystemExit) as excinfo:
+        asyncio.run(server._run("127.0.0.1", 8765, False, None))
+
+    assert "already in use" in str(excinfo.value)
+
+
+def test_run_reraises_unrelated_oserror(monkeypatch) -> None:
+    """A non-bind OSError must NOT be swallowed as a port-in-use SystemExit."""
+    websockets = pytest.importorskip("websockets")
+    server = importlib.import_module("tools.ai_sidecar.server")
+
+    class _BoomServe:
+        async def __aenter__(self):
+            raise OSError("disk on fire")  # no errno set → not EADDRINUSE
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    monkeypatch.setattr(websockets, "serve", lambda *a, **k: _BoomServe())
+
+    with pytest.raises(OSError, match="disk on fire"):
+        asyncio.run(server._run("127.0.0.1", 8765, False, None))

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -66,6 +66,26 @@ class _Proc:
         self.terminated = True
 
 
+def _refused_urlopen(_url: str, timeout: float) -> _Response:
+    """Health probe that always fails — keeps spawn-path tests hermetic.
+
+    ``start_sidecar`` now probes ``/health`` before spawning so it can adopt an already-running
+    sidecar instead of double-binding the port. Tests that assert a *spawn* inject this so the
+    probe deterministically misses regardless of whatever is (or isn't) listening on 8765.
+    """
+    del timeout
+    raise OSError("connection refused")
+
+
+def _no_simhub_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+    """`tasklist` stub reporting no SimHub — keeps probe_simhub tests off the real machine.
+
+    ``_simhub_running()`` shells out to the real ``tasklist`` by default, so on a dev box with
+    SimHub actually running the absence/start assertions would flake. Inject this for determinism.
+    """
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
 def test_sidecar_command_uses_env_for_token_and_voice(tmp_path: Path) -> None:
     cfg = GamePointConfig(
         external_bind="0.0.0.0",
@@ -254,7 +274,9 @@ def test_start_sidecar_writes_to_predictable_log_dir(tmp_path: Path) -> None:
         calls.append({"args": args, "kwargs": kwargs})
         return _Proc()
 
-    sup = GamePointSupervisor(cfg, environ={}, popen=fake_popen, python_executable="python")
+    sup = GamePointSupervisor(
+        cfg, environ={}, popen=fake_popen, urlopen=_refused_urlopen, python_executable="python"
+    )
     result = sup.start_sidecar()
     sup.close()
 
@@ -264,13 +286,45 @@ def test_start_sidecar_writes_to_predictable_log_dir(tmp_path: Path) -> None:
     assert "AC_COPILOT_SIDECAR_TOKEN" in calls[0]["kwargs"]["env"]
 
 
+def test_start_sidecar_adopts_healthy_existing_instance(tmp_path: Path) -> None:
+    """Clicking Start when a sidecar is already healthy must adopt it, never spawn a duplicate.
+
+    A second spawn would bind the same port and crash the child with WinError 10048 — exactly the
+    failure in the rig log. Guards that regression: a healthy /health probe → no popen call.
+    """
+    cfg = GamePointConfig(external_bind="0.0.0.0", token="token", paths=LauncherPaths(tmp_path))
+    spawned: list[Any] = []
+
+    def fake_popen(*args: Any, **kwargs: Any) -> _Proc:
+        spawned.append((args, kwargs))
+        return _Proc()
+
+    def healthy_urlopen(_url: str, timeout: float) -> _Response:
+        del timeout
+        return _Response({"status": "ok", "connected_peers": 1, "screen_peers": 1})
+
+    sup = GamePointSupervisor(
+        cfg, environ={}, popen=fake_popen, urlopen=healthy_urlopen, python_executable="python"
+    )
+    result = sup.start_sidecar()
+
+    assert spawned == []  # no duplicate spawn → no WinError 10048
+    assert result.ok is True
+    assert result.state == "running"
+    assert "adopted" in (result.detail or "")
+    assert sup._sidecar_process is None
+    assert sup._log_handles == []
+
+
 def test_start_sidecar_returns_probe_result_on_spawn_failure(tmp_path: Path) -> None:
     cfg = GamePointConfig(external_bind="0.0.0.0", token="token", paths=LauncherPaths(tmp_path))
 
     def failing_popen(*_args: Any, **_kwargs: Any) -> _Proc:
         raise FileNotFoundError("missing sidecar executable")
 
-    sup = GamePointSupervisor(cfg, environ={}, popen=failing_popen, python_executable="python")
+    sup = GamePointSupervisor(
+        cfg, environ={}, popen=failing_popen, urlopen=_refused_urlopen, python_executable="python"
+    )
     result = sup.start_sidecar()
 
     assert result.ok is False
@@ -310,6 +364,7 @@ def test_start_sidecar_uses_repo_root_cwd_in_dev_mode(tmp_path: Path) -> None:
         cfg,
         environ={},
         popen=fake_popen,
+        urlopen=_refused_urlopen,
         python_executable="python",
         frozen=False,
     )
@@ -340,7 +395,9 @@ def test_sidecar_environment_resolves_relative_voice_paths(tmp_path: Path) -> No
 def test_close_terminates_supervised_sidecar(tmp_path: Path) -> None:
     proc = _Proc()
     cfg = GamePointConfig(external_bind="127.0.0.1", paths=LauncherPaths(tmp_path))
-    sup = GamePointSupervisor(cfg, environ={}, popen=lambda *a, **kw: proc)
+    sup = GamePointSupervisor(
+        cfg, environ={}, popen=lambda *a, **kw: proc, urlopen=_refused_urlopen
+    )
 
     sup.start_sidecar()
     sup.close()
@@ -350,7 +407,9 @@ def test_close_terminates_supervised_sidecar(tmp_path: Path) -> None:
 
 def test_simhub_absence_is_visible_but_not_fatal(tmp_path: Path) -> None:
     cfg = GamePointConfig(paths=LauncherPaths(tmp_path))
-    sup = GamePointSupervisor(cfg, environ={"ProgramFiles": str(tmp_path / "missing")})
+    sup = GamePointSupervisor(
+        cfg, environ={"ProgramFiles": str(tmp_path / "missing")}, run=_no_simhub_run
+    )
 
     result = sup.probe_simhub(start=True)
 
@@ -374,6 +433,7 @@ def test_simhub_starts_when_requested_and_executable_exists(tmp_path: Path) -> N
         cfg,
         environ={"ProgramFiles": str(tmp_path)},
         popen=fake_popen,
+        run=_no_simhub_run,
     )
 
     result = sup.probe_simhub(start=True)
@@ -573,7 +633,9 @@ def test_restart_sidecar_reuses_single_log_handle(tmp_path: Path) -> None:
         return proc
 
     cfg = GamePointConfig(external_bind="0.0.0.0", token="token", paths=LauncherPaths(tmp_path))
-    sup = GamePointSupervisor(cfg, environ={}, popen=fake_popen, python_executable="python")
+    sup = GamePointSupervisor(
+        cfg, environ={}, popen=fake_popen, urlopen=_refused_urlopen, python_executable="python"
+    )
     sup.start_sidecar()
     assert len(sup._log_handles) == 1
     procs[0].terminated = True

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -658,11 +658,39 @@ def test_launcher_extra_includes_sidecar_voice_runtime_deps() -> None:
     project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     launcher = set(project["project"]["optional-dependencies"]["launcher"])
 
+    # Always-installable floor: numpy + sounddevice ship bundled-PortAudio wheels that install
+    # cleanly on a clean Windows rig, so `pip install -e ".[launcher]"` does not hard-fail there.
     assert "websockets>=16.0" in launcher
     assert "numpy>=2.4.4" in launcher
     assert "sounddevice>=0.5.1" in launcher
-    assert "rtmixer>=0.1.7" in launcher
     assert "pyttsx3>=2.90" in launcher
+    # rtmixer (#383) has no prebuilt Windows wheels and would hard-fail the documented launcher
+    # install path — it must stay OUT of this default extra and is opt-in via `voice-rtmixer`
+    # (asserted by test_voice_rtmixer_extra_is_opt_in_and_pulls_floor).
+    assert not any(dep.startswith("rtmixer") for dep in launcher)
+
+
+def test_voice_extra_floor_excludes_rtmixer() -> None:
+    project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    voice = set(project["project"]["optional-dependencies"]["voice"])
+
+    # numpy + sounddevice are the always-installable voice floor; the engine falls back to the
+    # sounddevice backend when rtmixer is absent (PR #387), so rtmixer is opt-in only.
+    assert "numpy>=2.4.4" in voice
+    assert "sounddevice>=0.5.1" in voice
+    assert not any(dep.startswith("rtmixer") for dep in voice)
+
+
+def test_voice_rtmixer_extra_is_opt_in_and_pulls_floor() -> None:
+    project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    extras = project["project"]["optional-dependencies"]
+    voice_rtmixer = set(extras["voice-rtmixer"])
+
+    # The opt-in, best-effort low-latency rtmixer backend lives here (and only here).
+    assert "rtmixer>=0.1.7" in voice_rtmixer
+    # Self-references the `voice` extra so `pip install -e ".[voice-rtmixer]"` also installs the
+    # numpy + sounddevice floor — rtmixer alone is not useful.
+    assert "ac-copilot-trainer[voice]" in voice_rtmixer
 
 
 def test_default_exe_path_targets_dist_launcher(tmp_path: Path) -> None:

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -316,6 +316,47 @@ def test_start_sidecar_adopts_healthy_existing_instance(tmp_path: Path) -> None:
     assert sup._log_handles == []
 
 
+def test_start_sidecar_adoption_closes_stale_log_handles(tmp_path: Path) -> None:
+    """Adopting after a prior supervised spawn must close the leftover log handle, not leak it.
+
+    Regression for the Qodo finding on PR #387: the adopt early-return ran before
+    ``_close_log_handles()``, so a handle opened by an earlier spawn stayed open for the launcher's
+    lifetime (kept sidecar.log held open). The cleanup now precedes the health probe.
+    """
+    cfg = GamePointConfig(external_bind="0.0.0.0", token="token", paths=LauncherPaths(tmp_path))
+    health = {"ok": False}
+
+    def staged_urlopen(_url: str, timeout: float) -> _Response:
+        del timeout
+        if not health["ok"]:
+            raise OSError("connection refused")
+        return _Response({"status": "ok", "connected_peers": 1, "screen_peers": 1})
+
+    procs: list[_Proc] = []
+
+    def fake_popen(*_args: Any, **_kwargs: Any) -> _Proc:
+        proc = _Proc()
+        procs.append(proc)
+        return proc
+
+    sup = GamePointSupervisor(
+        cfg, environ={}, popen=fake_popen, urlopen=staged_urlopen, python_executable="python"
+    )
+    # First start: nothing healthy yet → spawns and opens a log handle.
+    first = sup.start_sidecar()
+    assert first.state == "starting"
+    assert len(sup._log_handles) == 1
+    # The supervised child exits; an external healthy sidecar is now on the port.
+    procs[0].terminated = True
+    health["ok"] = True
+    second = sup.start_sidecar()
+    # Adopts the external sidecar (no second spawn) and closes the stale handle.
+    assert second.state == "running"
+    assert "adopted" in (second.detail or "")
+    assert len(procs) == 1
+    assert sup._log_handles == []
+
+
 def test_start_sidecar_returns_probe_result_on_spawn_failure(tmp_path: Path) -> None:
     cfg = GamePointConfig(external_bind="0.0.0.0", token="token", paths=LauncherPaths(tmp_path))
 

--- a/tests/test_voice_engine.py
+++ b/tests/test_voice_engine.py
@@ -74,3 +74,96 @@ def test_disabled_coach_factory() -> None:
     assert not coach.enabled
     assert coach.disabled_reason == "test reason"
     coach.subscribe(make_advisory())  # no-op, no crash
+
+
+def test_build_playback_falls_back_to_sounddevice_when_rtmixer_missing(
+    monkeypatch, tmp_path
+) -> None:
+    """rtmixer absent must NOT silence the coach — it degrades to the sounddevice backend.
+
+    Reproduces the rig log `ModuleNotFoundError: No module named 'rtmixer'` → "coach disabled".
+    Fakes the audio classes so the test needs no numpy / PortAudio / device.
+    """
+    import tools.ai_sidecar.voice.playback as pb_mod
+
+    class _FakeBank:
+        @staticmethod
+        def from_manifest(_manifest, _bank_dir):
+            return object()
+
+    constructed: dict[str, object] = {}
+
+    class _FakeRtMixer:
+        def __init__(self, *_args, **_kwargs):
+            raise ModuleNotFoundError("No module named 'rtmixer'")
+
+    class _FakeSoundDevice:
+        def __init__(self, _bank, *, device_name, host_api, **_kwargs):
+            constructed["device_name"] = device_name
+            constructed["host_api"] = host_api
+
+    monkeypatch.setattr(pb_mod, "Bank", _FakeBank)
+    monkeypatch.setattr(pb_mod, "RtMixerPlayback", _FakeRtMixer)
+    monkeypatch.setattr(pb_mod, "SoundDevicePlayback", _FakeSoundDevice)
+
+    playback = VoiceCoach._build_playback(
+        object(), tmp_path, VoiceConfig(device_name="Headset", host_api="WASAPI"), "rtmixer"
+    )
+
+    assert isinstance(playback, _FakeSoundDevice)
+    assert constructed == {"device_name": "Headset", "host_api": "WASAPI"}
+
+
+def test_build_playback_disables_when_no_backend_importable(monkeypatch, tmp_path) -> None:
+    """If neither rtmixer nor sounddevice imports, disable (None) rather than crash."""
+    import tools.ai_sidecar.voice.playback as pb_mod
+
+    class _FakeBank:
+        @staticmethod
+        def from_manifest(_manifest, _bank_dir):
+            return object()
+
+    class _FakeRtMixer:
+        def __init__(self, *_args, **_kwargs):
+            raise ModuleNotFoundError("No module named 'rtmixer'")
+
+    class _FakeSoundDevice:
+        def __init__(self, *_args, **_kwargs):
+            raise ModuleNotFoundError("No module named 'sounddevice'")
+
+    monkeypatch.setattr(pb_mod, "Bank", _FakeBank)
+    monkeypatch.setattr(pb_mod, "RtMixerPlayback", _FakeRtMixer)
+    monkeypatch.setattr(pb_mod, "SoundDevicePlayback", _FakeSoundDevice)
+
+    assert VoiceCoach._build_playback(object(), tmp_path, VoiceConfig(), "rtmixer") is None
+
+
+def test_build_playback_device_fault_still_disables_without_fallback(monkeypatch, tmp_path) -> None:
+    """A real device/driver fault (not a missing module) disables — no silent sounddevice retry.
+
+    The same fault would recur on sounddevice, and staying silent beats routing onto the wrong
+    endpoint. Only a *missing module* triggers the fallback.
+    """
+    import tools.ai_sidecar.voice.playback as pb_mod
+
+    class _FakeBank:
+        @staticmethod
+        def from_manifest(_manifest, _bank_dir):
+            return object()
+
+    sd_calls: list[object] = []
+
+    class _FakeRtMixer:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("PortAudio device error -9996")
+
+    class _FakeSoundDevice:
+        def __init__(self, *_args, **_kwargs):
+            sd_calls.append(object())
+
+    monkeypatch.setattr(pb_mod, "Bank", _FakeBank)
+    monkeypatch.setattr(pb_mod, "RtMixerPlayback", _FakeRtMixer)
+    monkeypatch.setattr(pb_mod, "SoundDevicePlayback", _FakeSoundDevice)
+
+    assert VoiceCoach._build_playback(object(), tmp_path, VoiceConfig(), "rtmixer") is None
+    assert sd_calls == []  # device fault must not fall through to sounddevice

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import ipaddress
 import json
 import logging
@@ -230,6 +231,10 @@ def _env_float(name: str, default: float, *, min_value: float, max_value: float)
 TELEMETRY_TICK_MAX_HZ = 20.0
 HAPTIC_EVENT_MAX_HZ = 25.0
 LEGACY_SCREEN_CLIENT_PREFIXES = ("ac-copilot-screen",)
+
+# Windows reports a port-in-use bind as WSAEADDRINUSE (10048), which is distinct from the POSIX
+# errno.EADDRINUSE value; accept both so the clean-exit path fires on every platform.
+_WSAEADDRINUSE = getattr(errno, "WSAEADDRINUSE", 10048)
 
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 CLIENT_TO_SERVER_TYPES = frozenset(
@@ -1414,21 +1419,34 @@ async def _run(
     configured_setups_root = user_setups_root or os.environ.get(ENV_USER_SETUPS_DIR)
     _setup_exchange_user_setups_root = _user_setups_root_from_config(configured_setups_root)
     try:
-        async with websockets.serve(
-            lambda ws: _handler(ws, reply_coaching),
-            host,
-            port,
-            process_request=process_request,
-        ):
-            logger.info(
-                "AI sidecar listening host=%s port=%s protocol=%s reply_coaching=%s token=%s",
+        try:
+            async with websockets.serve(
+                lambda ws: _handler(ws, reply_coaching),
                 host,
                 port,
-                PROTOCOL_VERSION,
-                reply_coaching,
-                "set" if token else "unset",
-            )
-            await asyncio.Future()
+                process_request=process_request,
+            ):
+                logger.info(
+                    "AI sidecar listening host=%s port=%s protocol=%s reply_coaching=%s token=%s",
+                    host,
+                    port,
+                    PROTOCOL_VERSION,
+                    reply_coaching,
+                    "set" if token else "unset",
+                )
+                await asyncio.Future()
+        except OSError as exc:
+            # WinError 10048 / errno EADDRINUSE: another sidecar already owns the port. Exit
+            # cleanly with a one-line reason instead of a traceback — a frozen --noconsole build
+            # turns an unhandled exception into a scary "Unhandled exception in script" dialog,
+            # whereas SystemExit(str) just logs the message and returns a non-zero code.
+            if exc.errno in {errno.EADDRINUSE, _WSAEADDRINUSE}:
+                raise SystemExit(
+                    f"sidecar port {port} on {host} is already in use — another AC Copilot "
+                    f"sidecar is probably running. Stop it first, or set "
+                    f"AC_COPILOT_SIDECAR_PORT to a free port."
+                ) from exc
+            raise
     finally:
         _reset_external_state()
 

--- a/tools/ai_sidecar/voice/engine.py
+++ b/tools/ai_sidecar/voice/engine.py
@@ -146,7 +146,17 @@ class VoiceCoach:
     def _build_playback(
         manifest: Manifest, bank_dir: Path, config: VoiceConfig, backend: str
     ) -> Playback | None:
-        """Lazily construct the real audio backend (deps imported here only)."""
+        """Lazily construct the real audio backend (deps imported here only).
+
+        When ``backend="rtmixer"`` but the ``rtmixer`` extra is not importable, fall back to
+        :class:`SoundDevicePlayback` rather than disabling the coach. This is the common Windows
+        reality: ``rtmixer`` needs a C/PortAudio build (and is frequently absent from a PyInstaller
+        bundle or a plain ``pip install``), while ``sounddevice`` ships a bundled-PortAudio wheel.
+        ``sounddevice`` is the documented interim backend behind the same interface (issue #340), so
+        the coach keeps speaking instead of going silent on a missing optional dep. A *device* or
+        *driver* fault (not a missing module) still disables — that fault would recur on sounddevice
+        too, and "stay silent" beats "play onto the wrong endpoint".
+        """
         try:
             from tools.ai_sidecar.voice.playback import (
                 Bank,
@@ -155,14 +165,25 @@ class VoiceCoach:
             )
 
             bank = Bank.from_manifest(manifest, bank_dir)
-            if backend == "rtmixer":
-                return RtMixerPlayback(
-                    bank, device_name=config.device_name, host_api=config.host_api
-                )
             if backend == "sounddevice":
                 return SoundDevicePlayback(
                     bank, device_name=config.device_name, host_api=config.host_api
                 )
+            if backend == "rtmixer":
+                try:
+                    return RtMixerPlayback(
+                        bank, device_name=config.device_name, host_api=config.host_api
+                    )
+                except ImportError:
+                    # rtmixer (or its native PortAudio dep) is not installed/bundled. Degrade to
+                    # the sounddevice backend so the coach still speaks (issue #340 fallback).
+                    _log.warning(
+                        "voice: rtmixer backend unavailable (module not importable); "
+                        "falling back to the sounddevice backend"
+                    )
+                    return SoundDevicePlayback(
+                        bank, device_name=config.device_name, host_api=config.host_api
+                    )
             _log.error("voice: unknown backend %r", backend)
             return None
         except Exception:  # noqa: BLE001 - missing extra / no device / driver fault → disable, not crash

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -313,6 +313,9 @@ class GamePointSupervisor:
             return ProbeResult("sidecar", True, "running", f"pid={self._sidecar_process.pid}")
         if self._sidecar_process is not None and self._sidecar_process.poll() is not None:
             self._sidecar_process = None
+        # Close handles left by a prior supervised spawn before EITHER adopting or spawning, so the
+        # adopt early-return below cannot leak a held-open sidecar.log handle (Qodo, PR #387).
+        self._close_log_handles()
         # A sidecar from a previous launcher run (or a boot autostart) may already own the port.
         # Spawning a second one would crash the child with WinError 10048 (address already in use)
         # and pop an unhandled-exception dialog. Adopt the healthy instance instead.
@@ -324,7 +327,6 @@ class GamePointSupervisor:
                 "running",
                 f"adopted existing sidecar on port {self.config.port}",
             )
-        self._close_log_handles()
         try:
             self.paths.logs_dir.mkdir(parents=True, exist_ok=True)
             log = self.paths.sidecar_log_path.open("a", encoding="utf-8")

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -313,6 +313,17 @@ class GamePointSupervisor:
             return ProbeResult("sidecar", True, "running", f"pid={self._sidecar_process.pid}")
         if self._sidecar_process is not None and self._sidecar_process.poll() is not None:
             self._sidecar_process = None
+        # A sidecar from a previous launcher run (or a boot autostart) may already own the port.
+        # Spawning a second one would crash the child with WinError 10048 (address already in use)
+        # and pop an unhandled-exception dialog. Adopt the healthy instance instead.
+        existing = self._read_health()
+        if existing.ok:
+            return ProbeResult(
+                "sidecar",
+                True,
+                "running",
+                f"adopted existing sidecar on port {self.config.port}",
+            )
         self._close_log_handles()
         try:
             self.paths.logs_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #383. (Supersedes #384, which was opened from the non-policy-compliant auto-generated `claude/…` branch.)

The Game Point launcher was unusable on the rig. The log showed two faults; this PR fixes both at the root plus a defensive third.

## What was broken
1. **`ModuleNotFoundError: No module named 'rtmixer'` → coach DISABLED.** `rtmixer` needs a native PortAudio/C build and is commonly absent from a Windows `pip install` / PyInstaller bundle. The acceptable interim backend `SoundDevicePlayback` (bundled-PortAudio wheel, #340) existed but was never used as an automatic fallback.
2. **`OSError 10048` (port already in use) → unhandled-exception dialog.** Status already showed `sidecar: healthy`, so a sidecar was already running; clicking **Start** spawned a *second* one that crashed binding `8765`. The `--noconsole` exe turned the unhandled `OSError` into a Windows error dialog.

## Fixes
| File | Change |
|---|---|
| `tools/ai_sidecar/voice/engine.py` | `_build_playback`: rtmixer not importable → fall back to `SoundDevicePlayback`. A real device/driver fault still disables (would recur on sounddevice; staying silent beats wrong-endpoint playback). |
| `tools/rig_launcher/supervisor.py` | `start_sidecar()` probes `/health` first and **adopts** a healthy existing sidecar (`state="running"`, `detail="adopted existing sidecar on port N"`) instead of double-binding. |
| `tools/ai_sidecar/server.py` | Bind `OSError` for `EADDRINUSE`/`WSAEADDRINUSE` → clean `SystemExit(<reason>)` instead of a traceback dialog. |

## Tests
- `test_build_playback_falls_back_to_sounddevice_when_rtmixer_missing`
- `test_build_playback_disables_when_no_backend_importable`
- `test_build_playback_device_fault_still_disables_without_fallback`
- `test_start_sidecar_adopts_healthy_existing_instance` (no duplicate spawn → no 10048)
- `test_run_exits_cleanly_when_port_already_in_use` / `test_run_reraises_unrelated_oserror`
- Existing spawn-path tests made hermetic via injected `urlopen`; SimHub probe tests made hermetic via injected `run`.

`ruff format`/`check` clean; full suite green (1813 passed locally) apart from pre-existing host-only env gaps (governance-hub `inference_egress`, agentic-memory fleet-registry probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)