### PR TITLE
docs(design): Claude Design design-sync component cards (#390)

### DIFF
--- a/docs/10_Development/design/components/README.md
+++ b/docs/10_Development/design/components/README.md
@@ -1,0 +1,38 @@
+# Claude Design — component cards (design-sync source)
+
+Per-component preview cards for **Claude Design** (`claude.ai/design`). Each `*.html` is
+self-contained (fonts via Google Fonts) and starts with a `<!-- @dsCard group="…" -->`
+marker, so Claude Design indexes it into the Design System pane automatically.
+
+The **in-game HUD is the north star** (`group="HUD"`, reproduced from
+`src/ac_copilot_trainer/modules/hud.lua` + `coaching_overlay.lua`); the launcher and rig
+screens are aligned to it.
+
+```
+foundations/  colors.html, type.html          # tokens + Michroma/Montserrat/Syncopate
+hud/          active-suggestion.html, approach-panel.html
+launcher/     healthy.html, recovery.html
+rig/          ac-copilot.html, pocket-technician.html, settings.html, voice-haptics.html
+```
+
+## Push these into a Claude Design project (`/design-sync`)
+
+Run from an **interactive** Claude Code session (or Claude Desktop with design login),
+because the first sync needs a one-time design-access grant (`/design-login`):
+
+```
+/design-sync
+```
+
+Point it at this directory (`docs/10_Development/design/components`). It will:
+`list_projects` → `create_project` (or target an existing **design-system** project) →
+`finalize_plan` (you approve the exact file list) → `write_files` (uploads each card).
+Sync is **incremental** — one component at a time, never a wholesale replace.
+
+Alternatively, from Claude Design use **"Send to Claude Code Web"** to seed a project into
+the workspace, then sync these cards up.
+
+Keep the HUD cards in step with the Lua source first when the design changes — the HUD
+leads, the other surfaces follow. Regenerate all cards with
+`python .scratch/build_ds_components.py` (kept in scratch; promote to `tools/` if it earns a
+permanent home).

--- a/docs/10_Development/design/components/foundations/colors.html
+++ b/docs/10_Development/design/components/foundations/colors.html
@@ -1,0 +1,33 @@
+<!-- @dsCard group="Foundations" subtitle="Glass, hairline, semantic, text" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div style="display:grid;grid-template-columns:repeat(2,160px);gap:14px;">
+  <div style="display:flex;gap:9px;align-items:center;"><span class="sw" style="background:#111;opacity:.6;"></span><div><div>Glass</div><div class="num" style="font-size:10px;color:var(--label)">#111 60%</div></div></div>
+  <div style="display:flex;gap:9px;align-items:center;"><span class="sw" style="background:#4d5261;"></span><div><div>Hairline</div><div class="num" style="font-size:10px;color:var(--label)">#4D5261 40%</div></div></div>
+  <div style="display:flex;gap:9px;align-items:center;"><span class="sw" style="background:#ef4444;"></span><div><div>Brake / alert</div><div class="num" style="font-size:10px;color:var(--label)">#EF4444</div></div></div>
+  <div style="display:flex;gap:9px;align-items:center;"><span class="sw" style="background:#fbbf24;"></span><div><div>Line / secondary</div><div class="num" style="font-size:10px;color:var(--label)">#FBBF24</div></div></div>
+  <div style="display:flex;gap:9px;align-items:center;"><span class="sw" style="background:#4ade80;"></span><div><div>On pace</div><div class="num" style="font-size:10px;color:var(--label)">#4ADE80</div></div></div>
+  <div style="display:flex;gap:9px;align-items:center;"><span class="sw" style="background:#8c909c;"></span><div><div>Label grey</div><div class="num" style="font-size:10px;color:var(--label)">#8C909C</div></div></div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/foundations/type.html
+++ b/docs/10_Development/design/components/foundations/type.html
@@ -1,0 +1,30 @@
+<!-- @dsCard group="Foundations" subtitle="Michroma / Montserrat / Syncopate" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div style="display:flex;flex-direction:column;gap:18px;">
+  <div><div class="num" style="font-size:30px;">196 · ASCARI</div><div class="lbl" style="margin-top:4px;">Michroma — numerics, corner, action</div></div>
+  <div><div style="font-weight:700;font-size:14px;letter-spacing:.05em;">TARGET ENTRY</div><div class="lbl" style="margin-top:4px;">Montserrat — labels &amp; body</div></div>
+  <div><div class="wm" style="font-size:14px;">AG PORSCHE ACADEMY</div><div class="lbl" style="margin-top:4px;">Syncopate Bold — brand footer</div></div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/hud/active-suggestion.html
+++ b/docs/10_Development/design/components/hud/active-suggestion.html
@@ -1,0 +1,32 @@
+<!-- @dsCard group="HUD" subtitle="WINDOW_0 · centred suggestion tile" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="panel" style="width:300px;padding:14px 16px;text-align:center;">
+  <div class="lbl" style="color:var(--red);letter-spacing:.18em;">ACTIVE SUGGESTION</div>
+  <div class="num" style="font-size:22px;margin-top:12px;">T4 · ASCARI</div>
+  <div class="num" style="font-size:18px;color:var(--red);margin-top:10px;">BRAKE LATER</div>
+  <div class="num" style="font-size:13px;color:var(--amber);margin-top:8px;">CARRY 8 KM/H MORE</div>
+  <div style="font-size:11px;color:#d4d4d4;margin-top:12px;">You lost 0.18s here last lap — trail the brake to the apex.</div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/hud/approach-panel.html
+++ b/docs/10_Development/design/components/hud/approach-panel.html
@@ -1,0 +1,37 @@
+<!-- @dsCard group="HUD" subtitle="WINDOW_1 · target/current + brake bar" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="panel" style="width:440px;border-radius:12px;padding:20px 24px;">
+  <div style="display:flex;gap:16px;">
+    <div style="flex:1;"><div class="lbl">APPROACHING</div><div class="num" style="font-size:28px;margin-top:8px;">ASCARI</div></div>
+    <div style="flex:1;background:var(--inner);border:1px solid var(--hair);border-radius:8px;display:flex;padding:12px 0;">
+      <div style="flex:1;padding:0 14px;border-right:1px solid var(--hair);"><div class="lbl" style="font-size:9px;">TARGET ENTRY</div><div class="num" style="font-size:26px;">182<span class="lbl" style="font-size:9px;"> KM/H</span></div></div>
+      <div style="flex:1;padding:0 14px;"><div class="lbl" style="font-size:9px;color:var(--red);">CURRENT</div><div class="num" style="font-size:28px;color:var(--red);">196<span class="lbl" style="font-size:9px;color:var(--red);"> KM/H</span></div></div>
+    </div>
+  </div>
+  <div style="margin-top:18px;display:flex;justify-content:space-between;align-items:baseline;"><div class="lbl">DISTANCE TO BRAKING POINT</div><div class="num" style="font-size:24px;">86 M</div></div>
+  <div class="bar" style="margin-top:8px;"><div style="width:62%;height:100%;background:var(--red);border-radius:7px;"></div></div>
+  <div style="margin-top:16px;border-top:1px solid var(--hair);padding-top:10px;text-align:center;"><span class="wm" style="font-size:12px;">AG PORSCHE ACADEMY</span></div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/launcher/healthy.html
+++ b/docs/10_Development/design/components/launcher/healthy.html
@@ -1,0 +1,33 @@
+<!-- @dsCard group="Launcher" subtitle="Ready to drive — all live" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="win">
+  <div class="titlebar"><span style="width:8px;height:8px;border-radius:50%;background:var(--green);"></span><span style="font-size:12.5px;font-weight:700;letter-spacing:.02em;">AC COPILOT · GAME POINT</span></div>
+  <div style="padding:16px;">
+    <div style="padding:6px 0 12px;"><span class="num" style="font-size:15px;color:var(--green);">READY TO DRIVE</span><span style="color:var(--label);font-size:12px;margin-left:8px;">sidecar · screen · hotspot live</span></div>
+    <div class="row"><span class="lbl" style="width:96px;text-align:left;">SIDECAR</span><span class="state" style="color:var(--green)">healthy</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">peers=1 screen_peers=1</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">SCREEN</span><span class="state" style="color:var(--green)">connected</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">screen_peers=1</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">HOTSPOT</span><span class="state" style="color:var(--green)">on</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">clients=1</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">VOICE</span><span class="state" style="color:var(--amber)">configured</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">bank · sounddevice</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">SIMHUB</span><span class="state" style="color:var(--label)">absent</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">not found</span></div>
+    <div style="display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:8px;margin-top:16px;"><button class="btn primary">▶ Start</button><button class="btn">Refresh</button><button class="btn">Logs</button><button class="btn">Settings</button></div>
+  </div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/launcher/recovery.html
+++ b/docs/10_Development/design/components/launcher/recovery.html
@@ -1,0 +1,33 @@
+<!-- @dsCard group="Launcher" subtitle="Sidecar stopped — press Start" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="win">
+  <div class="titlebar"><span style="width:8px;height:8px;border-radius:50%;background:var(--label);"></span><span style="font-size:12.5px;font-weight:700;letter-spacing:.02em;">AC COPILOT · GAME POINT</span></div>
+  <div style="padding:16px;">
+    <div style="padding:6px 0 12px;"><span class="num" style="font-size:15px;color:var(--red);">PRESS START</span><span style="color:var(--label);font-size:12px;margin-left:8px;">nothing on port 8765 yet</span></div>
+    <div class="row"><span class="lbl" style="width:96px;text-align:left;">SIDECAR</span><span class="state" style="color:var(--label)">stopped</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">—</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">SCREEN</span><span class="state" style="color:var(--red)">waiting</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">no peer</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">HOTSPOT</span><span class="state" style="color:var(--green)">on</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">clients=0</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">VOICE</span><span class="state" style="color:var(--label)">configured</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">reference + bank</span></div><div class="row"><span class="lbl" style="width:96px;text-align:left;">SIMHUB</span><span class="state" style="color:var(--label)">absent</span><span class="num" style="font-size:11px;color:var(--label);margin-left:12px;">not found</span></div>
+    <div style="display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:8px;margin-top:16px;"><button class="btn primary">▶ Start</button><button class="btn">Refresh</button><button class="btn">Logs</button><button class="btn">Settings</button></div>
+  </div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/rig/ac-copilot.html
+++ b/docs/10_Development/design/components/rig/ac-copilot.html
@@ -1,0 +1,35 @@
+<!-- @dsCard group="Rig screen" subtitle="320×480 · mirrors the approach panel" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="device">
+  <div class="dhead"><span style="color:var(--label);font-size:12px;">‹ BACK</span><span class="num" style="font-size:13px;margin-left:4px;">AC COPILOT</span><span style="margin-left:auto;width:8px;height:8px;border-radius:50%;background:var(--green);"></span></div>
+  <div style="margin:12px;" class="panel"><div style="padding:11px 13px;"><div class="lbl" style="color:var(--red);">ACTIVE SUGGESTION</div><div class="num" style="font-size:20px;margin-top:8px;">T4 · ASCARI</div><div class="num" style="font-size:17px;color:var(--red);margin-top:8px;">BRAKE LATER</div><div class="num" style="font-size:12px;color:var(--amber);margin-top:6px;">CARRY 8 KM/H MORE</div></div></div>
+  <div style="margin:0 12px;display:flex;gap:10px;">
+    <div style="flex:1;background:var(--inner);border:1px solid var(--hair);border-radius:8px;padding:8px 11px;"><div class="lbl" style="font-size:9px;">TARGET</div><div class="num" style="font-size:20px;">182</div></div>
+    <div style="flex:1;background:var(--inner);border:1px solid var(--hair);border-radius:8px;padding:8px 11px;"><div class="lbl" style="font-size:9px;color:var(--red)">CURRENT</div><div class="num" style="font-size:20px;color:var(--red);">196</div></div>
+  </div>
+  <div style="margin:12px;"><div style="display:flex;justify-content:space-between;align-items:baseline;"><span class="lbl" style="font-size:9px;">DISTANCE TO BRAKING</span><span class="num" style="font-size:15px;">86 M</span></div><div class="bar" style="height:12px;margin-top:7px;box-shadow:0 0 8px rgba(239,68,68,.45);"><div style="width:62%;height:100%;background:var(--red);border-radius:6px;"></div></div></div>
+  <div style="margin-top:auto;padding:10px;border-top:1px solid var(--hair);text-align:center;"><span class="wm" style="font-size:10px;color:var(--brand);">AG PORSCHE ACADEMY</span></div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/rig/pocket-technician.html
+++ b/docs/10_Development/design/components/rig/pocket-technician.html
@@ -1,0 +1,36 @@
+<!-- @dsCard group="Rig screen" subtitle="320×480 · adjust + saved setups" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="device">
+  <div class="dhead"><span style="color:var(--label);font-size:12px;">‹ BACK</span><span class="num" style="font-size:13px;margin-left:4px;">POCKET TECHNICIAN</span><span style="margin-left:auto;width:8px;height:8px;border-radius:50%;background:var(--green);"></span></div>
+  <div style="margin:12px;" class="panel"><div style="padding:9px 12px;"><div style="display:flex;justify-content:space-between;"><span class="lbl" style="font-size:9px;">MONZA</span><span class="lbl" style="font-size:9px;">FERRARI 296</span></div><div class="num" style="font-size:14px;margin-top:4px;">QUALI — LOW DF</div></div></div>
+  <div style="margin:0 12px;">
+    <div class="lbl" style="color:var(--amber);margin-bottom:8px;">ADJUST</div>
+    <div class="row" style="padding:9px 0;"><span style="flex:1;font-size:12px;">Brake bias</span><span style="color:var(--label);">−</span><span class="num" style="font-size:13px;min-width:54px;text-align:center;">56.5%</span><span style="color:var(--gold);">+</span></div>
+    <div class="row" style="padding:9px 0;"><span style="flex:1;font-size:12px;">TC</span><span style="color:var(--label);">−</span><span class="num" style="font-size:13px;min-width:54px;text-align:center;">3</span><span style="color:var(--gold);">+</span></div>
+    <div class="lbl" style="color:var(--amber);margin:12px 0 8px;">SAVED</div>
+    <div class="row" style="padding:8px 0;border-bottom:none;"><span style="flex:1;"><div style="font-size:12px;">Race — stable</div><div class="num" style="font-size:10px;color:var(--label);">1:21.4 · BB 54 · TC 4</div></span><span style="color:var(--gold);">›</span></div>
+  </div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/rig/settings.html
+++ b/docs/10_Development/design/components/rig/settings.html
@@ -1,0 +1,36 @@
+<!-- @dsCard group="Rig screen" subtitle="320×480 · diagnostics (token hidden)" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="device">
+  <div class="dhead"><span style="color:var(--label);font-size:12px;">‹ BACK</span><span class="num" style="font-size:13px;margin-left:4px;">SETTINGS</span><span style="margin-left:auto;width:8px;height:8px;border-radius:50%;background:var(--green);"></span></div>
+  <div style="margin:12px;">
+    <div class="row"><span style="flex:1;font-size:12px;">Wi-Fi</span><span class="num" style="font-size:11px;">RIG-HOTSPOT</span></div>
+    <div class="row"><span style="flex:1;font-size:12px;">Sidecar</span><span class="state" style="color:var(--green)">connected</span></div>
+    <div class="row"><span style="flex:1;font-size:12px;">Token</span><span class="state" style="color:var(--green)">present</span></div>
+    <div class="row"><span style="flex:1;font-size:12px;">Firmware</span><span class="num" style="font-size:11px;">v1.4.2</span></div>
+    <div class="row" style="border-bottom:none;"><span style="flex:1;font-size:12px;">Snapshot age</span><span class="num" style="font-size:11px;color:var(--green);">0.1 s</span></div>
+  </div>
+  <div style="margin:6px 12px;color:var(--label);font-size:10px;">Token shown present/absent only — never the value.</div>
+</div>
+</body></html>

--- a/docs/10_Development/design/components/rig/voice-haptics.html
+++ b/docs/10_Development/design/components/rig/voice-haptics.html
@@ -1,0 +1,34 @@
+<!-- @dsCard group="Rig screen" subtitle="320×480 · voice + haptics status" -->
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<style>@import url('https://fonts.googleapis.com/css2?family=Michroma&family=Montserrat:wght@400;700&family=Syncopate:wght@700&display=swap');
+:root{--glass:rgba(17,17,17,.6);--solid:#111;--hair:rgba(77,82,97,.4);--inner:rgba(10,10,13,.55);
+--white:#F2F2F5;--label:#8C909C;--brand:#6F7585;--red:#EF4444;--amber:#FBBF24;--green:#4ADE80;
+--barbg:rgba(38,38,46,.85);--gold:#FFD700;--num:Michroma,sans-serif;--ui:Montserrat,sans-serif;--wm:Syncopate,sans-serif;}
+*{box-sizing:border-box;}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#26262b;background-image:repeating-linear-gradient(115deg,#26262b 0 40px,#212126 40px 80px);
+font-family:var(--ui);color:var(--white);padding:24px;}
+.num{font-family:var(--num);}.wm{font-family:var(--wm);font-weight:700;letter-spacing:.16em;}
+.lbl{font-family:var(--ui);font-weight:700;font-size:10px;letter-spacing:.14em;color:var(--label);text-transform:uppercase;}
+.panel{background:var(--glass);border:1px solid var(--hair);border-radius:8px;}
+.win{background:var(--solid);border:1px solid #2a2a2a;border-radius:10px;width:400px;overflow:hidden;}
+.titlebar{background:#161616;height:34px;display:flex;align-items:center;gap:8px;padding:0 12px;border-bottom:1px solid var(--hair);}
+.row{display:flex;align-items:center;gap:10px;padding:9px 2px;border-bottom:1px solid rgba(77,82,97,.18);}
+.state{font-family:var(--num);font-size:10px;letter-spacing:.05em;text-transform:uppercase;margin-left:auto;}
+.btn{background:transparent;color:var(--white);border:1px solid var(--hair);border-radius:7px;padding:9px 0;font:700 12px var(--ui);letter-spacing:.04em;text-transform:uppercase;}
+.btn.primary{border-color:rgba(255,215,0,.5);color:var(--gold);}
+.device{width:320px;height:480px;background:#000;border:1px solid #2a2a2a;border-radius:16px;overflow:hidden;display:flex;flex-direction:column;}
+.dhead{height:44px;background:#0d0d0f;display:flex;align-items:center;padding:0 14px;gap:8px;border-bottom:1px solid var(--hair);}
+.bar{height:14px;background:var(--barbg);border-radius:7px;overflow:hidden;box-shadow:0 0 10px rgba(239,68,68,.5);}
+.sw{width:34px;height:34px;border-radius:8px;border:1px solid #333;}</style></head><body>
+<div class="device">
+  <div class="dhead"><span style="color:var(--label);font-size:12px;">‹ BACK</span><span class="num" style="font-size:13px;margin-left:4px;">VOICE &amp; HAPTICS</span><span style="margin-left:auto;width:8px;height:8px;border-radius:50%;background:var(--green);"></span></div>
+  <div style="margin:12px;" class="panel"><div style="padding:9px 11px;"><div class="lbl" style="color:var(--amber);">VOICE COACH</div><div class="num" style="font-size:17px;color:var(--green);margin-top:4px;">ARMED</div><div style="color:var(--label);font-size:11px;margin-top:2px;">bank · sounddevice · USB headset</div></div></div>
+  <div style="margin:0 12px;">
+    <div class="row"><span style="flex:1;font-size:12px;">Wind fan</span><span class="state" style="color:var(--green)">on</span></div>
+    <div class="row"><span style="flex:1;font-size:12px;">Seat shaker</span><span class="state" style="color:var(--green)">on</span></div>
+    <div class="row" style="border-bottom:none;"><span style="flex:1;font-size:12px;">Pedal rumble</span><span class="state" style="color:var(--label)">off</span></div>
+  </div>
+</div>
+</body></html>


### PR DESCRIPTION
Closes #390.

Splits the merged cockpit package into **per-component `@dsCard` cards** so they can be pushed into a **Claude Design** project (`claude.ai/design`) via `/design-sync` — the mature, native path (vs. a manual hand-off bundle).

`docs/10_Development/design/components/`:
- **Foundations** — colors, type (Michroma/Montserrat/Syncopate)
- **HUD** (north star) — active-suggestion, approach-panel (reproduced from `hud.lua`/`coaching_overlay.lua`)
- **Launcher** — healthy, recovery
- **Rig screen** — ac-copilot, pocket-technician, settings, voice-haptics

Each card is self-contained (Google Fonts) with a first-line `<!-- @dsCard group=… -->` marker → Claude Design indexes them into the Design System pane automatically. `README.md` documents the `/design-sync` workflow (and that the first upload needs an interactive `/design-login`, unavailable in headless sessions).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)