### PR TITLE
feat: build telemetry session data platform (#402)

### DIFF
--- a/docs/10_Development/13_Lap_Archive_Export.md
+++ b/docs/10_Development/13_Lap_Archive_Export.md
@@ -25,6 +25,15 @@ rejected. Laps with `lap.is_valid=false` are skipped by default; pass
 exports stream archive files one at a time and replace the output only after
 the export completes.
 
+Pass `--output -` to stream stable CSV rows to stdout for external tools:
+
+```bash
+python -m tools.lap_archive_export --output - /path/to/journal/laps > exports/laps.csv
+```
+
+The summary line is written to stderr in stdout-streaming mode, so the CSV stream
+stays clean for a pipe.
+
 Stable columns:
 
 ```text

--- a/docs/10_Development/16_Telemetry_Data_Platform.md
+++ b/docs/10_Development/16_Telemetry_Data_Platform.md
@@ -1,0 +1,100 @@
+# Telemetry Data Platform
+
+Issue #402 adds the first longitudinal data layer on top of the immutable lap
+archive corpus.
+
+## Source And Derived Stores
+
+Raw evidence remains the schema-v1 lap archive JSON under `journal/laps/lap_*.json`.
+The Track Titan lake under `journal/tt/**` is also raw personal evidence. Analysis
+code reads those files and does not edit them in place.
+
+Derived stores:
+
+- `journal/analytics.duckdb` or `journal/lake.duckdb`: disposable DuckDB lake built
+  by `python -m tools.coaching_lake.build_analytics`.
+- `journal/driver/profile.json`: compacted driver profile roll-up built by
+  `python -m tools.ai_sidecar.driver_profile`.
+- `journal/tt/index.json` and `journal/tt/sessions_index.json`: derived Track Titan
+  indexes rebuilt by the ingest tooling.
+
+## Sessions And Stints
+
+Build the lake:
+
+```bash
+python -m tools.coaching_lake.build_analytics --lap-dir journal/laps --db journal/analytics.duckdb
+```
+
+The lake now includes:
+
+- `sessions`: one row per `session_uuid`, with lap counts, valid lap counts, best
+  lap, median lap, consistency, and the PB lap UUID.
+- `stints`: contiguous blocks inside a session. The current offline archive does
+  not carry a first-class tyre-set id, so `setup_hash` is the deterministic tyre-set
+  proxy until capture grows a real tyre-set field.
+
+Reports:
+
+```bash
+python -m tools.coaching_lake.build_analytics --db journal/analytics.duckdb --report sessions
+python -m tools.coaching_lake.build_analytics --db journal/analytics.duckdb --report stints
+```
+
+## Driver Profile
+
+Update the local profile:
+
+```bash
+python -m tools.ai_sidecar.driver_profile --lap-dir journal/laps --driver-id local-driver
+```
+
+The profile preserves:
+
+- `preferences`: operator/runtime preferences for future driver-model work.
+- `focus_corners`: remembered track/corner focus lists.
+- `session_rollups`: compacted per-session summaries.
+- `personal_bests`: PB ledger by car/track/layout.
+- `consistency`: cross-session consistency roll-ups by car/track/layout.
+
+Because retention can remove old raw laps, `profile.json` is a compacted roll-up,
+not a purely disposable view. Re-running the builder merges current archive roll-ups
+with existing historical session roll-ups.
+
+## Retention
+
+Plan retention first:
+
+```bash
+python -m tools.coaching_lake.retention \
+  --lap-dir journal/laps \
+  --tt-dir journal/tt \
+  --profile journal/driver/profile.json \
+  --max-lap-files 1000 \
+  --max-tt-files 5000
+```
+
+The CLI is dry-run by default. Add `--apply` only after inspecting the plan.
+
+Protected files are never selected for deletion:
+
+- lap archives whose `lap.is_pb` is true
+- imported/generated reference archives
+- lap UUIDs present in the profile PB ledger
+- files with adjacent `.pin` or `.keep` sidecar markers
+- unreadable lap archives
+- Track Titan derived index files
+
+Retention deletes whole files only; it never rewrites raw JSON in place.
+
+## Streamed CSV Bridge
+
+External tools can consume stable analysis CSV from stdout:
+
+```bash
+python -m tools.lap_archive_export --output - journal/laps > exports/laps.csv
+```
+
+When `--output -` is used, CSV rows go to stdout and the summary line goes to stderr
+so downstream tools receive a clean stream. MoTeC-shaped CSV still writes to a file
+because it performs a bounded pre-scan for header statistics.

--- a/scripts/mcp/agentic-memory.sh
+++ b/scripts/mcp/agentic-memory.sh
@@ -55,9 +55,27 @@ _expand_home() {
   printf '%s' "${p}"
 }
 
+_normalize_windows_path() {
+  local p="${1:-}"
+  if [[ "${p}" =~ ^[A-Za-z]:[\\/] ]]; then
+    if command -v cygpath >/dev/null 2>&1; then
+      cygpath -u -- "${p}"
+      return $?
+    fi
+    local drive rest
+    drive="$(printf '%s' "${p:0:1}" | tr '[:upper:]' '[:lower:]')"
+    rest="${p:2}"
+    rest="${rest//\\//}"
+    printf '/%s%s' "${drive}" "${rest}"
+    return 0
+  fi
+  printf '%s' "${p}"
+}
+
 _to_abs_path() {
   local p
   p="$(_expand_home "${1:-}")" || return 1
+  p="$(_normalize_windows_path "${p}")" || return 1
   if [[ "${p}" != /* ]]; then
     p="${CHILD_REPO_ROOT}/${p}"
   fi
@@ -114,6 +132,7 @@ _resolve_python() {
   local candidate="${1:-}"
   if [[ -n "${candidate}" ]]; then
     candidate="$(_expand_home "${candidate}")" || return 1
+    candidate="$(_normalize_windows_path "${candidate}")" || return 1
     if [[ "${candidate}" == */* || "${candidate}" == ./* ]]; then
       if [[ "${candidate}" != /* ]]; then
         candidate="${CHILD_REPO_ROOT}/${candidate}"
@@ -150,6 +169,7 @@ AF_ROOT="$(_resolve_root "AGENTIC_MEMORY_AGENT_FACTORY_ROOT" "${AGENTIC_MEMORY_A
 
 if [[ -n "${AGENTIC_MEMORY_SOURCE_REGISTRY:-}" ]]; then
   SRC_REGISTRY="$(_expand_home "${AGENTIC_MEMORY_SOURCE_REGISTRY}")" || exit 1
+  SRC_REGISTRY="$(_normalize_windows_path "${SRC_REGISTRY}")" || exit 1
   if [[ "${SRC_REGISTRY}" != /* ]]; then
     SRC_REGISTRY="${AF_ROOT}/${SRC_REGISTRY}"
   fi

--- a/tests/test_coaching_lake.py
+++ b/tests/test_coaching_lake.py
@@ -28,9 +28,11 @@ def _archive(
     track: str,
     lap_ms: int,
     *,
+    session_uuid="sess",
     is_valid=True,
     min_speed=80.0,
     snapshot=None,
+    setup_hash="setup-default",
     n_samples=4,
 ) -> dict:
     fields = list(TRACE_FIELDS)
@@ -42,13 +44,13 @@ def _archive(
         "schema_version": 1,
         "source": "in_game",
         "lap_uuid": lap_uuid,
-        "session_uuid": "sess",
+        "session_uuid": session_uuid,
         "exported_at": "2026-06-28T00:00:00Z",
         "car": {"id": car},
         "track": {"id": track, "lengthM": 4000.0},
         "conditions": {"ambientTempC": 26, "trackGripLevel": 0.98, "weatherType": "clear"},
         "lap": {"lap_n": 1, "lap_ms": lap_ms, "is_pb": True, "is_valid": is_valid},
-        "setup": {"hash": f"h{lap_uuid}", "path": "x/race.ini", "snapshot": snapshot or {}},
+        "setup": {"hash": setup_hash, "path": "x/race.ini", "snapshot": snapshot or {}},
         "trace": {"samples_count": n_samples, "fields": fields, "samples": samples},
         "corners": [
             {
@@ -85,10 +87,33 @@ def _db_path() -> Path:
 def _build(lake_cwd):
     laps = lake_cwd / "laps"
     laps.mkdir()
-    _write(laps, "a", _archive("a", "bmw_z4_gt3", "spa", 110000, min_speed=80.0))
-    _write(laps, "b", _archive("b", "bmw_z4_gt3", "spa", 108000, min_speed=85.0))
-    _write(laps, "c", _archive("c", "ks_audi_r8_lms", "imola", 95000, min_speed=70.0))
-    _write(laps, "d", _archive("d", "bmw_z4_gt3", "spa", 0, is_valid=False))  # invalid (0 ms)
+    _write(
+        laps,
+        "a",
+        _archive("a", "bmw_z4_gt3", "spa", 110000, session_uuid="sess-a", min_speed=80.0),
+    )
+    _write(
+        laps,
+        "b",
+        _archive("b", "bmw_z4_gt3", "spa", 108000, session_uuid="sess-a", min_speed=85.0),
+    )
+    _write(
+        laps,
+        "c",
+        _archive(
+            "c",
+            "ks_audi_r8_lms",
+            "imola",
+            95000,
+            session_uuid="sess-b",
+            min_speed=70.0,
+        ),
+    )
+    _write(
+        laps,
+        "d",
+        _archive("d", "bmw_z4_gt3", "spa", 0, session_uuid="sess-a", is_valid=False),
+    )
     db = _db_path()
     summary = build_lake(laps, db)
     return db, summary
@@ -98,6 +123,8 @@ def test_build_lake_counts(lake_cwd):
     db, summary = _build(lake_cwd)
     assert summary.laps == 4
     assert summary.valid_laps == 3  # the 0-ms lap is invalid
+    assert summary.sessions == 2
+    assert summary.stints == 2
     assert summary.corners == 4  # one corner each
     assert summary.samples == 16  # 4 laps x 4 samples
     assert summary.cars == 2
@@ -109,11 +136,29 @@ def test_summary_and_best_laps_reports(lake_cwd):
     db, _ = _build(lake_cwd)
     cols, rows = run_report(db, "summary")
     assert rows[0][cols.index("laps")] == 4
+    assert rows[0][cols.index("sessions")] == 2
+    assert rows[0][cols.index("stints")] == 2
     assert rows[0][cols.index("samples")] == 16
 
     cols, rows = run_report(db, "best-laps")
     spa = [r for r in rows if r[cols.index("track_id")] == "spa"][0]
     assert spa[cols.index("best_ms")] == 108000  # min valid lap on spa
+
+
+def test_session_and_stint_rollups_are_queryable(lake_cwd):
+    db, _ = _build(lake_cwd)
+    cols, rows = run_report(db, "sessions")
+    sess_a = [r for r in rows if r[cols.index("session_uuid")] == "sess-a"][0]
+    assert sess_a[cols.index("lap_count")] == 3
+    assert sess_a[cols.index("valid_laps")] == 2
+    assert sess_a[cols.index("best_lap_ms")] == 108000
+    assert sess_a[cols.index("pb_lap_uuid")] == "b"
+
+    cols, rows = run_report(db, "stints")
+    assert len(rows) == 2
+    stint_a = [r for r in rows if r[cols.index("session_uuid")] == "sess-a"][0]
+    assert stint_a[cols.index("tyre_set_key")] == "setup-default"
+    assert stint_a[cols.index("lap_count")] == 3
 
 
 def test_corner_speed_report_is_corner_grain(lake_cwd):
@@ -189,7 +234,9 @@ def test_run_query_arbitrary_sql(lake_cwd):
 
 
 def test_reports_registry_nonempty():
-    assert {"summary", "best-laps", "corner-speed", "setup-effect"} <= set(list_reports())
+    assert {"summary", "sessions", "stints", "best-laps", "corner-speed", "setup-effect"} <= set(
+        list_reports()
+    )
 
 
 def test_db_path_outside_journal_rejected(lake_cwd):

--- a/tests/test_driver_profile.py
+++ b/tests/test_driver_profile.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from tools.ai_sidecar.driver_profile import build_profile, update_profile, write_profile
+from tools.ai_sidecar.driver_profile import (
+    ProfileLoadError,
+    build_profile,
+    update_profile,
+    write_profile,
+)
 
 
 def _archive(
@@ -96,6 +101,43 @@ def test_profile_keeps_compacted_pb_when_raw_archive_was_pruned(tmp_path: Path) 
     assert len(profile["session_rollups"]) == 2
 
 
+def test_profile_merges_partial_session_without_losing_compacted_best(tmp_path: Path) -> None:
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    _write_lap(laps, "new", _archive("lap-new", session_uuid="sess-a", lap_ms=90000))
+    existing = {
+        "session_rollups": {
+            "sess-a|bmw_z4_gt3|spa|": {
+                "session_uuid": "sess-a",
+                "car_id": "bmw_z4_gt3",
+                "track_id": "spa",
+                "track_layout": None,
+                "lap_count": 4,
+                "valid_laps": 4,
+                "best_lap_ms": 85000,
+                "median_lap_ms": 87000.0,
+                "consistency_ms": 500.0,
+                "best_lap_uuid": "lap-old",
+                "best_source_file": "lap_old.json",
+                "first_exported_at": "2026-06-01T00:00:00Z",
+                "last_exported_at": "2026-06-02T00:00:00Z",
+            }
+        }
+    }
+
+    profile = build_profile([laps], existing=existing, generated_at="stamp")
+
+    rollup = profile["session_rollups"]["sess-a|bmw_z4_gt3|spa|"]
+    assert rollup["lap_count"] == 4
+    assert rollup["valid_laps"] == 4
+    assert rollup["best_lap_ms"] == 85000
+    assert rollup["best_lap_uuid"] == "lap-old"
+    assert rollup["best_source_file"] == "lap_old.json"
+    pb = profile["personal_bests"]["bmw_z4_gt3|spa|"]
+    assert pb["lap_ms"] == 85000
+    assert pb["lap_uuid"] == "lap-old"
+
+
 def test_profile_keeps_existing_pb_ledger_without_rollup(tmp_path: Path) -> None:
     laps = tmp_path / "laps"
     laps.mkdir()
@@ -135,6 +177,20 @@ def test_update_profile_writes_under_journal_driver(tmp_path: Path, monkeypatch)
     profile_path = tmp_path / "journal" / "driver" / "profile.json"
     assert profile_path.exists()
     assert json.loads(profile_path.read_text(encoding="utf-8"))["driver_id"] == "driver-1"
+
+
+def test_update_profile_fails_closed_on_invalid_existing_profile(tmp_path: Path) -> None:
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    _write_lap(laps, "a", _archive("lap-a", session_uuid="sess-a", lap_ms=91000))
+    profile_path = tmp_path / "journal" / "driver" / "profile.json"
+    profile_path.parent.mkdir(parents=True)
+    profile_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ProfileLoadError, match="profile invalid JSON"):
+        update_profile([laps], profile_path=profile_path)
+
+    assert profile_path.read_text(encoding="utf-8") == "{not-json"
 
 
 def test_profile_write_rejects_noncanonical_path(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_driver_profile.py
+++ b/tests/test_driver_profile.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.ai_sidecar.driver_profile import build_profile, update_profile, write_profile
+
+
+def _archive(
+    lap_uuid: str,
+    *,
+    session_uuid: str,
+    lap_ms: int,
+    car_id: str = "bmw_z4_gt3",
+    track_id: str = "spa",
+    exported_at: str = "2026-06-28T00:00:00Z",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "source": "in_game",
+        "lap_uuid": lap_uuid,
+        "session_uuid": session_uuid,
+        "exported_at": exported_at,
+        "car": {"id": car_id},
+        "track": {"id": track_id, "layout": None},
+        "lap": {"lap_n": 1, "lap_ms": lap_ms, "is_pb": True, "is_valid": True},
+        "trace": {"fields": ["eMs"], "samples": [[0], [lap_ms]]},
+    }
+
+
+def _write_lap(root: Path, name: str, payload: dict) -> Path:
+    path = root / f"lap_{name}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_profile_builds_session_rollups_pb_and_preserves_preferences(tmp_path: Path) -> None:
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    _write_lap(
+        laps,
+        "a",
+        _archive("lap-a", session_uuid="sess-a", lap_ms=91000, exported_at="2026-06-28T00:00:00Z"),
+    )
+    _write_lap(
+        laps,
+        "b",
+        _archive("lap-b", session_uuid="sess-b", lap_ms=89000, exported_at="2026-06-29T00:00:00Z"),
+    )
+    existing = {
+        "preferences": {"voice_verbosity": "low"},
+        "focus_corners": {"spa": ["T1"]},
+    }
+
+    profile = build_profile([laps], driver_id="driver-1", existing=existing, generated_at="stamp")
+
+    assert profile["driver_id"] == "driver-1"
+    assert profile["preferences"] == {"voice_verbosity": "low"}
+    assert profile["focus_corners"] == {"spa": ["T1"]}
+    assert len(profile["session_rollups"]) == 2
+    pb = profile["personal_bests"]["bmw_z4_gt3|spa|"]
+    assert pb["lap_ms"] == 89000
+    assert pb["lap_uuid"] == "lap-b"
+    consistency = profile["consistency"]["bmw_z4_gt3|spa|"]
+    assert consistency["session_count"] == 2
+    assert consistency["valid_laps"] == 2
+
+
+def test_profile_keeps_compacted_pb_when_raw_archive_was_pruned(tmp_path: Path) -> None:
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    _write_lap(laps, "new", _archive("lap-new", session_uuid="sess-new", lap_ms=90000))
+    existing = {
+        "session_rollups": {
+            "sess-old|bmw_z4_gt3|spa|": {
+                "session_uuid": "sess-old",
+                "car_id": "bmw_z4_gt3",
+                "track_id": "spa",
+                "track_layout": None,
+                "valid_laps": 1,
+                "best_lap_ms": 85000,
+                "best_lap_uuid": "lap-old",
+                "best_source_file": "lap_old.json",
+                "last_exported_at": "2026-06-01T00:00:00Z",
+            }
+        }
+    }
+
+    profile = build_profile([laps], existing=existing, generated_at="stamp")
+
+    pb = profile["personal_bests"]["bmw_z4_gt3|spa|"]
+    assert pb["lap_ms"] == 85000
+    assert pb["lap_uuid"] == "lap-old"
+    assert len(profile["session_rollups"]) == 2
+
+
+def test_profile_keeps_existing_pb_ledger_without_rollup(tmp_path: Path) -> None:
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    _write_lap(laps, "new", _archive("lap-new", session_uuid="sess-new", lap_ms=90000))
+    existing = {
+        "personal_bests": {
+            "bmw_z4_gt3|spa|": {
+                "car_id": "bmw_z4_gt3",
+                "track_id": "spa",
+                "lap_ms": 85000,
+                "lap_uuid": "lap-old",
+                "session_uuid": "sess-old",
+                "source_file": "lap_old.json",
+                "exported_at": "2026-06-01T00:00:00Z",
+            }
+        }
+    }
+
+    profile = build_profile([laps], existing=existing, generated_at="stamp")
+
+    pb = profile["personal_bests"]["bmw_z4_gt3|spa|"]
+    assert pb["lap_ms"] == 85000
+    assert pb["lap_uuid"] == "lap-old"
+    assert "sess-old|bmw_z4_gt3|spa|" in profile["session_rollups"]
+
+
+def test_update_profile_writes_under_journal_driver(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "journal").mkdir()
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    _write_lap(laps, "a", _archive("lap-a", session_uuid="sess-a", lap_ms=91000))
+
+    summary = update_profile([laps], driver_id="driver-1")
+
+    assert summary.personal_bests == 1
+    profile_path = tmp_path / "journal" / "driver" / "profile.json"
+    assert profile_path.exists()
+    assert json.loads(profile_path.read_text(encoding="utf-8"))["driver_id"] == "driver-1"
+
+
+def test_profile_write_rejects_noncanonical_path(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "journal").mkdir()
+    with pytest.raises(ValueError, match="journal/driver"):
+        write_profile({}, "profile.json")

--- a/tests/test_lap_archive_export.py
+++ b/tests/test_lap_archive_export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import io
 import json
 from pathlib import Path
 
@@ -250,6 +251,27 @@ def test_cli_writes_csv(tmp_path: Path, monkeypatch, capsys) -> None:  # type: i
     assert rc == 0
     assert "wrote 3 sample rows" in captured.out
     assert _rows(out)[0]["lap_uuid"] == "lap-valid"
+
+
+def test_csv_stream_writes_to_file_like_without_temp_path() -> None:
+    out = io.StringIO()
+
+    count = lap_archive_export.export_csv_stream([_FIXTURES / "lap_archive_valid.json"], out)
+
+    assert count == 3
+    rows = list(csv.DictReader(io.StringIO(out.getvalue())))
+    assert rows[0]["lap_uuid"] == "lap-valid"
+    assert rows[0]["session_uuid"] == "session-a"
+
+
+def test_cli_streams_csv_to_stdout_and_summary_to_stderr(capsys) -> None:
+    rc = lap_archive_export.main(["--output", "-", str(_FIXTURES / "lap_archive_valid.json")])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.startswith("source_file,lap_uuid,session_uuid")
+    assert "lap-valid" in captured.out
+    assert "wrote 3 sample rows to -" in captured.err
 
 
 def test_cli_rejects_missing_input_path(tmp_path: Path, monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -5,7 +5,16 @@ import os
 from datetime import UTC, datetime
 from pathlib import Path
 
-from tools.coaching_lake.retention import RetentionPolicy, apply_retention, plan_retention
+import pytest
+
+from tools.coaching_lake.retention import (
+    RetentionPolicy,
+    apply_retention,
+    plan_retention,
+)
+from tools.coaching_lake.retention import (
+    main as retention_main,
+)
 
 
 def _archive(
@@ -102,6 +111,23 @@ def test_lap_retention_deletes_only_unprotected_candidates(tmp_path: Path) -> No
     assert protected_profile.exists()
 
 
+def test_lap_retention_fails_closed_when_profile_is_invalid(tmp_path: Path) -> None:
+    laps = tmp_path / "journal" / "laps"
+    profile_path = tmp_path / "journal" / "driver" / "profile.json"
+    profile_path.parent.mkdir(parents=True)
+    laps.mkdir(parents=True)
+    profile_path.write_text("{not-json", encoding="utf-8")
+    _write_lap(laps, "eligible", _archive("lap-eligible", exported_at="2026-01-01T00:00:00Z"))
+
+    with pytest.raises(ValueError, match="profile invalid JSON"):
+        plan_retention(
+            lap_dir=laps,
+            policy=RetentionPolicy(max_lap_files=0),
+            profile_path=profile_path,
+            now=datetime(2026, 6, 30, tzinfo=UTC),
+        )
+
+
 def test_lap_retention_age_cap_is_dry_run_until_apply(tmp_path: Path) -> None:
     laps = tmp_path / "journal" / "laps"
     laps.mkdir(parents=True)
@@ -120,6 +146,17 @@ def test_lap_retention_age_cap_is_dry_run_until_apply(tmp_path: Path) -> None:
     assert new.exists()
 
 
+def test_retention_rejects_negative_caps(tmp_path: Path) -> None:
+    laps = tmp_path / "journal" / "laps"
+    laps.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="max_lap_age_days must be non-negative"):
+        RetentionPolicy(max_lap_age_days=-1)
+    with pytest.raises(SystemExit) as exc_info:
+        retention_main(["--lap-dir", str(laps), "--max-lap-age-days", "-1"])
+    assert exc_info.value.code == 2
+
+
 def test_tt_retention_excludes_indexes_and_honors_pins(tmp_path: Path) -> None:
     tt = tmp_path / "journal" / "tt"
     raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"
@@ -127,10 +164,12 @@ def test_tt_retention_excludes_indexes_and_honors_pins(tmp_path: Path) -> None:
     delete_me = raw_dir / "session.json"
     keep_me = raw_dir / "coaching_lap1.json"
     index = tt / "index.json"
+    sessions_index = tt / "sessions_index.json"
     delete_me.write_text('{"raw":1}', encoding="utf-8")
     keep_me.write_text('{"raw":2}', encoding="utf-8")
     keep_me.with_suffix(".pin").write_text("manual", encoding="utf-8")
     index.write_text('{"derived":true}', encoding="utf-8")
+    sessions_index.write_text('{"derived":true}', encoding="utf-8")
     old = datetime(2026, 1, 1, tzinfo=UTC).timestamp()
     os.utime(delete_me, (old, old))
     os.utime(keep_me, (old + 1, old + 1))
@@ -144,7 +183,9 @@ def test_tt_retention_excludes_indexes_and_honors_pins(tmp_path: Path) -> None:
 
     assert [item.path for item in plan.delete] == [delete_me]
     assert index not in {item.path for item in plan.items}
-    apply_retention(plan)
+    result = apply_retention(plan)
+    assert result.invalidated_indexes == 2
     assert not delete_me.exists()
     assert keep_me.exists()
-    assert index.exists()
+    assert not index.exists()
+    assert not sessions_index.exists()

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tools.coaching_lake.retention import RetentionPolicy, apply_retention, plan_retention
+
+
+def _archive(
+    lap_uuid: str,
+    *,
+    exported_at: str,
+    is_pb: bool = False,
+    source: str = "in_game",
+    import_format: str | None = None,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "source": source,
+        "import_format": import_format,
+        "lap_uuid": lap_uuid,
+        "session_uuid": "sess",
+        "exported_at": exported_at,
+        "car": {"id": "bmw_z4_gt3"},
+        "track": {"id": "spa"},
+        "lap": {"lap_n": 1, "lap_ms": 90000, "is_pb": is_pb, "is_valid": True},
+        "trace": {"fields": ["eMs"], "samples": [[0], [90000]]},
+    }
+
+
+def _write_lap(root: Path, name: str, payload: dict) -> Path:
+    path = root / f"lap_{name}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_lap_retention_deletes_only_unprotected_candidates(tmp_path: Path) -> None:
+    laps = tmp_path / "journal" / "laps"
+    profile_path = tmp_path / "journal" / "driver" / "profile.json"
+    profile_path.parent.mkdir(parents=True)
+    laps.mkdir(parents=True)
+    profile_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "personal_bests": {"bmw_z4_gt3|spa|": {"lap_uuid": "lap-profile"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    eligible = _write_lap(
+        laps,
+        "eligible",
+        _archive("lap-eligible", exported_at="2026-01-01T00:00:00Z"),
+    )
+    protected_pb = _write_lap(
+        laps,
+        "pb",
+        _archive("lap-pb", exported_at="2026-01-02T00:00:00Z", is_pb=True),
+    )
+    protected_ref = _write_lap(
+        laps,
+        "ref",
+        _archive(
+            "lap-ref",
+            exported_at="2026-01-03T00:00:00Z",
+            source="imported",
+            import_format="motec_csv",
+        ),
+    )
+    protected_pin = _write_lap(
+        laps,
+        "pin",
+        _archive("lap-pin", exported_at="2026-01-04T00:00:00Z"),
+    )
+    protected_pin.with_suffix(".pin").write_text("manual", encoding="utf-8")
+    protected_profile = _write_lap(
+        laps,
+        "profile",
+        _archive("lap-profile", exported_at="2026-01-05T00:00:00Z"),
+    )
+
+    plan = plan_retention(
+        lap_dir=laps,
+        policy=RetentionPolicy(max_lap_files=3),
+        profile_path=profile_path,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [eligible]
+    protected_paths = {item.path for item in plan.protected}
+    assert {protected_pb, protected_ref, protected_pin, protected_profile} <= protected_paths
+
+    result = apply_retention(plan)
+    assert result.deleted == 1
+    assert not eligible.exists()
+    assert protected_pb.exists()
+    assert protected_ref.exists()
+    assert protected_pin.exists()
+    assert protected_profile.exists()
+
+
+def test_lap_retention_age_cap_is_dry_run_until_apply(tmp_path: Path) -> None:
+    laps = tmp_path / "journal" / "laps"
+    laps.mkdir(parents=True)
+    old = _write_lap(laps, "old", _archive("lap-old", exported_at="2026-01-01T00:00:00Z"))
+    new = _write_lap(laps, "new", _archive("lap-new", exported_at="2026-06-29T00:00:00Z"))
+
+    plan = plan_retention(
+        lap_dir=laps,
+        policy=RetentionPolicy(max_lap_age_days=30),
+        profile_path=None,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [old]
+    assert old.exists()
+    assert new.exists()
+
+
+def test_tt_retention_excludes_indexes_and_honors_pins(tmp_path: Path) -> None:
+    tt = tmp_path / "journal" / "tt"
+    raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"
+    raw_dir.mkdir(parents=True)
+    delete_me = raw_dir / "session.json"
+    keep_me = raw_dir / "coaching_lap1.json"
+    index = tt / "index.json"
+    delete_me.write_text('{"raw":1}', encoding="utf-8")
+    keep_me.write_text('{"raw":2}', encoding="utf-8")
+    keep_me.with_suffix(".pin").write_text("manual", encoding="utf-8")
+    index.write_text('{"derived":true}', encoding="utf-8")
+    old = datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+    os.utime(delete_me, (old, old))
+    os.utime(keep_me, (old + 1, old + 1))
+
+    plan = plan_retention(
+        tt_dir=tt,
+        policy=RetentionPolicy(max_tt_files=1),
+        profile_path=None,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [delete_me]
+    assert index not in {item.path for item in plan.items}
+    apply_retention(plan)
+    assert not delete_me.exists()
+    assert keep_me.exists()
+    assert index.exists()

--- a/tools/ai_sidecar/car_schema.py
+++ b/tools/ai_sidecar/car_schema.py
@@ -278,7 +278,7 @@ class CarSetupSchema:
 
 
 def _main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description="Ingest an ac.getSetupSpinners() dump → schema asset.")
+    p = argparse.ArgumentParser(description="Ingest an ac.getSetupSpinners() dump -> schema asset.")
     p.add_argument("dump", help="JSON file: a list of getSetupSpinners() descriptors")
     p.add_argument("--car-id", required=True)
     p.add_argument("--schema-dir", default=DEFAULT_SCHEMA_DIR)

--- a/tools/ai_sidecar/driver_profile.py
+++ b/tools/ai_sidecar/driver_profile.py
@@ -28,6 +28,10 @@ DEFAULT_DRIVER_ID = "local-driver"
 DEFAULT_PROFILE_PATH = Path("journal/driver/profile.json")
 
 
+class ProfileLoadError(ValueError):
+    """Raised when an existing profile ledger cannot be trusted."""
+
+
 @dataclass(frozen=True)
 class ProfileSummary:
     """Summary of one profile update."""
@@ -136,7 +140,10 @@ def _rollups_from_existing_bests(existing: Mapping[str, Any]) -> dict[str, dict[
 
 
 def load_profile(
-    path: str | Path = DEFAULT_PROFILE_PATH, *, driver_id: str = DEFAULT_DRIVER_ID
+    path: str | Path = DEFAULT_PROFILE_PATH,
+    *,
+    driver_id: str = DEFAULT_DRIVER_ID,
+    strict: bool = False,
 ) -> dict:
     """Load an existing profile, returning a default shell when the file is absent."""
     profile_path = Path(path)
@@ -144,9 +151,19 @@ def load_profile(
         return _default_profile(driver_id)
     try:
         loaded = json.loads(profile_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+    except OSError as exc:
+        if strict:
+            raise ProfileLoadError(f"profile unreadable at {profile_path}: {exc}") from exc
+        return _default_profile(driver_id)
+    except ValueError as exc:
+        if strict:
+            raise ProfileLoadError(f"profile invalid JSON at {profile_path}: {exc}") from exc
         return _default_profile(driver_id)
     if not isinstance(loaded, dict) or loaded.get("schema_version") != PROFILE_SCHEMA_VERSION:
+        if strict:
+            raise ProfileLoadError(
+                f"profile schema mismatch at {profile_path}: expected {PROFILE_SCHEMA_VERSION}"
+            )
         return _default_profile(driver_id)
     loaded.setdefault("driver_id", driver_id)
     loaded.setdefault("preferences", {})
@@ -156,6 +173,50 @@ def load_profile(
     loaded.setdefault("consistency", {})
     loaded.setdefault("source", {"lap_count": 0, "valid_laps": 0, "skipped": []})
     return loaded
+
+
+def _min_present(*values: Any) -> Any:
+    present = [value for value in values if value is not None]
+    return min(present) if present else None
+
+
+def _max_present(*values: Any) -> Any:
+    present = [value for value in values if value is not None]
+    return max(present) if present else None
+
+
+def _merge_session_rollup(existing: Mapping[str, Any] | None, incoming: Mapping[str, Any]) -> dict:
+    if not isinstance(existing, Mapping):
+        return dict(incoming)
+    merged = {**dict(existing), **dict(incoming)}
+    merged["first_exported_at"] = _min_present(
+        existing.get("first_exported_at"), incoming.get("first_exported_at")
+    )
+    merged["last_exported_at"] = _max_present(
+        existing.get("last_exported_at"), incoming.get("last_exported_at")
+    )
+    merged["first_lap_n"] = _min_present(existing.get("first_lap_n"), incoming.get("first_lap_n"))
+    merged["last_lap_n"] = _max_present(existing.get("last_lap_n"), incoming.get("last_lap_n"))
+    merged["lap_count"] = max(
+        int(existing.get("lap_count") or 0), int(incoming.get("lap_count") or 0)
+    )
+    merged["valid_laps"] = max(
+        int(existing.get("valid_laps") or 0), int(incoming.get("valid_laps") or 0)
+    )
+
+    existing_best = _num_ms(existing.get("best_lap_ms"))
+    incoming_best = _num_ms(incoming.get("best_lap_ms"))
+    if existing_best is not None and (incoming_best is None or existing_best <= incoming_best):
+        merged["best_lap_ms"] = existing_best
+        merged["best_lap_uuid"] = existing.get("best_lap_uuid")
+        merged["best_source_file"] = existing.get("best_source_file")
+    elif incoming_best is not None:
+        merged["best_lap_ms"] = incoming_best
+
+    if int(existing.get("valid_laps") or 0) >= int(incoming.get("valid_laps") or 0):
+        merged["median_lap_ms"] = existing.get("median_lap_ms")
+        merged["consistency_ms"] = existing.get("consistency_ms")
+    return merged
 
 
 def _rollups_from_archives(
@@ -259,7 +320,10 @@ def build_profile(
         }
 
     new_rollups, source_laps, valid_laps, skipped = _rollups_from_archives(inputs)
-    base["session_rollups"].update(new_rollups)
+    for key, rollup in new_rollups.items():
+        base["session_rollups"][key] = _merge_session_rollup(
+            base["session_rollups"].get(key), rollup
+        )
     rollups = base["session_rollups"]
 
     by_combo: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -362,7 +426,7 @@ def update_profile(
     generated_at: str | None = None,
 ) -> ProfileSummary:
     """Load, merge, and persist the driver profile."""
-    existing = load_profile(profile_path, driver_id=driver_id)
+    existing = load_profile(profile_path, driver_id=driver_id, strict=True)
     profile = build_profile(
         inputs, driver_id=driver_id, existing=existing, generated_at=generated_at
     )

--- a/tools/ai_sidecar/driver_profile.py
+++ b/tools/ai_sidecar/driver_profile.py
@@ -1,0 +1,404 @@
+"""Persistent driver profile roll-up over immutable lap archives (issue #402).
+
+The profile is a compacted state file under ``journal/driver/profile.json``. It is
+rebuilt or updated from ``journal/laps/lap_*.json`` without mutating those raw
+archives, and it intentionally preserves historical PB/session roll-ups after old
+raw laps are pruned by the retention policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import tempfile
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+from tools.lap_archive_export import iter_lap_archive_paths, lap_is_valid, load_lap_archive
+
+PROFILE_SCHEMA_VERSION = 1
+DEFAULT_DRIVER_ID = "local-driver"
+DEFAULT_PROFILE_PATH = Path("journal/driver/profile.json")
+
+
+@dataclass(frozen=True)
+class ProfileSummary:
+    """Summary of one profile update."""
+
+    path: Path
+    driver_id: str
+    sessions: int
+    personal_bests: int
+    source_laps: int
+
+    def render(self) -> str:
+        return (
+            f"driver profile updated: {self.path} "
+            f"(driver={self.driver_id}, sessions={self.sessions}, "
+            f"personal_bests={self.personal_bests}, source_laps={self.source_laps})"
+        )
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _num_ms(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed) or parsed <= 0:
+        return None
+    return int(round(parsed))
+
+
+def _combo_key(car_id: Any, track_id: Any, track_layout: Any = None) -> str:
+    car = str(car_id or "unknown_car")
+    track = str(track_id or "unknown_track")
+    layout = str(track_layout or "")
+    return f"{car}|{track}|{layout}"
+
+
+def _session_key(session_uuid: Any, car_id: Any, track_id: Any, track_layout: Any = None) -> str:
+    session = str(session_uuid or "unknown_session")
+    return f"{session}|{_combo_key(car_id, track_id, track_layout)}"
+
+
+def _safe_population_stdev(values: list[int]) -> float | None:
+    if len(values) < 2:
+        return None
+    avg = sum(values) / len(values)
+    return math.sqrt(sum((value - avg) ** 2 for value in values) / len(values))
+
+
+def _default_profile(driver_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": PROFILE_SCHEMA_VERSION,
+        "driver_id": driver_id,
+        "updated_at": None,
+        "preferences": {},
+        "focus_corners": {},
+        "session_rollups": {},
+        "personal_bests": {},
+        "consistency": {},
+        "source": {"lap_count": 0, "valid_laps": 0, "skipped": []},
+    }
+
+
+def _rollups_from_existing_bests(existing: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    rollups: dict[str, dict[str, Any]] = {}
+    for combo, row in (existing.get("personal_bests") or {}).items():
+        if not isinstance(row, Mapping):
+            continue
+        lap_ms = _num_ms(row.get("lap_ms"))
+        if lap_ms is None:
+            continue
+        car_id = row.get("car_id")
+        track_id = row.get("track_id")
+        track_layout = row.get("track_layout")
+        if not car_id or not track_id:
+            parts = str(combo).split("|")
+            car_id = car_id or (parts[0] if len(parts) > 0 else None)
+            track_id = track_id or (parts[1] if len(parts) > 1 else None)
+            track_layout = (
+                track_layout if track_layout is not None else (parts[2] if len(parts) > 2 else None)
+            )
+        session_uuid = row.get("session_uuid") or f"pb-{row.get('lap_uuid') or combo}"
+        key = _session_key(session_uuid, car_id, track_id, track_layout)
+        rollups[key] = {
+            "session_uuid": session_uuid,
+            "car_id": car_id,
+            "track_id": track_id,
+            "track_layout": track_layout,
+            "first_exported_at": row.get("exported_at"),
+            "last_exported_at": row.get("exported_at"),
+            "first_lap_n": None,
+            "last_lap_n": None,
+            "lap_count": 1,
+            "valid_laps": 1,
+            "best_lap_ms": lap_ms,
+            "median_lap_ms": float(lap_ms),
+            "consistency_ms": None,
+            "best_lap_uuid": row.get("lap_uuid"),
+            "best_source_file": row.get("source_file"),
+        }
+    return rollups
+
+
+def load_profile(
+    path: str | Path = DEFAULT_PROFILE_PATH, *, driver_id: str = DEFAULT_DRIVER_ID
+) -> dict:
+    """Load an existing profile, returning a default shell when the file is absent."""
+    profile_path = Path(path)
+    if not profile_path.exists():
+        return _default_profile(driver_id)
+    try:
+        loaded = json.loads(profile_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return _default_profile(driver_id)
+    if not isinstance(loaded, dict) or loaded.get("schema_version") != PROFILE_SCHEMA_VERSION:
+        return _default_profile(driver_id)
+    loaded.setdefault("driver_id", driver_id)
+    loaded.setdefault("preferences", {})
+    loaded.setdefault("focus_corners", {})
+    loaded.setdefault("session_rollups", {})
+    loaded.setdefault("personal_bests", {})
+    loaded.setdefault("consistency", {})
+    loaded.setdefault("source", {"lap_count": 0, "valid_laps": 0, "skipped": []})
+    return loaded
+
+
+def _rollups_from_archives(
+    inputs: Iterable[str | Path],
+) -> tuple[dict[str, dict], int, int, list[str]]:
+    grouped: dict[str, list[tuple[Path, dict[str, Any]]]] = defaultdict(list)
+    source_laps = 0
+    valid_laps = 0
+    skipped: list[str] = []
+    for path in iter_lap_archive_paths(inputs):
+        try:
+            record = load_lap_archive(path)
+        except Exception as exc:  # noqa: BLE001 - one corrupt archive must not erase a profile
+            skipped.append(f"{Path(path).name}: {type(exc).__name__}")
+            continue
+        source_laps += 1
+        if lap_is_valid(record):
+            valid_laps += 1
+        car = record.get("car") if isinstance(record.get("car"), Mapping) else {}
+        track = record.get("track") if isinstance(record.get("track"), Mapping) else {}
+        grouped[
+            _session_key(
+                record.get("session_uuid"),
+                car.get("id"),
+                track.get("id"),
+                track.get("layout"),
+            )
+        ].append((Path(path), record))
+
+    rollups: dict[str, dict] = {}
+    for key, rows in grouped.items():
+        rows.sort(
+            key=lambda item: (
+                (item[1].get("lap") or {}).get("lap_n")
+                if isinstance(item[1].get("lap"), dict)
+                else 0,
+                item[1].get("exported_at") or "",
+                item[0].name,
+            )
+        )
+        first = rows[0][1]
+        car = first.get("car") if isinstance(first.get("car"), Mapping) else {}
+        track = first.get("track") if isinstance(first.get("track"), Mapping) else {}
+        valid_rows = [
+            (path, record, _num_ms((record.get("lap") or {}).get("lap_ms")))
+            for path, record in rows
+            if isinstance(record.get("lap"), Mapping) and lap_is_valid(record)
+        ]
+        valid_rows = [(path, record, lap_ms) for path, record, lap_ms in valid_rows if lap_ms]
+        lap_times = [lap_ms for _, _, lap_ms in valid_rows if lap_ms is not None]
+        best_path: Path | None = None
+        best_record: dict[str, Any] | None = None
+        best_ms: int | None = None
+        if valid_rows:
+            best_path, best_record, best_ms = min(
+                valid_rows,
+                key=lambda item: (item[2] or 0, item[1].get("exported_at") or "", item[0].name),
+            )
+        exported = [r.get("exported_at") for _, r in rows if isinstance(r.get("exported_at"), str)]
+        lap_ns = [
+            (r.get("lap") or {}).get("lap_n")
+            for _, r in rows
+            if isinstance(r.get("lap"), Mapping)
+            and isinstance((r.get("lap") or {}).get("lap_n"), int)
+        ]
+        rollups[key] = {
+            "session_uuid": first.get("session_uuid"),
+            "car_id": car.get("id"),
+            "track_id": track.get("id"),
+            "track_layout": track.get("layout"),
+            "first_exported_at": min(exported) if exported else None,
+            "last_exported_at": max(exported) if exported else None,
+            "first_lap_n": min(lap_ns) if lap_ns else None,
+            "last_lap_n": max(lap_ns) if lap_ns else None,
+            "lap_count": len(rows),
+            "valid_laps": len(lap_times),
+            "best_lap_ms": best_ms,
+            "median_lap_ms": float(median(lap_times)) if lap_times else None,
+            "consistency_ms": _safe_population_stdev(lap_times),
+            "best_lap_uuid": best_record.get("lap_uuid") if best_record else None,
+            "best_source_file": best_path.name if best_path else None,
+        }
+    return rollups, source_laps, valid_laps, skipped
+
+
+def build_profile(
+    inputs: Iterable[str | Path],
+    *,
+    driver_id: str = DEFAULT_DRIVER_ID,
+    existing: Mapping[str, Any] | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Build a compacted driver profile by merging archive-derived roll-ups."""
+    base = _default_profile(driver_id)
+    if existing:
+        base["preferences"] = dict(existing.get("preferences") or {})
+        base["focus_corners"] = dict(existing.get("focus_corners") or {})
+        base["session_rollups"] = {
+            **_rollups_from_existing_bests(existing),
+            **dict(existing.get("session_rollups") or {}),
+        }
+
+    new_rollups, source_laps, valid_laps, skipped = _rollups_from_archives(inputs)
+    base["session_rollups"].update(new_rollups)
+    rollups = base["session_rollups"]
+
+    by_combo: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rollup in rollups.values():
+        if not isinstance(rollup, Mapping):
+            continue
+        combo = _combo_key(rollup.get("car_id"), rollup.get("track_id"), rollup.get("track_layout"))
+        by_combo[combo].append(dict(rollup))
+
+    personal_bests: dict[str, dict[str, Any]] = {}
+    consistency: dict[str, dict[str, Any]] = {}
+    for combo, combo_rollups in sorted(by_combo.items()):
+        valid_combo = [r for r in combo_rollups if _num_ms(r.get("best_lap_ms")) is not None]
+        if not valid_combo:
+            continue
+        best = min(
+            valid_combo,
+            key=lambda r: (
+                int(r["best_lap_ms"]),
+                r.get("last_exported_at") or "",
+                r.get("best_source_file") or "",
+            ),
+        )
+        personal_bests[combo] = {
+            "car_id": best.get("car_id"),
+            "track_id": best.get("track_id"),
+            "track_layout": best.get("track_layout"),
+            "lap_ms": int(best["best_lap_ms"]),
+            "lap_uuid": best.get("best_lap_uuid"),
+            "session_uuid": best.get("session_uuid"),
+            "source_file": best.get("best_source_file"),
+            "exported_at": best.get("last_exported_at"),
+        }
+        session_bests = [int(r["best_lap_ms"]) for r in valid_combo]
+        consistency[combo] = {
+            "car_id": best.get("car_id"),
+            "track_id": best.get("track_id"),
+            "track_layout": best.get("track_layout"),
+            "session_count": len(valid_combo),
+            "valid_laps": sum(int(r.get("valid_laps") or 0) for r in valid_combo),
+            "best_lap_ms": min(session_bests),
+            "median_session_best_ms": float(median(session_bests)),
+            "consistency_ms": _safe_population_stdev(session_bests),
+        }
+
+    base.update(
+        {
+            "driver_id": str(driver_id or base.get("driver_id") or DEFAULT_DRIVER_ID),
+            "updated_at": generated_at or _iso_now(),
+            "personal_bests": personal_bests,
+            "consistency": consistency,
+            "source": {
+                "lap_count": source_laps,
+                "valid_laps": valid_laps,
+                "skipped": skipped,
+            },
+        }
+    )
+    return base
+
+
+def _resolve_profile_path(path: str | Path) -> Path:
+    raw = Path(path)
+    base_dir = Path.cwd().resolve()
+    resolved = raw.resolve() if raw.is_absolute() else (base_dir / raw).resolve()
+    journal_driver = (base_dir / "journal" / "driver").resolve()
+    try:
+        resolved.relative_to(journal_driver)
+    except ValueError as exc:
+        raise ValueError(f"{raw}: profile path must stay under journal/driver/") from exc
+    if resolved.name != "profile.json":
+        raise ValueError(f"{raw}: profile filename must be profile.json")
+    return resolved
+
+
+def write_profile(profile: Mapping[str, Any], path: str | Path = DEFAULT_PROFILE_PATH) -> Path:
+    """Atomically write ``profile`` under ``journal/driver/profile.json``."""
+    profile_path = _resolve_profile_path(path)
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(profile, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(dir=str(profile_path.parent), prefix=".profile.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(data)
+        os.replace(tmp_name, profile_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return profile_path
+
+
+def update_profile(
+    inputs: Iterable[str | Path],
+    *,
+    profile_path: str | Path = DEFAULT_PROFILE_PATH,
+    driver_id: str = DEFAULT_DRIVER_ID,
+    generated_at: str | None = None,
+) -> ProfileSummary:
+    """Load, merge, and persist the driver profile."""
+    existing = load_profile(profile_path, driver_id=driver_id)
+    profile = build_profile(
+        inputs, driver_id=driver_id, existing=existing, generated_at=generated_at
+    )
+    path = write_profile(profile, profile_path)
+    return ProfileSummary(
+        path=path,
+        driver_id=profile["driver_id"],
+        sessions=len(profile.get("session_rollups") or {}),
+        personal_bests=len(profile.get("personal_bests") or {}),
+        source_laps=int((profile.get("source") or {}).get("lap_count") or 0),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lap-dir",
+        action="append",
+        type=Path,
+        default=[],
+        help="Directory of lap_*.json archives; repeat for multiple corpora.",
+    )
+    parser.add_argument("--profile", type=Path, default=DEFAULT_PROFILE_PATH)
+    parser.add_argument("--driver-id", default=DEFAULT_DRIVER_ID)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if not args.lap_dir:
+        parser.error("pass at least one --lap-dir")
+    summary = update_profile(args.lap_dir, profile_path=args.profile, driver_id=args.driver_id)
+    print(summary.render())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/coaching_lake/__init__.py
+++ b/tools/coaching_lake/__init__.py
@@ -13,13 +13,17 @@ the JSON is never mutated (data-immutability invariant). See
 
 from __future__ import annotations
 
-from tools.coaching_lake.build_analytics import (
-    LakeSummary,
-    build_lake,
-    list_reports,
-    run_query,
-    run_report,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tools.coaching_lake.build_analytics import (
+        LakeSummary,
+        build_lake,
+        list_reports,
+        run_query,
+        run_report,
+    )
 
 __all__ = [
     "LakeSummary",
@@ -28,3 +32,10 @@ __all__ = [
     "run_query",
     "run_report",
 ]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = import_module("tools.coaching_lake.build_analytics")
+        return getattr(module, name)
+    raise AttributeError(name)

--- a/tools/coaching_lake/build_analytics.py
+++ b/tools/coaching_lake/build_analytics.py
@@ -56,6 +56,8 @@ class LakeSummary:
     db_path: str
     laps: int = 0
     valid_laps: int = 0
+    sessions: int = 0
+    stints: int = 0
     corners: int = 0
     samples: int = 0
     setup_params: int = 0
@@ -67,6 +69,7 @@ class LakeSummary:
         lines = [
             f"coaching lake built: {self.db_path}",
             f"  laps={self.laps} (valid={self.valid_laps})  cars={self.cars}  tracks={self.tracks}",
+            f"  sessions={self.sessions}  stints={self.stints}",
             f"  corners={self.corners}  samples={self.samples}  setup_params={self.setup_params}",
         ]
         if self.skipped:
@@ -131,6 +134,8 @@ def _create_schema(con) -> None:  # noqa: ANN001
     con.execute("DROP TABLE IF EXISTS samples")
     con.execute("DROP TABLE IF EXISTS setup_params")
     con.execute("DROP TABLE IF EXISTS corners")
+    con.execute("DROP TABLE IF EXISTS stints")
+    con.execute("DROP TABLE IF EXISTS sessions")
     con.execute("DROP TABLE IF EXISTS laps")
     con.execute(
         """
@@ -141,6 +146,30 @@ def _create_schema(con) -> None:  # noqa: ANN001
             weather_type TEXT, track_grip DOUBLE, ambient_temp_c DOUBLE, track_temp_c DOUBLE,
             setup_hash TEXT, setup_path TEXT, n_setup_params INTEGER,
             n_corners INTEGER, sample_count INTEGER, exported_at TEXT
+        )
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE sessions (
+            session_uuid TEXT, car_id TEXT, track_id TEXT, track_layout TEXT,
+            first_exported_at TEXT, last_exported_at TEXT,
+            first_lap_n INTEGER, last_lap_n INTEGER,
+            lap_count INTEGER, valid_laps INTEGER,
+            best_lap_ms BIGINT, median_lap_ms DOUBLE, consistency_ms DOUBLE,
+            pb_lap_uuid TEXT
+        )
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE stints (
+            stint_id TEXT, session_uuid TEXT, stint_index INTEGER,
+            car_id TEXT, track_id TEXT, setup_hash TEXT, tyre_set_key TEXT,
+            first_lap_n INTEGER, last_lap_n INTEGER,
+            lap_count INTEGER, valid_laps INTEGER,
+            best_lap_ms BIGINT, median_lap_ms DOUBLE, consistency_ms DOUBLE,
+            first_file TEXT, last_file TEXT
         )
         """
     )
@@ -222,6 +251,88 @@ def _lap_row(rec: dict, path: Path) -> tuple:
         len(rec.get("corners") or []),
         trace.get("samples_count") or len(trace.get("samples") or []),
         rec.get("exported_at"),
+    )
+
+
+def _materialize_session_tables(con) -> None:  # noqa: ANN001
+    """Project first-class session/stint rollups from the loaded lap fact table."""
+    con.execute(
+        """
+        INSERT INTO sessions
+        WITH best AS (
+            SELECT session_uuid, lap_uuid
+            FROM (
+                SELECT session_uuid, lap_uuid,
+                       row_number() OVER (
+                           PARTITION BY session_uuid
+                           ORDER BY lap_ms ASC NULLS LAST, exported_at ASC NULLS LAST, file ASC
+                       ) AS rn
+                FROM laps
+                WHERE is_valid AND lap_ms IS NOT NULL AND lap_ms > 0
+            )
+            WHERE rn = 1
+        )
+        SELECT l.session_uuid,
+               any_value(l.car_id),
+               any_value(l.track_id),
+               any_value(l.track_layout),
+               min(l.exported_at),
+               max(l.exported_at),
+               min(l.lap_n),
+               max(l.lap_n),
+               count(*)::INTEGER,
+               count(*) FILTER (WHERE l.is_valid)::INTEGER,
+               min(l.lap_ms) FILTER (WHERE l.is_valid AND l.lap_ms > 0),
+               median(l.lap_ms) FILTER (WHERE l.is_valid AND l.lap_ms > 0),
+               stddev_samp(l.lap_ms) FILTER (WHERE l.is_valid AND l.lap_ms > 0),
+               any_value(best.lap_uuid)
+        FROM laps l
+        LEFT JOIN best ON l.session_uuid IS NOT DISTINCT FROM best.session_uuid
+        GROUP BY l.session_uuid
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO stints
+        WITH ordered AS (
+            SELECT *,
+                   CASE
+                     WHEN lag(coalesce(setup_hash, '')) OVER (
+                         PARTITION BY session_uuid
+                         ORDER BY lap_n ASC NULLS LAST, exported_at ASC NULLS LAST, file ASC
+                     ) IS NOT DISTINCT FROM coalesce(setup_hash, '')
+                     THEN 0 ELSE 1
+                   END AS stint_start
+            FROM laps
+        ),
+        grouped AS (
+            SELECT *,
+                   sum(stint_start) OVER (
+                       PARTITION BY session_uuid
+                       ORDER BY lap_n ASC NULLS LAST, exported_at ASC NULLS LAST, file ASC
+                       ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                   ) - 1 AS stint_index
+            FROM ordered
+        )
+        SELECT coalesce(session_uuid, 'session') || ':' || stint_index::TEXT AS stint_id,
+               session_uuid,
+               stint_index::INTEGER,
+               any_value(car_id),
+               any_value(track_id),
+               nullif(any_value(setup_hash), ''),
+               coalesce(nullif(any_value(setup_hash), ''), 'unknown-tyre-set'),
+               min(lap_n),
+               max(lap_n),
+               count(*)::INTEGER,
+               count(*) FILTER (WHERE is_valid)::INTEGER,
+               min(lap_ms) FILTER (WHERE is_valid AND lap_ms > 0),
+               median(lap_ms) FILTER (WHERE is_valid AND lap_ms > 0),
+               stddev_samp(lap_ms) FILTER (WHERE is_valid AND lap_ms > 0),
+               min(file),
+               max(file)
+        FROM grouped
+        GROUP BY session_uuid, stint_index
+        """
     )
 
 
@@ -373,10 +484,13 @@ def build_lake(
                         samples_staging.write_rows(rows)
             if samples_staging is not None:
                 summary.samples = samples_staging.copy_into(con)
+            _materialize_session_tables(con)
             con.execute("COMMIT")
             summary.valid_laps = con.execute("SELECT count(*) FROM laps WHERE is_valid").fetchone()[
                 0
             ]
+            summary.sessions = con.execute("SELECT count(*) FROM sessions").fetchone()[0]
+            summary.stints = con.execute("SELECT count(*) FROM stints").fetchone()[0]
             summary.cars = con.execute("SELECT count(DISTINCT car_id) FROM laps").fetchone()[0]
             summary.tracks = con.execute("SELECT count(DISTINCT track_id) FROM laps").fetchone()[0]
             build_ok = True
@@ -406,8 +520,27 @@ REPORTS: dict[str, str] = {
         SELECT count(*) AS laps, count(*) FILTER (WHERE is_valid) AS valid_laps,
                count(DISTINCT car_id) AS cars, count(DISTINCT track_id) AS tracks,
                min(exported_at) AS first_lap, max(exported_at) AS last_lap,
+               (SELECT count(*) FROM sessions) AS sessions,
+               (SELECT count(*) FROM stints) AS stints,
                (SELECT count(*) FROM samples) AS samples
         FROM laps
+    """,
+    "sessions": """
+        SELECT car_id, track_id, session_uuid, lap_count, valid_laps,
+               best_lap_ms, round(median_lap_ms, 1) AS median_lap_ms,
+               round(consistency_ms, 1) AS consistency_ms, pb_lap_uuid,
+               first_exported_at, last_exported_at
+        FROM sessions
+        ORDER BY last_exported_at, session_uuid
+    """,
+    "stints": """
+        SELECT car_id, track_id, session_uuid, stint_index, tyre_set_key,
+               lap_count, valid_laps, best_lap_ms,
+               round(median_lap_ms, 1) AS median_lap_ms,
+               round(consistency_ms, 1) AS consistency_ms,
+               first_lap_n, last_lap_n
+        FROM stints
+        ORDER BY session_uuid, stint_index
     """,
     "best-laps": """
         SELECT car_id, track_id, count(*) AS laps,

--- a/tools/coaching_lake/retention.py
+++ b/tools/coaching_lake/retention.py
@@ -30,6 +30,17 @@ class RetentionPolicy:
     max_tt_files: int | None = None
     max_tt_age_days: int | None = None
 
+    def __post_init__(self) -> None:
+        for name in (
+            "max_lap_files",
+            "max_lap_age_days",
+            "max_tt_files",
+            "max_tt_age_days",
+        ):
+            value = getattr(self, name)
+            if value is not None and value < 0:
+                raise ValueError(f"{name} must be non-negative")
+
 
 @dataclass(frozen=True)
 class RetentionItem:
@@ -73,10 +84,13 @@ class RetentionApplyResult:
 
     deleted: int
     bytes_deleted: int
+    invalidated_indexes: int = 0
     failures: tuple[str, ...] = ()
 
     def render(self) -> str:
         text = f"retention applied: deleted={self.deleted}, bytes={self.bytes_deleted}"
+        if self.invalidated_indexes:
+            text += f", invalidated_indexes={self.invalidated_indexes}"
         if self.failures:
             text += f", failures={len(self.failures)}"
         return text
@@ -242,6 +256,21 @@ def _select_by_cap(
     return sorted(selected.values(), key=lambda item: (item.sort_time, item.path.as_posix()))
 
 
+def _tt_index_paths_for_deleted(items: Sequence[RetentionItem]) -> list[Path]:
+    roots: set[Path] = set()
+    for item in items:
+        if item.domain != "tt":
+            continue
+        for parent in item.path.parents:
+            if any((parent / name).exists() for name in DERIVED_TT_INDEXES):
+                roots.add(parent)
+                break
+    return sorted(
+        (root / name for root in roots for name in DERIVED_TT_INDEXES if (root / name).exists()),
+        key=lambda path: path.as_posix(),
+    )
+
+
 def plan_retention(
     *,
     lap_dir: str | Path | None = None,
@@ -252,7 +281,7 @@ def plan_retention(
 ) -> RetentionPlan:
     """Build a deterministic retention plan without deleting anything."""
     stamp = now or datetime.now(UTC)
-    profile = load_profile(profile_path) if profile_path is not None else None
+    profile = load_profile(profile_path, strict=True) if profile_path is not None else None
     items: list[RetentionItem] = []
     delete: list[RetentionItem] = []
 
@@ -295,6 +324,7 @@ def apply_retention(plan: RetentionPlan) -> RetentionApplyResult:
     """Delete files selected by a plan. Pin/protection is decided only during planning."""
     deleted = 0
     bytes_deleted = 0
+    deleted_tt_items: list[RetentionItem] = []
     failures: list[str] = []
     for item in plan.delete:
         try:
@@ -304,8 +334,21 @@ def apply_retention(plan: RetentionPlan) -> RetentionApplyResult:
             continue
         deleted += 1
         bytes_deleted += item.bytes
+        if item.domain == "tt":
+            deleted_tt_items.append(item)
+    invalidated_indexes = 0
+    for index_path in _tt_index_paths_for_deleted(deleted_tt_items):
+        try:
+            index_path.unlink()
+        except OSError as exc:
+            failures.append(f"{index_path}: {exc}")
+            continue
+        invalidated_indexes += 1
     return RetentionApplyResult(
-        deleted=deleted, bytes_deleted=bytes_deleted, failures=tuple(failures)
+        deleted=deleted,
+        bytes_deleted=bytes_deleted,
+        invalidated_indexes=invalidated_indexes,
+        failures=tuple(failures),
     )
 
 
@@ -329,18 +372,21 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.lap_dir is None and args.tt_dir is None:
         parser.error("pass --lap-dir and/or --tt-dir")
-    policy = RetentionPolicy(
-        max_lap_files=args.max_lap_files,
-        max_lap_age_days=args.max_lap_age_days,
-        max_tt_files=args.max_tt_files,
-        max_tt_age_days=args.max_tt_age_days,
-    )
-    plan = plan_retention(
-        lap_dir=args.lap_dir,
-        tt_dir=args.tt_dir,
-        policy=policy,
-        profile_path=args.profile,
-    )
+    try:
+        policy = RetentionPolicy(
+            max_lap_files=args.max_lap_files,
+            max_lap_age_days=args.max_lap_age_days,
+            max_tt_files=args.max_tt_files,
+            max_tt_age_days=args.max_tt_age_days,
+        )
+        plan = plan_retention(
+            lap_dir=args.lap_dir,
+            tt_dir=args.tt_dir,
+            policy=policy,
+            profile_path=args.profile,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
     print(plan.render())
     if args.apply:
         print(apply_retention(plan).render())

--- a/tools/coaching_lake/retention.py
+++ b/tools/coaching_lake/retention.py
@@ -1,0 +1,353 @@
+"""Retention planner for AC Copilot journal data (issue #402).
+
+The raw lap and Track Titan lakes are immutable evidence until an explicit lifecycle
+policy prunes them. This module makes that pruning deterministic and auditable:
+planning is pure, dry-run is the CLI default, and deletion preserves PB, imported
+reference, sidecar-pinned, and profile-ledger PB files.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from tools.ai_sidecar.driver_profile import DEFAULT_PROFILE_PATH, load_profile
+from tools.lap_archive_export import LapArchiveExportError, iter_lap_archive_paths, load_lap_archive
+
+DERIVED_TT_INDEXES = frozenset({"index.json", "sessions_index.json"})
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """Retention caps. ``None`` means that dimension is disabled."""
+
+    max_lap_files: int | None = None
+    max_lap_age_days: int | None = None
+    max_tt_files: int | None = None
+    max_tt_age_days: int | None = None
+
+
+@dataclass(frozen=True)
+class RetentionItem:
+    """One file considered by the retention planner."""
+
+    path: Path
+    domain: str
+    protected: bool
+    reasons: tuple[str, ...]
+    sort_time: datetime
+    bytes: int = 0
+
+
+@dataclass(frozen=True)
+class RetentionPlan:
+    """Deterministic retention outcome."""
+
+    policy: RetentionPolicy
+    items: tuple[RetentionItem, ...] = field(default_factory=tuple)
+    delete: tuple[RetentionItem, ...] = field(default_factory=tuple)
+
+    @property
+    def protected(self) -> tuple[RetentionItem, ...]:
+        return tuple(item for item in self.items if item.protected)
+
+    def render(self) -> str:
+        lines = [
+            f"retention plan: {len(self.delete)} delete candidate(s), "
+            f"{len(self.protected)} protected, {len(self.items)} scanned"
+        ]
+        for item in self.delete[:20]:
+            lines.append(f"  DELETE {item.domain} {item.path} ({', '.join(item.reasons)})")
+        if len(self.delete) > 20:
+            lines.append(f"  ... {len(self.delete) - 20} more")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class RetentionApplyResult:
+    """Summary of files removed by ``apply_retention``."""
+
+    deleted: int
+    bytes_deleted: int
+    failures: tuple[str, ...] = ()
+
+    def render(self) -> str:
+        text = f"retention applied: deleted={self.deleted}, bytes={self.bytes_deleted}"
+        if self.failures:
+            text += f", failures={len(self.failures)}"
+        return text
+
+
+def _parse_time(raw: Any, fallback: datetime) -> datetime:
+    if isinstance(raw, str) and raw:
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(UTC)
+        except ValueError:
+            pass
+    return fallback
+
+
+def _mtime(path: Path) -> datetime:
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return datetime.fromtimestamp(0, tz=UTC)
+
+
+def _has_pin_marker(path: Path) -> bool:
+    markers = (
+        path.with_suffix(path.suffix + ".pin"),
+        path.with_suffix(path.suffix + ".keep"),
+        path.with_suffix(".pin"),
+        path.with_suffix(".keep"),
+    )
+    return any(marker.exists() for marker in markers)
+
+
+def _profile_pb_lap_uuids(profile: Mapping[str, Any] | None) -> set[str]:
+    out: set[str] = set()
+    if not isinstance(profile, Mapping):
+        return out
+    for row in (profile.get("personal_bests") or {}).values():
+        if isinstance(row, Mapping) and isinstance(row.get("lap_uuid"), str):
+            out.add(row["lap_uuid"])
+    return out
+
+
+def _is_reference_archive(record: Mapping[str, Any]) -> bool:
+    return (
+        record.get("source") == "imported"
+        or isinstance(record.get("import_format"), str)
+        or isinstance(record.get("generator"), Mapping)
+    )
+
+
+def _lap_items(lap_dir: Path, profile: Mapping[str, Any] | None) -> list[RetentionItem]:
+    pb_lap_uuids = _profile_pb_lap_uuids(profile)
+    items: list[RetentionItem] = []
+    for path in iter_lap_archive_paths([lap_dir]):
+        reasons: list[str] = []
+        protected = False
+        fallback_time = _mtime(path)
+        sort_time = fallback_time
+        try:
+            record = load_lap_archive(path)
+        except (LapArchiveExportError, OSError, ValueError):
+            record = {}
+            protected = True
+            reasons.append("unreadable")
+        if record:
+            sort_time = _parse_time(record.get("exported_at"), fallback_time)
+            lap = record.get("lap") if isinstance(record.get("lap"), Mapping) else {}
+            if lap.get("is_pb") is True:
+                protected = True
+                reasons.append("lap-pb")
+            if record.get("lap_uuid") in pb_lap_uuids:
+                protected = True
+                reasons.append("profile-pb")
+            if _is_reference_archive(record):
+                protected = True
+                reasons.append("reference")
+        if _has_pin_marker(path):
+            protected = True
+            reasons.append("pinned")
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = 0
+        items.append(
+            RetentionItem(
+                path=path,
+                domain="laps",
+                protected=protected,
+                reasons=tuple(reasons) if reasons else ("eligible",),
+                sort_time=sort_time,
+                bytes=size,
+            )
+        )
+    return sorted(items, key=lambda item: (item.sort_time, item.path.as_posix()))
+
+
+def _tt_raw_paths(tt_dir: Path) -> Iterable[Path]:
+    if not tt_dir.exists():
+        return []
+    return (
+        path
+        for path in sorted(tt_dir.rglob("*.json"))
+        if path.is_file() and path.name not in DERIVED_TT_INDEXES
+    )
+
+
+def _tt_items(tt_dir: Path) -> list[RetentionItem]:
+    items: list[RetentionItem] = []
+    for path in _tt_raw_paths(tt_dir):
+        reasons: list[str] = []
+        protected = False
+        if _has_pin_marker(path):
+            protected = True
+            reasons.append("pinned")
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = 0
+        items.append(
+            RetentionItem(
+                path=path,
+                domain="tt",
+                protected=protected,
+                reasons=tuple(reasons) if reasons else ("eligible",),
+                sort_time=_mtime(path),
+                bytes=size,
+            )
+        )
+    return sorted(items, key=lambda item: (item.sort_time, item.path.as_posix()))
+
+
+def _select_by_cap(
+    items: Sequence[RetentionItem],
+    *,
+    max_files: int | None,
+    max_age_days: int | None,
+    now: datetime,
+) -> list[RetentionItem]:
+    eligible = [item for item in items if not item.protected]
+    selected: dict[Path, RetentionItem] = {}
+    if max_age_days is not None:
+        cutoff = now - timedelta(days=max_age_days)
+        for item in eligible:
+            if item.sort_time < cutoff:
+                selected[item.path] = RetentionItem(
+                    path=item.path,
+                    domain=item.domain,
+                    protected=item.protected,
+                    reasons=tuple(sorted(set(item.reasons + ("age-cap",)))),
+                    sort_time=item.sort_time,
+                    bytes=item.bytes,
+                )
+    if max_files is not None and max_files >= 0 and len(items) > max_files:
+        needed = len(items) - max_files
+        for item in eligible[:needed]:
+            selected[item.path] = RetentionItem(
+                path=item.path,
+                domain=item.domain,
+                protected=item.protected,
+                reasons=tuple(sorted(set(item.reasons + ("count-cap",)))),
+                sort_time=item.sort_time,
+                bytes=item.bytes,
+            )
+    return sorted(selected.values(), key=lambda item: (item.sort_time, item.path.as_posix()))
+
+
+def plan_retention(
+    *,
+    lap_dir: str | Path | None = None,
+    tt_dir: str | Path | None = None,
+    policy: RetentionPolicy,
+    profile_path: str | Path | None = DEFAULT_PROFILE_PATH,
+    now: datetime | None = None,
+) -> RetentionPlan:
+    """Build a deterministic retention plan without deleting anything."""
+    stamp = now or datetime.now(UTC)
+    profile = load_profile(profile_path) if profile_path is not None else None
+    items: list[RetentionItem] = []
+    delete: list[RetentionItem] = []
+
+    if lap_dir is not None:
+        lap_items = _lap_items(Path(lap_dir), profile)
+        items.extend(lap_items)
+        delete.extend(
+            _select_by_cap(
+                lap_items,
+                max_files=policy.max_lap_files,
+                max_age_days=policy.max_lap_age_days,
+                now=stamp,
+            )
+        )
+
+    if tt_dir is not None:
+        tt_items = _tt_items(Path(tt_dir))
+        items.extend(tt_items)
+        delete.extend(
+            _select_by_cap(
+                tt_items,
+                max_files=policy.max_tt_files,
+                max_age_days=policy.max_tt_age_days,
+                now=stamp,
+            )
+        )
+
+    return RetentionPlan(
+        policy=policy,
+        items=tuple(
+            sorted(items, key=lambda item: (item.domain, item.sort_time, item.path.as_posix()))
+        ),
+        delete=tuple(
+            sorted(delete, key=lambda item: (item.domain, item.sort_time, item.path.as_posix()))
+        ),
+    )
+
+
+def apply_retention(plan: RetentionPlan) -> RetentionApplyResult:
+    """Delete files selected by a plan. Pin/protection is decided only during planning."""
+    deleted = 0
+    bytes_deleted = 0
+    failures: list[str] = []
+    for item in plan.delete:
+        try:
+            item.path.unlink()
+        except OSError as exc:
+            failures.append(f"{item.path}: {exc}")
+            continue
+        deleted += 1
+        bytes_deleted += item.bytes
+    return RetentionApplyResult(
+        deleted=deleted, bytes_deleted=bytes_deleted, failures=tuple(failures)
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lap-dir", type=Path, default=None)
+    parser.add_argument("--tt-dir", type=Path, default=None)
+    parser.add_argument("--profile", type=Path, default=DEFAULT_PROFILE_PATH)
+    parser.add_argument("--max-lap-files", type=int, default=None)
+    parser.add_argument("--max-lap-age-days", type=int, default=None)
+    parser.add_argument("--max-tt-files", type=int, default=None)
+    parser.add_argument("--max-tt-age-days", type=int, default=None)
+    parser.add_argument(
+        "--apply", action="store_true", help="delete planned files; default is dry-run"
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.lap_dir is None and args.tt_dir is None:
+        parser.error("pass --lap-dir and/or --tt-dir")
+    policy = RetentionPolicy(
+        max_lap_files=args.max_lap_files,
+        max_lap_age_days=args.max_lap_age_days,
+        max_tt_files=args.max_tt_files,
+        max_tt_age_days=args.max_tt_age_days,
+    )
+    plan = plan_retention(
+        lap_dir=args.lap_dir,
+        tt_dir=args.tt_dir,
+        policy=policy,
+        profile_path=args.profile,
+    )
+    print(plan.render())
+    if args.apply:
+        print(apply_retention(plan).render())
+    else:
+        print("dry-run only; pass --apply to delete planned files")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -312,6 +312,25 @@ def export_csv(
     return rows_written
 
 
+def export_csv_stream(
+    inputs: Iterable[str | Path],
+    output: TextIO,
+    *,
+    include_invalid: bool = False,
+    include_header: bool = True,
+) -> int:
+    """Stream stable analysis CSV rows to an already-open text file."""
+    writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS, lineterminator="\n")
+    if include_header:
+        writer.writeheader()
+    rows_written = 0
+    archives = _iter_loaded_archives(inputs, include_invalid=include_invalid)
+    for row in iter_csv_rows(archives):
+        writer.writerow({column: _format_cell(row.get(column)) for column in CSV_COLUMNS})
+        rows_written += 1
+    return rows_written
+
+
 def _parse_exported_at(record: dict[str, Any]) -> datetime | None:
     raw = record.get("exported_at")
     if not isinstance(raw, str) or not raw:
@@ -580,14 +599,21 @@ def main(argv: Sequence[str] | None = None, *, stderr: TextIO | None = None) -> 
     args = parser.parse_args(argv)
     err = stderr if stderr is not None else sys.stderr
     try:
-        if args.format == "csv":
+        if args.output == "-" and args.format != "csv":
+            raise LapArchiveExportError("stdout streaming is only supported for --format csv")
+        if args.output == "-":
+            count = export_csv_stream(args.inputs, sys.stdout, include_invalid=args.include_invalid)
+        elif args.format == "csv":
             count = export_csv(args.inputs, args.output, include_invalid=args.include_invalid)
         else:
             count = export_motec_csv(args.inputs, args.output, include_invalid=args.include_invalid)
     except LapArchiveExportError as exc:
         print(f"lap-archive-export: {exc}", file=err)
         return 2
-    print(f"wrote {count} sample rows to {args.output}")
+    print(
+        f"wrote {count} sample rows to {args.output}",
+        file=err if args.output == "-" else sys.stdout,
+    )
     return 0
 
 


### PR DESCRIPTION
﻿## Summary

- Adds first-class `sessions` and `stints` rollups to the DuckDB coaching lake, including `sessions` / `stints` reports.
- Adds `tools.ai_sidecar.driver_profile` for a compacted `journal/driver/profile.json` driver ledger with PBs, focus corners, preferences, and session consistency rollups.
- Adds `tools.coaching_lake.retention` dry-run-first lifecycle planning for `journal/laps` and `journal/tt`, preserving PB/reference/profile-pinned/sidecar-pinned evidence.
- Adds stdout CSV streaming for `tools.lap_archive_export --output -` and documents the #402 data-platform entrypoints.
- Hardens lifecycle safeguards from review: profile reads fail closed when an existing ledger is invalid, compacted session bests survive partial rebuilds, retention caps reject negative values, TT derived indexes are invalidated after TT raw deletions, and Git Bash normalizes Windows drive-letter paths in the agentic-memory wrapper.

## Verification

- Focused ruff over changed #402 modules/tests: all checks passed.
- Focused pytest over coaching lake, driver profile, retention, lap archive export, and agentic-memory wrapper: `47 passed`.
- Scratch CLI smoke in `.scratch/issue402-verify`: built `journal/lake.duckdb` from 3 synthetic archive files -> `laps=3`, `sessions=2`, `stints=2`; `--report sessions` returned `verify-session-a` PB `verify-b` and `verify-session-b` PB `verify-c`; driver profile wrote 2 session rollups / 1 PB; retention dry-run selected only `lap_verify_a.json`; `lap_archive_export --output -` streamed 9 CSV rows with summary on stderr.
- Full local parity in clean LF checkout `C:\Users\arsen\Projects\ac-copilot-trainer-ci-402-lf`: `make ci-fast PYTHON=python` with repo venv + Git Bash on PATH -> `ci-fast: OK` (`1977 passed, 76 skipped`, coverage 85.59%; ruff, bandit, secrets, policy docs, agent proof, CSP API/UI safety all passed; root-file allowlist warnings only for existing `.copier-answers.yml` and `doppler.yaml`).
- GitHub PR checks on head `63ba78d`: `build`, `Canonical docs exist`, and `conformance` passed; Vault auto-merge skipped as expected. All review threads resolved after the final cooldown.

Closes #402.
