### PR TITLE
feat: add sector benchmarks and SuperLap targets (#408)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1625,17 +1625,18 @@ local function tryLoadDisk()
 end
 
 ---@param simTime number
-local function sectorMessage(refMs, actualMs, simTime)
+local function sectorMessage(refMs, actualMs, simTime, label)
   if not refMs or refMs <= 0 or not actualMs then
     return
   end
   local d = actualMs - refMs
+  local prefix = tostring(label or "Sector")
   if d < -5 then
-    state.sectorHudMsg = string.format("Sector: %.2f s faster than ref lap", -d / 1000)
+    state.sectorHudMsg = string.format("%s: %.2f s faster than ref lap", prefix, -d / 1000)
   elseif d > 5 then
-    state.sectorHudMsg = string.format("Sector: %.2f s slower than ref lap", d / 1000)
+    state.sectorHudMsg = string.format("%s: %.2f s slower than ref lap", prefix, d / 1000)
   else
-    state.sectorHudMsg = string.format("Sector: on pace (Δ %+d ms)", math.floor(d + 0.5))
+    state.sectorHudMsg = string.format("%s: on pace (Δ %+d ms)", prefix, math.floor(d + 0.5))
   end
   state.sectorHudUntil = simTime + config.sectorMessageSeconds
 end
@@ -2405,7 +2406,7 @@ function script.update(dt)
     local s3 = (state.sectorIndex == 3 and state.sectorStartSimT)
         and ((ch.simSeconds(sim) - state.sectorStartSimT) * 1000) or nil
     if s3 and state.bestSectorMs[3] and state.bestSectorMs[3] > 0 then
-      sectorMessage(state.bestSectorMs[3], s3, ch.simSeconds(sim))
+      sectorMessage(state.bestSectorMs[3], s3, ch.simSeconds(sim), "S3")
     end
 
     local evLap = brakes:finalizeQualifiedWhileHolding(car)
@@ -2688,12 +2689,12 @@ function script.update(dt)
     local b1, b2 = 1 / 3, 2 / 3
     if state.sectorIndex == 1 and lsp < b1 and sp >= b1 then
       local aMs = (ch.simSeconds(sim) - state.sectorStartSimT) * 1000
-      sectorMessage(state.bestSectorMs[1], aMs, ch.simSeconds(sim))
+      sectorMessage(state.bestSectorMs[1], aMs, ch.simSeconds(sim), "S1")
       state.sectorIndex = 2
       state.sectorStartSimT = ch.simSeconds(sim)
     elseif state.sectorIndex == 2 and lsp < b2 and sp >= b2 then
       local aMs = (ch.simSeconds(sim) - state.sectorStartSimT) * 1000
-      sectorMessage(state.bestSectorMs[2], aMs, ch.simSeconds(sim))
+      sectorMessage(state.bestSectorMs[2], aMs, ch.simSeconds(sim), "S2")
       state.sectorIndex = 3
       state.sectorStartSimT = ch.simSeconds(sim)
     end

--- a/src/ac_copilot_trainer/modules/delta.lua
+++ b/src/ac_copilot_trainer/modules/delta.lua
@@ -216,4 +216,79 @@ function M.sectorBoundariesMs(sortedTrace)
   return { e1, e2, eEnd }
 end
 
+--- Deterministic sector and micro-sector windows in spline space.
+---@param microPerSector integer|nil subdivisions per sector (default 3)
+---@return table { sectors: table[], microSectors: table[] }
+function M.segmentWindows(microPerSector)
+  local microN = tonumber(microPerSector) or 3
+  microN = math.max(1, math.floor(microN))
+  local sectors = {}
+  local microSectors = {}
+  for si = 1, 3 do
+    local s0 = (si - 1) / 3
+    local s1 = si / 3
+    local label = "S" .. tostring(si)
+    sectors[#sectors + 1] = {
+      key = string.lower(label),
+      label = label,
+      splineStart = s0,
+      splineEnd = s1,
+      sectorIndex = si,
+    }
+    local span = s1 - s0
+    for mi = 1, microN do
+      local m0 = s0 + span * (mi - 1) / microN
+      local m1 = s0 + span * mi / microN
+      local mlabel = label .. "." .. tostring(mi)
+      microSectors[#microSectors + 1] = {
+        key = string.lower(mlabel),
+        label = mlabel,
+        splineStart = m0,
+        splineEnd = m1,
+        sectorIndex = si,
+        microIndex = mi,
+      }
+    end
+  end
+  return { sectors = sectors, microSectors = microSectors }
+end
+
+--- Reference duration (ms) between two spline positions.
+---@param sortedTrace LapTraceSample[]|nil
+---@param splineLo number
+---@param splineHi number
+---@return number|nil
+function M.segmentDurationMs(sortedTrace, splineLo, splineHi)
+  if not sortedTrace or #sortedTrace < 2 then
+    return nil
+  end
+  local a = M.bestElapsedMsAtSpline(sortedTrace, splineLo)
+  local b = M.bestElapsedMsAtSpline(sortedTrace, splineHi)
+  if not a or not b then
+    return nil
+  end
+  local d = b - a
+  if d < -1e-6 then
+    return nil
+  end
+  return math.max(0, d)
+end
+
+--- Segment delta (ms): positive = slower than the reference segment.
+---@param sortedTrace LapTraceSample[]|nil
+---@param splineLo number
+---@param splineHi number
+---@param actualMs number|nil
+---@return number|nil
+function M.segmentDeltaMs(sortedTrace, splineLo, splineHi, actualMs)
+  if actualMs == nil then
+    return nil
+  end
+  local refMs = M.segmentDurationMs(sortedTrace, splineLo, splineHi)
+  if not refMs then
+    return nil
+  end
+  return actualMs - refMs
+end
+
 return M

--- a/src/ac_copilot_trainer/modules/hud.lua
+++ b/src/ac_copilot_trainer/modules/hud.lua
@@ -46,6 +46,7 @@ end
 ---@field bestLapMs number|nil
 ---@field lastLapMs number|nil
 ---@field deltaSmoothedSec number|nil
+---@field sectorMessage string|nil
 ---@field appVersionUi string|nil
 ---@field debriefText string|nil
 ---@field realtimeHint table|nil  @legacy {text, kind, cornerLabel} for back-compat
@@ -87,6 +88,13 @@ local function colorForKind(kind)
   if kind == "positive" then return COLOR_GREEN end
   if kind == "placeholder" then return COLOR_TEXT_GREY end
   return COLOR_WHITE
+end
+
+local function colorForSectorMessage(text)
+  local s = string.lower(text or "")
+  if string.find(s, "faster", 1, true) then return COLOR_GREEN end
+  if string.find(s, "slower", 1, true) then return COLOR_RED_HARD end
+  return COLOR_TEXT_GREY
 end
 
 local function measure(text, fontPx)
@@ -246,6 +254,18 @@ function M.draw(vm)
     dwriteSafe(secStr, secFontPx, secPos, sColor)
     fontMod.pop(sk)
     y = y + 20
+  end
+
+  -- Sector/micro-sector delta toast from the live delta pipeline.
+  if type(vm.sectorMessage) == "string" and vm.sectorMessage ~= "" then
+    local sectorFontPx = 11
+    local sectorStr = string.upper(vm.sectorMessage)
+    local sectorSize = measure(sectorStr, sectorFontPx)
+    local sectorPos = vec2(centerX - sectorSize.x * 0.5, y)
+    local sk = fontMod.pushNamed("labels_bold", sectorFontPx)
+    dwriteSafe(sectorStr, sectorFontPx, sectorPos, colorForSectorMessage(vm.sectorMessage))
+    fontMod.pop(sk)
+    y = y + 16
   end
 
   -- Sidecar debrief (rules + optional Ollama follow-up); keeps LLM output visible

--- a/tests/test_ai_sidecar_protocol.py
+++ b/tests/test_ai_sidecar_protocol.py
@@ -84,6 +84,24 @@ def test_brain_followup_forwards_structured_blocks(monkeypatch: pytest.MonkeyPat
     assert out["conditions"]["grip_band"] == "green"
 
 
+def test_brain_followup_forwards_sector_benchmarks_with_reference(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(proto, "debrief_feature_enabled", lambda: True)
+    laps = tmp_path / "journal" / "laps"
+    laps.mkdir(parents=True)
+    ref = laps / "lap_ref.json"
+    ref.write_text(json.dumps(_rich_corner_archive()), encoding="utf-8")
+
+    out = build_brain_followup(_rich_corner_archive() | {"referenceArchivePath": str(ref)})
+
+    assert out is not None
+    assert out.get("sectorDeltas")
+    assert out["sectorDeltas"]["micro_sectors"][0]["label"] == "S1.1"
+    assert out.get("superLap")
+    assert out["superLap"]["segments"][0]["label"] == "S1.1"
+
+
 def test_prepare_rejects_bad_protocol() -> None:
     out = prepare_outbound_message(
         {"protocol": 99, "event": "lap_complete", "lap": 1},

--- a/tests/test_brain_wiring.py
+++ b/tests/test_brain_wiring.py
@@ -170,3 +170,7 @@ def test_brain_followup_uses_reference_for_time_loss(tmp_path, monkeypatch):
     # the per-corner reference block is forwarded to live clients (codex #291) and honestly sourced
     assert out.get("cornerReference")
     assert out["cornerReference"][0]["source"] == "reference_lap"
+    assert out.get("sectorDeltas")
+    assert out["sectorDeltas"]["micro_sectors"][0]["label"] == "S1.1"
+    assert out.get("superLap")
+    assert out["superLap"]["segments"][0]["label"] == "S1.1"

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -66,6 +66,13 @@ def _corner_archive(*, degrade: float = 0.0) -> dict:
     }
 
 
+def _scale_archive_time(archive: dict, factor: float) -> None:
+    e_ms_idx = archive["trace"]["fields"].index("eMs")
+    for sample in archive["trace"]["samples"]:
+        sample[e_ms_idx] *= factor
+    archive["lap"]["lap_ms"] = int(archive["lap"]["lap_ms"] * factor)
+
+
 def test_build_debrief_renders_sections():
     text = build_debrief(_corner_archive(), grip_ceiling_g=2.5)
     assert "Coaching debrief" in text
@@ -171,6 +178,38 @@ def test_structured_debrief_includes_sector_deltas_and_superlap():
     assert superlap is not None
     assert superlap["segments"][0]["label"] == "S1.1"
     assert superlap["source_count"] >= 1
+
+
+def test_superlap_ignores_invalid_current_lap():
+    ref = _corner_archive(degrade=8.0)
+    student = _corner_archive(degrade=0.0)
+    _scale_archive_time(student, 0.5)
+    student["lap"]["is_valid"] = False
+
+    d = build_structured_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
+
+    superlap = d["superlap"]
+    assert superlap is not None
+    assert {seg["source_index"] for seg in superlap["segments"]} == {0}
+
+
+def test_superlap_filters_corpus_to_same_car_and_track():
+    ref = _corner_archive(degrade=8.0)
+    student = _corner_archive(degrade=8.0)
+    wrong_track = _corner_archive(degrade=0.0)
+    _scale_archive_time(wrong_track, 0.5)
+    wrong_track["track"]["id"] = "spa"
+
+    d = build_structured_debrief(
+        student,
+        reference_archive=ref,
+        corpus_archives=[wrong_track],
+        grip_ceiling_g=2.5,
+    )
+
+    superlap = d["superlap"]
+    assert superlap is not None
+    assert {seg["track_id"] for seg in superlap["segments"]} == {"magione"}
 
 
 def test_debrief_text_includes_tyre_and_conditions_sections():

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -80,6 +80,8 @@ def test_build_debrief_with_reference_shows_time_loss():
     student = _corner_archive(degrade=8.0)  # student carries less apex speed
     text = build_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
     assert "vs reference" in text or "losing time" in text
+    assert "Sector deltas vs reference" in text
+    assert "SuperLap target" in text
 
 
 def test_cli_main_runs(tmp_path, capsys):
@@ -151,6 +153,24 @@ def test_corner_reference_present_with_reference_and_honest_source():
         assert "optimal_apex_kmh" not in entry  # must NOT over-claim a theoretical optimum
         assert isinstance(entry["deficit_to_target_kmh"], (int, float))
         assert isinstance(entry["target_apex_kmh"], (int, float))
+
+
+def test_structured_debrief_includes_sector_deltas_and_superlap():
+    ref = _corner_archive(degrade=0.0)
+    student = _corner_archive(degrade=8.0)
+    d = build_structured_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
+
+    sector_deltas = d["sector_deltas"]
+    assert sector_deltas is not None
+    assert sector_deltas["track_id"] == "magione"
+    assert len(sector_deltas["sectors"]) == 3
+    assert len(sector_deltas["micro_sectors"]) == 9
+    assert sector_deltas["micro_sectors"][0]["label"] == "S1.1"
+
+    superlap = d["superlap"]
+    assert superlap is not None
+    assert superlap["segments"][0]["label"] == "S1.1"
+    assert superlap["source_count"] >= 1
 
 
 def test_debrief_text_includes_tyre_and_conditions_sections():

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -180,6 +180,26 @@ def test_structured_debrief_includes_sector_deltas_and_superlap():
     assert superlap["source_count"] >= 1
 
 
+def test_sector_deltas_skip_invalid_reference_lap():
+    ref = _corner_archive(degrade=0.0)
+    ref["lap"]["is_valid"] = False
+    student = _corner_archive(degrade=8.0)
+
+    d = build_structured_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
+
+    assert d["sector_deltas"] is None
+
+
+def test_sector_deltas_skip_reference_from_different_combo():
+    ref = _corner_archive(degrade=0.0)
+    ref["track"]["id"] = "spa"
+    student = _corner_archive(degrade=8.0)
+
+    d = build_structured_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
+
+    assert d["sector_deltas"] is None
+
+
 def test_superlap_ignores_invalid_current_lap():
     ref = _corner_archive(degrade=8.0)
     student = _corner_archive(degrade=0.0)

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -200,6 +200,17 @@ def test_sector_deltas_skip_reference_from_different_combo():
     assert d["sector_deltas"] is None
 
 
+def test_sector_deltas_skip_reference_from_different_track_layout():
+    ref = _corner_archive(degrade=0.0)
+    ref["track"]["layout"] = "junior"
+    student = _corner_archive(degrade=8.0)
+    student["track"]["layout"] = "gp"
+
+    d = build_structured_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
+
+    assert d["sector_deltas"] is None
+
+
 def test_superlap_ignores_invalid_current_lap():
     ref = _corner_archive(degrade=8.0)
     student = _corner_archive(degrade=0.0)
@@ -230,6 +241,27 @@ def test_superlap_filters_corpus_to_same_car_and_track():
     superlap = d["superlap"]
     assert superlap is not None
     assert {seg["track_id"] for seg in superlap["segments"]} == {"magione"}
+
+
+def test_superlap_filters_corpus_to_same_track_layout():
+    ref = _corner_archive(degrade=8.0)
+    ref["track"]["layout"] = "gp"
+    student = _corner_archive(degrade=8.0)
+    student["track"]["layout"] = "gp"
+    wrong_layout = _corner_archive(degrade=0.0)
+    _scale_archive_time(wrong_layout, 0.5)
+    wrong_layout["track"]["layout"] = "junior"
+
+    d = build_structured_debrief(
+        student,
+        reference_archive=ref,
+        corpus_archives=[wrong_layout],
+        grip_ceiling_g=2.5,
+    )
+
+    superlap = d["superlap"]
+    assert superlap is not None
+    assert 2 not in {seg["source_index"] for seg in superlap["segments"]}
 
 
 def test_debrief_text_includes_tyre_and_conditions_sections():

--- a/tests/test_lua_trace_replay.py
+++ b/tests/test_lua_trace_replay.py
@@ -297,6 +297,15 @@ def test_telemetry_ingest_then_corner_and_delta_pipeline(harness: TraceReplayHar
     assert dsec == pytest.approx(1.0, abs=1e-6), (
         f"deltaSecondsAtSpline with +1000 ms current must be +1.0 s, got {dsec}"
     )
+    windows = dl.segmentWindows(3)
+    n_micro = harness.lua.eval("function(w) return #w.microSectors end")(windows)
+    first_label = harness.lua.eval("function(w) return w.microSectors[1].label end")(windows)
+    assert n_micro == 9
+    assert first_label == "S1.1"
+    seg_ms = dl.segmentDurationMs(sorted_tr, 0.0, 1 / 3)
+    assert seg_ms is not None and seg_ms > 0
+    seg_delta_ms = dl.segmentDeltaMs(sorted_tr, 0.0, 1 / 3, seg_ms + 125.0)
+    assert seg_delta_ms == pytest.approx(125.0, abs=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_phase5_rebuild_ete.py
+++ b/tests/test_phase5_rebuild_ete.py
@@ -336,6 +336,7 @@ def test_ete01_empty_session_returns_placeholder(lua):
         {
             recording = false, speed = 0, brake = 0, lapCount = 0,
             bestLapMs = nil, lastLapMs = nil, deltaSmoothedSec = nil,
+            sectorMessage = "S1: 0.20 s faster than ref lap",
             appVersionUi = "v0.5.0",
             realtimeHint = nil,
             realtimeView = {
@@ -354,6 +355,9 @@ def test_ete01_empty_session_returns_placeholder(lua):
     )
     assert lua.execute('return _count_dwrite_text("DRIVE A LAP")') >= 1, (
         "empty state must render 'DRIVE A LAP' placeholder"
+    )
+    assert lua.execute('return _count_dwrite_text("S1: 0.20 S FASTER")') >= 1, (
+        "sector delta toast must render in WINDOW_0"
     )
 
 

--- a/tests/test_sector_benchmark.py
+++ b/tests/test_sector_benchmark.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.ai_sidecar.lap_dynamics import LapTrace
+from tools.ai_sidecar.sector_benchmark import (
+    build_sector_delta_report,
+    build_sector_map,
+    build_superlap,
+)
+
+
+def _lap_from_micro_durations(durations: list[float], *, car: str = "car", track: str = "track"):
+    spline = [i / len(durations) for i in range(len(durations) + 1)]
+    t_s = [0.0]
+    for duration in durations:
+        t_s.append(t_s[-1] + duration)
+    n = len(spline)
+    return LapTrace(
+        spline=spline,
+        t_s=t_s,
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[1.0] * n,
+        steer=[0.0] * n,
+        gear=[4.0] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+        lap_ms=t_s[-1] * 1000.0,
+        car_id=car,
+        track_id=track,
+    )
+
+
+def test_sector_map_defaults_to_three_by_three_micro_sectors() -> None:
+    smap = build_sector_map()
+    assert [s.label for s in smap.sectors] == ["S1", "S2", "S3"]
+    assert [m.label for m in smap.micro_sectors[:4]] == ["S1.1", "S1.2", "S1.3", "S2.1"]
+    assert smap.micro_sectors[-1].label == "S3.3"
+
+
+def test_sector_delta_report_localizes_micro_sector_loss_and_gain() -> None:
+    reference = _lap_from_micro_durations([10.0] * 9)
+    candidate = _lap_from_micro_durations([10.0, 12.0, 10.0, 9.0, 10.0, 10.0, 10.0, 10.0, 10.0])
+
+    report = build_sector_delta_report(candidate, reference)
+
+    assert report.total_delta_s == pytest.approx(1.0)
+    assert report.sectors[0].label == "S1"
+    assert report.sectors[0].delta_s == pytest.approx(2.0)
+    assert report.sectors[1].delta_s == pytest.approx(-1.0)
+    deltas = {seg.label: seg.delta_s for seg in report.micro_sectors}
+    assert deltas["S1.2"] == pytest.approx(2.0)
+    assert deltas["S2.1"] == pytest.approx(-1.0)
+
+
+def test_superlap_stitches_fastest_micro_sectors() -> None:
+    steady = _lap_from_micro_durations([10.0] * 9)
+    spiky = _lap_from_micro_durations([12.0, 12.0, 8.0, 12.0, 12.0, 12.0, 12.0, 12.0, 12.0])
+
+    superlap = build_superlap([steady, spiky])
+
+    assert superlap is not None
+    assert superlap.lap_time_s == pytest.approx(88.0)
+    assert superlap.baseline_best_lap_s == pytest.approx(90.0)
+    assert superlap.gain_vs_best_s == pytest.approx(2.0)
+    assert {seg.label: seg.source_index for seg in superlap.segments}["S1.3"] == 1

--- a/tests/test_sector_benchmark.py
+++ b/tests/test_sector_benchmark.py
@@ -7,6 +7,7 @@ from tools.ai_sidecar.sector_benchmark import (
     build_sector_delta_report,
     build_sector_map,
     build_superlap,
+    segment_duration_s,
 )
 
 
@@ -65,3 +66,43 @@ def test_superlap_stitches_fastest_micro_sectors() -> None:
     assert superlap.baseline_best_lap_s == pytest.approx(90.0)
     assert superlap.gain_vs_best_s == pytest.approx(2.0)
     assert {seg.label: seg.source_index for seg in superlap.segments}["S1.3"] == 1
+
+
+def test_segment_duration_requires_sampled_window_edges() -> None:
+    lap = _lap_from_micro_durations([10.0] * 9)
+    sparse = LapTrace(
+        spline=lap.spline[1:],
+        t_s=lap.t_s[1:],
+        v_ms=lap.v_ms[1:],
+        brake=lap.brake[1:],
+        throttle=lap.throttle[1:],
+        steer=lap.steer[1:],
+        gear=lap.gear[1:],
+        x=lap.x[1:],
+        z=lap.z[1:],
+        lap_ms=lap.lap_ms,
+        car_id=lap.car_id,
+        track_id=lap.track_id,
+    )
+
+    assert segment_duration_s(sparse, build_sector_map().micro_sectors[0]) is None
+
+
+def test_superlap_requires_complete_micro_sector_coverage() -> None:
+    lap = _lap_from_micro_durations([10.0] * 9)
+    sparse = LapTrace(
+        spline=lap.spline[1:],
+        t_s=lap.t_s[1:],
+        v_ms=lap.v_ms[1:],
+        brake=lap.brake[1:],
+        throttle=lap.throttle[1:],
+        steer=lap.steer[1:],
+        gear=lap.gear[1:],
+        x=lap.x[1:],
+        z=lap.z[1:],
+        lap_ms=lap.lap_ms,
+        car_id=lap.car_id,
+        track_id=lap.track_id,
+    )
+
+    assert build_superlap([sparse]) is None

--- a/tests/test_sector_benchmark.py
+++ b/tests/test_sector_benchmark.py
@@ -50,10 +50,10 @@ def _drop_first_sample(lap: LapTrace, *, keep_lap_ms: bool = True) -> LapTrace:
     )
 
 
-def _lap_with_edge_gap() -> LapTrace:
+def _lap_with_edge_gap(*, start: float = 0.05, end: float = 0.95) -> LapTrace:
     n = 10
-    spline = [0.05 + 0.90 * i / (n - 1) for i in range(n)]
-    t_s = [5.0 + 90.0 * i / (n - 1) for i in range(n)]
+    spline = [start + (end - start) * i / (n - 1) for i in range(n)]
+    t_s = [100.0 * s for s in spline]
     return LapTrace(
         spline=spline,
         t_s=t_s,
@@ -122,6 +122,16 @@ def test_segment_duration_uses_lap_clock_for_archive_boundaries() -> None:
     assert segment_duration_s(lap, smap.micro_sectors[-1]) is not None
     assert build_sector_delta_report(lap, lap) is not None
     assert build_superlap([lap]) is not None
+
+
+def test_segment_duration_rejects_unsampled_interior_boundaries() -> None:
+    lap = _lap_with_edge_gap(start=0.20, end=0.80)
+    smap = build_sector_map()
+
+    assert segment_duration_s(lap, smap.micro_sectors[0]) is None
+    assert segment_duration_s(lap, smap.micro_sectors[-1]) is None
+    assert build_sector_delta_report(lap, lap) is None
+    assert build_superlap([lap]) is None
 
 
 def test_sector_delta_report_requires_complete_sector_coverage() -> None:

--- a/tests/test_sector_benchmark.py
+++ b/tests/test_sector_benchmark.py
@@ -33,6 +33,23 @@ def _lap_from_micro_durations(durations: list[float], *, car: str = "car", track
     )
 
 
+def _drop_first_sample(lap: LapTrace) -> LapTrace:
+    return LapTrace(
+        spline=lap.spline[1:],
+        t_s=lap.t_s[1:],
+        v_ms=lap.v_ms[1:],
+        brake=lap.brake[1:],
+        throttle=lap.throttle[1:],
+        steer=lap.steer[1:],
+        gear=lap.gear[1:],
+        x=lap.x[1:],
+        z=lap.z[1:],
+        lap_ms=lap.lap_ms,
+        car_id=lap.car_id,
+        track_id=lap.track_id,
+    )
+
+
 def test_sector_map_defaults_to_three_by_three_micro_sectors() -> None:
     smap = build_sector_map()
     assert [s.label for s in smap.sectors] == ["S1", "S2", "S3"]
@@ -70,39 +87,20 @@ def test_superlap_stitches_fastest_micro_sectors() -> None:
 
 def test_segment_duration_requires_sampled_window_edges() -> None:
     lap = _lap_from_micro_durations([10.0] * 9)
-    sparse = LapTrace(
-        spline=lap.spline[1:],
-        t_s=lap.t_s[1:],
-        v_ms=lap.v_ms[1:],
-        brake=lap.brake[1:],
-        throttle=lap.throttle[1:],
-        steer=lap.steer[1:],
-        gear=lap.gear[1:],
-        x=lap.x[1:],
-        z=lap.z[1:],
-        lap_ms=lap.lap_ms,
-        car_id=lap.car_id,
-        track_id=lap.track_id,
-    )
+    sparse = _drop_first_sample(lap)
 
     assert segment_duration_s(sparse, build_sector_map().micro_sectors[0]) is None
 
 
+def test_sector_delta_report_requires_complete_sector_coverage() -> None:
+    reference = _lap_from_micro_durations([10.0] * 9)
+    sparse_candidate = _drop_first_sample(_lap_from_micro_durations([10.0] * 9))
+
+    assert build_sector_delta_report(sparse_candidate, reference) is None
+
+
 def test_superlap_requires_complete_micro_sector_coverage() -> None:
     lap = _lap_from_micro_durations([10.0] * 9)
-    sparse = LapTrace(
-        spline=lap.spline[1:],
-        t_s=lap.t_s[1:],
-        v_ms=lap.v_ms[1:],
-        brake=lap.brake[1:],
-        throttle=lap.throttle[1:],
-        steer=lap.steer[1:],
-        gear=lap.gear[1:],
-        x=lap.x[1:],
-        z=lap.z[1:],
-        lap_ms=lap.lap_ms,
-        car_id=lap.car_id,
-        track_id=lap.track_id,
-    )
+    sparse = _drop_first_sample(lap)
 
     assert build_superlap([sparse]) is None

--- a/tests/test_sector_benchmark.py
+++ b/tests/test_sector_benchmark.py
@@ -33,7 +33,7 @@ def _lap_from_micro_durations(durations: list[float], *, car: str = "car", track
     )
 
 
-def _drop_first_sample(lap: LapTrace) -> LapTrace:
+def _drop_first_sample(lap: LapTrace, *, keep_lap_ms: bool = True) -> LapTrace:
     return LapTrace(
         spline=lap.spline[1:],
         t_s=lap.t_s[1:],
@@ -44,9 +44,29 @@ def _drop_first_sample(lap: LapTrace) -> LapTrace:
         gear=lap.gear[1:],
         x=lap.x[1:],
         z=lap.z[1:],
-        lap_ms=lap.lap_ms,
+        lap_ms=lap.lap_ms if keep_lap_ms else None,
         car_id=lap.car_id,
         track_id=lap.track_id,
+    )
+
+
+def _lap_with_edge_gap() -> LapTrace:
+    n = 10
+    spline = [0.05 + 0.90 * i / (n - 1) for i in range(n)]
+    t_s = [5.0 + 90.0 * i / (n - 1) for i in range(n)]
+    return LapTrace(
+        spline=spline,
+        t_s=t_s,
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[1.0] * n,
+        steer=[0.0] * n,
+        gear=[4.0] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+        lap_ms=100_000.0,
+        car_id="car",
+        track_id="track",
     )
 
 
@@ -55,6 +75,9 @@ def test_sector_map_defaults_to_three_by_three_micro_sectors() -> None:
     assert [s.label for s in smap.sectors] == ["S1", "S2", "S3"]
     assert [m.label for m in smap.micro_sectors[:4]] == ["S1.1", "S1.2", "S1.3", "S2.1"]
     assert smap.micro_sectors[-1].label == "S3.3"
+    assert [s.sector_index for s in smap.sectors] == [1, 2, 3]
+    assert (smap.micro_sectors[0].sector_index, smap.micro_sectors[0].micro_index) == (1, 1)
+    assert (smap.micro_sectors[-1].sector_index, smap.micro_sectors[-1].micro_index) == (3, 3)
 
 
 def test_sector_delta_report_localizes_micro_sector_loss_and_gain() -> None:
@@ -87,20 +110,29 @@ def test_superlap_stitches_fastest_micro_sectors() -> None:
 
 def test_segment_duration_requires_sampled_window_edges() -> None:
     lap = _lap_from_micro_durations([10.0] * 9)
-    sparse = _drop_first_sample(lap)
+    sparse = _drop_first_sample(lap, keep_lap_ms=False)
 
     assert segment_duration_s(sparse, build_sector_map().micro_sectors[0]) is None
 
 
+def test_segment_duration_uses_lap_clock_for_archive_boundaries() -> None:
+    lap = _lap_with_edge_gap()
+    smap = build_sector_map()
+
+    assert segment_duration_s(lap, smap.micro_sectors[-1]) is not None
+    assert build_sector_delta_report(lap, lap) is not None
+    assert build_superlap([lap]) is not None
+
+
 def test_sector_delta_report_requires_complete_sector_coverage() -> None:
     reference = _lap_from_micro_durations([10.0] * 9)
-    sparse_candidate = _drop_first_sample(_lap_from_micro_durations([10.0] * 9))
+    sparse_candidate = _drop_first_sample(_lap_from_micro_durations([10.0] * 9), keep_lap_ms=False)
 
     assert build_sector_delta_report(sparse_candidate, reference) is None
 
 
 def test_superlap_requires_complete_micro_sector_coverage() -> None:
     lap = _lap_from_micro_durations([10.0] * 9)
-    sparse = _drop_first_sample(lap)
+    sparse = _drop_first_sample(lap, keep_lap_ms=False)
 
     assert build_superlap([sparse]) is None

--- a/tools/ai_sidecar/car_schema.py
+++ b/tools/ai_sidecar/car_schema.py
@@ -278,7 +278,7 @@ class CarSetupSchema:
 
 
 def _main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description="Ingest an ac.getSetupSpinners() dump -> schema asset.")
+    p = argparse.ArgumentParser(description="Ingest an ac.getSetupSpinners() dump to schema asset.")
     p.add_argument("dump", help="JSON file: a list of getSetupSpinners() descriptors")
     p.add_argument("--car-id", required=True)
     p.add_argument("--schema-dir", default=DEFAULT_SCHEMA_DIR)

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -104,6 +104,21 @@ def _same_lap_scope(candidate: LapTrace, anchor: LapTrace) -> bool:
     return not (anchor.track_id is not None and candidate.track_id != anchor.track_id)
 
 
+def _archive_track_layout(archive: dict | None) -> str | None:
+    track = archive.get("track") if isinstance(archive, dict) else None
+    layout = track.get("layout") if isinstance(track, dict) else None
+    if layout is None or layout == "":
+        return None
+    return str(layout)
+
+
+def _same_archive_layout(candidate: dict | None, anchor: dict | None) -> bool:
+    anchor_layout = _archive_track_layout(anchor)
+    if anchor_layout is None:
+        return True
+    return _archive_track_layout(candidate) == anchor_layout
+
+
 def format_debrief(
     corners: list[CornerCoaching],
     balance: BalanceFinding | None = None,
@@ -411,6 +426,7 @@ def _analyze(
         if raw_ref is not None
         and _archive_lap_is_valid(reference_archive)
         and _same_lap_scope(raw_ref, lap)
+        and _same_archive_layout(reference_archive, lap_archive)
         else None
     )
     report = coach_lap(lap, setup, reference=ref, grip_ceiling_g=grip_ceiling_g)
@@ -440,7 +456,7 @@ def _analyze(
             corpus_lap = lap_trace_from_archive(archive)
         except ValueError:
             continue
-        if _same_lap_scope(corpus_lap, lap):
+        if _same_lap_scope(corpus_lap, lap) and _same_archive_layout(archive, lap_archive):
             corpus_laps.append(corpus_lap)
     superlap = build_superlap(corpus_laps) if corpus_laps else None
     return {

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -93,6 +93,17 @@ def _corner_reference_scores(
     return scores or None
 
 
+def _archive_lap_is_valid(archive: dict | None) -> bool:
+    lap = archive.get("lap") if isinstance(archive, dict) else None
+    return not (isinstance(lap, dict) and lap.get("is_valid") is False)
+
+
+def _same_lap_scope(candidate: LapTrace, anchor: LapTrace) -> bool:
+    if anchor.car_id is not None and candidate.car_id != anchor.car_id:
+        return False
+    return not (anchor.track_id is not None and candidate.track_id != anchor.track_id)
+
+
 def format_debrief(
     corners: list[CornerCoaching],
     balance: BalanceFinding | None = None,
@@ -411,15 +422,19 @@ def _analyze(
     trail_braking = [f for f in analyze_trail_braking(lap) if f.classification != "no_braking"]
     sector_deltas = build_sector_delta_report(lap, ref) if ref is not None else None
     corpus_laps: list[LapTrace] = []
-    if ref is not None:
+    if ref is not None and _archive_lap_is_valid(reference_archive) and _same_lap_scope(ref, lap):
         corpus_laps.append(ref)
-    if ref is not None or corpus_archives:
+    if (ref is not None or corpus_archives) and _archive_lap_is_valid(lap_archive):
         corpus_laps.append(lap)
     for archive in corpus_archives or []:
+        if not _archive_lap_is_valid(archive):
+            continue
         try:
-            corpus_laps.append(lap_trace_from_archive(archive))
+            corpus_lap = lap_trace_from_archive(archive)
         except ValueError:
             continue
+        if _same_lap_scope(corpus_lap, lap):
+            corpus_laps.append(corpus_lap)
     superlap = build_superlap(corpus_laps) if corpus_laps else None
     return {
         "lap": lap,

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -36,6 +36,12 @@ from tools.ai_sidecar.lap_dynamics import (
     lap_trace_from_archive,
     segment_corners,
 )
+from tools.ai_sidecar.sector_benchmark import (
+    SectorDeltaReport,
+    SuperLap,
+    build_sector_delta_report,
+    build_superlap,
+)
 from tools.ai_sidecar.setup_model import CarSetup, from_lap_archive, load_setup_file
 from tools.ai_sidecar.track_reference import (
     CornerScore,
@@ -97,6 +103,8 @@ def format_debrief(
     conditions: ConditionsReport | None = None,
     corner_reference: list[CornerScore] | None = None,
     trail_braking: list[TrailBrakeFinding] | None = None,
+    sector_deltas: SectorDeltaReport | None = None,
+    superlap: SuperLap | None = None,
 ) -> str:
     """Render the full debrief as text."""
     out: list[str] = [f"=== {title} ==="]
@@ -158,12 +166,40 @@ def format_debrief(
             out.append("  " + s.headline)
             for fnd in s.findings[:1]:
                 out.append(f"      - {fnd}")
+    if sector_deltas and sector_deltas.sectors:
+        total = sector_deltas.total_delta_s
+        out.append(f"\nSector deltas vs reference (total {_signed_seconds(total)}):")
+        for seg in sector_deltas.sectors:
+            out.append(f"  {seg.label}: {_signed_seconds(seg.delta_s)}")
+        losses = sorted(
+            (s for s in sector_deltas.micro_sectors if s.delta_s > 0.03),
+            key=lambda s: s.delta_s,
+            reverse=True,
+        )
+        if losses:
+            out.append("  Biggest micro-sector losses:")
+            for seg in losses[:3]:
+                out.append(f"      - {seg.label}: {_signed_seconds(seg.delta_s)}")
+    if superlap and superlap.segments:
+        gain = (
+            "unknown gain"
+            if superlap.gain_vs_best_s is None
+            else f"{max(0.0, superlap.gain_vs_best_s):.2f}s available"
+        )
+        out.append(
+            f"\nSuperLap target: {superlap.lap_time_s:.2f}s ({gain}), stitched from "
+            f"{len(superlap.segments)} micro-sectors across {superlap.source_count} source lap(s)."
+        )
     flagged = [f for f in (trail_braking or []) if f.classification != "good_trail_brake"]
     if flagged:
         out.append(f"\nTrail braking ({len(flagged)} corner(s) to work on):")
         for f in flagged:
             out.append(f"  T{f.corner + 1} ({f.classification}): {f.coaching}")
     return "\n".join(out)
+
+
+def _signed_seconds(value: float) -> str:
+    return f"{value:+.2f}s"
 
 
 def _load_archive(path: str | Path) -> dict:
@@ -288,10 +324,66 @@ def _trail_braking_struct(findings: list[TrailBrakeFinding] | None) -> list[dict
     ]
 
 
+def _sector_delta_struct(report: SectorDeltaReport | None) -> dict | None:
+    if report is None:
+        return None
+
+    def segment(seg) -> dict:
+        return {
+            "key": seg.key,
+            "label": seg.label,
+            "spline_start": round(seg.spline_start, 6),
+            "spline_end": round(seg.spline_end, 6),
+            "candidate_s": round(seg.candidate_s, 4),
+            "reference_s": round(seg.reference_s, 4),
+            "delta_s": round(seg.delta_s, 4),
+            "sector_index": seg.sector_index,
+            "micro_index": seg.micro_index,
+        }
+
+    return {
+        "total_delta_s": round(report.total_delta_s, 4),
+        "car_id": report.car_id,
+        "track_id": report.track_id,
+        "sectors": [segment(s) for s in report.sectors],
+        "micro_sectors": [segment(s) for s in report.micro_sectors],
+    }
+
+
+def _superlap_struct(superlap: SuperLap | None) -> dict | None:
+    if superlap is None:
+        return None
+    return {
+        "lap_time_s": round(superlap.lap_time_s, 4),
+        "baseline_best_lap_s": (
+            None if superlap.baseline_best_lap_s is None else round(superlap.baseline_best_lap_s, 4)
+        ),
+        "gain_vs_best_s": (
+            None if superlap.gain_vs_best_s is None else round(superlap.gain_vs_best_s, 4)
+        ),
+        "source_count": superlap.source_count,
+        "segments": [
+            {
+                "key": seg.key,
+                "label": seg.label,
+                "spline_start": round(seg.spline_start, 6),
+                "spline_end": round(seg.spline_end, 6),
+                "duration_s": round(seg.duration_s, 4),
+                "source_index": seg.source_index,
+                "source_lap_s": (None if seg.source_lap_s is None else round(seg.source_lap_s, 4)),
+                "car_id": seg.car_id,
+                "track_id": seg.track_id,
+            }
+            for seg in superlap.segments
+        ],
+    }
+
+
 def _analyze(
     lap_archive: dict,
     *,
     reference_archive: dict | None,
+    corpus_archives: list[dict] | None,
     setup: CarSetup | None,
     grip_ceiling_g: float | None,
 ) -> dict:
@@ -317,6 +409,18 @@ def _analyze(
     corner_reference = _corner_reference_scores(ref, lap)
     # trail-braking technique read, per corner (only corners that actually braked surface a finding)
     trail_braking = [f for f in analyze_trail_braking(lap) if f.classification != "no_braking"]
+    sector_deltas = build_sector_delta_report(lap, ref) if ref is not None else None
+    corpus_laps: list[LapTrace] = []
+    if ref is not None:
+        corpus_laps.append(ref)
+    if ref is not None or corpus_archives:
+        corpus_laps.append(lap)
+    for archive in corpus_archives or []:
+        try:
+            corpus_laps.append(lap_trace_from_archive(archive))
+        except ValueError:
+            continue
+    superlap = build_superlap(corpus_laps) if corpus_laps else None
     return {
         "lap": lap,
         "setup": setup,
@@ -326,6 +430,8 @@ def _analyze(
         "conditions": conditions,
         "corner_reference": corner_reference,
         "trail_braking": trail_braking,
+        "sector_deltas": sector_deltas,
+        "superlap": superlap,
     }
 
 
@@ -333,6 +439,7 @@ def build_structured_debrief(
     lap_archive: dict,
     *,
     reference_archive: dict | None = None,
+    corpus_archives: list[dict] | None = None,
     setup: CarSetup | None = None,
     grip_ceiling_g: float | None = None,
 ) -> dict | None:
@@ -349,6 +456,7 @@ def build_structured_debrief(
         a = _analyze(
             lap_archive,
             reference_archive=reference_archive,
+            corpus_archives=corpus_archives,
             setup=setup,
             grip_ceiling_g=grip_ceiling_g,
         )
@@ -365,6 +473,8 @@ def build_structured_debrief(
         conditions=a["conditions"],
         corner_reference=a["corner_reference"],
         trail_braking=a["trail_braking"],
+        sector_deltas=a["sector_deltas"],
+        superlap=a["superlap"],
     )
     corners = [
         {
@@ -406,6 +516,8 @@ def build_structured_debrief(
         "conditions": _conditions_struct(a["conditions"]),
         "corner_reference": _corner_reference_struct(a["corner_reference"]),
         "trail_braking": _trail_braking_struct(a["trail_braking"]),
+        "sector_deltas": _sector_delta_struct(a["sector_deltas"]),
+        "superlap": _superlap_struct(a["superlap"]),
     }
 
 
@@ -413,6 +525,7 @@ def build_debrief(
     lap_archive: dict,
     *,
     reference_archive: dict | None = None,
+    corpus_archives: list[dict] | None = None,
     setup: CarSetup | None = None,
     grip_ceiling_g: float | None = None,
 ) -> str:
@@ -420,6 +533,7 @@ def build_debrief(
     a = _analyze(
         lap_archive,
         reference_archive=reference_archive,
+        corpus_archives=corpus_archives,
         setup=setup,
         grip_ceiling_g=grip_ceiling_g,
     )
@@ -433,6 +547,8 @@ def build_debrief(
         conditions=a["conditions"],
         corner_reference=a["corner_reference"],
         trail_braking=a["trail_braking"],
+        sector_deltas=a["sector_deltas"],
+        superlap=a["superlap"],
     )
 
 
@@ -440,6 +556,12 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description="Per-corner setup-vs-technique coaching debrief")
     p.add_argument("lap", help="lap archive JSON to coach")
     p.add_argument("--reference", help="reference lap archive JSON (e.g. a faster lap)")
+    p.add_argument(
+        "--corpus",
+        action="append",
+        default=[],
+        help="additional lap archive JSON to include in the SuperLap corpus",
+    )
     p.add_argument("--setup", help="setup .ini to use instead of the lap's snapshot")
     p.add_argument(
         "--grip-ceiling-g",
@@ -450,10 +572,12 @@ def main(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
     setup = load_setup_file(args.setup) if args.setup else None
     ref = _load_archive(args.reference) if args.reference else None
+    corpus = [_load_archive(path) for path in args.corpus]
     print(
         build_debrief(
             _load_archive(args.lap),
             reference_archive=ref,
+            corpus_archives=corpus,
             setup=setup,
             grip_ceiling_g=args.grip_ceiling_g,
         )

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -405,7 +405,14 @@ def _analyze(
     """
     lap = lap_trace_from_archive(lap_archive)
     setup = setup or from_lap_archive(lap_archive)
-    ref = lap_trace_from_archive(reference_archive) if reference_archive else None
+    raw_ref = lap_trace_from_archive(reference_archive) if reference_archive else None
+    ref = (
+        raw_ref
+        if raw_ref is not None
+        and _archive_lap_is_valid(reference_archive)
+        and _same_lap_scope(raw_ref, lap)
+        else None
+    )
     report = coach_lap(lap, setup, reference=ref, grip_ceiling_g=grip_ceiling_g)
     sigs = corner_signatures(lap, segment_corners(lap))
     deltas = compare_laps(lap, ref) if ref is not None else None
@@ -422,7 +429,7 @@ def _analyze(
     trail_braking = [f for f in analyze_trail_braking(lap) if f.classification != "no_braking"]
     sector_deltas = build_sector_delta_report(lap, ref) if ref is not None else None
     corpus_laps: list[LapTrace] = []
-    if ref is not None and _archive_lap_is_valid(reference_archive) and _same_lap_scope(ref, lap):
+    if ref is not None:
         corpus_laps.append(ref)
     if (ref is not None or corpus_archives) and _archive_lap_is_valid(lap_archive):
         corpus_laps.append(lap)

--- a/tools/ai_sidecar/protocol.py
+++ b/tools/ai_sidecar/protocol.py
@@ -139,6 +139,10 @@ def build_brain_followup(inbound: dict[str, Any]) -> dict[str, Any] | None:
         response["cornerReference"] = structured["corner_reference"]
     if structured.get("trail_braking") is not None:
         response["trailBraking"] = structured["trail_braking"]
+    if structured.get("sector_deltas") is not None:
+        response["sectorDeltas"] = structured["sector_deltas"]
+    if structured.get("superlap") is not None:
+        response["superLap"] = structured["superlap"]
     return response
 
 

--- a/tools/ai_sidecar/sector_benchmark.py
+++ b/tools/ai_sidecar/sector_benchmark.py
@@ -120,7 +120,7 @@ def build_sector_map(
                 label=label,
                 spline_start=s0,
                 spline_end=s1,
-                sector_index=si,
+                sector_index=si + 1,
             )
         )
         span = s1 - s0
@@ -134,8 +134,8 @@ def build_sector_map(
                     label=mlabel,
                     spline_start=m0,
                     spline_end=m1,
-                    sector_index=si,
-                    micro_index=mi,
+                    sector_index=si + 1,
+                    micro_index=mi + 1,
                 )
             )
     return SectorMap(sectors=sectors, micro_sectors=micro_sectors)
@@ -279,8 +279,11 @@ def _time_at_spline(lap: LapTrace, spline_pos: float) -> float | None:
     if not math.isfinite(sp):
         return None
     eps = 1e-6
-    if sp < points[0][0] - eps or sp > points[-1][0] + eps:
-        return None
+    lap_clock_s = lap.lap_ms / 1000.0 if lap.lap_ms is not None and lap.lap_ms > 0 else None
+    if sp < points[0][0] - eps:
+        return 0.0 if sp >= -eps and lap_clock_s is not None else None
+    if sp > points[-1][0] + eps:
+        return lap_clock_s if sp <= 1.0 + eps else None
     if sp <= points[0][0]:
         return points[0][1]
     if sp >= points[-1][0]:

--- a/tools/ai_sidecar/sector_benchmark.py
+++ b/tools/ai_sidecar/sector_benchmark.py
@@ -281,9 +281,9 @@ def _time_at_spline(lap: LapTrace, spline_pos: float) -> float | None:
     eps = 1e-6
     lap_clock_s = lap.lap_ms / 1000.0 if lap.lap_ms is not None and lap.lap_ms > 0 else None
     if sp < points[0][0] - eps:
-        return 0.0 if sp >= -eps and lap_clock_s is not None else None
+        return 0.0 if -eps <= sp <= eps and lap_clock_s is not None else None
     if sp > points[-1][0] + eps:
-        return lap_clock_s if sp <= 1.0 + eps else None
+        return lap_clock_s if 1.0 - eps <= sp <= 1.0 + eps else None
     if sp <= points[0][0]:
         return points[0][1]
     if sp >= points[-1][0]:

--- a/tools/ai_sidecar/sector_benchmark.py
+++ b/tools/ai_sidecar/sector_benchmark.py
@@ -159,7 +159,7 @@ def build_sector_delta_report(
     reference: LapTrace,
     *,
     sector_map: SectorMap | None = None,
-) -> SectorDeltaReport:
+) -> SectorDeltaReport | None:
     """Compare candidate vs reference by sector and micro-sector.
 
     Positive deltas mean the candidate was slower than the reference over that
@@ -169,6 +169,8 @@ def build_sector_delta_report(
     smap = sector_map or build_sector_map()
     sectors = _delta_windows(candidate, reference, smap.sectors)
     micro_sectors = _delta_windows(candidate, reference, smap.micro_sectors)
+    if len(sectors) != len(smap.sectors) or len(micro_sectors) != len(smap.micro_sectors):
+        return None
     total_delta_s = sum(s.delta_s for s in sectors)
     return SectorDeltaReport(
         total_delta_s=total_delta_s,

--- a/tools/ai_sidecar/sector_benchmark.py
+++ b/tools/ai_sidecar/sector_benchmark.py
@@ -1,0 +1,296 @@
+"""Sector, micro-sector, and SuperLap benchmarks for lap traces.
+
+This module is intentionally pure-stdlib and works from :class:`LapTrace`, so
+the sidecar can reuse it for imported laps, saved archives, Track Titan exports,
+and live-lap follow-ups without coupling to any one source.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from tools.ai_sidecar.lap_dynamics import LapTrace
+
+
+@dataclass(frozen=True)
+class SegmentWindow:
+    """Spline-bounded benchmark segment."""
+
+    key: str
+    label: str
+    spline_start: float
+    spline_end: float
+    sector_index: int
+    micro_index: int | None = None
+
+
+@dataclass(frozen=True)
+class SectorMap:
+    """Deterministic sector map plus equal-width micro-sector subdivisions."""
+
+    sectors: list[SegmentWindow]
+    micro_sectors: list[SegmentWindow]
+
+
+@dataclass(frozen=True)
+class SegmentDelta:
+    """Duration delta for one sector or micro-sector.
+
+    ``delta_s`` is positive when the candidate lost time to the reference.
+    """
+
+    key: str
+    label: str
+    spline_start: float
+    spline_end: float
+    candidate_s: float
+    reference_s: float
+    delta_s: float
+    sector_index: int
+    micro_index: int | None = None
+
+
+@dataclass(frozen=True)
+class SectorDeltaReport:
+    """All sector/micro-sector deltas for one candidate/reference pair."""
+
+    total_delta_s: float
+    sectors: list[SegmentDelta]
+    micro_sectors: list[SegmentDelta]
+    car_id: str | None = None
+    track_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SuperLapSegment:
+    """Best observed micro-sector selected for a stitched SuperLap."""
+
+    key: str
+    label: str
+    spline_start: float
+    spline_end: float
+    duration_s: float
+    source_index: int
+    source_lap_s: float | None
+    car_id: str | None = None
+    track_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SuperLap:
+    """Best-of-bests composite lap from the fastest observed micro-sectors."""
+
+    lap_time_s: float
+    baseline_best_lap_s: float | None
+    gain_vs_best_s: float | None
+    segments: list[SuperLapSegment]
+    source_count: int
+
+
+def build_sector_map(
+    *, sector_count: int = 3, micro_per_sector: int = 3, sector_names: list[str] | None = None
+) -> SectorMap:
+    """Return equal spline sectors and micro-sectors.
+
+    AC exposes live sector boundaries separately, but saved lap archives do not
+    carry a per-track sector-definition file yet. Equal spline thirds make the
+    benchmark deterministic now, and ``sector_names`` lets a future track map
+    swap labels without changing the payload shape.
+    """
+
+    if sector_count <= 0:
+        raise ValueError("sector_count must be positive")
+    if micro_per_sector <= 0:
+        raise ValueError("micro_per_sector must be positive")
+    names = sector_names or [f"S{i + 1}" for i in range(sector_count)]
+    if len(names) != sector_count:
+        raise ValueError("sector_names length must match sector_count")
+
+    sectors: list[SegmentWindow] = []
+    micro_sectors: list[SegmentWindow] = []
+    for si in range(sector_count):
+        s0 = si / sector_count
+        s1 = (si + 1) / sector_count
+        label = names[si]
+        sectors.append(
+            SegmentWindow(
+                key=label.lower(),
+                label=label,
+                spline_start=s0,
+                spline_end=s1,
+                sector_index=si,
+            )
+        )
+        span = s1 - s0
+        for mi in range(micro_per_sector):
+            m0 = s0 + span * mi / micro_per_sector
+            m1 = s0 + span * (mi + 1) / micro_per_sector
+            mlabel = f"{label}.{mi + 1}"
+            micro_sectors.append(
+                SegmentWindow(
+                    key=mlabel.lower(),
+                    label=mlabel,
+                    spline_start=m0,
+                    spline_end=m1,
+                    sector_index=si,
+                    micro_index=mi,
+                )
+            )
+    return SectorMap(sectors=sectors, micro_sectors=micro_sectors)
+
+
+def segment_duration_s(lap: LapTrace, window: SegmentWindow) -> float | None:
+    """Duration in seconds across ``window`` using spline/time interpolation."""
+
+    t0 = _time_at_spline(lap, window.spline_start)
+    t1 = _time_at_spline(lap, window.spline_end)
+    if t0 is None or t1 is None:
+        return None
+    duration = t1 - t0
+    if not math.isfinite(duration) or duration < -1e-6:
+        return None
+    return max(0.0, duration)
+
+
+def build_sector_delta_report(
+    candidate: LapTrace,
+    reference: LapTrace,
+    *,
+    sector_map: SectorMap | None = None,
+) -> SectorDeltaReport:
+    """Compare candidate vs reference by sector and micro-sector.
+
+    Positive deltas mean the candidate was slower than the reference over that
+    segment; negative deltas mean the candidate gained time.
+    """
+
+    smap = sector_map or build_sector_map()
+    sectors = _delta_windows(candidate, reference, smap.sectors)
+    micro_sectors = _delta_windows(candidate, reference, smap.micro_sectors)
+    total_delta_s = sum(s.delta_s for s in sectors)
+    return SectorDeltaReport(
+        total_delta_s=total_delta_s,
+        sectors=sectors,
+        micro_sectors=micro_sectors,
+        car_id=candidate.car_id or reference.car_id,
+        track_id=candidate.track_id or reference.track_id,
+    )
+
+
+def build_superlap(
+    laps: Iterable[LapTrace],
+    *,
+    sector_map: SectorMap | None = None,
+) -> SuperLap | None:
+    """Stitch the fastest observed micro-sector from a corpus into a SuperLap."""
+
+    valid_laps = [lap for lap in laps if len(lap) >= 2]
+    if not valid_laps:
+        return None
+
+    smap = sector_map or build_sector_map()
+    segments: list[SuperLapSegment] = []
+    for window in smap.micro_sectors:
+        best: tuple[float, int, LapTrace] | None = None
+        for idx, lap in enumerate(valid_laps):
+            duration = segment_duration_s(lap, window)
+            if duration is None:
+                continue
+            if best is None or duration < best[0]:
+                best = (duration, idx, lap)
+        if best is None:
+            continue
+        duration, source_index, lap = best
+        segments.append(
+            SuperLapSegment(
+                key=window.key,
+                label=window.label,
+                spline_start=window.spline_start,
+                spline_end=window.spline_end,
+                duration_s=duration,
+                source_index=source_index,
+                source_lap_s=_lap_duration_s(lap),
+                car_id=lap.car_id,
+                track_id=lap.track_id,
+            )
+        )
+
+    if not segments:
+        return None
+    lap_time_s = sum(s.duration_s for s in segments)
+    lap_durations = [d for lap in valid_laps if (d := _lap_duration_s(lap)) is not None]
+    baseline = min(lap_durations) if lap_durations else None
+    gain = (baseline - lap_time_s) if baseline is not None else None
+    return SuperLap(
+        lap_time_s=lap_time_s,
+        baseline_best_lap_s=baseline,
+        gain_vs_best_s=gain,
+        segments=segments,
+        source_count=len({s.source_index for s in segments}),
+    )
+
+
+def _delta_windows(
+    candidate: LapTrace, reference: LapTrace, windows: list[SegmentWindow]
+) -> list[SegmentDelta]:
+    out: list[SegmentDelta] = []
+    for window in windows:
+        cand = segment_duration_s(candidate, window)
+        ref = segment_duration_s(reference, window)
+        if cand is None or ref is None:
+            continue
+        out.append(
+            SegmentDelta(
+                key=window.key,
+                label=window.label,
+                spline_start=window.spline_start,
+                spline_end=window.spline_end,
+                candidate_s=cand,
+                reference_s=ref,
+                delta_s=cand - ref,
+                sector_index=window.sector_index,
+                micro_index=window.micro_index,
+            )
+        )
+    return out
+
+
+def _time_at_spline(lap: LapTrace, spline_pos: float) -> float | None:
+    points = sorted(
+        (float(sp), float(t))
+        for sp, t in zip(lap.spline, lap.t_s, strict=False)
+        if math.isfinite(float(sp)) and math.isfinite(float(t))
+    )
+    if len(points) < 2:
+        return None
+    sp = min(1.0, max(0.0, float(spline_pos)))
+    if sp <= points[0][0]:
+        return points[0][1]
+    if sp >= points[-1][0]:
+        return points[-1][1]
+    lo, hi = 0, len(points) - 1
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if points[mid][0] <= sp:
+            lo = mid
+        else:
+            hi = mid
+    a_sp, a_t = points[lo]
+    b_sp, b_t = points[hi]
+    span = b_sp - a_sp
+    if span <= 1e-9:
+        return a_t
+    frac = (sp - a_sp) / span
+    return a_t + frac * (b_t - a_t)
+
+
+def _lap_duration_s(lap: LapTrace) -> float | None:
+    if lap.lap_ms is not None and lap.lap_ms > 0:
+        return lap.lap_ms / 1000.0
+    if len(lap.t_s) >= 2:
+        duration = lap.t_s[-1] - lap.t_s[0]
+        if duration > 0 and math.isfinite(duration):
+            return duration
+    return None

--- a/tools/ai_sidecar/sector_benchmark.py
+++ b/tools/ai_sidecar/sector_benchmark.py
@@ -217,7 +217,7 @@ def build_superlap(
             )
         )
 
-    if not segments:
+    if len(segments) != len(smap.micro_sectors):
         return None
     lap_time_s = sum(s.duration_s for s in segments)
     lap_durations = [d for lap in valid_laps if (d := _lap_duration_s(lap)) is not None]
@@ -258,14 +258,27 @@ def _delta_windows(
 
 
 def _time_at_spline(lap: LapTrace, spline_pos: float) -> float | None:
-    points = sorted(
-        (float(sp), float(t))
-        for sp, t in zip(lap.spline, lap.t_s, strict=False)
-        if math.isfinite(float(sp)) and math.isfinite(float(t))
-    )
+    points: list[tuple[float, float]] = []
+    for raw_sp, raw_t in zip(lap.spline, lap.t_s, strict=False):
+        try:
+            sp = float(raw_sp)
+            t = float(raw_t)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(sp) and math.isfinite(t):
+            points.append((sp, t))
+    points.sort()
     if len(points) < 2:
         return None
-    sp = min(1.0, max(0.0, float(spline_pos)))
+    try:
+        sp = float(spline_pos)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(sp):
+        return None
+    eps = 1e-6
+    if sp < points[0][0] - eps or sp > points[-1][0] + eps:
+        return None
     if sp <= points[0][0]:
         return points[0][1]
     if sp >= points[-1][0]:


### PR DESCRIPTION
## Summary
- Adds `tools.ai_sidecar.sector_benchmark` for deterministic 3x3 sector/micro-sector deltas and stitched SuperLap targets over lap archives.
- Wires sector deltas and SuperLap into `coach_report` text/JSON and forwards them through `build_brain_followup` as `sectorDeltas` and `superLap`.
- Extends the Lua delta/HUD path so live sector toasts are labeled (`S1`/`S2`/`S3`) and actually render in WINDOW_0.
- Fixes `car_schema.py --help` to be ASCII-safe on Windows cp1252 consoles, which surfaced during full CI verification.

Refs #408. Track Titan service extraction remains owned by #353; this PR consumes reference archives/corpus data once available.

## Verification
- `py -3 -m pytest -q tests\\test_sector_benchmark.py tests\\test_coach_report.py tests\\test_brain_wiring.py tests\\test_ai_sidecar_protocol.py tests\\test_lua_trace_replay.py tests\\test_phase5_rebuild_ete.py` -> 83 passed
- LF verification worktree with `FLEET_GOVERNANCE_ROOT=.fleet-governance-vendor`:
  - `make ci-fast` progressed through format, lint, full pytest, and Bandit; pytest: 1922 passed, 117 skipped, coverage 85.63%; Bandit: no issues
  - `ci-secrets` equivalent: `PYTHON=/c/Users/arsen/AppData/Local/Programs/Python/Python313/python.exe bash scripts/policy_tracked_files.sh` -> pass
  - `bash scripts/check_policy_docs.sh` -> pass
  - `python3 scripts/check_agent_forbidden.py` -> pass (allowlist warnings only for existing root files)
  - `python3 scripts/check_csp_api.py src` -> pass
  - `python3 scripts/check_csp_ui_safety.py` -> pass

Note: on this Windows shell, the Makefile line `PYTHON=python3 bash scripts/policy_tracked_files.sh` fails before the script body because `bash` is not on PATH / POSIX env assignment is not honored by the shell. The underlying secrets gate passes via explicit Git Bash + Python path.