### PR TITLE
docs(vault): post-merge handoff for PR #399

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -57,9 +57,13 @@ relates_to:
 
 # Next session handoff
 
-## In flight (2026-06-30) — PR #399 Coach v2
+## Delivered (2026-06-30) — PR #399 MERGED: Coach v2 (#396)
 
-Merge-ready (OPEN) on [`2908fc6`](https://github.com/agorokh/ac-copilot-trainer/commit/2908fc61fed5a43f489f422671a9234751d6406b).
+PR [#399](https://github.com/agorokh/ac-copilot-trainer/pull/399) squash-merged to `main` as
+[`e41383e`](https://github.com/agorokh/ac-copilot-trainer/commit/e41383ebc600649ea429bbf72f641dd4a7072b28).
+Issue [#396](https://github.com/agorokh/ac-copilot-trainer/issues/396) is **CLOSED**.
+
+**Shipped:** Coach v2: real-time diagnosed, anticipatory in-ear coaching (replace post-hoc delta reporter).
 Detail: [[pr-399-coach-v2-review-loop-2026-06-30]].
 
 ## Delivered (2026-06-30) — PR #394 MERGED: voice reliability for packaged Game Point (#392)

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/pr-399-coach-v2-review-loop-2026-06-30.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/pr-399-coach-v2-review-loop-2026-06-30.md
@@ -13,8 +13,8 @@ relates_to:
 
 ## Status
 
-PR [#399](https://github.com/agorokh/ac-copilot-trainer/pull/399) is **OPEN, merge-ready** on head
-[`2908fc6`](https://github.com/agorokh/ac-copilot-trainer/commit/2908fc61fed5a43f489f422671a9234751d6406b)
+PR [#399](https://github.com/agorokh/ac-copilot-trainer/pull/399) is **MERGED** on head
+[`e41383e`](https://github.com/agorokh/ac-copilot-trainer/commit/e41383ebc600649ea429bbf72f641dd4a7072b28)
 (`feat/coach-v2-real-coaching`, closes #396). CI green (`build`, `Canonical docs exist`,
 `conformance`; `guard-and-automerge` skipped). GraphQL review threads resolved; resolve-gate clean.
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #399.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).