### PR TITLE
feat: add deeper corner diagnostics

### DIFF
--- a/docs/10_Development/12_WS_Sidecar_Protocol.md
+++ b/docs/10_Development/12_WS_Sidecar_Protocol.md
@@ -83,7 +83,7 @@ The brain follow-up emits one object per segmented corner. Existing fields (`ind
 | `steering` | Steering smoothness score, correction count, p95 steering rate, and a scrub proxy derived from steering rate while loaded. |
 | `brake_shape` | Brake trace classification (`ideal_trace`, `increasing_pressure`, `abrupt_release`, `braking_at_apex`, or `no_brake`) plus release smoothness. |
 | `gear` | Entry/apex/exit gear, gear-change count, and apex-gear delta vs `referenceArchivePath` when a reference lap is supplied. |
-| `exit_road_usage` | Reference-path exit-width proxy. `available=false` without a reference lap; true curb/track-edge distance requires map-edge geometry. |
+| `exit_road_usage` | Reference-path lateral-delta proxy. `available=false` without a reference lap; true curb/track-edge under-use coaching requires map-edge geometry or caller-supplied `under_used_exit_width_m`. |
 | `consistency` | Lap-to-lap per-corner spread and 0-100 repeatability score when at least one valid `historyArchivePaths` lap plus the current lap segment the same corner. |
 
 ### `analysis_error` (Python → Lua)

--- a/docs/10_Development/12_WS_Sidecar_Protocol.md
+++ b/docs/10_Development/12_WS_Sidecar_Protocol.md
@@ -24,6 +24,7 @@ Sent after each completed lap when `config.wsSidecarUrl` is set and the socket i
 | `telemetry`     | object      | no       | Optional structured lap data for sidecar analysis (issue **#49**); see below |
 | `archivePath`   | string      | no       | Issue **#277**: archive-backed follow-up path, sent only after the async lap archive write completes |
 | `referenceArchivePath` | string | no    | Optional safe lap archive path for the driver's written PB/reference, enabling delta-based brain rules |
+| `historyArchivePaths` | string[] | no    | Optional bounded list of recent safe lap archive paths; enables per-corner lap-to-lap consistency diagnostics |
 | `brainOnly`     | bool        | no       | When `true`, the sidecar skips the generic immediate ack and only emits the archive-backed brain follow-up |
 
 \*Missing `protocol` on `lap_complete` is accepted with a server warning (legacy); new clients should always send `protocol: 1`.
@@ -72,6 +73,18 @@ When present, `improvementRanking` is a JSON array of objects, **highest priorit
 | `suggestion`  | string | yes      | Human-readable line for UI or logging. |
 
 For the current speed metrics, **higher** telemetry is better; an item usually indicates a possible gain when `reference > last`. Consumers may ignore unknown fields for forward compatibility.
+
+#### `cornerAnalysis` items (issue **#405**)
+
+The brain follow-up emits one object per segmented corner. Existing fields (`index`, `apex_spline`, `min_speed_kmh`, `time_loss_s`, `headline`, `attributions`) remain stable. Issue **#405** adds `diagnostics`, a machine-readable block that lets clients render deeper coach tiles even when an attribution does not rank in the top prose lines.
+
+| Diagnostic key | Meaning |
+| -------------- | ------- |
+| `steering` | Steering smoothness score, correction count, p95 steering rate, and a scrub proxy derived from steering rate while loaded. |
+| `brake_shape` | Brake trace classification (`ideal_trace`, `increasing_pressure`, `abrupt_release`, `braking_at_apex`, or `no_brake`) plus release smoothness. |
+| `gear` | Entry/apex/exit gear, gear-change count, and apex-gear delta vs `referenceArchivePath` when a reference lap is supplied. |
+| `exit_road_usage` | Reference-path exit-width proxy. `available=false` without a reference lap; true curb/track-edge distance requires map-edge geometry. |
+| `consistency` | Lap-to-lap per-corner spread and 0-100 repeatability score when at least one valid `historyArchivePaths` lap plus the current lap segment the same corner. |
 
 ### `analysis_error` (Python → Lua)
 

--- a/tests/test_ai_sidecar_protocol.py
+++ b/tests/test_ai_sidecar_protocol.py
@@ -84,6 +84,23 @@ def test_brain_followup_forwards_structured_blocks(monkeypatch: pytest.MonkeyPat
     assert out["conditions"]["grip_band"] == "green"
 
 
+def test_brain_followup_loads_history_paths_for_consistency(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(proto, "debrief_feature_enabled", lambda: True)
+    laps_dir = tmp_path / "journal" / "laps"
+    laps_dir.mkdir(parents=True)
+    hist_path = laps_dir / "lap_history.json"
+    hist_path.write_text(json.dumps(_rich_corner_archive()), encoding="utf-8")
+    inbound = _rich_corner_archive()
+    inbound["historyArchivePaths"] = [str(hist_path)]
+    out = build_brain_followup(inbound)
+    assert out is not None
+    diagnostics = out["cornerAnalysis"][0]["diagnostics"]
+    assert diagnostics["consistency"]["available"] is True
+    assert diagnostics["consistency"]["sample_count"] == 2
+
+
 def test_prepare_rejects_bad_protocol() -> None:
     out = prepare_outbound_message(
         {"protocol": 99, "event": "lap_complete", "lap": 1},

--- a/tests/test_ai_sidecar_protocol.py
+++ b/tests/test_ai_sidecar_protocol.py
@@ -91,7 +91,11 @@ def test_brain_followup_loads_history_paths_for_consistency(
     laps_dir = tmp_path / "journal" / "laps"
     laps_dir.mkdir(parents=True)
     hist_path = laps_dir / "lap_history.json"
-    hist_path.write_text(json.dumps(_rich_corner_archive()), encoding="utf-8")
+    history = _rich_corner_archive()
+    speed_idx = history["trace"]["fields"].index("speed")
+    for sample in history["trace"]["samples"][40:60]:
+        sample[speed_idx] *= 0.95
+    hist_path.write_text(json.dumps(history), encoding="utf-8")
     inbound = _rich_corner_archive()
     inbound["historyArchivePaths"] = [str(hist_path)]
     out = build_brain_followup(inbound)

--- a/tests/test_ai_sidecar_protocol.py
+++ b/tests/test_ai_sidecar_protocol.py
@@ -92,6 +92,7 @@ def test_brain_followup_loads_history_paths_for_consistency(
     laps_dir.mkdir(parents=True)
     hist_path = laps_dir / "lap_history.json"
     history = _rich_corner_archive()
+    history["lap"] = 8
     speed_idx = history["trace"]["fields"].index("speed")
     for sample in history["trace"]["samples"][40:60]:
         sample[speed_idx] *= 0.95

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -305,6 +305,20 @@ def test_slower_reference_corners_are_not_published_as_targets():
     assert d["corner_reference"] is None
 
 
+def test_reference_still_works_when_both_archives_omit_identity():
+    ref = _corner_archive(degrade=0.0)
+    student = _corner_archive(degrade=8.0)
+    del ref["car"]["id"]
+    del student["car"]["id"]
+    del ref["track"]["id"]
+    del student["track"]["id"]
+
+    d = build_structured_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
+
+    assert d["corner_reference"] is not None
+    assert d["corners"][0]["time_loss_s"] is not None
+
+
 def test_trail_braking_block_in_structured_debrief():
     # the trail-braking analyzer's per-corner read flows into the structured debrief + text (#296)
     d = build_structured_debrief(_corner_archive(), grip_ceiling_g=2.5)
@@ -387,6 +401,30 @@ def test_structured_debrief_rejects_history_with_missing_car_id():
     d = build_structured_debrief(
         _corner_archive(degrade=2.0),
         history_archives=[other],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is False
+    assert diag["sample_count"] == 1
+
+
+def test_structured_debrief_dedupes_repeated_history_archive():
+    history = _corner_archive(degrade=4.0)
+    d = build_structured_debrief(
+        _corner_archive(degrade=2.0),
+        history_archives=[history, history],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is True
+    assert diag["sample_count"] == 2
+
+
+def test_structured_debrief_excludes_current_archive_from_history():
+    current = _corner_archive(degrade=2.0)
+    d = build_structured_debrief(
+        current,
+        history_archives=[current],
         grip_ceiling_g=2.5,
     )
     diag = d["corners"][0]["diagnostics"]["consistency"]

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -203,3 +203,16 @@ def test_trail_braking_block_in_structured_debrief():
     assert "classification" in entry and "trail_overlap" in entry and "coaching" in entry
     # the square-brake fixture is a non-"good" technique → surfaces in the text section
     assert "Trail braking" in d["text"]
+
+
+def test_structured_debrief_includes_corner_diagnostics():
+    d = build_structured_debrief(
+        _corner_archive(degrade=2.0),
+        reference_archive=_corner_archive(degrade=0.0),
+        history_archives=[_corner_archive(degrade=4.0)],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]
+    assert set(diag) >= {"steering", "brake_shape", "gear", "exit_road_usage", "consistency"}
+    assert diag["exit_road_usage"]["available"] is True
+    assert diag["consistency"]["available"] is True

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -342,7 +342,7 @@ def test_structured_debrief_ignores_history_from_other_track():
     assert diag["sample_count"] == 1
 
 
-def test_structured_debrief_allows_history_when_current_track_id_missing():
+def test_structured_debrief_rejects_history_when_current_track_id_missing():
     current = _corner_archive(degrade=2.0)
     del current["track"]["id"]
     d = build_structured_debrief(
@@ -351,17 +351,28 @@ def test_structured_debrief_allows_history_when_current_track_id_missing():
         grip_ceiling_g=2.5,
     )
     diag = d["corners"][0]["diagnostics"]["consistency"]
-    assert diag["available"] is True
-    assert diag["sample_count"] == 2
+    assert diag["available"] is False
+    assert diag["sample_count"] == 1
 
 
-def test_structured_debrief_rejects_missing_track_id_history_with_different_fingerprint():
-    current = _corner_archive(degrade=2.0)
-    del current["track"]["id"]
+def test_structured_debrief_rejects_history_when_history_track_id_missing():
     other = _corner_archive(degrade=4.0)
-    other["track"]["lengthM"] = current["track"]["lengthM"] + 500.0
+    del other["track"]["id"]
     d = build_structured_debrief(
-        current,
+        _corner_archive(degrade=2.0),
+        history_archives=[other],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is False
+    assert diag["sample_count"] == 1
+
+
+def test_structured_debrief_rejects_one_sided_track_layout():
+    other = _corner_archive(degrade=4.0)
+    other["track"]["layout"] = "junior"
+    d = build_structured_debrief(
+        _corner_archive(degrade=2.0),
         history_archives=[other],
         grip_ceiling_g=2.5,
     )

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -353,3 +353,31 @@ def test_structured_debrief_allows_history_when_current_track_id_missing():
     diag = d["corners"][0]["diagnostics"]["consistency"]
     assert diag["available"] is True
     assert diag["sample_count"] == 2
+
+
+def test_structured_debrief_rejects_missing_track_id_history_with_different_fingerprint():
+    current = _corner_archive(degrade=2.0)
+    del current["track"]["id"]
+    other = _corner_archive(degrade=4.0)
+    other["track"]["lengthM"] = current["track"]["lengthM"] + 500.0
+    d = build_structured_debrief(
+        current,
+        history_archives=[other],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is False
+    assert diag["sample_count"] == 1
+
+
+def test_structured_debrief_rejects_history_with_missing_car_id():
+    other = _corner_archive(degrade=4.0)
+    del other["car"]["id"]
+    d = build_structured_debrief(
+        _corner_archive(degrade=2.0),
+        history_archives=[other],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is False
+    assert diag["sample_count"] == 1

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -216,3 +216,16 @@ def test_structured_debrief_includes_corner_diagnostics():
     assert set(diag) >= {"steering", "brake_shape", "gear", "exit_road_usage", "consistency"}
     assert diag["exit_road_usage"]["available"] is True
     assert diag["consistency"]["available"] is True
+
+
+def test_structured_debrief_ignores_history_from_other_track():
+    other = _corner_archive(degrade=4.0)
+    other["track"]["id"] = "different_track"
+    d = build_structured_debrief(
+        _corner_archive(degrade=2.0),
+        history_archives=[other],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is False
+    assert diag["sample_count"] == 1

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -433,6 +433,22 @@ def test_structured_debrief_dedupes_repeated_history_archive():
     assert diag["sample_count"] == 2
 
 
+def test_structured_debrief_keeps_same_metadata_different_history_trace():
+    history_a = _corner_archive(degrade=4.0)
+    history_b = json.loads(json.dumps(history_a))
+    speed_idx = history_b["trace"]["fields"].index("speed")
+    for sample in history_b["trace"]["samples"][40:60]:
+        sample[speed_idx] *= 0.95
+    d = build_structured_debrief(
+        _corner_archive(degrade=2.0),
+        history_archives=[history_a, history_b],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is True
+    assert diag["sample_count"] == 3
+
+
 def test_structured_debrief_excludes_current_archive_from_history():
     current = _corner_archive(degrade=2.0)
     d = build_structured_debrief(

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -319,6 +319,19 @@ def test_reference_still_works_when_both_archives_omit_identity():
     assert d["corners"][0]["time_loss_s"] is not None
 
 
+def test_reference_allows_legacy_archive_with_missing_identity_and_layout():
+    ref = _corner_archive(degrade=0.0)
+    student = _corner_archive(degrade=8.0)
+    student["track"]["layout"] = "gp"
+    del ref["car"]["id"]
+    del ref["track"]["id"]
+
+    d = build_structured_debrief(student, reference_archive=ref, grip_ceiling_g=2.5)
+
+    assert d["corner_reference"] is not None
+    assert d["corners"][0]["time_loss_s"] is not None
+
+
 def test_trail_braking_block_in_structured_debrief():
     # the trail-braking analyzer's per-corner read flows into the structured debrief + text (#296)
     d = build_structured_debrief(_corner_archive(), grip_ceiling_g=2.5)

--- a/tests/test_coach_report.py
+++ b/tests/test_coach_report.py
@@ -395,6 +395,23 @@ def test_structured_debrief_rejects_history_when_history_track_id_missing():
     assert diag["sample_count"] == 1
 
 
+def test_structured_debrief_allows_history_when_both_archives_omit_identity():
+    current = _corner_archive(degrade=2.0)
+    history = _corner_archive(degrade=4.0)
+    del current["car"]["id"]
+    del history["car"]["id"]
+    del current["track"]["id"]
+    del history["track"]["id"]
+    d = build_structured_debrief(
+        current,
+        history_archives=[history],
+        grip_ceiling_g=2.5,
+    )
+    diag = d["corners"][0]["diagnostics"]["consistency"]
+    assert diag["available"] is True
+    assert diag["sample_count"] == 2
+
+
 def test_structured_debrief_rejects_one_sided_track_layout():
     other = _corner_archive(degrade=4.0)
     other["track"]["layout"] = "junior"

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -142,6 +142,53 @@ def test_compare_laps_localizes_lost_time():
     assert deltas[0].min_speed_delta_kmh < 0  # carried less apex speed
 
 
+def test_compare_laps_matches_reference_by_apex_spline(monkeypatch):
+    n = 10
+    spline = [i / (n - 1) for i in range(n)]
+    reference = LapTrace(
+        spline=spline,
+        t_s=[float(i) for i in range(n)],
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        steer=[0.0] * n,
+        gear=[3] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+    )
+    cand_t = [float(i) for i in range(n)]
+    cand_t[7] += 0.2
+    cand_t[8] += 0.4
+    candidate = LapTrace(
+        spline=spline,
+        t_s=cand_t,
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        steer=[0.0] * n,
+        gear=[4] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+    )
+    cand_sig = _sig(index=0, entry_i=4, apex_i=5, exit_i=6, apex_spline=spline[5])
+    ref_sigs = [
+        _sig(index=0, entry_i=1, apex_i=2, exit_i=3, apex_spline=spline[2]),
+        _sig(index=1, entry_i=6, apex_i=7, exit_i=8, apex_spline=spline[5]),
+    ]
+
+    monkeypatch.setattr(
+        ca,
+        "corner_signatures",
+        lambda lap_arg, _corners=None: [cand_sig] if lap_arg is candidate else ref_sigs,
+    )
+
+    deltas = compare_laps(candidate, reference)
+    assert len(deltas) == 1
+    assert deltas[0].index == 0
+    assert deltas[0].spline_lo == round(spline[6], 4)
+    assert deltas[0].delta_s == 0.4
+
+
 # --- attribute_corner -------------------------------------------------------
 def test_grip_limited_fires_and_is_advisory_without_pressure():
     ctx = CornerContext(sig=_sig(peak_lat_g=1.5), setup=SETUP, grip_ceiling_g=1.5)

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -230,6 +230,64 @@ def test_exit_traction_leads_with_technique_and_diff():
     assert "throttle technique" in joined
 
 
+def test_steering_aggression_is_technique_verdict():
+    ctx = CornerContext(
+        sig=_sig(
+            steering_correction_count=4,
+            steering_smoothness_score=55.0,
+            steering_scrub_index=0.24,
+        ),
+        setup=SETUP,
+    )
+    attr = next(a for a in attribute_corner(ctx) if a.key == "steering_aggression")
+    assert attr.technique_causes and not attr.setup_causes
+    assert "one input" in attr.coaching.lower()
+
+
+def test_exit_road_usage_fires_from_reference_path_proxy():
+    ctx = CornerContext(
+        sig=_sig(),
+        setup=SETUP,
+        delta=_delta(delta_s=0.2),
+        extra={"exit_road_usage": {"available": True, "missed_exit_width_m": 2.4}},
+    )
+    attr = next(a for a in attribute_corner(ctx) if a.key == "exit_road_usage")
+    assert attr.confidence > 0.6
+    assert "using the road" in attr.symptom
+
+
+def test_gear_selection_compares_apex_gear_to_reference():
+    ctx = CornerContext(
+        sig=_sig(gear_at_apex=4),
+        reference_sig=_sig(gear_at_apex=3),
+        setup=SETUP,
+    )
+    attr = next(a for a in attribute_corner(ctx) if a.key == "gear_selection")
+    assert attr.confidence > 0.5
+    assert "Apex gear 4 vs reference 3" in attr.coaching
+
+
+def test_brake_shape_attribution_names_pressure_rise():
+    ctx = CornerContext(
+        sig=_sig(brake_shape="increasing_pressure", brake_late_rise_count=3),
+        setup=SETUP,
+    )
+    attr = next(a for a in attribute_corner(ctx) if a.key == "brake_trace_shape")
+    assert attr.phase == "braking"
+    assert "rises late" in attr.coaching
+
+
+def test_corner_consistency_attribution_uses_history_score():
+    ctx = CornerContext(
+        sig=_sig(),
+        setup=SETUP,
+        extra={"consistency": {"available": True, "score": 61.0, "sample_count": 3}},
+    )
+    attr = next(a for a in attribute_corner(ctx) if a.key == "corner_consistency")
+    assert attr.phase == "session"
+    assert "repeatability" in attr.coaching
+
+
 # --- analyze_balance (the master discriminator) -----------------------------
 def test_balance_routes_high_speed_saturation_to_aero():
     # grip-limited (saturated) in HIGH-speed corners, grip in hand at low speed -> aero
@@ -456,6 +514,20 @@ def test_coach_lap_produces_per_corner_verdicts():
     assert isinstance(c0.attributions, list)
     # the synthetic apex (~90 km/h) at ~2.1 g vs 2.5 ceiling is near the limit -> grip-limited shows
     assert any(a.key == "grip_limited" for a in c0.attributions) or c0.min_speed_kmh > 0
+
+
+def test_coach_lap_exposes_diagnostics_with_reference_and_history():
+    lap = _corner_lap_trace(v_apex=23.0)
+    reference = _corner_lap_trace(v_apex=25.0)
+    history = [_corner_lap_trace(v_apex=21.0)]
+    report = coach_lap(lap, SETUP, reference=reference, history=history, grip_ceiling_g=2.5)
+    diagnostics = report[0].diagnostics
+    assert diagnostics["steering"]["available"] is True
+    assert diagnostics["brake_shape"]["classification"]
+    assert diagnostics["gear"]["available"] is True
+    assert diagnostics["exit_road_usage"]["available"] is True
+    assert diagnostics["consistency"]["available"] is True
+    assert diagnostics["consistency"]["sample_count"] == 2
 
 
 # --- trail-braking folded into the attribution layer (#301) ------------------

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -12,6 +12,7 @@ from tools.ai_sidecar.corner_attribution import (
     _corner_history_matches,
     _match_corner_signature,
     analyze_balance,
+    analyze_corner_consistency,
     attribute_corner,
     coach_lap,
     compare_laps,
@@ -326,6 +327,22 @@ def test_corner_history_matching_consumes_candidates_once(monkeypatch):
     assert matched_history_count == 1
 
 
+def test_analyze_corner_consistency_reuses_precomputed_matches(monkeypatch):
+    def fail_if_segmented(_lap):
+        raise AssertionError("precomputed matches should not re-segment history")
+
+    monkeypatch.setattr(ca, "corner_signatures", fail_if_segmented)
+    matches = {
+        0: [
+            _sig(index=0, entry_speed_kmh=160.0, min_speed_kmh=95.0, exit_speed_kmh=140.0),
+            _sig(index=7, entry_speed_kmh=150.0, min_speed_kmh=88.0, exit_speed_kmh=132.0),
+        ]
+    }
+    consistency = analyze_corner_consistency(matches=matches)
+    assert consistency[0].sample_count == 2
+    assert consistency[0].score < 100.0
+
+
 # --- analyze_balance (the master discriminator) -----------------------------
 def test_balance_routes_high_speed_saturation_to_aero():
     # grip-limited (saturated) in HIGH-speed corners, grip in hand at low speed -> aero
@@ -588,6 +605,62 @@ def test_coach_lap_preserves_caller_supplied_exit_width():
     assert diagnostics["source"] == "track_edge"
     assert diagnostics["under_used_exit_width_m"] == 2.0
     assert any(a.key == "exit_road_usage" for a in report[0].attributions)
+
+
+def test_coach_lap_uses_matched_reference_window_for_delta(monkeypatch):
+    n = 10
+    spline = [i / (n - 1) for i in range(n)]
+    ref_t = [float(i) for i in range(n)]
+    cand_t = [float(i) for i in range(n)]
+    cand_t[7] += 0.2
+    cand_t[8] += 0.4
+    lap = LapTrace(
+        spline=spline,
+        t_s=cand_t,
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        steer=[0.0] * n,
+        gear=[4] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+    )
+    reference = LapTrace(
+        spline=spline,
+        t_s=ref_t,
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        steer=[0.0] * n,
+        gear=[3] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+    )
+    cand_sig = _sig(
+        index=0,
+        entry_i=4,
+        apex_i=5,
+        exit_i=6,
+        apex_spline=spline[5],
+        gear_at_apex=4,
+    )
+    ref_sigs = [
+        _sig(index=0, entry_i=1, apex_i=2, exit_i=3, apex_spline=spline[2], gear_at_apex=4),
+        _sig(index=1, entry_i=6, apex_i=7, exit_i=8, apex_spline=spline[5], gear_at_apex=3),
+    ]
+
+    monkeypatch.setattr(ca, "segment_corners", lambda _lap: [(4, 5, 6)])
+    monkeypatch.setattr(
+        ca,
+        "corner_signatures",
+        lambda lap_arg, _corners=None: [cand_sig] if lap_arg is lap else ref_sigs,
+    )
+    monkeypatch.setattr(ca, "analyze_trail_braking", lambda *_args, **_kw: [])
+
+    report = coach_lap(lap, SETUP, reference=reference)
+    assert report[0].delta_s == 0.4
+    assert report[0].diagnostics["gear"]["reference_apex_gear"] == 3
+    assert any(a.key == "gear_selection" for a in report[0].attributions)
 
 
 # --- trail-braking folded into the attribution layer (#301) ------------------

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -8,6 +8,7 @@ from tools.ai_sidecar.corner_attribution import (
     WHEEL_RADIUS_M,
     CornerContext,
     CornerDelta,
+    _match_corner_signature,
     analyze_balance,
     attribute_corner,
     coach_lap,
@@ -261,10 +262,21 @@ def test_gear_selection_compares_apex_gear_to_reference():
         sig=_sig(gear_at_apex=4),
         reference_sig=_sig(gear_at_apex=3),
         setup=SETUP,
+        delta=_delta(delta_s=0.2),
     )
     attr = next(a for a in attribute_corner(ctx) if a.key == "gear_selection")
     assert attr.confidence > 0.5
     assert "Apex gear 4 vs reference 3" in attr.coaching
+
+
+def test_gear_selection_ignores_stale_slower_reference():
+    ctx = CornerContext(
+        sig=_sig(gear_at_apex=4),
+        reference_sig=_sig(gear_at_apex=3),
+        setup=SETUP,
+        delta=_delta(delta_s=-0.1),
+    )
+    assert not any(a.key == "gear_selection" for a in attribute_corner(ctx))
 
 
 def test_brake_shape_attribution_names_pressure_rise():
@@ -286,6 +298,18 @@ def test_corner_consistency_attribution_uses_history_score():
     attr = next(a for a in attribute_corner(ctx) if a.key == "corner_consistency")
     assert attr.phase == "session"
     assert "repeatability" in attr.coaching
+
+
+def test_reference_matching_uses_apex_spline_not_index():
+    anchor = _sig(index=0, apex_spline=0.50)
+    ref = [
+        _sig(index=0, apex_spline=0.20, gear_at_apex=2),
+        _sig(index=1, apex_spline=0.505, gear_at_apex=3),
+    ]
+    match = _match_corner_signature(anchor, ref)
+    assert match is not None
+    assert match.index == 1
+    assert match.gear_at_apex == 3
 
 
 # --- analyze_balance (the master discriminator) -----------------------------
@@ -528,6 +552,28 @@ def test_coach_lap_exposes_diagnostics_with_reference_and_history():
     assert diagnostics["exit_road_usage"]["available"] is True
     assert diagnostics["consistency"]["available"] is True
     assert diagnostics["consistency"]["sample_count"] == 2
+
+
+def test_coach_lap_preserves_caller_supplied_exit_width():
+    lap = _corner_lap_trace()
+    report = coach_lap(
+        lap,
+        SETUP,
+        grip_ceiling_g=2.5,
+        extra_by_corner={
+            0: {
+                "exit_road_usage": {
+                    "available": True,
+                    "source": "track_edge",
+                    "under_used_exit_width_m": 2.0,
+                }
+            }
+        },
+    )
+    diagnostics = report[0].diagnostics["exit_road_usage"]
+    assert diagnostics["source"] == "track_edge"
+    assert diagnostics["under_used_exit_width_m"] == 2.0
+    assert any(a.key == "exit_road_usage" for a in report[0].attributions)
 
 
 # --- trail-braking folded into the attribution layer (#301) ------------------

--- a/tests/test_lap_dynamics.py
+++ b/tests/test_lap_dynamics.py
@@ -184,6 +184,51 @@ def test_trail_brake_detected_when_braking_into_steer():
     assert sig.trail_brake_frac > 0.0
 
 
+def test_signature_records_steering_smoothness_and_scrub_proxy():
+    arch = _make_corner_archive()
+    fields = arch["trace"]["fields"]
+    si = fields.index("steer")
+    flip = 1.0
+    for row in arch["trace"]["samples"]:
+        if abs(row[si]) > 0.05:
+            row[si] = flip * 0.45
+            flip *= -1.0
+    sig = corner_signatures(lap_trace_from_archive(arch))[0]
+    assert sig.steering_correction_count >= 10
+    assert sig.steering_rate_p95 > 0.0
+    assert sig.steering_smoothness_score < 80.0
+    assert sig.steering_scrub_index > 0.0
+
+
+def test_signature_records_gear_selection_through_corner():
+    arch = _make_corner_archive()
+    fields = arch["trace"]["fields"]
+    gi, si = fields.index("gear"), fields.index("steer")
+    for i, row in enumerate(arch["trace"]["samples"]):
+        row[gi] = 3 if 40 <= i < 60 and abs(row[si]) > 0.05 else 4
+    sig = corner_signatures(lap_trace_from_archive(arch))[0]
+    assert sig.entry_gear == 4
+    assert sig.gear_at_apex == 3
+    assert sig.exit_gear == 4
+    assert sig.gear_change_count >= 2
+
+
+def test_signature_classifies_late_brake_pressure_rise():
+    arch = _make_corner_archive()
+    fields = arch["trace"]["fields"]
+    bi = fields.index("brake")
+    for i, row in enumerate(arch["trace"]["samples"]):
+        if 25 <= i < 40:
+            row[bi] = 0.15
+        elif 40 <= i <= 55:
+            row[bi] = min(0.95, 0.15 + (i - 40) * 0.06)
+        else:
+            row[bi] = 0.0
+    sig = corner_signatures(lap_trace_from_archive(arch))[0]
+    assert sig.brake_shape == "increasing_pressure"
+    assert sig.brake_late_rise_count >= 2
+
+
 def test_real_fixture_too_short_yields_no_corners():
     archive = json.loads((FIXTURES / "lap_archive_valid.json").read_text(encoding="utf-8"))
     lap = lap_trace_from_archive(archive)

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -112,6 +112,17 @@ def _same_lap_scope(candidate: LapTrace, anchor: LapTrace) -> bool:
     )
 
 
+def _archive_track_length_m(archive: dict | None) -> float | None:
+    track = archive.get("track") if isinstance(archive, dict) else None
+    if not isinstance(track, dict):
+        return None
+    try:
+        length = float(track.get("lengthM"))
+    except (TypeError, ValueError):
+        return None
+    return length if length > 0 else None
+
+
 def _archive_track_layout(archive: dict | None) -> str | None:
     track = archive.get("track") if isinstance(archive, dict) else None
     layout = track.get("layout") if isinstance(track, dict) else None
@@ -125,6 +136,36 @@ def _same_archive_layout(candidate: dict | None, anchor: dict | None) -> bool:
     if anchor_layout is None:
         return True
     return _archive_track_layout(candidate) == anchor_layout
+
+
+def _same_archive_track_fingerprint(candidate: dict | None, anchor: dict | None) -> bool:
+    candidate_layout = _archive_track_layout(candidate)
+    anchor_layout = _archive_track_layout(anchor)
+    if candidate_layout is not None and anchor_layout is not None:
+        return candidate_layout == anchor_layout
+    candidate_length = _archive_track_length_m(candidate)
+    anchor_length = _archive_track_length_m(anchor)
+    if candidate_length is None or anchor_length is None:
+        return False
+    return abs(candidate_length - anchor_length) <= 1.0
+
+
+def _same_archive_scope(
+    candidate_lap: LapTrace,
+    anchor_lap: LapTrace,
+    candidate_archive: dict | None,
+    anchor_archive: dict | None,
+) -> bool:
+    if not _same_lap_scope(candidate_lap, anchor_lap):
+        return False
+    # Car identity has no reliable fallback fingerprint in lap archives.
+    if (candidate_lap.car_id is None) != (anchor_lap.car_id is None):
+        return False
+    if (candidate_lap.track_id is None) != (anchor_lap.track_id is None):
+        return _same_archive_track_fingerprint(candidate_archive, anchor_archive)
+    if candidate_lap.track_id is None and anchor_lap.track_id is None:
+        return _same_archive_track_fingerprint(candidate_archive, anchor_archive)
+    return _same_archive_layout(candidate_archive, anchor_archive)
 
 
 def format_debrief(
@@ -434,8 +475,7 @@ def _analyze(
         raw_ref
         if raw_ref is not None
         and _archive_lap_is_valid(reference_archive)
-        and _same_lap_scope(raw_ref, lap)
-        and _same_archive_layout(reference_archive, lap_archive)
+        and _same_archive_scope(raw_ref, lap, reference_archive, lap_archive)
         else None
     )
     history_laps: list[LapTrace] = []
@@ -446,7 +486,7 @@ def _analyze(
             history_lap = lap_trace_from_archive(history_archive)
         except ValueError:
             continue
-        if _same_lap_scope(history_lap, lap) and _same_archive_layout(history_archive, lap_archive):
+        if _same_archive_scope(history_lap, lap, history_archive, lap_archive):
             history_laps.append(history_lap)
     report = coach_lap(
         lap,
@@ -481,7 +521,7 @@ def _analyze(
             corpus_lap = lap_trace_from_archive(archive)
         except ValueError:
             continue
-        if _same_lap_scope(corpus_lap, lap) and _same_archive_layout(archive, lap_archive):
+        if _same_archive_scope(corpus_lap, lap, archive, lap_archive):
             corpus_laps.append(corpus_lap)
     superlap = build_superlap(corpus_laps) if corpus_laps else None
     return {

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -98,31 +98,6 @@ def _archive_lap_is_valid(archive: dict | None) -> bool:
     return not (isinstance(lap, dict) and lap.get("is_valid") is False)
 
 
-def _same_lap_scope(candidate: LapTrace, anchor: LapTrace) -> bool:
-    if (
-        anchor.car_id is not None
-        and candidate.car_id is not None
-        and candidate.car_id != anchor.car_id
-    ):
-        return False
-    return not (
-        anchor.track_id is not None
-        and candidate.track_id is not None
-        and candidate.track_id != anchor.track_id
-    )
-
-
-def _archive_track_length_m(archive: dict | None) -> float | None:
-    track = archive.get("track") if isinstance(archive, dict) else None
-    if not isinstance(track, dict):
-        return None
-    try:
-        length = float(track.get("lengthM"))
-    except (TypeError, ValueError):
-        return None
-    return length if length > 0 else None
-
-
 def _archive_track_layout(archive: dict | None) -> str | None:
     track = archive.get("track") if isinstance(archive, dict) else None
     layout = track.get("layout") if isinstance(track, dict) else None
@@ -132,22 +107,11 @@ def _archive_track_layout(archive: dict | None) -> str | None:
 
 
 def _same_archive_layout(candidate: dict | None, anchor: dict | None) -> bool:
-    anchor_layout = _archive_track_layout(anchor)
-    if anchor_layout is None:
-        return True
-    return _archive_track_layout(candidate) == anchor_layout
-
-
-def _same_archive_track_fingerprint(candidate: dict | None, anchor: dict | None) -> bool:
     candidate_layout = _archive_track_layout(candidate)
     anchor_layout = _archive_track_layout(anchor)
-    if candidate_layout is not None and anchor_layout is not None:
-        return candidate_layout == anchor_layout
-    candidate_length = _archive_track_length_m(candidate)
-    anchor_length = _archive_track_length_m(anchor)
-    if candidate_length is None or anchor_length is None:
-        return False
-    return abs(candidate_length - anchor_length) <= 1.0
+    if candidate_layout is None and anchor_layout is None:
+        return True
+    return candidate_layout == anchor_layout
 
 
 def _same_archive_scope(
@@ -156,15 +120,18 @@ def _same_archive_scope(
     candidate_archive: dict | None,
     anchor_archive: dict | None,
 ) -> bool:
-    if not _same_lap_scope(candidate_lap, anchor_lap):
+    if (
+        candidate_lap.car_id is None
+        or anchor_lap.car_id is None
+        or candidate_lap.car_id != anchor_lap.car_id
+    ):
         return False
-    # Car identity has no reliable fallback fingerprint in lap archives.
-    if (candidate_lap.car_id is None) != (anchor_lap.car_id is None):
+    if (
+        candidate_lap.track_id is None
+        or anchor_lap.track_id is None
+        or candidate_lap.track_id != anchor_lap.track_id
+    ):
         return False
-    if (candidate_lap.track_id is None) != (anchor_lap.track_id is None):
-        return _same_archive_track_fingerprint(candidate_archive, anchor_archive)
-    if candidate_lap.track_id is None and anchor_lap.track_id is None:
-        return _same_archive_track_fingerprint(candidate_archive, anchor_archive)
     return _same_archive_layout(candidate_archive, anchor_archive)
 
 

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -307,9 +307,12 @@ def _analyze(
     history_laps: list[LapTrace] = []
     for history_archive in history_archives or []:
         try:
-            history_laps.append(lap_trace_from_archive(history_archive))
+            history_lap = lap_trace_from_archive(history_archive)
         except ValueError:
             continue
+        if history_lap.car_id != lap.car_id or history_lap.track_id != lap.track_id:
+            continue
+        history_laps.append(history_lap)
     report = coach_lap(
         lap,
         setup,

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -107,17 +107,21 @@ def _archive_track_layout(archive: dict | None) -> str | None:
     return str(layout)
 
 
-def _same_archive_layout(candidate: dict | None, anchor: dict | None) -> bool:
+def _same_archive_layout(candidate: dict | None, anchor: dict | None, *, required: bool) -> bool:
     candidate_layout = _archive_track_layout(candidate)
     anchor_layout = _archive_track_layout(anchor)
+    if not required and (candidate_layout is None or anchor_layout is None):
+        return True
     if candidate_layout is None and anchor_layout is None:
         return True
     return candidate_layout == anchor_layout
 
 
 def _same_optional_identity(candidate: str | None, anchor: str | None, *, required: bool) -> bool:
+    if not required and (candidate is None or anchor is None):
+        return True
     if candidate is None or anchor is None:
-        return False if required else candidate is None and anchor is None
+        return False
     return candidate == anchor
 
 
@@ -128,6 +132,7 @@ def _same_archive_scope(
     anchor_archive: dict | None,
     *,
     require_identity: bool,
+    require_layout: bool,
 ) -> bool:
     if not _same_optional_identity(
         candidate_lap.car_id, anchor_lap.car_id, required=require_identity
@@ -137,15 +142,26 @@ def _same_archive_scope(
         candidate_lap.track_id, anchor_lap.track_id, required=require_identity
     ):
         return False
-    return _same_archive_layout(candidate_archive, anchor_archive)
+    return _same_archive_layout(candidate_archive, anchor_archive, required=require_layout)
 
 
 def _archive_content_key(archive: dict | None) -> str:
+    trace = archive.get("trace") if isinstance(archive, dict) else None
+    trace_shape: dict[str, object] = {}
+    if isinstance(trace, dict):
+        samples = trace.get("samples")
+        trace_shape = {
+            "fields": trace.get("fields"),
+            "samples_count": trace.get("samples_count")
+            if trace.get("samples_count") is not None
+            else len(samples)
+            if isinstance(samples, list)
+            else None,
+        }
     identity = {
-        key: archive.get(key)
-        for key in ("car", "track", "lap", "trace")
-        if isinstance(archive, dict)
+        key: archive.get(key) for key in ("car", "track", "lap") if isinstance(archive, dict)
     }
+    identity["trace_shape"] = trace_shape
     payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
@@ -463,6 +479,7 @@ def _analyze(
             reference_archive,
             lap_archive,
             require_identity=False,
+            require_layout=False,
         )
         else None
     )
@@ -486,6 +503,7 @@ def _analyze(
             history_archive,
             lap_archive,
             require_identity=True,
+            require_layout=True,
         ):
             history_laps.append(history_lap)
     corners = segment_corners(lap)
@@ -526,7 +544,14 @@ def _analyze(
             corpus_lap = lap_trace_from_archive(archive)
         except ValueError:
             continue
-        if _same_archive_scope(corpus_lap, lap, archive, lap_archive, require_identity=True):
+        if _same_archive_scope(
+            corpus_lap,
+            lap,
+            archive,
+            lap_archive,
+            require_identity=True,
+            require_layout=True,
+        ):
             corpus_laps.append(corpus_lap)
     superlap = build_superlap(corpus_laps) if corpus_laps else None
     return {

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -292,6 +292,7 @@ def _analyze(
     lap_archive: dict,
     *,
     reference_archive: dict | None,
+    history_archives: list[dict] | None = None,
     setup: CarSetup | None,
     grip_ceiling_g: float | None,
 ) -> dict:
@@ -303,7 +304,19 @@ def _analyze(
     lap = lap_trace_from_archive(lap_archive)
     setup = setup or from_lap_archive(lap_archive)
     ref = lap_trace_from_archive(reference_archive) if reference_archive else None
-    report = coach_lap(lap, setup, reference=ref, grip_ceiling_g=grip_ceiling_g)
+    history_laps: list[LapTrace] = []
+    for history_archive in history_archives or []:
+        try:
+            history_laps.append(lap_trace_from_archive(history_archive))
+        except ValueError:
+            continue
+    report = coach_lap(
+        lap,
+        setup,
+        reference=ref,
+        history=history_laps,
+        grip_ceiling_g=grip_ceiling_g,
+    )
     sigs = corner_signatures(lap, segment_corners(lap))
     deltas = compare_laps(lap, ref) if ref is not None else None
     balance = analyze_balance(lap, sigs, deltas=deltas, grip_ceiling_g=grip_ceiling_g)
@@ -333,6 +346,7 @@ def build_structured_debrief(
     lap_archive: dict,
     *,
     reference_archive: dict | None = None,
+    history_archives: list[dict] | None = None,
     setup: CarSetup | None = None,
     grip_ceiling_g: float | None = None,
 ) -> dict | None:
@@ -349,6 +363,7 @@ def build_structured_debrief(
         a = _analyze(
             lap_archive,
             reference_archive=reference_archive,
+            history_archives=history_archives,
             setup=setup,
             grip_ceiling_g=grip_ceiling_g,
         )
@@ -373,6 +388,7 @@ def build_structured_debrief(
             "min_speed_kmh": c.min_speed_kmh,
             "time_loss_s": c.delta_s,
             "headline": c.headline,
+            "diagnostics": c.diagnostics,
             "attributions": [
                 {
                     "key": at.key,
@@ -413,6 +429,7 @@ def build_debrief(
     lap_archive: dict,
     *,
     reference_archive: dict | None = None,
+    history_archives: list[dict] | None = None,
     setup: CarSetup | None = None,
     grip_ceiling_g: float | None = None,
 ) -> str:
@@ -420,6 +437,7 @@ def build_debrief(
     a = _analyze(
         lap_archive,
         reference_archive=reference_archive,
+        history_archives=history_archives,
         setup=setup,
         grip_ceiling_g=grip_ceiling_g,
     )

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -118,6 +118,8 @@ def _same_archive_layout(candidate: dict | None, anchor: dict | None, *, require
 
 
 def _same_optional_identity(candidate: str | None, anchor: str | None, *, required: bool) -> bool:
+    if candidate is None and anchor is None:
+        return True
     if not required and (candidate is None or anchor is None):
         return True
     if candidate is None or anchor is None:

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -150,6 +150,15 @@ def _archive_content_key(archive: dict | None) -> str:
     trace_shape: dict[str, object] = {}
     if isinstance(trace, dict):
         samples = trace.get("samples")
+        samples_digest = None
+        if isinstance(samples, list):
+            digest = hashlib.sha256()
+            for sample in samples:
+                digest.update(
+                    json.dumps(sample, separators=(",", ":"), default=str).encode("utf-8")
+                )
+                digest.update(b"\n")
+            samples_digest = digest.hexdigest()
         trace_shape = {
             "fields": trace.get("fields"),
             "samples_count": trace.get("samples_count")
@@ -157,6 +166,7 @@ def _archive_content_key(archive: dict | None) -> str:
             else len(samples)
             if isinstance(samples, list)
             else None,
+            "samples_digest": samples_digest,
         }
     identity = {
         key: archive.get(key) for key in ("car", "track", "lap") if isinstance(archive, dict)

--- a/tools/ai_sidecar/coach_report.py
+++ b/tools/ai_sidecar/coach_report.py
@@ -15,6 +15,7 @@ CLI::
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
 
@@ -26,9 +27,9 @@ from tools.ai_sidecar.corner_attribution import (
     Attribution,
     BalanceFinding,
     CornerCoaching,
+    _match_reference_corners,
     analyze_balance,
     coach_lap,
-    compare_laps,
 )
 from tools.ai_sidecar.lap_dynamics import (
     LapTrace,
@@ -114,25 +115,39 @@ def _same_archive_layout(candidate: dict | None, anchor: dict | None) -> bool:
     return candidate_layout == anchor_layout
 
 
+def _same_optional_identity(candidate: str | None, anchor: str | None, *, required: bool) -> bool:
+    if candidate is None or anchor is None:
+        return False if required else candidate is None and anchor is None
+    return candidate == anchor
+
+
 def _same_archive_scope(
     candidate_lap: LapTrace,
     anchor_lap: LapTrace,
     candidate_archive: dict | None,
     anchor_archive: dict | None,
+    *,
+    require_identity: bool,
 ) -> bool:
-    if (
-        candidate_lap.car_id is None
-        or anchor_lap.car_id is None
-        or candidate_lap.car_id != anchor_lap.car_id
+    if not _same_optional_identity(
+        candidate_lap.car_id, anchor_lap.car_id, required=require_identity
     ):
         return False
-    if (
-        candidate_lap.track_id is None
-        or anchor_lap.track_id is None
-        or candidate_lap.track_id != anchor_lap.track_id
+    if not _same_optional_identity(
+        candidate_lap.track_id, anchor_lap.track_id, required=require_identity
     ):
         return False
     return _same_archive_layout(candidate_archive, anchor_archive)
+
+
+def _archive_content_key(archive: dict | None) -> str:
+    identity = {
+        key: archive.get(key)
+        for key in ("car", "track", "lap", "trace")
+        if isinstance(archive, dict)
+    }
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def format_debrief(
@@ -442,28 +457,51 @@ def _analyze(
         raw_ref
         if raw_ref is not None
         and _archive_lap_is_valid(reference_archive)
-        and _same_archive_scope(raw_ref, lap, reference_archive, lap_archive)
+        and _same_archive_scope(
+            raw_ref,
+            lap,
+            reference_archive,
+            lap_archive,
+            require_identity=False,
+        )
         else None
     )
+    current_archive_key = _archive_content_key(lap_archive)
+    seen_history_keys = {current_archive_key}
     history_laps: list[LapTrace] = []
     for history_archive in history_archives or []:
         if not _archive_lap_is_valid(history_archive):
             continue
+        history_key = _archive_content_key(history_archive)
+        if history_key in seen_history_keys:
+            continue
+        seen_history_keys.add(history_key)
         try:
             history_lap = lap_trace_from_archive(history_archive)
         except ValueError:
             continue
-        if _same_archive_scope(history_lap, lap, history_archive, lap_archive):
+        if _same_archive_scope(
+            history_lap,
+            lap,
+            history_archive,
+            lap_archive,
+            require_identity=True,
+        ):
             history_laps.append(history_lap)
+    corners = segment_corners(lap)
+    sigs = corner_signatures(lap, corners)
+    reference_matches = _match_reference_corners(lap, ref, anchors=sigs) if ref is not None else {}
     report = coach_lap(
         lap,
         setup,
         reference=ref,
         history=history_laps,
         grip_ceiling_g=grip_ceiling_g,
+        corners=corners,
+        signatures=sigs,
+        reference_matches=reference_matches,
     )
-    sigs = corner_signatures(lap, segment_corners(lap))
-    deltas = compare_laps(lap, ref) if ref is not None else None
+    deltas = [delta for _ref_sig, delta in reference_matches.values()] if ref is not None else None
     balance = analyze_balance(lap, sigs, deltas=deltas, grip_ceiling_g=grip_ceiling_g)
     tyres = tyres_from_lap_archive(lap_archive)
     conditions = conditions_from_lap_archive(lap_archive, reference_archive=reference_archive)
@@ -488,7 +526,7 @@ def _analyze(
             corpus_lap = lap_trace_from_archive(archive)
         except ValueError:
             continue
-        if _same_archive_scope(corpus_lap, lap, archive, lap_archive):
+        if _same_archive_scope(corpus_lap, lap, archive, lap_archive, require_identity=True):
             corpus_laps.append(corpus_lap)
     superlap = build_superlap(corpus_laps) if corpus_laps else None
     return {

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -122,6 +122,49 @@ def _min_speed_in_window(lap: LapTrace, lo: float, hi: float) -> float:
     return (min(vals) if vals else 0.0) * 3.6
 
 
+def _corner_delta_for_window(
+    candidate: LapTrace,
+    reference: LapTrace,
+    *,
+    index: int,
+    lo: float,
+    hi: float,
+) -> CornerDelta:
+    c_t = _interp_time(candidate, hi) - _interp_time(candidate, lo)
+    r_t = _interp_time(reference, hi) - _interp_time(reference, lo)
+    c_min = _min_speed_in_window(candidate, lo, hi)
+    r_min = _min_speed_in_window(reference, lo, hi)
+    return CornerDelta(
+        index=index,
+        spline_lo=round(lo, 4),
+        spline_hi=round(hi, 4),
+        cand_time_s=round(c_t, 3),
+        ref_time_s=round(r_t, 3),
+        delta_s=round(c_t - r_t, 3),
+        cand_min_kmh=round(c_min, 1),
+        ref_min_kmh=round(r_min, 1),
+        min_speed_delta_kmh=round(c_min - r_min, 1),
+    )
+
+
+def _corner_delta_for_match(
+    candidate: LapTrace,
+    reference: LapTrace,
+    cand_sig: CornerSignature,
+    ref_sig: CornerSignature,
+) -> CornerDelta:
+    """Compare candidate against the same physical reference corner used by diagnostics."""
+    lo = reference.spline[ref_sig.entry_i]
+    hi = reference.spline[ref_sig.exit_i]
+    return _corner_delta_for_window(
+        candidate,
+        reference,
+        index=cand_sig.index,
+        lo=lo,
+        hi=hi,
+    )
+
+
 def compare_laps(
     candidate: LapTrace,
     reference: LapTrace,
@@ -139,23 +182,7 @@ def compare_laps(
     for idx, (entry_i, _apex_i, exit_i) in enumerate(corners):
         lo = reference.spline[entry_i]
         hi = reference.spline[exit_i]
-        c_t = _interp_time(candidate, hi) - _interp_time(candidate, lo)
-        r_t = _interp_time(reference, hi) - _interp_time(reference, lo)
-        c_min = _min_speed_in_window(candidate, lo, hi)
-        r_min = _min_speed_in_window(reference, lo, hi)
-        out.append(
-            CornerDelta(
-                index=idx,
-                spline_lo=round(lo, 4),
-                spline_hi=round(hi, 4),
-                cand_time_s=round(c_t, 3),
-                ref_time_s=round(r_t, 3),
-                delta_s=round(c_t - r_t, 3),
-                cand_min_kmh=round(c_min, 1),
-                ref_min_kmh=round(r_min, 1),
-                min_speed_delta_kmh=round(c_min - r_min, 1),
-            )
-        )
+        out.append(_corner_delta_for_window(candidate, reference, index=idx, lo=lo, hi=hi))
     return out
 
 
@@ -197,9 +224,10 @@ def _corner_history_matches(
 
 
 def analyze_corner_consistency(
-    laps: list[LapTrace],
+    laps: list[LapTrace] | None = None,
     *,
     anchors: list[CornerSignature] | None = None,
+    matches: dict[int, list[CornerSignature]] | None = None,
 ) -> dict[int, CornerConsistency]:
     """Per-corner lap-to-lap variance, mirroring the Lua HUD consistency score.
 
@@ -207,10 +235,13 @@ def analyze_corner_consistency(
     more variance), with speed spread carrying most of the weight and brake-point spline spread
     down-weighted because spline wrap/segmentation noise is more fragile.
     """
-    if len(laps) < 2:
-        return {}
-    anchors = anchors if anchors is not None else corner_signatures(laps[-1])
-    by_idx = _corner_history_matches(laps[:-1], anchors)
+    if matches is None:
+        if laps is None or len(laps) < 2:
+            return {}
+        anchors = anchors if anchors is not None else corner_signatures(laps[-1])
+        by_idx = _corner_history_matches(laps[:-1], anchors)
+    else:
+        by_idx = matches
     out: dict[int, CornerConsistency] = {}
     for idx, sigs in by_idx.items():
         if len(sigs) < 2:
@@ -481,15 +512,24 @@ def coach_lap(
     """Full per-corner coaching pass over a lap (optionally vs reference, optionally with setup)."""
     corners = segment_corners(lap)
     sigs = corner_signatures(lap, corners)
-    deltas = compare_laps(lap, reference, corners=corners) if reference is not None else []
-    by_idx = {d.index: d for d in deltas}
     ref_sigs = corner_signatures(reference) if reference is not None else []
+    ref_by_idx: dict[int, CornerSignature] = {}
+    delta_by_idx: dict[int, CornerDelta] = {}
+    if reference is not None:
+        unused_ref_sigs = list(ref_sigs)
+        for sig in sigs:
+            ref_sig = _match_corner_signature(sig, unused_ref_sigs)
+            if ref_sig is None:
+                continue
+            ref_by_idx[sig.index] = ref_sig
+            unused_ref_sigs.remove(ref_sig)
+            delta_by_idx[sig.index] = _corner_delta_for_match(lap, reference, sig, ref_sig)
     history_laps = [*(history or []), lap]
     history_matches = (
         _corner_history_matches(history_laps[:-1], sigs) if len(history_laps) >= 2 else {}
     )
     consistency = (
-        analyze_corner_consistency(history_laps, anchors=sigs) if len(history_laps) >= 2 else {}
+        analyze_corner_consistency(matches=history_matches) if len(history_laps) >= 2 else {}
     )
     # Trail-braking technique read (#301): computed once over the SAME segmentation as the
     # signatures so the per-corner finding lines up with sig.index, then injected into each corner's
@@ -500,7 +540,7 @@ def coach_lap(
     }
     out: list[CornerCoaching] = []
     for sig in sigs:
-        ref_sig = _match_corner_signature(sig, ref_sigs)
+        ref_sig = ref_by_idx.get(sig.index)
         diagnostics = _corner_diagnostics(
             lap=lap,
             reference=reference,
@@ -541,7 +581,7 @@ def coach_lap(
         ctx = CornerContext(
             sig=sig,
             setup=setup,
-            delta=by_idx.get(sig.index),
+            delta=delta_by_idx.get(sig.index),
             reference_sig=ref_sig,
             grip_ceiling_g=grip_ceiling_g,
             extra=extra,

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -529,14 +529,29 @@ def coach_lap(
     grip_ceiling_g: float | None = None,
     extra_by_corner: dict[int, dict[str, Any]] | None = None,
     rules: list[DiagnosticRule] | None = None,
+    corners: list[tuple[int, int, int]] | None = None,
+    signatures: list[CornerSignature] | None = None,
+    reference_matches: dict[int, tuple[CornerSignature, CornerDelta]] | None = None,
 ) -> list[CornerCoaching]:
     """Full per-corner coaching pass over a lap (optionally vs reference, optionally with setup)."""
-    corners = segment_corners(lap)
-    sigs = corner_signatures(lap, corners)
+    if signatures is None:
+        corners = corners if corners is not None else segment_corners(lap)
+        sigs = corner_signatures(lap, corners)
+    else:
+        sigs = signatures
+        corners = (
+            corners
+            if corners is not None
+            else [(sig.entry_i, sig.apex_i, sig.exit_i) for sig in sigs]
+        )
     ref_by_idx: dict[int, CornerSignature] = {}
     delta_by_idx: dict[int, CornerDelta] = {}
     if reference is not None:
-        ref_matches = _match_reference_corners(lap, reference, anchors=sigs)
+        ref_matches = (
+            reference_matches
+            if reference_matches is not None
+            else _match_reference_corners(lap, reference, anchors=sigs)
+        )
         ref_by_idx = {idx: ref_sig for idx, (ref_sig, _delta) in ref_matches.items()}
         delta_by_idx = {idx: delta for idx, (_ref_sig, delta) in ref_matches.items()}
     history_laps = [*(history or []), lap]

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -50,6 +50,20 @@ class CornerDelta:
     min_speed_delta_kmh: float  # >0 means candidate carried MORE apex speed
 
 
+@dataclass(frozen=True)
+class CornerConsistency:
+    """Lap-to-lap spread for one corner across a same car/track history."""
+
+    index: int
+    sample_count: int
+    score: float
+    spread: float
+    entry_speed_stddev_kmh: float
+    min_speed_stddev_kmh: float
+    exit_speed_stddev_kmh: float
+    brake_point_stddev: float
+
+
 def _interp_time(lap: LapTrace, spline: float) -> float:
     """Time (s) at a spline position via linear interpolation over the monotone spline channel."""
     sp = lap.spline
@@ -67,6 +81,40 @@ def _interp_time(lap: LapTrace, spline: float) -> float:
     span = sp[hi] - sp[lo]
     frac = 0.0 if span <= 1e-9 else (spline - sp[lo]) / span
     return lap.t_s[lo] + frac * (lap.t_s[hi] - lap.t_s[lo])
+
+
+def _interp_position(lap: LapTrace, spline: float) -> tuple[float, float]:
+    """Position (x, z) at a spline position via linear interpolation."""
+    sp = lap.spline
+    if spline <= sp[0]:
+        return lap.x[0], lap.z[0]
+    if spline >= sp[-1]:
+        return lap.x[-1], lap.z[-1]
+    lo, hi = 0, len(sp) - 1
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if sp[mid] <= spline:
+            lo = mid
+        else:
+            hi = mid
+    span = sp[hi] - sp[lo]
+    frac = 0.0 if span <= 1e-9 else (spline - sp[lo]) / span
+    return (
+        lap.x[lo] + (lap.x[hi] - lap.x[lo]) * frac,
+        lap.z[lo] + (lap.z[hi] - lap.z[lo]) * frac,
+    )
+
+
+def _interp_tangent(lap: LapTrace, spline: float) -> tuple[float, float]:
+    """Unit tangent at a spline position, from nearby interpolated points."""
+    eps = 0.002
+    lo = max(lap.spline[0], spline - eps)
+    hi = min(lap.spline[-1], spline + eps)
+    ax, az = _interp_position(lap, lo)
+    bx, bz = _interp_position(lap, hi)
+    dx, dz = bx - ax, bz - az
+    norm = (dx * dx + dz * dz) ** 0.5
+    return (1.0, 0.0) if norm <= 1e-9 else (dx / norm, dz / norm)
 
 
 def _min_speed_in_window(lap: LapTrace, lo: float, hi: float) -> float:
@@ -107,6 +155,55 @@ def compare_laps(
                 ref_min_kmh=round(r_min, 1),
                 min_speed_delta_kmh=round(c_min - r_min, 1),
             )
+        )
+    return out
+
+
+def _stddev(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    return (sum((value - mean) ** 2 for value in values) / (len(values) - 1)) ** 0.5
+
+
+def analyze_corner_consistency(laps: list[LapTrace]) -> dict[int, CornerConsistency]:
+    """Per-corner lap-to-lap variance, mirroring the Lua HUD consistency score.
+
+    Needs at least two segmentable laps. The score is dimensionless (100 = repeatable, lower =
+    more variance), with speed spread carrying most of the weight and brake-point spline spread
+    down-weighted because spline wrap/segmentation noise is more fragile.
+    """
+    if len(laps) < 2:
+        return {}
+    by_idx: dict[int, list[CornerSignature]] = {}
+    for lap in laps:
+        for sig in corner_signatures(lap):
+            by_idx.setdefault(sig.index, []).append(sig)
+    out: dict[int, CornerConsistency] = {}
+    for idx, sigs in by_idx.items():
+        if len(sigs) < 2:
+            continue
+        entry_sd = _stddev([s.entry_speed_kmh for s in sigs])
+        min_sd = _stddev([s.min_speed_kmh for s in sigs])
+        exit_sd = _stddev([s.exit_speed_kmh for s in sigs])
+        brake_vals = [s.brake_point_spline for s in sigs if s.brake_point_spline is not None]
+        brake_sd = _stddev(brake_vals)
+        spread = (
+            (entry_sd / 120.0) * 0.35
+            + (min_sd / 120.0) * 0.30
+            + (exit_sd / 120.0) * 0.30
+            + brake_sd * 0.05
+        )
+        score = max(0.0, min(100.0, 100.0 - spread * 45.0))
+        out[idx] = CornerConsistency(
+            index=idx,
+            sample_count=len(sigs),
+            score=round(score, 1),
+            spread=round(spread, 4),
+            entry_speed_stddev_kmh=round(entry_sd, 2),
+            min_speed_stddev_kmh=round(min_sd, 2),
+            exit_speed_stddev_kmh=round(exit_sd, 2),
+            brake_point_stddev=round(brake_sd, 5),
         )
     return out
 
@@ -256,6 +353,7 @@ class CornerContext:
     sig: CornerSignature
     setup: CarSetup
     delta: CornerDelta | None = None  # vs a reference lap, if available
+    reference_sig: CornerSignature | None = None  # same-index reference corner, if available
     grip_ceiling_g: float | None = None  # GGV/known lateral ceiling at this corner
     extra: dict[str, Any] = field(default_factory=dict)  # richer live signals (Tier-B)
 
@@ -335,6 +433,7 @@ class CornerCoaching:
     delta_s: float | None
     headline: str
     attributions: list[Attribution]
+    diagnostics: dict[str, Any] = field(default_factory=dict)
 
 
 def coach_lap(
@@ -342,6 +441,7 @@ def coach_lap(
     setup: CarSetup,
     *,
     reference: LapTrace | None = None,
+    history: list[LapTrace] | None = None,
     grip_ceiling_g: float | None = None,
     extra_by_corner: dict[int, dict[str, Any]] | None = None,
     rules: list[DiagnosticRule] | None = None,
@@ -351,6 +451,9 @@ def coach_lap(
     sigs = corner_signatures(lap, corners)
     deltas = compare_laps(lap, reference, corners=corners) if reference is not None else []
     by_idx = {d.index: d for d in deltas}
+    ref_sigs = {s.index: s for s in corner_signatures(reference)} if reference is not None else {}
+    history_laps = [*(history or []), lap]
+    consistency = analyze_corner_consistency(history_laps) if len(history_laps) >= 2 else {}
     # Trail-braking technique read (#301): computed once over the SAME segmentation as the
     # signatures so the per-corner finding lines up with sig.index, then injected into each corner's
     # ``extra`` so the trail_brake rule folds it into the attribution layer (cause_class reasoning)
@@ -360,10 +463,24 @@ def coach_lap(
     }
     out: list[CornerCoaching] = []
     for sig in sigs:
+        ref_sig = ref_sigs.get(sig.index)
+        diagnostics = _corner_diagnostics(
+            lap=lap,
+            reference=reference,
+            sig=sig,
+            ref_sig=ref_sig,
+            consistency=consistency.get(sig.index),
+            history_count=len(history_laps),
+        )
         # explicit caller-supplied signals win; else auto-compute Tier-B signals from per-wheel data
         extra = (extra_by_corner or {}).get(sig.index)
         if extra is None:
             extra = corner_live_signals(lap, sig) if lap.has_wheel_data else {}
+        extra = {
+            **extra,
+            "exit_road_usage": diagnostics["exit_road_usage"],
+            "consistency": diagnostics["consistency"],
+        }
         tb = trail_by_idx.get(sig.index)
         if tb is not None and "trail_brake" not in extra:
             # Copy (never mutate a caller-supplied extra dict); a caller that already set
@@ -382,6 +499,7 @@ def coach_lap(
             sig=sig,
             setup=setup,
             delta=by_idx.get(sig.index),
+            reference_sig=ref_sig,
             grip_ceiling_g=grip_ceiling_g,
             extra=extra,
         )
@@ -394,9 +512,124 @@ def coach_lap(
                 delta_s=ctx.delta.delta_s if ctx.delta else None,
                 headline=_headline(ctx, attrs),
                 attributions=attrs,
+                diagnostics=diagnostics,
             )
         )
     return out
+
+
+def _corner_diagnostics(
+    *,
+    lap: LapTrace,
+    reference: LapTrace | None,
+    sig: CornerSignature,
+    ref_sig: CornerSignature | None,
+    consistency: CornerConsistency | None,
+    history_count: int,
+) -> dict[str, Any]:
+    steering = {
+        "available": True,
+        "smoothness_score": sig.steering_smoothness_score,
+        "correction_count": sig.steering_correction_count,
+        "rate_p95_per_s": sig.steering_rate_p95,
+        "scrub_index": sig.steering_scrub_index,
+        "max_abs_steer": sig.max_abs_steer,
+    }
+    brake_shape = {
+        "available": True,
+        "classification": sig.brake_shape,
+        "late_rise_count": sig.brake_late_rise_count,
+        "release_smoothness": sig.brake_release_smoothness,
+    }
+    gear = _gear_diagnostics(sig, ref_sig)
+    road = _exit_road_usage(lap, reference, sig, ref_sig)
+    consistency_struct = (
+        {
+            "available": True,
+            "score": consistency.score,
+            "spread": consistency.spread,
+            "sample_count": consistency.sample_count,
+            "entry_speed_stddev_kmh": consistency.entry_speed_stddev_kmh,
+            "min_speed_stddev_kmh": consistency.min_speed_stddev_kmh,
+            "exit_speed_stddev_kmh": consistency.exit_speed_stddev_kmh,
+            "brake_point_stddev": consistency.brake_point_stddev,
+        }
+        if consistency is not None
+        else {
+            "available": False,
+            "reason": "needs at least two segmentable laps",
+            "sample_count": history_count,
+        }
+    )
+    return {
+        "steering": steering,
+        "brake_shape": brake_shape,
+        "gear": gear,
+        "exit_road_usage": road,
+        "consistency": consistency_struct,
+    }
+
+
+def _gear_diagnostics(sig: CornerSignature, ref_sig: CornerSignature | None) -> dict[str, Any]:
+    base = {
+        "available": sig.gear_at_apex is not None,
+        "apex_gear": sig.gear_at_apex,
+        "entry_gear": sig.entry_gear,
+        "exit_gear": sig.exit_gear,
+        "gear_change_count": sig.gear_change_count,
+    }
+    if sig.gear_at_apex is None:
+        return {**base, "reason": "no gear channel"}
+    if ref_sig is None or ref_sig.gear_at_apex is None:
+        return {
+            **base,
+            "reference_apex_gear": None,
+            "delta_vs_reference": None,
+            "classification": "no_reference",
+            "reason": "reference gear required for wrong-gear diagnosis",
+        }
+    delta = sig.gear_at_apex - ref_sig.gear_at_apex
+    classification = "matches_reference"
+    if delta > 0:
+        classification = "too_high"
+    elif delta < 0:
+        classification = "too_low"
+    return {
+        **base,
+        "reference_apex_gear": ref_sig.gear_at_apex,
+        "delta_vs_reference": delta,
+        "classification": classification,
+    }
+
+
+def _exit_road_usage(
+    lap: LapTrace,
+    reference: LapTrace | None,
+    sig: CornerSignature,
+    ref_sig: CornerSignature | None,
+) -> dict[str, Any]:
+    if reference is None or ref_sig is None:
+        return {
+            "available": False,
+            "source": "reference_path",
+            "reason": "reference path required",
+        }
+    exit_spline = reference.spline[ref_sig.exit_i]
+    cx, cz = _interp_position(lap, exit_spline)
+    rx, rz = _interp_position(reference, exit_spline)
+    tx, tz = _interp_tangent(reference, exit_spline)
+    # Lateral component of candidate-vs-reference exit displacement. Reference path is the only
+    # available proxy here; true track-edge distance needs map edge geometry.
+    dx, dz = cx - rx, cz - rz
+    lateral = dx * (-tz) + dz * tx
+    return {
+        "available": True,
+        "source": "reference_path",
+        "exit_spline": round(exit_spline, 4),
+        "lateral_delta_m": round(lateral, 2),
+        "missed_exit_width_m": round(abs(lateral), 2),
+        "caveat": "reference path proxy; true curb distance requires track-edge geometry",
+    }
 
 
 def _headline(ctx: CornerContext, attrs: list[Attribution]) -> str:
@@ -537,6 +770,63 @@ def _r_turn_in_lag(ctx: CornerContext) -> float:
     if used is not None and used >= 0.95:
         return 0.0
     return 0.35
+
+
+def _r_steering_aggression(ctx: CornerContext) -> float:
+    sig = ctx.sig
+    if (
+        sig.steering_correction_count < 2
+        and sig.steering_smoothness_score >= 72.0
+        and sig.steering_scrub_index < 0.18
+    ):
+        return 0.0
+    raw = (
+        0.25
+        + max(0.0, 72.0 - sig.steering_smoothness_score) / 55.0
+        + min(0.25, sig.steering_correction_count * 0.07)
+        + min(0.20, sig.steering_scrub_index)
+    )
+    return min(0.82, raw)
+
+
+def _r_exit_road_usage(ctx: CornerContext) -> float:
+    road = ctx.extra.get("exit_road_usage")
+    if not isinstance(road, dict) or road.get("available") is not True:
+        return 0.0
+    missed = road.get("missed_exit_width_m")
+    if not isinstance(missed, (int, float)) or missed < 1.5:
+        return 0.0
+    if ctx.delta is not None and ctx.delta.delta_s <= 0.03:
+        return 0.0
+    return min(0.85, 0.35 + missed / 6.0)
+
+
+def _r_gear_selection(ctx: CornerContext) -> float:
+    ref = ctx.reference_sig
+    if ref is None or ctx.sig.gear_at_apex is None or ref.gear_at_apex is None:
+        return 0.0
+    delta = ctx.sig.gear_at_apex - ref.gear_at_apex
+    if delta == 0:
+        return 0.0
+    return min(0.82, 0.45 + abs(delta) * 0.12)
+
+
+def _r_brake_shape(ctx: CornerContext) -> float:
+    return {
+        "increasing_pressure": 0.46,
+        "abrupt_release": 0.40,
+        "braking_at_apex": 0.36,
+    }.get(ctx.sig.brake_shape, 0.0)
+
+
+def _r_consistency(ctx: CornerContext) -> float:
+    cons = ctx.extra.get("consistency")
+    if not isinstance(cons, dict) or cons.get("available") is not True:
+        return 0.0
+    score = cons.get("score")
+    if not isinstance(score, (int, float)) or score >= 72.0:
+        return 0.0
+    return min(0.78, 0.32 + (72.0 - score) / 60.0)
 
 
 def _exit_setup_causes(ctx: CornerContext) -> list[str]:
@@ -681,6 +971,51 @@ def _trail_brake_coaching(ctx: CornerContext) -> str:
     )
 
 
+def _gear_coaching(ctx: CornerContext) -> str:
+    ref = ctx.reference_sig
+    if ref is None or ctx.sig.gear_at_apex is None or ref.gear_at_apex is None:
+        return "Gear comparison needs a reference lap."
+    if ctx.sig.gear_at_apex > ref.gear_at_apex:
+        return (
+            f"Apex gear {ctx.sig.gear_at_apex} vs reference {ref.gear_at_apex} — one gear too "
+            "tall; downshift earlier so the car rotates and drives off the apex."
+        )
+    return (
+        f"Apex gear {ctx.sig.gear_at_apex} vs reference {ref.gear_at_apex} — one gear too low; "
+        "avoid over-slowing/over-revving and carry the reference gear."
+    )
+
+
+def _exit_road_usage_coaching(ctx: CornerContext) -> str:
+    road = ctx.extra.get("exit_road_usage") if isinstance(ctx.extra, dict) else None
+    missed = road.get("missed_exit_width_m") if isinstance(road, dict) else None
+    miss_text = f"{missed:.1f} m" if isinstance(missed, (int, float)) else "the reference"
+    return (
+        f"Exit path is {miss_text} away from the reference exit width — look through the apex and "
+        "commit to using the road on exit."
+    )
+
+
+def _brake_shape_coaching(ctx: CornerContext) -> str:
+    if ctx.sig.brake_shape == "increasing_pressure":
+        return "Brake trace rises late toward the apex — hit pressure once, then bleed it off."
+    if ctx.sig.brake_shape == "abrupt_release":
+        return "Brake release is a step — bleed pressure off smoothly as steering loads."
+    if ctx.sig.brake_shape == "braking_at_apex":
+        return "Still carrying brake at the apex — finish the release before asking for throttle."
+    return "Brake trace shape needs the four phases: attack, hold, release, off."
+
+
+def _consistency_coaching(ctx: CornerContext) -> str:
+    cons = ctx.extra.get("consistency") if isinstance(ctx.extra, dict) else None
+    score = cons.get("score") if isinstance(cons, dict) else None
+    score_text = f"{score:.0f}%" if isinstance(score, (int, float)) else "low"
+    return (
+        f"Corner repeatability is {score_text} — pick one brake marker and one throttle marker, "
+        "then repeat before chasing pace."
+    )
+
+
 RULES: list[DiagnosticRule] = [
     DiagnosticRule(
         key="grip_limited",
@@ -773,6 +1108,77 @@ RULES: list[DiagnosticRule] = [
             "Sluggish turn-in (heading lags steer) — likely technique or front load, not "
             "necessarily toe. Confirm with live yaw-rate."
         ),
+    ),
+    DiagnosticRule(
+        key="steering_aggression",
+        symptom="steering corrections / scrub proxy",
+        phase="mid",
+        tier="A",
+        channels_needed=(),
+        test=_r_steering_aggression,
+        setup_causes=lambda c: [],
+        technique_causes=(
+            "Use one deliberate steering input; avoid saw-toothing the wheel while loaded.",
+        ),
+        coaching=lambda c: (
+            f"Hands are noisy (smoothness {c.sig.steering_smoothness_score:.0f}%, "
+            f"{c.sig.steering_correction_count} correction(s)) — make one input and let the car "
+            "settle."
+        ),
+    ),
+    DiagnosticRule(
+        key="exit_road_usage",
+        symptom="not using the road on exit",
+        phase="exit",
+        tier="A",
+        channels_needed=(),
+        test=_r_exit_road_usage,
+        setup_causes=lambda c: [],
+        technique_causes=(
+            "Vision / commitment: look through the apex and let the car run to the exit width.",
+        ),
+        coaching=_exit_road_usage_coaching,
+    ),
+    DiagnosticRule(
+        key="gear_selection",
+        symptom="wrong gear vs reference",
+        phase="mid",
+        tier="A",
+        channels_needed=(),
+        test=_r_gear_selection,
+        setup_causes=lambda c: [],
+        technique_causes=(
+            "Carry the reference gear through the apex; wrong gear changes rotation and "
+            "exit drive.",
+        ),
+        coaching=_gear_coaching,
+    ),
+    DiagnosticRule(
+        key="brake_trace_shape",
+        symptom="brake trace shape",
+        phase="braking",
+        tier="A",
+        channels_needed=(),
+        test=_r_brake_shape,
+        setup_causes=lambda c: [],
+        technique_causes=(
+            "Shape the brake as attack → hold → release → off; do not add pressure late "
+            "or dump it.",
+        ),
+        coaching=_brake_shape_coaching,
+    ),
+    DiagnosticRule(
+        key="corner_consistency",
+        symptom="low lap-to-lap consistency",
+        phase="session",
+        tier="A",
+        channels_needed=(),
+        test=_r_consistency,
+        setup_causes=lambda c: [],
+        technique_causes=(
+            "Repeat the same markers before tuning pace; this feeds driver skill classification.",
+        ),
+        coaching=_consistency_coaching,
     ),
     DiagnosticRule(
         key="trail_brake",

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -166,7 +166,40 @@ def _stddev(values: list[float]) -> float:
     return (sum((value - mean) ** 2 for value in values) / (len(values) - 1)) ** 0.5
 
 
-def analyze_corner_consistency(laps: list[LapTrace]) -> dict[int, CornerConsistency]:
+def _match_corner_signature(
+    anchor: CornerSignature,
+    candidates: list[CornerSignature],
+    *,
+    max_apex_delta: float = 0.04,
+) -> CornerSignature | None:
+    """Closest physical corner by apex spline, not by per-lap ordinal index."""
+    if not candidates:
+        return None
+    best = min(candidates, key=lambda c: abs(c.apex_spline - anchor.apex_spline))
+    return best if abs(best.apex_spline - anchor.apex_spline) <= max_apex_delta else None
+
+
+def _corner_history_matches(
+    laps: list[LapTrace],
+    anchors: list[CornerSignature],
+) -> dict[int, list[CornerSignature]]:
+    by_idx: dict[int, list[CornerSignature]] = {anchor.index: [anchor] for anchor in anchors}
+    if not anchors:
+        return by_idx
+    for lap in laps:
+        lap_sigs = corner_signatures(lap)
+        for anchor in anchors:
+            match = _match_corner_signature(anchor, lap_sigs)
+            if match is not None:
+                by_idx.setdefault(anchor.index, []).append(match)
+    return by_idx
+
+
+def analyze_corner_consistency(
+    laps: list[LapTrace],
+    *,
+    anchors: list[CornerSignature] | None = None,
+) -> dict[int, CornerConsistency]:
     """Per-corner lap-to-lap variance, mirroring the Lua HUD consistency score.
 
     Needs at least two segmentable laps. The score is dimensionless (100 = repeatable, lower =
@@ -175,10 +208,8 @@ def analyze_corner_consistency(laps: list[LapTrace]) -> dict[int, CornerConsiste
     """
     if len(laps) < 2:
         return {}
-    by_idx: dict[int, list[CornerSignature]] = {}
-    for lap in laps:
-        for sig in corner_signatures(lap):
-            by_idx.setdefault(sig.index, []).append(sig)
+    anchors = anchors if anchors is not None else corner_signatures(laps[-1])
+    by_idx = _corner_history_matches(laps[:-1], anchors)
     out: dict[int, CornerConsistency] = {}
     for idx, sigs in by_idx.items():
         if len(sigs) < 2:
@@ -451,9 +482,14 @@ def coach_lap(
     sigs = corner_signatures(lap, corners)
     deltas = compare_laps(lap, reference, corners=corners) if reference is not None else []
     by_idx = {d.index: d for d in deltas}
-    ref_sigs = {s.index: s for s in corner_signatures(reference)} if reference is not None else {}
+    ref_sigs = corner_signatures(reference) if reference is not None else []
     history_laps = [*(history or []), lap]
-    consistency = analyze_corner_consistency(history_laps) if len(history_laps) >= 2 else {}
+    history_matches = (
+        _corner_history_matches(history_laps[:-1], sigs) if len(history_laps) >= 2 else {}
+    )
+    consistency = (
+        analyze_corner_consistency(history_laps, anchors=sigs) if len(history_laps) >= 2 else {}
+    )
     # Trail-braking technique read (#301): computed once over the SAME segmentation as the
     # signatures so the per-corner finding lines up with sig.index, then injected into each corner's
     # ``extra`` so the trail_brake rule folds it into the attribution layer (cause_class reasoning)
@@ -463,23 +499,29 @@ def coach_lap(
     }
     out: list[CornerCoaching] = []
     for sig in sigs:
-        ref_sig = ref_sigs.get(sig.index)
+        ref_sig = _match_corner_signature(sig, ref_sigs)
         diagnostics = _corner_diagnostics(
             lap=lap,
             reference=reference,
             sig=sig,
             ref_sig=ref_sig,
             consistency=consistency.get(sig.index),
-            history_count=len(history_laps),
+            consistency_sample_count=len(history_matches.get(sig.index, [sig])),
+            history_laps_loaded=len(history_laps),
         )
         # explicit caller-supplied signals win; else auto-compute Tier-B signals from per-wheel data
         extra = (extra_by_corner or {}).get(sig.index)
         if extra is None:
             extra = corner_live_signals(lap, sig) if lap.has_wheel_data else {}
         extra = {
-            **extra,
             "exit_road_usage": diagnostics["exit_road_usage"],
             "consistency": diagnostics["consistency"],
+            **extra,
+        }
+        effective_diagnostics = {
+            **diagnostics,
+            "exit_road_usage": extra["exit_road_usage"],
+            "consistency": extra["consistency"],
         }
         tb = trail_by_idx.get(sig.index)
         if tb is not None and "trail_brake" not in extra:
@@ -512,7 +554,7 @@ def coach_lap(
                 delta_s=ctx.delta.delta_s if ctx.delta else None,
                 headline=_headline(ctx, attrs),
                 attributions=attrs,
-                diagnostics=diagnostics,
+                diagnostics=effective_diagnostics,
             )
         )
     return out
@@ -525,7 +567,8 @@ def _corner_diagnostics(
     sig: CornerSignature,
     ref_sig: CornerSignature | None,
     consistency: CornerConsistency | None,
-    history_count: int,
+    consistency_sample_count: int,
+    history_laps_loaded: int,
 ) -> dict[str, Any]:
     steering = {
         "available": True,
@@ -558,7 +601,8 @@ def _corner_diagnostics(
         else {
             "available": False,
             "reason": "needs at least two segmentable laps",
-            "sample_count": history_count,
+            "sample_count": consistency_sample_count,
+            "history_laps_loaded": history_laps_loaded,
         }
     )
     return {
@@ -627,8 +671,13 @@ def _exit_road_usage(
         "source": "reference_path",
         "exit_spline": round(exit_spline, 4),
         "lateral_delta_m": round(lateral, 2),
-        "missed_exit_width_m": round(abs(lateral), 2),
-        "caveat": "reference path proxy; true curb distance requires track-edge geometry",
+        "lateral_delta_abs_m": round(abs(lateral), 2),
+        "classification": "reference_path_delta",
+        "coaching_available": False,
+        "caveat": (
+            "reference path proxy only; true under-use needs track-edge geometry or "
+            "caller-supplied under_used_exit_width_m"
+        ),
     }
 
 
@@ -793,8 +842,10 @@ def _r_exit_road_usage(ctx: CornerContext) -> float:
     road = ctx.extra.get("exit_road_usage")
     if not isinstance(road, dict) or road.get("available") is not True:
         return 0.0
-    missed = road.get("missed_exit_width_m")
+    missed = road.get("under_used_exit_width_m", road.get("missed_exit_width_m"))
     if not isinstance(missed, (int, float)) or missed < 1.5:
+        return 0.0
+    if road.get("source") == "reference_path" and "under_used_exit_width_m" not in road:
         return 0.0
     if ctx.delta is not None and ctx.delta.delta_s <= 0.03:
         return 0.0
@@ -804,6 +855,8 @@ def _r_exit_road_usage(ctx: CornerContext) -> float:
 def _r_gear_selection(ctx: CornerContext) -> float:
     ref = ctx.reference_sig
     if ref is None or ctx.sig.gear_at_apex is None or ref.gear_at_apex is None:
+        return 0.0
+    if ctx.delta is None or ctx.delta.delta_s <= 0.03:
         return 0.0
     delta = ctx.sig.gear_at_apex - ref.gear_at_apex
     if delta == 0:
@@ -988,7 +1041,11 @@ def _gear_coaching(ctx: CornerContext) -> str:
 
 def _exit_road_usage_coaching(ctx: CornerContext) -> str:
     road = ctx.extra.get("exit_road_usage") if isinstance(ctx.extra, dict) else None
-    missed = road.get("missed_exit_width_m") if isinstance(road, dict) else None
+    missed = (
+        road.get("under_used_exit_width_m", road.get("missed_exit_width_m"))
+        if isinstance(road, dict)
+        else None
+    )
     miss_text = f"{missed:.1f} m" if isinstance(missed, (int, float)) else "the reference"
     return (
         f"Exit path is {miss_text} away from the reference exit width — look through the apex and "

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -171,13 +171,16 @@ def compare_laps(
     *,
     corners: list[tuple[int, int, int]] | None = None,
 ) -> list[CornerDelta]:
-    """Per-corner time/speed deltas of ``candidate`` vs ``reference`` (corners from the reference).
+    """Per-corner time/speed deltas of ``candidate`` vs ``reference``.
 
-    Both laps are assumed to cover the same track with a monotone ``spline`` 0..1. Time is compared
-    over each corner's spline window, so the deltas localize where the candidate gained/lost time.
+    By default, candidate corners are matched to reference corners by apex spline so deltas describe
+    the same physical corner even when segmentation differs. Supplying ``corners`` keeps the legacy
+    explicit-window mode, where the tuples are interpreted as reference-lap sample indexes.
     """
     if corners is None:
-        corners = segment_corners(reference)
+        return [
+            delta for _ref_sig, delta in _match_reference_corners(candidate, reference).values()
+        ]
     out: list[CornerDelta] = []
     for idx, (entry_i, _apex_i, exit_i) in enumerate(corners):
         lo = reference.spline[entry_i]
@@ -204,6 +207,24 @@ def _match_corner_signature(
         return None
     best = min(candidates, key=lambda c: abs(c.apex_spline - anchor.apex_spline))
     return best if abs(best.apex_spline - anchor.apex_spline) <= max_apex_delta else None
+
+
+def _match_reference_corners(
+    candidate: LapTrace,
+    reference: LapTrace,
+    *,
+    anchors: list[CornerSignature] | None = None,
+) -> dict[int, tuple[CornerSignature, CornerDelta]]:
+    anchors = anchors if anchors is not None else corner_signatures(candidate)
+    unused_ref_sigs = corner_signatures(reference)
+    out: dict[int, tuple[CornerSignature, CornerDelta]] = {}
+    for sig in anchors:
+        ref_sig = _match_corner_signature(sig, unused_ref_sigs)
+        if ref_sig is None:
+            continue
+        unused_ref_sigs.remove(ref_sig)
+        out[sig.index] = (ref_sig, _corner_delta_for_match(candidate, reference, sig, ref_sig))
+    return out
 
 
 def _corner_history_matches(
@@ -512,18 +533,12 @@ def coach_lap(
     """Full per-corner coaching pass over a lap (optionally vs reference, optionally with setup)."""
     corners = segment_corners(lap)
     sigs = corner_signatures(lap, corners)
-    ref_sigs = corner_signatures(reference) if reference is not None else []
     ref_by_idx: dict[int, CornerSignature] = {}
     delta_by_idx: dict[int, CornerDelta] = {}
     if reference is not None:
-        unused_ref_sigs = list(ref_sigs)
-        for sig in sigs:
-            ref_sig = _match_corner_signature(sig, unused_ref_sigs)
-            if ref_sig is None:
-                continue
-            ref_by_idx[sig.index] = ref_sig
-            unused_ref_sigs.remove(ref_sig)
-            delta_by_idx[sig.index] = _corner_delta_for_match(lap, reference, sig, ref_sig)
+        ref_matches = _match_reference_corners(lap, reference, anchors=sigs)
+        ref_by_idx = {idx: ref_sig for idx, (ref_sig, _delta) in ref_matches.items()}
+        delta_by_idx = {idx: delta for idx, (_ref_sig, delta) in ref_matches.items()}
     history_laps = [*(history or []), lap]
     history_matches = (
         _corner_history_matches(history_laps[:-1], sigs) if len(history_laps) >= 2 else {}

--- a/tools/ai_sidecar/lap_dynamics.py
+++ b/tools/ai_sidecar/lap_dynamics.py
@@ -224,6 +224,17 @@ class CornerSignature:
     trail_brake_frac: float  # fraction of entry samples with brake & steer both active
     max_abs_steer: float
     direction: str  # 'left' | 'right' | 'straightish'
+    steering_correction_count: int = 0
+    steering_rate_p95: float = 0.0
+    steering_smoothness_score: float = 100.0
+    steering_scrub_index: float = 0.0
+    gear_at_apex: int | None = None
+    entry_gear: int | None = None
+    exit_gear: int | None = None
+    gear_change_count: int = 0
+    brake_shape: str = "unknown"
+    brake_late_rise_count: int = 0
+    brake_release_smoothness: float = 1.0
 
     def describe(self) -> str:
         bp = "n/a" if self.brake_point_spline is None else f"{self.brake_point_spline:.3f}"
@@ -375,6 +386,9 @@ def _signature(
     steers = [lap.steer[k] for k in seg]
     max_abs_steer = max((abs(s) for s in steers), default=0.0)
     mean_steer = sum(steers) / max(1, len(steers))
+    steering = _steering_metrics(lap, entry_i, apex_i, exit_i, steer_thresh=steer_thresh)
+    gear = _gear_metrics(lap, entry_i, apex_i, exit_i)
+    brake_shape = _brake_shape_metrics(lap, entry_i, apex_i, brake_thresh=brake_thresh)
     direction = (
         "right"
         if mean_steer > steer_thresh
@@ -401,10 +415,143 @@ def _signature(
         trail_brake_frac=round(trail_frac, 3),
         max_abs_steer=round(max_abs_steer, 3),
         direction=direction,
+        steering_correction_count=steering["corrections"],
+        steering_rate_p95=steering["rate_p95"],
+        steering_smoothness_score=steering["smoothness_score"],
+        steering_scrub_index=steering["scrub_index"],
+        gear_at_apex=gear["apex"],
+        entry_gear=gear["entry"],
+        exit_gear=gear["exit"],
+        gear_change_count=gear["changes"],
+        brake_shape=brake_shape["classification"],
+        brake_late_rise_count=brake_shape["late_rises"],
+        brake_release_smoothness=brake_shape["release_smoothness"],
     )
 
 
 # --- geometry / signal helpers ---------------------------------------------
+def _quantile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    pos = max(0, min(len(ordered) - 1, int(round((len(ordered) - 1) * q))))
+    return ordered[pos]
+
+
+def _steering_metrics(
+    lap: LapTrace,
+    entry_i: int,
+    apex_i: int,
+    exit_i: int,
+    *,
+    steer_thresh: float,
+) -> dict[str, float | int]:
+    """Single-lap steering smoothness facts.
+
+    The archive has steering input but no tyre scrub telemetry. We therefore expose an honest
+    *scrub proxy*: high steering rate and repeated corrections while the car is fast and loaded.
+    """
+    seg = list(range(entry_i, exit_i + 1))
+    if len(seg) < 2:
+        return {
+            "corrections": 0,
+            "rate_p95": 0.0,
+            "smoothness_score": 100.0,
+            "scrub_index": 0.0,
+        }
+    rates: list[float] = []
+    signed: list[int] = []
+    scrub_terms: list[float] = []
+    for a, b in zip(seg, seg[1:], strict=False):
+        dt = max(1e-3, lap.t_s[b] - lap.t_s[a])
+        delta = lap.steer[b] - lap.steer[a]
+        rate = abs(delta) / dt
+        rates.append(rate)
+        # Proxy for scrub risk: steering saw while loaded/speedy. It is NOT tyre slip.
+        scrub_terms.append(rate * max(0.0, abs(lap.lat_g[b])) * max(0.0, lap.v_ms[b]) / 50.0)
+    for k in seg:
+        steer = lap.steer[k]
+        if abs(steer) > steer_thresh:
+            signed.append(1 if steer > 0 else -1)
+    corrections = 0
+    last = signed[0] if signed else 0
+    for sign in signed[1:]:
+        if sign != last:
+            corrections += 1
+            last = sign
+    rate_p95 = _quantile(rates, 0.95)
+    scrub = sum(scrub_terms) / max(1, len(scrub_terms))
+    smoothness = 100.0 - min(70.0, rate_p95 * 16.0) - min(30.0, corrections * 8.0)
+    return {
+        "corrections": corrections,
+        "rate_p95": round(rate_p95, 3),
+        "smoothness_score": round(max(0.0, smoothness), 1),
+        "scrub_index": round(scrub, 3),
+    }
+
+
+def _gear_value(value: float) -> int | None:
+    if not math.isfinite(value):
+        return None
+    gear = int(round(value))
+    return gear if gear > 0 else None
+
+
+def _gear_metrics(lap: LapTrace, entry_i: int, apex_i: int, exit_i: int) -> dict[str, int | None]:
+    gears = [_gear_value(lap.gear[k]) for k in range(entry_i, exit_i + 1)]
+    compact = [g for g in gears if g is not None]
+    changes = 0
+    last = compact[0] if compact else None
+    for gear in compact[1:]:
+        if gear != last:
+            changes += 1
+            last = gear
+    return {
+        "entry": _gear_value(lap.gear[entry_i]),
+        "apex": _gear_value(lap.gear[apex_i]),
+        "exit": _gear_value(lap.gear[exit_i]),
+        "changes": changes,
+    }
+
+
+def _brake_shape_metrics(
+    lap: LapTrace,
+    entry_i: int,
+    apex_i: int,
+    *,
+    brake_thresh: float,
+) -> dict[str, float | int | str]:
+    active = [k for k in range(entry_i, apex_i + 1) if lap.brake[k] > brake_thresh]
+    if not active:
+        return {"classification": "no_brake", "late_rises": 0, "release_smoothness": 1.0}
+    peak_i = max(active, key=lambda k: lap.brake[k])
+    peak = lap.brake[peak_i]
+    late_rises = 0
+    max_drop = 0.0
+    late_start = entry_i + max(0, apex_i - entry_i) // 2
+    for a, b in zip(range(late_start, apex_i), range(late_start + 1, apex_i + 1), strict=False):
+        if lap.brake[b] - lap.brake[a] > 0.05:
+            late_rises += 1
+    for a, b in zip(range(peak_i, apex_i), range(peak_i + 1, apex_i + 1), strict=False):
+        delta = lap.brake[b] - lap.brake[a]
+        max_drop = max(max_drop, -delta)
+    release_total = max(0.0, peak - lap.brake[apex_i])
+    release_smoothness = 1.0 if release_total <= 1e-6 else 1.0 - min(1.0, max_drop / release_total)
+    if late_rises >= 2:
+        classification = "increasing_pressure"
+    elif max_drop >= 0.35:
+        classification = "abrupt_release"
+    elif lap.brake[apex_i] >= 0.25:
+        classification = "braking_at_apex"
+    else:
+        classification = "ideal_trace"
+    return {
+        "classification": classification,
+        "late_rises": late_rises,
+        "release_smoothness": round(max(0.0, release_smoothness), 3),
+    }
+
+
 def _menger(a: tuple[float, float], b: tuple[float, float], c: tuple[float, float]) -> float:
     abx, aby = b[0] - a[0], b[1] - a[1]
     cbx, cby = b[0] - c[0], b[1] - c[1]

--- a/tools/ai_sidecar/protocol.py
+++ b/tools/ai_sidecar/protocol.py
@@ -34,6 +34,7 @@ EVENT_CORNER_ADVICE = "corner_advice"
 
 #: A lap archive is at most a few MB; refuse to load anything larger from an archivePath.
 _MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
+_MAX_HISTORY_ARCHIVES = 8
 
 
 def _load_safe_archive_path(raw_path: Any) -> dict[str, Any] | None:
@@ -64,6 +65,18 @@ def _load_safe_archive_path(raw_path: Any) -> dict[str, Any] | None:
         logger.info("brain: could not load archivePath %r: %s", raw_path, exc)
         return None
     return data if isinstance(data, dict) else None
+
+
+def _load_safe_archive_paths(raw_paths: Any) -> list[dict[str, Any]]:
+    """Load a bounded list of safe lap archives, skipping invalid entries."""
+    if not isinstance(raw_paths, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for raw_path in raw_paths[:_MAX_HISTORY_ARCHIVES]:
+        archive = _load_safe_archive_path(raw_path)
+        if archive is not None:
+            out.append(archive)
+    return out
 
 
 def _resolve_lap_archive(inbound: dict[str, Any]) -> dict[str, Any] | None:
@@ -108,11 +121,17 @@ def build_brain_followup(inbound: dict[str, Any]) -> dict[str, Any] | None:
     # corner, "carried too little apex speed"). Without it the brain still emits grip/balance/exit/
     # braking attributions, just no time-loss deltas.
     reference = _load_safe_archive_path(inbound.get("referenceArchivePath"))
+    # optional recent same-session laps: unlocks per-corner consistency metrics. Paths are bounded
+    # and validated exactly like archivePath/referenceArchivePath.
+    history = _load_safe_archive_paths(inbound.get("historyArchivePaths"))
     try:
         from tools.ai_sidecar.coach_report import build_structured_debrief
 
         structured = build_structured_debrief(
-            archive, reference_archive=reference, grip_ceiling_g=grip_ceiling_g
+            archive,
+            reference_archive=reference,
+            history_archives=history,
+            grip_ceiling_g=grip_ceiling_g,
         )
     except Exception as exc:  # the brain must never break the coaching socket
         logger.info("brain debrief raised: %s", exc)


### PR DESCRIPTION
Closes #405.

## Summary
- Adds per-corner diagnosis facts for steering smoothness/corrections, brake-trace shape, gear selection, exit-road usage via reference-path proxy, and lap-to-lap consistency.
- Carries those diagnostics through `coach_lap`, structured debriefs, and `build_brain_followup` as `cornerAnalysis[].diagnostics`.
- Adds bounded `historyArchivePaths` loading for same-session consistency and documents the protocol contract.

## Live reconciliation
- `gh issue view 396 --repo agorokh/ac-copilot-trainer --json number,state,title` returned `CLOSED` for Coach v2, with its body narrowed to delivered scope and deferred follow-ups.
- #405 remains `OPEN`; this PR covers Parts A-D and the Part 0 reconciliation state above.

## Verification
- `python -m pytest -q tests/test_lap_dynamics.py tests/test_corner_attribution.py tests/test_coach_report.py tests/test_brain_wiring.py tests/test_ai_sidecar_protocol.py tests/test_coach_handoff.py tests/test_ai_sidecar_improvement.py` -> 123 passed.
- `python -m ruff check tools/ai_sidecar/lap_dynamics.py tools/ai_sidecar/corner_attribution.py tools/ai_sidecar/coach_report.py tools/ai_sidecar/protocol.py tests/test_lap_dynamics.py tests/test_corner_attribution.py tests/test_coach_report.py tests/test_ai_sidecar_protocol.py` -> all checks passed.
- Git Bash parity: `FLEET_GOVERNANCE_ROOT=$PWD/.fleet-governance-vendor make ci-fast PYTHON=python` -> OK, 1996 passed, 77 skipped, coverage 85.48%.
- Observed sidecar brain path with safe `referenceArchivePath` + `historyArchivePaths`: emitted diagnostics keys `[brake_shape, consistency, exit_road_usage, gear, steering]`, `exit_road_usage.source=reference_path`, `consistency.sample_count=2`.
