### PR TITLE
docs(vault): post-merge handoff for PR #415

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-06-30T20:44:28Z
+last_updated: 2026-06-30T20:49:44Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/pr-394-voice-reliability-2026-06-30.md
@@ -105,6 +105,14 @@ Stream A (rig screen Phase-2 LVGL + Figma UI + final on-device proof) is the hot
 
 ## Recently landed (reverse chronological)
 
+- **2026-06-30** - PR [#415](https://github.com/agorokh/ac-copilot-trainer/pull/415)
+  **MERGED** at `c407d46` - **telemetry data platform** ([#402](https://github.com/agorokh/ac-copilot-trainer/issues/402)
+  **CLOSED**): DuckDB `sessions` / `stints` rollups, compacted driver profile ledger, dry-run-first
+  lap/TT retention, stdout CSV streaming, and telemetry data-platform docs. Review hardening made
+  retention fail closed on invalid profiles, preserve compacted bests through partial rebuilds,
+  reject negative caps, invalidate TT derived indexes after TT deletions, and normalize Windows
+  drive-letter paths in the Git Bash agentic-memory wrapper. Classification: `scripts/` changed due
+  wrapper hardening; no migration/env/deps/workflow action required.
 - **2026-06-30** - PR [#416](https://github.com/agorokh/ac-copilot-trainer/pull/416)
   **MERGED** at `9832004` - **race management cues** ([#406](https://github.com/agorokh/ac-copilot-trainer/issues/406)
   **CLOSED**): live stint-level fuel-to-finish, tyre, brake, and conditions advisories now ride

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-06-30T20:44:28Z
+last_updated: 2026-06-30T20:49:44Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/pr-410-racing-atelier-design-package-2026-06-30.md
   - AcCopilotTrainer/03_Investigations/pr-394-voice-reliability-2026-06-30.md
@@ -58,6 +58,43 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-06-30) - PR #415 MERGED: telemetry data platform (#402)
+
+PR [#415](https://github.com/agorokh/ac-copilot-trainer/pull/415) squash-merged to `main` as
+[`c407d46`](https://github.com/agorokh/ac-copilot-trainer/commit/c407d46820974e37554b1b3c29317cc8459d7f76)
+at 2026-06-30T20:46:36Z. Issue [#402](https://github.com/agorokh/ac-copilot-trainer/issues/402)
+is **CLOSED**.
+
+**Shipped:** The coaching lake now materializes first-class `sessions` and `stints` rollups in
+DuckDB, with `sessions` / `stints` reports. `tools.ai_sidecar.driver_profile` maintains a compacted
+`journal/driver/profile.json` ledger with preferences, focus corners, session rollups, PBs, and
+consistency summaries so driver history survives raw-lap pruning. `tools.coaching_lake.retention`
+adds dry-run-first lifecycle planning/apply for `journal/laps` and `journal/tt`, preserving PB,
+reference, profile-ledger, pinned, and unreadable evidence. `tools.lap_archive_export --output -`
+streams CSV to stdout for live export bridges. Docs landed in
+`docs/10_Development/16_Telemetry_Data_Platform.md` plus the lap-archive export docs.
+
+**Review hardening:** Retention/profile safety now fails closed on invalid existing profile ledgers,
+merges partial session rebuilds without discarding older compacted bests, rejects negative retention
+caps, and invalidates TT derived indexes after TT raw deletions. `scripts/mcp/agentic-memory.sh`
+also normalizes Windows drive-letter paths under Git Bash, fixing local `ci-fast` parity when Bash is
+present on Windows.
+
+**Verification:** GitHub checks on head `63ba78d` passed (`build`, `Canonical docs exist`,
+`conformance`; vault automerge skipped). Required review cooldowns were observed; GraphQL review
+threads are resolved; no current-SHA self-hosted reviewer body was present after the final cooldown.
+Local full parity in the clean LF checkout
+`C:\Users\arsen\Projects\ac-copilot-trainer-ci-402-lf` passed with
+`make ci-fast PYTHON=python` (`1977 passed, 76 skipped`, coverage 85.59%, `ci-fast: OK`; root-file
+allowlist warnings only for existing `.copier-answers.yml` and `doppler.yaml`). Focused slice passed
+(`47 passed`) across coaching lake, driver profile, retention, lap export, and agentic-memory wrapper
+tests. Scratch CLI smoke built a synthetic lake with `laps=3`, `sessions=2`, `stints=2`, wrote a
+driver profile with 2 session rollups / 1 PB, selected only the old non-PB lap for retention, and
+streamed 9 CSV rows to stdout.
+
+**Post-merge classification:** `scripts/` changed due the agentic-memory wrapper hardening; no
+migration/env/deps/workflow action required.
 
 ## Delivered (2026-06-30) - PR #416 MERGED: race management cues (#406)
 


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #415.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).