### PR TITLE
feat(tt-ingest): build Track Titan reference archives (#353)

### DIFF
--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -20,6 +20,7 @@ from tools.tt_ingest.cli import (
     coaching_endpoint,
     discover_reference_payloads,
     last_session_endpoint,
+    last_session_window_endpoint,
     main,
     retain_coaching,
     retain_sessions,
@@ -196,6 +197,26 @@ def test_retain_coaching_is_write_once(tmp_path) -> None:
     assert "nothing new" in again.render()
 
 
+def test_retain_coaching_writes_distinct_segment_windows(tmp_path) -> None:
+    first = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
+    second = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
+    second["data"]["telemetry"]["telemetry"]["reference"][0]["dist"] = 0.333333
+
+    retain_coaching(
+        _last_session(), _bundle(), lap=5, last_session_payload=first, lake_base=tmp_path
+    )
+    summary = retain_coaching(
+        _last_session(), _bundle(), lap=5, last_session_payload=second, lake_base=tmp_path
+    )
+
+    root = tmp_path / "journal" / "tt"
+    session_dir = root / "assettoCorsa" / "ks_porsche_911_gt3_r_2016" / "magione" / "20260629005756"
+    endpoint = last_session_window_endpoint(5, second)
+    assert endpoint in summary.written
+    assert (session_dir / f"{endpoint}.json").exists()
+    assert (session_dir / f"{last_session_endpoint(5)}.json").exists()
+
+
 def test_retain_coaching_summary_render(tmp_path) -> None:
     rendered = retain_coaching(_last_session(), _bundle(), lap=5, lake_base=tmp_path).render()
     assert "session 20260629005756" in rendered
@@ -297,15 +318,31 @@ def test_build_reference_archive_from_files_wraps_write_error(tmp_path) -> None:
 def test_discover_reference_payloads_filters_lake(tmp_path) -> None:
     root = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     root.mkdir(parents=True)
+    raw = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
     target = root / f"{last_session_endpoint(5)}.json"
-    target.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    window = root / f"{last_session_window_endpoint(5, raw)}.json"
+    target.write_text(json.dumps(raw), encoding="utf-8")
+    window.write_text(json.dumps(raw), encoding="utf-8")
 
-    assert discover_reference_payloads(lake_base=tmp_path, session_key="sess-1", lap=5) == [target]
+    assert discover_reference_payloads(lake_base=tmp_path, session_key="sess-1", lap=5) == [
+        target,
+        window,
+    ]
     with pytest.raises(TTNormalizeError, match="no retained"):
-        discover_reference_payloads(lake_base=tmp_path, session_key="sess-2")
+        discover_reference_payloads(lake_base=tmp_path, session_key="sess-2", lap=5)
 
 
-def test_reference_cli_rejects_mixed_discovered_sessions(tmp_path) -> None:
+def test_discover_reference_payloads_requires_scope(tmp_path) -> None:
+    root = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    root.mkdir(parents=True)
+
+    with pytest.raises(TTNormalizeError, match="requires both"):
+        discover_reference_payloads(lake_base=tmp_path, session_key="sess-1")
+    with pytest.raises(TTNormalizeError, match="requires both"):
+        discover_reference_payloads(lake_base=tmp_path, lap=5)
+
+
+def test_reference_cli_requires_discovery_scope(tmp_path) -> None:
     first = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     second = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-2"
     first.mkdir(parents=True)

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -16,11 +16,15 @@ from tools.tt_ingest.cli import (
     INDEX_FILENAME,
     SESSIONS_INDEX_FILENAME,
     build_arg_parser,
+    build_reference_archive_from_files,
     coaching_endpoint,
+    discover_reference_payloads,
     last_session_endpoint,
+    main,
     retain_coaching,
     retain_sessions,
 )
+from tools.tt_ingest.tt_normalize import TTNormalizeError
 
 FIXTURE = Path(__file__).parent / "fixtures" / "tt_sessions_page.json"
 LAST_SESSION_FIXTURE = Path(__file__).parent / "fixtures" / "tt_services_last_session.json"
@@ -138,6 +142,24 @@ def test_parser_coaching_flags() -> None:
     assert args.uid == "u9"
 
 
+def test_parser_reference_flags(tmp_path) -> None:
+    out = tmp_path / "ref.json"
+    args = build_arg_parser().parse_args(
+        [
+            "reference",
+            "--input",
+            str(LAST_SESSION_FIXTURE),
+            "--output",
+            str(out),
+            "--allow-partial",
+        ]
+    )
+    assert args.command == "reference"
+    assert args.input == [LAST_SESSION_FIXTURE]
+    assert args.output == out
+    assert args.allow_partial is True
+
+
 # --- retain_coaching (M-TT1) ------------------------------------------------------
 
 
@@ -224,6 +246,77 @@ def test_retain_coaching_keys_on_given_session(tmp_path) -> None:
         / "20240101120000"
         / f"{coaching_endpoint(3)}.json"
     ).exists()
+
+
+# --- reference archive (M-TT2) ----------------------------------------------------
+
+
+def test_build_reference_archive_from_files_writes_debug_partial(tmp_path) -> None:
+    output = tmp_path / "tt_ref.json"
+    summary = build_reference_archive_from_files(
+        [LAST_SESSION_FIXTURE],
+        output=output,
+        allow_partial=True,
+        track_length_m=2525.0,
+        pretty=True,
+    )
+
+    record = json.loads(output.read_text(encoding="utf-8"))
+    assert record["import_format"] == "track_titan_reference_v1"
+    assert record["generator"]["tt_reference"]["partial"] is True
+    assert summary.partial is True
+    assert summary.samples == record["trace"]["samples_count"]
+    assert "PARTIAL debug" in summary.render()
+
+
+def test_build_reference_archive_from_files_refuses_overwrite(tmp_path) -> None:
+    output = tmp_path / "tt_ref.json"
+    output.write_text("{}", encoding="utf-8")
+    with pytest.raises(TTNormalizeError, match="output already exists"):
+        build_reference_archive_from_files(
+            [LAST_SESSION_FIXTURE],
+            output=output,
+            allow_partial=True,
+            track_length_m=2525.0,
+        )
+
+
+def test_discover_reference_payloads_filters_lake(tmp_path) -> None:
+    root = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    root.mkdir(parents=True)
+    target = root / f"{last_session_endpoint(5)}.json"
+    target.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    assert discover_reference_payloads(lake_base=tmp_path, session_key="sess-1", lap=5) == [target]
+    with pytest.raises(TTNormalizeError, match="no retained"):
+        discover_reference_payloads(lake_base=tmp_path, session_key="sess-2")
+
+
+def test_reference_cli_writes_from_explicit_input(tmp_path, capsys) -> None:
+    output = tmp_path / "cli_ref.json"
+    rc = main(
+        [
+            "reference",
+            "--input",
+            str(LAST_SESSION_FIXTURE),
+            "--output",
+            str(output),
+            "--allow-partial",
+            "--track-length-m",
+            "2525",
+        ]
+    )
+
+    assert rc == 0
+    assert output.exists()
+    captured = capsys.readouterr().out
+    assert "TT reference archive" in captured
+    assert json.loads(output.read_text(encoding="utf-8"))["generator"]["tt_reference"]["partial"]
+
+
+def test_reference_cli_requires_one_input_mode(tmp_path) -> None:
+    with pytest.raises(SystemExit):
+        main(["reference", "--output", str(tmp_path / "ref.json")])
 
 
 def test_parser_requires_subcommand() -> None:

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -281,6 +281,19 @@ def test_build_reference_archive_from_files_refuses_overwrite(tmp_path) -> None:
         )
 
 
+def test_build_reference_archive_from_files_wraps_write_error(tmp_path) -> None:
+    parent_is_file = tmp_path / "not-a-dir"
+    parent_is_file.write_text("x", encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="could not write"):
+        build_reference_archive_from_files(
+            [LAST_SESSION_FIXTURE],
+            output=parent_is_file / "ref.json",
+            allow_partial=True,
+            track_length_m=2525.0,
+        )
+
+
 def test_discover_reference_payloads_filters_lake(tmp_path) -> None:
     root = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     root.mkdir(parents=True)
@@ -290,6 +303,33 @@ def test_discover_reference_payloads_filters_lake(tmp_path) -> None:
     assert discover_reference_payloads(lake_base=tmp_path, session_key="sess-1", lap=5) == [target]
     with pytest.raises(TTNormalizeError, match="no retained"):
         discover_reference_payloads(lake_base=tmp_path, session_key="sess-2")
+
+
+def test_reference_cli_rejects_mixed_discovered_sessions(tmp_path) -> None:
+    first = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    second = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-2"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    raw = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
+    raw["data"]["session"]["id"] = "own#sess-1"
+    raw["data"]["session"]["session_id"] = "own#sess-1"
+    (first / f"{last_session_endpoint(5)}.json").write_text(json.dumps(raw), encoding="utf-8")
+    raw["data"]["session"]["id"] = "own#sess-2"
+    raw["data"]["session"]["session_id"] = "own#sess-2"
+    (second / f"{last_session_endpoint(5)}.json").write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "reference",
+                "--discover-lake",
+                "--lake-base",
+                str(tmp_path),
+                "--output",
+                str(tmp_path / "ref.json"),
+                "--allow-partial",
+            ]
+        )
 
 
 def test_reference_cli_writes_from_explicit_input(tmp_path, capsys) -> None:

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -302,6 +302,20 @@ def test_build_reference_archive_from_files_refuses_overwrite(tmp_path) -> None:
         )
 
 
+def test_build_reference_archive_from_files_rejects_output_over_input(tmp_path) -> None:
+    retained = tmp_path / f"{last_session_endpoint(5)}.json"
+    retained.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="must not overwrite retained input"):
+        build_reference_archive_from_files(
+            [retained],
+            output=retained,
+            allow_partial=True,
+            overwrite=True,
+            track_length_m=2525.0,
+        )
+
+
 def test_build_reference_archive_from_files_wraps_write_error(tmp_path) -> None:
     parent_is_file = tmp_path / "not-a-dir"
     parent_is_file.write_text("x", encoding="utf-8")

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -17,6 +17,7 @@ from tools.tt_ingest.tt_normalize import (
     build_sessions_index,
     normalize_session,
     normalize_sessions,
+    reference_coverage,
     reference_frames_from_payload,
     split_session_id,
 )
@@ -173,6 +174,11 @@ def test_reference_frames_from_payload_maps_tt_channels() -> None:
     assert frame["pz"] == pytest.approx(19.2)
 
 
+def test_reference_frames_reject_malformed_services_envelope() -> None:
+    with pytest.raises(TTNormalizeError, match="missing data object"):
+        reference_frames_from_payload({"success": True})
+
+
 def test_reference_frames_clamp_minor_pedal_noise() -> None:
     payload = _tt_reference_payload(0.4, 0.41, samples=2)
     payload["data"]["telemetry"]["telemetry"]["reference"][0]["throt"] = 1.00001
@@ -221,7 +227,30 @@ def test_build_reference_archive_stitches_full_lap_windows() -> None:
     assert record["generator"]["tt_reference"]["payload_count"] == 2
     assert record["generator"]["tt_reference"]["max_spline_gap"] == pytest.approx(0.08)
     assert record["generator"]["tt_reference"]["observed_max_spline_gap"] < 0.08
+    assert record["generator"]["tt_reference"]["reference_lap_ms"] == 71000
+    assert record["generator"]["tt_reference"]["lap_time_mismatch_ms"] == 0
     assert record["corners"]  # non-vacuous for the M0 observer path
+
+
+def test_build_reference_archive_uses_reference_lap_identity() -> None:
+    first = _tt_reference_payload(0.0, 0.5, samples=26)
+    second = _tt_reference_payload(0.5, 1.0, samples=26)
+    for payload in (first, second):
+        payload["data"]["session"]["lap_number"] = 5
+        payload["data"]["referenceLap"]["lap_number"] = 4
+        payload["data"]["referenceLap"]["session_key"] = "pro-reference-session"
+
+    record = build_reference_archive([first, second], exported_at="2026-06-30T00:00:00Z")
+
+    assert record["lap"]["lap_n"] == 4
+    assert record["lap"]["lap_ms"] == 71000
+
+
+def test_build_reference_archive_rejects_incomplete_lap_time() -> None:
+    payload = _tt_reference_payload(0.02, 0.98, samples=80)
+
+    with pytest.raises(TTNormalizeError, match="reference_lap_ms=71000"):
+        build_reference_archive([payload], max_spline_gap=0.05)
 
 
 def test_build_reference_archive_rejects_spatial_gaps_even_with_wide_range() -> None:
@@ -244,15 +273,28 @@ def test_build_reference_archive_rejects_single_corner_sized_hole() -> None:
         )
 
 
-def test_build_reference_archive_counts_start_finish_wrap_as_closed_loop() -> None:
+def test_reference_coverage_counts_start_finish_wrap_as_closed_loop() -> None:
+    frames = reference_frames_from_payload(_tt_reference_payload(0.02, 0.98, samples=80))
+
+    coverage = reference_coverage(frames, max_spline_gap=0.05)
+
+    assert coverage.partial is False
+    assert coverage.coverage == pytest.approx(1.0)
+
+
+def test_build_reference_archive_marks_lap_time_mismatch_partial() -> None:
     record = build_reference_archive(
         [_tt_reference_payload(0.02, 0.98, samples=80)],
         max_spline_gap=0.05,
+        allow_partial=True,
         exported_at="2026-06-30T00:00:00Z",
     )
 
-    assert record["generator"]["tt_reference"]["partial"] is False
+    assert record["generator"]["tt_reference"]["partial"] is True
     assert record["generator"]["tt_reference"]["coverage"] == pytest.approx(1.0)
+    assert record["generator"]["tt_reference"]["reference_lap_ms"] == 71000
+    assert record["generator"]["tt_reference"]["trace_lap_ms"] == 69580
+    assert record["generator"]["tt_reference"]["lap_time_mismatch_ms"] == 1420
 
 
 def test_build_reference_archive_resolves_car_id_from_object() -> None:

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -146,6 +146,23 @@ def _tt_reference_payload(start: float, end: float, *, samples: int = 16) -> dic
     }
 
 
+def _session_payload(
+    start: float,
+    end: float,
+    *,
+    session_key: str,
+    car: object = "ks_porsche_911_gt3_r_2016",
+    track_id: str = "magione",
+) -> dict:
+    payload = _tt_reference_payload(start, end)
+    session = payload["data"]["session"]
+    session["id"] = f"own-uid#{session_key}"
+    session["session_id"] = f"own-uid#{session_key}"
+    session["car"] = car
+    session["track_id"] = track_id
+    return payload
+
+
 def test_reference_frames_from_payload_maps_tt_channels() -> None:
     frame = reference_frames_from_payload(_tt_reference_payload(0.4, 0.41, samples=2))[0]
     assert frame["spline"] == pytest.approx(0.4)
@@ -154,6 +171,17 @@ def test_reference_frames_from_payload_maps_tt_channels() -> None:
     assert frame["px"] == pytest.approx(400.0)
     assert frame["py"] == 0.0
     assert frame["pz"] == pytest.approx(19.2)
+
+
+def test_reference_frames_clamp_minor_pedal_noise() -> None:
+    payload = _tt_reference_payload(0.4, 0.41, samples=2)
+    payload["data"]["telemetry"]["telemetry"]["reference"][0]["throt"] = 1.00001
+    payload["data"]["telemetry"]["telemetry"]["reference"][0]["brak"] = -0.00001
+
+    frame = reference_frames_from_payload(payload)[0]
+
+    assert frame["throttle"] == 1.0
+    assert frame["brake"] == 0.0
 
 
 def test_build_reference_archive_rejects_single_segment_window() -> None:
@@ -191,6 +219,8 @@ def test_build_reference_archive_stitches_full_lap_windows() -> None:
     assert record["generator"]["decision_issue"] == 353
     assert record["generator"]["tt_reference"]["partial"] is False
     assert record["generator"]["tt_reference"]["payload_count"] == 2
+    assert record["generator"]["tt_reference"]["max_spline_gap"] == pytest.approx(0.08)
+    assert record["generator"]["tt_reference"]["observed_max_spline_gap"] < 0.08
     assert record["corners"]  # non-vacuous for the M0 observer path
 
 
@@ -200,5 +230,58 @@ def test_build_reference_archive_rejects_spatial_gaps_even_with_wide_range() -> 
             [
                 _tt_reference_payload(0.0, 0.2, samples=12),
                 _tt_reference_payload(0.8, 1.0, samples=12),
+            ],
+        )
+
+
+def test_build_reference_archive_rejects_single_corner_sized_hole() -> None:
+    with pytest.raises(TTNormalizeError, match="partial"):
+        build_reference_archive(
+            [
+                _tt_reference_payload(0.0, 0.46, samples=30),
+                _tt_reference_payload(0.55, 1.0, samples=30),
+            ],
+        )
+
+
+def test_build_reference_archive_counts_start_finish_wrap_as_closed_loop() -> None:
+    record = build_reference_archive(
+        [_tt_reference_payload(0.02, 0.98, samples=80)],
+        max_spline_gap=0.05,
+        exported_at="2026-06-30T00:00:00Z",
+    )
+
+    assert record["generator"]["tt_reference"]["partial"] is False
+    assert record["generator"]["tt_reference"]["coverage"] == pytest.approx(1.0)
+
+
+def test_build_reference_archive_resolves_car_id_from_object() -> None:
+    record = build_reference_archive(
+        [
+            _session_payload(
+                0.0,
+                0.5,
+                session_key="sess-object-car",
+                car={"car_id": "ks_audi_r8_lms", "name": "Audi R8 LMS"},
+            ),
+            _session_payload(
+                0.5,
+                1.0,
+                session_key="sess-object-car",
+                car={"car_id": "ks_audi_r8_lms", "name": "Audi R8 LMS"},
+            ),
+        ],
+        exported_at="2026-06-30T00:00:00Z",
+    )
+
+    assert record["car"]["id"] == "ks_audi_r8_lms"
+
+
+def test_build_reference_archive_rejects_mixed_sessions() -> None:
+    with pytest.raises(TTNormalizeError, match="one session/lap"):
+        build_reference_archive(
+            [
+                _session_payload(0.0, 0.5, session_key="sess-a"),
+                _session_payload(0.5, 1.0, session_key="sess-b"),
             ],
         )

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -7,11 +7,17 @@ from pathlib import Path
 
 import pytest
 
+from tools.ac_harness.reference_lap import validate_lap_archive_record
 from tools.tt_ingest.tt_normalize import (
+    DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
     INDEX_SCHEMA_VERSION,
+    TT_REFERENCE_IMPORT_FORMAT,
+    TTNormalizeError,
+    build_reference_archive,
     build_sessions_index,
     normalize_session,
     normalize_sessions,
+    reference_frames_from_payload,
     split_session_id,
 )
 
@@ -85,3 +91,114 @@ def test_build_sessions_index() -> None:
     assert index["session_count"] == 3
     assert index["generated_at"] == "2026-06-28T00:00:00Z"
     assert len(index["sessions"]) == 3
+
+
+def _tt_reference_payload(start: float, end: float, *, samples: int = 16) -> dict:
+    frames = []
+    for i in range(samples):
+        t = i / (samples - 1)
+        dist = start + (end - start) * t
+        frames.append(
+            {
+                "dist": round(dist, 6),
+                "brak": 0.7 if 0.18 <= dist <= 0.28 else 0.0,
+                "gear": 3 if dist < 0.4 else 4,
+                "Kmh": 155.0 - 45.0 * max(0.0, 1.0 - abs(dist - 0.24) / 0.12)
+                if 0.12 <= dist <= 0.36
+                else 155.0,
+                "lTime": round(71000.0 * dist, 3),
+                "ovSteer": 0,
+                "steer": 0.35 if 0.12 <= dist <= 0.36 else 0.02,
+                "throt": 0.1 if 0.18 <= dist <= 0.28 else 1.0,
+                "unSteer": 0,
+                "useGrip": 0,
+                "X": 1000.0 * dist,
+                "Y": 120.0 * dist * dist,
+                "distM": None,
+            }
+        )
+    return {
+        "success": True,
+        "status": 200,
+        "data": {
+            "session": {
+                "id": "own-uid#sess-full",
+                "session_id": "own-uid#sess-full",
+                "game_id": "assettoCorsa",
+                "car": "ks_porsche_911_gt3_r_2016",
+                "track_id": "magione",
+                "lap_number": 5,
+            },
+            "referenceLap": {
+                "user_id": "ref-uid",
+                "session_key": "ref-session",
+                "lap_number": 5,
+                "lap_time": "71000",
+            },
+            "telemetry": {
+                "telemetry": {
+                    "reference": frames,
+                    "user": frames,
+                },
+                "format": "sanitized-test",
+            },
+        },
+    }
+
+
+def test_reference_frames_from_payload_maps_tt_channels() -> None:
+    frame = reference_frames_from_payload(_tt_reference_payload(0.4, 0.41, samples=2))[0]
+    assert frame["spline"] == pytest.approx(0.4)
+    assert frame["speed"] == pytest.approx(155.0)
+    assert frame["eMs"] == pytest.approx(28400.0)
+    assert frame["px"] == pytest.approx(400.0)
+    assert frame["py"] == 0.0
+    assert frame["pz"] == pytest.approx(19.2)
+
+
+def test_build_reference_archive_rejects_single_segment_window() -> None:
+    with pytest.raises(TTNormalizeError, match="partial"):
+        build_reference_archive([_tt_reference_payload(0.265, 0.359, samples=20)])
+
+
+def test_build_reference_archive_allows_partial_with_marker() -> None:
+    record = build_reference_archive(
+        [_tt_reference_payload(0.265, 0.359, samples=20)],
+        allow_partial=True,
+        exported_at="2026-06-30T00:00:00Z",
+    )
+
+    validate_lap_archive_record(record)
+    assert record["import_format"] == TT_REFERENCE_IMPORT_FORMAT
+    meta = record["generator"]["tt_reference"]
+    assert meta["partial"] is True
+    assert meta["coverage"] < DEFAULT_REFERENCE_COVERAGE_THRESHOLD
+
+
+def test_build_reference_archive_stitches_full_lap_windows() -> None:
+    record = build_reference_archive(
+        [
+            _tt_reference_payload(0.0, 0.5, samples=26),
+            _tt_reference_payload(0.5, 1.0, samples=26),
+        ],
+        exported_at="2026-06-30T00:00:00Z",
+    )
+
+    validate_lap_archive_record(record)
+    assert record["car"]["id"] == "ks_porsche_911_gt3_r_2016"
+    assert record["track"]["id"] == "magione"
+    assert record["lap"]["lap_ms"] == 71000
+    assert record["generator"]["decision_issue"] == 353
+    assert record["generator"]["tt_reference"]["partial"] is False
+    assert record["generator"]["tt_reference"]["payload_count"] == 2
+    assert record["corners"]  # non-vacuous for the M0 observer path
+
+
+def test_build_reference_archive_rejects_spatial_gaps_even_with_wide_range() -> None:
+    with pytest.raises(TTNormalizeError, match="partial"):
+        build_reference_archive(
+            [
+                _tt_reference_payload(0.0, 0.2, samples=12),
+                _tt_reference_payload(0.8, 1.0, samples=12),
+            ],
+        )

--- a/tests/test_tt_reference_runtime_guard.py
+++ b/tests/test_tt_reference_runtime_guard.py
@@ -17,3 +17,7 @@ def test_partial_tt_reference_archive_is_not_installed_as_live_observer() -> Non
     }
 
     assert build_observer_from_reference(archive) is None
+
+
+def test_non_dict_reference_archive_is_not_installed_as_live_observer() -> None:
+    assert build_observer_from_reference(None) is None  # type: ignore[arg-type]

--- a/tests/test_tt_reference_runtime_guard.py
+++ b/tests/test_tt_reference_runtime_guard.py
@@ -1,0 +1,19 @@
+"""Runtime guard for Track Titan reference archives (issue #353 M-TT2)."""
+
+from __future__ import annotations
+
+from tests.test_realtime_observer import _corner_archive
+from tools.ai_sidecar.realtime_observer import build_observer_from_reference
+
+
+def test_partial_tt_reference_archive_is_not_installed_as_live_observer() -> None:
+    archive = _corner_archive()
+    archive["generator"] = {
+        "tt_reference": {
+            "format": "track_titan_reference_v1",
+            "partial": True,
+            "coverage": 0.094,
+        }
+    }
+
+    assert build_observer_from_reference(archive) is None

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -581,7 +581,9 @@ def build_observer_from_reference(reference_archive: dict) -> RealtimeObserver |
     GGV theoretical ceiling (we never fabricate one from a driven lap). Returns None when the
     archive has no usable trace or no segmentable corners.
     """
-    generator = reference_archive.get("generator") if isinstance(reference_archive, dict) else None
+    if not isinstance(reference_archive, dict):
+        return None
+    generator = reference_archive.get("generator")
     tt_reference = generator.get("tt_reference") if isinstance(generator, dict) else None
     if isinstance(tt_reference, dict) and tt_reference.get("partial") is True:
         return None

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -581,6 +581,10 @@ def build_observer_from_reference(reference_archive: dict) -> RealtimeObserver |
     GGV theoretical ceiling (we never fabricate one from a driven lap). Returns None when the
     archive has no usable trace or no segmentable corners.
     """
+    generator = reference_archive.get("generator") if isinstance(reference_archive, dict) else None
+    tt_reference = generator.get("tt_reference") if isinstance(generator, dict) else None
+    if isinstance(tt_reference, dict) and tt_reference.get("partial") is True:
+        return None
     try:
         ref_lap = lap_trace_from_archive(reference_archive)
     except ValueError:

--- a/tools/tt_ingest/__init__.py
+++ b/tools/tt_ingest/__init__.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 from tools.tt_ingest.cli import (
     ExportSummary,
+    ReferenceArchiveSummary,
     build_arg_parser,
+    build_reference_archive_from_files,
+    discover_reference_payloads,
     main,
     reindex_lake,
     retain_sessions,
@@ -45,9 +48,12 @@ from tools.tt_ingest.tt_export import (
     write_immutable_json,
 )
 from tools.tt_ingest.tt_normalize import (
+    TTNormalizeError,
+    build_reference_archive,
     build_sessions_index,
     normalize_session,
     normalize_sessions,
+    reference_frames_from_payload,
 )
 from tools.tt_ingest.tt_vulcan import (
     SessionsPage,
@@ -61,18 +67,23 @@ from tools.tt_ingest.tt_vulcan import (
 __all__ = [
     "ExportSummary",
     "MintedTokens",
+    "ReferenceArchiveSummary",
     "RetainedFile",
     "SessionsPage",
     "TTAuthError",
     "TTConfig",
     "TTExportError",
+    "TTNormalizeError",
     "TTVulcanError",
     "WriteResult",
     "build_arg_parser",
     "build_index",
     "build_initiate_auth_request",
+    "build_reference_archive",
+    "build_reference_archive_from_files",
     "build_sessions_index",
     "decode_jwt_payload",
+    "discover_reference_payloads",
     "extract_refresh_token_from_text",
     "extract_uid_from_text",
     "is_token_expired",
@@ -82,6 +93,7 @@ __all__ = [
     "normalize_sessions",
     "parse_initiate_auth_response",
     "parse_sessions_page",
+    "reference_frames_from_payload",
     "reindex_lake",
     "resolve_refresh_token",
     "retain_sessions",

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -427,12 +427,15 @@ def build_reference_archive_from_files(
         allow_partial=allow_partial,
         track_length_m=track_length_m,
     )
-    output.parent.mkdir(parents=True, exist_ok=True)
     if pretty:
         text = json.dumps(archive, indent=2, sort_keys=True) + "\n"
     else:
         text = json.dumps(archive, separators=(",", ":"), sort_keys=True) + "\n"
-    output.write_text(text, encoding="utf-8")
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+    except OSError as exc:
+        raise TTNormalizeError(f"could not write {output}: {exc}") from exc
     meta = archive["generator"]["tt_reference"]
     return ReferenceArchiveSummary(
         output=output,

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -443,6 +443,10 @@ def build_reference_archive_from_files(
     pretty: bool = False,
 ) -> ReferenceArchiveSummary:
     """Build and write a TT reference archive from retained payload files."""
+    resolved_output = output.resolve()
+    for path in paths:
+        if resolved_output == path.resolve():
+            raise TTNormalizeError(f"output must not overwrite retained input: {output}")
     if output.exists() and not overwrite:
         raise TTNormalizeError(f"output already exists (pass --overwrite): {output}")
     payloads = [_load_json_file(path) for path in paths]

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -75,6 +75,16 @@ def last_session_endpoint(lap: Any) -> str:
     return f"{LAST_SESSION_ENDPOINT_PREFIX}{lap}"
 
 
+def last_session_window_endpoint(lap: Any, payload: Mapping[str, Any]) -> str:
+    """Endpoint for an additional distinct /last-session segment window for one lap."""
+    return f"{last_session_endpoint(lap)}_window_{stable_fingerprint(dict(payload))}"
+
+
+def _last_session_endpoint_matches_lap(stem: str, lap: Any) -> bool:
+    base = last_session_endpoint(lap)
+    return stem == base or stem.startswith(f"{base}_window_")
+
+
 def coaching_endpoint(lap: Any) -> str:
     """Endpoint (file stem) for a lap's coaching bundle: ``coaching_lap{lap}``."""
     return f"{COACHING_ENDPOINT_PREFIX}{lap}"
@@ -327,10 +337,12 @@ def retain_coaching(
     ``coaching_lap{lap}.json`` **write-once** under ``journal/tt/{game}/{car}/{track}/{sk}/``
     keyed by the given ``session``. BOTH files are **per-lap**: the /last-session telemetry is
     lap-specific, so lap-keying it keeps each lap's raw evidence coherent with its coaching even
-    when the same session later gains another lap (#353 review). ``last_session_payload`` is the
-    FULL raw services response (session + referenceLap + telemetry) — preserved so the lake
-    reconstructs exactly what the endpoint returned (the M-TT2 reference-lap input); it defaults
-    to ``session`` when not supplied.
+    when the same session later gains another lap (#353 review). Distinct later captures for the
+    same lap are retained as ``last_session_lap{lap}_window_{fingerprint}.json`` so M-TT2 lake
+    discovery can stitch multiple segment windows without overwriting the first capture.
+    ``last_session_payload`` is the FULL raw services response (session + referenceLap + telemetry)
+    — preserved so the lake reconstructs exactly what the endpoint returned (the M-TT2
+    reference-lap input); it defaults to ``session`` when not supplied.
     After writing, the lake indexes are rebuilt from disk (:func:`reindex_lake`) so the new
     services endpoints are discoverable and integrity-checkable. ``allow_nan`` keeps
     non-finite telemetry floats lossless, matching raw session retention.
@@ -343,13 +355,26 @@ def retain_coaching(
     )
     last_payload = dict(last_session_payload) if last_session_payload is not None else dict(session)
     written: list[str] = []
-    for endpoint, payload in (
-        (last_session_endpoint(lap), last_payload),
-        (coaching_endpoint(lap), dict(bundle)),
-    ):
-        result = write_immutable_json(endpoint_file(target_dir, endpoint), payload, allow_nan=True)
-        if result.written:
-            written.append(endpoint)
+    base_last_endpoint = last_session_endpoint(lap)
+    last_result = write_immutable_json(
+        endpoint_file(target_dir, base_last_endpoint), last_payload, allow_nan=True
+    )
+    if last_result.written:
+        written.append(base_last_endpoint)
+    elif last_result.sha256[:12] != stable_fingerprint(last_payload):
+        window_endpoint = last_session_window_endpoint(lap, last_payload)
+        window_result = write_immutable_json(
+            endpoint_file(target_dir, window_endpoint), last_payload, allow_nan=True
+        )
+        if window_result.written:
+            written.append(window_endpoint)
+
+    coaching_name = coaching_endpoint(lap)
+    coaching_result = write_immutable_json(
+        endpoint_file(target_dir, coaching_name), dict(bundle), allow_nan=True
+    )
+    if coaching_result.written:
+        written.append(coaching_name)
     indexed = reindex_lake(root, generated_at=stamp)
     return CoachingSummary(
         session_key=key["session_key"],
@@ -380,6 +405,8 @@ def discover_reference_payloads(
     lap: str | int | None = None,
 ) -> list[Path]:
     """Discover retained ``last_session_lap*.json`` payloads in the TT lake."""
+    if not session_key or lap is None:
+        raise TTNormalizeError("--discover-lake requires both --session-key and --lap")
     root = lake_root(lake_base)
     if not root.exists():
         raise TTNormalizeError(f"Track Titan lake not found: {root}")
@@ -387,9 +414,9 @@ def discover_reference_payloads(
     for path in sorted(root.rglob(REFERENCE_INPUT_GLOB)):
         if path.is_symlink() or not path.is_file():
             continue
-        if session_key and path.parent.name != str(session_key):
+        if path.parent.name != str(session_key):
             continue
-        if lap is not None and path.stem != last_session_endpoint(lap):
+        if not _last_session_endpoint_matches_lap(path.stem, lap):
             continue
         paths.append(path)
     if not paths:
@@ -511,13 +538,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
     reference.add_argument(
         "--discover-lake",
         action="store_true",
-        help="Discover retained last_session_lap*.json files under --lake-base/journal/tt.",
+        help=(
+            "Discover retained last_session_lap*.json files for --session-key/--lap under "
+            "--lake-base/journal/tt."
+        ),
     )
     reference.add_argument("--lake-base", type=Path, default=None)
     reference.add_argument(
-        "--session-key", default=None, help="Filter lake discovery to a session key."
+        "--session-key", default=None, help="Required with --discover-lake; retained session key."
     )
-    reference.add_argument("--lap", default=None, help="Filter lake discovery to one lap number.")
+    reference.add_argument("--lap", default=None, help="Required with --discover-lake; one lap.")
     reference.add_argument(
         "--channel",
         choices=("reference", "user"),

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -40,6 +40,10 @@ from tools.tt_ingest.tt_export import (
     write_immutable_json,
 )
 from tools.tt_ingest.tt_normalize import (
+    DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
+    DEFAULT_REFERENCE_MAX_SPLINE_GAP,
+    TTNormalizeError,
+    build_reference_archive,
     build_sessions_index,
     normalize_session,
     split_session_id,
@@ -63,6 +67,7 @@ LAST_SESSION_ENDPOINT_PREFIX = "last_session_lap"
 LAST_SESSION_ENDPOINT_GLOB = f"{LAST_SESSION_ENDPOINT_PREFIX}*.json"
 COACHING_ENDPOINT_PREFIX = "coaching_lap"
 COACHING_ENDPOINT_GLOB = f"{COACHING_ENDPOINT_PREFIX}*.json"
+REFERENCE_INPUT_GLOB = LAST_SESSION_ENDPOINT_GLOB
 
 
 def last_session_endpoint(lap: Any) -> str:
@@ -244,6 +249,25 @@ class CoachingSummary:
         )
 
 
+@dataclass(frozen=True)
+class ReferenceArchiveSummary:
+    """Outcome of building one M-TT2 Track Titan reference archive."""
+
+    output: Path
+    samples: int
+    coverage: float
+    partial: bool
+    payload_count: int
+
+    def render(self) -> str:
+        state = "PARTIAL debug" if self.partial else "full"
+        return (
+            f"wrote {state} TT reference archive to {self.output} "
+            f"({self.samples} samples, coverage={self.coverage:.3f}, "
+            f"{self.payload_count} payload(s))"
+        )
+
+
 def _car_segment(session: Mapping[str, Any]) -> Any:
     """Resolve a STRING car id for the lake path.
 
@@ -337,6 +361,88 @@ def retain_coaching(
     )
 
 
+def _load_json_file(path: Path) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise TTNormalizeError(f"could not read {path}: {exc}") from exc
+    except ValueError as exc:
+        raise TTNormalizeError(f"{path} is not valid JSON") from exc
+    if not isinstance(payload, Mapping):
+        raise TTNormalizeError(f"{path} did not contain a JSON object")
+    return payload
+
+
+def discover_reference_payloads(
+    *,
+    lake_base: Path | None = None,
+    session_key: str | None = None,
+    lap: str | int | None = None,
+) -> list[Path]:
+    """Discover retained ``last_session_lap*.json`` payloads in the TT lake."""
+    root = lake_root(lake_base)
+    if not root.exists():
+        raise TTNormalizeError(f"Track Titan lake not found: {root}")
+    paths: list[Path] = []
+    for path in sorted(root.rglob(REFERENCE_INPUT_GLOB)):
+        if path.is_symlink() or not path.is_file():
+            continue
+        if session_key and path.parent.name != str(session_key):
+            continue
+        if lap is not None and path.stem != last_session_endpoint(lap):
+            continue
+        paths.append(path)
+    if not paths:
+        details = []
+        if session_key:
+            details.append(f"session_key={session_key}")
+        if lap is not None:
+            details.append(f"lap={lap}")
+        suffix = f" ({', '.join(details)})" if details else ""
+        raise TTNormalizeError(f"no retained last-session payloads found under {root}{suffix}")
+    return paths
+
+
+def build_reference_archive_from_files(
+    paths: Sequence[Path],
+    *,
+    output: Path,
+    channel: str = "reference",
+    allow_partial: bool = False,
+    coverage_threshold: float = DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
+    max_spline_gap: float = DEFAULT_REFERENCE_MAX_SPLINE_GAP,
+    track_length_m: float,
+    overwrite: bool = False,
+    pretty: bool = False,
+) -> ReferenceArchiveSummary:
+    """Build and write a TT reference archive from retained payload files."""
+    if output.exists() and not overwrite:
+        raise TTNormalizeError(f"output already exists (pass --overwrite): {output}")
+    payloads = [_load_json_file(path) for path in paths]
+    archive = build_reference_archive(
+        list(payloads),
+        channel=channel,
+        coverage_threshold=coverage_threshold,
+        max_spline_gap=max_spline_gap,
+        allow_partial=allow_partial,
+        track_length_m=track_length_m,
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if pretty:
+        text = json.dumps(archive, indent=2, sort_keys=True) + "\n"
+    else:
+        text = json.dumps(archive, separators=(",", ":"), sort_keys=True) + "\n"
+    output.write_text(text, encoding="utf-8")
+    meta = archive["generator"]["tt_reference"]
+    return ReferenceArchiveSummary(
+        output=output,
+        samples=int(meta["samples"]),
+        coverage=float(meta["coverage"]),
+        partial=bool(meta["partial"]),
+        payload_count=int(meta["payload_count"]),
+    )
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     """Build the ``tools.tt_ingest`` argument parser."""
     parser = argparse.ArgumentParser(
@@ -387,6 +493,62 @@ def build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print the resolved session + a sanitized advice summary; write nothing.",
     )
+
+    reference = sub.add_parser(
+        "reference",
+        help="Build an M-TT2 lap_archive reference from retained TT last-session telemetry.",
+    )
+    reference.add_argument(
+        "--input",
+        action="append",
+        type=Path,
+        default=[],
+        help="Retained last_session_lap*.json payload; repeat to stitch multiple windows.",
+    )
+    reference.add_argument(
+        "--discover-lake",
+        action="store_true",
+        help="Discover retained last_session_lap*.json files under --lake-base/journal/tt.",
+    )
+    reference.add_argument("--lake-base", type=Path, default=None)
+    reference.add_argument(
+        "--session-key", default=None, help="Filter lake discovery to a session key."
+    )
+    reference.add_argument("--lap", default=None, help="Filter lake discovery to one lap number.")
+    reference.add_argument(
+        "--channel",
+        choices=("reference", "user"),
+        default="reference",
+        help="TT telemetry channel to normalize (default: reference).",
+    )
+    reference.add_argument(
+        "--output", type=Path, required=True, help="Reference archive JSON path."
+    )
+    reference.add_argument(
+        "--track-length-m",
+        type=float,
+        default=4500.0,
+        help="Track length for the archive metadata when TT does not provide one.",
+    )
+    reference.add_argument(
+        "--min-coverage",
+        type=float,
+        default=DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
+        help="Required contiguous spline coverage for a full reference (default 0.90).",
+    )
+    reference.add_argument(
+        "--max-spline-gap",
+        type=float,
+        default=DEFAULT_REFERENCE_MAX_SPLINE_GAP,
+        help="Largest spline gap counted as contiguous coverage (default 0.08).",
+    )
+    reference.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Emit a debug-only archive even when full-lap coverage is not met.",
+    )
+    reference.add_argument("--overwrite", action="store_true")
+    reference.add_argument("--pretty", action="store_true")
     return parser
 
 
@@ -470,6 +632,32 @@ def cmd_coaching(args: argparse.Namespace) -> int:  # pragma: no cover - network
     return 0
 
 
+def cmd_reference(args: argparse.Namespace) -> int:
+    explicit_inputs = list(args.input or [])
+    if bool(explicit_inputs) == bool(args.discover_lake):
+        raise TTNormalizeError("reference requires exactly one of --input or --discover-lake")
+    paths = (
+        explicit_inputs
+        if explicit_inputs
+        else discover_reference_payloads(
+            lake_base=args.lake_base, session_key=args.session_key, lap=args.lap
+        )
+    )
+    summary = build_reference_archive_from_files(
+        paths,
+        output=args.output,
+        channel=args.channel,
+        allow_partial=args.allow_partial,
+        coverage_threshold=args.min_coverage,
+        max_spline_gap=args.max_spline_gap,
+        track_length_m=args.track_length_m,
+        overwrite=args.overwrite,
+        pretty=args.pretty,
+    )
+    _print(summary.render())
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
@@ -480,7 +668,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             return cmd_export(args)
         if args.command == "coaching":
             return cmd_coaching(args)
-    except (TTAuthError, TTServicesError) as exc:  # pragma: no cover - surfaced live
+        if args.command == "reference":
+            return cmd_reference(args)
+    except (
+        TTAuthError,
+        TTServicesError,
+        TTNormalizeError,
+    ) as exc:  # pragma: no cover - surfaced live
         parser.exit(2, f"tt_ingest: {exc}\n")
     parser.error(f"unknown command: {args.command}")  # pragma: no cover - argparse guards
     return 2

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -140,6 +140,20 @@ class ReferenceCoverage:
     partial: bool
 
 
+@dataclass(frozen=True)
+class ReferenceIdentity:
+    """Identity and lap timing metadata for a stitched Track Titan archive."""
+
+    game_id: str | None
+    car_id: str | None
+    track_id: str | None
+    source_session_key: str | None
+    source_lap_number: str | None
+    session_key: str | None
+    lap_number: str | None
+    lap_ms: int | None
+
+
 def _finite_float(raw: Any, field: str) -> float:
     try:
         value = float(raw)
@@ -166,7 +180,7 @@ def _services_data(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     """Return the services ``data`` object from an enveloped or already-unwrapped payload."""
     if not isinstance(payload, Mapping):
         raise TTNormalizeError("Track Titan payload must be a JSON object")
-    data = payload.get("data") if "data" in payload and "success" in payload else payload
+    data = payload.get("data") if "success" in payload else payload
     if not isinstance(data, Mapping):
         raise TTNormalizeError("Track Titan services payload missing data object")
     return data
@@ -220,18 +234,76 @@ def _identity_value(value: Any) -> str | None:
     return str(value) if value not in (None, "") else None
 
 
-def _session_identity(session: Mapping[str, Any]) -> dict[str, str | None]:
-    return {
-        "game_id": _identity_value(session.get("game_id")),
-        "car_id": _resolve_car_id(session),
-        "track_id": _identity_value(session.get("track_id")),
-        "session_key": _session_key(session),
-        "lap_number": _identity_value(session.get("lap_number")),
-    }
+def _positive_int_ms(raw: Any, field: str) -> int | None:
+    if raw in (None, ""):
+        return None
+    value = _finite_float(raw, field)
+    if value <= 0:
+        raise TTNormalizeError(f"{field} must be positive, got {raw!r}")
+    return int(round(value))
 
 
-def _validated_session_identity(payloads: list[Mapping[str, Any]]) -> dict[str, str | None]:
-    identities = [_session_identity(_payload_session(payload)) for payload in payloads]
+def _session_lap_ms(session: Mapping[str, Any]) -> int | None:
+    for key in ("lap_time", "lapTime", "lastLapTime", "bestLapTime"):
+        if session.get(key) not in (None, ""):
+            return _positive_int_ms(session.get(key), f"session.{key}")
+    return None
+
+
+def _reference_lap_identity(
+    session: Mapping[str, Any],
+    ref: Mapping[str, Any],
+) -> ReferenceIdentity:
+    if not ref:
+        raise TTNormalizeError(
+            "Track Titan reference-channel payload missing referenceLap metadata"
+        )
+    lap_ms = _positive_int_ms(ref.get("lap_time"), "referenceLap.lap_time")
+    if lap_ms is None:
+        raise TTNormalizeError(
+            "Track Titan reference-channel payload missing referenceLap.lap_time"
+        )
+    return ReferenceIdentity(
+        game_id=_identity_value(session.get("game_id")),
+        car_id=_resolve_car_id(session),
+        track_id=_identity_value(session.get("track_id")),
+        source_session_key=_session_key(session),
+        source_lap_number=_identity_value(session.get("lap_number")),
+        session_key=_identity_value(ref.get("session_key") or ref.get("id")),
+        lap_number=_identity_value(ref.get("lap_number")),
+        lap_ms=lap_ms,
+    )
+
+
+def _session_identity(session: Mapping[str, Any]) -> ReferenceIdentity:
+    return ReferenceIdentity(
+        game_id=_identity_value(session.get("game_id")),
+        car_id=_resolve_car_id(session),
+        track_id=_identity_value(session.get("track_id")),
+        source_session_key=_session_key(session),
+        source_lap_number=_identity_value(session.get("lap_number")),
+        session_key=_session_key(session),
+        lap_number=_identity_value(session.get("lap_number")),
+        lap_ms=_session_lap_ms(session),
+    )
+
+
+def _payload_identity(payload: Mapping[str, Any], *, channel: str) -> ReferenceIdentity:
+    session = _payload_session(payload)
+    if channel == "reference":
+        ref = _reference_lap_from_payload([payload])
+        return _reference_lap_identity(session, ref)
+    if channel == "user":
+        return _session_identity(session)
+    raise TTNormalizeError(f"unsupported Track Titan telemetry channel: {channel}")
+
+
+def _validated_payload_identity(
+    payloads: list[Mapping[str, Any]],
+    *,
+    channel: str,
+) -> ReferenceIdentity:
+    identities = [_payload_identity(payload, channel=channel) for payload in payloads]
     if not identities:
         return _session_identity({})
     first = identities[0]
@@ -379,25 +451,34 @@ def build_reference_archive(
     """
     if not payloads:
         raise TTNormalizeError("no Track Titan payloads supplied")
+    identity = _validated_payload_identity(payloads, channel=channel)
     frames = merge_reference_frames(payloads, channel=channel)
     coverage = reference_coverage(
         frames, max_spline_gap=max_spline_gap, threshold=coverage_threshold
     )
-    if coverage.partial and not allow_partial:
+    trace_lap_ms = int(round(frames[-1]["eMs"]))
+    lap_time_mismatch_ms = (
+        abs(identity.lap_ms - trace_lap_ms) if identity.lap_ms is not None else None
+    )
+    lap_time_partial = lap_time_mismatch_ms is not None and lap_time_mismatch_ms > 1
+    partial = coverage.partial or lap_time_partial
+    if partial and not allow_partial:
+        timing_detail = (
+            f", reference_lap_ms={identity.lap_ms}, trace_lap_ms={trace_lap_ms}"
+            if lap_time_partial
+            else ""
+        )
         raise TTNormalizeError(
             "Track Titan reference telemetry is partial "
             f"(coverage={coverage.coverage:.3f}, threshold={coverage_threshold:.3f}, "
             f"min={coverage.min_spline:.3f}, max={coverage.max_spline:.3f}, "
-            f"max_gap={coverage.max_gap:.3f}); capture/stitch more segment windows "
+            f"max_gap={coverage.max_gap:.3f}{timing_detail}); capture/stitch more segment windows "
             "or pass --allow-partial for a debug-only archive"
         )
 
-    identity = _validated_session_identity(payloads)
-    session = _session_from_payload(payloads)
-    ref = _reference_lap_from_payload(payloads)
-    car_id = identity["car_id"] or "track_titan_car"
-    track_id = identity["track_id"] or "track_titan_track"
-    lap_n = identity["lap_number"] or ref.get("lap_number") or session.get("lap_number") or 1
+    car_id = identity.car_id or "track_titan_car"
+    track_id = identity.track_id or "track_titan_track"
+    lap_n = identity.lap_number or 1
     record = build_archive_record(
         frames,
         car_id=str(car_id),
@@ -417,13 +498,19 @@ def build_reference_archive(
         "schema_version": 1,
         "channel": channel,
         "payload_count": len(payloads),
-        "partial": coverage.partial,
+        "partial": partial,
         "coverage": coverage.coverage,
         "coverage_threshold": coverage_threshold,
         "min_spline": coverage.min_spline,
         "max_spline": coverage.max_spline,
         "max_spline_gap": max_spline_gap,
         "observed_max_spline_gap": coverage.max_gap,
+        "source_session_key": identity.source_session_key,
+        "source_lap_number": identity.source_lap_number,
+        "reference_session_key": identity.session_key,
+        "reference_lap_ms": identity.lap_ms,
+        "trace_lap_ms": trace_lap_ms,
+        "lap_time_mismatch_ms": lap_time_mismatch_ms,
         "samples": coverage.samples,
         "format": TT_REFERENCE_IMPORT_FORMAT,
     }

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -157,6 +157,11 @@ def _bounded01(raw: Any, field: str) -> float:
     return value
 
 
+def _clamped01(raw: Any, field: str) -> float:
+    value = _finite_float(raw, field)
+    return max(0.0, min(1.0, value))
+
+
 def _services_data(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     """Return the services ``data`` object from an enveloped or already-unwrapped payload."""
     if not isinstance(payload, Mapping):
@@ -167,11 +172,16 @@ def _services_data(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return data
 
 
+def _payload_session(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    data = _services_data(payload)
+    session = data.get("session")
+    return session if isinstance(session, Mapping) else {}
+
+
 def _session_from_payload(payloads: list[Mapping[str, Any]]) -> Mapping[str, Any]:
     for payload in payloads:
-        data = _services_data(payload)
-        session = data.get("session")
-        if isinstance(session, Mapping):
+        session = _payload_session(payload)
+        if session:
             return session
     return {}
 
@@ -183,6 +193,55 @@ def _reference_lap_from_payload(payloads: list[Mapping[str, Any]]) -> Mapping[st
         if isinstance(ref, Mapping):
             return ref
     return {}
+
+
+def _resolve_car_id(session: Mapping[str, Any]) -> str | None:
+    for value in (session.get("car_id"), session.get("car")):
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, Mapping):
+            inner = value.get("car_id") or value.get("id")
+            if isinstance(inner, str) and inner:
+                return inner
+    return None
+
+
+def _session_key(session: Mapping[str, Any]) -> str | None:
+    raw_id = session.get("session_id") or session.get("id")
+    if isinstance(raw_id, str):
+        _, key = split_session_id(raw_id)
+        if key:
+            return key
+    key = session.get("session_key")
+    return key if isinstance(key, str) and key else None
+
+
+def _identity_value(value: Any) -> str | None:
+    return str(value) if value not in (None, "") else None
+
+
+def _session_identity(session: Mapping[str, Any]) -> dict[str, str | None]:
+    return {
+        "game_id": _identity_value(session.get("game_id")),
+        "car_id": _resolve_car_id(session),
+        "track_id": _identity_value(session.get("track_id")),
+        "session_key": _session_key(session),
+        "lap_number": _identity_value(session.get("lap_number")),
+    }
+
+
+def _validated_session_identity(payloads: list[Mapping[str, Any]]) -> dict[str, str | None]:
+    identities = [_session_identity(_payload_session(payload)) for payload in payloads]
+    if not identities:
+        return _session_identity({})
+    first = identities[0]
+    for index, identity in enumerate(identities[1:], start=1):
+        if identity != first:
+            raise TTNormalizeError(
+                "Track Titan reference payloads must come from one session/lap "
+                f"(payload 0={first}, payload {index}={identity})"
+            )
+    return first
 
 
 def _raw_trace(payload: Mapping[str, Any], *, channel: str) -> list[Mapping[str, Any]]:
@@ -217,8 +276,8 @@ def _tt_frame_to_archive_frame(frame: Mapping[str, Any], index: int) -> dict[str
         "spline": spline,
         "speed": speed,
         "eMs": _finite_float(frame.get("lTime"), f"tt_frame[{index}].lTime"),
-        "throttle": _bounded01(frame.get("throt"), f"tt_frame[{index}].throt"),
-        "brake": _bounded01(frame.get("brak"), f"tt_frame[{index}].brak"),
+        "throttle": _clamped01(frame.get("throt"), f"tt_frame[{index}].throt"),
+        "brake": _clamped01(frame.get("brak"), f"tt_frame[{index}].brak"),
         "steer": _finite_float(frame.get("steer"), f"tt_frame[{index}].steer"),
         "gear": _finite_float(frame.get("gear"), f"tt_frame[{index}].gear"),
         # TT exposes a 2-D path projection. AC's schema wants px/py/pz; keep the
@@ -288,9 +347,10 @@ def reference_coverage(
     if len(splines) < 2:
         raise TTNormalizeError("reference telemetry needs at least two distinct spline samples")
     gaps = [b - a for a, b in zip(splines, splines[1:], strict=False)]
+    gaps.append((1.0 - splines[-1]) + splines[0])
     max_gap = max(gaps, default=1.0)
-    coverage = sum(gap for gap in gaps if gap <= max_spline_gap)
-    partial = coverage < threshold
+    coverage = min(1.0, sum(gap for gap in gaps if gap <= max_spline_gap))
+    partial = coverage < threshold or max_gap > max_spline_gap
     return ReferenceCoverage(
         samples=len(frames),
         coverage=coverage,
@@ -332,11 +392,12 @@ def build_reference_archive(
             "or pass --allow-partial for a debug-only archive"
         )
 
+    identity = _validated_session_identity(payloads)
     session = _session_from_payload(payloads)
     ref = _reference_lap_from_payload(payloads)
-    car_id = session.get("car") or session.get("car_id") or "track_titan_car"
-    track_id = session.get("track_id") or "track_titan_track"
-    lap_n = ref.get("lap_number") or session.get("lap_number") or 1
+    car_id = identity["car_id"] or "track_titan_car"
+    track_id = identity["track_id"] or "track_titan_track"
+    lap_n = identity["lap_number"] or ref.get("lap_number") or session.get("lap_number") or 1
     record = build_archive_record(
         frames,
         car_id=str(car_id),
@@ -361,7 +422,8 @@ def build_reference_archive(
         "coverage_threshold": coverage_threshold,
         "min_spline": coverage.min_spline,
         "max_spline": coverage.max_spline,
-        "max_spline_gap": coverage.max_gap,
+        "max_spline_gap": max_spline_gap,
+        "observed_max_spline_gap": coverage.max_gap,
         "samples": coverage.samples,
         "format": TT_REFERENCE_IMPORT_FORMAT,
     }

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -1,21 +1,33 @@
-"""Normalize raw Track Titan vulcan sessions into a stable, queryable index row
-(issue #353, milestone M-TT0).
+"""Normalize raw Track Titan exports into stable local trainer data (issue #353).
 
 The raw session JSON is retained immutably in the lake (``tt_export``); this layer
 projects each session into a flat, lossless-for-indexing row keyed by
 car + track + setup + conditions — the join key the autonomous harness and the
-coaching lake consume. The reference-lap → ``lap_archive`` schema bridge (the M0
-``--reference-archive`` feed) is milestone M-TT2 and lands separately.
+coaching lake consume.
+
+M-TT2 adds the reference-lap → ``lap_archive`` schema bridge that feeds M0
+``--reference-archive``. It intentionally refuses to turn a single Track Titan
+``/last-session`` segment window into a fake full-lap reference: callers must
+provide enough retained windows to cover the lap, or opt into an explicitly
+partial debug artifact.
 
 Pure functions only — fixture-tested, no network.
 """
 
 from __future__ import annotations
 
+import math
+from collections import OrderedDict
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
+from tools.ac_harness.reference_lap import DEFAULT_TRACK_LENGTH_M, build_archive_record
+
 INDEX_SCHEMA_VERSION = 1
+TT_REFERENCE_IMPORT_FORMAT = "track_titan_reference_v1"
+DEFAULT_REFERENCE_COVERAGE_THRESHOLD = 0.9
+DEFAULT_REFERENCE_MAX_SPLINE_GAP = 0.08
 
 #: ``lap_attributes`` keys we lift into the flat conditions block. Anything absent
 #: degrades to ``None`` rather than raising — retention must never drop a session.
@@ -110,3 +122,247 @@ def build_sessions_index(rows: list[Mapping[str, Any]], *, generated_at: str) ->
         "session_count": len(rows),
         "sessions": [dict(r) for r in rows],
     }
+
+
+class TTNormalizeError(ValueError):
+    """A raw Track Titan payload cannot be safely normalized."""
+
+
+@dataclass(frozen=True)
+class ReferenceCoverage:
+    """Coverage diagnostics for stitched Track Titan reference telemetry."""
+
+    samples: int
+    coverage: float
+    min_spline: float
+    max_spline: float
+    max_gap: float
+    partial: bool
+
+
+def _finite_float(raw: Any, field: str) -> float:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise TTNormalizeError(f"{field} must be numeric, got {raw!r}") from exc
+    if not math.isfinite(value):
+        raise TTNormalizeError(f"{field} must be finite, got {raw!r}")
+    return value
+
+
+def _bounded01(raw: Any, field: str) -> float:
+    value = _finite_float(raw, field)
+    if value < 0.0 or value > 1.0:
+        raise TTNormalizeError(f"{field} must be in [0, 1], got {raw!r}")
+    return value
+
+
+def _services_data(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the services ``data`` object from an enveloped or already-unwrapped payload."""
+    if not isinstance(payload, Mapping):
+        raise TTNormalizeError("Track Titan payload must be a JSON object")
+    data = payload.get("data") if "data" in payload and "success" in payload else payload
+    if not isinstance(data, Mapping):
+        raise TTNormalizeError("Track Titan services payload missing data object")
+    return data
+
+
+def _session_from_payload(payloads: list[Mapping[str, Any]]) -> Mapping[str, Any]:
+    for payload in payloads:
+        data = _services_data(payload)
+        session = data.get("session")
+        if isinstance(session, Mapping):
+            return session
+    return {}
+
+
+def _reference_lap_from_payload(payloads: list[Mapping[str, Any]]) -> Mapping[str, Any]:
+    for payload in payloads:
+        data = _services_data(payload)
+        ref = data.get("referenceLap")
+        if isinstance(ref, Mapping):
+            return ref
+    return {}
+
+
+def _raw_trace(payload: Mapping[str, Any], *, channel: str) -> list[Mapping[str, Any]]:
+    data = _services_data(payload)
+    telemetry = data.get("telemetry")
+    if not isinstance(telemetry, Mapping):
+        raise TTNormalizeError("Track Titan payload missing telemetry object")
+    trace_root = telemetry.get("telemetry")
+    if not isinstance(trace_root, Mapping):
+        raise TTNormalizeError("Track Titan payload missing telemetry.telemetry object")
+    frames = trace_root.get(channel)
+    if not isinstance(frames, list) or not frames:
+        raise TTNormalizeError(f"Track Titan payload missing telemetry.telemetry.{channel} frames")
+    out: list[Mapping[str, Any]] = []
+    for frame in frames:
+        if not isinstance(frame, Mapping):
+            raise TTNormalizeError(f"telemetry.telemetry.{channel} contains a non-object frame")
+        out.append(frame)
+    return out
+
+
+def _tt_frame_to_archive_frame(frame: Mapping[str, Any], index: int) -> dict[str, float]:
+    spline = _bounded01(frame.get("dist"), f"tt_frame[{index}].dist")
+    speed = _finite_float(frame.get("Kmh"), f"tt_frame[{index}].Kmh")
+    if speed < 0.0:
+        raise TTNormalizeError(f"tt_frame[{index}].Kmh must be non-negative")
+    x_raw = frame.get("X")
+    y_raw = frame.get("Y")
+    px = _finite_float(x_raw, f"tt_frame[{index}].X") if x_raw is not None else spline
+    pz = _finite_float(y_raw, f"tt_frame[{index}].Y") if y_raw is not None else 0.0
+    return {
+        "spline": spline,
+        "speed": speed,
+        "eMs": _finite_float(frame.get("lTime"), f"tt_frame[{index}].lTime"),
+        "throttle": _bounded01(frame.get("throt"), f"tt_frame[{index}].throt"),
+        "brake": _bounded01(frame.get("brak"), f"tt_frame[{index}].brak"),
+        "steer": _finite_float(frame.get("steer"), f"tt_frame[{index}].steer"),
+        "gear": _finite_float(frame.get("gear"), f"tt_frame[{index}].gear"),
+        # TT exposes a 2-D path projection. AC's schema wants px/py/pz; keep the
+        # path in px/pz and make the absent elevation explicit instead of inventing it.
+        "px": px,
+        "py": 0.0,
+        "pz": pz,
+    }
+
+
+def reference_frames_from_payload(
+    payload: Mapping[str, Any],
+    *,
+    channel: str = "reference",
+) -> list[dict[str, float]]:
+    """Extract one Track Titan telemetry channel as object-style lap-archive frames."""
+    return [
+        _tt_frame_to_archive_frame(frame, i)
+        for i, frame in enumerate(_raw_trace(payload, channel=channel))
+    ]
+
+
+def merge_reference_frames(
+    payloads: list[Mapping[str, Any]],
+    *,
+    channel: str = "reference",
+) -> list[dict[str, float]]:
+    """Merge one or more retained TT telemetry windows deterministically.
+
+    ``lTime`` is the primary ordering key because it is lap-time absolute in the
+    live captures. ``dist`` remains the spatial integrity check performed by
+    :func:`reference_coverage`.
+    """
+    keyed: OrderedDict[tuple[float, float], dict[str, float]] = OrderedDict()
+    for payload_index, payload in enumerate(payloads):
+        frames = reference_frames_from_payload(payload, channel=channel)
+        last_time = -math.inf
+        for frame_index, frame in enumerate(frames):
+            if frame["eMs"] < last_time:
+                raise TTNormalizeError(
+                    f"payload {payload_index} telemetry time moves backward at frame {frame_index}"
+                )
+            last_time = frame["eMs"]
+            key = (round(frame["eMs"], 3), round(frame["spline"], 6))
+            keyed.setdefault(key, frame)
+    merged = sorted(keyed.values(), key=lambda f: (f["eMs"], f["spline"]))
+    if len(merged) < 2:
+        raise TTNormalizeError("Track Titan reference telemetry needs at least two samples")
+    return merged
+
+
+def reference_coverage(
+    frames: list[Mapping[str, Any]],
+    *,
+    max_spline_gap: float = DEFAULT_REFERENCE_MAX_SPLINE_GAP,
+    threshold: float = DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
+) -> ReferenceCoverage:
+    """Measure contiguous spline coverage for merged reference frames."""
+    if not frames:
+        raise TTNormalizeError("reference telemetry is empty")
+    splines = sorted(
+        {
+            _bounded01(frame.get("spline"), f"reference[{i}].spline")
+            for i, frame in enumerate(frames)
+        }
+    )
+    if len(splines) < 2:
+        raise TTNormalizeError("reference telemetry needs at least two distinct spline samples")
+    gaps = [b - a for a, b in zip(splines, splines[1:], strict=False)]
+    max_gap = max(gaps, default=1.0)
+    coverage = sum(gap for gap in gaps if gap <= max_spline_gap)
+    partial = coverage < threshold
+    return ReferenceCoverage(
+        samples=len(frames),
+        coverage=coverage,
+        min_spline=splines[0],
+        max_spline=splines[-1],
+        max_gap=max_gap,
+        partial=partial,
+    )
+
+
+def build_reference_archive(
+    payloads: list[Mapping[str, Any]],
+    *,
+    channel: str = "reference",
+    coverage_threshold: float = DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
+    max_spline_gap: float = DEFAULT_REFERENCE_MAX_SPLINE_GAP,
+    allow_partial: bool = False,
+    track_length_m: float = DEFAULT_TRACK_LENGTH_M,
+    exported_at: str | None = None,
+) -> dict[str, Any]:
+    """Build a schema-v1 lap archive from retained Track Titan reference telemetry.
+
+    By default this refuses partial stitched windows. ``allow_partial`` exists for
+    debugging capture coverage only; the emitted archive carries
+    ``generator.tt_reference.partial = true`` so runtime consumers can reject it.
+    """
+    if not payloads:
+        raise TTNormalizeError("no Track Titan payloads supplied")
+    frames = merge_reference_frames(payloads, channel=channel)
+    coverage = reference_coverage(
+        frames, max_spline_gap=max_spline_gap, threshold=coverage_threshold
+    )
+    if coverage.partial and not allow_partial:
+        raise TTNormalizeError(
+            "Track Titan reference telemetry is partial "
+            f"(coverage={coverage.coverage:.3f}, threshold={coverage_threshold:.3f}, "
+            f"min={coverage.min_spline:.3f}, max={coverage.max_spline:.3f}, "
+            f"max_gap={coverage.max_gap:.3f}); capture/stitch more segment windows "
+            "or pass --allow-partial for a debug-only archive"
+        )
+
+    session = _session_from_payload(payloads)
+    ref = _reference_lap_from_payload(payloads)
+    car_id = session.get("car") or session.get("car_id") or "track_titan_car"
+    track_id = session.get("track_id") or "track_titan_track"
+    lap_n = ref.get("lap_number") or session.get("lap_number") or 1
+    record = build_archive_record(
+        frames,
+        car_id=str(car_id),
+        track_id=str(track_id),
+        track_length_m=track_length_m,
+        lap_n=int(lap_n),
+        exported_at=exported_at,
+        generator_name="tools.tt_ingest.tt_normalize",
+    )
+    record["import_format"] = TT_REFERENCE_IMPORT_FORMAT
+    record["coaching"]["rules_hints"] = [
+        "Track Titan imported reference; provenance is personal own-account services export.",
+        "TT X/Y are preserved as a 2-D px/pz path projection; py is set to 0.0.",
+    ]
+    record["generator"]["decision_issue"] = 353
+    record["generator"]["tt_reference"] = {
+        "schema_version": 1,
+        "channel": channel,
+        "payload_count": len(payloads),
+        "partial": coverage.partial,
+        "coverage": coverage.coverage,
+        "coverage_threshold": coverage_threshold,
+        "min_spline": coverage.min_spline,
+        "max_spline": coverage.max_spline,
+        "max_spline_gap": coverage.max_gap,
+        "samples": coverage.samples,
+        "format": TT_REFERENCE_IMPORT_FORMAT,
+    }
+    return record


### PR DESCRIPTION
## Summary
- add the M-TT2 Track Titan reference normalizer that maps retained services telemetry into schema-v1 lap archives
- add `python -m tools.tt_ingest reference` for explicit input files or scoped lake discovery, with strict full-lap coverage and lap-time validation by default
- retain distinct same-lap `/last-session` segment windows with deterministic window filenames, and reject output paths that would overwrite retained TT inputs
- mark debug partial archives and prevent them from installing as live M0 observer references

## Verification
- focused: `.venv/bin/python -m pytest tests/test_tt_normalize.py tests/test_tt_ingest_cli.py tests/test_tt_reference_runtime_guard.py tests/test_realtime_observer.py -q` -> `79 passed`
- focused final guard: `.venv/bin/python -m pytest tests/test_tt_ingest_cli.py tests/test_tt_normalize.py -q` -> `55 passed`
- CLI trap check: strict mode refused the one-segment fixture; `--allow-partial` emitted a schema-valid debug archive marked `partial=True` and observer install returned false
- clean worktree: `make ci-fast PYTHON=/Users/arseny_gorokh/Projects/ac-copilot-trainer/.venv/bin/python` -> `1907 passed, 75 skipped`, coverage 85.47%, `ci-fast: OK`
- GitHub checks on `b6fcbaf`: CI, canonical docs, and conformance passed; fleet resolve gate reports no substantive findings hanging

## Notes
- M-TT2 still requires enough real retained TT windows to cover a lap before strict mode emits a production reference archive. A single `/last-session` segment window remains a rejected partial input by design.

Closes part of #353.