### PR TITLE
fix(launcher): report real voice runtime status (#392)

### DIFF
--- a/docs/10_Development/14_Game_Point_Launcher.md
+++ b/docs/10_Development/14_Game_Point_Launcher.md
@@ -14,6 +14,13 @@ pip install -e ".[launcher]"
 python -m tools.rig_launcher --build-exe
 ```
 
+The build extra includes the runtime voice floor (`numpy`, `sounddevice`,
+`pyttsx3`, and PyInstaller collection for sounddevice's PortAudio binaries).
+`rtmixer` remains opt-in via `pip install -e ".[voice-rtmixer]"`; when it is
+installed, the build helper collects it opportunistically. Bake-time neural
+voice prosody still requires a system `ffmpeg` on `PATH` before running
+`python -m tools.ai_sidecar.voice.bake`.
+
 Create or refresh the Desktop shortcut:
 
 ```powershell
@@ -79,6 +86,12 @@ Settings precedence is:
 `settings.json` is created by the launcher's **Settings** button, or can be
 created ahead of time by calling `ensure_settings_file()` from
 `tools.rig_launcher.settings`.
+
+The launcher status row for `voice` is sourced from the sidecar `/health`
+payload when the sidecar is reachable. A stale bank, missing reference archive,
+or failed audio backend reports `voice: DISABLED - <reason>` and makes the
+overall status `needs_attention`; the launcher does not treat the mere presence
+of `AC_COPILOT_VOICE_BANK` as proof that audio initialized.
 
 ## Setup Exchange
 

--- a/tests/test_ai_sidecar_observability.py
+++ b/tests/test_ai_sidecar_observability.py
@@ -28,6 +28,7 @@ from tools.ai_sidecar.server import (  # noqa: E402
     _external_peers,
     _handler,
     make_process_request,
+    set_voice_runtime_status,
 )
 
 
@@ -45,6 +46,7 @@ async def _running_sidecar(token: str | None = None) -> AsyncIterator[int]:
     port = _free_port()
     _external_peers.clear()
     _external_peer_classes.clear()
+    set_voice_runtime_status()
     try:
         async with ws_serve(
             lambda ws: _handler(ws, reply_coaching=True),
@@ -56,6 +58,7 @@ async def _running_sidecar(token: str | None = None) -> AsyncIterator[int]:
     finally:
         _external_peers.clear()
         _external_peer_classes.clear()
+        set_voice_runtime_status()
 
 
 def _http_get(port: int, path: str) -> tuple[int, list[str], str]:
@@ -76,6 +79,8 @@ def test_health_endpoint_on_ws_port() -> None:
     assert payload["status"] == "ok"
     assert payload["connected_peers"] == 0
     assert payload["screen_peers"] == 0
+    assert payload["voice"]["state"] == "skipped"
+    assert payload["voice"]["enabled"] is False
 
 
 def test_metrics_endpoint_single_content_type_and_core_series() -> None:

--- a/tests/test_ai_sidecar_observability.py
+++ b/tests/test_ai_sidecar_observability.py
@@ -83,6 +83,25 @@ def test_health_endpoint_on_ws_port() -> None:
     assert payload["voice"]["enabled"] is False
 
 
+def test_health_endpoint_sanitizes_voice_disabled_paths() -> None:
+    async def _run() -> tuple[int, list[str], str]:
+        async with _running_sidecar() as port:
+            set_voice_runtime_status(
+                configured=True,
+                enabled=False,
+                state="disabled",
+                disabled_reason="failed to load reference /Users/driver/rig/ref.json: bad json",
+            )
+            return await asyncio.to_thread(_http_get, port, "/health")
+
+    status, _content_types, body = asyncio.run(_run())
+    payload = json.loads(body)
+
+    assert status == 200
+    assert payload["voice"]["disabled_reason"] == "failed to load reference <path> bad json"
+    assert "/Users/driver" not in body
+
+
 def test_metrics_endpoint_single_content_type_and_core_series() -> None:
     async def _run() -> tuple[int, list[str], str]:
         async with _running_sidecar() as port:

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -212,6 +212,41 @@ def test_status_uses_sidecar_voice_health(tmp_path: Path) -> None:
     assert status.voice.detail == "backend=sounddevice"
 
 
+def test_status_rejects_skipped_sidecar_voice_when_launcher_requested_voice(
+    tmp_path: Path,
+) -> None:
+    cfg = GamePointConfig(
+        external_bind="0.0.0.0",
+        token="token",
+        reference_archive="ref.json",
+        voice_bank="bank",
+        paths=LauncherPaths(tmp_path),
+    )
+
+    def fake_urlopen(_url: str, timeout: float) -> _Response:
+        del timeout
+        return _Response(
+            {
+                "status": "ok",
+                "connected_peers": 1,
+                "screen_peers": 1,
+                "voice": {
+                    "configured": False,
+                    "enabled": False,
+                    "state": "skipped",
+                },
+            }
+        )
+
+    sup = GamePointSupervisor(cfg, environ={}, urlopen=fake_urlopen)
+    status = sup.poll_status()
+
+    assert status.ok is False
+    assert status.voice.ok is False
+    assert status.voice.state == "DISABLED"
+    assert "requested" in status.voice.detail
+
+
 def test_status_surfaces_disabled_voice_reason_and_overall_summary(tmp_path: Path) -> None:
     cfg = GamePointConfig(
         external_bind="0.0.0.0",

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -247,6 +247,97 @@ def test_status_rejects_skipped_sidecar_voice_when_launcher_requested_voice(
     assert "requested" in status.voice.detail
 
 
+def test_status_rejects_missing_voice_health_when_launcher_requested_voice(
+    tmp_path: Path,
+) -> None:
+    cfg = GamePointConfig(
+        external_bind="0.0.0.0",
+        token="token",
+        reference_archive="ref.json",
+        voice_bank="bank",
+        paths=LauncherPaths(tmp_path),
+    )
+
+    def fake_urlopen(_url: str, timeout: float) -> _Response:
+        del timeout
+        return _Response({"status": "ok", "connected_peers": 1, "screen_peers": 1})
+
+    sup = GamePointSupervisor(cfg, environ={}, urlopen=fake_urlopen)
+    status = sup.poll_status()
+
+    assert status.ok is False
+    assert status.voice.ok is False
+    assert status.voice.state == "DISABLED"
+    assert "no voice runtime status" in status.voice.detail
+
+
+def test_status_rejects_observer_only_health_when_playback_requested(
+    tmp_path: Path,
+) -> None:
+    cfg = GamePointConfig(
+        external_bind="0.0.0.0",
+        token="token",
+        reference_archive="ref.json",
+        voice_bank="bank",
+        paths=LauncherPaths(tmp_path),
+    )
+
+    def fake_urlopen(_url: str, timeout: float) -> _Response:
+        del timeout
+        return _Response(
+            {
+                "status": "ok",
+                "connected_peers": 1,
+                "screen_peers": 1,
+                "voice": {
+                    "configured": True,
+                    "enabled": False,
+                    "state": "observer_only",
+                },
+            }
+        )
+
+    sup = GamePointSupervisor(cfg, environ={}, urlopen=fake_urlopen)
+    status = sup.poll_status()
+
+    assert status.ok is False
+    assert status.voice.ok is False
+    assert status.voice.state == "DISABLED"
+    assert "observer-only" in status.voice.detail
+
+
+def test_status_accepts_observer_only_health_for_reference_only_launcher(
+    tmp_path: Path,
+) -> None:
+    cfg = GamePointConfig(
+        external_bind="0.0.0.0",
+        token="token",
+        reference_archive="ref.json",
+        paths=LauncherPaths(tmp_path),
+    )
+
+    def fake_urlopen(_url: str, timeout: float) -> _Response:
+        del timeout
+        return _Response(
+            {
+                "status": "ok",
+                "connected_peers": 1,
+                "screen_peers": 1,
+                "voice": {
+                    "configured": True,
+                    "enabled": False,
+                    "state": "observer_only",
+                },
+            }
+        )
+
+    sup = GamePointSupervisor(cfg, environ={}, urlopen=fake_urlopen)
+    status = sup.poll_status()
+
+    assert status.voice.ok is True
+    assert status.voice.state == "observer_only"
+
+
 def test_status_surfaces_disabled_voice_reason_and_overall_summary(tmp_path: Path) -> None:
     cfg = GamePointConfig(
         external_bind="0.0.0.0",

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -28,6 +28,7 @@ from tools.rig_launcher.supervisor import (
     _resolve_launcher_path,
     _subprocess_kwargs,
     build_pyinstaller_args,
+    render_status_lines,
 )
 
 
@@ -176,6 +177,77 @@ def test_status_reads_health_and_writes_status_file(tmp_path: Path) -> None:
     saved = json.loads((tmp_path / "status.json").read_text(encoding="utf-8"))
     assert saved["screen"]["state"] == "connected"
     assert saved["log_path"].endswith("sidecar.log")
+
+
+def test_status_uses_sidecar_voice_health(tmp_path: Path) -> None:
+    cfg = GamePointConfig(
+        external_bind="0.0.0.0",
+        token="token",
+        reference_archive="ref.json",
+        voice_bank="bank",
+        paths=LauncherPaths(tmp_path),
+    )
+
+    def fake_urlopen(_url: str, timeout: float) -> _Response:
+        assert timeout == 1.0
+        return _Response(
+            {
+                "status": "ok",
+                "connected_peers": 1,
+                "screen_peers": 1,
+                "voice": {
+                    "configured": True,
+                    "enabled": True,
+                    "state": "enabled",
+                    "backend": "sounddevice",
+                },
+            }
+        )
+
+    sup = GamePointSupervisor(cfg, environ={}, urlopen=fake_urlopen)
+    status = sup.poll_status()
+
+    assert status.voice.ok is True
+    assert status.voice.state == "enabled"
+    assert status.voice.detail == "backend=sounddevice"
+
+
+def test_status_surfaces_disabled_voice_reason_and_overall_summary(tmp_path: Path) -> None:
+    cfg = GamePointConfig(
+        external_bind="0.0.0.0",
+        token="token",
+        reference_archive="ref.json",
+        voice_bank="bank",
+        paths=LauncherPaths(tmp_path),
+    )
+
+    def fake_urlopen(_url: str, timeout: float) -> _Response:
+        del timeout
+        return _Response(
+            {
+                "status": "ok",
+                "connected_peers": 1,
+                "screen_peers": 1,
+                "voice": {
+                    "configured": True,
+                    "enabled": False,
+                    "state": "disabled",
+                    "disabled_reason": "manifest version 1 is not supported by schema 2",
+                    "backend": "rtmixer",
+                },
+            }
+        )
+
+    sup = GamePointSupervisor(cfg, environ={}, urlopen=fake_urlopen)
+    status = sup.poll_status()
+    lines = render_status_lines(status)
+
+    assert status.ok is False
+    assert status.voice.ok is False
+    assert status.voice.state == "DISABLED"
+    assert "manifest version 1" in status.voice.detail
+    assert lines[0] == "overall: needs_attention"
+    assert any(line.startswith("voice: DISABLED - manifest version 1") for line in lines)
 
 
 def test_read_health_tolerates_non_utf8_response_bytes(tmp_path: Path) -> None:
@@ -693,6 +765,40 @@ def test_build_pyinstaller_args_targets_launcher_entrypoint(tmp_path: Path) -> N
     assert "tools.ai_sidecar" in args
     assert "--collect-data" in args
     assert str(tmp_path / "tools" / "rig_launcher" / "__main__.py") == args[-1]
+
+
+def test_build_pyinstaller_args_collects_voice_runtime_floor(tmp_path: Path) -> None:
+    args = build_pyinstaller_args(tmp_path, onefile=True, windowed=True)
+
+    assert _has_option_value(args, "--collect-data", "_sounddevice_data")
+    assert _has_option_value(args, "--collect-dynamic-libs", "sounddevice")
+    assert _has_option_value(args, "--hidden-import", "numpy")
+    assert _has_option_value(args, "--hidden-import", "sounddevice")
+    assert _has_option_value(args, "--hidden-import", "pyttsx3")
+    assert _has_option_value(args, "--hidden-import", "pyttsx3.drivers.sapi5")
+
+
+def test_build_pyinstaller_args_collects_optional_rtmixer_when_installed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    def fake_find_spec(module: str) -> object | None:
+        if module in {"rtmixer", "pa_ringbuffer"}:
+            return object()
+        return None
+
+    monkeypatch.setattr(supervisor_module, "find_spec", fake_find_spec)
+    args = build_pyinstaller_args(tmp_path, onefile=True, windowed=True)
+
+    assert _has_option_value(args, "--hidden-import", "rtmixer")
+    assert _has_option_value(args, "--collect-dynamic-libs", "rtmixer")
+    assert _has_option_value(args, "--hidden-import", "pa_ringbuffer")
+    assert _has_option_value(args, "--collect-dynamic-libs", "pa_ringbuffer")
+
+
+def _has_option_value(args: list[str], option: str, value: str) -> bool:
+    return any(
+        left == option and right == value for left, right in zip(args, args[1:], strict=False)
+    )
 
 
 def test_launcher_extra_includes_sidecar_voice_runtime_deps() -> None:

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -771,7 +771,7 @@ def test_build_pyinstaller_args_collects_voice_runtime_floor(tmp_path: Path) -> 
     args = build_pyinstaller_args(tmp_path, onefile=True, windowed=True)
 
     assert _has_option_value(args, "--collect-data", "_sounddevice_data")
-    assert _has_option_value(args, "--collect-dynamic-libs", "sounddevice")
+    assert _has_option_value(args, "--collect-binaries", "sounddevice")
     assert _has_option_value(args, "--hidden-import", "numpy")
     assert _has_option_value(args, "--hidden-import", "sounddevice")
     assert _has_option_value(args, "--hidden-import", "pyttsx3")
@@ -790,9 +790,9 @@ def test_build_pyinstaller_args_collects_optional_rtmixer_when_installed(
     args = build_pyinstaller_args(tmp_path, onefile=True, windowed=True)
 
     assert _has_option_value(args, "--hidden-import", "rtmixer")
-    assert _has_option_value(args, "--collect-dynamic-libs", "rtmixer")
+    assert _has_option_value(args, "--collect-binaries", "rtmixer")
     assert _has_option_value(args, "--hidden-import", "pa_ringbuffer")
-    assert _has_option_value(args, "--collect-dynamic-libs", "pa_ringbuffer")
+    assert _has_option_value(args, "--collect-binaries", "pa_ringbuffer")
 
 
 def _has_option_value(args: list[str], option: str, value: str) -> bool:

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -163,6 +163,10 @@ def test_wire_voice_no_corners_reference_disables_observer(tmp_path, monkeypatch
     ref.write_text(json.dumps({}), encoding="utf-8")
     server._wire_voice(server.VoiceRuntimeConfig(reference_path=str(ref), bank_dir=None))
     assert server._observer is sentinel
+    status = server.voice_runtime_status()
+    assert status["state"] == "disabled"
+    assert status["disabled_reason"] == "reference archive has no usable corners"
+    assert str(ref) not in str(status["disabled_reason"])
 
 
 def test_wire_voice_missing_reference_is_best_effort(monkeypatch):
@@ -175,7 +179,10 @@ def test_wire_voice_missing_reference_is_best_effort(monkeypatch):
         server.VoiceRuntimeConfig(reference_path="does-not-exist-9f3a.json", bank_dir=None)
     )
     assert server._observer is sentinel
-    assert server.voice_runtime_status()["state"] == "disabled"
+    status = server.voice_runtime_status()
+    assert status["state"] == "disabled"
+    assert "failed to load reference" in str(status["disabled_reason"])
+    assert "does-not-exist-9f3a.json" not in str(status["disabled_reason"])
 
 
 def test_wire_voice_bank_without_reference_reports_disabled(monkeypatch):
@@ -189,6 +196,33 @@ def test_wire_voice_bank_without_reference_reports_disabled(monkeypatch):
     assert status["enabled"] is False
     assert status["state"] == "disabled"
     assert "REFERENCE_ARCHIVE" in str(status["disabled_reason"])
+
+
+def test_wire_voice_tts_without_reference_reports_disabled(monkeypatch):
+    server.set_voice_coach(None)
+    monkeypatch.setattr(server, "_observer", None)
+
+    server._wire_voice(
+        server.VoiceRuntimeConfig(reference_path=None, bank_dir=None, tts_enabled=True)
+    )
+
+    status = server.voice_runtime_status()
+    assert status["configured"] is True
+    assert status["enabled"] is False
+    assert status["state"] == "disabled"
+    assert status["backend"] == "pyttsx3"
+    assert "REFERENCE_ARCHIVE" in str(status["disabled_reason"])
+
+
+def test_voice_runtime_status_replaces_snapshot_atomically():
+    server.set_voice_runtime_status(configured=True, state="initializing")
+    prior = server.voice_runtime_status()
+
+    server.set_voice_runtime_status()
+
+    assert prior["configured"] is True
+    assert prior["state"] == "initializing"
+    assert server.voice_runtime_status()["state"] == "skipped"
 
 
 def test_wire_voice_tts_installs_pyttsx3_adapter(tmp_path, monkeypatch):

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -175,13 +175,30 @@ def test_wire_voice_missing_reference_is_best_effort(monkeypatch):
         server.VoiceRuntimeConfig(reference_path="does-not-exist-9f3a.json", bank_dir=None)
     )
     assert server._observer is sentinel
+    assert server.voice_runtime_status()["state"] == "disabled"
 
 
-def test_wire_voice_tts_installs_pyttsx3_adapter(monkeypatch):
+def test_wire_voice_bank_without_reference_reports_disabled(monkeypatch):
+    server.set_voice_coach(None)
+    monkeypatch.setattr(server, "_observer", None)
+
+    server._wire_voice(server.VoiceRuntimeConfig(reference_path=None, bank_dir="bank-dir"))
+
+    status = server.voice_runtime_status()
+    assert status["configured"] is True
+    assert status["enabled"] is False
+    assert status["state"] == "disabled"
+    assert "REFERENCE_ARCHIVE" in str(status["disabled_reason"])
+
+
+def test_wire_voice_tts_installs_pyttsx3_adapter(tmp_path, monkeypatch):
     import tools.ai_sidecar.voice.client as voice_client
 
     spoken: list[tuple[str, str]] = []
     seen: dict[str, float | int] = {}
+    ref = tmp_path / "ref.json"
+    ref.write_text(json.dumps(_corner_archive()), encoding="utf-8")
+    monkeypatch.setattr(server, "_observer", None)
     server.set_voice_coach(None)
 
     def fake_speaker(*, base_rate: int, base_volume: float, require_opt_in: bool):
@@ -200,10 +217,11 @@ def test_wire_voice_tts_installs_pyttsx3_adapter(monkeypatch):
 
     try:
         server._wire_voice(
-            server.VoiceRuntimeConfig(reference_path=None, bank_dir=None, tts_enabled=True)
+            server.VoiceRuntimeConfig(reference_path=str(ref), bank_dir=None, tts_enabled=True)
         )
         assert server._voice_coach is not None
         server._voice_coach.subscribe(_adv(kind="apex_deficit", corner=1, urgency="info"))
+        assert server.voice_runtime_status()["state"] == "tts"
     finally:
         server.set_voice_coach(None)
 
@@ -211,10 +229,12 @@ def test_wire_voice_tts_installs_pyttsx3_adapter(monkeypatch):
     assert seen == {"rate": 260, "volume": 0.8, "require_opt_in": 0}
 
 
-def test_wire_voice_bank_uses_env_audio_routing(monkeypatch):
+def test_wire_voice_bank_uses_env_audio_routing(tmp_path, monkeypatch):
     from tools.ai_sidecar.voice import engine
 
     seen: dict[str, object] = {}
+    ref = tmp_path / "ref.json"
+    ref.write_text(json.dumps(_corner_archive()), encoding="utf-8")
 
     class _Coach:
         enabled = True
@@ -237,10 +257,12 @@ def test_wire_voice_bank_uses_env_audio_routing(monkeypatch):
     monkeypatch.setenv("AC_COPILOT_VOICE_HOST_API", "Windows DirectSound")
     monkeypatch.setenv("AC_COPILOT_VOICE_VERBOSITY", "high")
     monkeypatch.setattr(engine.VoiceCoach, "from_bank", fake_from_bank)
+    monkeypatch.setattr(server, "_observer", None)
 
     try:
-        server._wire_voice(server.VoiceRuntimeConfig(reference_path=None, bank_dir="bank-dir"))
+        server._wire_voice(server.VoiceRuntimeConfig(reference_path=str(ref), bank_dir="bank-dir"))
         assert server._voice_coach is not None
+        assert server.voice_runtime_status()["state"] == "enabled"
     finally:
         server.set_voice_coach(None)
 

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -235,10 +235,17 @@ def test_wire_voice_tts_installs_pyttsx3_adapter(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_observer", None)
     server.set_voice_coach(None)
 
-    def fake_speaker(*, base_rate: int, base_volume: float, require_opt_in: bool):
+    def fake_speaker(
+        *,
+        base_rate: int,
+        base_volume: float,
+        require_opt_in: bool,
+        startup_timeout_s: float | None,
+    ):
         seen["rate"] = base_rate
         seen["volume"] = base_volume
         seen["require_opt_in"] = int(require_opt_in)
+        seen["startup_timeout_s"] = startup_timeout_s
 
         def speak(text: str, register: str = "calm") -> None:
             spoken.append((text, register))
@@ -260,7 +267,7 @@ def test_wire_voice_tts_installs_pyttsx3_adapter(tmp_path, monkeypatch):
         server.set_voice_coach(None)
 
     assert spoken == [("More entry speed, Turn 2.", "calm")]
-    assert seen == {"rate": 260, "volume": 0.8, "require_opt_in": 0}
+    assert seen == {"rate": 260, "volume": 0.8, "require_opt_in": 0, "startup_timeout_s": 2.0}
 
 
 def test_wire_voice_bank_uses_env_audio_routing(tmp_path, monkeypatch):

--- a/tests/test_voice_client.py
+++ b/tests/test_voice_client.py
@@ -6,6 +6,8 @@ import sys
 import threading
 import time
 
+import pytest
+
 from tools.ai_sidecar.external_protocol import (
     CLIENT_CLASS_VOICE,
     TOPIC_COACHING_CUE,
@@ -106,6 +108,18 @@ def test_pyttsx3_speaker_drops_cues_when_init_fails(monkeypatch):
     speak = _pyttsx3_speaker(require_opt_in=False)
     time.sleep(0.05)
     speak("hello")  # worker failed; must not raise
+
+
+def test_pyttsx3_speaker_can_fail_fast_when_startup_fails(monkeypatch):
+    class _BrokenPyttsx3:
+        @staticmethod
+        def init():
+            raise RuntimeError("no engine")
+
+    monkeypatch.setitem(sys.modules, "pyttsx3", _BrokenPyttsx3())
+
+    with pytest.raises(RuntimeError, match="failed to initialize"):
+        _pyttsx3_speaker(require_opt_in=False, startup_timeout_s=0.2)
 
 
 def test_pyttsx3_speaker_requires_tts_opt_in_and_no_bank(monkeypatch):

--- a/tools/ai_sidecar/observability.py
+++ b/tools/ai_sidecar/observability.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from tools.ai_sidecar.external_protocol import SERVER_VERSION
@@ -76,16 +77,21 @@ def _labels(pairs: dict[str, str]) -> str:
     return "{" + inner + "}"
 
 
-def build_health_json(connected_peers: int, *, screen_peers: int = 0) -> str:
+def build_health_json(
+    connected_peers: int,
+    *,
+    screen_peers: int = 0,
+    voice: Mapping[str, object] | None = None,
+) -> str:
     """Instant health body: the endpoint answering IS liveness."""
-    return json.dumps(
-        {
-            "status": "ok",
-            "connected_peers": connected_peers,
-            "screen_peers": screen_peers,
-        },
-        separators=(",", ":"),
-    )
+    payload: dict[str, object] = {
+        "status": "ok",
+        "connected_peers": connected_peers,
+        "screen_peers": screen_peers,
+    }
+    if voice is not None:
+        payload["voice"] = dict(voice)
+    return json.dumps(payload, separators=(",", ":"))
 
 
 def build_metrics_text(connected_peers: int, *, screen_peers: int = 0) -> str:

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -18,6 +18,7 @@ import ipaddress
 import json
 import logging
 import os
+import re
 import secrets
 import time
 from collections.abc import Callable
@@ -152,6 +153,7 @@ _voice_runtime_status: dict[str, object] = {
     "state": "skipped",
     "disabled_reason": "",
 }
+_ABSOLUTE_PATH_RE = re.compile(r"(?:(?:[A-Za-z]:[\\/]|/)[^\s'\"<>]+)")
 
 
 @dataclass(frozen=True)
@@ -195,6 +197,15 @@ def set_voice_runtime_status(**updates: object) -> None:
 def voice_runtime_status() -> dict[str, object]:
     """Return a JSON-safe snapshot of the current voice runtime state."""
     return dict(_voice_runtime_status)
+
+
+def public_voice_runtime_status() -> dict[str, object]:
+    """Return voice runtime state safe for unauthenticated health responses."""
+    status = voice_runtime_status()
+    reason = str(status.get("disabled_reason") or "")
+    if reason:
+        status["disabled_reason"] = _ABSOLUTE_PATH_RE.sub("<path>", reason)
+    return status
 
 
 def _exception_detail(exc: BaseException) -> str:
@@ -621,7 +632,7 @@ def make_process_request(token: str | None):
                 observability.build_health_json(
                     connected_peers,
                     screen_peers=screen_peers,
-                    voice=voice_runtime_status(),
+                    voice=public_voice_runtime_status(),
                 ),
                 observability.HEALTH_CONTENT_TYPE,
             )
@@ -1687,6 +1698,7 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                         base_rate=rate,
                         base_volume=volume,
                         require_opt_in=False,
+                        startup_timeout_s=2.0,
                     )
                 )
             )

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -181,21 +181,27 @@ def set_voice_coach(coach: Any | None) -> None:
 
 def set_voice_runtime_status(**updates: object) -> None:
     """Record the voice runtime state reported by ``/health`` and the launcher."""
-    _voice_runtime_status.clear()
-    _voice_runtime_status.update(
-        {
-            "configured": False,
-            "enabled": False,
-            "state": "skipped",
-            "disabled_reason": "",
-        }
-    )
-    _voice_runtime_status.update(updates)
+    global _voice_runtime_status
+    next_status = {
+        "configured": False,
+        "enabled": False,
+        "state": "skipped",
+        "disabled_reason": "",
+    }
+    next_status.update(updates)
+    _voice_runtime_status = next_status
 
 
 def voice_runtime_status() -> dict[str, object]:
     """Return a JSON-safe snapshot of the current voice runtime state."""
     return dict(_voice_runtime_status)
+
+
+def _exception_detail(exc: BaseException) -> str:
+    """Return useful public error text even for exceptions with an empty string form."""
+    if isinstance(exc, OSError) and getattr(exc, "filename", None):
+        return exc.strerror or type(exc).__name__
+    return str(exc) or type(exc).__name__
 
 
 class _Pyttsx3VoiceCoach:
@@ -1518,16 +1524,16 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
     )
     if not configured:
         return
-    if bank_dir and not reference_path:
-        reason = "voice bank configured without AC_COPILOT_REFERENCE_ARCHIVE"
+    if (bank_dir or voice_settings.tts_enabled) and not reference_path:
+        reason = "voice configured without AC_COPILOT_REFERENCE_ARCHIVE"
         logger.error("voice: %s", reason)
         set_voice_runtime_status(
             configured=True,
             enabled=False,
             state="disabled",
             disabled_reason=reason,
-            backend=bank_backend or "",
-            bank_configured=True,
+            backend=bank_backend or ("pyttsx3" if voice_settings.tts_enabled else ""),
+            bank_configured=bool(bank_dir),
             reference_configured=False,
             tts_enabled=bool(voice_settings.tts_enabled),
         )
@@ -1542,8 +1548,10 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                 archive = json.load(fh)
             observer = build_observer_from_reference(archive)
             if observer is None:
-                reason = f"reference {reference_path} has no usable corners"
-                logger.error("voice: %s — observer disabled", reason)
+                reason = "reference archive has no usable corners"
+                logger.error(
+                    "voice: reference %s has no usable corners — observer disabled", reference_path
+                )
                 set_voice_runtime_status(
                     configured=True,
                     enabled=False,
@@ -1569,7 +1577,7 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                 )
                 logger.info("voice: realtime observer wired from reference %s", reference_path)
         except Exception as exc:  # noqa: BLE001 - malformed archive must not abort the sidecar
-            reason = f"failed to load reference {reference_path}: {exc or type(exc).__name__}"
+            reason = f"failed to load reference: {_exception_detail(exc)}"
             logger.exception("voice: failed to load reference %s", reference_path)
             set_voice_runtime_status(
                 configured=True,
@@ -1641,7 +1649,7 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                 configured=True,
                 enabled=False,
                 state="disabled",
-                disabled_reason=f"failed to initialize voice coach: {exc or type(exc).__name__}",
+                disabled_reason=f"failed to initialize voice coach: {_exception_detail(exc)}",
                 backend=bank_backend or "",
                 bank_configured=True,
                 reference_configured=True,
@@ -1698,7 +1706,7 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                 volume,
             )
         except Exception as exc:  # noqa: BLE001 - pyttsx3 must never abort the sidecar
-            reason = f"failed to initialize pyttsx3 voice coach: {exc or type(exc).__name__}"
+            reason = f"failed to initialize pyttsx3 voice coach: {_exception_detail(exc)}"
             set_voice_runtime_status(
                 configured=True,
                 enabled=False,

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -146,6 +146,12 @@ _observer_feed_warned = False
 # are imported lazily when ``--voice-bank`` is supplied, so the sidecar core stays dep-free.
 # (``_observer`` is declared once above with its RealtimeObserver type; not re-declared here.)
 _voice_coach: Any | None = None
+_voice_runtime_status: dict[str, object] = {
+    "configured": False,
+    "enabled": False,
+    "state": "skipped",
+    "disabled_reason": "",
+}
 
 
 @dataclass(frozen=True)
@@ -171,6 +177,25 @@ def set_voice_coach(coach: Any | None) -> None:
     """Install (or clear) the in-process voice coach that speaks advisories on the rig (#341)."""
     global _voice_coach
     _voice_coach = coach
+
+
+def set_voice_runtime_status(**updates: object) -> None:
+    """Record the voice runtime state reported by ``/health`` and the launcher."""
+    _voice_runtime_status.clear()
+    _voice_runtime_status.update(
+        {
+            "configured": False,
+            "enabled": False,
+            "state": "skipped",
+            "disabled_reason": "",
+        }
+    )
+    _voice_runtime_status.update(updates)
+
+
+def voice_runtime_status() -> dict[str, object]:
+    """Return a JSON-safe snapshot of the current voice runtime state."""
+    return dict(_voice_runtime_status)
 
 
 class _Pyttsx3VoiceCoach:
@@ -587,7 +612,11 @@ def make_process_request(token: str | None):
             return _http_response(
                 connection,
                 HTTPStatus.OK,
-                observability.build_health_json(connected_peers, screen_peers=screen_peers),
+                observability.build_health_json(
+                    connected_peers,
+                    screen_peers=screen_peers,
+                    voice=voice_runtime_status(),
+                ),
                 observability.HEALTH_CONTENT_TYPE,
             )
         if path == "/metrics":
@@ -1471,11 +1500,40 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
     """
     reference_path = voice_settings.reference_path
     bank_dir = voice_settings.bank_dir
+    bank_backend = (
+        voice_settings.backend or os.environ.get("AC_COPILOT_VOICE_BACKEND") or "rtmixer"
+        if bank_dir
+        else None
+    )
+    configured = bool(reference_path or bank_dir or voice_settings.tts_enabled)
+    set_voice_runtime_status(
+        configured=configured,
+        enabled=False,
+        state="initializing" if configured else "skipped",
+        disabled_reason="",
+        backend=bank_backend or "",
+        bank_configured=bool(bank_dir),
+        reference_configured=bool(reference_path),
+        tts_enabled=bool(voice_settings.tts_enabled),
+    )
+    if not configured:
+        return
     if bank_dir and not reference_path:
-        logger.warning(
-            "voice: --voice-bank is set but --voice-reference is missing; voice coach will be idle"
+        reason = "voice bank configured without AC_COPILOT_REFERENCE_ARCHIVE"
+        logger.error("voice: %s", reason)
+        set_voice_runtime_status(
+            configured=True,
+            enabled=False,
+            state="disabled",
+            disabled_reason=reason,
+            backend=bank_backend or "",
+            bank_configured=True,
+            reference_configured=False,
+            tts_enabled=bool(voice_settings.tts_enabled),
         )
+        return
 
+    observer_ready = False
     if reference_path:
         try:
             from tools.ai_sidecar.realtime_observer import build_observer_from_reference
@@ -1484,22 +1542,53 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                 archive = json.load(fh)
             observer = build_observer_from_reference(archive)
             if observer is None:
-                logger.error(
-                    "voice: reference %s has no usable corners — observer disabled", reference_path
+                reason = f"reference {reference_path} has no usable corners"
+                logger.error("voice: %s — observer disabled", reason)
+                set_voice_runtime_status(
+                    configured=True,
+                    enabled=False,
+                    state="disabled",
+                    disabled_reason=reason,
+                    backend=bank_backend or "",
+                    bank_configured=bool(bank_dir),
+                    reference_configured=True,
+                    tts_enabled=bool(voice_settings.tts_enabled),
                 )
             else:
                 set_realtime_observer(observer)
+                observer_ready = True
+                set_voice_runtime_status(
+                    configured=True,
+                    enabled=False,
+                    state="observer_only",
+                    disabled_reason="",
+                    backend=bank_backend or "",
+                    bank_configured=bool(bank_dir),
+                    reference_configured=True,
+                    tts_enabled=bool(voice_settings.tts_enabled),
+                )
                 logger.info("voice: realtime observer wired from reference %s", reference_path)
-        except Exception:  # noqa: BLE001 - malformed archive must not abort the sidecar
+        except Exception as exc:  # noqa: BLE001 - malformed archive must not abort the sidecar
+            reason = f"failed to load reference {reference_path}: {exc or type(exc).__name__}"
             logger.exception("voice: failed to load reference %s", reference_path)
+            set_voice_runtime_status(
+                configured=True,
+                enabled=False,
+                state="disabled",
+                disabled_reason=reason,
+                backend=bank_backend or "",
+                bank_configured=bool(bank_dir),
+                reference_configured=True,
+                tts_enabled=bool(voice_settings.tts_enabled),
+            )
+    if (bank_dir or voice_settings.tts_enabled) and not observer_ready:
+        return
     if bank_dir:
         try:
             from tools.ai_sidecar.voice.config import VoiceConfig
             from tools.ai_sidecar.voice.engine import VoiceCoach
 
-            backend = (
-                voice_settings.backend or os.environ.get("AC_COPILOT_VOICE_BACKEND") or "rtmixer"
-            )
+            backend = bank_backend or "rtmixer"
             config = VoiceConfig(
                 device_name=voice_settings.device or os.environ.get("AC_COPILOT_VOICE_DEVICE"),
                 host_api=voice_settings.host_api or os.environ.get("AC_COPILOT_VOICE_HOST_API"),
@@ -1511,12 +1600,33 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
             )
             coach = VoiceCoach.from_bank(bank_dir, config, backend=backend)
             if not coach.enabled:
+                set_voice_coach(coach)
+                set_voice_runtime_status(
+                    configured=True,
+                    enabled=False,
+                    state="disabled",
+                    disabled_reason=coach.disabled_reason,
+                    backend=backend,
+                    bank_configured=True,
+                    reference_configured=True,
+                    tts_enabled=False,
+                )
                 logger.error(
                     "voice: bank %s disabled the coach (%s)", bank_dir, coach.disabled_reason
                 )
             else:
                 coach.start()
                 set_voice_coach(coach)
+                set_voice_runtime_status(
+                    configured=True,
+                    enabled=True,
+                    state="enabled",
+                    disabled_reason="",
+                    backend=backend,
+                    bank_configured=True,
+                    reference_configured=True,
+                    tts_enabled=False,
+                )
                 logger.info(
                     "voice: in-process voice coach wired from bank %s "
                     "backend=%s device=%r host_api=%r verbosity=%s",
@@ -1526,7 +1636,17 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                     config.host_api,
                     config.verbosity.name.lower(),
                 )
-        except Exception:  # noqa: BLE001 - any backend/import fault disables voice, never aborts
+        except Exception as exc:  # noqa: BLE001 - any backend/import fault disables voice, never aborts
+            set_voice_runtime_status(
+                configured=True,
+                enabled=False,
+                state="disabled",
+                disabled_reason=f"failed to initialize voice coach: {exc or type(exc).__name__}",
+                backend=bank_backend or "",
+                bank_configured=True,
+                reference_configured=True,
+                tts_enabled=False,
+            )
             logger.exception("voice: failed to initialize voice coach from %s", bank_dir)
     elif voice_settings.tts_enabled:
         try:
@@ -1562,12 +1682,33 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                     )
                 )
             )
+            set_voice_runtime_status(
+                configured=True,
+                enabled=True,
+                state="tts",
+                disabled_reason="",
+                backend="pyttsx3",
+                bank_configured=False,
+                reference_configured=True,
+                tts_enabled=True,
+            )
             logger.info(
                 "voice: in-process pyttsx3 voice coach wired rate=%s volume=%.2f",
                 rate,
                 volume,
             )
-        except Exception:  # noqa: BLE001 - pyttsx3 must never abort the sidecar
+        except Exception as exc:  # noqa: BLE001 - pyttsx3 must never abort the sidecar
+            reason = f"failed to initialize pyttsx3 voice coach: {exc or type(exc).__name__}"
+            set_voice_runtime_status(
+                configured=True,
+                enabled=False,
+                state="disabled",
+                disabled_reason=reason,
+                backend="pyttsx3",
+                bank_configured=False,
+                reference_configured=True,
+                tts_enabled=True,
+            )
             logger.exception("voice: failed to initialize pyttsx3 voice coach")
 
 

--- a/tools/ai_sidecar/voice/client.py
+++ b/tools/ai_sidecar/voice/client.py
@@ -12,6 +12,7 @@ Run on the rig alongside the sidecar (``pip install -e ".[voice-client]"``):
 from __future__ import annotations
 
 import argparse
+import time
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -131,6 +132,7 @@ def _pyttsx3_speaker(
     environ: Mapping[str, str] | None = None,
     rate: int | None = None,
     volume: float | None = None,
+    startup_timeout_s: float | None = None,
 ) -> Callable[[str, str], None]:
     """Build a non-blocking speak(text, register) backed by pyttsx3 on a dedicated worker thread.
 
@@ -185,6 +187,16 @@ def _pyttsx3_speaker(
 
     t = threading.Thread(target=worker, daemon=True, name="pyttsx3-voice")
     t.start()
+    if startup_timeout_s is not None:
+        deadline = time.monotonic() + max(0.0, startup_timeout_s)
+        while not ready.is_set():
+            if failed.is_set():
+                raise RuntimeError("pyttsx3 voice worker failed to initialize")
+            if not t.is_alive():
+                raise RuntimeError("pyttsx3 voice worker exited before initialization")
+            if time.monotonic() >= deadline:
+                raise RuntimeError("pyttsx3 voice worker did not become ready")
+            time.sleep(0.01)
 
     def speak(text: str, register: str = "calm") -> None:
         if not should_enqueue_voice_cue(failed=failed.is_set(), worker_alive=t.is_alive()):

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -401,7 +401,18 @@ class GamePointSupervisor:
         if health_payload is not None:
             voice = health_payload.get("voice")
             if isinstance(voice, Mapping):
-                return _voice_from_health(voice, requested=self._voice_requested())
+                return _voice_from_health(
+                    voice,
+                    requested=self._voice_requested(),
+                    playback_requested=self._voice_playback_requested(),
+                )
+            if self._voice_requested():
+                return ProbeResult(
+                    "voice",
+                    False,
+                    "DISABLED",
+                    "voice requested but sidecar health has no voice runtime status",
+                )
         if self.config.reference_archive and self.config.voice_bank:
             return ProbeResult("voice", True, "configured", "reference archive + bank configured")
         if self.config.reference_archive and self.config.voice_tts:
@@ -416,6 +427,9 @@ class GamePointSupervisor:
         return bool(
             self.config.reference_archive or self.config.voice_bank or self.config.voice_tts
         )
+
+    def _voice_playback_requested(self) -> bool:
+        return bool(self.config.voice_bank or self.config.voice_tts)
 
     def probe_hotspot(self) -> ProbeResult:
         if os.name != "nt":
@@ -614,7 +628,12 @@ def _screen_from_health(health: ProbeResult) -> ProbeResult:
     return ProbeResult("screen", False, "waiting", "no ESP32 screen peer connected")
 
 
-def _voice_from_health(voice: Mapping[str, object], *, requested: bool = False) -> ProbeResult:
+def _voice_from_health(
+    voice: Mapping[str, object],
+    *,
+    requested: bool = False,
+    playback_requested: bool = False,
+) -> ProbeResult:
     configured = bool(voice.get("configured"))
     enabled = bool(voice.get("enabled"))
     state = str(voice.get("state") or "").strip().lower()
@@ -626,6 +645,13 @@ def _voice_from_health(voice: Mapping[str, object], *, requested: bool = False) 
         detail = f"backend={backend}" if backend else ""
         return ProbeResult("voice", True, label, detail)
     if state == "observer_only":
+        if playback_requested:
+            return ProbeResult(
+                "voice",
+                False,
+                "DISABLED",
+                "voice playback requested but sidecar is observer-only",
+            )
         return ProbeResult("voice", True, "observer_only", "reference archive configured")
     if state == "skipped" or not configured:
         if requested:

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -401,7 +401,7 @@ class GamePointSupervisor:
         if health_payload is not None:
             voice = health_payload.get("voice")
             if isinstance(voice, Mapping):
-                return _voice_from_health(voice)
+                return _voice_from_health(voice, requested=self._voice_requested())
         if self.config.reference_archive and self.config.voice_bank:
             return ProbeResult("voice", True, "configured", "reference archive + bank configured")
         if self.config.reference_archive and self.config.voice_tts:
@@ -411,6 +411,11 @@ class GamePointSupervisor:
         if self.config.reference_archive:
             return ProbeResult("voice", True, "observer_only", "reference archive configured")
         return ProbeResult("voice", True, "skipped", "no voice env configured")
+
+    def _voice_requested(self) -> bool:
+        return bool(
+            self.config.reference_archive or self.config.voice_bank or self.config.voice_tts
+        )
 
     def probe_hotspot(self) -> ProbeResult:
         if os.name != "nt":
@@ -609,7 +614,7 @@ def _screen_from_health(health: ProbeResult) -> ProbeResult:
     return ProbeResult("screen", False, "waiting", "no ESP32 screen peer connected")
 
 
-def _voice_from_health(voice: Mapping[str, object]) -> ProbeResult:
+def _voice_from_health(voice: Mapping[str, object], *, requested: bool = False) -> ProbeResult:
     configured = bool(voice.get("configured"))
     enabled = bool(voice.get("enabled"))
     state = str(voice.get("state") or "").strip().lower()
@@ -623,6 +628,13 @@ def _voice_from_health(voice: Mapping[str, object]) -> ProbeResult:
     if state == "observer_only":
         return ProbeResult("voice", True, "observer_only", "reference archive configured")
     if state == "skipped" or not configured:
+        if requested:
+            return ProbeResult(
+                "voice",
+                False,
+                "DISABLED",
+                "voice requested but sidecar was started without voice configuration",
+            )
         return ProbeResult("voice", True, "skipped", "no voice env configured")
     if state == "initializing":
         return ProbeResult("voice", False, "initializing", "sidecar voice still initializing")

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -16,6 +16,7 @@ import urllib.error
 import urllib.request
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass, field
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
@@ -371,7 +372,7 @@ class GamePointSupervisor:
     def poll_status(self) -> GamePointStatus:
         checks = self.preflight()
         sidecar = self._sidecar_process_status()
-        health = self._read_health()
+        health, health_payload = self._read_health_payload()
         if health.ok:
             sidecar = health
         screen = _screen_from_health(health)
@@ -380,7 +381,7 @@ class GamePointSupervisor:
             sidecar=sidecar,
             screen=screen,
             hotspot=self.probe_hotspot(),
-            voice=self.probe_voice(),
+            voice=self.probe_voice(health_payload),
             simhub=self.probe_simhub(start=self.config.start_simhub),
             log_path=str(self.paths.sidecar_log_path),
             status_path=str(self.paths.status_path),
@@ -396,7 +397,11 @@ class GamePointSupervisor:
             encoding="utf-8",
         )
 
-    def probe_voice(self) -> ProbeResult:
+    def probe_voice(self, health_payload: Mapping[str, object] | None = None) -> ProbeResult:
+        if health_payload is not None:
+            voice = health_payload.get("voice")
+            if isinstance(voice, Mapping):
+                return _voice_from_health(voice)
         if self.config.reference_archive and self.config.voice_bank:
             return ProbeResult("voice", True, "configured", "reference archive + bank configured")
         if self.config.reference_archive and self.config.voice_tts:
@@ -462,17 +467,26 @@ class GamePointSupervisor:
         self._close_log_handles()
 
     def _read_health(self) -> ProbeResult:
+        return self._read_health_payload()[0]
+
+    def _read_health_payload(self) -> tuple[ProbeResult, dict[str, object] | None]:
         url = f"http://{_url_host(self._health_host())}:{self.config.port}/health"
         try:
             with self._urlopen(url, timeout=1.0) as response:
                 payload = json.loads(response.read().decode("utf-8", errors="replace"))
         except (OSError, urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-            return ProbeResult("sidecar", False, "unreachable", str(exc))
+            return ProbeResult("sidecar", False, "unreachable", str(exc)), None
         if not isinstance(payload, dict):
-            return ProbeResult("sidecar", False, "unreachable", "health payload is not an object")
+            return (
+                ProbeResult("sidecar", False, "unreachable", "health payload is not an object"),
+                None,
+            )
         peers = int(payload.get("connected_peers") or 0)
         screens = int(payload.get("screen_peers") or 0)
-        return ProbeResult("sidecar", True, "healthy", f"peers={peers} screen_peers={screens}")
+        return (
+            ProbeResult("sidecar", True, "healthy", f"peers={peers} screen_peers={screens}"),
+            payload,
+        )
 
     def _health_host(self) -> str:
         bind = self.config.external_bind
@@ -544,17 +558,39 @@ def build_pyinstaller_args(
         "tools.rig_launcher",
         "--collect-data",
         "tools.ai_sidecar",
+        "--collect-data",
+        "_sounddevice_data",
+        "--collect-dynamic-libs",
+        "sounddevice",
         "--hidden-import",
         "tools.ai_sidecar.voice.engine",
         "--hidden-import",
         "tools.ai_sidecar.voice.playback",
+        "--hidden-import",
+        "numpy",
+        "--hidden-import",
+        "sounddevice",
+        "--hidden-import",
+        "pyttsx3",
+        "--hidden-import",
+        "pyttsx3.drivers",
+        "--hidden-import",
+        "pyttsx3.drivers.sapi5",
     ]
+    _append_optional_pyinstaller_module(args, "rtmixer")
+    _append_optional_pyinstaller_module(args, "pa_ringbuffer")
     if onefile:
         args.append("--onefile")
     if windowed:
         args.append("--noconsole")
     args.append(str(entry))
     return args
+
+
+def _append_optional_pyinstaller_module(args: list[str], module: str) -> None:
+    if find_spec(module) is None:
+        return
+    args.extend(["--hidden-import", module, "--collect-dynamic-libs", module])
 
 
 def _screen_from_health(health: ProbeResult) -> ProbeResult:
@@ -571,6 +607,29 @@ def _screen_from_health(health: ProbeResult) -> ProbeResult:
     if count > 0:
         return ProbeResult("screen", True, "connected", f"screen_peers={count}")
     return ProbeResult("screen", False, "waiting", "no ESP32 screen peer connected")
+
+
+def _voice_from_health(voice: Mapping[str, object]) -> ProbeResult:
+    configured = bool(voice.get("configured"))
+    enabled = bool(voice.get("enabled"))
+    state = str(voice.get("state") or "").strip().lower()
+    reason = str(voice.get("disabled_reason") or "").strip()
+    backend = str(voice.get("backend") or "").strip()
+
+    if enabled:
+        label = "tts" if state == "tts" else "enabled"
+        detail = f"backend={backend}" if backend else ""
+        return ProbeResult("voice", True, label, detail)
+    if state == "observer_only":
+        return ProbeResult("voice", True, "observer_only", "reference archive configured")
+    if state == "skipped" or not configured:
+        return ProbeResult("voice", True, "skipped", "no voice env configured")
+    if state == "initializing":
+        return ProbeResult("voice", False, "initializing", "sidecar voice still initializing")
+    detail = reason or "voice coach is not enabled"
+    if backend and reason:
+        detail = f"{detail} (backend={backend})"
+    return ProbeResult("voice", False, "DISABLED", detail)
 
 
 def _coerce_port(value: str | None, default: int) -> int:
@@ -679,7 +738,9 @@ _HOTSPOT_PROBE_SCRIPT = "\n".join(
 
 
 def render_status_lines(status: GamePointStatus) -> list[str]:
+    summary = ProbeResult("overall", status.ok, "ok" if status.ok else "needs_attention")
     rows = [
+        summary,
         status.sidecar,
         status.screen,
         status.hotspot,

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -560,7 +560,7 @@ def build_pyinstaller_args(
         "tools.ai_sidecar",
         "--collect-data",
         "_sounddevice_data",
-        "--collect-dynamic-libs",
+        "--collect-binaries",
         "sounddevice",
         "--hidden-import",
         "tools.ai_sidecar.voice.engine",
@@ -590,7 +590,7 @@ def build_pyinstaller_args(
 def _append_optional_pyinstaller_module(args: list[str], module: str) -> None:
     if find_spec(module) is None:
         return
-    args.extend(["--hidden-import", module, "--collect-dynamic-libs", module])
+    args.extend(["--hidden-import", module, "--collect-binaries", module])
 
 
 def _screen_from_health(health: ProbeResult) -> ProbeResult:


### PR DESCRIPTION
Fixes #392.

## Summary
- Add sidecar voice runtime state to `/health` so the launcher can report the actual coach state and disabled reason.
- Make Game Point `voice` status consume `/health` instead of treating configured bank paths as proof that audio initialized, including adopted/stale sidecar cases.
- Tighten PyInstaller collection for the installable voice floor (`numpy`, `sounddevice`, `pyttsx3`) and opportunistically collect opt-in `rtmixer`/`pa_ringbuffer` when installed.
- Keep unauthenticated `/health` voice details path-safe and make pyttsx3 TTS status wait for worker startup before reporting enabled.
- Document the system `ffmpeg` requirement for phrase-bank prosody baking.

## Live reconciliation
- #383 is closed and PR #387 is merged: default launcher builds must keep `rtmixer` opt-in because it has no prebuilt Windows wheels; missing `rtmixer` falls back to `sounddevice`. This PR preserves that policy while collecting `rtmixer` if the opt-in extra is present.

## Verification
- `/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python -m pytest tests/test_rig_launcher.py tests/test_ai_sidecar_observability.py tests/test_server_observer_wiring.py tests/test_voice_engine.py tests/test_voice_client.py -q` — 96 passed
- `/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python -m ruff check tools/ai_sidecar/observability.py tools/ai_sidecar/server.py tools/ai_sidecar/voice/client.py tools/rig_launcher/supervisor.py tests/test_rig_launcher.py tests/test_ai_sidecar_observability.py tests/test_server_observer_wiring.py tests/test_voice_client.py` — passed
- `make ci-fast PYTHON=/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python` — latest run: `1893 passed, 75 skipped`, coverage 85.43%, `ci-fast: OK`
- `git diff --check origin/main...HEAD` — passed
- GitHub checks on `be2fb50`: `build`, `conformance`, `Canonical docs exist` passed; `guard-and-automerge` skipped as expected.
- Review loop: post-push cooldown completed through `2026-06-30T08:24:15Z`; no non-outdated unresolved review threads remain; no current-SHA review body landed after the cooldown.

## Observed Runtime Proof
- Final-head local runtime smoke (`be2fb50`) with real sidecar processes + real launcher CLI:
  - Stale schema-v1 bank: sidecar `/health.voice.state=disabled`; launcher status row `voice.state=DISABLED` with the schema-v2 re-bake reason.
  - Existing no-voice sidecar adopted by a voice-requesting launcher: launcher status row `voice.state=DISABLED` with `voice requested but sidecar was started without voice configuration`.
  - Missing reference path: unauthenticated `/health.voice.disabled_reason=failed to load reference: No such file or directory`; no local path leaked.
- Windows rig throwaway worktree `C:\Users\arsen\Projects\ac-copilot-trainer-issue392`, branch head `4d5a610`: `.venv\Scripts\python.exe -m tools.rig_launcher --build-exe` built `dist\AC-Copilot-Game-Point.exe` successfully with PyInstaller 6.21.0.
- Frozen Windows exe smoke on the rig at that packaging head:
  - Baked temporary schema-v2 tone bank: `baked 46 clips -> ...\bank-v2\manifest.json`.
  - `AC-Copilot-Game-Point.exe --sidecar-child` with v2 bank reported `/health.voice={"backend":"sounddevice","enabled":true,"state":"enabled","bank_configured":true,"reference_configured":true}` and no module import errors.
  - `AC-Copilot-Game-Point.exe --sidecar-child` with stale schema-v1 bank reported `/health.voice.state=disabled` and the schema-v2 re-bake reason.
  - Frozen launcher `--once --json` against that stale-bank sidecar returned `voice={"state":"DISABLED","ok":false,"detail":"...schema 2 — upgrade the sidecar or re-bake the bank (backend=sounddevice)"}` and `overall_ok=false`, with no stderr and no module import errors.
- Final Windows rerun note: after the review-fix commits, `pc` was offline in Tailscale (`offline, last seen 31m ago`) and SSH to `100.75.251.87:22` timed out. The post-packaging commits did not change PyInstaller collection flags; final-head runtime behavior was re-smoked locally as above.
