### PR TITLE
feat(tt-ingest): build Track Titan harness curriculum (#353)

### DIFF
--- a/docs/10_Development/16_Telemetry_Data_Platform.md
+++ b/docs/10_Development/16_Telemetry_Data_Platform.md
@@ -17,6 +17,27 @@ Derived stores:
   `python -m tools.ai_sidecar.driver_profile`.
 - `journal/tt/index.json` and `journal/tt/sessions_index.json`: derived Track Titan
   indexes rebuilt by the ingest tooling.
+- `journal/tt/**/curriculum_lapN.json`: optional derived Track Titan harness
+  curriculum built from retained `coaching_lapN.json` advice.
+
+## Track Titan Derived Artifacts
+
+Build an M0 reference archive from retained full-lap TT reference windows:
+
+```bash
+python -m tools.tt_ingest reference --discover-lake --session-key <session> --lap <n> --output journal/tt_ref.json
+```
+
+Build an M-TT3 harness curriculum from retained per-corner advice:
+
+```bash
+python -m tools.tt_ingest curriculum --discover-lake --session-key <session> --lap <n> --output journal/tt_curriculum.json
+```
+
+The curriculum artifact preserves TT diagnosis keys, time loss, phase/highlight
+spans, and segment timing as objective rows. It is derived from the write-once
+services evidence; keep the raw `last_session_lapN.json` and `coaching_lapN.json`
+files as the source of truth.
 
 ## Sessions And Stints
 

--- a/docs/10_Development/16_Telemetry_Data_Platform.md
+++ b/docs/10_Development/16_Telemetry_Data_Platform.md
@@ -17,10 +17,11 @@ Derived stores:
   `python -m tools.ai_sidecar.driver_profile`.
 - `journal/tt/index.json` and `journal/tt/sessions_index.json`: derived Track Titan
   indexes rebuilt by the ingest tooling.
-- `journal/tt/**/curriculum_lapN.json` or `journal/tt_curriculum.json`: optional
-  derived Track Titan harness curriculum built from retained `coaching_lapN.json`
-  advice. Curriculum files are not raw TT evidence, are not included in the raw TT
-  content index, and do not count against raw TT retention quotas.
+- `journal/tt/**/curriculum_lapN.json`: optional derived Track Titan harness
+  curriculum built from retained `coaching_lapN.json` advice. Curriculum files are
+  not raw TT evidence and are not included in the raw TT content index. Retention
+  dry-runs show derived curricula as cascade deletes when their paired
+  `coaching_lapN.json` source is pruned; pin/keep markers are honored.
 
 ## Track Titan Derived Artifacts
 
@@ -33,13 +34,15 @@ python -m tools.tt_ingest reference --discover-lake --session-key <session> --la
 Build an M-TT3 harness curriculum from retained per-corner advice:
 
 ```bash
-python -m tools.tt_ingest curriculum --discover-lake --session-key <session> --lap <n> --output journal/tt_curriculum.json
+python -m tools.tt_ingest curriculum --discover-lake --session-key <session> --lap <n> --output journal/tt/<game>/<car>/<track>/<session>/curriculum_lap<n>.json
 ```
 
 The curriculum artifact preserves TT diagnosis keys, time loss, phase/highlight
 spans, and segment timing as objective rows. It is derived from the write-once
 services evidence; keep the raw `last_session_lapN.json` and `coaching_lapN.json`
 files as the indexed source of truth.
+Scratch/debug copies may be written under `.scratch/`; they are outside the TT
+lake lifecycle and should be regenerated after source pruning.
 
 ## Sessions And Stints
 

--- a/docs/10_Development/16_Telemetry_Data_Platform.md
+++ b/docs/10_Development/16_Telemetry_Data_Platform.md
@@ -17,8 +17,10 @@ Derived stores:
   `python -m tools.ai_sidecar.driver_profile`.
 - `journal/tt/index.json` and `journal/tt/sessions_index.json`: derived Track Titan
   indexes rebuilt by the ingest tooling.
-- `journal/tt/**/curriculum_lapN.json`: optional derived Track Titan harness
-  curriculum built from retained `coaching_lapN.json` advice.
+- `journal/tt/**/curriculum_lapN.json` or `journal/tt_curriculum.json`: optional
+  derived Track Titan harness curriculum built from retained `coaching_lapN.json`
+  advice. Curriculum files are not raw TT evidence, are not included in the raw TT
+  content index, and do not count against raw TT retention quotas.
 
 ## Track Titan Derived Artifacts
 
@@ -37,7 +39,7 @@ python -m tools.tt_ingest curriculum --discover-lake --session-key <session> --l
 The curriculum artifact preserves TT diagnosis keys, time loss, phase/highlight
 spans, and segment timing as objective rows. It is derived from the write-once
 services evidence; keep the raw `last_session_lapN.json` and `coaching_lapN.json`
-files as the source of truth.
+files as the indexed source of truth.
 
 ## Sessions And Stints
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -193,3 +193,34 @@ def test_tt_retention_excludes_indexes_and_honors_pins(tmp_path: Path) -> None:
     assert curriculum.exists()
     assert not index.exists()
     assert not sessions_index.exists()
+
+
+def test_tt_retention_cascades_curriculum_when_source_is_deleted(tmp_path: Path) -> None:
+    tt = tmp_path / "journal" / "tt"
+    raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"
+    raw_dir.mkdir(parents=True)
+    source = raw_dir / "coaching_lap5.json"
+    curriculum = raw_dir / "curriculum_lap5.json"
+    survivor = raw_dir / "session.json"
+    source.write_text('{"raw":true}', encoding="utf-8")
+    curriculum.write_text('{"derived":true}', encoding="utf-8")
+    survivor.write_text('{"raw":2}', encoding="utf-8")
+    old = datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+    os.utime(source, (old, old))
+    os.utime(curriculum, (old + 1, old + 1))
+    os.utime(survivor, (old + 2, old + 2))
+
+    plan = plan_retention(
+        tt_dir=tt,
+        policy=RetentionPolicy(max_tt_files=1),
+        profile_path=None,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [source]
+    assert curriculum not in {item.path for item in plan.items}
+    result = apply_retention(plan)
+    assert result.deleted == 2
+    assert not source.exists()
+    assert not curriculum.exists()
+    assert survivor.exists()

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -224,3 +224,33 @@ def test_tt_retention_cascades_curriculum_when_source_is_deleted(tmp_path: Path)
     assert not source.exists()
     assert not curriculum.exists()
     assert survivor.exists()
+
+
+def test_tt_retention_does_not_cascade_curriculum_for_last_session_only(tmp_path: Path) -> None:
+    tt = tmp_path / "journal" / "tt"
+    raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"
+    raw_dir.mkdir(parents=True)
+    source = raw_dir / "last_session_lap5.json"
+    curriculum = raw_dir / "curriculum_lap5.json"
+    survivor = raw_dir / "coaching_lap5.json"
+    source.write_text('{"raw":true}', encoding="utf-8")
+    curriculum.write_text('{"derived":true}', encoding="utf-8")
+    survivor.write_text('{"raw":2}', encoding="utf-8")
+    old = datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+    os.utime(source, (old, old))
+    os.utime(curriculum, (old + 1, old + 1))
+    os.utime(survivor, (old + 2, old + 2))
+
+    plan = plan_retention(
+        tt_dir=tt,
+        policy=RetentionPolicy(max_tt_files=1),
+        profile_path=None,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [source]
+    result = apply_retention(plan)
+    assert result.deleted == 1
+    assert not source.exists()
+    assert curriculum.exists()
+    assert survivor.exists()

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -163,10 +163,12 @@ def test_tt_retention_excludes_indexes_and_honors_pins(tmp_path: Path) -> None:
     raw_dir.mkdir(parents=True)
     delete_me = raw_dir / "session.json"
     keep_me = raw_dir / "coaching_lap1.json"
+    curriculum = raw_dir / "curriculum_lap1.json"
     index = tt / "index.json"
     sessions_index = tt / "sessions_index.json"
     delete_me.write_text('{"raw":1}', encoding="utf-8")
     keep_me.write_text('{"raw":2}', encoding="utf-8")
+    curriculum.write_text('{"derived":true}', encoding="utf-8")
     keep_me.with_suffix(".pin").write_text("manual", encoding="utf-8")
     index.write_text('{"derived":true}', encoding="utf-8")
     sessions_index.write_text('{"derived":true}', encoding="utf-8")
@@ -183,9 +185,11 @@ def test_tt_retention_excludes_indexes_and_honors_pins(tmp_path: Path) -> None:
 
     assert [item.path for item in plan.delete] == [delete_me]
     assert index not in {item.path for item in plan.items}
+    assert curriculum not in {item.path for item in plan.items}
     result = apply_retention(plan)
     assert result.invalidated_indexes == 2
     assert not delete_me.exists()
     assert keep_me.exists()
+    assert curriculum.exists()
     assert not index.exists()
     assert not sessions_index.exists()

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -229,6 +229,70 @@ def test_tt_retention_cascades_curriculum_when_source_is_deleted(tmp_path: Path)
     assert survivor.exists()
 
 
+def test_tt_retention_skips_non_file_curriculum_during_cascade(tmp_path: Path) -> None:
+    tt = tmp_path / "journal" / "tt"
+    raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"
+    raw_dir.mkdir(parents=True)
+    source = raw_dir / "coaching_lap5.json"
+    curriculum_dir = raw_dir / "curriculum_lap5.json"
+    survivor = raw_dir / "session.json"
+    source.write_text('{"raw":true}', encoding="utf-8")
+    curriculum_dir.mkdir()
+    survivor.write_text('{"raw":2}', encoding="utf-8")
+    old = datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+    os.utime(source, (old, old))
+    os.utime(survivor, (old + 2, old + 2))
+
+    plan = plan_retention(
+        tt_dir=tt,
+        policy=RetentionPolicy(max_tt_files=1),
+        profile_path=None,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [source]
+    result = apply_retention(plan)
+    assert result.deleted == 1
+    assert not source.exists()
+    assert curriculum_dir.exists()
+    assert survivor.exists()
+
+
+def test_tt_retention_skips_symlinked_curriculum_during_cascade(tmp_path: Path) -> None:
+    tt = tmp_path / "journal" / "tt"
+    raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"
+    raw_dir.mkdir(parents=True)
+    source = raw_dir / "coaching_lap5.json"
+    curriculum_link = raw_dir / "curriculum_lap5.json"
+    survivor = raw_dir / "session.json"
+    target = tmp_path / "external_curriculum.json"
+    source.write_text('{"raw":true}', encoding="utf-8")
+    target.write_text('{"derived":true}', encoding="utf-8")
+    try:
+        curriculum_link.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unsupported on this platform: {exc!r}")
+    survivor.write_text('{"raw":2}', encoding="utf-8")
+    old = datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+    os.utime(source, (old, old))
+    os.utime(survivor, (old + 2, old + 2))
+
+    plan = plan_retention(
+        tt_dir=tt,
+        policy=RetentionPolicy(max_tt_files=1),
+        profile_path=None,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [source]
+    result = apply_retention(plan)
+    assert result.deleted == 1
+    assert not source.exists()
+    assert curriculum_link.exists()
+    assert target.exists()
+    assert survivor.exists()
+
+
 def test_tt_retention_honors_pinned_curriculum_during_cascade(tmp_path: Path) -> None:
     tt = tmp_path / "journal" / "tt"
     raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -217,12 +217,46 @@ def test_tt_retention_cascades_curriculum_when_source_is_deleted(tmp_path: Path)
         now=datetime(2026, 6, 30, tzinfo=UTC),
     )
 
-    assert [item.path for item in plan.delete] == [source]
-    assert curriculum not in {item.path for item in plan.items}
+    assert [item.path for item in plan.delete] == [source, curriculum]
+    assert curriculum in {item.path for item in plan.items}
+    assert {item.path: item.reasons for item in plan.delete}[curriculum] == (
+        "cascade-from-coaching",
+    )
     result = apply_retention(plan)
     assert result.deleted == 2
     assert not source.exists()
     assert not curriculum.exists()
+    assert survivor.exists()
+
+
+def test_tt_retention_honors_pinned_curriculum_during_cascade(tmp_path: Path) -> None:
+    tt = tmp_path / "journal" / "tt"
+    raw_dir = tt / "assettoCorsa" / "car" / "spa" / "sess"
+    raw_dir.mkdir(parents=True)
+    source = raw_dir / "coaching_lap5.json"
+    curriculum = raw_dir / "curriculum_lap5.json"
+    survivor = raw_dir / "session.json"
+    source.write_text('{"raw":true}', encoding="utf-8")
+    curriculum.write_text('{"derived":true}', encoding="utf-8")
+    curriculum.with_suffix(".pin").write_text("manual", encoding="utf-8")
+    survivor.write_text('{"raw":2}', encoding="utf-8")
+    old = datetime(2026, 1, 1, tzinfo=UTC).timestamp()
+    os.utime(source, (old, old))
+    os.utime(curriculum, (old + 1, old + 1))
+    os.utime(survivor, (old + 2, old + 2))
+
+    plan = plan_retention(
+        tt_dir=tt,
+        policy=RetentionPolicy(max_tt_files=1),
+        profile_path=None,
+        now=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assert [item.path for item in plan.delete] == [source]
+    result = apply_retention(plan)
+    assert result.deleted == 1
+    assert not source.exists()
+    assert curriculum.exists()
     assert survivor.exists()
 
 

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -508,6 +508,20 @@ def test_build_curriculum_from_files_rejects_unapproved_output_root(tmp_path) ->
         )
 
 
+def test_build_curriculum_from_files_rejects_custom_name_inside_tt_lake(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = session_dir / f"{last_session_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="must be named curriculum_lap"):
+        build_curriculum_from_files(
+            coaching_path, output=tmp_path / "journal" / "tt" / "custom.json"
+        )
+
+
 def test_discover_curriculum_payloads_filters_lake(tmp_path) -> None:
     session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     session_dir.mkdir(parents=True)

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -522,6 +522,20 @@ def test_build_curriculum_from_files_rejects_custom_name_inside_tt_lake(tmp_path
         )
 
 
+def test_build_curriculum_from_files_rejects_wrong_lap_name_inside_tt_lake(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = session_dir / f"{last_session_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="output lap must match"):
+        build_curriculum_from_files(
+            coaching_path, output=session_dir / f"{curriculum_endpoint(6)}.json"
+        )
+
+
 def test_discover_curriculum_payloads_filters_lake(tmp_path) -> None:
     session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     session_dir.mkdir(parents=True)
@@ -597,7 +611,7 @@ def test_curriculum_cli_discover_lake_honors_session_override(tmp_path) -> None:
     session_dir.mkdir(parents=True)
     coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
     session_path = tmp_path / "provided_last_session.json"
-    output = tmp_path / "journal" / "tt_curriculum.json"
+    output = session_dir / f"{curriculum_endpoint(5)}.json"
     coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
     session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
 
@@ -627,7 +641,7 @@ def test_curriculum_cli_discover_lake_rejects_session_override_mismatch(tmp_path
     session_dir.mkdir(parents=True)
     coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
     session_path = tmp_path / "wrong_last_session.json"
-    output = tmp_path / "journal" / "tt_curriculum.json"
+    output = session_dir / f"{curriculum_endpoint(5)}.json"
     coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
     session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
 

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -559,6 +559,21 @@ def test_build_curriculum_from_files_validates_lake_base_output_root(tmp_path) -
         )
 
 
+def test_build_curriculum_from_files_rejects_different_session_inside_tt_lake(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    other_session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-2"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = session_dir / f"{last_session_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="must stay next to coaching_lap5.json"):
+        build_curriculum_from_files(
+            coaching_path, output=other_session_dir / f"{curriculum_endpoint(5)}.json"
+        )
+
+
 def test_discover_curriculum_payloads_filters_lake(tmp_path) -> None:
     session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     session_dir.mkdir(parents=True)

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -452,11 +452,17 @@ def test_build_curriculum_from_files_writes_artifact_and_pairs_session(tmp_path)
     session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
     output = session_dir / f"{curriculum_endpoint(5)}.json"
 
-    summary = build_curriculum_from_files(coaching_path, output=output, pretty=True)
+    summary = build_curriculum_from_files(
+        coaching_path,
+        output=output,
+        generated_at="2026-06-30T00:00:00Z",
+        pretty=True,
+    )
 
     curriculum = json.loads(output.read_text(encoding="utf-8"))
     assert summary.objectives == 1
     assert summary.total_time_loss_s == pytest.approx(0.001)
+    assert curriculum["generated_at"] == "2026-06-30T00:00:00Z"
     assert curriculum["session"]["session_key"] == "20260629005756"
     assert curriculum["objectives"][0]["intent"] == "improve_rotation_to_apex"
 

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -479,6 +479,34 @@ def test_build_curriculum_from_files_accepts_utf8_bom_json(tmp_path) -> None:
     assert summary.objectives == 1
 
 
+def test_build_curriculum_from_files_rejects_symlinked_inputs(tmp_path) -> None:
+    real_coaching = tmp_path / "real" / f"{coaching_endpoint(5)}.json"
+    real_session = tmp_path / "real" / f"{last_session_endpoint(5)}.json"
+    real_coaching.parent.mkdir()
+    real_coaching.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    real_session.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    coaching_link = tmp_path / f"{coaching_endpoint(5)}.json"
+    session_link = tmp_path / f"{last_session_endpoint(5)}.json"
+    try:
+        coaching_link.symlink_to(real_coaching)
+        session_link.symlink_to(real_session)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unsupported on this platform: {exc!r}")
+
+    with pytest.raises(TTNormalizeError, match="coaching input must be a regular file"):
+        build_curriculum_from_files(
+            coaching_link,
+            session_path=real_session,
+            output=tmp_path / f"{curriculum_endpoint(5)}.json",
+        )
+    with pytest.raises(TTNormalizeError, match="last-session input must be a regular file"):
+        build_curriculum_from_files(
+            real_coaching,
+            session_path=session_link,
+            output=tmp_path / f"{curriculum_endpoint(5)}.json",
+        )
+
+
 def test_build_curriculum_from_files_refuses_overwrite_input(tmp_path) -> None:
     coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
     session_path = tmp_path / f"{last_session_endpoint(5)}.json"

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -593,7 +593,7 @@ def test_curriculum_cli_writes_from_explicit_input(tmp_path, capsys) -> None:
 
 
 def test_curriculum_cli_discover_lake_honors_session_override(tmp_path) -> None:
-    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "20260629005756"
     session_dir.mkdir(parents=True)
     coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
     session_path = tmp_path / "provided_last_session.json"
@@ -608,7 +608,7 @@ def test_curriculum_cli_discover_lake_honors_session_override(tmp_path) -> None:
             "--lake-base",
             str(tmp_path),
             "--session-key",
-            "sess-1",
+            "20260629005756",
             "--lap",
             "5",
             "--session",
@@ -620,6 +620,34 @@ def test_curriculum_cli_discover_lake_honors_session_override(tmp_path) -> None:
 
     assert rc == 0
     assert json.loads(output.read_text(encoding="utf-8"))["summary"]["objectives"] == 1
+
+
+def test_curriculum_cli_discover_lake_rejects_session_override_mismatch(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = tmp_path / "wrong_last_session.json"
+    output = tmp_path / "journal" / "tt_curriculum.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "curriculum",
+                "--discover-lake",
+                "--lake-base",
+                str(tmp_path),
+                "--session-key",
+                "sess-1",
+                "--lap",
+                "5",
+                "--session",
+                str(session_path),
+                "--output",
+                str(output),
+            ]
+        )
 
 
 def test_curriculum_cli_requires_one_input_mode(tmp_path) -> None:

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -536,6 +536,29 @@ def test_build_curriculum_from_files_rejects_wrong_lap_name_inside_tt_lake(tmp_p
         )
 
 
+def test_build_curriculum_from_files_validates_lake_base_output_root(tmp_path) -> None:
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    coaching_path = input_dir / f"{coaching_endpoint(5)}.json"
+    session_path = input_dir / f"{last_session_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    output_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+
+    with pytest.raises(TTNormalizeError, match="must be named curriculum_lap"):
+        build_curriculum_from_files(
+            coaching_path,
+            output=output_dir / "custom.json",
+            output_base=tmp_path,
+        )
+    with pytest.raises(TTNormalizeError, match="output lap must match"):
+        build_curriculum_from_files(
+            coaching_path,
+            output=output_dir / f"{curriculum_endpoint(6)}.json",
+            output_base=tmp_path,
+        )
+
+
 def test_discover_curriculum_payloads_filters_lake(tmp_path) -> None:
     session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     session_dir.mkdir(parents=True)

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -570,7 +570,7 @@ def test_build_curriculum_from_files_rejects_wrong_lap_name_inside_tt_lake(tmp_p
         )
 
 
-def test_build_curriculum_from_files_validates_lake_base_output_root(tmp_path) -> None:
+def test_build_curriculum_from_files_rejects_external_input_inside_tt_lake(tmp_path) -> None:
     input_dir = tmp_path / "inputs"
     input_dir.mkdir()
     coaching_path = input_dir / f"{coaching_endpoint(5)}.json"
@@ -579,16 +579,10 @@ def test_build_curriculum_from_files_validates_lake_base_output_root(tmp_path) -
     session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
     output_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
 
-    with pytest.raises(TTNormalizeError, match="must be named curriculum_lap"):
+    with pytest.raises(TTNormalizeError, match="require coaching input from the same journal/tt"):
         build_curriculum_from_files(
             coaching_path,
-            output=output_dir / "custom.json",
-            output_base=tmp_path,
-        )
-    with pytest.raises(TTNormalizeError, match="output lap must match"):
-        build_curriculum_from_files(
-            coaching_path,
-            output=output_dir / f"{curriculum_endpoint(6)}.json",
+            output=output_dir / f"{curriculum_endpoint(5)}.json",
             output_base=tmp_path,
         )
 

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -16,8 +16,11 @@ from tools.tt_ingest.cli import (
     INDEX_FILENAME,
     SESSIONS_INDEX_FILENAME,
     build_arg_parser,
+    build_curriculum_from_files,
     build_reference_archive_from_files,
     coaching_endpoint,
+    curriculum_endpoint,
+    discover_curriculum_payloads,
     discover_reference_payloads,
     last_session_endpoint,
     last_session_window_endpoint,
@@ -29,6 +32,10 @@ from tools.tt_ingest.tt_normalize import TTNormalizeError
 
 FIXTURE = Path(__file__).parent / "fixtures" / "tt_sessions_page.json"
 LAST_SESSION_FIXTURE = Path(__file__).parent / "fixtures" / "tt_services_last_session.json"
+DYNAMIC_REFERENCE_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "tt_services_dynamic_reference.json"
+)
+ADVICE_FIXTURE = Path(__file__).parent / "fixtures" / "tt_services_advice.json"
 
 
 def _sessions() -> list[dict]:
@@ -46,6 +53,17 @@ def _bundle() -> dict:
         "segments": [
             {"segment": 1, "stories": [{"diagnosis": "Brake later", "time_loss": 0.12}]},
             {"segment": 2, "stories": [{"diagnosis": "Good corner", "time_loss": 0.0}]},
+        ],
+    }
+
+
+def _curriculum_bundle() -> dict:
+    return {
+        "reference_lap": json.loads(DYNAMIC_REFERENCE_FIXTURE.read_text(encoding="utf-8"))["lap"],
+        "dynamic_reference": ["ref-uid-002", "20220611194228"],
+        "advice_reference": ["fake-uid-001", "20260629005756", "theoreticalBestRef"],
+        "segments": [
+            {"segment": 3, "advice_raw": json.loads(ADVICE_FIXTURE.read_text(encoding="utf-8"))}
         ],
     }
 
@@ -247,6 +265,18 @@ def test_retain_coaching_indexes_endpoint_files(tmp_path) -> None:
     assert summary.indexed == file_index["file_count"] >= 2
 
 
+def test_reindex_lake_includes_curriculum_endpoint(tmp_path) -> None:
+    root = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    root.mkdir(parents=True)
+    (root / f"{curriculum_endpoint(5)}.json").write_text("{}", encoding="utf-8")
+
+    indexed = retain_sessions([], lake_base=tmp_path, generated_at="2026-06-30T00:00:00Z").indexed
+
+    file_index = json.loads((tmp_path / "journal" / "tt" / INDEX_FILENAME).read_text())
+    assert indexed == 1
+    assert file_index["files"][0]["endpoint"] == curriculum_endpoint(5)
+
+
 def test_retain_coaching_keys_on_given_session(tmp_path) -> None:
     # The lake key comes from the GIVEN session (game/car/track/session_key); a car object
     # (sessions-list shape) is unwrapped to its string id, never a dict-repr (#353 review).
@@ -408,6 +438,87 @@ def test_reference_cli_writes_from_explicit_input(tmp_path, capsys) -> None:
 def test_reference_cli_requires_one_input_mode(tmp_path) -> None:
     with pytest.raises(SystemExit):
         main(["reference", "--output", str(tmp_path / "ref.json")])
+
+
+# --- harness curriculum (M-TT3) ---------------------------------------------------
+
+
+def test_build_curriculum_from_files_writes_artifact_and_pairs_session(tmp_path) -> None:
+    session_dir = tmp_path / "lake" / "assettoCorsa" / "car" / "track" / "20260629005756"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = session_dir / f"{last_session_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    output = session_dir / f"{curriculum_endpoint(5)}.json"
+
+    summary = build_curriculum_from_files(coaching_path, output=output, pretty=True)
+
+    curriculum = json.loads(output.read_text(encoding="utf-8"))
+    assert summary.objectives == 1
+    assert summary.total_time_loss_s == pytest.approx(0.001)
+    assert curriculum["session"]["session_key"] == "20260629005756"
+    assert curriculum["objectives"][0]["intent"] == "improve_rotation_to_apex"
+
+
+def test_build_curriculum_from_files_accepts_utf8_bom_json(tmp_path) -> None:
+    coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
+    output = tmp_path / f"{curriculum_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8-sig")
+
+    summary = build_curriculum_from_files(coaching_path, output=output)
+
+    assert summary.objectives == 1
+
+
+def test_build_curriculum_from_files_refuses_overwrite_input(tmp_path) -> None:
+    coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="must not overwrite retained input"):
+        build_curriculum_from_files(coaching_path, output=coaching_path, overwrite=True)
+
+
+def test_discover_curriculum_payloads_filters_lake(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = session_dir / f"{last_session_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    assert discover_curriculum_payloads(lake_base=tmp_path, session_key="sess-1", lap=5) == (
+        coaching_path,
+        session_path,
+    )
+    with pytest.raises(TTNormalizeError, match="no retained coaching"):
+        discover_curriculum_payloads(lake_base=tmp_path, session_key="sess-2", lap=5)
+
+
+def test_curriculum_cli_writes_from_explicit_input(tmp_path, capsys) -> None:
+    coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
+    output = tmp_path / "curriculum.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+
+    rc = main(
+        [
+            "curriculum",
+            "--coaching",
+            str(coaching_path),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
+    assert output.exists()
+    assert "TT harness curriculum" in capsys.readouterr().out
+    assert json.loads(output.read_text(encoding="utf-8"))["summary"]["objectives"] == 1
+
+
+def test_curriculum_cli_requires_one_input_mode(tmp_path) -> None:
+    with pytest.raises(SystemExit):
+        main(["curriculum", "--output", str(tmp_path / "curriculum.json")])
 
 
 def test_parser_requires_subcommand() -> None:

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -265,7 +265,7 @@ def test_retain_coaching_indexes_endpoint_files(tmp_path) -> None:
     assert summary.indexed == file_index["file_count"] >= 2
 
 
-def test_reindex_lake_includes_curriculum_endpoint(tmp_path) -> None:
+def test_reindex_lake_excludes_curriculum_endpoint(tmp_path) -> None:
     root = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
     root.mkdir(parents=True)
     (root / f"{curriculum_endpoint(5)}.json").write_text("{}", encoding="utf-8")
@@ -273,8 +273,8 @@ def test_reindex_lake_includes_curriculum_endpoint(tmp_path) -> None:
     indexed = retain_sessions([], lake_base=tmp_path, generated_at="2026-06-30T00:00:00Z").indexed
 
     file_index = json.loads((tmp_path / "journal" / "tt" / INDEX_FILENAME).read_text())
-    assert indexed == 1
-    assert file_index["files"][0]["endpoint"] == curriculum_endpoint(5)
+    assert indexed == 0
+    assert file_index["files"] == []
 
 
 def test_retain_coaching_keys_on_given_session(tmp_path) -> None:
@@ -463,8 +463,10 @@ def test_build_curriculum_from_files_writes_artifact_and_pairs_session(tmp_path)
 
 def test_build_curriculum_from_files_accepts_utf8_bom_json(tmp_path) -> None:
     coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
+    session_path = tmp_path / f"{last_session_endpoint(5)}.json"
     output = tmp_path / f"{curriculum_endpoint(5)}.json"
     coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8-sig")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
 
     summary = build_curriculum_from_files(coaching_path, output=output)
 
@@ -473,10 +475,37 @@ def test_build_curriculum_from_files_accepts_utf8_bom_json(tmp_path) -> None:
 
 def test_build_curriculum_from_files_refuses_overwrite_input(tmp_path) -> None:
     coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
+    session_path = tmp_path / f"{last_session_endpoint(5)}.json"
     coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
 
     with pytest.raises(TTNormalizeError, match="must not overwrite retained input"):
         build_curriculum_from_files(coaching_path, output=coaching_path, overwrite=True)
+
+
+def test_build_curriculum_from_files_requires_session_payload(tmp_path) -> None:
+    coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="no paired last-session payload"):
+        build_curriculum_from_files(
+            coaching_path, output=tmp_path / f"{curriculum_endpoint(5)}.json"
+        )
+
+
+def test_build_curriculum_from_files_rejects_unapproved_output_root(tmp_path) -> None:
+    session_dir = tmp_path / "lake" / "assettoCorsa" / "car" / "track" / "sess-1"
+    other_dir = tmp_path / "elsewhere"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = session_dir / f"{last_session_endpoint(5)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="curriculum output must stay"):
+        build_curriculum_from_files(
+            coaching_path, output=other_dir / f"{curriculum_endpoint(5)}.json"
+        )
 
 
 def test_discover_curriculum_payloads_filters_lake(tmp_path) -> None:
@@ -495,10 +524,27 @@ def test_discover_curriculum_payloads_filters_lake(tmp_path) -> None:
         discover_curriculum_payloads(lake_base=tmp_path, session_key="sess-2", lap=5)
 
 
+def test_discover_curriculum_payloads_pairs_window_when_base_missing(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir.mkdir(parents=True)
+    raw = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = session_dir / f"{last_session_window_endpoint(5, raw)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    assert discover_curriculum_payloads(lake_base=tmp_path, session_key="sess-1", lap=5) == (
+        coaching_path,
+        session_path,
+    )
+
+
 def test_curriculum_cli_writes_from_explicit_input(tmp_path, capsys) -> None:
     coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
+    session_path = tmp_path / f"{last_session_endpoint(5)}.json"
     output = tmp_path / "curriculum.json"
     coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
 
     rc = main(
         [

--- a/tests/test_tt_ingest_cli.py
+++ b/tests/test_tt_ingest_cli.py
@@ -553,6 +553,22 @@ def test_discover_curriculum_payloads_pairs_window_when_base_missing(tmp_path) -
     )
 
 
+def test_discover_curriculum_payloads_rejects_ambiguous_session_windows(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir.mkdir(parents=True)
+    raw = json.loads(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"))
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    base_path = session_dir / f"{last_session_endpoint(5)}.json"
+    window_path = session_dir / f"{last_session_window_endpoint(5, raw)}.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    base_path.write_text(json.dumps(raw), encoding="utf-8")
+    raw["data"]["telemetry"]["telemetry"]["reference"][0]["dist"] = 0.444444
+    window_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(TTNormalizeError, match="multiple paired last-session payloads"):
+        discover_curriculum_payloads(lake_base=tmp_path, session_key="sess-1", lap=5)
+
+
 def test_curriculum_cli_writes_from_explicit_input(tmp_path, capsys) -> None:
     coaching_path = tmp_path / f"{coaching_endpoint(5)}.json"
     session_path = tmp_path / f"{last_session_endpoint(5)}.json"
@@ -573,6 +589,36 @@ def test_curriculum_cli_writes_from_explicit_input(tmp_path, capsys) -> None:
     assert rc == 0
     assert output.exists()
     assert "TT harness curriculum" in capsys.readouterr().out
+    assert json.loads(output.read_text(encoding="utf-8"))["summary"]["objectives"] == 1
+
+
+def test_curriculum_cli_discover_lake_honors_session_override(tmp_path) -> None:
+    session_dir = tmp_path / "journal" / "tt" / "assettoCorsa" / "car" / "track" / "sess-1"
+    session_dir.mkdir(parents=True)
+    coaching_path = session_dir / f"{coaching_endpoint(5)}.json"
+    session_path = tmp_path / "provided_last_session.json"
+    output = tmp_path / "journal" / "tt_curriculum.json"
+    coaching_path.write_text(json.dumps(_curriculum_bundle()), encoding="utf-8")
+    session_path.write_text(LAST_SESSION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    rc = main(
+        [
+            "curriculum",
+            "--discover-lake",
+            "--lake-base",
+            str(tmp_path),
+            "--session-key",
+            "sess-1",
+            "--lap",
+            "5",
+            "--session",
+            str(session_path),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
     assert json.loads(output.read_text(encoding="utf-8"))["summary"]["objectives"] == 1
 
 

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -356,6 +356,7 @@ def test_build_harness_curriculum_maps_tt_advice_to_objective() -> None:
     )
 
     assert curriculum["format"] == TT_CURRICULUM_FORMAT
+    assert curriculum["generator"]["decision_issue"] == 353
     assert curriculum["session"]["car_id"] == "ks_porsche_911_gt3_r_2016"
     assert curriculum["session"]["track_id"] == "magione"
     assert curriculum["reference"]["username"] == "Reference Driver"

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -374,9 +374,9 @@ def test_build_harness_curriculum_maps_tt_advice_to_objective() -> None:
         "start": 0.04054,
         "end": 0.073504,
     }
-    assert objective["targets"]["reference_segment_time_ms"] == pytest.approx(8765.1)
+    assert objective["targets"]["reference_segment_time_ms"] is None
     assert objective["targets"]["driver_segment_time_ms"] == pytest.approx(10815.7)
-    assert objective["targets"]["segment_delta_ms"] == pytest.approx(2050.6)
+    assert objective["targets"]["segment_delta_ms"] is None
     assert objective["harness"]["acceptance"]["baseline_s"] == pytest.approx(0.001)
 
 
@@ -387,6 +387,20 @@ def test_build_harness_curriculum_uses_unwrapped_session_timing() -> None:
 
     objective = curriculum["objectives"][0]
     assert objective["targets"]["driver_segment_time_ms"] == pytest.approx(10815.7)
+    assert objective["targets"]["segment_delta_ms"] is None
+
+
+def test_build_harness_curriculum_uses_reference_times_when_advice_reference_matches() -> None:
+    bundle = _curriculum_bundle()
+    bundle["advice_reference"] = list(bundle["dynamic_reference"])
+
+    curriculum = build_harness_curriculum(
+        bundle,
+        session_payload=_load_fixture("tt_services_last_session.json"),
+    )
+
+    objective = curriculum["objectives"][0]
+    assert objective["targets"]["reference_segment_time_ms"] == pytest.approx(8765.1)
     assert objective["targets"]["segment_delta_ms"] == pytest.approx(2050.6)
 
 

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -11,8 +11,10 @@ from tools.ac_harness.reference_lap import validate_lap_archive_record
 from tools.tt_ingest.tt_normalize import (
     DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
     INDEX_SCHEMA_VERSION,
+    TT_CURRICULUM_FORMAT,
     TT_REFERENCE_IMPORT_FORMAT,
     TTNormalizeError,
+    build_harness_curriculum,
     build_reference_archive,
     build_sessions_index,
     normalize_session,
@@ -23,10 +25,15 @@ from tools.tt_ingest.tt_normalize import (
 )
 
 FIXTURE = Path(__file__).parent / "fixtures" / "tt_sessions_page.json"
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def _sessions() -> list[dict]:
     return json.loads(FIXTURE.read_text(encoding="utf-8"))["data"]["sessions"]
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
 
 
 def test_split_session_id() -> None:
@@ -327,3 +334,54 @@ def test_build_reference_archive_rejects_mixed_sessions() -> None:
                 _session_payload(0.5, 1.0, session_key="sess-b"),
             ],
         )
+
+
+def _curriculum_bundle() -> dict:
+    return {
+        "reference_lap": _load_fixture("tt_services_dynamic_reference.json")["lap"],
+        "dynamic_reference": ["ref-uid-002", "20220611194228"],
+        "advice_reference": ["fake-uid-001", "20260629005756", "theoreticalBestRef"],
+        "segments": [
+            {"segment": 3, "advice_raw": _load_fixture("tt_services_advice.json")},
+            {"segment": 4, "stories": [{"diagnosis": "Good corner", "time_loss": 0.0}]},
+        ],
+    }
+
+
+def test_build_harness_curriculum_maps_tt_advice_to_objective() -> None:
+    curriculum = build_harness_curriculum(
+        _curriculum_bundle(),
+        session_payload=_load_fixture("tt_services_last_session.json"),
+        exported_at="2026-06-30T00:00:00Z",
+    )
+
+    assert curriculum["format"] == TT_CURRICULUM_FORMAT
+    assert curriculum["session"]["car_id"] == "ks_porsche_911_gt3_r_2016"
+    assert curriculum["session"]["track_id"] == "magione"
+    assert curriculum["reference"]["username"] == "Reference Driver"
+    assert curriculum["summary"] == {
+        "segments": 2,
+        "objectives": 1,
+        "total_time_loss_s": 0.001,
+        "primary_objective_id": "tt-c03-coaching-diagnosis-rotation-insufficient-1",
+    }
+    objective = curriculum["objectives"][0]
+    assert objective["corner"] == 3
+    assert objective["skill"] == "rotation"
+    assert objective["intent"] == "improve_rotation_to_apex"
+    assert objective["diagnosis_key"] == "coaching.diagnosis.rotation_insufficient"
+    assert objective["highlight_norm"] == {
+        "start": 0.04054,
+        "end": 0.073504,
+    }
+    assert objective["targets"]["reference_segment_time_ms"] == pytest.approx(8765.1)
+    assert objective["targets"]["driver_segment_time_ms"] == pytest.approx(10815.7)
+    assert objective["targets"]["segment_delta_ms"] == pytest.approx(2050.6)
+    assert objective["harness"]["acceptance"]["baseline_s"] == pytest.approx(0.001)
+
+
+def test_build_harness_curriculum_filters_non_actionable_stories() -> None:
+    curriculum = build_harness_curriculum(_curriculum_bundle(), min_time_loss_s=0.01)
+
+    assert curriculum["objectives"] == []
+    assert curriculum["summary"]["objectives"] == 0

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -380,6 +380,16 @@ def test_build_harness_curriculum_maps_tt_advice_to_objective() -> None:
     assert objective["harness"]["acceptance"]["baseline_s"] == pytest.approx(0.001)
 
 
+def test_build_harness_curriculum_uses_unwrapped_session_timing() -> None:
+    session = _load_fixture("tt_services_last_session.json")["data"]["session"]
+
+    curriculum = build_harness_curriculum(_curriculum_bundle(), session_payload=session)
+
+    objective = curriculum["objectives"][0]
+    assert objective["targets"]["driver_segment_time_ms"] == pytest.approx(10815.7)
+    assert objective["targets"]["segment_delta_ms"] == pytest.approx(2050.6)
+
+
 def test_build_harness_curriculum_filters_non_actionable_stories() -> None:
     curriculum = build_harness_curriculum(_curriculum_bundle(), min_time_loss_s=0.01)
 

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -412,6 +412,19 @@ def test_build_harness_curriculum_filters_non_actionable_stories() -> None:
     assert curriculum["summary"]["objectives"] == 0
 
 
+def test_build_harness_curriculum_rejects_fractional_segment_numbers() -> None:
+    bundle = _curriculum_bundle()
+    bundle["segments"][0]["segment"] = "3.9"
+
+    curriculum = build_harness_curriculum(
+        bundle,
+        session_payload=_load_fixture("tt_services_last_session.json"),
+    )
+
+    assert curriculum["objectives"] == []
+    assert curriculum["summary"]["objectives"] == 0
+
+
 def test_build_harness_curriculum_falls_back_when_advice_raw_is_malformed() -> None:
     bundle = _curriculum_bundle()
     bundle["segments"][0] = {

--- a/tests/test_tt_normalize.py
+++ b/tests/test_tt_normalize.py
@@ -385,3 +385,26 @@ def test_build_harness_curriculum_filters_non_actionable_stories() -> None:
 
     assert curriculum["objectives"] == []
     assert curriculum["summary"]["objectives"] == 0
+
+
+def test_build_harness_curriculum_falls_back_when_advice_raw_is_malformed() -> None:
+    bundle = _curriculum_bundle()
+    bundle["segments"][0] = {
+        "segment": 3,
+        "advice_raw": {"success": True, "data": []},
+        "stories": [
+            {
+                "diagnosis": "Turn in earlier",
+                "diagnosis_key": "coaching.diagnosis.rotation_insufficient",
+                "time_loss": 0.2,
+            }
+        ],
+    }
+
+    curriculum = build_harness_curriculum(
+        bundle,
+        session_payload=_load_fixture("tt_services_last_session.json"),
+    )
+
+    assert curriculum["summary"]["objectives"] == 1
+    assert curriculum["objectives"][0]["time_loss_s"] == pytest.approx(0.2)

--- a/tools/coaching_lake/retention.py
+++ b/tools/coaching_lake/retention.py
@@ -20,6 +20,10 @@ from tools.lap_archive_export import LapArchiveExportError, iter_lap_archive_pat
 
 DERIVED_TT_INDEXES = frozenset({"index.json", "sessions_index.json"})
 DERIVED_TT_PATTERNS = ("curriculum_lap*.json",)
+TT_COACHING_PREFIX = "coaching_lap"
+TT_LAST_SESSION_PREFIX = "last_session_lap"
+TT_LAST_SESSION_WINDOW_MARKER = "_window_"
+TT_CURRICULUM_PREFIX = "curriculum_lap"
 
 
 @dataclass(frozen=True)
@@ -274,6 +278,19 @@ def _tt_index_paths_for_deleted(items: Sequence[RetentionItem]) -> list[Path]:
     )
 
 
+def _curriculum_path_for_tt_source(path: Path) -> Path | None:
+    stem = path.stem
+    lap: str | None = None
+    if stem.startswith(TT_COACHING_PREFIX):
+        lap = stem[len(TT_COACHING_PREFIX) :]
+    elif stem.startswith(TT_LAST_SESSION_PREFIX):
+        tail = stem[len(TT_LAST_SESSION_PREFIX) :]
+        lap = tail.split(TT_LAST_SESSION_WINDOW_MARKER, 1)[0]
+    if not lap:
+        return None
+    return path.with_name(f"{TT_CURRICULUM_PREFIX}{lap}.json")
+
+
 def plan_retention(
     *,
     lap_dir: str | Path | None = None,
@@ -339,6 +356,16 @@ def apply_retention(plan: RetentionPlan) -> RetentionApplyResult:
         bytes_deleted += item.bytes
         if item.domain == "tt":
             deleted_tt_items.append(item)
+            curriculum_path = _curriculum_path_for_tt_source(item.path)
+            if curriculum_path is not None and curriculum_path.exists():
+                try:
+                    curriculum_size = curriculum_path.stat().st_size
+                    curriculum_path.unlink()
+                except OSError as exc:
+                    failures.append(f"{curriculum_path}: {exc}")
+                else:
+                    deleted += 1
+                    bytes_deleted += curriculum_size
     invalidated_indexes = 0
     for index_path in _tt_index_paths_for_deleted(deleted_tt_items):
         try:

--- a/tools/coaching_lake/retention.py
+++ b/tools/coaching_lake/retention.py
@@ -285,6 +285,33 @@ def _curriculum_path_for_tt_source(path: Path) -> Path | None:
     return path.with_name(f"{CURRICULUM_ENDPOINT_PREFIX}{lap}.json")
 
 
+def _cascade_tt_items(items: Sequence[RetentionItem]) -> list[RetentionItem]:
+    cascade: list[RetentionItem] = []
+    seen: set[Path] = set()
+    for item in items:
+        curriculum_path = _curriculum_path_for_tt_source(item.path)
+        if curriculum_path is None or curriculum_path in seen:
+            continue
+        seen.add(curriculum_path)
+        if not curriculum_path.exists() or _has_pin_marker(curriculum_path):
+            continue
+        try:
+            size = curriculum_path.stat().st_size
+        except OSError:
+            size = 0
+        cascade.append(
+            RetentionItem(
+                path=curriculum_path,
+                domain="tt",
+                protected=False,
+                reasons=("cascade-from-coaching",),
+                sort_time=item.sort_time,
+                bytes=size,
+            )
+        )
+    return cascade
+
+
 def plan_retention(
     *,
     lap_dir: str | Path | None = None,
@@ -313,15 +340,17 @@ def plan_retention(
 
     if tt_dir is not None:
         tt_items = _tt_items(Path(tt_dir))
-        items.extend(tt_items)
-        delete.extend(
-            _select_by_cap(
-                tt_items,
-                max_files=policy.max_tt_files,
-                max_age_days=policy.max_tt_age_days,
-                now=stamp,
-            )
+        tt_delete = _select_by_cap(
+            tt_items,
+            max_files=policy.max_tt_files,
+            max_age_days=policy.max_tt_age_days,
+            now=stamp,
         )
+        tt_cascade = _cascade_tt_items(tt_delete)
+        items.extend(tt_items)
+        items.extend(tt_cascade)
+        delete.extend(tt_delete)
+        delete.extend(tt_cascade)
 
     return RetentionPlan(
         policy=policy,
@@ -350,16 +379,6 @@ def apply_retention(plan: RetentionPlan) -> RetentionApplyResult:
         bytes_deleted += item.bytes
         if item.domain == "tt":
             deleted_tt_items.append(item)
-            curriculum_path = _curriculum_path_for_tt_source(item.path)
-            if curriculum_path is not None and curriculum_path.exists():
-                try:
-                    curriculum_size = curriculum_path.stat().st_size
-                    curriculum_path.unlink()
-                except OSError as exc:
-                    failures.append(f"{curriculum_path}: {exc}")
-                else:
-                    deleted += 1
-                    bytes_deleted += curriculum_size
     invalidated_indexes = 0
     for index_path in _tt_index_paths_for_deleted(deleted_tt_items):
         try:

--- a/tools/coaching_lake/retention.py
+++ b/tools/coaching_lake/retention.py
@@ -293,7 +293,11 @@ def _cascade_tt_items(items: Sequence[RetentionItem]) -> list[RetentionItem]:
         if curriculum_path is None or curriculum_path in seen:
             continue
         seen.add(curriculum_path)
-        if not curriculum_path.exists() or _has_pin_marker(curriculum_path):
+        if (
+            curriculum_path.is_symlink()
+            or not curriculum_path.is_file()
+            or _has_pin_marker(curriculum_path)
+        ):
             continue
         try:
             size = curriculum_path.stat().st_size

--- a/tools/coaching_lake/retention.py
+++ b/tools/coaching_lake/retention.py
@@ -19,6 +19,7 @@ from tools.ai_sidecar.driver_profile import DEFAULT_PROFILE_PATH, load_profile
 from tools.lap_archive_export import LapArchiveExportError, iter_lap_archive_paths, load_lap_archive
 
 DERIVED_TT_INDEXES = frozenset({"index.json", "sessions_index.json"})
+DERIVED_TT_PATTERNS = ("curriculum_lap*.json",)
 
 
 @dataclass(frozen=True)
@@ -192,7 +193,9 @@ def _tt_raw_paths(tt_dir: Path) -> Iterable[Path]:
     return (
         path
         for path in sorted(tt_dir.rglob("*.json"))
-        if path.is_file() and path.name not in DERIVED_TT_INDEXES
+        if path.is_file()
+        and path.name not in DERIVED_TT_INDEXES
+        and not any(path.match(pattern) for pattern in DERIVED_TT_PATTERNS)
     )
 
 

--- a/tools/coaching_lake/retention.py
+++ b/tools/coaching_lake/retention.py
@@ -17,13 +17,10 @@ from typing import Any
 
 from tools.ai_sidecar.driver_profile import DEFAULT_PROFILE_PATH, load_profile
 from tools.lap_archive_export import LapArchiveExportError, iter_lap_archive_paths, load_lap_archive
+from tools.tt_ingest.tt_export import COACHING_ENDPOINT_PREFIX, CURRICULUM_ENDPOINT_PREFIX
 
 DERIVED_TT_INDEXES = frozenset({"index.json", "sessions_index.json"})
-DERIVED_TT_PATTERNS = ("curriculum_lap*.json",)
-TT_COACHING_PREFIX = "coaching_lap"
-TT_LAST_SESSION_PREFIX = "last_session_lap"
-TT_LAST_SESSION_WINDOW_MARKER = "_window_"
-TT_CURRICULUM_PREFIX = "curriculum_lap"
+DERIVED_TT_PATTERNS = (f"{CURRICULUM_ENDPOINT_PREFIX}*.json",)
 
 
 @dataclass(frozen=True)
@@ -280,15 +277,12 @@ def _tt_index_paths_for_deleted(items: Sequence[RetentionItem]) -> list[Path]:
 
 def _curriculum_path_for_tt_source(path: Path) -> Path | None:
     stem = path.stem
-    lap: str | None = None
-    if stem.startswith(TT_COACHING_PREFIX):
-        lap = stem[len(TT_COACHING_PREFIX) :]
-    elif stem.startswith(TT_LAST_SESSION_PREFIX):
-        tail = stem[len(TT_LAST_SESSION_PREFIX) :]
-        lap = tail.split(TT_LAST_SESSION_WINDOW_MARKER, 1)[0]
+    if not stem.startswith(COACHING_ENDPOINT_PREFIX):
+        return None
+    lap = stem[len(COACHING_ENDPOINT_PREFIX) :]
     if not lap:
         return None
-    return path.with_name(f"{TT_CURRICULUM_PREFIX}{lap}.json")
+    return path.with_name(f"{CURRICULUM_ENDPOINT_PREFIX}{lap}.json")
 
 
 def plan_retention(

--- a/tools/tt_ingest/__init__.py
+++ b/tools/tt_ingest/__init__.py
@@ -13,10 +13,13 @@ Cognito identifiers are hardcoded (env-overridable). See :mod:`tools.tt_ingest.t
 from __future__ import annotations
 
 from tools.tt_ingest.cli import (
+    CurriculumSummary,
     ExportSummary,
     ReferenceArchiveSummary,
     build_arg_parser,
+    build_curriculum_from_files,
     build_reference_archive_from_files,
+    discover_curriculum_payloads,
     discover_reference_payloads,
     main,
     reindex_lake,
@@ -48,7 +51,9 @@ from tools.tt_ingest.tt_export import (
     write_immutable_json,
 )
 from tools.tt_ingest.tt_normalize import (
+    TT_CURRICULUM_FORMAT,
     TTNormalizeError,
+    build_harness_curriculum,
     build_reference_archive,
     build_sessions_index,
     normalize_session,
@@ -65,6 +70,7 @@ from tools.tt_ingest.tt_vulcan import (
 )
 
 __all__ = [
+    "CurriculumSummary",
     "ExportSummary",
     "MintedTokens",
     "ReferenceArchiveSummary",
@@ -72,17 +78,21 @@ __all__ = [
     "SessionsPage",
     "TTAuthError",
     "TTConfig",
+    "TT_CURRICULUM_FORMAT",
     "TTExportError",
     "TTNormalizeError",
     "TTVulcanError",
     "WriteResult",
     "build_arg_parser",
+    "build_curriculum_from_files",
+    "build_harness_curriculum",
     "build_index",
     "build_initiate_auth_request",
     "build_reference_archive",
     "build_reference_archive_from_files",
     "build_sessions_index",
     "decode_jwt_payload",
+    "discover_curriculum_payloads",
     "discover_reference_payloads",
     "extract_refresh_token_from_text",
     "extract_uid_from_text",

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -430,6 +430,11 @@ def _load_json_file(path: Path) -> Mapping[str, Any]:
     return payload
 
 
+def _validate_curriculum_input_file(path: Path, *, label: str) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise TTNormalizeError(f"{path}: curriculum {label} input must be a regular file")
+
+
 def _lap_from_coaching_path(path: Path) -> str | None:
     stem = path.stem
     if not stem.startswith(COACHING_ENDPOINT_PREFIX):
@@ -720,6 +725,9 @@ def build_curriculum_from_files(
     pretty: bool = False,
 ) -> CurriculumSummary:
     """Build and write a TT harness curriculum from retained coaching evidence."""
+    _validate_curriculum_input_file(coaching_path, label="coaching")
+    if session_path is not None:
+        _validate_curriculum_input_file(session_path, label="last-session")
     resolved_output = _resolve_curriculum_output_path(
         output, coaching_path=coaching_path, output_base=output_base
     )

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -437,27 +437,24 @@ def _paired_last_session_path(coaching_path: Path) -> Path | None:
     lap = _lap_from_coaching_path(coaching_path)
     if not lap:
         return None
+    candidates: list[Path] = []
     base = coaching_path.with_name(f"{last_session_endpoint(lap)}.json")
     if base.exists() and base.is_file() and not base.is_symlink():
-        return base
-    candidates = [
+        candidates.append(base)
+    candidates.extend(
         path
-        for path in coaching_path.parent.glob(f"{LAST_SESSION_ENDPOINT_PREFIX}*.json")
-        if path.is_file()
-        and not path.is_symlink()
-        and _last_session_endpoint_matches_lap(path.stem, lap)
-    ]
+        for path in coaching_path.parent.glob(f"{last_session_endpoint(lap)}_window_*.json")
+        if path.is_file() and not path.is_symlink()
+    )
     if not candidates:
         return None
-
-    def sort_key(path: Path) -> tuple[float, str]:
-        try:
-            mtime = path.stat().st_mtime
-        except OSError:
-            mtime = 0.0
-        return (mtime, path.name)
-
-    return max(candidates, key=sort_key)
+    if len(candidates) > 1:
+        rel = ", ".join(path.name for path in sorted(candidates))
+        raise TTNormalizeError(
+            f"multiple paired last-session payloads found for {coaching_path}: {rel}; "
+            "pass --session explicitly"
+        )
+    return candidates[0]
 
 
 def discover_reference_payloads(
@@ -492,13 +489,13 @@ def discover_reference_payloads(
     return paths
 
 
-def discover_curriculum_payloads(
+def _discover_curriculum_coaching_path(
     *,
     lake_base: Path | None = None,
     session_key: str | None = None,
     lap: str | int | None = None,
-) -> tuple[Path, Path]:
-    """Discover the retained coaching bundle and paired last-session payload for M-TT3."""
+) -> Path:
+    """Discover the retained coaching bundle for one lake session/lap."""
     if not session_key or lap is None:
         raise TTNormalizeError("--discover-lake requires both --session-key and --lap")
     root = lake_root(lake_base)
@@ -522,12 +519,25 @@ def discover_curriculum_payloads(
             f"multiple retained coaching payloads matched session_key={session_key}, "
             f"lap={lap}: {rel}"
         )
-    session_path = _paired_last_session_path(matches[0])
+    return matches[0]
+
+
+def discover_curriculum_payloads(
+    *,
+    lake_base: Path | None = None,
+    session_key: str | None = None,
+    lap: str | int | None = None,
+) -> tuple[Path, Path]:
+    """Discover the retained coaching bundle and paired last-session payload for M-TT3."""
+    coaching_path = _discover_curriculum_coaching_path(
+        lake_base=lake_base, session_key=session_key, lap=lap
+    )
+    session_path = _paired_last_session_path(coaching_path)
     if session_path is None:
         raise TTNormalizeError(
-            f"no paired last-session payload found for {matches[0]} (pass --session)"
+            f"no paired last-session payload found for {coaching_path} (pass --session)"
         )
-    return matches[0], session_path
+    return coaching_path, session_path
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:
@@ -547,18 +557,22 @@ def _tt_lake_roots_for_output(*, coaching_path: Path) -> tuple[Path, ...]:
     return tuple(sorted(roots, key=str))
 
 
-def _resolve_curriculum_output_path(output: Path, *, coaching_path: Path) -> Path:
+def _resolve_curriculum_output_path(
+    output: Path, *, coaching_path: Path, output_base: Path | None = None
+) -> Path:
     raw = output
     base_dir = Path.cwd().resolve()
     resolved = output.resolve() if output.is_absolute() else (base_dir / output).resolve()
     coaching_dir = coaching_path.resolve().parent
     tt_lake_roots = _tt_lake_roots_for_output(coaching_path=coaching_path)
-    approved_roots = (
+    approved_roots = [
         base_dir / ".scratch",
         base_dir / "journal",
         coaching_dir,
         *tt_lake_roots,
-    )
+    ]
+    if output_base is not None:
+        approved_roots.append(Path(output_base).resolve() / "journal")
     if not any(_is_relative_to(resolved, root.resolve()) for root in approved_roots):
         roots = ".scratch/, journal/, or the retained input directory"
         raise TTNormalizeError(f"{raw}: curriculum output must stay under {roots}")
@@ -623,12 +637,15 @@ def build_curriculum_from_files(
     *,
     output: Path,
     session_path: Path | None = None,
+    output_base: Path | None = None,
     min_time_loss_s: float = DEFAULT_CURRICULUM_MIN_TIME_LOSS_S,
     overwrite: bool = False,
     pretty: bool = False,
 ) -> CurriculumSummary:
     """Build and write a TT harness curriculum from retained coaching evidence."""
-    resolved_output = _resolve_curriculum_output_path(output, coaching_path=coaching_path)
+    resolved_output = _resolve_curriculum_output_path(
+        output, coaching_path=coaching_path, output_base=output_base
+    )
     inputs = [coaching_path]
     paired_session_path = session_path or _paired_last_session_path(coaching_path)
     if paired_session_path is None:
@@ -931,14 +948,20 @@ def cmd_curriculum(args: argparse.Namespace) -> int:
         coaching_path = args.coaching
         session_path = args.session
     else:
-        coaching_path, discovered_session = discover_curriculum_payloads(
-            lake_base=args.lake_base, session_key=args.session_key, lap=args.lap
-        )
-        session_path = args.session or discovered_session
+        if args.session:
+            coaching_path = _discover_curriculum_coaching_path(
+                lake_base=args.lake_base, session_key=args.session_key, lap=args.lap
+            )
+            session_path = args.session
+        else:
+            coaching_path, session_path = discover_curriculum_payloads(
+                lake_base=args.lake_base, session_key=args.session_key, lap=args.lap
+            )
     summary = build_curriculum_from_files(
         coaching_path,
         output=args.output,
         session_path=session_path,
+        output_base=args.lake_base,
         min_time_loss_s=args.min_time_loss_s,
         overwrite=args.overwrite,
         pretty=args.pretty,

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -27,7 +27,11 @@ from tools.tt_ingest.tt_auth import (
     uid_from_token,
 )
 from tools.tt_ingest.tt_export import (
+    COACHING_ENDPOINT_PREFIX,
+    CURRICULUM_ENDPOINT_PREFIX,
     INDEX_FILENAME,
+    LAST_SESSION_ENDPOINT_PREFIX,
+    LAST_SESSION_WINDOW_MARKER,
     RetainedFile,
     TTExportError,
     build_index,
@@ -66,12 +70,9 @@ RAW_SESSION_ENDPOINT = "session"
 # lap-specific, so lap-keying it keeps each lap's raw evidence COHERENT with its coaching even
 # when the same session later gains another lap (a single write-once ``last_session.json``
 # would otherwise go stale against a newer lap's bundle).
-LAST_SESSION_ENDPOINT_PREFIX = "last_session_lap"
 LAST_SESSION_ENDPOINT_GLOB = f"{LAST_SESSION_ENDPOINT_PREFIX}*.json"
-COACHING_ENDPOINT_PREFIX = "coaching_lap"
 COACHING_ENDPOINT_GLOB = f"{COACHING_ENDPOINT_PREFIX}*.json"
 REFERENCE_INPUT_GLOB = LAST_SESSION_ENDPOINT_GLOB
-CURRICULUM_ENDPOINT_PREFIX = "curriculum_lap"
 CURRICULUM_ENDPOINT_GLOB = f"{CURRICULUM_ENDPOINT_PREFIX}*.json"
 
 
@@ -82,12 +83,16 @@ def last_session_endpoint(lap: Any) -> str:
 
 def last_session_window_endpoint(lap: Any, payload: Mapping[str, Any]) -> str:
     """Endpoint for an additional distinct /last-session segment window for one lap."""
-    return f"{last_session_endpoint(lap)}_window_{stable_fingerprint(dict(payload))}"
+    return (
+        f"{last_session_endpoint(lap)}"
+        f"{LAST_SESSION_WINDOW_MARKER}"
+        f"{stable_fingerprint(dict(payload))}"
+    )
 
 
 def _last_session_endpoint_matches_lap(stem: str, lap: Any) -> bool:
     base = last_session_endpoint(lap)
-    return stem == base or stem.startswith(f"{base}_window_")
+    return stem == base or stem.startswith(f"{base}{LAST_SESSION_WINDOW_MARKER}")
 
 
 def coaching_endpoint(lap: Any) -> str:
@@ -585,6 +590,57 @@ def _resolve_curriculum_output_path(
     return resolved
 
 
+def _services_session_for_validation(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    data = payload.get("data") if "success" in payload else payload
+    if not isinstance(data, Mapping):
+        return {}
+    session = data.get("session")
+    return session if isinstance(session, Mapping) else data
+
+
+def _lake_session_key_for_path(path: Path) -> str | None:
+    for parent in path.resolve().parents:
+        if parent.name == "tt" and parent.parent.name == "journal":
+            try:
+                return path.parent.relative_to(parent).parts[-1]
+            except (IndexError, ValueError):
+                return None
+    return None
+
+
+def _validate_curriculum_session_pair(
+    coaching_path: Path, *, session_payload: Mapping[str, Any]
+) -> None:
+    expected_lap = _lap_from_coaching_path(coaching_path)
+    session = _services_session_for_validation(session_payload)
+    if expected_lap is not None:
+        actual_lap = session.get("lap_number")
+        if actual_lap is None:
+            raise TTNormalizeError(
+                f"{session_payload!r}: paired last-session payload missing lap_number"
+            )
+        if str(actual_lap) != str(expected_lap):
+            raise TTNormalizeError(
+                f"paired last-session lap {actual_lap} does not match {coaching_path.name}"
+            )
+
+    expected_session_key = _lake_session_key_for_path(coaching_path)
+    if expected_session_key:
+        raw_id = session.get("id") or session.get("session_id") or ""
+        _, actual_session_key = split_session_id(str(raw_id))
+        actual_session_key = actual_session_key or session.get("session_key")
+        if not actual_session_key:
+            raise TTNormalizeError(
+                f"{session_payload!r}: paired last-session payload missing session key"
+            )
+        if str(actual_session_key) != expected_session_key:
+            raise TTNormalizeError(
+                "paired last-session session key "
+                f"{actual_session_key} does not match retained coaching session "
+                f"{expected_session_key}"
+            )
+
+
 def build_reference_archive_from_files(
     paths: Sequence[Path],
     *,
@@ -661,6 +717,8 @@ def build_curriculum_from_files(
         raise TTNormalizeError(f"output already exists (pass --overwrite): {output}")
     coaching = _load_json_file(coaching_path)
     session_payload = _load_json_file(paired_session_path) if paired_session_path else None
+    if session_payload is not None:
+        _validate_curriculum_session_pair(coaching_path, session_payload=session_payload)
     curriculum = build_harness_curriculum(
         coaching,
         session_payload=session_payload,

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -593,6 +593,12 @@ def _resolve_curriculum_output_path(
     for tt_root in tt_lake_roots:
         resolved_tt_root = tt_root.resolve()
         output_in_tt_root = _is_relative_to(resolved, resolved_tt_root)
+        coaching_in_tt_root = _is_relative_to(resolved_coaching, resolved_tt_root)
+        if output_in_tt_root and not coaching_in_tt_root:
+            raise TTNormalizeError(
+                f"{raw}: curriculum outputs inside {tt_root} require coaching input from "
+                "the same journal/tt lake"
+            )
         if output_in_tt_root and not resolved.match(CURRICULUM_ENDPOINT_GLOB):
             raise TTNormalizeError(
                 f"{raw}: curriculum outputs inside {tt_root} must be named "
@@ -606,7 +612,7 @@ def _resolve_curriculum_output_path(
             raise TTNormalizeError(f"{raw}: curriculum output lap must match {coaching_path.name}")
         if (
             output_in_tt_root
-            and _is_relative_to(resolved_coaching, resolved_tt_root)
+            and coaching_in_tt_root
             and resolved.parent != resolved_coaching.parent
         ):
             raise TTNormalizeError(

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -728,17 +728,15 @@ def build_curriculum_from_files(
         raise TTNormalizeError(
             f"no paired last-session payload found for {coaching_path} (pass --session)"
         )
-    if paired_session_path is not None:
-        inputs.append(paired_session_path)
+    inputs.append(paired_session_path)
     for path in inputs:
         if resolved_output == path.resolve():
             raise TTNormalizeError(f"output must not overwrite retained input: {output}")
     if resolved_output.exists() and not overwrite:
         raise TTNormalizeError(f"output already exists (pass --overwrite): {output}")
     coaching = _load_json_file(coaching_path)
-    session_payload = _load_json_file(paired_session_path) if paired_session_path else None
-    if session_payload is not None:
-        _validate_curriculum_session_pair(coaching_path, session_payload=session_payload)
+    session_payload = _load_json_file(paired_session_path)
+    _validate_curriculum_session_pair(coaching_path, session_payload=session_payload)
     curriculum = build_harness_curriculum(
         coaching,
         session_payload=session_payload,

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -448,7 +448,9 @@ def _paired_last_session_path(coaching_path: Path) -> Path | None:
         candidates.append(base)
     candidates.extend(
         path
-        for path in coaching_path.parent.glob(f"{last_session_endpoint(lap)}_window_*.json")
+        for path in coaching_path.parent.glob(
+            f"{last_session_endpoint(lap)}{LAST_SESSION_WINDOW_MARKER}*.json"
+        )
         if path.is_file() and not path.is_symlink()
     )
     if not candidates:
@@ -572,12 +574,11 @@ def _resolve_curriculum_output_path(
     tt_lake_roots = _tt_lake_roots_for_output(coaching_path=coaching_path)
     approved_roots = [
         base_dir / ".scratch",
-        base_dir / "journal",
         coaching_dir,
         *tt_lake_roots,
     ]
     if output_base is not None:
-        approved_roots.append(Path(output_base).resolve() / "journal")
+        approved_roots.append(Path(output_base).resolve() / "journal" / "tt")
     if not any(_is_relative_to(resolved, root.resolve()) for root in approved_roots):
         roots = ".scratch/, journal/, or the retained input directory"
         raise TTNormalizeError(f"{raw}: curriculum output must stay under {roots}")
@@ -587,6 +588,13 @@ def _resolve_curriculum_output_path(
                 f"{raw}: curriculum outputs inside {tt_root} must be named "
                 f"{CURRICULUM_ENDPOINT_GLOB}"
             )
+        expected_lap = _lap_from_coaching_path(coaching_path)
+        if (
+            expected_lap is not None
+            and _is_relative_to(resolved, tt_root)
+            and resolved.name != f"{curriculum_endpoint(expected_lap)}.json"
+        ):
+            raise TTNormalizeError(f"{raw}: curriculum output lap must match {coaching_path.name}")
     return resolved
 
 
@@ -617,7 +625,7 @@ def _validate_curriculum_session_pair(
         actual_lap = session.get("lap_number")
         if actual_lap is None:
             raise TTNormalizeError(
-                f"{session_payload!r}: paired last-session payload missing lap_number"
+                f"{coaching_path.name}: paired last-session payload missing lap_number"
             )
         if str(actual_lap) != str(expected_lap):
             raise TTNormalizeError(
@@ -631,7 +639,7 @@ def _validate_curriculum_session_pair(
         actual_session_key = actual_session_key or session.get("session_key")
         if not actual_session_key:
             raise TTNormalizeError(
-                f"{session_payload!r}: paired last-session payload missing session key"
+                f"{coaching_path.name}: paired last-session payload missing session key"
             )
         if str(actual_session_key) != expected_session_key:
             raise TTNormalizeError(

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -583,19 +583,30 @@ def _resolve_curriculum_output_path(
     if not any(_is_relative_to(resolved, root.resolve()) for root in approved_roots):
         roots = ".scratch/, journal/, or the retained input directory"
         raise TTNormalizeError(f"{raw}: curriculum output must stay under {roots}")
+    resolved_coaching = coaching_path.resolve()
+    expected_lap = _lap_from_coaching_path(coaching_path)
     for tt_root in tt_lake_roots:
-        if _is_relative_to(resolved, tt_root) and not resolved.match(CURRICULUM_ENDPOINT_GLOB):
+        resolved_tt_root = tt_root.resolve()
+        output_in_tt_root = _is_relative_to(resolved, resolved_tt_root)
+        if output_in_tt_root and not resolved.match(CURRICULUM_ENDPOINT_GLOB):
             raise TTNormalizeError(
                 f"{raw}: curriculum outputs inside {tt_root} must be named "
                 f"{CURRICULUM_ENDPOINT_GLOB}"
             )
-        expected_lap = _lap_from_coaching_path(coaching_path)
         if (
             expected_lap is not None
-            and _is_relative_to(resolved, tt_root)
+            and output_in_tt_root
             and resolved.name != f"{curriculum_endpoint(expected_lap)}.json"
         ):
             raise TTNormalizeError(f"{raw}: curriculum output lap must match {coaching_path.name}")
+        if (
+            output_in_tt_root
+            and _is_relative_to(resolved_coaching, resolved_tt_root)
+            and resolved.parent != resolved_coaching.parent
+        ):
+            raise TTNormalizeError(
+                f"{raw}: curriculum output inside {tt_root} must stay next to {coaching_path.name}"
+            )
     return resolved
 
 

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -714,6 +714,7 @@ def build_curriculum_from_files(
     output: Path,
     session_path: Path | None = None,
     output_base: Path | None = None,
+    generated_at: str | None = None,
     min_time_loss_s: float = DEFAULT_CURRICULUM_MIN_TIME_LOSS_S,
     overwrite: bool = False,
     pretty: bool = False,
@@ -737,9 +738,11 @@ def build_curriculum_from_files(
     coaching = _load_json_file(coaching_path)
     session_payload = _load_json_file(paired_session_path)
     _validate_curriculum_session_pair(coaching_path, session_payload=session_payload)
+    stamp = generated_at or _iso_now()
     curriculum = build_harness_curriculum(
         coaching,
         session_payload=session_payload,
+        exported_at=stamp,
         min_time_loss_s=min_time_loss_s,
     )
     if pretty:

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -538,19 +538,36 @@ def _is_relative_to(path: Path, root: Path) -> bool:
     return True
 
 
+def _tt_lake_roots_for_output(*, coaching_path: Path) -> tuple[Path, ...]:
+    roots = {Path.cwd().resolve() / "journal" / "tt"}
+    resolved_coaching = coaching_path.resolve()
+    for parent in resolved_coaching.parents:
+        if parent.name == "tt" and parent.parent.name == "journal":
+            roots.add(parent)
+    return tuple(sorted(roots, key=str))
+
+
 def _resolve_curriculum_output_path(output: Path, *, coaching_path: Path) -> Path:
     raw = output
     base_dir = Path.cwd().resolve()
     resolved = output.resolve() if output.is_absolute() else (base_dir / output).resolve()
     coaching_dir = coaching_path.resolve().parent
+    tt_lake_roots = _tt_lake_roots_for_output(coaching_path=coaching_path)
     approved_roots = (
         base_dir / ".scratch",
         base_dir / "journal",
         coaching_dir,
+        *tt_lake_roots,
     )
     if not any(_is_relative_to(resolved, root.resolve()) for root in approved_roots):
         roots = ".scratch/, journal/, or the retained input directory"
         raise TTNormalizeError(f"{raw}: curriculum output must stay under {roots}")
+    for tt_root in tt_lake_roots:
+        if _is_relative_to(resolved, tt_root) and not resolved.match(CURRICULUM_ENDPOINT_GLOB):
+            raise TTNormalizeError(
+                f"{raw}: curriculum outputs inside {tt_root} must be named "
+                f"{CURRICULUM_ENDPOINT_GLOB}"
+            )
     return resolved
 
 

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -571,14 +571,15 @@ def _resolve_curriculum_output_path(
     base_dir = Path.cwd().resolve()
     resolved = output.resolve() if output.is_absolute() else (base_dir / output).resolve()
     coaching_dir = coaching_path.resolve().parent
-    tt_lake_roots = _tt_lake_roots_for_output(coaching_path=coaching_path)
+    tt_lake_roots = set(_tt_lake_roots_for_output(coaching_path=coaching_path))
+    if output_base is not None:
+        tt_lake_roots.add(Path(output_base).resolve() / "journal" / "tt")
+    tt_lake_roots = tuple(sorted(tt_lake_roots, key=str))
     approved_roots = [
         base_dir / ".scratch",
         coaching_dir,
         *tt_lake_roots,
     ]
-    if output_base is not None:
-        approved_roots.append(Path(output_base).resolve() / "journal" / "tt")
     if not any(_is_relative_to(resolved, root.resolve()) for root in approved_roots):
         roots = ".scratch/, journal/, or the retained input directory"
         raise TTNormalizeError(f"{raw}: curriculum output must stay under {roots}")

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -40,9 +40,11 @@ from tools.tt_ingest.tt_export import (
     write_immutable_json,
 )
 from tools.tt_ingest.tt_normalize import (
+    DEFAULT_CURRICULUM_MIN_TIME_LOSS_S,
     DEFAULT_REFERENCE_COVERAGE_THRESHOLD,
     DEFAULT_REFERENCE_MAX_SPLINE_GAP,
     TTNormalizeError,
+    build_harness_curriculum,
     build_reference_archive,
     build_sessions_index,
     normalize_session,
@@ -68,6 +70,8 @@ LAST_SESSION_ENDPOINT_GLOB = f"{LAST_SESSION_ENDPOINT_PREFIX}*.json"
 COACHING_ENDPOINT_PREFIX = "coaching_lap"
 COACHING_ENDPOINT_GLOB = f"{COACHING_ENDPOINT_PREFIX}*.json"
 REFERENCE_INPUT_GLOB = LAST_SESSION_ENDPOINT_GLOB
+CURRICULUM_ENDPOINT_PREFIX = "curriculum_lap"
+CURRICULUM_ENDPOINT_GLOB = f"{CURRICULUM_ENDPOINT_PREFIX}*.json"
 
 
 def last_session_endpoint(lap: Any) -> str:
@@ -88,6 +92,11 @@ def _last_session_endpoint_matches_lap(stem: str, lap: Any) -> bool:
 def coaching_endpoint(lap: Any) -> str:
     """Endpoint (file stem) for a lap's coaching bundle: ``coaching_lap{lap}``."""
     return f"{COACHING_ENDPOINT_PREFIX}{lap}"
+
+
+def curriculum_endpoint(lap: Any) -> str:
+    """Endpoint (file stem) for a derived M-TT3 curriculum: ``curriculum_lap{lap}``."""
+    return f"{CURRICULUM_ENDPOINT_PREFIX}{lap}"
 
 
 @dataclass(frozen=True)
@@ -123,6 +132,7 @@ INDEXED_ENDPOINT_GLOBS = (
     f"{RAW_SESSION_ENDPOINT}.json",
     LAST_SESSION_ENDPOINT_GLOB,
     COACHING_ENDPOINT_GLOB,
+    CURRICULUM_ENDPOINT_GLOB,
 )
 
 
@@ -278,6 +288,23 @@ class ReferenceArchiveSummary:
         )
 
 
+@dataclass(frozen=True)
+class CurriculumSummary:
+    """Outcome of building one M-TT3 Track Titan harness curriculum."""
+
+    output: Path
+    objectives: int
+    total_time_loss_s: float
+    source: Path
+
+    def render(self) -> str:
+        return (
+            f"wrote TT harness curriculum to {self.output} "
+            f"({self.objectives} objective(s), "
+            f"total_loss={self.total_time_loss_s:.3f}s, source={self.source.name})"
+        )
+
+
 def _car_segment(session: Mapping[str, Any]) -> Any:
     """Resolve a STRING car id for the lake path.
 
@@ -388,7 +415,7 @@ def retain_coaching(
 
 def _load_json_file(path: Path) -> Mapping[str, Any]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
     except OSError as exc:
         raise TTNormalizeError(f"could not read {path}: {exc}") from exc
     except ValueError as exc:
@@ -396,6 +423,22 @@ def _load_json_file(path: Path) -> Mapping[str, Any]:
     if not isinstance(payload, Mapping):
         raise TTNormalizeError(f"{path} did not contain a JSON object")
     return payload
+
+
+def _lap_from_coaching_path(path: Path) -> str | None:
+    stem = path.stem
+    if not stem.startswith(COACHING_ENDPOINT_PREFIX):
+        return None
+    lap = stem[len(COACHING_ENDPOINT_PREFIX) :]
+    return lap or None
+
+
+def _paired_last_session_path(coaching_path: Path) -> Path | None:
+    lap = _lap_from_coaching_path(coaching_path)
+    if not lap:
+        return None
+    candidate = coaching_path.with_name(f"{last_session_endpoint(lap)}.json")
+    return candidate if candidate.exists() else None
 
 
 def discover_reference_payloads(
@@ -428,6 +471,39 @@ def discover_reference_payloads(
         suffix = f" ({', '.join(details)})" if details else ""
         raise TTNormalizeError(f"no retained last-session payloads found under {root}{suffix}")
     return paths
+
+
+def discover_curriculum_payloads(
+    *,
+    lake_base: Path | None = None,
+    session_key: str | None = None,
+    lap: str | int | None = None,
+) -> tuple[Path, Path | None]:
+    """Discover the retained coaching bundle and paired last-session payload for M-TT3."""
+    if not session_key or lap is None:
+        raise TTNormalizeError("--discover-lake requires both --session-key and --lap")
+    root = lake_root(lake_base)
+    if not root.exists():
+        raise TTNormalizeError(f"Track Titan lake not found: {root}")
+    matches: list[Path] = []
+    target_name = f"{coaching_endpoint(lap)}.json"
+    for path in sorted(root.rglob(target_name)):
+        if path.is_symlink() or not path.is_file():
+            continue
+        if path.parent.name == str(session_key):
+            matches.append(path)
+    if not matches:
+        raise TTNormalizeError(
+            f"no retained coaching payload found under {root} "
+            f"(session_key={session_key}, lap={lap})"
+        )
+    if len(matches) > 1:
+        rel = ", ".join(str(p.relative_to(root)) for p in matches[:5])
+        raise TTNormalizeError(
+            f"multiple retained coaching payloads matched session_key={session_key}, "
+            f"lap={lap}: {rel}"
+        )
+    return matches[0], _paired_last_session_path(matches[0])
 
 
 def build_reference_archive_from_files(
@@ -474,6 +550,51 @@ def build_reference_archive_from_files(
         coverage=float(meta["coverage"]),
         partial=bool(meta["partial"]),
         payload_count=int(meta["payload_count"]),
+    )
+
+
+def build_curriculum_from_files(
+    coaching_path: Path,
+    *,
+    output: Path,
+    session_path: Path | None = None,
+    min_time_loss_s: float = DEFAULT_CURRICULUM_MIN_TIME_LOSS_S,
+    overwrite: bool = False,
+    pretty: bool = False,
+) -> CurriculumSummary:
+    """Build and write a TT harness curriculum from retained coaching evidence."""
+    resolved_output = output.resolve()
+    inputs = [coaching_path]
+    paired_session_path = session_path or _paired_last_session_path(coaching_path)
+    if paired_session_path is not None:
+        inputs.append(paired_session_path)
+    for path in inputs:
+        if resolved_output == path.resolve():
+            raise TTNormalizeError(f"output must not overwrite retained input: {output}")
+    if output.exists() and not overwrite:
+        raise TTNormalizeError(f"output already exists (pass --overwrite): {output}")
+    coaching = _load_json_file(coaching_path)
+    session_payload = _load_json_file(paired_session_path) if paired_session_path else None
+    curriculum = build_harness_curriculum(
+        coaching,
+        session_payload=session_payload,
+        min_time_loss_s=min_time_loss_s,
+    )
+    if pretty:
+        text = json.dumps(curriculum, indent=2, sort_keys=True) + "\n"
+    else:
+        text = json.dumps(curriculum, separators=(",", ":"), sort_keys=True) + "\n"
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+    except OSError as exc:
+        raise TTNormalizeError(f"could not write {output}: {exc}") from exc
+    summary = curriculum["summary"]
+    return CurriculumSummary(
+        output=output,
+        objectives=int(summary["objectives"]),
+        total_time_loss_s=float(summary["total_time_loss_s"]),
+        source=coaching_path,
     )
 
 
@@ -586,6 +707,45 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     reference.add_argument("--overwrite", action="store_true")
     reference.add_argument("--pretty", action="store_true")
+
+    curriculum = sub.add_parser(
+        "curriculum",
+        help=("Build an M-TT3 harness curriculum from retained TT coaching_lap*.json advice."),
+    )
+    curriculum.add_argument(
+        "--coaching",
+        type=Path,
+        default=None,
+        help="Retained coaching_lap*.json bundle to normalize.",
+    )
+    curriculum.add_argument(
+        "--session",
+        type=Path,
+        default=None,
+        help=(
+            "Optional paired last_session_lap*.json payload; defaults to the sibling "
+            "last_session file when present."
+        ),
+    )
+    curriculum.add_argument(
+        "--discover-lake",
+        action="store_true",
+        help="Discover coaching_lap*.json for --session-key/--lap under --lake-base/journal/tt.",
+    )
+    curriculum.add_argument("--lake-base", type=Path, default=None)
+    curriculum.add_argument(
+        "--session-key", default=None, help="Required with --discover-lake; retained session key."
+    )
+    curriculum.add_argument("--lap", default=None, help="Required with --discover-lake; one lap.")
+    curriculum.add_argument(
+        "--min-time-loss-s",
+        type=float,
+        default=DEFAULT_CURRICULUM_MIN_TIME_LOSS_S,
+        help="Only emit objectives whose TT time loss is above this threshold (default 0).",
+    )
+    curriculum.add_argument("--output", type=Path, required=True)
+    curriculum.add_argument("--overwrite", action="store_true")
+    curriculum.add_argument("--pretty", action="store_true")
     return parser
 
 
@@ -695,6 +855,29 @@ def cmd_reference(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_curriculum(args: argparse.Namespace) -> int:
+    if bool(args.coaching) == bool(args.discover_lake):
+        raise TTNormalizeError("curriculum requires exactly one of --coaching or --discover-lake")
+    if args.coaching:
+        coaching_path = args.coaching
+        session_path = args.session
+    else:
+        coaching_path, discovered_session = discover_curriculum_payloads(
+            lake_base=args.lake_base, session_key=args.session_key, lap=args.lap
+        )
+        session_path = args.session or discovered_session
+    summary = build_curriculum_from_files(
+        coaching_path,
+        output=args.output,
+        session_path=session_path,
+        min_time_loss_s=args.min_time_loss_s,
+        overwrite=args.overwrite,
+        pretty=args.pretty,
+    )
+    _print(summary.render())
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
@@ -707,6 +890,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return cmd_coaching(args)
         if args.command == "reference":
             return cmd_reference(args)
+        if args.command == "curriculum":
+            return cmd_curriculum(args)
     except (
         TTAuthError,
         TTServicesError,

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -34,6 +34,7 @@ from tools.tt_ingest.tt_export import (
     endpoint_file,
     lake_root,
     relative_to_lake,
+    sanitize_segment,
     session_lake_dir,
     sha256_hex,
     stable_fingerprint,
@@ -132,7 +133,6 @@ INDEXED_ENDPOINT_GLOBS = (
     f"{RAW_SESSION_ENDPOINT}.json",
     LAST_SESSION_ENDPOINT_GLOB,
     COACHING_ENDPOINT_GLOB,
-    CURRICULUM_ENDPOINT_GLOB,
 )
 
 
@@ -437,8 +437,27 @@ def _paired_last_session_path(coaching_path: Path) -> Path | None:
     lap = _lap_from_coaching_path(coaching_path)
     if not lap:
         return None
-    candidate = coaching_path.with_name(f"{last_session_endpoint(lap)}.json")
-    return candidate if candidate.exists() else None
+    base = coaching_path.with_name(f"{last_session_endpoint(lap)}.json")
+    if base.exists() and base.is_file() and not base.is_symlink():
+        return base
+    candidates = [
+        path
+        for path in coaching_path.parent.glob(f"{LAST_SESSION_ENDPOINT_PREFIX}*.json")
+        if path.is_file()
+        and not path.is_symlink()
+        and _last_session_endpoint_matches_lap(path.stem, lap)
+    ]
+    if not candidates:
+        return None
+
+    def sort_key(path: Path) -> tuple[float, str]:
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        return (mtime, path.name)
+
+    return max(candidates, key=sort_key)
 
 
 def discover_reference_payloads(
@@ -478,20 +497,20 @@ def discover_curriculum_payloads(
     lake_base: Path | None = None,
     session_key: str | None = None,
     lap: str | int | None = None,
-) -> tuple[Path, Path | None]:
+) -> tuple[Path, Path]:
     """Discover the retained coaching bundle and paired last-session payload for M-TT3."""
     if not session_key or lap is None:
         raise TTNormalizeError("--discover-lake requires both --session-key and --lap")
     root = lake_root(lake_base)
     if not root.exists():
         raise TTNormalizeError(f"Track Titan lake not found: {root}")
-    matches: list[Path] = []
     target_name = f"{coaching_endpoint(lap)}.json"
-    for path in sorted(root.rglob(target_name)):
+    session_leaf = sanitize_segment(session_key, fallback="unknown_session")
+    matches: list[Path] = []
+    for path in sorted(root.glob(f"*/*/*/{session_leaf}/{target_name}")):
         if path.is_symlink() or not path.is_file():
             continue
-        if path.parent.name == str(session_key):
-            matches.append(path)
+        matches.append(path)
     if not matches:
         raise TTNormalizeError(
             f"no retained coaching payload found under {root} "
@@ -503,7 +522,36 @@ def discover_curriculum_payloads(
             f"multiple retained coaching payloads matched session_key={session_key}, "
             f"lap={lap}: {rel}"
         )
-    return matches[0], _paired_last_session_path(matches[0])
+    session_path = _paired_last_session_path(matches[0])
+    if session_path is None:
+        raise TTNormalizeError(
+            f"no paired last-session payload found for {matches[0]} (pass --session)"
+        )
+    return matches[0], session_path
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_curriculum_output_path(output: Path, *, coaching_path: Path) -> Path:
+    raw = output
+    base_dir = Path.cwd().resolve()
+    resolved = output.resolve() if output.is_absolute() else (base_dir / output).resolve()
+    coaching_dir = coaching_path.resolve().parent
+    approved_roots = (
+        base_dir / ".scratch",
+        base_dir / "journal",
+        coaching_dir,
+    )
+    if not any(_is_relative_to(resolved, root.resolve()) for root in approved_roots):
+        roots = ".scratch/, journal/, or the retained input directory"
+        raise TTNormalizeError(f"{raw}: curriculum output must stay under {roots}")
+    return resolved
 
 
 def build_reference_archive_from_files(
@@ -563,15 +611,19 @@ def build_curriculum_from_files(
     pretty: bool = False,
 ) -> CurriculumSummary:
     """Build and write a TT harness curriculum from retained coaching evidence."""
-    resolved_output = output.resolve()
+    resolved_output = _resolve_curriculum_output_path(output, coaching_path=coaching_path)
     inputs = [coaching_path]
     paired_session_path = session_path or _paired_last_session_path(coaching_path)
+    if paired_session_path is None:
+        raise TTNormalizeError(
+            f"no paired last-session payload found for {coaching_path} (pass --session)"
+        )
     if paired_session_path is not None:
         inputs.append(paired_session_path)
     for path in inputs:
         if resolved_output == path.resolve():
             raise TTNormalizeError(f"output must not overwrite retained input: {output}")
-    if output.exists() and not overwrite:
+    if resolved_output.exists() and not overwrite:
         raise TTNormalizeError(f"output already exists (pass --overwrite): {output}")
     coaching = _load_json_file(coaching_path)
     session_payload = _load_json_file(paired_session_path) if paired_session_path else None
@@ -585,13 +637,13 @@ def build_curriculum_from_files(
     else:
         text = json.dumps(curriculum, separators=(",", ":"), sort_keys=True) + "\n"
     try:
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(text, encoding="utf-8")
+        resolved_output.parent.mkdir(parents=True, exist_ok=True)
+        resolved_output.write_text(text, encoding="utf-8")
     except OSError as exc:
         raise TTNormalizeError(f"could not write {output}: {exc}") from exc
     summary = curriculum["summary"]
     return CurriculumSummary(
-        output=output,
+        output=resolved_output,
         objectives=int(summary["objectives"]),
         total_time_loss_s=float(summary["total_time_loss_s"]),
         source=coaching_path,

--- a/tools/tt_ingest/cli.py
+++ b/tools/tt_ingest/cli.py
@@ -581,7 +581,7 @@ def _resolve_curriculum_output_path(
         *tt_lake_roots,
     ]
     if not any(_is_relative_to(resolved, root.resolve()) for root in approved_roots):
-        roots = ".scratch/, journal/, or the retained input directory"
+        roots = ".scratch/, journal/tt/, or the retained input directory"
         raise TTNormalizeError(f"{raw}: curriculum output must stay under {roots}")
     resolved_coaching = coaching_path.resolve()
     expected_lap = _lap_from_coaching_path(coaching_path)

--- a/tools/tt_ingest/tt_export.py
+++ b/tools/tt_ingest/tt_export.py
@@ -25,6 +25,10 @@ from typing import Any
 LAKE_SUBDIR = "tt"
 INDEX_FILENAME = "index.json"
 INDEX_SCHEMA_VERSION = 1
+LAST_SESSION_ENDPOINT_PREFIX = "last_session_lap"
+LAST_SESSION_WINDOW_MARKER = "_window_"
+COACHING_ENDPOINT_PREFIX = "coaching_lap"
+CURRICULUM_ENDPOINT_PREFIX = "curriculum_lap"
 
 #: Characters allowed in a single lake path segment; everything else collapses to ``_``.
 _SAFE_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._-]+")

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -17,6 +17,7 @@ Pure functions only — fixture-tested, no network.
 from __future__ import annotations
 
 import math
+import re
 from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -26,8 +27,10 @@ from tools.ac_harness.reference_lap import DEFAULT_TRACK_LENGTH_M, build_archive
 
 INDEX_SCHEMA_VERSION = 1
 TT_REFERENCE_IMPORT_FORMAT = "track_titan_reference_v1"
+TT_CURRICULUM_FORMAT = "track_titan_harness_curriculum_v1"
 DEFAULT_REFERENCE_COVERAGE_THRESHOLD = 0.9
 DEFAULT_REFERENCE_MAX_SPLINE_GAP = 0.08
+DEFAULT_CURRICULUM_MIN_TIME_LOSS_S = 0.0
 
 #: ``lap_attributes`` keys we lift into the flat conditions block. Anything absent
 #: degrades to ``None`` rather than raising — retention must never drop a session.
@@ -515,3 +518,282 @@ def build_reference_archive(
         "format": TT_REFERENCE_IMPORT_FORMAT,
     }
     return record
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_float_optional(value: Any) -> float | None:
+    if isinstance(value, bool) or value in (None, ""):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _as_int_optional(value: Any) -> int | None:
+    parsed = _as_float_optional(value)
+    return None if parsed is None else int(parsed)
+
+
+def _round_optional(value: float | None, digits: int = 3) -> float | None:
+    return None if value is None else round(value, digits)
+
+
+def _norm_pair(value: Any) -> dict[str, float] | None:
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        return None
+    start = _as_float_optional(value[0])
+    end = _as_float_optional(value[1])
+    if start is None or end is None:
+        return None
+    if not 0.0 <= start <= 1.0 or not 0.0 <= end <= 1.0:
+        return None
+    lo, hi = (start, end) if start <= end else (end, start)
+    return {"start": round(lo, 6), "end": round(hi, 6)}
+
+
+def _slug(value: Any) -> str:
+    text = str(value or "").lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    return text[:48] or "objective"
+
+
+def _story_value(story: Mapping[str, Any], snake: str, camel: str | None = None) -> Any:
+    if snake in story:
+        return story.get(snake)
+    if camel and camel in story:
+        return story.get(camel)
+    return None
+
+
+def _story_time_loss(story: Mapping[str, Any]) -> float | None:
+    for key in ("time_loss", "timeLoss", "time_loss_shown", "timeLossShown", "timeLoss_shown"):
+        value = _as_float_optional(story.get(key))
+        if value is not None:
+            return value
+    vars_obj = _as_mapping(story.get("vars"))
+    return _as_float_optional(vars_obj.get("timeLoss"))
+
+
+def _story_skill(story: Mapping[str, Any]) -> str:
+    key = str(
+        _story_value(story, "diagnosis_key", "diagnosisKey")
+        or _story_value(story, "phase_mistake")
+        or _story_value(story, "diagnosis")
+        or ""
+    ).lower()
+    if "brak" in key:
+        return "braking"
+    if any(token in key for token in ("throttle", "power", "fte", "exit")):
+        return "throttle_commitment"
+    if any(token in key for token in ("rotation", "steer", "line", "nfta")):
+        return "rotation"
+    if "apex" in key:
+        return "apex_speed"
+    return "technique"
+
+
+def _harness_intent(skill: str) -> str:
+    return {
+        "braking": "brake_to_reference",
+        "throttle_commitment": "earlier_power_application",
+        "rotation": "improve_rotation_to_apex",
+        "apex_speed": "raise_apex_speed",
+    }.get(skill, "reduce_corner_time_loss")
+
+
+def _segment_time_map(raw: Any) -> dict[int, float]:
+    out: dict[int, float] = {}
+    if isinstance(raw, Mapping):
+        for key, value in raw.items():
+            segment = _as_int_optional(key)
+            item = _as_mapping(value)
+            time_ms = _as_float_optional(item.get("segment_time") if item else value)
+            if segment is not None and time_ms is not None:
+                out[segment] = time_ms
+        return out
+    if isinstance(raw, list):
+        for item_raw in raw:
+            item = _as_mapping(item_raw)
+            segment = _as_int_optional(
+                item.get("segment_number") or item.get("segment") or item.get("number")
+            )
+            time_ms = _as_float_optional(item.get("segment_time") or item.get("time"))
+            if segment is not None and time_ms is not None:
+                out[segment] = time_ms
+    return out
+
+
+def _merged_advice_stories(segment: Mapping[str, Any]) -> list[dict[str, Any]]:
+    parsed = segment.get("stories")
+    parsed_items = [s for s in parsed if isinstance(s, Mapping)] if isinstance(parsed, list) else []
+    raw_items: list[Mapping[str, Any]] = []
+    raw = segment.get("advice_raw")
+    if isinstance(raw, Mapping):
+        data = _services_data(raw)
+        stories = data.get("stories")
+        if isinstance(stories, list):
+            raw_items = [s for s in stories if isinstance(s, Mapping)]
+    count = max(len(parsed_items), len(raw_items))
+    out: list[dict[str, Any]] = []
+    for index in range(count):
+        merged: dict[str, Any] = {}
+        if index < len(raw_items):
+            merged.update(dict(raw_items[index]))
+        if index < len(parsed_items):
+            merged.update(dict(parsed_items[index]))
+        out.append(merged)
+    return out
+
+
+def _curriculum_session_metadata(session_payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    payload = _as_mapping(session_payload)
+    session = _payload_session(payload) if payload else {}
+    if not session and payload:
+        session = payload
+    attrs = session.get("attributes")
+    if not isinstance(attrs, Mapping):
+        attrs = session.get("lap_attributes")
+    attrs = attrs if isinstance(attrs, Mapping) else {}
+    uid, split_key = split_session_id(str(session.get("id") or session.get("session_id") or ""))
+    lap_ms = _positive_int_ms(
+        session.get("lap_time") or session.get("lapTime") or session.get("bestLapTime"),
+        "session.lap_time",
+    )
+    return {
+        "uid": uid or _identity_value(session.get("user_id")),
+        "session_key": _session_key(session) or split_key,
+        "lap_number": _identity_value(session.get("lap_number")),
+        "lap_time_ms": lap_ms,
+        "game_id": _identity_value(session.get("game_id")),
+        "car_id": _resolve_car_id(session),
+        "track_id": _identity_value(session.get("track_id")),
+        "setup_name": _identity_value(attrs.get("carSetupName")),
+        "tyre_compound": _identity_value(attrs.get("tyreCompound")),
+    }
+
+
+def _curriculum_reference_metadata(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    lap = _as_mapping(bundle.get("reference_lap"))
+    lap_ms = _positive_int_ms(lap.get("lap_time"), "reference_lap.lap_time")
+    dynamic_ref = bundle.get("dynamic_reference")
+    advice_ref = bundle.get("advice_reference")
+    return {
+        "user_id": _identity_value(lap.get("user_id")),
+        "session_key": _identity_value(lap.get("session_key")),
+        "lap_number": _identity_value(lap.get("lap_number")),
+        "lap_time_ms": lap_ms,
+        "username": _identity_value(lap.get("username")),
+        "dynamic_reference": list(dynamic_ref) if isinstance(dynamic_ref, list) else None,
+        "advice_reference": list(advice_ref) if isinstance(advice_ref, list) else None,
+    }
+
+
+def build_harness_curriculum(
+    coaching_bundle: Mapping[str, Any],
+    *,
+    session_payload: Mapping[str, Any] | None = None,
+    min_time_loss_s: float = DEFAULT_CURRICULUM_MIN_TIME_LOSS_S,
+    exported_at: str | None = None,
+) -> dict[str, Any]:
+    """Project retained TT per-corner advice into a harness-consumable curriculum.
+
+    The output is deliberately a derived artifact, not a replacement for the retained raw
+    services evidence. It keeps Track Titan's diagnosis keys, phase/highlight spans, time
+    loss, and reference segment timing so the autonomous harness can pick concrete
+    drive-to-reference objectives without reparsing the API envelope.
+    """
+    if not isinstance(coaching_bundle, Mapping):
+        raise TTNormalizeError("Track Titan coaching bundle must be a JSON object")
+    segments = coaching_bundle.get("segments")
+    if not isinstance(segments, list):
+        raise TTNormalizeError("Track Titan coaching bundle missing segments list")
+    min_loss = max(0.0, float(min_time_loss_s))
+    reference_lap = _as_mapping(coaching_bundle.get("reference_lap"))
+    reference_times = _segment_time_map(reference_lap.get("segments"))
+    session = _payload_session(session_payload or {}) if session_payload else {}
+    user_times = _segment_time_map(session.get("segments"))
+
+    objectives: list[dict[str, Any]] = []
+    for segment_obj in segments:
+        segment = _as_mapping(segment_obj)
+        segment_number = _as_int_optional(segment.get("segment"))
+        if segment_number is None:
+            continue
+        for story_index, story in enumerate(_merged_advice_stories(segment), start=1):
+            time_loss_s = _story_time_loss(story)
+            if time_loss_s is None or time_loss_s <= min_loss:
+                continue
+            skill = _story_skill(story)
+            intent = _harness_intent(skill)
+            diagnosis_key = _identity_value(_story_value(story, "diagnosis_key", "diagnosisKey"))
+            consequence_key = _identity_value(
+                _story_value(story, "consequence_key", "consequenceKey")
+            )
+            highlight = _norm_pair(story.get("highlight")) or _norm_pair(
+                story.get("phase_dists_norm")
+            )
+            ref_ms = reference_times.get(segment_number)
+            user_ms = user_times.get(segment_number)
+            delta_ms = user_ms - ref_ms if user_ms is not None and ref_ms is not None else None
+            vars_obj = _as_mapping(story.get("vars"))
+            objective = {
+                "id": f"tt-c{segment_number:02d}-{_slug(diagnosis_key or skill)}-{story_index}",
+                "priority": 0,
+                "corner": segment_number,
+                "segment": segment_number,
+                "skill": skill,
+                "intent": intent,
+                "time_loss_s": round(time_loss_s, 3),
+                "diagnosis": _identity_value(_story_value(story, "diagnosis")) or "",
+                "consequence": _identity_value(_story_value(story, "consequence")) or "",
+                "diagnosis_key": diagnosis_key,
+                "consequence_key": consequence_key,
+                "phase": _identity_value(_story_value(story, "phase_mistake")),
+                "highlight_norm": highlight,
+                "targets": {
+                    "reference_segment_time_ms": _round_optional(ref_ms, 3),
+                    "driver_segment_time_ms": _round_optional(user_ms, 3),
+                    "segment_delta_ms": _round_optional(delta_ms, 3),
+                },
+                "harness": {
+                    "objective": intent,
+                    "focus_window_norm": highlight,
+                    "acceptance": {
+                        "metric": "track_titan_time_loss_s",
+                        "baseline_s": round(time_loss_s, 3),
+                        "target": "reduce_or_clear",
+                    },
+                },
+                "evidence": {
+                    "source": "track_titan_services_advice",
+                    "vars": dict(vars_obj) if vars_obj else None,
+                },
+            }
+            objectives.append(objective)
+
+    objectives.sort(key=lambda row: (-float(row["time_loss_s"]), int(row["segment"]), row["id"]))
+    for priority, objective in enumerate(objectives, start=1):
+        objective["priority"] = priority
+
+    total_loss = round(sum(float(row["time_loss_s"]) for row in objectives), 3)
+    return {
+        "schema_version": 1,
+        "format": TT_CURRICULUM_FORMAT,
+        "source": "track_titan_services",
+        "generated_at": exported_at,
+        "issue": 353,
+        "session": _curriculum_session_metadata(session_payload),
+        "reference": _curriculum_reference_metadata(coaching_bundle),
+        "summary": {
+            "segments": len(segments),
+            "objectives": len(objectives),
+            "total_time_loss_s": total_loss,
+            "primary_objective_id": objectives[0]["id"] if objectives else None,
+        },
+        "objectives": objectives,
+    }

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -634,7 +634,10 @@ def _merged_advice_stories(segment: Mapping[str, Any]) -> list[dict[str, Any]]:
     raw_items: list[Mapping[str, Any]] = []
     raw = segment.get("advice_raw")
     if isinstance(raw, Mapping):
-        data = _services_data(raw)
+        try:
+            data = _services_data(raw)
+        except TTNormalizeError:
+            data = {}
         stories = data.get("stories")
         if isinstance(stories, list):
             raw_items = [s for s in stories if isinstance(s, Mapping)]

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -701,6 +701,14 @@ def _curriculum_reference_metadata(bundle: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _uses_dynamic_reference_for_advice(bundle: Mapping[str, Any]) -> bool:
+    dynamic_ref = bundle.get("dynamic_reference")
+    advice_ref = bundle.get("advice_reference")
+    return (
+        isinstance(dynamic_ref, list) and isinstance(advice_ref, list) and dynamic_ref == advice_ref
+    )
+
+
 def build_harness_curriculum(
     coaching_bundle: Mapping[str, Any],
     *,
@@ -722,7 +730,11 @@ def build_harness_curriculum(
         raise TTNormalizeError("Track Titan coaching bundle missing segments list")
     min_loss = max(0.0, float(min_time_loss_s))
     reference_lap = _as_mapping(coaching_bundle.get("reference_lap"))
-    reference_times = _segment_time_map(reference_lap.get("segments"))
+    reference_times = (
+        _segment_time_map(reference_lap.get("segments"))
+        if _uses_dynamic_reference_for_advice(coaching_bundle)
+        else {}
+    )
     session = _curriculum_session_payload(session_payload)
     user_times = _segment_time_map(session.get("segments"))
 

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -536,7 +536,9 @@ def _as_float_optional(value: Any) -> float | None:
 
 def _as_int_optional(value: Any) -> int | None:
     parsed = _as_float_optional(value)
-    return None if parsed is None else int(parsed)
+    if parsed is None or not parsed.is_integer():
+        return None
+    return int(parsed)
 
 
 def _round_optional(value: float | None, digits: int = 3) -> float | None:

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -806,7 +806,11 @@ def build_harness_curriculum(
         "format": TT_CURRICULUM_FORMAT,
         "source": "track_titan_services",
         "generated_at": exported_at,
-        "issue": 353,
+        "generator": {
+            "name": "tools.tt_ingest.tt_normalize",
+            "version": 1,
+            "decision_issue": 353,
+        },
         "session": _curriculum_session_metadata(session_payload),
         "reference": _curriculum_reference_metadata(coaching_bundle),
         "summary": {

--- a/tools/tt_ingest/tt_normalize.py
+++ b/tools/tt_ingest/tt_normalize.py
@@ -654,10 +654,7 @@ def _merged_advice_stories(segment: Mapping[str, Any]) -> list[dict[str, Any]]:
 
 
 def _curriculum_session_metadata(session_payload: Mapping[str, Any] | None) -> dict[str, Any]:
-    payload = _as_mapping(session_payload)
-    session = _payload_session(payload) if payload else {}
-    if not session and payload:
-        session = payload
+    session = _curriculum_session_payload(session_payload)
     attrs = session.get("attributes")
     if not isinstance(attrs, Mapping):
         attrs = session.get("lap_attributes")
@@ -678,6 +675,14 @@ def _curriculum_session_metadata(session_payload: Mapping[str, Any] | None) -> d
         "setup_name": _identity_value(attrs.get("carSetupName")),
         "tyre_compound": _identity_value(attrs.get("tyreCompound")),
     }
+
+
+def _curriculum_session_payload(session_payload: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    payload = _as_mapping(session_payload)
+    if not payload:
+        return {}
+    session = _payload_session(payload)
+    return session if session else payload
 
 
 def _curriculum_reference_metadata(bundle: Mapping[str, Any]) -> dict[str, Any]:
@@ -718,7 +723,7 @@ def build_harness_curriculum(
     min_loss = max(0.0, float(min_time_loss_s))
     reference_lap = _as_mapping(coaching_bundle.get("reference_lap"))
     reference_times = _segment_time_map(reference_lap.get("segments"))
-    session = _payload_session(session_payload or {}) if session_payload else {}
+    session = _curriculum_session_payload(session_payload)
     user_times = _segment_time_map(session.get("segments"))
 
     objectives: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- add `track_titan_harness_curriculum_v1`, a derived M-TT3 artifact that turns retained `coaching_lap*.json` advice into prioritized harness objectives
- add `python -m tools.tt_ingest curriculum` for explicit retained inputs or scoped lake discovery, including sibling `last_session_lap*.json` pairing
- index `curriculum_lap*.json` artifacts and document the raw-evidence-to-derived-curriculum workflow

## Verification
- `FLEET_GOVERNANCE_ROOT=C:\Users\arsen\Projects\governance-hub make ci-fast PYTHON=C:/Users/arsen/Projects/ac-copilot-trainer/.venv/Scripts/python.exe` -> `2047 passed, 116 skipped`, coverage 86.05%, `ci-fast: OK`
- `python -m tools.tt_ingest curriculum --coaching .scratch\tt-mtt3-smoke\coaching_lap5.json --output .scratch\tt-mtt3-smoke\curriculum_lap5.json --overwrite --pretty` -> wrote 1 objective, total_loss=0.001s
- smoke artifact format: `track_titan_harness_curriculum_v1`; primary objective `tt-c03-coaching-diagnosis-rotation-insufficient-1`

Closes #353.