### PR TITLE
feat(coach): add race management cues (#406)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2317,9 +2317,10 @@ function script.update(dt)
         wsBridge = wsBridge,
       })
     end
+    local currentTireTemps = tires:currentTemps(car)
     telemetryPublisher.publishTireTempsIfDue({
       dt = dt,
-      temps = tires:currentTemps(car),
+      temps = currentTireTemps,
       wsBridge = wsBridge,
     })
     telemetryPublisher.publishTelemetryTickIfDue({
@@ -2328,6 +2329,7 @@ function script.update(dt)
       wsBridge = wsBridge,
       lat_g = 0,
       long_g = 0,
+      temps = currentTireTemps,
     })
   end)
   -- Round 10: drain any corner_advice replies into state.cornerAdvisories.

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -165,8 +165,27 @@ local function _field(obj, key)
 end
 
 
+local function _cornerMap(values)
+  if type(values) ~= "table" then
+    return nil
+  end
+  local out = {}
+  local any = false
+  for _, key in ipairs({ "fl", "fr", "rl", "rr" }) do
+    local v = _finite(values[key])
+    if v ~= nil then
+      out[key] = v
+      any = true
+    end
+  end
+  if any then
+    return out
+  end
+  return nil
+end
+
 --- Publish client→server ``telemetry_tick`` at ~20 Hz (M0 #341). Requires ``wsBridge.sendJson``.
----@param opts table  {dt:number, car:any, wsBridge, lat_g?:number, long_g?:number}
+---@param opts table  {dt:number, car:any, wsBridge, lat_g?:number, long_g?:number, temps?:table}
 ---@return boolean
 function M.publishTelemetryTickIfDue(opts)
   if type(opts) ~= "table" then
@@ -196,22 +215,35 @@ function M.publishTelemetryTickIfDue(opts)
       gear = math.max(0, math.floor(g))
     end
   end
+  local payload = {
+    speed_kmh = math.max(0, _finite(_field(car, "speedKmh")) or 0),
+    rpm = math.max(0, _finite(_field(car, "rpm")) or 0),
+    throttle = _clamp(_field(car, "gas") or 0, 0, 1),
+    brake = _clamp(_field(car, "brake") or 0, 0, 1),
+    steer = _clamp(_field(car, "steer") or 0, -1, 1),
+    gear = gear,
+    lat_g = _finite(opts.lat_g) or 0,
+    long_g = _finite(opts.long_g) or 0,
+    spline = _clamp(_field(car, "splinePosition") or 0, 0, 1),
+    lap = math.max(0, math.floor(tonumber(_field(car, "lapCount")) or 0)),
+  }
+  local fuel = _finite(_field(car, "fuel"))
+  if fuel ~= nil then
+    payload.fuel_l = math.max(0, fuel)
+  end
+  local fuelCapacity = _finite(_field(car, "fuelCapacity") or _field(car, "maxFuel"))
+  if fuelCapacity ~= nil then
+    payload.fuel_capacity_l = math.max(0, fuelCapacity)
+  end
+  local tyreTemps = _cornerMap(opts.temps)
+  if tyreTemps ~= nil then
+    payload.tyre_temps_c = tyreTemps
+  end
   return wsBridge.sendJson({
     v = 1,
     type = "telemetry_tick",
     seq = _tickSeq,
-    payload = {
-      speed_kmh = math.max(0, _finite(_field(car, "speedKmh")) or 0),
-      rpm = math.max(0, _finite(_field(car, "rpm")) or 0),
-      throttle = _clamp(_field(car, "gas") or 0, 0, 1),
-      brake = _clamp(_field(car, "brake") or 0, 0, 1),
-      steer = _clamp(_field(car, "steer") or 0, -1, 1),
-      gear = gear,
-      lat_g = _finite(opts.lat_g) or 0,
-      long_g = _finite(opts.long_g) or 0,
-      spline = _clamp(_field(car, "splinePosition") or 0, 0, 1),
-      lap = math.max(0, math.floor(tonumber(_field(car, "lapCount")) or 0)),
-    },
+    payload = payload,
   }) == true
 end
 

--- a/tests/test_external_protocol_m0.py
+++ b/tests/test_external_protocol_m0.py
@@ -69,3 +69,31 @@ def test_telemetry_tick_rejects_negative_lap():
 def test_telemetry_tick_valid_without_spline_backcompat():
     # spline is additive/optional — a legacy peripheral frame without it still validates.
     assert validate_inbound(make_telemetry_tick(_full_payload())) is None
+
+
+def test_telemetry_tick_accepts_race_management_channels():
+    frame = make_telemetry_tick(
+        _full_payload(
+            fuel_l=12.5,
+            target_laps_remaining=5.0,
+            tyre_temps_c={"fl": 92.0, "fr": 93.0, "rl": 89.0, "rr": 90.0},
+            tyre_wear_pct={"fl": 12.0, "fr": 11.0},
+            brake_temps_c={"fl": 500.0, "fr": 510.0},
+            weather_type="dry",
+            track_temp_c=32.0,
+            track_grip_level=0.98,
+        )
+    )
+    assert validate_inbound(frame) is None
+
+
+def test_telemetry_tick_rejects_bad_race_management_channels():
+    assert "fuel_l must be >= 0" in (
+        validate_inbound(make_telemetry_tick(_full_payload(fuel_l=-1.0))) or ""
+    )
+    assert "tyre_wear_pct.xx is not a known corner" in (
+        validate_inbound(make_telemetry_tick(_full_payload(tyre_wear_pct={"xx": 1.0}))) or ""
+    )
+    assert "weather_type must be a string" in (
+        validate_inbound(make_telemetry_tick(_full_payload(weather_type=7))) or ""
+    )

--- a/tests/test_race_management.py
+++ b/tests/test_race_management.py
@@ -1,0 +1,157 @@
+"""Tests for live stint-level race management cues."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.race_management import RaceManagementObserver
+
+
+def _tick(**payload):
+    base = {
+        "spline": 0.2,
+        "speed_kmh": 120.0,
+        "brake": 0.0,
+        "throttle": 0.8,
+        "lap": 0,
+    }
+    base.update(payload)
+    return {"type": "telemetry_tick", "payload": base}
+
+
+def test_fuel_save_cue_uses_observed_per_lap_burn_and_target() -> None:
+    observer = RaceManagementObserver()
+
+    assert observer.observe(_tick(lap=0, fuel_l=10.0)) == []
+    out = observer.observe(_tick(lap=1, fuel_l=8.0, target_laps_remaining=5.0))
+
+    save = next(a for a in out if a.kind == "fuel_save")
+    assert save.register == "critical"
+    assert "lift and coast" in save.message
+    assert save.detail["fuel_per_lap_l"] == 2.0
+    assert save.detail["laps_remaining"] == 4.0
+    assert save.detail["target_laps_remaining"] == 5.0
+    assert save.detail["deficit_laps"] == 1.0
+
+
+def test_fuel_status_cue_when_fuel_is_enough() -> None:
+    observer = RaceManagementObserver()
+
+    observer.observe(_tick(lap=0, fuel_l=10.0))
+    out = observer.observe(_tick(lap=1, fuel_l=8.0, target_laps_remaining=3.0))
+
+    assert [a.kind for a in out] == ["fuel_status"]
+    assert out[0].detail["laps_remaining"] == 4.0
+
+
+def test_fuel_uses_frame_per_lap_until_observed_lap_sample_exists() -> None:
+    observer = RaceManagementObserver()
+
+    out = observer.observe(_tick(lap=2, fuel_l=3.0, fuel_per_lap_l=1.0, target_laps_remaining=4.0))
+
+    cue = next(a for a in out if a.kind == "fuel_save")
+    assert cue.detail["fuel_per_lap_l"] == 1.0
+    assert cue.detail["fuel_per_lap_source"] == "frame"
+
+
+def test_fuel_burn_normalizes_when_lap_counter_skips() -> None:
+    observer = RaceManagementObserver()
+
+    observer.observe(_tick(lap=0, fuel_l=10.0))
+    out = observer.observe(_tick(lap=2, fuel_l=6.0, target_laps_remaining=2.0))
+
+    status = next(a for a in out if a.kind == "fuel_status")
+    assert status.detail["fuel_per_lap_l"] == 2.0
+    assert status.detail["fuel_per_lap_source"] == "observed_laps"
+
+
+def test_fuel_sampling_resets_when_lap_counter_rolls_back() -> None:
+    observer = RaceManagementObserver()
+
+    observer.observe(_tick(lap=0, fuel_l=10.0))
+    observer.observe(_tick(lap=1, fuel_l=6.0, target_laps_remaining=1.0))
+    assert observer.observe(_tick(lap=0, fuel_l=30.0, target_laps_remaining=2.0)) == []
+    out = observer.observe(_tick(lap=1, fuel_l=29.0, target_laps_remaining=2.0))
+
+    status = next(a for a in out if a.kind == "fuel_status")
+    assert status.detail["fuel_per_lap_l"] == 1.0
+    assert status.detail["samples"] == 1
+
+
+def test_tyre_overheat_is_distinct_from_wear() -> None:
+    observer = RaceManagementObserver()
+    out = observer.observe(
+        _tick(
+            lap=4,
+            tyre_temps_c={"fl": 112.0, "fr": 111.0, "rl": 93.0, "rr": 94.0},
+            tyre_wear_pct={"fl": 30.0, "fr": 28.0, "rl": 35.0, "rr": 34.0},
+            tyre_compound="medium",
+        )
+    )
+
+    cue = next(a for a in out if a.kind == "tyre_manage")
+    assert cue.detail["classification"] == "overheat"
+    assert "overheating" in cue.message
+    assert cue.detail["wear_signal"] is True
+
+
+def test_tyre_critical_escalates_after_overheat_on_same_lap() -> None:
+    observer = RaceManagementObserver()
+
+    first = observer.observe(
+        _tick(
+            lap=4,
+            tyre_temps_c={"fl": 112.0, "fr": 111.0, "rl": 93.0, "rr": 94.0},
+            tyre_compound="medium",
+        )
+    )
+    second = observer.observe(
+        _tick(
+            lap=4,
+            tyre_temps_c={"fl": 126.0, "fr": 127.0, "rl": 96.0, "rr": 97.0},
+            tyre_compound="medium",
+        )
+    )
+
+    assert next(a for a in first if a.kind == "tyre_manage").detail["classification"] == "overheat"
+    escalated = next(a for a in second if a.kind == "tyre_manage")
+    assert escalated.detail["classification"] == "critical"
+    assert escalated.register == "critical"
+
+
+def test_tyre_wear_cue_when_worn_but_not_hot() -> None:
+    observer = RaceManagementObserver()
+    out = observer.observe(
+        _tick(
+            lap=8,
+            tyre_temps_c={"fl": 88.0, "fr": 88.0, "rl": 90.0, "rr": 91.0},
+            tyre_wear_pct={"fl": 20.0, "fr": 25.0, "rl": 78.0, "rr": 80.0},
+            tyre_compound="medium",
+        )
+    )
+
+    cue = next(a for a in out if a.kind == "tyre_manage")
+    assert cue.detail["classification"] == "wear"
+    assert "without an overheat signal" in cue.message
+
+
+def test_brake_temperature_management_cue_when_channel_is_available() -> None:
+    observer = RaceManagementObserver()
+    out = observer.observe(
+        _tick(lap=3, brake_temps_c={"fl": 880.0, "fr": 870.0, "rl": 600.0, "rr": 610.0})
+    )
+
+    cue = next(a for a in out if a.kind == "brake_manage")
+    assert cue.detail["classification"] == "critical_temp"
+    assert cue.register == "critical"
+
+
+def test_conditions_strategy_wet_and_deduped() -> None:
+    observer = RaceManagementObserver()
+    frame = _tick(weather_type="light_rain", track_temp_c=15.0, track_grip_level=0.92)
+
+    first = observer.observe(frame)
+    second = observer.observe(frame)
+
+    cue = next(a for a in first if a.kind == "conditions_strategy")
+    assert cue.urgency == "act"
+    assert cue.detail["classification"] == "wet_regime"
+    assert second == []

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -44,6 +44,7 @@ def _reset_feed(monkeypatch):
     """Isolate the single-producer feed globals per test."""
     monkeypatch.setattr(server, "_observer_feed_peer", None)
     monkeypatch.setattr(server, "_observer_feed_warned", False)
+    server.set_race_manager(server.RaceManagementObserver())
     server._peripheral_rate_limiter.reset()
     server._background_tasks.clear()
 
@@ -96,6 +97,27 @@ def test_publish_coaching_cues_noop_without_observer(monkeypatch):
     sent = _capture_broadcast(monkeypatch)
     asyncio.run(_run_publish_cues({"type": "telemetry_tick", "payload": {}}, exclude=None))
     assert sent == []
+
+
+def test_publish_coaching_cues_fans_out_race_management_without_corner_observer(monkeypatch):
+    _reset_feed(monkeypatch)
+    race = _FakeObserver([_adv(kind="fuel_save", corner=-1, urgency="act")])
+    monkeypatch.setattr(server, "_observer", None)
+    server.set_race_manager(race)
+    sent = _capture_broadcast(monkeypatch)
+    try:
+        asyncio.run(
+            _run_publish_cues(
+                {"type": "telemetry_tick", "payload": {"fuel_l": 8.0, "lap": 2}},
+                exclude="ws-1",
+            )
+        )
+    finally:
+        server.set_race_manager(server.RaceManagementObserver())
+
+    assert race.calls == 1
+    assert len(sent) == 1
+    assert sent[0][0]["payload"]["kind"] == "fuel_save"
 
 
 def test_publish_coaching_cues_swallows_observer_error(monkeypatch):

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -354,6 +354,36 @@ def test_telemetry_tick_rate_limited_to_20hz():
     assert out["lap"] == 2
 
 
+def test_telemetry_tick_carries_fuel_and_tyre_temps_when_available():
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2, fuel = 18.5, fuelCapacity = 60,
+          }
+          M.publishTelemetryTickIfDue({
+            dt = 0.06, car = car, wsBridge = ws,
+            temps = { fl = 85, fr = 86, rl = 83, rr = 84 },
+          })
+          local p = ws._calls[1] and ws._calls[1].send.payload
+          return {
+            fuel = p and p.fuel_l,
+            capacity = p and p.fuel_capacity_l,
+            fl = p and p.tyre_temps_c and p.tyre_temps_c.fl,
+            rr = p and p.tyre_temps_c and p.tyre_temps_c.rr,
+          }
+        end)()
+        """
+    )
+    assert out["fuel"] == 18.5
+    assert out["capacity"] == 60
+    assert (out["fl"], out["rr"]) == (85, 84)
+
+
 def test_telemetry_tick_seq_resets_on_module_reset():
     rt = _runtime()
     out = rt.eval(

--- a/tools/ai_sidecar/car_schema.py
+++ b/tools/ai_sidecar/car_schema.py
@@ -278,7 +278,7 @@ class CarSetupSchema:
 
 
 def _main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description="Ingest an ac.getSetupSpinners() dump → schema asset.")
+    p = argparse.ArgumentParser(description="Ingest an ac.getSetupSpinners() dump -> schema asset.")
     p.add_argument("dump", help="JSON file: a list of getSetupSpinners() descriptors")
     p.add_argument("--car-id", required=True)
     p.add_argument("--schema-dir", default=DEFAULT_SCHEMA_DIR)

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -376,10 +376,36 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
         err = _validate_optional_number(payload, lap_key, min_value=0)
         if err is not None:
             return err
-    for key in ("tyre_temps_c", "tyre_pressures_psi"):
+    for key in (
+        "tyre_temps_c",
+        "tyre_pressures_psi",
+        "tyre_wear_pct",
+        "brake_temps_c",
+        "brake_wear_pct",
+    ):
         err = _validate_corner_number_map(payload, key)
         if err is not None:
             return err
+    optional_ranges = {
+        "fuel_l": (0, None),
+        "fuel_capacity_l": (0, None),
+        "fuel_per_lap_l": (0, None),
+        "target_laps_remaining": (0, None),
+        "laps_to_finish": (0, None),
+        "race_laps_remaining": (0, None),
+        "race_laps": (0, None),
+        "session_laps_total": (0, None),
+        "track_grip_level": (0, None),
+        "track_temp_c": (None, None),
+        "ambient_temp_c": (None, None),
+    }
+    for key, (min_value, max_value) in optional_ranges.items():
+        err = _validate_optional_number(payload, key, min_value=min_value, max_value=max_value)
+        if err is not None:
+            return err
+    for key in ("weather_type", "tyre_compound"):
+        if key in payload and not isinstance(payload[key], str):
+            return f"{key} must be a string"
     for key in ("abs_active", "brake_lock", "wheel_lock"):
         if key in payload and not isinstance(payload[key], bool):
             return f"{key} must be a boolean"

--- a/tools/ai_sidecar/race_management.py
+++ b/tools/ai_sidecar/race_management.py
@@ -1,0 +1,457 @@
+"""Stint-level race-management cues from live telemetry.
+
+This module is deliberately independent of the corner coach engines. The sidecar can run the
+legacy ``RealtimeObserver`` or Coach v2; fuel, tyre, brake, and condition management should ride
+along either way. The model is pure stdlib and conservative: it emits only when the live frame
+carries the required channel, and every advisory detail records the measured/estimated basis.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from tools.ai_sidecar.conditions_model import ConditionsFinding, analyze_conditions
+from tools.ai_sidecar.realtime_observer import Advisory
+from tools.ai_sidecar.tyre_model import TyreFinding, analyze_tyres
+
+_WHEELS = ("fl", "fr", "rl", "rr")
+
+_MIN_FUEL_LAP_USE_L = 0.05
+_FUEL_SHORT_MARGIN_LAPS = 0.25
+_FUEL_CRITICAL_DEFICIT_LAPS = 1.0
+_FUEL_SAMPLE_WINDOW = 5
+
+_WEAR_CAUTION_PCT = 70.0
+_BRAKE_HOT_C = 650.0
+_BRAKE_CRITICAL_C = 850.0
+
+
+def _payload(frame: dict[str, Any]) -> dict[str, Any]:
+    return frame.get("payload") if isinstance(frame.get("payload"), dict) else {}
+
+
+def _pick(frame: dict[str, Any], *keys: str) -> Any:
+    payload = _payload(frame)
+    for src in (frame, payload):
+        for key in keys:
+            if key in src:
+                return src[key]
+    return None
+
+
+def _num(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f and abs(f) != float("inf") else None
+
+
+def _lap(frame: dict[str, Any]) -> int | None:
+    raw = _pick(frame, "lap", "lap_count", "lapCount", "completed_laps", "completedLaps")
+    value = _num(raw)
+    if value is None or value < 0:
+        return None
+    return int(value)
+
+
+def _corner_map(value: Any) -> dict[str, float]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, float] = {}
+    for wheel in _WHEELS:
+        v = _num(value.get(wheel))
+        if v is not None:
+            out[wheel] = v
+    return out
+
+
+def _frame_corner_map(frame: dict[str, Any], *keys: str) -> dict[str, float]:
+    for key in keys:
+        value = _pick(frame, key)
+        out = _corner_map(value)
+        if out:
+            return out
+    return {}
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _dominant_axle(values: dict[str, float]) -> str:
+    front = [values[w] for w in ("fl", "fr") if w in values]
+    rear = [values[w] for w in ("rl", "rr") if w in values]
+    if not front and not rear:
+        return "unknown"
+    if not rear:
+        return "front"
+    if not front:
+        return "rear"
+    return "front" if _mean(front) >= _mean(rear) else "rear"
+
+
+def _serial_findings(findings: list[TyreFinding | ConditionsFinding]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for finding in findings:
+        row = {
+            "key": finding.key,
+            "summary": finding.summary,
+            "coaching": finding.coaching,
+            "confidence": finding.confidence,
+        }
+        severity = getattr(finding, "severity", None)
+        if severity is not None:
+            row["severity"] = severity
+        approximate = getattr(finding, "approximate", None)
+        if approximate is not None:
+            row["approximate"] = approximate
+        out.append(row)
+    return out
+
+
+@dataclass
+class RaceManagementObserver:
+    """Stateful live race-management observer.
+
+    Feed it the same ``telemetry_tick`` frames used by the realtime coach. It returns ``Advisory``
+    objects so server/voice/haptic fan-out does not need a second event path.
+    """
+
+    fuel_samples: deque[float] = field(default_factory=lambda: deque(maxlen=_FUEL_SAMPLE_WINDOW))
+    _last_lap: int | None = None
+    _lap_start_fuel_l: float | None = None
+    _last_fuel_cue: tuple[int | None, str] | None = None
+    _last_tyre_cue: tuple[int | None, str] | None = None
+    _last_brake_cue: tuple[int | None, str] | None = None
+    _conditions_seen: set[str] = field(default_factory=set)
+
+    def reset(self) -> None:
+        self._reset_fuel()
+        self._last_tyre_cue = None
+        self._last_brake_cue = None
+        self._conditions_seen.clear()
+
+    def _reset_fuel(self) -> None:
+        self.fuel_samples.clear()
+        self._last_lap = None
+        self._lap_start_fuel_l = None
+        self._last_fuel_cue = None
+
+    def observe(self, frame: dict[str, Any]) -> list[Advisory]:
+        lap = _lap(frame)
+        lap_advanced = self._update_fuel_lap(frame, lap)
+        out: list[Advisory] = []
+        fuel = self._fuel_advisory(frame, lap, lap_advanced=lap_advanced)
+        if fuel is not None:
+            out.append(fuel)
+        tyre = self._tyre_advisory(frame, lap)
+        if tyre is not None:
+            out.append(tyre)
+        brake = self._brake_advisory(frame, lap)
+        if brake is not None:
+            out.append(brake)
+        conditions = self._conditions_advisory(frame)
+        if conditions is not None:
+            out.append(conditions)
+        return out
+
+    def _update_fuel_lap(self, frame: dict[str, Any], lap: int | None) -> bool:
+        fuel_l = _num(_pick(frame, "fuel_l", "fuelLevel", "fuel"))
+        if fuel_l is None:
+            return False
+        if lap is None:
+            if self._lap_start_fuel_l is None:
+                self._lap_start_fuel_l = fuel_l
+            return False
+        if self._last_lap is None:
+            self._last_lap = lap
+            self._lap_start_fuel_l = fuel_l
+            return False
+        if lap < self._last_lap:
+            self._reset_fuel()
+            self._last_lap = lap
+            self._lap_start_fuel_l = fuel_l
+            return False
+        if lap == self._last_lap:
+            return False
+        lap_delta = lap - self._last_lap
+        if self._lap_start_fuel_l is not None:
+            used = (self._lap_start_fuel_l - fuel_l) / lap_delta
+            if used >= _MIN_FUEL_LAP_USE_L:
+                self.fuel_samples.append(used)
+        self._last_lap = lap
+        self._lap_start_fuel_l = fuel_l
+        return True
+
+    def _fuel_advisory(
+        self, frame: dict[str, Any], lap: int | None, *, lap_advanced: bool
+    ) -> Advisory | None:
+        fuel_l = _num(_pick(frame, "fuel_l", "fuelLevel", "fuel"))
+        direct_per_lap = _num(_pick(frame, "fuel_per_lap_l", "fuelPerLapL"))
+        if fuel_l is None or (not self.fuel_samples and direct_per_lap is None):
+            return None
+        per_lap = _mean(list(self.fuel_samples)) if self.fuel_samples else direct_per_lap
+        if per_lap <= 0:
+            return None
+        laps_remaining = fuel_l / per_lap
+        target = _target_laps_remaining(frame, lap)
+        detail = {
+            "fuel_l": round(fuel_l, 2),
+            "fuel_per_lap_l": round(per_lap, 3),
+            "laps_remaining": round(laps_remaining, 2),
+            "samples": len(self.fuel_samples),
+            "fuel_per_lap_source": "observed_laps" if self.fuel_samples else "frame",
+        }
+        if target is not None:
+            detail["target_laps_remaining"] = round(target, 2)
+            deficit = target - laps_remaining
+            if deficit > _FUEL_SHORT_MARGIN_LAPS:
+                register = "critical" if deficit >= _FUEL_CRITICAL_DEFICIT_LAPS else "firm"
+                key = (lap, register)
+                if self._last_fuel_cue == key:
+                    return None
+                self._last_fuel_cue = key
+                detail["deficit_laps"] = round(deficit, 2)
+                return Advisory(
+                    kind="fuel_save",
+                    corner=-1,
+                    spline=float(_num(_pick(frame, "spline")) or 0.0),
+                    urgency="act",
+                    message=(f"Fuel short by {deficit:.1f} laps; lift and coast on the straights."),
+                    detail=detail,
+                    intensity=min(1.0, deficit / 2.0),
+                    register=register,
+                )
+        if not lap_advanced:
+            return None
+        key = (lap, "status")
+        if self._last_fuel_cue == key:
+            return None
+        self._last_fuel_cue = key
+        return Advisory(
+            kind="fuel_status",
+            corner=-1,
+            spline=float(_num(_pick(frame, "spline")) or 0.0),
+            urgency="info",
+            message=f"Fuel {laps_remaining:.1f} laps remaining at {per_lap:.2f} L/lap.",
+            detail=detail,
+            intensity=0.0,
+            register="calm",
+        )
+
+    def _tyre_advisory(self, frame: dict[str, Any], lap: int | None) -> Advisory | None:
+        temps = _frame_corner_map(frame, "tyre_temps_c", "tire_temps_c")
+        wear = _frame_corner_map(frame, "tyre_wear_pct", "tire_wear_pct")
+        if not temps and not wear:
+            return None
+        if temps:
+            compound = _pick(frame, "tyre_compound", "tire_compound")
+            report = analyze_tyres(
+                temps,
+                compound=compound if isinstance(compound, str) else None,
+                laps_since_start=lap,
+            )
+            keys = {f.key for f in report.findings}
+            status_values = set(report.status.values())
+            if "critical" in status_values:
+                return self._tyre_cue(
+                    lap,
+                    "critical",
+                    "critical",
+                    "Tyres critical; back off now and protect the hottest axle.",
+                    temps,
+                    wear,
+                    report.findings,
+                    "act",
+                )
+            if "overheat" in keys:
+                axle = _dominant_axle(temps)
+                return self._tyre_cue(
+                    lap,
+                    "overheat",
+                    "firm",
+                    f"{axle.title()} tyres overheating; smooth inputs and protect the axle.",
+                    temps,
+                    wear,
+                    report.findings,
+                    "act",
+                )
+            if "degradation_onset" in keys:
+                return self._tyre_cue(
+                    lap,
+                    "thermal_rolloff",
+                    "firm",
+                    "Tyres are near thermal roll-off; smooth the stint and stop sliding them.",
+                    temps,
+                    wear,
+                    report.findings,
+                    "prepare",
+                )
+        high_wear = {wheel: value for wheel, value in wear.items() if value >= _WEAR_CAUTION_PCT}
+        if high_wear:
+            axle = _dominant_axle(high_wear)
+            return self._tyre_cue(
+                lap,
+                "wear",
+                "firm",
+                f"{axle.title()} tyre wear is high without an overheat signal; "
+                "protect it from slides.",
+                temps,
+                wear,
+                [],
+                "prepare",
+            )
+        return None
+
+    def _tyre_cue(
+        self,
+        lap: int | None,
+        classification: str,
+        register: str,
+        message: str,
+        temps: dict[str, float],
+        wear: dict[str, float],
+        findings: list[TyreFinding],
+        urgency: str,
+    ) -> Advisory | None:
+        key = (lap, classification)
+        if self._last_tyre_cue == key:
+            return None
+        self._last_tyre_cue = key
+        return Advisory(
+            kind="tyre_manage",
+            corner=-1,
+            spline=0.0,
+            urgency=urgency,
+            message=message,
+            detail={
+                "classification": classification,
+                "tyre_temps_c": {k: round(v, 1) for k, v in temps.items()},
+                "tyre_wear_pct": {k: round(v, 1) for k, v in wear.items()},
+                "wear_signal": bool(wear),
+                "findings": _serial_findings(findings[:3]),
+            },
+            intensity=1.0 if register == "critical" else 0.55,
+            register=register,
+        )
+
+    def _brake_advisory(self, frame: dict[str, Any], lap: int | None) -> Advisory | None:
+        temps = _frame_corner_map(frame, "brake_temps_c", "brake_temp_c")
+        wear = _frame_corner_map(frame, "brake_wear_pct")
+        if not temps and not wear:
+            return None
+        hot = {wheel: temp for wheel, temp in temps.items() if temp >= _BRAKE_HOT_C}
+        critical = {wheel: temp for wheel, temp in temps.items() if temp >= _BRAKE_CRITICAL_C}
+        high_wear = {wheel: value for wheel, value in wear.items() if value >= _WEAR_CAUTION_PCT}
+        if critical:
+            classification = "critical_temp"
+            register = "critical"
+            urgency = "act"
+            message = "Brakes are in the critical heat band; cool them with earlier lifts."
+        elif hot:
+            classification = "hot"
+            register = "firm"
+            urgency = "prepare"
+            message = "Brake temps are hot; stop dragging brake and add cooling laps."
+        elif high_wear:
+            classification = "wear"
+            register = "firm"
+            urgency = "prepare"
+            message = "Brake wear is building; reduce peak brake time over the stint."
+        else:
+            return None
+        key = (lap, classification)
+        if self._last_brake_cue == key:
+            return None
+        self._last_brake_cue = key
+        return Advisory(
+            kind="brake_manage",
+            corner=-1,
+            spline=float(_num(_pick(frame, "spline")) or 0.0),
+            urgency=urgency,
+            message=message,
+            detail={
+                "classification": classification,
+                "brake_temps_c": {k: round(v, 1) for k, v in temps.items()},
+                "brake_wear_pct": {k: round(v, 1) for k, v in wear.items()},
+            },
+            intensity=1.0 if register == "critical" else 0.55,
+            register=register,
+        )
+
+    def _conditions_advisory(self, frame: dict[str, Any]) -> Advisory | None:
+        conditions = _conditions_from_frame(frame)
+        if conditions is None:
+            return None
+        report = analyze_conditions(conditions)
+        finding = next(
+            (
+                f
+                for f in report.findings
+                if f.key in {"wet_regime", "cold_track", "hot_track", "green_track"}
+            ),
+            None,
+        )
+        if finding is None:
+            return None
+        if finding.key in self._conditions_seen:
+            return None
+        self._conditions_seen.add(finding.key)
+        if finding.key == "wet_regime":
+            urgency = "act"
+            register = "firm"
+            message = "Wet track strategy: brake earlier, use smoother throttle, and avoid puddles."
+        elif finding.key == "cold_track":
+            urgency = "prepare"
+            register = "firm"
+            message = "Cold track strategy: build tyre heat before pushing."
+        elif finding.key == "hot_track":
+            urgency = "prepare"
+            register = "firm"
+            message = "Hot track strategy: manage tyre temperature over the stint."
+        else:
+            urgency = "prepare"
+            register = "calm"
+            message = "Green track strategy: let grip build before judging setup."
+        return Advisory(
+            kind="conditions_strategy",
+            corner=-1,
+            spline=float(_num(_pick(frame, "spline")) or 0.0),
+            urgency=urgency,
+            message=message,
+            detail={
+                "classification": finding.key,
+                "conditions": conditions,
+                "finding": _serial_findings([finding])[0],
+            },
+            intensity=0.55 if register == "firm" else 0.25,
+            register=register,
+        )
+
+
+def _target_laps_remaining(frame: dict[str, Any], lap: int | None) -> float | None:
+    for key in ("target_laps_remaining", "laps_to_finish", "race_laps_remaining"):
+        value = _num(_pick(frame, key))
+        if value is not None and value >= 0:
+            return value
+    total = _num(_pick(frame, "race_laps", "session_laps_total"))
+    if total is not None and total >= 0 and lap is not None:
+        return max(0.0, total - lap)
+    return None
+
+
+def _conditions_from_frame(frame: dict[str, Any]) -> dict[str, Any] | None:
+    keys = {
+        "trackGripLevel": _pick(frame, "track_grip_level", "trackGripLevel"),
+        "trackTempC": _pick(frame, "track_temp_c", "trackTempC"),
+        "ambientTempC": _pick(frame, "ambient_temp_c", "ambientTempC"),
+        "weatherType": _pick(frame, "weather_type", "weatherType"),
+    }
+    if all(v is None for v in keys.values()):
+        return None
+    return keys

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -89,6 +89,7 @@ from tools.ai_sidecar.protocol import (
     build_ollama_followup,
     prepare_outbound_message,
 )
+from tools.ai_sidecar.race_management import RaceManagementObserver
 from tools.ai_sidecar.realtime_observer import (
     RealtimeObserver,
 )
@@ -136,6 +137,7 @@ _observer: RealtimeObserver | None = None
 # Coach v2 (diagnosed, anticipatory, paced). When installed via AC_COPILOT_COACH_V2=1 it is the cue
 # producer in place of the legacy observer's apex_deficit/late_brake output.
 _coach_runtime: Any | None = None
+_race_manager: Any | None = RaceManagementObserver()
 # The observer holds single-monotonic-stream state (last spline/lap, per-corner passes), so only ONE
 # producer may feed it. The first telemetry producer claims the feed; a second concurrent loopback
 # producer is still routed to peripherals but NOT into the observer (interleaving would corrupt wrap
@@ -183,6 +185,12 @@ def set_coach_runtime(coach: Any | None) -> None:
     producer. When set (``AC_COPILOT_COACH_V2=1``) it replaces the legacy observer's cue output."""
     global _coach_runtime
     _coach_runtime = coach
+
+
+def set_race_manager(manager: Any | None) -> None:
+    """Install (or clear) the stint-level race-management observer."""
+    global _race_manager
+    _race_manager = manager
 
 
 def set_voice_coach(coach: Any | None) -> None:
@@ -377,6 +385,8 @@ def _reset_external_state() -> None:
     _external_peers.clear()
     _external_peer_classes.clear()
     _peripheral_rate_limiter.reset()
+    if _race_manager is not None:
+        _race_manager.reset()
     # The single-producer observer feed is external-peer state: a full reset (server (re)start or
     # teardown) leaves no producer owning the feed, so the next telemetry producer can claim it.
     # Without this, a stale owner persists and the next producer is silently rejected by the guard
@@ -685,6 +695,8 @@ def _release_observer_feed(websocket: Any) -> None:
             _observer.reset()
         if _coach_runtime is not None:  # B4: clear v2 stint state so the next producer starts clean
             _coach_runtime.reset()
+        if _race_manager is not None:
+            _race_manager.reset()
 
 
 async def _broadcast_targets(frame: dict[str, Any], *, targets: list[Any]) -> None:
@@ -822,9 +834,12 @@ async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None
     websocket) may continue to; a second concurrent producer is ignored here.
     """
     global _observer_feed_peer, _observer_feed_warned
-    # Coach v2 (diagnosed, anticipatory, paced) replaces the legacy observer's cues when wired.
+    # Coach v2 (diagnosed, anticipatory, paced) replaces the legacy observer's corner cues when
+    # wired. Race management rides alongside either producer because it depends on stint channels,
+    # not reference-corner geometry.
     observer = _coach_runtime if _coach_runtime is not None else _observer
-    if observer is None:
+    race_manager = _race_manager
+    if observer is None and race_manager is None:
         return
     if not _peripheral_rate_limiter.allow((TYPE_TELEMETRY_TICK, "observer"), TELEMETRY_TICK_MAX_HZ):
         return
@@ -840,11 +855,17 @@ async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None
             )
             _observer_feed_warned = True
         return
-    try:
-        advisories = observer.observe(frame)
-    except Exception:
-        logger.exception("realtime observer failed on telemetry_tick")
-        return
+    advisories: list[Any] = []
+    if observer is not None:
+        try:
+            advisories.extend(observer.observe(frame))
+        except Exception:
+            logger.exception("realtime observer failed on telemetry_tick")
+    if race_manager is not None:
+        try:
+            advisories.extend(race_manager.observe(frame))
+        except Exception:
+            logger.exception("race-management observer failed on telemetry_tick")
     if not advisories:
         return
     ts_sim = frame.get("ts_sim")

--- a/tools/ai_sidecar/voice/cue.py
+++ b/tools/ai_sidecar/voice/cue.py
@@ -94,6 +94,18 @@ def advisory_to_phrase(advisory: dict[str, Any]) -> str:
         return "Release." if register == "firm" else "Ease off."
     if kind == "apex_deficit":
         return f"More entry speed, {_turn(corner)}."
+    if kind == "fuel_status":
+        return "Fuel check."
+    if kind == "fuel_save":
+        return "Lift and coast." if register == "critical" else "Save fuel."
+    if kind == "tyre_manage":
+        if register == "critical":
+            return "Save tyres!"
+        return "Save tyres." if advisory.get("urgency") == "act" else "Manage tyres."
+    if kind == "brake_manage":
+        return "Cool brakes!" if register == "critical" else "Cool brakes."
+    if kind == "conditions_strategy":
+        return "Smooth inputs." if advisory.get("urgency") == "act" else "Adjust to track."
     # Unknown kind: fall back to the observer's own message (already human-readable), trimmed.
     message = advisory.get("message")
     if isinstance(message, str) and message.strip():

--- a/tools/ai_sidecar/voice/vocabulary.py
+++ b/tools/ai_sidecar/voice/vocabulary.py
@@ -61,6 +61,11 @@ KINDS: tuple[str, ...] = (
     "late_throttle",
     "save",
     "confirm",
+    "fuel_status",
+    "fuel_save",
+    "tyre_manage",
+    "brake_manage",
+    "conditions_strategy",
 )
 
 #: Advisory ``urgency`` tiers, low -> high (mirrors ``realtime_observer.Advisory.urgency``). Drives
@@ -148,6 +153,20 @@ _STEMS: dict[tuple[str, str, str], str] = {
     ("late_throttle", "act", "critical"): "Power.",
     ("save", "act", "critical"): "Brake!",
     ("confirm", "info", "calm"): "Good.",
+    # Stint-level race-management cues. These are generic by design: the detailed fuel/tyre/brake
+    # numbers ride in the advisory payload for screens/logs, while the voice keeps the hot path
+    # short enough to act on.
+    ("fuel_status", "info", "calm"): "Fuel check.",
+    ("fuel_save", "act", "firm"): "Save fuel.",
+    ("fuel_save", "act", "critical"): "Lift and coast.",
+    ("tyre_manage", "prepare", "firm"): "Manage tyres.",
+    ("tyre_manage", "act", "firm"): "Save tyres.",
+    ("tyre_manage", "act", "critical"): "Save tyres!",
+    ("brake_manage", "prepare", "firm"): "Cool brakes.",
+    ("brake_manage", "act", "critical"): "Cool brakes!",
+    ("conditions_strategy", "prepare", "calm"): "Track is green.",
+    ("conditions_strategy", "prepare", "firm"): "Adjust to track.",
+    ("conditions_strategy", "act", "firm"): "Smooth inputs.",
 }
 
 


### PR DESCRIPTION
## Summary
- Add a stint-level `RaceManagementObserver` for fuel-to-finish, tyre management, brake management, and changing-condition cues.
- Extend telemetry validation and Lua telemetry publishing with fuel/tyre channels used by the observer.
- Route race-management advisories through the existing coaching cue fan-out and voice vocabulary.

## Verification
- `python -m ruff check tools\\ai_sidecar\\race_management.py tools\\ai_sidecar\\external_protocol.py tools\\ai_sidecar\\server.py tools\\ai_sidecar\\voice\\cue.py tools\\ai_sidecar\\voice\\vocabulary.py tests\\test_race_management.py tests\\test_external_protocol_m0.py tests\\test_server_observer_wiring.py tests\\test_telemetry_publisher.py`
- `python -m pytest tests\\test_race_management.py tests\\test_external_protocol_m0.py tests\\test_ai_sidecar_external.py tests\\test_server_observer_wiring.py tests\\test_voice_vocabulary.py tests\\test_voice_cue.py tests\\test_telemetry_publisher.py -q`

Replaces closed draft #413, which used a branch prefix rejected by `make ci-fast`.
Closes #406