### PR TITLE
Implement setup intelligence loop (#407)

### DIFF
--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -198,6 +198,21 @@ def test_validate_inbound_accepts_known_types() -> None:
         is None
     )
     assert ep.validate_inbound({"v": 1, "type": "setup.suggest", "track_id": "magione"}) is None
+    assert (
+        ep.validate_inbound({"v": 1, "type": "setup.advice", "complaint": "loose on exit"}) is None
+    )
+    assert (
+        ep.validate_inbound(
+            {
+                "v": 1,
+                "type": "setup.diff",
+                "baseline_snapshot": {"FRONT_BIAS.VALUE": "66"},
+                "candidate_snapshot": {"FRONT_BIAS.VALUE": "64"},
+            }
+        )
+        is None
+    )
+    assert ep.validate_inbound({"v": 1, "type": "setup.closed_loop", "param": "FRONT_BIAS"}) is None
     assert ep.validate_inbound({"v": 1, "type": "se.search", "limit": 10}) is None
     assert (
         ep.validate_inbound(
@@ -247,6 +262,9 @@ def test_validate_inbound_rejects_invalid() -> None:
     )
     assert "store_path" in (ep.validate_inbound({"v": 1, "type": "setup.experiment.store"}) or "")
     assert "baseline_setup" in (ep.validate_inbound({"v": 1, "type": "setup.compare"}) or "")
+    assert "complaint" in (ep.validate_inbound({"v": 1, "type": "setup.advice"}) or "")
+    assert "baseline_snapshot" in (ep.validate_inbound({"v": 1, "type": "setup.diff"}) or "")
+    assert "param" in (ep.validate_inbound({"v": 1, "type": "setup.closed_loop"}) or "")
     assert "limit must be <= 40" in (
         ep.validate_inbound({"v": 1, "type": "se.search", "limit": 80}) or ""
     )
@@ -754,6 +772,110 @@ def test_setup_experiment_record_and_suggest_roundtrip(tmp_path: Path) -> None:
     assert result["type"] == ep.TYPE_SETUP_SUGGEST_RESULT
     assert result["ok"] is True
     assert result["candidate"]["changed_params"]
+
+
+def test_setup_advice_and_diff_roundtrip() -> None:
+    async def _run() -> tuple[dict, dict]:
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.advice",
+                            "complaint": "car is loose on exit",
+                            "car_id": "ks_porsche_911_gt3_r_2016",
+                            "track_id": "magione",
+                            "setup_snapshot": {
+                                "FRONT_BIAS.VALUE": "66",
+                                "TRACTION_CONTROL.VALUE": "3",
+                                "DIFF_POWER.VALUE": "40",
+                            },
+                        }
+                    )
+                )
+                advice = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.diff",
+                            "car_id": "ks_porsche_911_gt3_r_2016",
+                            "track_id": "magione",
+                            "baseline_snapshot": {
+                                "FRONT_BIAS.VALUE": "66",
+                                "TRACTION_CONTROL.VALUE": "3",
+                            },
+                            "candidate_snapshot": {
+                                "FRONT_BIAS.VALUE": "64",
+                                "TRACTION_CONTROL.VALUE": "4",
+                            },
+                        }
+                    )
+                )
+                diff = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                return advice, diff
+
+    advice, diff = asyncio.run(_run())
+    assert advice["type"] == ep.TYPE_SETUP_ADVICE_RESULT
+    assert advice["ok"] is True
+    assert advice["suggestions"][0]["section"] == "TRACTION_CONTROL"
+    assert advice["suggestions"][0]["target"] == 4.0
+    assert diff["type"] == ep.TYPE_SETUP_DIFF_RESULT
+    assert diff["ok"] is True
+    assert diff["changed_count"] == 2
+    assert any("Brake bias" in line for line in diff["display_lines"])
+
+
+def test_setup_closed_loop_roundtrip(tmp_path: Path) -> None:
+    async def _run() -> dict:
+        from tools.ai_sidecar import server as srv
+
+        srv._setup_experiment_store_path = None
+        lap_dir = tmp_path / "journal" / "laps"
+        first = _write_setup_lap(lap_dir, "lap-a", "old", 100_000, 64)
+        second = _write_setup_lap(lap_dir, "lap-b", "new", 98_000, 65)
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                for lap_path in (first, second):
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "v": 1,
+                                "type": "setup.experiment.record",
+                                "archive_path": str(lap_path),
+                            }
+                        )
+                    )
+                    ack = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                    assert ack["type"] == ep.TYPE_SETUP_EXPERIMENT_RECORD_ACK
+                    assert ack["ok"] is True
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.closed_loop",
+                            "param": "FRONT_BIAS",
+                            "car_id": "ks_porsche_911_gt3_r_2016",
+                            "track_id": "magione",
+                        }
+                    )
+                )
+                return json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+
+    result = asyncio.run(_run())
+    assert result["type"] == ep.TYPE_SETUP_CLOSED_LOOP_RESULT
+    assert result["ok"] is True
+    assert result["method"] == "one_param_measured_delta"
+    assert result["previous_result"]["measured_delta_ms"] == 2000.0
+    assert result["candidate"]["changed_params"]["FRONT_BIAS.VALUE"] == {
+        "from": 65.0,
+        "to": 66.0,
+    }
 
 
 def test_setup_experiment_store_registration_loads_rebuilt_rows(tmp_path: Path) -> None:

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -8,8 +8,17 @@ import types
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 import tools.rig_launcher.supervisor as supervisor_module
-from tools.rig_launcher.app import _open_path, config_from_args, run_gui, run_sidecar_child
+from tools.rig_launcher.app import (
+    _open_path,
+    config_from_args,
+    main,
+    render_setup_diff_lines,
+    run_gui,
+    run_sidecar_child,
+)
 from tools.rig_launcher.install import (
     SHORTCUT_NAME,
     default_exe_path,
@@ -717,6 +726,29 @@ def test_config_from_env_defaults_to_loopback_without_token(tmp_path: Path) -> N
         "127.0.0.1",
     ]
     assert {row.name: row for row in sup.preflight()}["sidecar_token"].state == "loopback"
+
+
+def test_launcher_setup_diff_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    baseline = tmp_path / "baseline.ini"
+    candidate = tmp_path / "candidate.ini"
+    baseline.write_text(
+        "[FRONT_BIAS]\nVALUE=66\n[TRACTION_CONTROL]\nVALUE=3\n",
+        encoding="utf-8",
+    )
+    candidate.write_text(
+        "[FRONT_BIAS]\nVALUE=64\n[TRACTION_CONTROL]\nVALUE=4\n",
+        encoding="utf-8",
+    )
+
+    assert main(["--setup-diff", str(baseline), str(candidate), "--json"]) == 0
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["changed_count"] == 2
+    assert any("Brake bias" in line for line in out["display_lines"])
+    lines = render_setup_diff_lines(out)
+    assert lines[0] == "setup diff: 2 changed knobs"
+    assert any(str(candidate) in line for line in lines)
 
 
 def test_direct_config_default_is_loopback_safe(tmp_path: Path) -> None:

--- a/tests/test_setup_advisor.py
+++ b/tests/test_setup_advisor.py
@@ -1,0 +1,90 @@
+"""Tests for complaint-language setup advice and setup diffs."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.setup_advisor import advise_from_complaint, setup_diff_summary
+from tools.ai_sidecar.setup_model import from_snapshot
+
+GT3_SNAPSHOT = {
+    "FRONT_BIAS.VALUE": "66",
+    "ABS.VALUE": "7",
+    "TRACTION_CONTROL.VALUE": "3",
+    "BRAKE_POWER_MULT.VALUE": "100",
+    "WING_1.VALUE": "2",
+    "WING_2.VALUE": "20",
+    "ARB_FRONT.VALUE": "5",
+    "ARB_REAR.VALUE": "3",
+    "DIFF_POWER.VALUE": "40",
+    "DIFF_COAST.VALUE": "20",
+}
+
+
+def test_exit_loose_complaint_maps_to_ranked_setup_changes() -> None:
+    out = advise_from_complaint(
+        "car is loose on exit",
+        setup_snapshot=GT3_SNAPSHOT,
+        car_id="ks_porsche_911_gt3_r_2016",
+        track_id="magione",
+    )
+
+    assert out["ok"] is True
+    assert out["parsed"] == {"issue": "oversteer", "phase": "exit", "speed_hint": None}
+    first = out["suggestions"][0]
+    assert first["section"] == "TRACTION_CONTROL"
+    assert first["direction"] == "increase"
+    assert first["current"] == 3.0
+    assert first["target"] == 4.0
+    assert "wheelspin" in first["reason"]
+    assert first["effect"]
+
+
+def test_front_locks_complaint_gets_911_bias_caution() -> None:
+    out = advise_from_complaint(
+        "front locks on entry",
+        setup_snapshot=GT3_SNAPSHOT,
+        car_id="ks_porsche_911_gt3_r_2016",
+    )
+
+    assert out["ok"] is True
+    assert out["parsed"]["issue"] == "lockup_front"
+    first = out["suggestions"][0]
+    assert first["section"] == "FRONT_BIAS"
+    assert first["direction"] == "decrease"
+    assert first["target"] == 65.0
+    assert any("911" in note for note in first["caution"])
+
+
+def test_high_speed_understeer_prefers_aero_lever() -> None:
+    out = advise_from_complaint(
+        "high speed understeer mid corner",
+        setup_snapshot=GT3_SNAPSHOT,
+        car_id="ks_porsche_911_gt3_r_2016",
+    )
+
+    assert out["ok"] is True
+    sections = [suggestion["section"] for suggestion in out["suggestions"]]
+    assert sections.index("WING_1") < sections.index("ARB_FRONT")
+
+
+def test_setup_diff_summary_returns_display_ready_rows() -> None:
+    baseline = from_snapshot(GT3_SNAPSHOT, car_id="ks_porsche_911_gt3_r_2016")
+    candidate = from_snapshot(
+        {
+            **GT3_SNAPSHOT,
+            "FRONT_BIAS.VALUE": "64",
+            "TRACTION_CONTROL.VALUE": "4",
+        },
+        car_id="ks_porsche_911_gt3_r_2016",
+    )
+
+    out = setup_diff_summary(baseline, candidate)
+
+    assert out["ok"] is True
+    assert out["changed_count"] == 2
+    first = out["rows"][0]
+    assert first["section"] == "FRONT_BIAS"
+    assert first["direction"] == "decrease"
+    assert first["from"] == 66.0
+    assert first["to"] == 64.0
+    assert "Brake bias" in first["display"]
+    assert out["display_lines"][0] == first["display"]

--- a/tests/test_setup_optimizer.py
+++ b/tests/test_setup_optimizer.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from tools.ai_sidecar.server import (
+    _run_setup_closed_loop,
     _run_setup_compare,
     _run_setup_rebuild,
     _run_setup_suggest,
@@ -21,6 +22,7 @@ from tools.ai_sidecar.setup_optimizer import (
     rebuild_experiments,
     record_from_lap_archive,
     record_lap_archive,
+    suggest_closed_loop,
     suggest_next_setup,
 )
 
@@ -171,6 +173,80 @@ def test_candidate_grid_clamps_nonnegative_params() -> None:
     assert all(candidate["FRONT_BIAS.VALUE"] >= 0 for candidate in grid)
 
 
+def test_closed_loop_continues_improving_one_parameter_move() -> None:
+    records = [
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-a1",
+                setup_hash="old",
+                setup_name="baseline",
+                lap_ms=100_000,
+                front_bias=64,
+                rear_wing=8,
+            )
+        ),
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-b2",
+                setup_hash="new",
+                setup_name="candidate",
+                lap_ms=98_000,
+                front_bias=65,
+                rear_wing=8,
+            )
+        ),
+    ]
+
+    suggestion = suggest_closed_loop(
+        records,
+        param="FRONT_BIAS",
+        car_id="ks_porsche_911_gt3_r_2016",
+        track_id="magione",
+    )
+
+    assert suggestion["ok"] is True
+    assert suggestion["method"] == "one_param_measured_delta"
+    assert suggestion["previous_result"]["measured_delta_ms"] == 2000.0
+    assert suggestion["candidate"]["changed_params"]["FRONT_BIAS.VALUE"] == {
+        "from": 65.0,
+        "to": 66.0,
+    }
+
+
+def test_closed_loop_reverses_hurting_one_parameter_move() -> None:
+    records = [
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-a1",
+                setup_hash="old",
+                setup_name="baseline",
+                lap_ms=100_000,
+                front_bias=64,
+                rear_wing=8,
+            )
+        ),
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-b2",
+                setup_hash="new",
+                setup_name="candidate",
+                lap_ms=101_000,
+                front_bias=65,
+                rear_wing=8,
+            )
+        ),
+    ]
+
+    suggestion = suggest_closed_loop(records, param="FRONT_BIAS")
+
+    assert suggestion["ok"] is True
+    assert suggestion["previous_result"]["improved"] is False
+    assert suggestion["candidate"]["changed_params"]["FRONT_BIAS.VALUE"] == {
+        "from": 65.0,
+        "to": 64.0,
+    }
+
+
 def test_record_lap_archive_upserts_without_duplicates(tmp_path: Path) -> None:
     lap_dir = tmp_path / "journal" / "laps"
     path = _write_laps(lap_dir)[0]
@@ -263,3 +339,13 @@ def test_setup_optimizer_cli_smoke(tmp_path: Path, capsys) -> None:
     suggest_out = json.loads(capsys.readouterr().out)
     assert suggest_out["ok"] is True
     assert suggest_out["candidate"]["changed_params"]
+
+    _run_setup_closed_loop(str(store), "WING_2", "ks_porsche_911_gt3_r_2016", "magione")
+    closed_loop_out = json.loads(capsys.readouterr().out)
+    assert closed_loop_out["ok"] is True
+    assert closed_loop_out["method"] == "one_param_measured_delta"
+    assert closed_loop_out["previous_result"]["measured_delta_ms"] == -1100.0
+    assert closed_loop_out["candidate"]["changed_params"]["WING_2.VALUE"] == {
+        "from": 10.0,
+        "to": 9.0,
+    }

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -68,6 +68,9 @@ TYPE_SETUP_EXPERIMENT_STORE = "setup.experiment.store"
 TYPE_SETUP_EXPERIMENT_RECORD = "setup.experiment.record"
 TYPE_SETUP_COMPARE = "setup.compare"
 TYPE_SETUP_SUGGEST = "setup.suggest"
+TYPE_SETUP_ADVICE = "setup.advice"
+TYPE_SETUP_DIFF = "setup.diff"
+TYPE_SETUP_CLOSED_LOOP = "setup.closed_loop"
 TYPE_SETUP_EXCHANGE_SEARCH = "se.search"
 TYPE_SETUP_EXCHANGE_DOWNLOAD = "se.download"
 
@@ -87,6 +90,9 @@ TYPE_SETUP_EXPERIMENT_STORE_ACK = "setup.experiment.store.ack"
 TYPE_SETUP_EXPERIMENT_RECORD_ACK = "setup.experiment.record.ack"
 TYPE_SETUP_COMPARE_RESULT = "setup.compare.result"
 TYPE_SETUP_SUGGEST_RESULT = "setup.suggest.result"
+TYPE_SETUP_ADVICE_RESULT = "setup.advice.result"
+TYPE_SETUP_DIFF_RESULT = "setup.diff.result"
+TYPE_SETUP_CLOSED_LOOP_RESULT = "setup.closed_loop.result"
 TYPE_SETUP_EXCHANGE_SEARCH_RESULT = "se.search.result"
 TYPE_SETUP_EXCHANGE_DOWNLOAD_ACK = "se.download.ack"
 # Issue #118: high-rate physical-peripheral frames. `telemetry_tick` is sent
@@ -125,6 +131,9 @@ SERVER_CAPABILITIES: tuple[str, ...] = (
     TYPE_STATE_SUBSCRIBE,
     TYPE_SETUP_COMPARE,
     TYPE_SETUP_SUGGEST,
+    TYPE_SETUP_ADVICE,
+    TYPE_SETUP_DIFF,
+    TYPE_SETUP_CLOSED_LOOP,
     TYPE_SETUP_EXCHANGE_SEARCH,
     TYPE_SETUP_EXCHANGE_DOWNLOAD,
     TYPE_SETUP_SPINNER_LIST,
@@ -293,6 +302,12 @@ def _validate_optional_number(
 def _validate_optional_string(frame: dict[str, Any], key: str) -> str | None:
     if key in frame and not isinstance(frame.get(key), str):
         return f"{key} must be a string"
+    return None
+
+
+def _validate_optional_object(frame: dict[str, Any], key: str) -> str | None:
+    if key in frame and not isinstance(frame.get(key), dict):
+        return f"{key} requires an object"
     return None
 
 
@@ -504,6 +519,33 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
             if key in frame and not isinstance(frame.get(key), str):
                 return f"setup.suggest optional '{key}' must be a string"
         return None
+    if t == TYPE_SETUP_ADVICE:
+        complaint = frame.get("complaint")
+        if not isinstance(complaint, str) or not complaint.strip():
+            return "setup.advice requires non-empty 'complaint'"
+        for key in ("car_id", "track_id"):
+            err = _validate_optional_string(frame, key)
+            if err is not None:
+                return err
+        return _validate_optional_object(frame, "setup_snapshot")
+    if t == TYPE_SETUP_DIFF:
+        for key in ("baseline_snapshot", "candidate_snapshot"):
+            if not isinstance(frame.get(key), dict):
+                return f"setup.diff requires object '{key}'"
+        for key in ("car_id", "track_id"):
+            err = _validate_optional_string(frame, key)
+            if err is not None:
+                return err
+        return None
+    if t == TYPE_SETUP_CLOSED_LOOP:
+        param = frame.get("param")
+        if not isinstance(param, str) or not param.strip():
+            return "setup.closed_loop requires non-empty 'param'"
+        for key in ("car_id", "track_id"):
+            err = _validate_optional_string(frame, key)
+            if err is not None:
+                return err
+        return None
     if t == TYPE_SETUP_EXCHANGE_SEARCH:
         for key in ("car_id", "track_id", "search", "order_by"):
             err = _validate_optional_string(frame, key)
@@ -542,6 +584,9 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
         TYPE_SETUP_EXPERIMENT_RECORD_ACK,
         TYPE_SETUP_COMPARE_RESULT,
         TYPE_SETUP_SUGGEST_RESULT,
+        TYPE_SETUP_ADVICE_RESULT,
+        TYPE_SETUP_DIFF_RESULT,
+        TYPE_SETUP_CLOSED_LOOP_RESULT,
         TYPE_SETUP_EXCHANGE_SEARCH_RESULT,
         TYPE_SETUP_EXCHANGE_DOWNLOAD_ACK,
     ):

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -50,8 +50,14 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_HELLO,
     TYPE_HELLO_ACK,
     TYPE_KEY,
+    TYPE_SETUP_ADVICE,
+    TYPE_SETUP_ADVICE_RESULT,
+    TYPE_SETUP_CLOSED_LOOP,
+    TYPE_SETUP_CLOSED_LOOP_RESULT,
     TYPE_SETUP_COMPARE,
     TYPE_SETUP_COMPARE_RESULT,
+    TYPE_SETUP_DIFF,
+    TYPE_SETUP_DIFF_RESULT,
     TYPE_SETUP_EXCHANGE_DOWNLOAD,
     TYPE_SETUP_EXCHANGE_DOWNLOAD_ACK,
     TYPE_SETUP_EXCHANGE_SEARCH,
@@ -102,6 +108,12 @@ from tools.ai_sidecar.se_proxy import (
     validate_user_setups_root,
 )
 from tools.ai_sidecar.session import LapComparisonState
+from tools.ai_sidecar.setup_advisor import (
+    advise_from_complaint,
+    diff_setup_files,
+    setup_diff_summary,
+)
+from tools.ai_sidecar.setup_model import from_snapshot, load_setup_file
 from tools.ai_sidecar.setup_optimizer import (
     SetupExperimentError,
     compare_setups,
@@ -109,6 +121,7 @@ from tools.ai_sidecar.setup_optimizer import (
     load_records,
     rebuild_experiments,
     record_lap_archive,
+    suggest_closed_loop,
     suggest_next_setup,
 )
 
@@ -310,6 +323,9 @@ CLIENT_TO_SERVER_TYPES = frozenset(
         TYPE_SETUP_EXPERIMENT_RECORD,
         TYPE_SETUP_COMPARE,
         TYPE_SETUP_SUGGEST,
+        TYPE_SETUP_ADVICE,
+        TYPE_SETUP_DIFF,
+        TYPE_SETUP_CLOSED_LOOP,
         TYPE_SETUP_EXCHANGE_SEARCH,
         TYPE_SETUP_EXCHANGE_DOWNLOAD,
     }
@@ -335,6 +351,9 @@ SERVER_TO_CLIENT_TYPES = frozenset(
         TYPE_SETUP_EXPERIMENT_RECORD_ACK,
         TYPE_SETUP_COMPARE_RESULT,
         TYPE_SETUP_SUGGEST_RESULT,
+        TYPE_SETUP_ADVICE_RESULT,
+        TYPE_SETUP_DIFF_RESULT,
+        TYPE_SETUP_CLOSED_LOOP_RESULT,
         TYPE_SETUP_EXCHANGE_SEARCH_RESULT,
         TYPE_SETUP_EXCHANGE_DOWNLOAD_ACK,
     }
@@ -345,6 +364,9 @@ SIDECAR_LOCAL_TYPES = frozenset(
         TYPE_SETUP_EXPERIMENT_RECORD,
         TYPE_SETUP_COMPARE,
         TYPE_SETUP_SUGGEST,
+        TYPE_SETUP_ADVICE,
+        TYPE_SETUP_DIFF,
+        TYPE_SETUP_CLOSED_LOOP,
         TYPE_SETUP_EXCHANGE_SEARCH,
         TYPE_SETUP_EXCHANGE_DOWNLOAD,
     }
@@ -442,6 +464,41 @@ def _run_setup_suggest(store_path: str, car_id: str | None, track_id: str | None
     print(json.dumps(out, indent=2, sort_keys=True))
 
 
+def _run_setup_closed_loop(
+    store_path: str,
+    param: str,
+    car_id: str | None,
+    track_id: str | None,
+) -> None:
+    out = suggest_closed_loop(
+        load_records(store_path),
+        param=param,
+        car_id=car_id,
+        track_id=track_id,
+    )
+    print(json.dumps(out, indent=2, sort_keys=True))
+
+
+def _run_setup_advice(
+    complaint: str,
+    setup_file: str | None,
+    car_id: str | None,
+    track_id: str | None,
+) -> None:
+    setup = load_setup_file(setup_file) if setup_file else None
+    out = advise_from_complaint(
+        complaint,
+        setup=setup,
+        car_id=car_id,
+        track_id=track_id,
+    )
+    print(json.dumps(out, indent=2, sort_keys=True))
+
+
+def _run_setup_diff(baseline: str, candidate: str) -> None:
+    print(json.dumps(diff_setup_files(baseline, candidate), indent=2, sort_keys=True))
+
+
 def _setup_store_record_count(store_path: str | Path) -> int:
     return len(load_records(store_path))
 
@@ -470,6 +527,21 @@ def _suggest_setup_store(
     track_id: str | None,
 ) -> dict[str, Any]:
     return suggest_next_setup(load_records(store_path), car_id=car_id, track_id=track_id)
+
+
+def _closed_loop_setup_store(
+    store_path: str | Path,
+    *,
+    param: str,
+    car_id: str | None,
+    track_id: str | None,
+) -> dict[str, Any]:
+    return suggest_closed_loop(
+        load_records(store_path),
+        param=param,
+        car_id=car_id,
+        track_id=track_id,
+    )
 
 
 def _user_setups_root_from_config(path: str | None) -> Path | None:
@@ -915,6 +987,57 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
     global _setup_experiment_store_path, _setup_experiment_store_seeded
 
     t = data.get(TYPE_KEY)
+    if t == TYPE_SETUP_ADVICE:
+        snapshot = data.get("setup_snapshot")
+        try:
+            out = await asyncio.to_thread(
+                advise_from_complaint,
+                str(data.get("complaint") or ""),
+                setup_snapshot=snapshot if isinstance(snapshot, dict) else None,
+                car_id=data.get("car_id"),
+                track_id=data.get("track_id"),
+            )
+        except Exception as e:
+            logger.info("setup advice failed err=%s", e)
+            out = {"ok": False, "error": str(e)}
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: TYPE_SETUP_ADVICE_RESULT,
+                **out,
+            },
+        )
+        return
+
+    if t == TYPE_SETUP_DIFF:
+        baseline_snapshot = data.get("baseline_snapshot")
+        candidate_snapshot = data.get("candidate_snapshot")
+        try:
+            baseline = from_snapshot(
+                baseline_snapshot if isinstance(baseline_snapshot, dict) else {},
+                car_id=data.get("car_id"),
+                track_id=data.get("track_id"),
+            )
+            candidate = from_snapshot(
+                candidate_snapshot if isinstance(candidate_snapshot, dict) else {},
+                car_id=data.get("car_id"),
+                track_id=data.get("track_id"),
+            )
+            out = await asyncio.to_thread(setup_diff_summary, baseline, candidate)
+        except Exception as e:
+            logger.info("setup diff failed err=%s", e)
+            out = {"ok": False, "error": str(e)}
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: TYPE_SETUP_DIFF_RESULT,
+                **out,
+            },
+        )
+        return
+
     if t == TYPE_SETUP_EXPERIMENT_STORE:
         if not _is_loopback_peer(websocket):
             await _safe_send(
@@ -1027,15 +1150,17 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
 
     store_path = _setup_experiment_store_path
     if store_path is None:
+        if t == TYPE_SETUP_COMPARE:
+            result_type = TYPE_SETUP_COMPARE_RESULT
+        elif t == TYPE_SETUP_CLOSED_LOOP:
+            result_type = TYPE_SETUP_CLOSED_LOOP_RESULT
+        else:
+            result_type = TYPE_SETUP_SUGGEST_RESULT
         await _safe_send(
             websocket,
             {
                 ENVELOPE_KEY: ENVELOPE_VERSION,
-                TYPE_KEY: (
-                    TYPE_SETUP_COMPARE_RESULT
-                    if t == TYPE_SETUP_COMPARE
-                    else TYPE_SETUP_SUGGEST_RESULT
-                ),
+                TYPE_KEY: result_type,
                 "ok": False,
                 "error": "no setup experiment store is loaded yet",
             },
@@ -1080,6 +1205,29 @@ async def _handle_setup_experiment_frame(websocket: Any, data: dict[str, Any]) -
             {
                 ENVELOPE_KEY: ENVELOPE_VERSION,
                 TYPE_KEY: TYPE_SETUP_SUGGEST_RESULT,
+                "store_path": str(store_path),
+                **out,
+            },
+        )
+        return
+
+    if t == TYPE_SETUP_CLOSED_LOOP:
+        try:
+            out = await asyncio.to_thread(
+                _closed_loop_setup_store,
+                store_path,
+                param=str(data.get("param") or ""),
+                car_id=data.get("car_id"),
+                track_id=data.get("track_id"),
+            )
+        except Exception as e:
+            logger.info("setup closed-loop failed store=%s err=%s", store_path, e)
+            out = {"ok": False, "error": str(e)}
+        await _safe_send(
+            websocket,
+            {
+                ENVELOPE_KEY: ENVELOPE_VERSION,
+                TYPE_KEY: TYPE_SETUP_CLOSED_LOOP_RESULT,
                 "store_path": str(store_path),
                 **out,
             },
@@ -1835,6 +1983,30 @@ def main() -> None:
         help="Return the next setup candidate from --setup-store and exit.",
     )
     p.add_argument(
+        "--setup-closed-loop",
+        metavar="PARAM",
+        help=(
+            "Return the next one-parameter setup move from --setup-store, informed by the latest "
+            "measured delta for PARAM."
+        ),
+    )
+    p.add_argument(
+        "--setup-advice",
+        metavar="COMPLAINT",
+        help="Map a driver handling complaint to ranked setup changes and exit.",
+    )
+    p.add_argument(
+        "--setup-file",
+        metavar="SETUP_INI",
+        help="Optional current setup INI for --setup-advice.",
+    )
+    p.add_argument(
+        "--setup-diff",
+        nargs=2,
+        metavar=("BASELINE_INI", "CANDIDATE_INI"),
+        help="Compare two setup INI files and print display-ready diff rows.",
+    )
+    p.add_argument(
         "--setup-car-id", default=None, help="Optional car id filter for --setup-suggest."
     )
     p.add_argument(
@@ -1959,6 +2131,27 @@ def main() -> None:
         if not args.setup_store:
             raise SystemExit("--setup-suggest requires --setup-store")
         _run_setup_suggest(args.setup_store, args.setup_car_id, args.setup_track_id)
+        return
+    if args.setup_closed_loop:
+        if not args.setup_store:
+            raise SystemExit("--setup-closed-loop requires --setup-store")
+        _run_setup_closed_loop(
+            args.setup_store,
+            args.setup_closed_loop,
+            args.setup_car_id,
+            args.setup_track_id,
+        )
+        return
+    if args.setup_advice:
+        _run_setup_advice(
+            args.setup_advice,
+            args.setup_file,
+            args.setup_car_id,
+            args.setup_track_id,
+        )
+        return
+    if args.setup_diff:
+        _run_setup_diff(args.setup_diff[0], args.setup_diff[1])
         return
     reply = not args.no_reply
 

--- a/tools/ai_sidecar/setup_advisor.py
+++ b/tools/ai_sidecar/setup_advisor.py
@@ -1,0 +1,536 @@
+"""Complaint-language setup advice and display-ready setup diffs.
+
+This module is the thin product surface over the existing setup intelligence
+building blocks: :mod:`setup_model` gives typed setup values and
+:mod:`setup_knowledge` supplies the verified GT3 parameter effects.  The
+functions here are deterministic and stdlib-only so the sidecar can answer a
+driver's "the car is loose on exit" request without involving an LLM.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tools.ai_sidecar.car_schema import CarSetupSchema
+from tools.ai_sidecar.setup_knowledge import AERO, MECHANICAL, effect_for
+from tools.ai_sidecar.setup_model import CarSetup, from_snapshot, load_setup_file, spec_for
+
+MAX_COMPLAINT_LEN = 240
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+_PORSCHE_911_IDS = ("ks_porsche_911_gt3_r_2016", "porsche_911", "911_gt3")
+
+_DEFAULT_STEPS: dict[str, float] = {
+    "FRONT_BIAS": 1.0,
+    "ABS": 1.0,
+    "TRACTION_CONTROL": 1.0,
+    "BRAKE_POWER_MULT": 5.0,
+    "WING_1": 1.0,
+    "WING_2": 1.0,
+    "ARB_FRONT": 1.0,
+    "ARB_REAR": 1.0,
+    "DIFF_POWER": 5.0,
+    "DIFF_COAST": 5.0,
+    "FINAL_RATIO": 1.0,
+    "PRESSURE": 0.5,
+    "CAMBER": 0.1,
+    "TOE_OUT": 0.05,
+    "SPRING_RATE": 1.0,
+    "ROD_LENGTH": 1.0,
+}
+
+_PRIORITY: tuple[str, ...] = (
+    "FRONT_BIAS",
+    "BRAKE_POWER_MULT",
+    "ABS",
+    "TRACTION_CONTROL",
+    "WING_1",
+    "WING_2",
+    "ARB_FRONT",
+    "ARB_REAR",
+    "DIFF_POWER",
+    "DIFF_COAST",
+    "PRESSURE_LF",
+    "PRESSURE_RF",
+    "PRESSURE_LR",
+    "PRESSURE_RR",
+    "CAMBER_LF",
+    "CAMBER_RF",
+    "CAMBER_LR",
+    "CAMBER_RR",
+    "TOE_OUT_LF",
+    "TOE_OUT_RF",
+    "TOE_OUT_LR",
+    "TOE_OUT_RR",
+    "SPRING_RATE_LF",
+    "SPRING_RATE_RF",
+    "SPRING_RATE_LR",
+    "SPRING_RATE_RR",
+    "FINAL_RATIO",
+)
+
+
+@dataclass(frozen=True)
+class ComplaintMove:
+    section: str
+    direction: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class ComplaintRule:
+    issue: str
+    phase: str
+    moves: tuple[ComplaintMove, ...]
+
+
+_RULES: tuple[ComplaintRule, ...] = (
+    ComplaintRule(
+        "understeer",
+        "entry",
+        (
+            ComplaintMove("FRONT_BIAS", -1, "free entry rotation while trail braking"),
+            ComplaintMove("DIFF_COAST", -1, "freer coast diff helps the car rotate off-throttle"),
+            ComplaintMove("ARB_FRONT", -1, "softer front bar adds mechanical front grip"),
+            ComplaintMove("WING_1", 1, "if it only pushes in fast entries, add front aero"),
+        ),
+    ),
+    ComplaintRule(
+        "understeer",
+        "mid",
+        (
+            ComplaintMove("ARB_FRONT", -1, "add all-speed front mechanical grip"),
+            ComplaintMove("ARB_REAR", 1, "shift mechanical balance rearward for more rotation"),
+            ComplaintMove("WING_1", 1, "if the push is high-speed only, add front aero"),
+            ComplaintMove("PRESSURE_LF", -1, "trim front pressure if hot pressure is high"),
+            ComplaintMove("PRESSURE_RF", -1, "match the front axle pressure change"),
+        ),
+    ),
+    ComplaintRule(
+        "understeer",
+        "exit",
+        (
+            ComplaintMove("DIFF_POWER", -1, "open the power diff to reduce power-on push"),
+            ComplaintMove("ARB_FRONT", -1, "soften front bar if the push exists before throttle"),
+            ComplaintMove(
+                "TRACTION_CONTROL", -1, "if TC is cutting hard, reduce intervention one step"
+            ),
+        ),
+    ),
+    ComplaintRule(
+        "oversteer",
+        "entry",
+        (
+            ComplaintMove(
+                "FRONT_BIAS", 1, "move bias forward if the rear is nervous under braking"
+            ),
+            ComplaintMove("DIFF_COAST", 1, "more coast lock calms lift/trail-brake rotation"),
+            ComplaintMove("ARB_REAR", -1, "softer rear bar adds rear mechanical grip"),
+            ComplaintMove("WING_2", 1, "if it snaps in fast entries, add rear aero"),
+        ),
+    ),
+    ComplaintRule(
+        "oversteer",
+        "mid",
+        (
+            ComplaintMove("ARB_REAR", -1, "softer rear bar adds mid-corner rear grip"),
+            ComplaintMove("ARB_FRONT", 1, "stiffer front bar shifts balance safer"),
+            ComplaintMove("WING_2", 1, "if the snap is high-speed only, add rear aero"),
+        ),
+    ),
+    ComplaintRule(
+        "oversteer",
+        "exit",
+        (
+            ComplaintMove("TRACTION_CONTROL", 1, "catch exit wheelspin earlier"),
+            ComplaintMove("DIFF_POWER", 1, "more power lock stabilizes straight-line drive"),
+            ComplaintMove("ARB_REAR", -1, "softer rear bar improves rear grip before throttle"),
+            ComplaintMove("WING_2", 1, "add rear aero only for genuinely fast exits"),
+        ),
+    ),
+    ComplaintRule(
+        "lockup_front",
+        "braking",
+        (
+            ComplaintMove("FRONT_BIAS", -1, "front lock means the bias is too far forward"),
+            ComplaintMove("BRAKE_POWER_MULT", -1, "lower bite if both fronts still lock"),
+            ComplaintMove("ABS", 1, "raise ABS one level as a safety net"),
+        ),
+    ),
+    ComplaintRule(
+        "lockup_rear",
+        "braking",
+        (
+            ComplaintMove("FRONT_BIAS", 1, "rear lock means the bias is too far rearward"),
+            ComplaintMove("BRAKE_POWER_MULT", -1, "reduce bite if the car locks both axles"),
+            ComplaintMove("ABS", 1, "raise ABS one level as a safety net"),
+        ),
+    ),
+    ComplaintRule(
+        "lockup",
+        "braking",
+        (
+            ComplaintMove("BRAKE_POWER_MULT", -1, "reduce bite until lockups are controllable"),
+            ComplaintMove("ABS", 1, "raise ABS one level if lockups are frequent"),
+            ComplaintMove("FRONT_BIAS", -1, "if the fronts lock first, move bias rearward"),
+        ),
+    ),
+    ComplaintRule(
+        "wheelspin",
+        "exit",
+        (
+            ComplaintMove("TRACTION_CONTROL", 1, "catch drive-wheel slip earlier"),
+            ComplaintMove("DIFF_POWER", 1, "more power lock reduces inside-wheel spin"),
+            ComplaintMove("FINAL_RATIO", -1, "longer gearing softens torque spikes"),
+            ComplaintMove("ARB_REAR", -1, "add rear mechanical grip before the power phase"),
+        ),
+    ),
+    ComplaintRule(
+        "instability",
+        "kerb",
+        (
+            ComplaintMove("ARB_REAR", -1, "soften the rear bar for kerb compliance"),
+            ComplaintMove("ARB_FRONT", -1, "soften the front bar if it skips across kerbs"),
+            ComplaintMove("SPRING_RATE_LR", -1, "soften rear spring rate one click if available"),
+            ComplaintMove("SPRING_RATE_RR", -1, "match the rear spring-rate move"),
+        ),
+    ),
+)
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_WORD_RE.findall(text.lower()))
+
+
+def _has_phrase(text: str, *phrases: str) -> bool:
+    low = " ".join(_WORD_RE.findall(text.lower()))
+    return any(phrase in low for phrase in phrases)
+
+
+def _parse_issue(text: str) -> str | None:
+    words = _tokens(text)
+    lock_words = {"lock", "locks", "locking", "lockup"}
+    if "front" in words and words & lock_words:
+        return "lockup_front"
+    if "rear" in words and words & lock_words:
+        return "lockup_rear"
+    if (lock_words | {"flatspot", "flatspots"}) & words:
+        return "lockup"
+    if (
+        _has_phrase(text, "wheel spin", "wheelspin")
+        or {
+            "traction",
+            "spin",
+            "spinning",
+            "lights",
+        }
+        & words
+    ):
+        return "wheelspin"
+    if {"understeer", "push", "pushing", "washes", "wash", "plough", "plow"} & words or _has_phrase(
+        text, "wont turn", "won t turn", "doesnt turn", "doesn t turn"
+    ):
+        return "understeer"
+    if {"oversteer", "loose", "snap", "snappy", "tail", "rear"} & words or _has_phrase(
+        text, "steps out", "stepping out", "rear steps"
+    ):
+        return "oversteer"
+    if {"kerb", "curb", "bump", "bumpy", "unstable", "nervous", "darty"} & words:
+        return "instability"
+    return None
+
+
+def _parse_phase(text: str, issue: str | None) -> str:
+    words = _tokens(text)
+    if {"kerb", "curb", "bump", "bumpy"} & words:
+        return "kerb"
+    if {"exit", "power", "throttle", "traction"} & words or _has_phrase(text, "corner exit"):
+        return "exit"
+    if {"entry", "turn", "turnin", "turn-in", "braking", "brake", "trail"} & words:
+        return "entry" if issue not in {"lockup", "lockup_front", "lockup_rear"} else "braking"
+    if {"mid", "apex", "middle", "center", "centre"} & words or _has_phrase(text, "mid corner"):
+        return "mid"
+    if issue in {"lockup", "lockup_front", "lockup_rear"}:
+        return "braking"
+    if issue == "wheelspin":
+        return "exit"
+    if issue == "instability":
+        return "kerb"
+    return "mid"
+
+
+def _parse_speed_hint(text: str) -> str | None:
+    words = _tokens(text)
+    if {"fast", "high", "speed", "aero"} & words or _has_phrase(text, "high speed"):
+        return "high"
+    if {"slow", "hairpin", "low"} & words or _has_phrase(text, "low speed"):
+        return "low"
+    return None
+
+
+def _base_section(section: str) -> str:
+    sec = section.strip().upper()
+    if sec.endswith(".VALUE"):
+        sec = sec[:-6]
+    for suffix in ("_LF", "_RF", "_LR", "_RR"):
+        if sec.endswith(suffix):
+            stem = sec[: -len(suffix)]
+            return stem if stem in _DEFAULT_STEPS else sec
+    return sec
+
+
+def _param_key(section: str) -> str:
+    sec = section.strip().upper()
+    return sec if sec.endswith(".VALUE") else f"{sec}.VALUE"
+
+
+def _step_for(section: str, schema: CarSetupSchema | None) -> float:
+    if schema is not None:
+        sp = schema.get(section)
+        if sp is not None and sp.step is not None and sp.step > 0:
+            return float(sp.step)
+    return _DEFAULT_STEPS.get(_base_section(section), 1.0)
+
+
+def _is_911(car_id: str | None) -> bool:
+    low = (car_id or "").lower()
+    return any(marker in low for marker in _PORSCHE_911_IDS)
+
+
+def _format_value(value: float | int | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(int(value)) if float(value).is_integer() else f"{float(value):g}"
+
+
+def _decoded(
+    schema: CarSetupSchema | None, section: str, value: float | None
+) -> float | str | None:
+    if schema is None or value is None:
+        return value
+    return schema.decode(section, value)
+
+
+def _move_to_suggestion(
+    move: ComplaintMove,
+    *,
+    setup: CarSetup,
+    schema: CarSetupSchema | None,
+    rank: int,
+) -> dict[str, Any]:
+    section = move.section.strip().upper()
+    spec = spec_for(section)
+    effect = effect_for(section)
+    current = setup.value(section)
+    step = _step_for(section, schema)
+    delta = move.direction * step
+    target = None
+    if current is not None:
+        target = current + delta
+        if schema is not None:
+            target = schema.clamp(section, target)
+        elif target < 0:
+            target = 0.0
+    direction = "increase" if move.direction > 0 else "decrease"
+    effect_text = ""
+    if effect is not None:
+        effect_text = effect.increase_does if move.direction > 0 else effect.decrease_does
+    caution: list[str] = []
+    if effect is not None and effect.car_dependent:
+        caution.append("Car-specific lever; verify this car's spinner label before applying.")
+    if section == "FRONT_BIAS" and _is_911(setup.car_id):
+        if move.direction < 0:
+            caution.append("911 GT3 R usually wants a lower front-bias window (~50-56%).")
+        elif current is not None and current < 50:
+            caution.append("Do not chase stability past the 911's usual low-front-bias window.")
+    return {
+        "rank": rank,
+        "section": section,
+        "param_key": _param_key(section),
+        "name": spec.human_name,
+        "category": spec.category,
+        "direction": direction,
+        "magnitude": step,
+        "units": spec.units or (effect.units if effect else ""),
+        "current": current,
+        "target": target,
+        "current_display": _format_value(_decoded(schema, section, current)),
+        "target_display": _format_value(_decoded(schema, section, target)),
+        "reason": move.reason,
+        "effect": effect_text,
+        "confidence": effect.confidence if effect is not None else "low",
+        "caution": caution,
+    }
+
+
+def _rank_moves(moves: tuple[ComplaintMove, ...], speed_hint: str | None) -> list[ComplaintMove]:
+    if speed_hint is None:
+        return list(moves)
+
+    def score(move: ComplaintMove) -> tuple[int, str]:
+        effect = effect_for(move.section)
+        if effect is None:
+            return (1, move.section)
+        if speed_hint == "high" and effect.speed_dependence == AERO:
+            return (0, move.section)
+        if speed_hint == "low" and effect.speed_dependence == MECHANICAL:
+            return (0, move.section)
+        return (1, move.section)
+
+    return sorted(moves, key=score)
+
+
+def advise_from_complaint(
+    complaint: str,
+    *,
+    setup: CarSetup | None = None,
+    setup_snapshot: dict[str, Any] | None = None,
+    car_id: str | None = None,
+    track_id: str | None = None,
+    schema: CarSetupSchema | None = None,
+    max_suggestions: int = 5,
+) -> dict[str, Any]:
+    """Return ranked setup changes for a driver handling complaint."""
+
+    text = (complaint or "").strip()
+    if not text:
+        return {"ok": False, "status": "empty_complaint", "error": "complaint is required"}
+    if len(text) > MAX_COMPLAINT_LEN:
+        return {
+            "ok": False,
+            "status": "complaint_too_long",
+            "error": f"complaint must be <= {MAX_COMPLAINT_LEN} characters",
+        }
+    issue = _parse_issue(text)
+    phase = _parse_phase(text, issue)
+    speed_hint = _parse_speed_hint(text)
+    if setup is None:
+        setup = from_snapshot(setup_snapshot or {}, car_id=car_id, track_id=track_id)
+    elif car_id and setup.car_id is None:
+        setup.car_id = car_id
+    if track_id and setup.track_id is None:
+        setup.track_id = track_id
+    if issue is None:
+        return {
+            "ok": False,
+            "status": "unknown_complaint",
+            "complaint": text,
+            "parsed": {"issue": None, "phase": phase, "speed_hint": speed_hint},
+            "error": "could not map complaint to handling vocabulary",
+        }
+
+    rule = next((r for r in _RULES if r.issue == issue and r.phase == phase), None)
+    if rule is None and phase != "mid":
+        rule = next((r for r in _RULES if r.issue == issue and r.phase == "mid"), None)
+    if rule is None:
+        return {
+            "ok": False,
+            "status": "unsupported_complaint",
+            "complaint": text,
+            "parsed": {"issue": issue, "phase": phase, "speed_hint": speed_hint},
+            "error": "handling vocabulary recognized, but no setup rule is available",
+        }
+    moves = _rank_moves(rule.moves, speed_hint)
+    suggestions = [
+        _move_to_suggestion(move, setup=setup, schema=schema, rank=i)
+        for i, move in enumerate(moves[:max_suggestions], start=1)
+    ]
+    return {
+        "ok": True,
+        "status": "suggested",
+        "complaint": text,
+        "parsed": {"issue": issue, "phase": phase, "speed_hint": speed_hint},
+        "car_id": setup.car_id,
+        "track_id": setup.track_id,
+        "suggestions": suggestions,
+        "rationale": [
+            "Complaint mapped through deterministic handling vocabulary.",
+            "Lever effects are grounded in setup_knowledge.py; live telemetry still wins.",
+        ],
+    }
+
+
+def setup_diff_summary(
+    baseline: CarSetup,
+    candidate: CarSetup,
+    *,
+    schema: CarSetupSchema | None = None,
+) -> dict[str, Any]:
+    """Return setup A/B changes as display-ready rows."""
+
+    raw = candidate.diff(baseline)
+    priority = {name: i for i, name in enumerate(_PRIORITY)}
+    rows: list[dict[str, Any]] = []
+    for section, values in sorted(
+        raw.items(), key=lambda item: (priority.get(item[0], 999), item[0])
+    ):
+        from_v = values.get("from")
+        to_v = values.get("to")
+        spec = spec_for(section)
+        effect = effect_for(section)
+        delta = None if from_v is None or to_v is None else float(to_v) - float(from_v)
+        direction = (
+            "added"
+            if from_v is None
+            else "removed"
+            if to_v is None
+            else "increase"
+            if delta is not None and delta > 0
+            else "decrease"
+            if delta is not None and delta < 0
+            else "unchanged"
+        )
+        effect_text = ""
+        if effect is not None and direction in {"increase", "decrease"}:
+            effect_text = effect.increase_does if direction == "increase" else effect.decrease_does
+        from_display = _format_value(_decoded(schema, section, from_v))
+        to_display = _format_value(_decoded(schema, section, to_v))
+        unit = spec.units or (effect.units if effect else "")
+        arrow = f"{from_display or '-'} -> {to_display or '-'}"
+        display = f"{spec.human_name}: {arrow}{(' ' + unit) if unit else ''}"
+        if effect_text:
+            display = f"{display} ({direction})"
+        rows.append(
+            {
+                "section": section,
+                "param_key": _param_key(section),
+                "name": spec.human_name,
+                "category": spec.category,
+                "from": from_v,
+                "to": to_v,
+                "delta": delta,
+                "from_display": from_display,
+                "to_display": to_display,
+                "units": unit,
+                "direction": direction,
+                "effect": effect_text,
+                "display": display,
+            }
+        )
+    return {
+        "ok": True,
+        "baseline": {"car_id": baseline.car_id, "track_id": baseline.track_id},
+        "candidate": {"car_id": candidate.car_id, "track_id": candidate.track_id},
+        "changed_count": len(rows),
+        "rows": rows,
+        "display_lines": [row["display"] for row in rows],
+    }
+
+
+def diff_setup_files(
+    baseline_path: str | Path,
+    candidate_path: str | Path,
+    *,
+    schema: CarSetupSchema | None = None,
+) -> dict[str, Any]:
+    baseline = load_setup_file(baseline_path)
+    candidate = load_setup_file(candidate_path)
+    out = setup_diff_summary(baseline, candidate, schema=schema)
+    out["baseline"]["path"] = str(baseline_path)
+    out["candidate"]["path"] = str(candidate_path)
+    return out

--- a/tools/ai_sidecar/setup_optimizer.py
+++ b/tools/ai_sidecar/setup_optimizer.py
@@ -556,6 +556,13 @@ def _candidate_value(records: list[dict[str, Any]], key: str, value: float) -> f
     return value
 
 
+def _normalize_param_key(param: str) -> str:
+    text = param.strip().upper()
+    if not text:
+        raise SetupExperimentError("param is required")
+    return text if text.endswith(".VALUE") else f"{text}.VALUE"
+
+
 def _candidate_grid(
     records: list[dict[str, Any]], best: dict[str, Any], keys: list[str]
 ) -> list[dict[str, float]]:
@@ -619,6 +626,141 @@ def _schema_allows(
         if not sp.is_valid(val):
             return False
     return True
+
+
+def _chronological_key(record: dict[str, Any]) -> tuple[str, str, int, str]:
+    lap = record.get("lap") if isinstance(record.get("lap"), dict) else {}
+    return (
+        str(record.get("exported_at") or ""),
+        str(record.get("session_uuid") or ""),
+        int(_as_finite_float(lap.get("lap_n")) or 0),
+        str(record.get("experiment_id") or ""),
+    )
+
+
+def suggest_closed_loop(
+    records: list[dict[str, Any]],
+    *,
+    param: str,
+    car_id: str | None = None,
+    track_id: str | None = None,
+    schema: Any = None,
+) -> dict[str, Any]:
+    """Suggest the next one-parameter move from the measured previous move.
+
+    This is deliberately simple and auditable: compare the latest two valid laps
+    where ``param`` exists, measure whether the previous value change improved
+    lap time, then continue in the same direction or reverse by one observed
+    step.  The broader surrogate optimizer remains available for exploratory
+    multi-param moves; this function is the closed suggest -> test -> measure
+    loop a driver can reason about at the rig.
+    """
+
+    key = _normalize_param_key(param)
+    scoped = _filter_records(records, car_id=car_id, track_id=track_id)
+    complete = [
+        rec
+        for rec in scoped
+        if _as_finite_float(rec.get("setup", {}).get("params", {}).get(key)) is not None
+    ]
+    if len(complete) < 2:
+        return {
+            "ok": False,
+            "status": "not_enough_param_experiments",
+            "param": key,
+            "experiments_used": len(complete),
+            "min_required": 2,
+        }
+    ordered = sorted(complete, key=_chronological_key)
+    prev, curr = ordered[-2], ordered[-1]
+    prev_params = prev["setup"]["params"]
+    curr_params = curr["setup"]["params"]
+    prev_value = float(prev_params[key])
+    curr_value = float(curr_params[key])
+    prev_lap_ms = float(prev["lap"]["lap_ms"])
+    curr_lap_ms = float(curr["lap"]["lap_ms"])
+    value_delta = curr_value - prev_value
+    measured_delta_ms = prev_lap_ms - curr_lap_ms
+    if abs(value_delta) <= 1e-9:
+        return {
+            "ok": False,
+            "status": "latest_laps_did_not_change_param",
+            "param": key,
+            "experiments_used": len(complete),
+            "previous_result": {
+                "from": prev_value,
+                "to": curr_value,
+                "measured_delta_ms": round(measured_delta_ms, 3),
+                "lap_ms_before": int(round(prev_lap_ms)),
+                "lap_ms_after": int(round(curr_lap_ms)),
+            },
+        }
+
+    step = _param_step(scoped, key)
+    previous_direction = 1.0 if value_delta > 0 else -1.0
+    next_direction = previous_direction if measured_delta_ms >= 0 else -previous_direction
+    raw_target = _candidate_value(scoped, key, curr_value + next_direction * step)
+    candidate = {key: raw_target}
+    if schema is not None and hasattr(schema, "constrain_params"):
+        candidate = schema.constrain_params(candidate)
+    target_value = float(candidate[key])
+    if schema is not None and not _schema_allows(candidate, schema, base={key: curr_value}):
+        return {
+            "ok": False,
+            "status": "candidate_out_of_schema",
+            "param": key,
+            "candidate": candidate,
+            "previous_result": {
+                "from": prev_value,
+                "to": curr_value,
+                "measured_delta_ms": round(measured_delta_ms, 3),
+            },
+        }
+    if abs(target_value - curr_value) <= 1e-9:
+        return {
+            "ok": False,
+            "status": "at_param_bound",
+            "param": key,
+            "experiments_used": len(complete),
+            "current": curr_value,
+            "previous_result": {
+                "from": prev_value,
+                "to": curr_value,
+                "measured_delta_ms": round(measured_delta_ms, 3),
+                "improved": measured_delta_ms > 0,
+            },
+        }
+
+    improved = measured_delta_ms > 0
+    direction_word = "continue" if improved else "reverse"
+    change = {"from": curr_value, "to": target_value}
+    return {
+        "ok": True,
+        "status": "suggested",
+        "method": "one_param_measured_delta",
+        "param": key,
+        "experiments_used": len(complete),
+        "previous_result": {
+            "from": prev_value,
+            "to": curr_value,
+            "delta": round(value_delta, 6),
+            "lap_ms_before": int(round(prev_lap_ms)),
+            "lap_ms_after": int(round(curr_lap_ms)),
+            "measured_delta_ms": round(measured_delta_ms, 3),
+            "improved": improved,
+        },
+        "candidate": {
+            "params": {key: target_value},
+            "changed_params": {key: change},
+        },
+        "rationale": [
+            (
+                f"Previous {key} move {'improved' if improved else 'hurt'} lap time by "
+                f"{abs(measured_delta_ms):.0f} ms."
+            ),
+            f"Next suggestion: {direction_word} that one-parameter direction by one step.",
+        ],
+    }
 
 
 def suggest_next_setup(

--- a/tools/rig_launcher/app.py
+++ b/tools/rig_launcher/app.py
@@ -8,7 +8,9 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
+from tools.ai_sidecar.setup_advisor import diff_setup_files
 from tools.rig_launcher.install import default_exe_path, install_desktop_shortcut
 from tools.rig_launcher.settings import ensure_settings_file
 from tools.rig_launcher.supervisor import (
@@ -38,7 +40,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="AC Copilot Game Point launcher")
     parser.add_argument("--once", action="store_true", help="Probe once and exit.")
     parser.add_argument("--start", action="store_true", help="Start supervised processes first.")
-    parser.add_argument("--json", action="store_true", help="Print status JSON in --once mode.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print status or setup output as JSON where supported.",
+    )
     parser.add_argument("--no-gui", action="store_true", help="Do not open the Tk status window.")
     parser.add_argument("--port", type=int, default=None)
     parser.add_argument("--external-bind", default=None)
@@ -58,6 +64,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--shortcut-target",
         default=None,
         help="Override the exe path used by --install-shortcut.",
+    )
+    parser.add_argument(
+        "--setup-diff",
+        nargs=2,
+        metavar=("BASELINE_INI", "CANDIDATE_INI"),
+        help="Compare two setup INI files and show a driver-readable setup diff.",
     )
     return parser
 
@@ -82,6 +94,58 @@ def config_from_args(args: argparse.Namespace) -> GamePointConfig:
         start_simhub=args.start_simhub or config.start_simhub,
         paths=paths,
     )
+
+
+def render_setup_diff_lines(diff: dict[str, Any]) -> list[str]:
+    if not diff.get("ok", False):
+        return [f"setup diff: {diff.get('error', 'failed')}"]
+    changed_count = int(diff.get("changed_count") or 0)
+    lines = [f"setup diff: {changed_count} changed knob{'s' if changed_count != 1 else ''}"]
+    baseline = diff.get("baseline")
+    candidate = diff.get("candidate")
+    if isinstance(baseline, dict) and isinstance(candidate, dict):
+        base_path = baseline.get("path")
+        candidate_path = candidate.get("path")
+        if base_path and candidate_path:
+            lines.append(f"baseline: {base_path}")
+            lines.append(f"candidate: {candidate_path}")
+    display_lines = diff.get("display_lines")
+    if isinstance(display_lines, list) and display_lines:
+        lines.extend(str(line) for line in display_lines)
+    else:
+        lines.append("no setup changes")
+    return lines
+
+
+def _open_setup_diff_window(diff: dict[str, Any], *, parent: Any | None = None) -> int:
+    import tkinter as tk
+    from tkinter import ttk
+
+    root = tk.Toplevel(parent) if parent is not None else tk.Tk()
+    root.title("Setup Diff")
+    root.geometry("760x460")
+    root.minsize(560, 320)
+
+    frame = ttk.Frame(root, padding=16)
+    frame.pack(fill="both", expand=True)
+    ttk.Label(frame, text="Setup Diff", font=("", 16, "bold")).pack(anchor="w")
+    text = tk.Text(frame, wrap="word", height=16)
+    text.pack(fill="both", expand=True, pady=(12, 0))
+    text.insert("1.0", "\n".join(render_setup_diff_lines(diff)))
+    text.configure(state="disabled")
+    ttk.Button(frame, text="Close", command=root.destroy).pack(anchor="e", pady=(12, 0))
+    if parent is None:
+        root.mainloop()
+    return 0 if diff.get("ok", False) else 1
+
+
+def run_setup_diff_gui(diff: dict[str, Any]) -> int:
+    try:
+        return _open_setup_diff_window(diff)
+    except Exception as exc:  # noqa: BLE001 - keep launcher useful on headless machines
+        print(f"Setup diff window unavailable: {exc}", file=sys.stderr)
+        print("\n".join(render_setup_diff_lines(diff)))
+        return 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -110,6 +174,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Installed Desktop shortcut: {result.shortcut_path}")
         print(f"Target: {result.target_path}")
         return 0
+
+    if args.setup_diff:
+        diff = diff_setup_files(args.setup_diff[0], args.setup_diff[1])
+        if args.json:
+            print(json.dumps(diff, indent=2, sort_keys=True))
+            return 0 if diff.get("ok", False) else 1
+        if args.no_gui:
+            print("\n".join(render_setup_diff_lines(diff)))
+            return 0 if diff.get("ok", False) else 1
+        return run_setup_diff_gui(diff)
 
     supervisor = GamePointSupervisor(config_from_args(args))
     try:
@@ -174,10 +248,33 @@ def run_gui(supervisor: GamePointSupervisor) -> int:
         path = ensure_settings_file(supervisor.paths)
         _open_path(path)
 
+    def open_setup_diff() -> None:
+        from tkinter import filedialog, messagebox
+
+        baseline = filedialog.askopenfilename(
+            parent=root,
+            title="Choose baseline setup",
+            filetypes=[("Assetto Corsa setup", "*.ini"), ("All files", "*.*")],
+        )
+        if not baseline:
+            return
+        candidate = filedialog.askopenfilename(
+            parent=root,
+            title="Choose candidate setup",
+            filetypes=[("Assetto Corsa setup", "*.ini"), ("All files", "*.*")],
+        )
+        if not candidate:
+            return
+        try:
+            _open_setup_diff_window(diff_setup_files(baseline, candidate), parent=root)
+        except Exception as exc:  # noqa: BLE001 - surface file/UI errors in the launcher
+            messagebox.showerror("Setup Diff", str(exc), parent=root)
+
     ttk.Button(button_row, text="Start", command=start).pack(side="left", padx=(0, 8))
     ttk.Button(button_row, text="Refresh", command=refresh).pack(side="left", padx=(0, 8))
     ttk.Button(button_row, text="Logs", command=open_logs).pack(side="left", padx=(0, 8))
-    ttk.Button(button_row, text="Settings", command=open_settings).pack(side="left")
+    ttk.Button(button_row, text="Settings", command=open_settings).pack(side="left", padx=(0, 8))
+    ttk.Button(button_row, text="Setup Diff", command=open_setup_diff).pack(side="left")
     ttk.Label(frame, text=f"Status: {supervisor.paths.status_path}").pack(anchor="w", pady=(16, 0))
 
     refresh()


### PR DESCRIPTION
Closes #407.\n\n## Summary\n- Add deterministic complaint-language setup advice grounded in setup_knowledge/setup_model.\n- Add one-parameter closed-loop setup suggestions informed by measured lap deltas.\n- Add display-ready setup diffs through sidecar protocol/CLI and the Game Point launcher.\n\n## Verification\n- python -m ruff check tools/ai_sidecar/setup_advisor.py tools/ai_sidecar/setup_optimizer.py tools/ai_sidecar/external_protocol.py tools/ai_sidecar/server.py tools/rig_launcher/app.py tests/test_setup_advisor.py tests/test_setup_optimizer.py tests/test_ai_sidecar_external.py tests/test_rig_launcher.py\n- python -m pytest tests/test_setup_advisor.py tests/test_setup_optimizer.py tests/test_ai_sidecar_external.py tests/test_rig_launcher.py