### PR TITLE
feat(voice): add four-tier expressive intensity ladder (#381)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,9 +3,10 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-01T00:13:41Z
+last_updated: 2026-07-01T00:51:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/01_Decisions/voice-intensity-register-2026-06-28.md
   - AcCopilotTrainer/03_Investigations/pr-394-voice-reliability-2026-06-30.md
   - AcCopilotTrainer/00_System/Project State.md
   - AcCopilotTrainer/03_Investigations/stanley-steering-live-verified-2026-06-19.md
@@ -19,6 +20,12 @@ relates_to:
 # Current focus
 
 **Repo:** ac-copilot-trainer.
+
+**Active draft (2026-07-01):** PR [#429](https://github.com/agorokh/ac-copilot-trainer/pull/429)
+implements [#381](https://github.com/agorokh/ac-copilot-trainer/issues/381) four-tier expressive
+voice intensity (`calm`/`alert`/`urgent`/`critical`, manifest v3, original race-engineer persona
+signature). Local `make ci-fast` and GitHub checks are green. It remains draft until the operator
+does the required on-rig A/B listening confirmation.
 
 **Active focus (2026-06-17):** EPIC [#154](https://github.com/agorokh/ac-copilot-trainer/issues/154) — **Part F harness daemon shipped** ([#228](https://github.com/agorokh/ac-copilot-trainer/issues/228)/PR #229) and its on-rig launch gap fixed ([#232](https://github.com/agorokh/ac-copilot-trainer/issues/232) **CLOSED** / PR [#233](https://github.com/agorokh/ac-copilot-trainer/pull/233) **MERGED** `c556dfe`): the daemon now launches AC **de-elevated via Content Manager** (`--launch-mode cm`), live-verified hands-off on `AG_PC`. The autonomous self-test is now **one command** ([#235](https://github.com/agorokh/ac-copilot-trainer/issues/235) **CLOSED** / PR [#236](https://github.com/agorokh/ac-copilot-trainer/pull/236) **MERGED** `d051096`): `python -m tools.ac_harness.self_test` drives the daemon hands-off and asserts the live coaching pipeline — **LIVE PASS** (`coaching.snapshot=335, tire_temps=168, connection=34`, no human at the wheel). The vision-oracle **"eyes"** also landed ([#238](https://github.com/agorokh/ac-copilot-trainer/issues/238) **CLOSED** / PR [#239](https://github.com/agorokh/ac-copilot-trainer/pull/239) **MERGED** `3e677c7`): `tools.ac_harness.hud_capture` (stdlib ctypes GDI, no new dep) captures the live AC HUD hands-off with a render-liveness check — **LIVE-VERIFIED** (in-cockpit at Spa, HUD text legible). [#188](https://github.com/agorokh/ac-copilot-trainer/issues/188)/[#190](https://github.com/agorokh/ac-copilot-trainer/issues/190) **CLOSED**. **The autonomous self-test now has launch + pipeline-assert + eyes, all hands-off + live-verified.**
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-01T00:13:41Z
+last_updated: 2026-07-01T00:51:00Z
 relates_to:
+  - AcCopilotTrainer/01_Decisions/voice-intensity-register-2026-06-28.md
   - AcCopilotTrainer/03_Investigations/issue-404-session-review-artifact-2026-06-30.md
   - AcCopilotTrainer/03_Investigations/pr-410-racing-atelier-design-package-2026-06-30.md
   - AcCopilotTrainer/03_Investigations/pr-394-voice-reliability-2026-06-30.md
@@ -104,6 +105,37 @@ dependency, script, or workflow flags.
 repo-prefetch attempts returned no relevant context. This SAVE is grounded in vault Tier-2 context,
 live GitHub state (`gh pr view 422` reported `MERGED`; `gh issue view 405` reported `CLOSED`), and the
 observed local/GitHub verification above.
+
+## In progress (2026-07-01) - Draft PR #429: expressive four-tier voice (#381)
+
+Draft PR [#429](https://github.com/agorokh/ac-copilot-trainer/pull/429) is open on
+`feat/issue-381-expressive-voice`; the rebased implementation commit is `f8b31af`. It is
+intentionally **draft**: code, local CI, and bake evidence are complete, but issue
+[#381](https://github.com/agorokh/ac-copilot-trainer/issues/381) still requires
+operator-confirmed on-rig A/B listening before the acceptance box can be honestly closed.
+
+**Delivered in branch:** voice registers are now `calm` / `alert` / `urgent` / `critical`; legacy
+`firm` advisory input normalizes to `urgent`. Manifest schema is v3. All backend
+`voice_signature` values include `race-engineer-original-v1+intensity2`, and the persona/license is
+documented as project-authored with no unconsented real-person clone. Severity mapping was updated
+across the realtime observer, Coach v2, race-management cues, scheduler/resolver, pyttsx3 fallback,
+Tone/Kokoro/Piper bake controls, benchmark tooling, and tests. A Windows CLI bug found during
+verification was fixed: `bench_voices` now prints ASCII `->` instead of a Unicode arrow.
+
+**Verification:** Focused voice/coaching suite passed (`188 passed`). Full local parity passed with
+`FLEET_GOVERNANCE_ROOT=(Resolve-Path .fleet-governance-vendor).Path; make ci-fast`:
+`2035 passed, 117 skipped`, coverage `85.91%`, `ci-fast: OK`. Local bake evidence:
+`python -m tools.ai_sidecar.voice.bake --backend tone --out .scratch\issue381-voice-bank --samplerate 22050`
+baked 76 clips, manifest v3, signature `tone-v3+race-engineer-original-v1+intensity2`. Local bench:
+`python -m tools.ai_sidecar.voice.bench_voices --out .scratch\issue381-voice-bench.md --json-out .scratch\issue381-voice-bench.json`
+measured ToneBackend act clips at `alert=165.6 ms`, `urgent=144.0 ms`, `critical=126.0 ms`.
+GitHub checks on PR #429 passed (`build`, `conformance`, `Canonical docs exist`; automerge skipped
+because draft).
+
+**Next:** On the rig, bake/listen with the intended expressive backend and drive Magione. Confirm a
+critical late-brake cue sounds materially urgent and a low-importance/minor apex cue sounds calm. If
+that passes, mark PR #429 ready and close #381 through merge; if not, tune the expressive backend or
+prosody chain on the same branch.
 
 ## Delivered (2026-06-30) - PR #423 MERGED: session review artifact (#404 Part A)
 

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/voice-intensity-register-2026-06-28.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/voice-intensity-register-2026-06-28.md
@@ -3,7 +3,7 @@ type: decision
 status: active
 memory_tier: canonical
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-01
 issue: https://github.com/agorokh/ac-copilot-trainer/issues/368
 relates_to:
   - AcCopilotTrainer/01_Decisions/voice-coach-architecture-2026-06-28.md
@@ -30,10 +30,11 @@ is offline, every cue is pre-rendered at a tone tier; the hot path stays jitter-
 (invariant: no live TTS). Tone is delivered with zero runtime cost.
 
 1. **Three orthogonal axes.** `urgency` (info/prepare/act) drives the SCHEDULER only (priority,
-   barge-in, verbosity). `register` (calm/firm/critical) drives the baked TONE only. The manifest key
-   grew from `(kind, urgency, corner)` → `(kind, urgency, register, corner)` (`MANIFEST_VERSION=2`);
-   `register` is in the `clip_id`, `ClipEntry`, and `vocabulary_hash`, so drift is still detected and
-   `rank` (arbitration) stays urgency-only.
+   barge-in, verbosity). `register` (calm/alert/urgent/critical) drives the baked TONE only. The
+   manifest key grew from `(kind, urgency, corner)` to `(kind, urgency, register, corner)`;
+   `MANIFEST_VERSION=3` is the current schema after issue #381 added the four-tier ladder and
+   persona/intensity metadata in `voice_signature`. `register` is in the `clip_id`, `ClipEntry`, and
+   `vocabulary_hash`, so drift is still detected and `rank` (arbitration) stays urgency-only.
 2. **Severity → register in the observer.** Each cue carries a continuous `intensity` scalar
    `s∈[0,1]` from real telemetry + the reference envelope (late_brake: zone-progress + closing speed
    above the apex target; brake_release: brake level past apex; apex_deficit: km/h deficit), quantized
@@ -54,6 +55,12 @@ is offline, every cue is pre-rendered at a tone tier; the hot path stays jitter-
    `brake_release` (over-braking past apex while off-throttle). `throttle` was emitted live but
    dropped by `_normalize_frame` — now extracted. `turn_in`/hold/unwind/throttle/track_out/gear are
    the documented next slice (need steering/line grounding to stay honest).
+7. **Issue #381 expressive ladder.** Canonical registers are now `calm`, `alert`, `urgent`, and
+   `critical`; legacy `firm` producer input is normalized to `urgent` so old logs and advisory
+   emitters do not go silent. The voice persona is explicitly project-authored:
+   `race-engineer-original-v1`, license/source `project-authored; no unconsented real-person clone`.
+   Every backend signature appends `race-engineer-original-v1+intensity2`, so a bank baked before the
+   persona/intensity-chain bump is refused as stale.
 
 ## Reconciliation that mattered
 
@@ -67,9 +74,10 @@ The stale comment was corrected. (A 5-agent design + adversary workflow had trus
 ## Verification (off-rig, observed)
 
 Acoustic measurement proves the headline rather than asserting it. Same word "Brake" across registers
-(say-expressive bank): **calm 805 ms / −26.7 dBFS / 1874 Hz → firm 428 ms / −22.9 dBFS → critical
+(say-expressive bank): **calm 805 ms / −26.7 dBFS / 1874 Hz → urgent 428 ms / −22.9 dBFS → critical
 407 ms / 1873 Hz** — monotonic shorter+louder+brighter = measurable urgency, all act cues ≤450 ms.
-ToneBackend bakes 3 byte-distinct registers (CI). ffmpeg shaper is byte-deterministic run-to-run.
+Issue #381 extends this to four baked tiers (`calm`/`alert`/`urgent`/`critical`); ToneBackend bakes
+four byte-distinct register clips in CI. ffmpeg shaper is byte-deterministic run-to-run.
 Timing-report harness + voice benchmark are durable tools (`tools/ai_sidecar/voice/{timing_report,
 bench_voices}.py`). **Perceptual** naturalness ("sounds like an authoritative engineer") remains a
 rig audit per AC d — not closed by CI.

--- a/tests/_voice_support.py
+++ b/tests/_voice_support.py
@@ -39,7 +39,7 @@ def make_advisory(
     kind: str = "late_brake",
     corner: int = 2,
     urgency: str = "act",
-    register: str = "firm",
+    register: str = "urgent",
     spline: float = 0.5,
     message: str = "",
     detail: dict | None = None,

--- a/tests/test_coaching_e2e.py
+++ b/tests/test_coaching_e2e.py
@@ -198,7 +198,10 @@ def test_root_error_spoken_at_anchor(t, inject, phrase, anchor_attr):
 
 
 # --- magnitude grading (P2): same word, register escalates with the size of the miss -------------
-@pytest.mark.parametrize("amount, expect_register", [(0.008, "firm"), (0.030, "critical")])
+@pytest.mark.parametrize(
+    "amount, expect_register",
+    [(0.008, "alert"), (0.012, "urgent"), (0.030, "critical")],
+)
 def test_magnitude_grades_register(amount, expect_register):
     sim = CoachSim()
     idx, ref = sim.corner(1)

--- a/tests/test_coaching_v2.py
+++ b/tests/test_coaching_v2.py
@@ -104,8 +104,10 @@ def test_v2_kinds_disjoint_from_legacy_observer_kinds():
 def test_severity_grades_by_magnitude():
     """severity() escalates register with the measured margin (P2)."""
     minor = Diagnosis(RootError.EARLY_BRAKE, {"brake_delta_spline": -0.006})
+    medium = Diagnosis(RootError.EARLY_BRAKE, {"brake_delta_spline": -0.012})
     gross = Diagnosis(RootError.EARLY_BRAKE, {"brake_delta_spline": -0.030})
-    assert severity(minor)[0] == "firm"
+    assert severity(minor)[0] == "alert"
+    assert severity(medium)[0] == "urgent"
     assert severity(gross)[0] == "critical"
     assert severity(gross)[1] > severity(minor)[1]  # higher intensity for the bigger miss
 

--- a/tests/test_realtime_observer.py
+++ b/tests/test_realtime_observer.py
@@ -98,14 +98,16 @@ def test_reference_lap_against_itself_emits_no_deficit():
     obs = build_observer_from_reference(ref)
     assert obs is not None
     advisories = _replay(obs, ref)
-    # driven == reference: on target → no apex deficit, and no brake FAULT (firm/critical "still
+    # driven == reference: on target → no apex deficit, and no brake FAULT (urgent/critical "still
     # coasting past the point"). A *calm anticipatory* brake heads-up before the mark is expected
     # and correct (#368 AC a: the cue's audio onset lands before/at the brake point). This used to
     # assert "no late_brake at all" only because the synthetic corner had no detectable brake point
     # until the corner-segmentation fix gave every real corner a valid brake point.
     assert [a for a in advisories if a.kind == "apex_deficit"] == []
     fault_brakes = [
-        a for a in advisories if a.kind == "late_brake" and a.register in ("firm", "critical")
+        a
+        for a in advisories
+        if a.kind == "late_brake" and a.register in ("alert", "urgent", "critical")
     ]
     assert fault_brakes == []
     for a in (a for a in advisories if a.kind == "late_brake"):
@@ -144,7 +146,7 @@ def test_late_brake_escalates_register_not_per_frame_when_coasting():
     assert late, "expected at least one brake cue"
     # Escalation, NOT per-frame spam (issue #368 / codex #371): the cue re-fires only when the tone
     # register steps UP, so registers are strictly increasing and there is at most one per tier.
-    rank = {"calm": 0, "firm": 1, "critical": 2}
+    rank = {"calm": 0, "alert": 1, "urgent": 2, "critical": 3}
     ranks = [rank[a.register] for a in late]
     assert ranks == sorted(ranks) and len(ranks) == len(set(ranks))
     assert len(late) <= len(frames)
@@ -246,10 +248,10 @@ def test_brake_release_can_escalate_after_calm_threshold_crossing():
     obs = RealtimeObserver([ref])
 
     calm = obs.observe({"spline": 0.52, "speed": 90.0, "brake": 0.46, "throttle": 0.0})
-    firm = obs.observe({"spline": 0.53, "speed": 88.0, "brake": 0.82, "throttle": 0.0})
+    urgent = obs.observe({"spline": 0.53, "speed": 88.0, "brake": 0.82, "throttle": 0.0})
 
-    releases = [a for a in [*calm, *firm] if a.kind == "brake_release"]
-    assert [a.register for a in releases] == ["calm", "firm"]
+    releases = [a for a in [*calm, *urgent] if a.kind == "brake_release"]
+    assert [a.register for a in releases] == ["calm", "urgent"]
     assert releases[-1].urgency == "act"
 
 

--- a/tests/test_realtime_observer_intensity.py
+++ b/tests/test_realtime_observer_intensity.py
@@ -31,19 +31,21 @@ def _ref(**kw) -> CornerReference:
 
 def test_register_for_thresholds_monotonic() -> None:
     assert _register_for(0.0, "calm") == "calm"
-    assert _register_for(0.4, "calm") == "firm"
+    assert _register_for(0.4, "calm") == "alert"
+    assert _register_for(0.62, "calm") == "urgent"
     assert _register_for(0.9, "calm") == "critical"
 
 
 def test_register_for_has_hysteresis() -> None:
     # Same severity, different incoming tier → different result (no frame-to-frame flicker).
-    s = 0.62  # between firm-rise (0.34) and crit-rise (0.67), above crit-fall (0.58)
-    assert _register_for(s, "calm") == "firm"  # rising from calm has not crossed crit-rise yet
-    assert _register_for(s, "critical") == "critical"  # falling from critical holds above crit-fall
+    s = 0.76  # below critical-rise, above critical-fall
+    assert _register_for(s, "urgent") == "urgent"  # rising has not crossed crit-rise yet
+    assert _register_for(s, "critical") == "critical"  # falling holds above crit-fall
 
 
 def test_register_for_cap_clamps() -> None:
-    assert _register_for(0.99, "calm", cap="firm") == "firm"
+    assert _register_for(0.99, "calm", cap="urgent") == "urgent"
+    assert _register_for(0.99, "calm", cap="firm") == "urgent"  # legacy alias
     assert _register_for(0.99, "calm", cap="calm") == "calm"
 
 
@@ -98,7 +100,7 @@ def test_brake_cue_escalates_calm_to_critical_across_frames() -> None:
     ]
     regs = [c.register for c in cues]
     assert "calm" in regs and "critical" in regs  # both lead-in AND the escalated alarm fired
-    rank = {"calm": 0, "firm": 1, "critical": 2}
+    rank = {"calm": 0, "alert": 1, "urgent": 2, "critical": 3}
     assert [rank[r] for r in regs] == sorted(rank[r] for r in regs)  # strictly escalating
 
 
@@ -119,8 +121,8 @@ def test_brake_release_fires_when_over_braking_past_apex_off_throttle() -> None:
     obs = RealtimeObserver([ref])
     out = obs.observe({"spline": 0.55, "speed": 80.0, "brake": 0.7, "throttle": 0.0})
     rel = [a for a in out if a.kind == "brake_release"]
-    assert rel and rel[0].register in ("calm", "firm")
-    assert rel[0].register != "critical"  # a correction, never an alarm (capped at firm)
+    assert rel and rel[0].register in ("calm", "alert", "urgent")
+    assert rel[0].register != "critical"  # a correction, never an alarm (capped at urgent)
 
 
 def test_brake_release_suppressed_when_on_throttle() -> None:

--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -28,7 +28,7 @@ def test_bake_renders_full_vocabulary_with_valid_manifest(tmp_path) -> None:
     assert len(manifest.clips) == len(vocab.vocabulary())
     # manifest stamps the current vocabulary hash + the backend voice signature
     assert manifest.vocabulary_hash == vocab.vocabulary_hash()
-    assert manifest.voice_signature == "tone-v2"
+    assert manifest.voice_signature.startswith("tone-v3+race-engineer-original-v1+intensity")
     # every clip file exists, is non-empty audio, and its sha matches the manifest
     for entry in manifest.clips.values():
         fp = tmp_path / entry.file
@@ -119,14 +119,14 @@ def test_bake_accepts_float32_external_backend(tmp_path) -> None:
 
 
 def test_tone_backend_registers_are_distinct(tmp_path) -> None:
-    # Issue #368: the register (intensity tier) must produce measurably distinct audio even from the
-    # stdlib CI backend, so CI exercises the tone dimension end-to-end (firm/critical differ from
-    # calm).
+    # Issue #381: the register (intensity tier) must produce measurably distinct audio even from the
+    # stdlib CI backend, so CI exercises calm/alert/urgent/critical end-to-end.
     manifest = bake_bank(tmp_path, ToneBackend())
-    firm = manifest.clips["late_brake.act.firm.generic"].sha256
+    alert = manifest.clips["late_brake.act.alert.generic"].sha256
+    urgent = manifest.clips["late_brake.act.urgent.generic"].sha256
     crit = manifest.clips["late_brake.act.critical.generic"].sha256
     calm = manifest.clips["late_brake.prepare.calm.generic"].sha256
-    assert len({firm, crit, calm}) == 3  # three distinct register clips
+    assert len({alert, urgent, crit, calm}) == 4  # four distinct register clips
 
 
 def test_prosody_shaper_is_run_to_run_deterministic(tmp_path) -> None:
@@ -143,7 +143,7 @@ def test_prosody_shaper_is_run_to_run_deterministic(tmp_path) -> None:
 
     # a plain tone WAV as the shaper input (no TTS engine needed)
     src = tmp_path / "src.wav"
-    ToneBackend().synthesize("Brake.", "firm", src, 22050)
+    ToneBackend().synthesize("Brake.", "urgent", src, 22050)
     shaper = ProsodyShaper(apply_tempo=True)
     a, b = tmp_path / "a.wav", tmp_path / "b.wav"
     shaper.shape(src, a, "critical", 22050)
@@ -203,7 +203,7 @@ def test_bake_uses_batch_backend_when_available(tmp_path) -> None:
 def test_cli_status_output_is_windows_codepage_safe(tmp_path, monkeypatch, capsys) -> None:
     def fake_bake_bank(out_dir, backend, *, samplerate: int = 48000):
         return Manifest(
-            version=1,
+            version=3,
             samplerate=samplerate,
             voice_signature=backend.voice_signature,
             vocabulary_hash=vocab.vocabulary_hash(),
@@ -261,9 +261,9 @@ def test_piper_batch_maps_clips_by_numeric_timestamp_order(tmp_path, monkeypatch
     backend = _piper_backend(tmp_path)
     out = tmp_path / "bank"
     items = [
-        ("brake one", "firm", out / "clip_a.wav"),
-        ("turn two", "firm", out / "clip_b.wav"),
-        ("apex three", "firm", out / "clip_c.wav"),
+        ("brake one", "urgent", out / "clip_a.wav"),
+        ("turn two", "urgent", out / "clip_b.wav"),
+        ("apex three", "urgent", out / "clip_c.wav"),
     ]
     names = ["8", "9", "10"]  # generation order; numeric != lexical
 
@@ -326,7 +326,10 @@ def test_piper_batch_falls_back_to_per_clip_when_batch_fails(tmp_path, monkeypat
     """
     backend = _piper_backend(tmp_path)
     out = tmp_path / "bank"
-    items = [("brake one", "firm", out / "clip_a.wav"), ("turn two", "calm", out / "clip_b.wav")]
+    items = [
+        ("brake one", "urgent", out / "clip_a.wav"),
+        ("turn two", "calm", out / "clip_b.wav"),
+    ]
     calls: list[str] = []
 
     def fake_run(cmd, *args, **kwargs):

--- a/tests/test_voice_bench_voices.py
+++ b/tests/test_voice_bench_voices.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from tools.ai_sidecar.voice.bench_voices import (
     BackendResult,
+    main,
     run_bench,
     to_markdown,
 )
@@ -29,8 +30,8 @@ def test_bench_runs_and_covers_every_backend_row() -> None:
 def test_tone_backend_row_is_available_with_measured_act_clips() -> None:
     tone = next(r for r in _results() if "tone" in r.backend)
     assert tone.available
-    # firm + critical act clips are measured (the time-critical cues)
-    assert set(tone.act_clip_ms) == {"firm", "critical"}
+    # alert + urgent + critical act clips are measured (the time-critical cues)
+    assert set(tone.act_clip_ms) == {"alert", "urgent", "critical"}
     assert all(ms > 0 for ms in tone.act_clip_ms.values())
 
 
@@ -46,3 +47,13 @@ def test_markdown_table_renders_with_recommendation() -> None:
     assert "| backend |" in md and "verdict |" in md
     assert "kokoro-82M" in md
     assert "Recommendation" in md
+
+
+def test_cli_status_output_is_windows_codepage_safe(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr("tools.ai_sidecar.voice.bench_voices.run_bench", lambda **_kw: _results())
+
+    assert main(["--out", str(tmp_path / "bench.md")]) == 0
+
+    out = capsys.readouterr().out
+    assert "->" in out
+    assert "→" not in out

--- a/tests/test_voice_client.py
+++ b/tests/test_voice_client.py
@@ -58,7 +58,9 @@ def test_extract_advisory_ignores_other_topics_and_types():
 def test_voice_client_speaks_selected_cue():
     spoken: list[tuple[str, str]] = []  # (text, register) — the speaker is register-aware (#368)
     vc = VoiceClient(lambda text, register: spoken.append((text, register)))
-    cue = vc.handle_frame(_cue_frame(), now_s=100.0)
+    # A realistic anticipatory late_brake: the observer emits calm register with `prepare` urgency
+    # (calm -> _URGENCY_FOR_REGISTER["prepare"]), so the phrasing keeps the corner number.
+    cue = vc.handle_frame(_cue_frame(urgency="prepare"), now_s=100.0)
     assert cue is not None
     assert cue.kind == "late_brake"
     assert spoken == [(cue.text, cue.register)]

--- a/tests/test_voice_client.py
+++ b/tests/test_voice_client.py
@@ -203,8 +203,8 @@ def test_pyttsx3_register_tuning_is_centered_on_configured_values(monkeypatch):
     while not spoken and time.monotonic() < deadline:
         time.sleep(0.01)
     assert spoken == ["Brake"]
-    assert ("rate", 275) in props
-    assert ("volume", 0.9) in props
+    assert ("rate", 280) in props
+    assert ("volume", 0.92) in props
 
 
 def test_standalone_speaker_does_not_require_fallback_env_opt_in(monkeypatch):

--- a/tests/test_voice_cue.py
+++ b/tests/test_voice_cue.py
@@ -19,15 +19,16 @@ def _adv(
 
 
 def test_advisory_to_phrase_is_register_aware_and_terse():
-    # the act tier (firm/critical) is terse + corner-less; the calm anticipatory tier keeps the
+    # the act tier (alert/urgent/critical) is terse + corner-less; calm anticipatory keeps the
     # corner number.
+    assert advisory_to_phrase(_adv("late_brake", 3, "act", register="urgent")) == "Brake."
     assert advisory_to_phrase(_adv("late_brake", 3, "act", register="firm")) == "Brake."
     assert advisory_to_phrase(_adv("late_brake", 3, "act", register="critical")) == "Brake!"
     assert (
         advisory_to_phrase(_adv("late_brake", 3, "prepare", register="calm"))
         == "Brake point, Turn 4."
     )
-    assert advisory_to_phrase(_adv("brake_release", 0, "act", register="firm")) == "Release."
+    assert advisory_to_phrase(_adv("brake_release", 0, "act", register="urgent")) == "Release."
     assert advisory_to_phrase(_adv("apex_deficit", 6, "info")) == "More entry speed, Turn 7."
 
 
@@ -47,12 +48,12 @@ def test_advisory_to_phrase_handles_bad_corner():
 def test_arbiter_speaks_one_cue_highest_urgency():
     arb = CueArbiter()
     cue = arb.select(
-        [_adv("apex_deficit", 1, "info"), _adv("late_brake", 2, "act", register="firm")],
+        [_adv("apex_deficit", 1, "info"), _adv("late_brake", 2, "act", register="urgent")],
         now_s=0.0,
     )
     assert isinstance(cue, SpokenCue)
     assert cue.kind == "late_brake"  # 'act' beats 'info'
-    assert cue.register == "firm"  # register carried through for the WS speaker
+    assert cue.register == "urgent"  # register carried through for the WS speaker
     assert cue.text == "Brake."  # terse act phrasing
 
 
@@ -82,7 +83,7 @@ def test_arbiter_per_corner_cooldown_avoids_nagging():
 
 
 def test_arbiter_act_escalation_bypasses_corner_cooldown():
-    # codex review #371: a critical/firm "Brake!" escalation must be heard even within the corner
+    # codex review #371: a critical/urgent "Brake!" escalation must be heard even within the corner
     # anti-nag window after an earlier calm lead-in for the SAME corner.
     arb = CueArbiter(global_cooldown_s=0.0, corner_cooldown_s=6.0)
     assert arb.select([_adv("late_brake", 4, "prepare", register="calm")], now_s=0.0) is not None

--- a/tests/test_voice_cue.py
+++ b/tests/test_voice_cue.py
@@ -32,6 +32,29 @@ def test_advisory_to_phrase_is_register_aware_and_terse():
     assert advisory_to_phrase(_adv("apex_deficit", 6, "info")) == "More entry speed, Turn 7."
 
 
+def test_act_advisory_with_default_calm_register_is_treated_as_urgent():
+    # A legacy / register-less producer emits an `act` advisory whose register defaults to `calm`.
+    # The observer never emits act+calm (calm -> urgency `prepare`), so this is the legacy case the
+    # in-process resolver upgrades to a hot tier (Resolver._register_fallback_chain). The fallback
+    # cue path must match (issue #381, PR #429) rather than under-react with anticipatory phrasing +
+    # calm intensity.
+    adv = {"kind": "late_brake", "corner": 3, "urgency": "act", "message": "m"}  # no register
+    assert advisory_to_phrase(adv) == "Brake."  # terse + corner-less, NOT "Brake point, Turn 4."
+    cue = CueArbiter().select([adv], now_s=100.0)
+    assert cue is not None
+    assert cue.register == "urgent"  # upgraded from the default calm for the time-critical act cue
+    # A genuine anticipatory cue (calm register, `prepare` urgency) stays calm and keeps the corner.
+    calm = advisory_to_phrase(_adv("late_brake", 3, "prepare", register="calm"))
+    assert calm == "Brake point, Turn 4."
+
+
+def test_brake_release_critical_is_terse():
+    # brake_release at the top tier is the same terse word as urgent (escalated by tone), not the
+    # calm "Ease off." (PR #429).
+    assert advisory_to_phrase(_adv("brake_release", 0, "act", register="critical")) == "Release."
+    assert advisory_to_phrase(_adv("brake_release", 0, "act", register="alert")) == "Release."
+
+
 def test_advisory_to_phrase_unknown_kind_falls_back_to_message():
     assert (
         advisory_to_phrase({"kind": "weird", "corner": 0, "message": "Do the thing"})

--- a/tests/test_voice_engine.py
+++ b/tests/test_voice_engine.py
@@ -38,8 +38,8 @@ def test_coach_speaks_advisory_and_meets_latency_budget(tmp_path) -> None:
     finally:
         coach.stop()
     assert pb.played, "advisory was never dispatched to playback"
-    # act cues are terse/corner-less; a firm late_brake resolves to the generic firm clip.
-    assert pb.played[-1].clip_id == "late_brake.act.firm.generic"
+    # act cues are terse/corner-less; a late_brake act cue resolves to the generic urgent clip.
+    assert pb.played[-1].clip_id == "late_brake.act.urgent.generic"
     # advisory-emit -> first-sample dispatch budget (target <= ~150 ms end-to-end). The
     # clip-playback
     # component is the pre-warmed audio stream, measured on-rig in the deferred live verification.

--- a/tests/test_voice_manifest.py
+++ b/tests/test_voice_manifest.py
@@ -22,7 +22,8 @@ def test_manifest_roundtrip_and_lookup() -> None:
     assert restored.samplerate == m.samplerate
     # lookup by the 4-axis advisory key (kind, urgency, register, corner)
     assert restored.lookup("late_brake", "prepare", "calm", 3) == "late_brake.prepare.calm.t03"
-    assert restored.lookup("late_brake", "act", "firm", None) == "late_brake.act.firm.generic"
+    assert restored.lookup("late_brake", "act", "urgent", None) == "late_brake.act.urgent.generic"
+    assert restored.lookup("late_brake", "act", "firm", None) == "late_brake.act.urgent.generic"
     assert (
         restored.lookup("late_brake", "act", "critical", None) == "late_brake.act.critical.generic"
     )
@@ -50,9 +51,9 @@ def test_validate_detects_missing_file_and_sha_mismatch(tmp_path) -> None:
     good.write_bytes(b"RIFFfake-wav-bytes")
     good_sha = sha256_bytes(good.read_bytes())
     data = {
-        "version": 2,
+        "version": 3,
         "samplerate": 22050,
-        "voice_signature": "tone-v2",
+        "voice_signature": "tone-v3+race-engineer-original-v1+intensity2",
         "vocabulary_hash": vocab.vocabulary_hash(),
         "clips": {
             "late_brake.act.t01": {
@@ -60,7 +61,7 @@ def test_validate_detects_missing_file_and_sha_mismatch(tmp_path) -> None:
                 "file": "late_brake.act.t01.wav",
                 "kind": "late_brake",
                 "urgency": "act",
-                "register": "firm",
+                "register": "urgent",
                 "corner": 1,
                 "text": "Brake turn one.",
                 "sha256": good_sha,
@@ -70,7 +71,7 @@ def test_validate_detects_missing_file_and_sha_mismatch(tmp_path) -> None:
                 "file": "late_brake.act.t02.wav",  # never written → missing
                 "kind": "late_brake",
                 "urgency": "act",
-                "register": "firm",
+                "register": "urgent",
                 "corner": 2,
                 "text": "Brake turn two.",
                 "sha256": "0" * 64,
@@ -143,15 +144,15 @@ def test_manifest_version_must_match_schema_even_if_fields_look_current() -> Non
     data = {
         "version": 1,
         "samplerate": 22050,
-        "voice_signature": "tone-v2",
+        "voice_signature": "tone-v3+race-engineer-original-v1+intensity2",
         "vocabulary_hash": "0" * 64,
         "clips": {
-            "late_brake.act.firm.generic": {
-                "clip_id": "late_brake.act.firm.generic",
+            "late_brake.act.urgent.generic": {
+                "clip_id": "late_brake.act.urgent.generic",
                 "file": "x.wav",
                 "kind": "late_brake",
                 "urgency": "act",
-                "register": "firm",
+                "register": "urgent",
                 "corner": None,
                 "text": "Brake.",
                 "sha256": "0" * 64,
@@ -164,11 +165,12 @@ def test_manifest_version_must_match_schema_even_if_fields_look_current() -> Non
 
 def test_unknown_register_is_rejected_at_load() -> None:
     # qodo/codex review #371: a hand-edited/corrupt manifest with a register outside the allowed
-    # tiers (calm|firm|critical) must fail loudly at LOAD, not as a silent lookup miss later.
+    # tiers (calm|alert|urgent|critical) must fail loudly at LOAD, not as a silent lookup miss
+    # later.
     data = {
-        "version": 2,
+        "version": 3,
         "samplerate": 22050,
-        "voice_signature": "tone-v2",
+        "voice_signature": "tone-v3+race-engineer-original-v1+intensity2",
         "vocabulary_hash": "0" * 64,
         "clips": {
             "late_brake.act.loud.generic": {
@@ -176,7 +178,7 @@ def test_unknown_register_is_rejected_at_load() -> None:
                 "file": "x.wav",
                 "kind": "late_brake",
                 "urgency": "act",
-                "register": "loud",  # not in calm|firm|critical
+                "register": "loud",  # not in calm|alert|urgent|critical
                 "corner": None,
                 "text": "Brake!",
                 "sha256": "0" * 64,

--- a/tests/test_voice_resolver.py
+++ b/tests/test_voice_resolver.py
@@ -22,17 +22,26 @@ def test_resolve_anticipatory_brake_maps_corner_0based_to_1based() -> None:
 
 def test_act_cue_is_terse_corner_dropped() -> None:
     r = Resolver(build_manifest())
-    # An act/firm cue for a numbered corner resolves to the TERSE generic clip (no corner number).
-    utt = r.resolve(make_advisory(kind="late_brake", urgency="act", register="firm", corner=2))
+    # An act/urgent cue for a numbered corner resolves to the TERSE generic clip (no corner number).
+    utt = r.resolve(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=2))
     assert utt is not None
-    assert utt.clip_id == "late_brake.act.firm.generic"
+    assert utt.clip_id == "late_brake.act.urgent.generic"
     assert utt.corner is None
-    assert utt.register == "firm"
-    assert utt.dedup_key == "late_brake:2:firm"  # dedup still tracks the real corner + register
+    assert utt.register == "urgent"
+    assert utt.dedup_key == "late_brake:2:urgent"  # dedup still tracks corner + register
     assert "turn" not in utt.text.lower()
 
 
-def test_legacy_act_cue_without_register_resolves_to_playable_firm() -> None:
+def test_legacy_firm_register_alias_resolves_to_urgent() -> None:
+    r = Resolver(build_manifest())
+    utt = r.resolve(make_advisory(kind="late_brake", urgency="act", register="firm", corner=2))
+    assert utt is not None
+    assert utt.clip_id == "late_brake.act.urgent.generic"
+    assert utt.register == "urgent"
+    assert utt.dedup_key == "late_brake:2:urgent"
+
+
+def test_legacy_act_cue_without_register_resolves_to_playable_urgent() -> None:
     r = Resolver(build_manifest())
     advisory = Advisory(
         kind="late_brake",
@@ -45,14 +54,14 @@ def test_legacy_act_cue_without_register_resolves_to_playable_firm() -> None:
     utt = r.resolve(advisory)
 
     assert utt is not None
-    assert utt.clip_id == "late_brake.act.firm.generic"
-    assert utt.register == "firm"
+    assert utt.clip_id == "late_brake.act.urgent.generic"
+    assert utt.register == "urgent"
     assert utt.dedup_key == "late_brake:2:calm"
 
 
-def test_register_fallback_critical_to_firm() -> None:
+def test_register_fallback_critical_to_urgent() -> None:
     # If the bank has no clip for the requested tier, fall back toward calm. Drop the critical clip
-    # and a critical advisory resolves to the firm clip (audible, never silent), and
+    # and a critical advisory resolves to the urgent clip (audible, never silent), and
     # Utterance.register reports the tier that ACTUALLY played.
     m = build_manifest()
     del m.clips["late_brake.act.critical.generic"]
@@ -60,8 +69,8 @@ def test_register_fallback_critical_to_firm() -> None:
     r = Resolver(m)
     utt = r.resolve(make_advisory(kind="late_brake", urgency="act", register="critical", corner=2))
     assert utt is not None
-    assert utt.clip_id == "late_brake.act.firm.generic"
-    assert utt.register == "firm"  # resolved tier, not the requested "critical"
+    assert utt.clip_id == "late_brake.act.urgent.generic"
+    assert utt.register == "urgent"  # resolved tier, not the requested "critical"
     assert utt.dedup_key == "late_brake:2:critical"  # dedup keyed on REQUESTED tier (escalation)
 
 
@@ -93,19 +102,23 @@ def test_unknown_kind_urgency_or_register_returns_none() -> None:
 
 def test_non_integer_corner_uses_generic() -> None:
     r = Resolver(build_manifest())
-    utt = r.resolve(make_advisory(kind="late_brake", urgency="act", register="firm", corner=None))
+    utt = r.resolve(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=None))
     assert utt is not None
-    assert utt.clip_id == "late_brake.act.firm.generic"
+    assert utt.clip_id == "late_brake.act.urgent.generic"
 
 
 def test_missing_clip_in_bank_returns_none() -> None:
     # A manifest with every fallback entry removed → resolver degrades to None (no wrong clip).
     m = build_manifest()
-    for cid in ("late_brake.act.firm.generic", "late_brake.act.calm.generic"):
+    for cid in (
+        "late_brake.act.urgent.generic",
+        "late_brake.act.alert.generic",
+        "late_brake.act.calm.generic",
+    ):
         m.clips.pop(cid, None)
     m.__post_init__()
     r = Resolver(m)
     assert (
-        r.resolve(make_advisory(kind="late_brake", urgency="act", register="firm", corner=2))
+        r.resolve(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=2))
         is None
     )

--- a/tests/test_voice_scheduler.py
+++ b/tests/test_voice_scheduler.py
@@ -25,20 +25,20 @@ def _scheduler(config: VoiceConfig | None = None) -> tuple[Scheduler, RecordingP
 
 def test_basic_dispatch() -> None:
     sched, pb, clock = _scheduler()
-    sched.submit(make_advisory(kind="late_brake", urgency="act", register="firm", corner=2))
+    sched.submit(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=2))
     spoken = sched.process_pending(clock())
     assert spoken is not None
-    assert pb.played[-1].clip_id == "late_brake.act.firm.generic"  # terse act clip
+    assert pb.played[-1].clip_id == "late_brake.act.urgent.generic"  # terse act clip
 
 
 def test_highest_urgency_wins_in_a_batch() -> None:
     sched, pb, clock = _scheduler()
     sched.submit(make_advisory(kind="apex_deficit", urgency="info", register="calm", corner=0))
-    sched.submit(make_advisory(kind="late_brake", urgency="act", register="firm", corner=4))
+    sched.submit(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=4))
     spoken = sched.process_pending(clock())
     assert spoken is not None and spoken.urgency == "act"
     assert len(pb.played) == 1  # only the winner speaks
-    assert pb.played[-1].clip_id == "late_brake.act.firm.generic"
+    assert pb.played[-1].clip_id == "late_brake.act.urgent.generic"
 
 
 def test_same_rank_tie_break_prefers_freshest_cue() -> None:
@@ -119,31 +119,31 @@ def test_act_escalation_after_prepare_same_corner_is_not_deduped() -> None:
     sched.submit(make_advisory(kind="late_brake", urgency="act", corner=2))
     spoken = sched.process_pending(clock())
     assert spoken is not None
-    assert spoken.clip_id == "late_brake.act.firm.generic"
+    assert spoken.clip_id == "late_brake.act.urgent.generic"
     assert pb.cancelled and pb.cancelled[-1].urgency == "prepare"
 
 
-def test_critical_barges_in_over_playing_firm_same_urgency() -> None:
-    # codex review #371: firm and critical share `act` urgency; a critical escalation must still
-    # interrupt a firm clip that is still sounding (barge-in tie broken on the tone register).
+def test_critical_barges_in_over_playing_urgent_same_urgency() -> None:
+    # critical and urgent share `act` urgency; a critical escalation must still interrupt an
+    # urgent clip that is still sounding (barge-in tie broken on the tone register).
     sched, pb, clock = _scheduler(VoiceConfig(dedup_window_s=8.0))
-    sched.submit(make_advisory(kind="late_brake", urgency="act", register="firm", corner=2))
+    sched.submit(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=2))
     sched.process_pending(clock())
-    assert pb.current is not None and pb.current.register == "firm"
+    assert pb.current is not None and pb.current.register == "urgent"
     clock.advance(0.1)
     sched.submit(make_advisory(kind="late_brake", urgency="act", register="critical", corner=2))
     sched.process_pending(clock())
-    assert pb.cancelled and pb.cancelled[-1].register == "firm"  # the firm clip was barged over
+    assert pb.cancelled and pb.cancelled[-1].register == "urgent"  # urgent was barged over
     assert pb.current is not None and pb.current.register == "critical"
 
 
 def test_fresh_act_for_a_new_corner_is_never_suppressed_by_dedup() -> None:
     sched, pb, clock = _scheduler(VoiceConfig(dedup_window_s=8.0))
-    sched.submit(make_advisory(kind="late_brake", urgency="act", register="firm", corner=2))
+    sched.submit(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=2))
     sched.process_pending(clock())
     pb.finish()
     clock.advance(0.5)  # within the dedup window, but a DIFFERENT corner
-    sched.submit(make_advisory(kind="late_brake", urgency="act", register="firm", corner=7))
+    sched.submit(make_advisory(kind="late_brake", urgency="act", register="urgent", corner=7))
     spoken = sched.process_pending(clock())
     assert spoken is not None  # different corner → different dedup_key → speaks again
     assert len(pb.played) == 2
@@ -176,7 +176,7 @@ def test_release_cue_is_deferred_until_brake_alarm_finishes() -> None:
     assert pb.current is not None and pb.current.kind == "late_brake"
 
     clock.advance(0.1)
-    sched.submit(make_advisory(kind="brake_release", urgency="act", register="firm", corner=2))
+    sched.submit(make_advisory(kind="brake_release", urgency="act", register="urgent", corner=2))
     assert sched.process_pending(clock()) is None
     assert pb.current is not None and pb.current.kind == "late_brake"
 

--- a/tests/test_voice_timing_report.py
+++ b/tests/test_voice_timing_report.py
@@ -41,11 +41,11 @@ def test_anticipatory_cue_onset_is_before_its_mark() -> None:
 
 
 def test_tone_register_escalates_with_situation() -> None:
-    # The headline: a hot approach yields a firm/critical brake cue (not a flat calm one).
+    # The headline: a hot approach yields an urgent/critical brake cue (not a flat calm one).
     rep = _report(Verbosity.NORMAL)
     spoken_brake = [c for c in rep.cues if c.kind == "late_brake" and c.spoken]
     assert spoken_brake
-    assert any(c.register in ("firm", "critical") for c in spoken_brake)
+    assert any(c.register in ("urgent", "critical") for c in spoken_brake)
 
 
 def test_low_verbosity_speaks_no_info() -> None:
@@ -76,7 +76,7 @@ def test_same_frame_advisories_are_arbitrated_as_one_batch() -> None:
         emitted = True
         return [
             make_advisory(kind="apex_deficit", urgency="info", register="calm", corner=0),
-            make_advisory(kind="late_brake", urgency="act", register="firm", corner=0),
+            make_advisory(kind="late_brake", urgency="act", register="urgent", corner=0),
         ]
 
     obs.observe = observe  # type: ignore[method-assign]

--- a/tests/test_voice_vocabulary.py
+++ b/tests/test_voice_vocabulary.py
@@ -31,7 +31,7 @@ def test_register_axis_is_present_and_bounded() -> None:
     regs = {p.register for p in vocab.vocabulary()}
     assert regs <= set(vocab.REGISTERS)
     assert "critical" in regs and "calm" in regs  # the headline escalation exists
-    # No (kind, urgency) lists ALL three registers (the anti-blowup cap) — a cue never needs every
+    # No (kind, urgency) lists ALL four registers (the anti-blowup cap) — a cue never needs every
     # tier; terse act cues escalate alert->urgent->critical, heads-ups stay calm.
     from collections import defaultdict
 

--- a/tests/test_voice_vocabulary.py
+++ b/tests/test_voice_vocabulary.py
@@ -32,7 +32,7 @@ def test_register_axis_is_present_and_bounded() -> None:
     assert regs <= set(vocab.REGISTERS)
     assert "critical" in regs and "calm" in regs  # the headline escalation exists
     # No (kind, urgency) lists ALL three registers (the anti-blowup cap) — a cue never needs every
-    # tier; terse act cues escalate firm→critical, heads-ups stay calm.
+    # tier; terse act cues escalate alert->urgent->critical, heads-ups stay calm.
     from collections import defaultdict
 
     by_ku: dict[tuple[str, str], set[str]] = defaultdict(set)
@@ -43,7 +43,7 @@ def test_register_axis_is_present_and_bounded() -> None:
 
 
 def test_clip_id_format_and_corner_words() -> None:
-    assert vocab.clip_id_for("late_brake", "act", "firm", None) == "late_brake.act.firm.generic"
+    assert vocab.clip_id_for("late_brake", "act", "urgent", None) == "late_brake.act.urgent.generic"
     assert vocab.clip_id_for("late_brake", "prepare", "calm", 3) == "late_brake.prepare.calm.t03"
     # 1-based spoken numbers map to words on the per-corner (anticipatory) clips
     t3 = next(p for p in vocab.vocabulary() if p.clip_id == "late_brake.prepare.calm.t03")
@@ -71,6 +71,6 @@ def test_vocabulary_hash_changes_when_wording_changes(monkeypatch) -> None:
     before = vocab.vocabulary_hash()
     # Simulate a wording edit and confirm the content hash moves (so a stale bank is detectable).
     patched = dict(vocab._STEMS)
-    patched[("late_brake", "act", "firm")] = "Hit the brakes!"
+    patched[("late_brake", "act", "urgent")] = "Hit the brakes!"
     monkeypatch.setattr(vocab, "_STEMS", patched)
     assert vocab.vocabulary_hash() != before

--- a/tools/ai_sidecar/coaching_diagnosis.py
+++ b/tools/ai_sidecar/coaching_diagnosis.py
@@ -67,7 +67,7 @@ _REF_TRAIL_MIN = 0.20
 
 
 #: Magnitude at/above which a root is GROSS -> spoken in the critical register (same word, hotter
-#: tone). Keyed by the detail margin each root records. Below it (but above the floor) -> firm.
+#: tone). Keyed by the detail margin each root records. Lower misses scale alert -> urgent.
 _CRITICAL_MARGIN: dict[RootError, tuple[str, float]] = {
     RootError.EARLY_BRAKE: ("brake_delta_spline", 0.018),
     RootError.LATE_BRAKE: ("brake_delta_spline", 0.018),
@@ -96,17 +96,23 @@ class Diagnosis:
 def severity(diag: Diagnosis) -> tuple[str, float]:
     """Map a diagnosis's measured margin to a (register, intensity) — magnitude grading (P2).
 
-    A bigger miss is spoken with a hotter register (``critical`` >= the gross threshold, else
-    ``firm``) and a higher continuous ``intensity`` (0..1, capped at the threshold). The WORD does
-    not change — the tone does ("elite coaching IS the magnitude").
+    A bigger miss is spoken with a hotter register (``alert`` -> ``urgent`` -> ``critical``) and a
+    higher continuous ``intensity`` (0..1, capped at the threshold). The WORD does not change — the
+    tone does ("elite coaching IS the magnitude").
     """
     spec = _CRITICAL_MARGIN.get(diag.root)
     if spec is None:
-        return ("firm", 0.5)
+        return ("urgent", 0.5)
     key, crit = spec  # crit is always a positive threshold from _CRITICAL_MARGIN
     mag = abs(diag.detail.get(key, 0.0))
-    register = "critical" if mag >= crit else "firm"
-    return (register, round(max(0.0, min(1.0, mag / crit)), 3))
+    intensity = round(max(0.0, min(1.0, mag / crit)), 3)
+    if intensity >= 1.0:
+        register = "critical"
+    elif intensity >= 0.5:
+        register = "urgent"
+    else:
+        register = "alert"
+    return (register, intensity)
 
 
 def classify_root_error(cand: CornerSignature, ref: CornerSignature) -> Diagnosis:

--- a/tools/ai_sidecar/coaching_ledger.py
+++ b/tools/ai_sidecar/coaching_ledger.py
@@ -48,7 +48,7 @@ class CornerState:
     time_lost_s: float = 0.0
     coached_count: int = 0
     clean_streak: int = 0  # consecutive passes the primed root was absent (fixed)
-    register: str = "firm"  # magnitude tier of the latest diagnosis (P2)
+    register: str = "urgent"  # magnitude tier of the latest diagnosis (P2/#381)
     intensity: float = 0.5
 
 

--- a/tools/ai_sidecar/coaching_runtime.py
+++ b/tools/ai_sidecar/coaching_runtime.py
@@ -205,7 +205,7 @@ class CoachRuntime:
                 spoken = self.ledger.due_prime(r.index)
                 if spoken is not None:
                     gst = self.ledger.state(r.index)
-                    reg = gst.register if gst else "firm"
+                    reg = gst.register if gst else "urgent"
                     inten = gst.intensity if gst else 0.5
                     out.append(_prime(r, spoken, spline, register=reg, intensity=inten))
 
@@ -363,7 +363,7 @@ def _prime(
     root: RootError,
     spline: float,
     *,
-    register: str = "firm",
+    register: str = "urgent",
     intensity: float = 0.5,
 ) -> Advisory:
     return Advisory(

--- a/tools/ai_sidecar/race_management.py
+++ b/tools/ai_sidecar/race_management.py
@@ -211,7 +211,7 @@ class RaceManagementObserver:
             detail["target_laps_remaining"] = round(target, 2)
             deficit = target - laps_remaining
             if deficit > _FUEL_SHORT_MARGIN_LAPS:
-                register = "critical" if deficit >= _FUEL_CRITICAL_DEFICIT_LAPS else "firm"
+                register = "critical" if deficit >= _FUEL_CRITICAL_DEFICIT_LAPS else "urgent"
                 key = (lap, register)
                 if self._last_fuel_cue == key:
                     return None
@@ -274,7 +274,7 @@ class RaceManagementObserver:
                 return self._tyre_cue(
                     lap,
                     "overheat",
-                    "firm",
+                    "urgent",
                     f"{axle.title()} tyres overheating; smooth inputs and protect the axle.",
                     temps,
                     wear,
@@ -285,7 +285,7 @@ class RaceManagementObserver:
                 return self._tyre_cue(
                     lap,
                     "thermal_rolloff",
-                    "firm",
+                    "alert",
                     "Tyres are near thermal roll-off; smooth the stint and stop sliding them.",
                     temps,
                     wear,
@@ -298,7 +298,7 @@ class RaceManagementObserver:
             return self._tyre_cue(
                 lap,
                 "wear",
-                "firm",
+                "alert",
                 f"{axle.title()} tyre wear is high without an overheat signal; "
                 "protect it from slides.",
                 temps,
@@ -336,7 +336,7 @@ class RaceManagementObserver:
                 "wear_signal": bool(wear),
                 "findings": _serial_findings(findings[:3]),
             },
-            intensity=1.0 if register == "critical" else 0.55,
+            intensity=1.0 if register == "critical" else 0.65 if register == "urgent" else 0.35,
             register=register,
         )
 
@@ -355,12 +355,12 @@ class RaceManagementObserver:
             message = "Brakes are in the critical heat band; cool them with earlier lifts."
         elif hot:
             classification = "hot"
-            register = "firm"
+            register = "alert"
             urgency = "prepare"
             message = "Brake temps are hot; stop dragging brake and add cooling laps."
         elif high_wear:
             classification = "wear"
-            register = "firm"
+            register = "alert"
             urgency = "prepare"
             message = "Brake wear is building; reduce peak brake time over the stint."
         else:
@@ -380,7 +380,7 @@ class RaceManagementObserver:
                 "brake_temps_c": {k: round(v, 1) for k, v in temps.items()},
                 "brake_wear_pct": {k: round(v, 1) for k, v in wear.items()},
             },
-            intensity=1.0 if register == "critical" else 0.55,
+            intensity=1.0 if register == "critical" else 0.35,
             register=register,
         )
 
@@ -404,15 +404,15 @@ class RaceManagementObserver:
         self._conditions_seen.add(finding.key)
         if finding.key == "wet_regime":
             urgency = "act"
-            register = "firm"
+            register = "urgent"
             message = "Wet track strategy: brake earlier, use smoother throttle, and avoid puddles."
         elif finding.key == "cold_track":
             urgency = "prepare"
-            register = "firm"
+            register = "alert"
             message = "Cold track strategy: build tyre heat before pushing."
         elif finding.key == "hot_track":
             urgency = "prepare"
-            register = "firm"
+            register = "alert"
             message = "Hot track strategy: manage tyre temperature over the stint."
         else:
             urgency = "prepare"
@@ -429,7 +429,7 @@ class RaceManagementObserver:
                 "conditions": conditions,
                 "finding": _serial_findings([finding])[0],
             },
-            intensity=0.55 if register == "firm" else 0.25,
+            intensity=0.65 if register == "urgent" else 0.35 if register == "alert" else 0.25,
             register=register,
         )
 

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -48,7 +48,7 @@ _THROTTLE_ON = 0.1
 
 # --- Intensity model (issue #368) -----------------------------------------------------------------
 # The observer computes a continuous severity scalar ``s ∈ [0,1]`` for each cue from telemetry +
-# the reference envelope, then quantizes it to a tone ``register`` (calm|firm|critical) with
+# the reference envelope, then quantizes it to a tone ``register`` (calm|alert|urgent|critical) with
 # hysteresis. ``register`` is what the manifest keys on; ``intensity`` (the float) rides on the
 # Advisory too (logs, haptics, the timing report). These constants are documented TUNING references,
 # NOT fabricated physical ceilings (the project's honesty invariant): they set how aggressively the
@@ -74,8 +74,9 @@ _MAX_LEAD_SPLINE = 0.05
 #: Schmitt-trigger thresholds for register quantization (rising / falling) — the falling edge
 #: sits below the rising edge so a severity hovering near a boundary does not flicker tone
 #: frame-to-frame.
-_REG_FIRM_RISE, _REG_FIRM_FALL = 0.34, 0.27
-_REG_CRIT_RISE, _REG_CRIT_FALL = 0.67, 0.58
+_REG_ALERT_RISE, _REG_ALERT_FALL = 0.25, 0.18
+_REG_URGENT_RISE, _REG_URGENT_FALL = 0.55, 0.46
+_REG_CRIT_RISE, _REG_CRIT_FALL = 0.82, 0.72
 
 
 def _clamp01(x: float) -> float:
@@ -92,13 +93,16 @@ def _register_for(s: float, prev: str, *, cap: str = "critical") -> str:
     ``cap`` clamps the result for cues whose tone must not reach the top tier (e.g. a slow-loss cue
     that should never sound like an alarm).
     """
+    prev = "urgent" if prev == "firm" else prev
+    cap = "urgent" if cap == "firm" else cap
     cap_rank = REGISTER_RANK.get(cap, REGISTER_RANK["critical"])
     prev_rank = REGISTER_RANK.get(prev, 0)
-    # Critical band (with hysteresis against the current tier).
     if s >= _REG_CRIT_RISE or (prev_rank >= REGISTER_RANK["critical"] and s >= _REG_CRIT_FALL):
         out = "critical"
-    elif s >= _REG_FIRM_RISE or (prev_rank >= REGISTER_RANK["firm"] and s >= _REG_FIRM_FALL):
-        out = "firm"
+    elif s >= _REG_URGENT_RISE or (prev_rank >= REGISTER_RANK["urgent"] and s >= _REG_URGENT_FALL):
+        out = "urgent"
+    elif s >= _REG_ALERT_RISE or (prev_rank >= REGISTER_RANK["alert"] and s >= _REG_ALERT_FALL):
+        out = "alert"
     else:
         out = "calm"
     if REGISTER_RANK[out] > cap_rank:
@@ -107,11 +111,16 @@ def _register_for(s: float, prev: str, *, cap: str = "critical") -> str:
 
 
 #: Register ordering (low → high) for the cap/hysteresis comparisons above.
-REGISTER_RANK: dict[str, int] = {"calm": 0, "firm": 1, "critical": 2}
-#: urgency a given register rides on: a calm heads-up is anticipatory (``prepare``); a firm/critical
-#: correction must be acted on now (``act``). Keeps tone (register) and scheduling (urgency)
+REGISTER_RANK: dict[str, int] = {"calm": 0, "alert": 1, "urgent": 2, "critical": 3}
+#: urgency a given register rides on: a calm heads-up is anticipatory (``prepare``);
+#: alert/urgent/critical correction must be acted on now (``act``). Keeps tone and scheduling
 #: correlated but distinct — the scheduler still arbitrates on urgency alone.
-_URGENCY_FOR_REGISTER: dict[str, str] = {"calm": "prepare", "firm": "act", "critical": "act"}
+_URGENCY_FOR_REGISTER: dict[str, str] = {
+    "calm": "prepare",
+    "alert": "act",
+    "urgent": "act",
+    "critical": "act",
+}
 
 
 def _target_source(ref: CornerReference) -> str:
@@ -129,9 +138,9 @@ class Advisory:
 
     ``intensity`` / ``register`` (issue #368): ``intensity`` is the continuous severity scalar
     ``s ∈ [0,1]`` the observer computed for the situation; ``register`` is its quantized tone tier
-    (calm|firm|critical), which the voice path keys on so the SPOKEN TONE reflects the situation
-    ("not just 'turn left'"). Both default to the calm/zero base so every existing construction and
-    the server's ``_advisory_to_payload`` keep working.
+    (calm|alert|urgent|critical), which the voice path keys on so the SPOKEN TONE reflects the
+    situation ("not just 'turn left'"). Both default to the calm/zero base so every existing
+    construction and the server's ``_advisory_to_payload`` keep working.
     """
 
     kind: str  # "late_brake" | "brake_release" | "turn_in" | "apex_deficit"
@@ -152,11 +161,11 @@ class _CornerPass:
     min_speed_kmh: float | None = None
     has_braked: bool = False  # any braking seen this pass — suppresses a false late-brake cue
     #: rank of the HIGHEST brake-cue register emitted this pass (-1 = none). A cue re-fires only
-    #: when severity escalates to a strictly higher tier (calm→firm→critical), so a calm lead-in
-    #: never locks out the later critical alarm (issue #368 escalation; codex review #371).
+    #: when severity escalates to a strictly higher tier (calm→alert→urgent→critical), so a calm
+    #: lead-in never locks out the later critical alarm (issue #368 escalation; codex review #371).
     brake_cue_rank: int = -1
     #: rank of the highest brake-release register emitted this pass. A barely-over-threshold
-    #: release warning can still escalate to firm if the driver stays hard on the brake.
+    #: release warning can still escalate to urgent if the driver stays hard on the brake.
     release_cue_rank: int = -1
     exit_emitted: bool = False
     #: last tone register spoken for this corner pass — feeds register hysteresis (issue #368).
@@ -418,13 +427,14 @@ class RealtimeObserver:
         """Fire an anticipatory brake cue whose TONE register reflects the situation (#368).
 
         Fires when the car is within the actionable brake window (from the anticipatory lead before
-        the brake point through the apex) and is not yet braking. The register (calm|firm|critical)
-        comes from :meth:`_brake_severity`, so a car arriving on pace gets a calm anticipatory
+        the brake point through the apex) and is not yet braking. The register
+        (calm|alert|urgent|critical) comes from :meth:`_brake_severity`, so a car arriving on pace
+        gets a calm anticipatory
         "brake point" while a car carrying far too much speed — or coasting past the point — gets a
-        firm/critical "Brake." / "Brake!".
+        alert/urgent/critical "Brake." / "Brake!".
 
         **Escalation (codex review #371):** the cue re-fires within one pass only when severity
-        rises to a *strictly higher* register (calm→firm→critical), so a calm lead-in never
+        rises to a *strictly higher* register (calm→alert→urgent→critical), so a calm lead-in never
         suppresses the later urgent alarm; the scheduler's register-keyed dedup + act barge-in
         deliver the escalation. A same- or lower-tier repeat is dropped.
 
@@ -448,8 +458,8 @@ class RealtimeObserver:
         anticipatory = 0.0 < _forward_spline_delta(spline, bp) <= _LAP_WRAP_DROP
         # BEFORE the brake point it is a calm anticipatory heads-up regardless of closing speed (the
         # driver hasn't missed anything yet — main's `brake_prepare` contract). Severity-based
-        # escalation (firm/critical) applies only AT/PAST the point, where coasting on is a real
-        # fault (#368 escalation; preserves the merged main brake_prepare semantics).
+        # escalation (alert/urgent/critical) applies only AT/PAST the point, where coasting on is a
+        # real fault (#368 escalation; preserves the merged main brake_prepare semantics).
         register = "calm" if anticipatory else _register_for(s, st.last_register, cap="critical")
         rank = REGISTER_RANK[register]
         if rank <= st.brake_cue_rank:
@@ -498,14 +508,14 @@ class RealtimeObserver:
 
         Heavy braking after the apex (still off the power) scrubs exit speed instead of releasing
         toward the throttle. Gated conservatively on a HIGH brake level and no throttle so a normal
-        trail-brake release is not flagged. Register caps at firm (a clear correction, never an
-        alarm), but can start calm near the threshold and escalate once if braking stays heavy.
+        trail-brake release is not flagged. Register caps at urgent (a clear correction, never an
+        alarm), but can start calm near the threshold and escalate if braking stays heavy.
         """
         past_apex = ref.apex_spline < spline <= ref.spline_hi
         if not past_apex or brake < _RELEASE_BRAKE_MIN or throttle >= _THROTTLE_ON:
             return None
         s = _clamp01((brake - _RELEASE_BRAKE_MIN) / max(1.0 - _RELEASE_BRAKE_MIN, 1e-6))
-        register = _register_for(s, st.last_register, cap="firm")  # a correction, never an alarm
+        register = _register_for(s, st.last_register, cap="urgent")  # a correction, never an alarm
         rank = REGISTER_RANK[register]
         if rank <= st.release_cue_rank:
             return None
@@ -535,7 +545,7 @@ class RealtimeObserver:
         # be honest about what the target IS: a demonstrated corpus best vs a GGV theoretical
         # ceiling (which the live TC-off car may not reach — see the #244 frontier diagnostics).
         target_label = "the best lap" if source == "corpus_best" else "the GGV optimum (a ceiling)"
-        # Severity from the magnitude of the deficit; register capped at firm (a slow-loss verdict
+        # Severity from the magnitude of the deficit; register capped at calm (a slow-loss verdict
         # is never an alarm). This is the suppressible heads-up — it rides `info` urgency so LOW
         # verbosity drops it from voice (issue #368 AC e: no post-fact narration in low verbosity).
         s = _clamp01(deficit / _DEFICIT_REF_KMH)

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from tools.ai_sidecar.lap_dynamics import LapTrace, lap_trace_from_archive
+from tools.ai_sidecar.registers import REGISTER_RANK, normalize_register
 from tools.ai_sidecar.track_reference import (
     CornerReference,
     add_corpus_lap,
@@ -93,8 +94,8 @@ def _register_for(s: float, prev: str, *, cap: str = "critical") -> str:
     ``cap`` clamps the result for cues whose tone must not reach the top tier (e.g. a slow-loss cue
     that should never sound like an alarm).
     """
-    prev = "urgent" if prev == "firm" else prev
-    cap = "urgent" if cap == "firm" else cap
+    prev = normalize_register(prev)
+    cap = normalize_register(cap)
     cap_rank = REGISTER_RANK.get(cap, REGISTER_RANK["critical"])
     prev_rank = REGISTER_RANK.get(prev, 0)
     if s >= _REG_CRIT_RISE or (prev_rank >= REGISTER_RANK["critical"] and s >= _REG_CRIT_FALL):
@@ -110,8 +111,6 @@ def _register_for(s: float, prev: str, *, cap: str = "critical") -> str:
     return out
 
 
-#: Register ordering (low → high) for the cap/hysteresis comparisons above.
-REGISTER_RANK: dict[str, int] = {"calm": 0, "alert": 1, "urgent": 2, "critical": 3}
 #: urgency a given register rides on: a calm heads-up is anticipatory (``prepare``);
 #: alert/urgent/critical correction must be acted on now (``act``). Keeps tone and scheduling
 #: correlated but distinct — the scheduler still arbitrates on urgency alone.

--- a/tools/ai_sidecar/registers.py
+++ b/tools/ai_sidecar/registers.py
@@ -1,0 +1,46 @@
+"""Canonical intensity-``register`` domain — the single source of truth shared by the observer
+(which *produces* a register by quantizing a severity scalar) and the voice vocabulary (which
+*consumes* it to key the tone manifest).
+
+This module is deliberately dependency-free (stdlib only) and lives OUTSIDE
+:mod:`tools.ai_sidecar.voice`. The voice package's ``__init__`` imports
+:class:`tools.ai_sidecar.realtime_observer.Advisory`, so the observer cannot import from
+``voice.vocabulary`` without a circular import. Hoisting the register ladder here lets both the
+observer and ``voice.vocabulary`` import the *same* constants and helpers instead of each
+re-declaring ``REGISTER_RANK`` and the legacy ``firm`` alias (which risked drift when the ladder
+scaled from three to four tiers — issue #381).
+"""
+
+from __future__ import annotations
+
+#: Intensity tiers, low -> high (issue #381). Drives the baked *tone* of a clip, never scheduling.
+#: ``calm`` = measured heads-up; ``alert`` = clear attention cue; ``urgent`` = act-now correction;
+#: ``critical`` = alarm. The observer quantizes a continuous severity scalar to one of these with
+#: hysteresis (:func:`tools.ai_sidecar.realtime_observer`), and the resolver keys the manifest on
+#: it.
+REGISTERS: tuple[str, ...] = ("calm", "alert", "urgent", "critical")
+
+#: Backward-compatible input aliases for advisory producers and older tests/log replays. New banks
+#: bake ``urgent``; legacy ``firm`` advisories resolve to that tier instead of going silent.
+REGISTER_ALIASES: dict[str, str] = {"firm": "urgent"}
+
+
+def normalize_register(register: object) -> str:
+    """Return the canonical intensity tier for ``register``.
+
+    ``firm`` is accepted as a legacy alias for ``urgent`` so old advisory logs and producers keep
+    speaking after the #381 vocabulary change. Unknown values are returned unchanged; callers still
+    validate against :data:`REGISTERS`.
+    """
+    raw = str(register)
+    return REGISTER_ALIASES.get(raw, raw)
+
+
+#: Register ordering (low -> high) for the cap/hysteresis comparisons in the observer and the
+#: scheduler's louder-same-urgency arbitration. Derived from :data:`REGISTERS` so they never drift.
+REGISTER_RANK: dict[str, int] = {register: rank for rank, register in enumerate(REGISTERS)}
+
+
+def register_rank(register: object, default: int = 0) -> int:
+    """Ordering helper for intensity comparisons, accepting legacy aliases."""
+    return REGISTER_RANK.get(normalize_register(register), default)

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -1,13 +1,14 @@
 """Offline phrase-bank baker — render the bounded vocabulary once to WAV + a content-addressed
 manifest, with a per-register **prosody** layer so the SAME command is rendered with a tone that
-reflects the situation (issue #368).
+reflects the situation (issue #381).
 
 Baking is **not** time-critical (it runs offline, not at the wheel), so it can use a naturalistic
 neural voice and shell to ``ffmpeg`` for prosody shaping. The runtime then plays the pre-rendered
 clips with deterministic, jitter-free latency — no live TTS in the hot path (invariant #1).
 
-**Register → tone.** Every clip carries a ``register`` (calm | firm | critical). A speech backend
-renders the words once; a :class:`ProsodyShaper` then applies a per-register ``ffmpeg`` filter chain
+**Register -> tone.** Every clip carries a ``register`` (calm | alert | urgent | critical). A
+speech backend renders the words once; a :class:`ProsodyShaper` then applies a per-register
+``ffmpeg`` filter chain
 (rate / pitch / loudness / compression / brightness) so the tone escalates with the register. The
 shaping is baked into the WAV bytes — tone is delivered with zero hot-path cost. ``ffmpeg`` is run
 with ``-bitexact`` + stripped metadata so a given ffmpeg build produces **byte-identical** output
@@ -59,14 +60,23 @@ from tools.ai_sidecar.voice.manifest import (
     Manifest,
     sha256_bytes,
 )
-from tools.ai_sidecar.voice.vocabulary import iter_vocabulary, vocabulary_hash
+from tools.ai_sidecar.voice.vocabulary import (
+    INTENSITY_CHAIN_VERSION,
+    VOICE_PERSONA_ID,
+    iter_vocabulary,
+    vocabulary_hash,
+)
 
 _log = logging.getLogger("ai_sidecar.voice.bake")
 
 #: Bump when the prosody filter chains change — folded into ``voice_signature`` so a chain edit
 #: without a re-bake is surfaced (the bank's signature no longer matches what the code would
 #: render).
-PROSODY_VERSION = 1
+PROSODY_VERSION = 2
+
+
+def _signature_suffix() -> str:
+    return f"{VOICE_PERSONA_ID}+intensity{INTENSITY_CHAIN_VERSION}"
 
 
 class VoiceBackend(Protocol):
@@ -123,7 +133,10 @@ def _prosody_filter(register: str, samplerate: int, *, apply_tempo: bool) -> str
     if register == "calm":
         # measured, warm, slightly softer — a guidance tone.
         body = "highpass=f=90,acompressor=threshold=-20dB:ratio=2.5:attack=10:release=80,treble=g=2:f=3000,volume=-2dB"  # noqa: E501
-    elif register == "firm":
+    elif register == "alert":
+        tempo = "atempo=1.06," if apply_tempo else ""
+        body = f"{tempo}highpass=f=100,acompressor=threshold=-19dB:ratio=3:attack=7:release=70,treble=g=3:f=3200,volume=1.5dB"  # noqa: E501
+    elif register == "urgent":
         tempo = "atempo=1.13," if apply_tempo else ""
         body = f"{tempo}highpass=f=110,acompressor=threshold=-18dB:ratio=3.5:attack=5:release=60,treble=g=3.5:f=3300,volume=3dB"  # noqa: E501
     elif register == "critical":
@@ -183,12 +196,13 @@ class ToneBackend:
     the bank is byte-reproducible across runs — CI exercises the register dimension end-to-end.
     """
 
-    voice_signature = "tone-v2"
+    voice_signature = f"tone-v3+{_signature_suffix()}"
 
     #: (frequency offset Hz, duration scale) per register — critical is brighter + shorter.
     _REGISTER_TONE: dict[str, tuple[float, float]] = {
         "calm": (0.0, 1.0),
-        "firm": (110.0, 0.85),
+        "alert": (70.0, 0.92),
+        "urgent": (140.0, 0.80),
         "critical": (240.0, 0.70),
     }
 
@@ -276,9 +290,14 @@ class KokoroBackend:
     lazily so the bake module stays importable without it.
     """
 
-    #: per-register synthesis speed (Kokoro renders neutral; the shaper adds tempo for firm/critical
+    #: per-register synthesis speed (Kokoro renders neutral; the shaper adds tempo for hot tiers
     #: too, so keep these modest to avoid double-fast unintelligibility on terse cues).
-    _REGISTER_SPEED: dict[str, float] = {"calm": 0.95, "firm": 1.0, "critical": 1.05}
+    _REGISTER_SPEED: dict[str, float] = {
+        "calm": 0.95,
+        "alert": 0.98,
+        "urgent": 1.02,
+        "critical": 1.05,
+    }
 
     def __init__(
         self,
@@ -299,7 +318,7 @@ class KokoroBackend:
 
     @property
     def voice_signature(self) -> str:
-        return f"kokoro:{self._voice}+{self._shaper.signature}"
+        return f"kokoro:{self._voice}+{self._shaper.signature}+{_signature_suffix()}"
 
     def _engine(self):
         if self._kokoro is None:
@@ -325,7 +344,12 @@ class PiperBackend:
     Renders at a register-appropriate ``length_scale`` (lower = faster), then shapes per register.
     """
 
-    _REGISTER_LENGTH_SCALE: dict[str, float] = {"calm": 1.05, "firm": 0.95, "critical": 0.88}
+    _REGISTER_LENGTH_SCALE: dict[str, float] = {
+        "calm": 1.05,
+        "alert": 1.00,
+        "urgent": 0.93,
+        "critical": 0.88,
+    }
 
     def __init__(self, model_path: str | Path, piper_bin: str = "piper") -> None:
         self._model = Path(model_path)
@@ -336,7 +360,7 @@ class PiperBackend:
 
     @property
     def voice_signature(self) -> str:
-        return f"piper:{self._model.stem}+{self._shaper.signature}"
+        return f"piper:{self._model.stem}+{self._shaper.signature}+{_signature_suffix()}"
 
     def synthesize(self, text: str, register: str, out_path: Path, samplerate: int) -> None:
         length_scale = self._REGISTER_LENGTH_SCALE.get(register, 1.0)
@@ -457,7 +481,7 @@ class MacSayExpressiveBackend:
 
     @property
     def voice_signature(self) -> str:
-        return f"macsay-expr:{self._voice}+{self._shaper.signature}"
+        return f"macsay-expr:{self._voice}+{self._shaper.signature}+{_signature_suffix()}"
 
     def synthesize(self, text: str, register: str, out_path: Path, samplerate: int) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -486,7 +510,7 @@ class MacSayBackend:
 
     @property
     def voice_signature(self) -> str:
-        return f"macsay:{self._voice}"
+        return f"macsay:{self._voice}+{_signature_suffix()}"
 
     def synthesize(self, text: str, register: str, out_path: Path, samplerate: int) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -191,7 +191,7 @@ class ToneBackend:
 
     Not speech; a smoke/verification voice that proves the bake + manifest + playback plumbing with
     zero third-party deps and **no ffmpeg** (stdlib ``wave`` only), so it runs in CI. Frequency and
-    duration derive from a stable hash of the text PLUS a per-register shift, so the three registers
+    duration derive from a stable hash of the text PLUS a per-register shift, so the four registers
     for one cue are **measurably distinct** (critical is higher-pitched and shorter than calm) and
     the bank is byte-reproducible across runs — CI exercises the register dimension end-to-end.
     """

--- a/tools/ai_sidecar/voice/bench_voices.py
+++ b/tools/ai_sidecar/voice/bench_voices.py
@@ -1,7 +1,7 @@
 """Voice-path benchmark (issue #368 AC d) — record which backend is accepted/rejected, with
 evidence.
 
-Bakes the time-critical brake cluster (the act/critical "Brake" clips + the calm heads-up) with each
+Bakes the time-critical brake cluster (the act "Brake" tiers + the calm heads-up) with each
 *available* backend and measures the objective evidence the acceptance criterion names:
 
 * **clip duration** (ms, from the WAV header) — the ≤450 ms act-cue budget.
@@ -46,7 +46,8 @@ from tools.ai_sidecar.voice.bake import (
 #: The cues the benchmark renders — the time-critical brake cluster across registers.
 _BENCH_CLIPS: tuple[tuple[str, str], ...] = (
     ("calm", "Brake point."),
-    ("firm", "Brake."),
+    ("alert", "Brake."),
+    ("urgent", "Brake."),
     ("critical", "Brake!"),
 )
 
@@ -122,7 +123,7 @@ def _bench_backend(name: str, backend: VoiceBackend, samplerate: int = 22050) ->
             fp = Path(tmp) / f"{register}.wav"
             backend.synthesize(text, register, fp, samplerate)
             feats[register] = _measure(fp)
-            if register in ("firm", "critical"):
+            if register in ("alert", "urgent", "critical"):
                 act_ms[register] = feats[register][0]
     cpu = round(time.perf_counter() - t0, 2)
     within = all(ms <= 450.0 for ms in act_ms.values())
@@ -197,31 +198,34 @@ def to_markdown(results: list[BackendResult]) -> str:
         "# Voice-path benchmark (issue #368 AC d)",
         "",
         "Objective columns are measured by `tools/ai_sidecar/voice/bench_voices.py`; **naturalness**",  # noqa: E501
-        "and cut-through are perceptual (rig audit). `firm`/`critical` are the time-critical act cues.",  # noqa: E501
+        "and cut-through are perceptual (rig audit). `alert`/`urgent`/`critical` are act cues.",  # noqa: E501
         "",
-        "| backend | avail | firm ms | crit ms | calm→crit dBFS | calm→crit centroid | bake s | license | dep risk | naturalness | verdict |",  # noqa: E501
-        "|---|---|---|---|---|---|---|---|---|---|---|",
+        "| backend | avail | alert ms | urgent ms | crit ms | calm->crit dBFS | calm->crit centroid | bake s | license | dep risk | naturalness | verdict |",  # noqa: E501
+        "|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for r in results:
-        fm = r.act_clip_ms.get("firm")
+        am = r.act_clip_ms.get("alert")
+        um = r.act_clip_ms.get("urgent")
         cm = r.act_clip_ms.get("critical")
-        dbfs = f"{r.calm_dbfs}→{r.critical_dbfs}" if r.calm_dbfs is not None else "—"
+        dbfs = f"{r.calm_dbfs}->{r.critical_dbfs}" if r.calm_dbfs is not None else "-"
         cen = (
-            f"{r.calm_centroid_hz}→{r.critical_centroid_hz}"
+            f"{r.calm_centroid_hz}->{r.critical_centroid_hz}"
             if r.calm_centroid_hz is not None
-            else "—"
+            else "-"
         )
         lines.append(
-            f"| {r.backend} | {'yes' if r.available else 'no'} | {fm or '—'} | {cm or '—'} | "
-            f"{dbfs} | {cen} | {r.bake_cpu_s or '—'} | {r.license} | {r.dep_risk} | "
-            f"{r.naturalness} | {r.verdict}{(' — ' + r.note) if r.note else ''} |"
+            f"| {r.backend} | {'yes' if r.available else 'no'} | {am or '-'} | "
+            f"{um or '-'} | {cm or '-'} | {dbfs} | {cen} | {r.bake_cpu_s or '-'} | "
+            f"{r.license} | {r.dep_risk} | {r.naturalness} | "
+            f"{r.verdict}{(' - ' + r.note) if r.note else ''} |"
         )
     lines += [
         "",
         "**Recommendation:** ship **kokoro-82M** (Apache-2.0, no GPL dep, best permissive naturalness)",  # noqa: E501
         "as the production rig voice; **macsay-expressive** is the macOS dev/listen path; **tone** is",  # noqa: E501
         "the deterministic CI smoke voice. `pyttsx3/SAPI` and flat `say` are the rejected flat baselines",  # noqa: E501
-        "(no tone variation). Centroid/dBFS deltas show the calm→critical tone escalation is real.",
+        "(no tone variation). Centroid/dBFS deltas show the calm->critical tone escalation is",
+        "real.",
         "",
     ]
     return "\n".join(lines)
@@ -243,7 +247,7 @@ def main(argv: list[str] | None = None) -> int:
     md = to_markdown(results)
     if args.out:
         Path(args.out).write_text(md, encoding="utf-8")
-        print(f"wrote benchmark → {args.out}")
+        print(f"wrote benchmark -> {args.out}")
     else:
         print(md)
     if args.json_out:

--- a/tools/ai_sidecar/voice/bench_voices.py
+++ b/tools/ai_sidecar/voice/bench_voices.py
@@ -214,8 +214,10 @@ def to_markdown(results: list[BackendResult]) -> str:
             else "-"
         )
         lines.append(
-            f"| {r.backend} | {'yes' if r.available else 'no'} | {am or '-'} | "
-            f"{um or '-'} | {cm or '-'} | {dbfs} | {cen} | {r.bake_cpu_s or '-'} | "
+            f"| {r.backend} | {'yes' if r.available else 'no'} "
+            f"| {am if am is not None else '-'} | {um if um is not None else '-'} "
+            f"| {cm if cm is not None else '-'} | {dbfs} | {cen} "
+            f"| {r.bake_cpu_s if r.bake_cpu_s is not None else '-'} | "
             f"{r.license} | {r.dep_risk} | {r.naturalness} | "
             f"{r.verdict}{(' - ' + r.note) if r.note else ''} |"
         )

--- a/tools/ai_sidecar/voice/client.py
+++ b/tools/ai_sidecar/voice/client.py
@@ -29,6 +29,7 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_STATE_SUBSCRIBE,
 )
 from tools.ai_sidecar.voice.cue import CueArbiter, SpokenCue
+from tools.ai_sidecar.voice.vocabulary import normalize_register
 
 #: Max pending TTS phrases; when full, drop the oldest so memory stays bounded under cue bursts.
 _VOICE_QUEUE_MAX = 4
@@ -38,8 +39,18 @@ DEFAULT_TTS_VOLUME = 1.0
 #: pyttsx3 rate/volume offsets per intensity register. The configured base rate/volume remains the
 #: center point so rig tuning knobs still work; the WS/pyttsx3 path just nudges calm down and
 #: critical up to convey intensity when there is no baked prosody.
-_REGISTER_RATE_DELTA: dict[str, int] = {"calm": -15, "firm": 0, "critical": 15}
-_REGISTER_VOLUME_DELTA: dict[str, float] = {"calm": -0.1, "firm": 0.0, "critical": 0.1}
+_REGISTER_RATE_DELTA: dict[str, int] = {
+    "calm": -18,
+    "alert": -6,
+    "urgent": 8,
+    "critical": 20,
+}
+_REGISTER_VOLUME_DELTA: dict[str, float] = {
+    "calm": -0.12,
+    "alert": -0.03,
+    "urgent": 0.05,
+    "critical": 0.12,
+}
 
 
 def extract_advisory(frame: dict[str, Any]) -> dict[str, Any] | None:
@@ -101,11 +112,14 @@ def _env_truthy(value: str | None) -> bool:
 
 
 def _register_rate(base_rate: int, register: str) -> int:
-    return max(1, base_rate + _REGISTER_RATE_DELTA.get(register, 0))
+    return max(1, base_rate + _REGISTER_RATE_DELTA.get(normalize_register(register), 0))
 
 
 def _register_volume(base_volume: float, register: str) -> float:
-    return min(1.0, max(0.0, base_volume + _REGISTER_VOLUME_DELTA.get(register, 0.0)))
+    return min(
+        1.0,
+        max(0.0, base_volume + _REGISTER_VOLUME_DELTA.get(normalize_register(register), 0.0)),
+    )
 
 
 def _disabled_speaker(reason: str) -> Callable[[str, str], None]:

--- a/tools/ai_sidecar/voice/cue.py
+++ b/tools/ai_sidecar/voice/cue.py
@@ -75,6 +75,20 @@ def _turn(corner: Any) -> str:
         return "this corner"
 
 
+def _effective_register(advisory: dict[str, Any]) -> str:
+    """Register for the fallback path, mirroring :func:`resolver._register_fallback_chain`.
+
+    An ``act`` advisory carrying the default ``calm`` register is a legacy / register-less producer:
+    act-now cues are never baked at ``calm`` (they live at ``alert``/``urgent``/``critical``), so
+    treat that case as ``urgent`` — otherwise the WS/pyttsx3 fallback under-reacts (non-terse
+    phrasing + low rate/volume) on a time-critical cue, diverging from the in-process resolver.
+    """
+    register = normalize_register(advisory.get("register", "calm"))
+    if advisory.get("urgency") == "act" and register == "calm":
+        return "urgent"
+    return register
+
+
 def advisory_to_phrase(advisory: dict[str, Any]) -> str:
     """Short, ear-first phrasing of one observer advisory dict, register-aware (issue #368).
 
@@ -85,7 +99,7 @@ def advisory_to_phrase(advisory: dict[str, Any]) -> str:
     intensity.
     """
     kind = advisory.get("kind")
-    register = normalize_register(advisory.get("register", "calm"))
+    register = _effective_register(advisory)
     corner = advisory.get("corner", 0)
     if kind == "late_brake":
         if register == "critical":
@@ -94,7 +108,7 @@ def advisory_to_phrase(advisory: dict[str, Any]) -> str:
             return "Brake."
         return f"Brake point, {_turn(corner)}."
     if kind == "brake_release":
-        return "Release." if register in {"alert", "urgent"} else "Ease off."
+        return "Release." if register in {"alert", "urgent", "critical"} else "Ease off."
     if kind == "apex_deficit":
         return f"More entry speed, {_turn(corner)}."
     if kind == "fuel_status":
@@ -167,7 +181,7 @@ class CueArbiter:
             urgency=str(best.get("urgency", "info")),
             corner=_corner_key(best),
             kind=str(best.get("kind", "")),
-            register=normalize_register(best.get("register", "calm")),
+            register=_effective_register(best),
         )
 
 

--- a/tools/ai_sidecar/voice/cue.py
+++ b/tools/ai_sidecar/voice/cue.py
@@ -17,6 +17,8 @@ import math
 from dataclasses import dataclass, field
 from typing import Any
 
+from tools.ai_sidecar.voice.vocabulary import normalize_register
+
 #: Higher rank preempts and may barge in through the global cooldown.
 _URGENCY_RANK: dict[str, int] = {"info": 1, "prepare": 2, "act": 3}
 #: Default lap length (m) for spline lookahead when track length is unknown.
@@ -76,22 +78,23 @@ def _turn(corner: Any) -> str:
 def advisory_to_phrase(advisory: dict[str, Any]) -> str:
     """Short, ear-first phrasing of one observer advisory dict, register-aware (issue #368).
 
-    The terse act tier (``firm``/``critical``) drops the corner number — the driver knows the corner
-    and needs the verb now; the calm anticipatory tier keeps it. Mirrors the baked phrase-bank
-    wording (``vocabulary._STEMS``) so the WS/pyttsx3 path speaks the same words as the in-process
-    bank coach, and the speaker varies rate/volume by ``register`` to convey the intensity.
+    The terse act tier (``alert``/``urgent``/``critical``) drops the corner number — the driver
+    knows the corner and needs the verb now; the calm anticipatory tier keeps it. Mirrors the baked
+    phrase-bank wording (``vocabulary._STEMS``) so the WS/pyttsx3 path speaks the same words as the
+    in-process bank coach, and the speaker varies rate/volume by ``register`` to convey the
+    intensity.
     """
     kind = advisory.get("kind")
-    register = str(advisory.get("register", "calm"))
+    register = normalize_register(advisory.get("register", "calm"))
     corner = advisory.get("corner", 0)
     if kind == "late_brake":
         if register == "critical":
             return "Brake!"
-        if register == "firm":
+        if register in {"alert", "urgent"}:
             return "Brake."
         return f"Brake point, {_turn(corner)}."
     if kind == "brake_release":
-        return "Release." if register == "firm" else "Ease off."
+        return "Release." if register in {"alert", "urgent"} else "Ease off."
     if kind == "apex_deficit":
         return f"More entry speed, {_turn(corner)}."
     if kind == "fuel_status":
@@ -133,8 +136,8 @@ class CueArbiter:
         if not advisories:
             return None
         # Drop advisories still within their per-(corner, kind) cooldown — EXCEPT an `act` cue,
-        # which bypasses the anti-nag window so a critical/firm escalation ("Brake!") is still heard
-        # after an earlier calm lead-in for the same corner (codex review #371). Mirrors the
+        # which bypasses the anti-nag window so a hotter escalation ("Brake!") is still heard after
+        # an earlier calm lead-in for the same corner (codex review #371). Mirrors the
         # in-process scheduler's act exemption.
         fresh: list[dict[str, Any]] = []
         for a in advisories:
@@ -164,7 +167,7 @@ class CueArbiter:
             urgency=str(best.get("urgency", "info")),
             corner=_corner_key(best),
             kind=str(best.get("kind", "")),
-            register=str(best.get("register", "calm")),
+            register=normalize_register(best.get("register", "calm")),
         )
 
 

--- a/tools/ai_sidecar/voice/manifest.py
+++ b/tools/ai_sidecar/voice/manifest.py
@@ -30,7 +30,9 @@ from tools.ai_sidecar.voice import vocabulary as vocab
 
 #: Manifest schema version. Bump on any breaking change to the on-disk shape.
 #: v2 (issue #368): adds ``register`` (intensity tier) to every clip + the index key.
-MANIFEST_VERSION = 2
+#: v3 (issue #381): changes canonical register values from calm/firm/critical to
+#: calm/alert/urgent/critical and folds persona/intensity-chain metadata into voice_signature.
+MANIFEST_VERSION = 3
 
 #: Canonical manifest filename inside a bank directory.
 MANIFEST_FILENAME = "manifest.json"
@@ -53,7 +55,7 @@ class ClipEntry:
     file: str  # relative to the bank directory
     kind: str
     urgency: str
-    register: str  # intensity tier (calm|firm|critical) — issue #368, v2 manifest
+    register: str  # intensity tier (calm|alert|urgent|critical) — issue #381, v3 manifest
     corner: int | None
     text: str
     sha256: str
@@ -78,11 +80,11 @@ class ClipEntry:
                 corner = int(corner)
             # ``register`` is REQUIRED in v2: a v1 manifest (no register) raises here at LOAD, so
             # ``engine.from_bank`` returns a disabled coach rather than ever playing a clip whose
-            # tier is unknown (issue #368). No lenient default — that would let a v1 bank masquerade
-            # as v2. The value is also validated against the allowed tiers (calm|firm|critical) at
+            # tier is unknown (issue #368). No lenient default — that would let an old bank
+            # masquerade as current. The value is also validated against the allowed tiers at
             # load so a hand-edited/corrupt manifest fails loudly here, not as a silent lookup miss
             # later (codex/qodo review #371).
-            register = str(d["register"])
+            register = vocab.normalize_register(d["register"])
             if register not in vocab.REGISTERS:
                 raise ValueError(f"register {register!r} not in {vocab.REGISTERS}")
             return ClipEntry(
@@ -130,7 +132,7 @@ class Manifest:
 
     def lookup(self, kind: str, urgency: str, register: str, corner: int | None) -> str | None:
         """Return the clip id for an advisory key, or ``None`` if the bank has no such clip."""
-        return self._by_key.get((kind, urgency, register, corner))
+        return self._by_key.get((kind, urgency, vocab.normalize_register(register), corner))
 
     # ---- (de)serialization -------------------------------------------------------------------
 

--- a/tools/ai_sidecar/voice/resolver.py
+++ b/tools/ai_sidecar/voice/resolver.py
@@ -5,19 +5,20 @@ against the :class:`~tools.ai_sidecar.voice.manifest.Manifest`; a future number-
 will slot in behind this *same* signature without the scheduler or playback knowing.
 
 Keying (issue #368): the manifest is keyed on ``(kind, urgency, register, corner)``. ``register`` is
-the intensity tier the observer chose for the situation (calm|firm|critical). Two fallbacks keep a
-cue audible rather than silent:
+the intensity tier the observer chose for the situation (calm|alert|urgent|critical). Two fallbacks
+keep a cue audible rather than silent:
 
 * **register fallback** — if the bank has no clip for the requested tier (the vocabulary may not
-  bake every register for every cue), fall back toward ``calm`` (critical -> firm -> calm).
-  ``calm`` is the always-present base tier.
+  bake every register for every cue), fall back toward ``calm`` (critical -> urgent -> alert ->
+  calm). Legacy ``firm`` input is normalized to ``urgent``.
+``calm`` is the base tier for measured heads-ups.
 * **corner fallback** — a corner beyond the baked range (T21+) or the terse act tier (which is
   corner-less by design) degrades to the generic, corner-less clip.
 
 ``Utterance.register`` is set to the register that was *actually resolved* (after fallback), so
 logs and the timing report never claim a tier that did not play. The ``dedup_key`` is keyed on the
-*requested* register, so a genuine escalation (calm -> firm -> critical for one corner) is treated
-as distinct coaching events.
+*requested* register, so a genuine escalation (calm -> alert -> urgent -> critical for one corner)
+is treated as distinct coaching events.
 
 Corner-number convention: ``Advisory.corner`` is **0-based** (``realtime_observer`` uses 0-based
 ``CornerReference.index``); the spoken vocabulary is **1-based** ("turn one"). The resolver bridges
@@ -59,14 +60,15 @@ def _spoken_corner(corner: object) -> int | None:
 def _register_fallback_chain(register: str, *, urgency: str) -> tuple[str, ...]:
     """Registers to try, from the requested tier down toward the always-present ``calm`` base.
 
-    ``critical`` -> ``(critical, firm, calm)``; ``firm`` -> ``(firm, calm)``;
-    ``calm`` -> ``(calm,)``.
+    ``critical`` -> ``(critical, urgent, alert, calm)``; ``urgent`` -> ``(urgent, alert, calm)``;
+    ``alert`` -> ``(alert, calm)``; ``calm`` -> ``(calm,)``.
     """
     if urgency == "act" and register == "calm":
         # Legacy Advisory construction predates the register field and therefore carries the
-        # dataclass default "calm". The v2 vocabulary intentionally bakes act-now clips at firm /
-        # critical, not calm, so try the playable firm act clip before dropping the cue.
-        return ("firm", "calm")
+        # dataclass default "calm". The v2 vocabulary intentionally baked act-now clips at
+        # firm/critical, not calm. In v3, try the playable urgent/alert act clips before dropping
+        # it.
+        return ("urgent", "alert", "calm")
     idx = vocab.REGISTERS.index(register)
     return tuple(reversed(vocab.REGISTERS[: idx + 1]))
 
@@ -85,7 +87,7 @@ class Resolver:
         """
         kind = getattr(advisory, "kind", None)
         urgency = getattr(advisory, "urgency", None)
-        register = getattr(advisory, "register", "calm")
+        register = vocab.normalize_register(getattr(advisory, "register", "calm"))
         if kind not in vocab.KINDS:
             _log.warning("voice: dropping advisory with unknown kind=%r", kind)
             return None
@@ -129,9 +131,9 @@ class Resolver:
         entry = self._manifest.clips.get(clip_id)
         text = entry.text if entry is not None else ""
         # Dedup is keyed on the *advisory's* identity (kind + 0-based corner + REQUESTED register),
-        # so a genuine escalation (calm→firm→critical for one corner) is distinct, while a repeat at
-        # the same register within a pass collapses to one utterance regardless of corner/register
-        # fallback.
+        # so a genuine escalation (calm→alert→urgent→critical for one corner) is distinct, while a
+        # repeat at the same register within a pass collapses to one utterance regardless of
+        # corner/register fallback.
         dedup_key = f"{kind}:{getattr(advisory, 'corner', None)}:{register}"
         return Utterance(
             clip_id=clip_id,

--- a/tools/ai_sidecar/voice/scheduler.py
+++ b/tools/ai_sidecar/voice/scheduler.py
@@ -41,13 +41,14 @@ from tools.ai_sidecar.voice.config import Verbosity, VoiceConfig
 from tools.ai_sidecar.voice.playback import Playback
 from tools.ai_sidecar.voice.resolver import Resolver
 from tools.ai_sidecar.voice.utterance import URGENCY_RANK, Utterance
+from tools.ai_sidecar.voice.vocabulary import REGISTER_RANK
 
 _log = logging.getLogger("ai_sidecar.voice.scheduler")
 
 _ACT_RANK = URGENCY_RANK["act"]
-#: tone-register ordering (low → high) — used only to break a same-urgency barge-in tie so a
-#: critical escalation can interrupt a still-playing firm clip (issue #368 / codex review #371).
-_REGISTER_RANK: dict[str, int] = {"calm": 0, "firm": 1, "critical": 2}
+#: tone-register ordering (low -> high) — used only to break a same-urgency barge-in tie so a
+#: critical escalation can interrupt a still-playing urgent clip (issue #381).
+_REGISTER_RANK = REGISTER_RANK
 
 
 @dataclass
@@ -172,9 +173,9 @@ class Scheduler:
         current = self._playback.current
         if current is not None:
             higher_urgency = winner.rank > current.rank
-            # A critical escalation over a still-playing FIRM clip shares the `act` urgency rank, so
-            # break the tie on the tone register — the more intense alarm must be heard (codex
-            # review #371). Same urgency + same/lower register never interrupts (it would be stale).
+            # A hotter escalation over a still-playing act clip shares the `act` urgency rank, so
+            # break the tie on the tone register — the more intense alarm must be heard. Same
+            # urgency + same/lower register never interrupts (it would be stale).
             louder_same_urgency = winner.rank == current.rank and _REGISTER_RANK.get(
                 winner.register, 0
             ) > _REGISTER_RANK.get(current.register, 0)

--- a/tools/ai_sidecar/voice/timing_report.py
+++ b/tools/ai_sidecar/voice/timing_report.py
@@ -134,7 +134,8 @@ def _inject_corner_frames(
     if bp is None:
         return [], 0.0
     apex = ref.apex_spline
-    # approach hot (well above the apex target) and not braking → forces a firm/critical brake cue
+    # approach hot (well above the apex target) and not braking → forces an urgent/critical brake
+    # cue
     speed = max(ref.target_apex_kmh + 60.0, 120.0)
     frames: list[dict[str, Any]] = []
     track_length_m = max(track_length_m, 1.0)

--- a/tools/ai_sidecar/voice/utterance.py
+++ b/tools/ai_sidecar/voice/utterance.py
@@ -27,16 +27,16 @@ class Utterance:
         kind: Originating advisory ``kind`` (carried for logging + cooldown bucketing).
         urgency: Originating advisory ``urgency`` — drives scheduling (act > prepare > info) and
             barge-in.
-        register: The intensity tier actually RESOLVED (calm|firm|critical) — issue #368. This is
-            the register of the clip that will sound, *after* any resolver fallback, so logs and the
+        register: The intensity tier actually RESOLVED (calm|alert|urgent|critical) — issue #381.
+            The register of the clip that will sound, *after* any resolver fallback, so logs and the
             timing report never claim a tier that did not play. It does NOT affect :attr:`rank`
             (tone must never perturb scheduler arbitration).
         corner: 1-based spoken corner number, or ``None`` for a generic (corner-less) clip.
         text: The spoken text (for logs / debugging; never re-synthesized at runtime in v1).
         dedup_key: Stable key identifying "the same cue this corner pass" —
             ``"{kind}:{corner}:{register}"``. Including the register lets a genuine escalation
-            (calm -> firm -> critical for the same corner) through as a distinct event, while a
-            same-register repeat within one pass is still suppressed.
+            (calm -> alert -> urgent -> critical for the same corner) through as a distinct event,
+            while a same-register repeat within one pass is still suppressed.
     """
 
     clip_id: str

--- a/tools/ai_sidecar/voice/vocabulary.py
+++ b/tools/ai_sidecar/voice/vocabulary.py
@@ -42,6 +42,26 @@ import json
 from collections.abc import Iterator
 from dataclasses import dataclass
 
+# The intensity-``register`` ladder is the SHARED domain of the observer (producer) and this
+# vocabulary (consumer); it lives in the dependency-free :mod:`tools.ai_sidecar.registers` so both
+# sides import the same constants instead of re-declaring them (issue #381). Re-exported here so
+# existing importers (scheduler, client, cue, resolver, manifest, tests) keep using ``vocabulary``.
+from tools.ai_sidecar.registers import (
+    REGISTER_ALIASES,
+    REGISTER_RANK,
+    REGISTERS,
+    normalize_register,
+    register_rank,
+)
+
+__all__ = [
+    "REGISTER_ALIASES",
+    "REGISTER_RANK",
+    "REGISTERS",
+    "normalize_register",
+    "register_rank",
+]
+
 #: Advisory ``kind`` values this vocabulary covers (mirrors ``realtime_observer.Advisory.kind``).
 #: The braking cluster (issue #368 "braking first" slice): the anticipatory late-brake cue, the
 #: over-braking release cue, and the (text-HUD) apex-deficit verdict. Every kind here is actually
@@ -72,16 +92,8 @@ KINDS: tuple[str, ...] = (
 #: SCHEDULING only (priority / barge-in / verbosity), never tone.
 URGENCIES: tuple[str, ...] = ("info", "prepare", "act")
 
-#: Intensity tiers, low -> high (issue #381). Drives the baked *tone* of a clip, never scheduling.
-#: ``calm`` = measured heads-up; ``alert`` = clear attention cue; ``urgent`` = act-now correction;
-#: ``critical`` = alarm. The observer quantizes a continuous severity scalar to one of these with
-#: hysteresis (:func:`tools.ai_sidecar.realtime_observer`), and the resolver keys the manifest on
-#: it.
-REGISTERS: tuple[str, ...] = ("calm", "alert", "urgent", "critical")
-
-#: Backward-compatible input aliases for advisory producers and older tests/log replays. New banks
-#: bake ``urgent``; legacy ``firm`` advisories resolve to that tier instead of going silent.
-REGISTER_ALIASES: dict[str, str] = {"firm": "urgent"}
+# Intensity tiers (``REGISTERS``) and the legacy ``firm`` alias now live in
+# :mod:`tools.ai_sidecar.registers` and are re-exported at the top of this module.
 
 #: Original/licensed persona metadata folded into every backend ``voice_signature``. This explicitly
 #: documents that the distributed voice is a project-authored race-engineer style, not a real driver
@@ -89,25 +101,6 @@ REGISTER_ALIASES: dict[str, str] = {"firm": "urgent"}
 VOICE_PERSONA_ID = "race-engineer-original-v1"
 VOICE_PERSONA_LICENSE = "project-authored; no unconsented real-person clone"
 INTENSITY_CHAIN_VERSION = 2
-
-
-def normalize_register(register: object) -> str:
-    """Return the canonical intensity tier for ``register``.
-
-    ``firm`` is accepted as a legacy alias for ``urgent`` so old advisory logs and producers keep
-    speaking after the #381 vocabulary change. Unknown values are returned unchanged; callers still
-    validate against :data:`REGISTERS`.
-    """
-    raw = str(register)
-    return REGISTER_ALIASES.get(raw, raw)
-
-
-REGISTER_RANK: dict[str, int] = {register: rank for rank, register in enumerate(REGISTERS)}
-
-
-def register_rank(register: object, default: int = 0) -> int:
-    """Ordering helper for intensity comparisons, accepting legacy aliases."""
-    return REGISTER_RANK.get(normalize_register(register), default)
 
 
 #: Universal corner numbers we bake (1-based, as spoken). T21+ degrades to the generic clip.

--- a/tools/ai_sidecar/voice/vocabulary.py
+++ b/tools/ai_sidecar/voice/vocabulary.py
@@ -6,11 +6,11 @@ The realtime coaching pipeline emits a *bounded* set of advisories across three 
   (``late_brake`` | ``brake_release`` | ``turn_in`` | ``apex_deficit``).
 * ``urgency`` (``info`` | ``prepare`` | ``act``) — drives the SCHEDULER (priority, barge-in,
   verbosity gating). Never a tone knob.
-* ``register`` (``calm`` | ``firm`` | ``critical``) — the **intensity tier**: which *tonal variant*
-  of the command is spoken. This is issue #368's headline — the SAME control point spoken with a
-  tone that reflects how severe the situation is ("not just 'turn left'"). The register is baked
-  into the clip's prosody (rate/pitch/loudness/brightness — see :mod:`tools.ai_sidecar.voice.bake`),
-  so tone is delivered with zero hot-path TTS.
+* ``register`` (``calm`` | ``alert`` | ``urgent`` | ``critical``) — the **intensity tier**:
+  which tonal variant of the command is spoken. This is issue #368's headline — the SAME control
+  point spoken with a tone that reflects how severe the situation is ("not just 'turn left'"). The
+  register is baked into the clip's prosody (rate/pitch/loudness/brightness — see
+  :mod:`tools.ai_sidecar.voice.bake`), so tone is delivered with zero hot-path TTS.
 
 plus a **universal corner number** (``turn one`` .. ``turn twenty`` — track-agnostic, safe to bake
 once). Because the set is finite and known ahead of time, we pre-render every utterance once and
@@ -20,9 +20,9 @@ look it up at runtime — no live TTS in the hot path.
 NOW" cue must be ≤450 ms. The corner number ("…turn seventeen") is ~700 ms of speech the driver does
 not need mid-corner — they know which corner they are in. So the **anticipatory/low-intensity** cues
 (``prepare``/``info``, where the driver has lead time) carry the corner number, while the
-**act-now** cues (``act`` urgency / ``firm``+``critical`` registers) are corner-less and terse
-("Brake.", "Brake, brake!"). A stem carries a corner number iff its text contains ``{turn}``; this
-single rule bounds the bank and guarantees the act tier stays terse.
+**act-now** cues (``act`` urgency / ``alert``+``urgent``+``critical`` registers) are corner-less and
+terse ("Brake.", "Brake, brake!"). A stem carries a corner number iff its text contains ``{turn}``;
+this single rule bounds the bank and guarantees the act tier stays terse.
 
 This module enumerates that vocabulary deterministically. Both the offline bake step
 (:mod:`tools.ai_sidecar.voice.bake`) and the runtime :mod:`~tools.ai_sidecar.voice.resolver`
@@ -72,11 +72,43 @@ KINDS: tuple[str, ...] = (
 #: SCHEDULING only (priority / barge-in / verbosity), never tone.
 URGENCIES: tuple[str, ...] = ("info", "prepare", "act")
 
-#: Intensity tiers, low -> high (issue #368). Drives the baked *tone* of a clip, never scheduling.
-#: ``calm`` = a measured heads-up; ``firm`` = a clear correction; ``critical`` = an alarm. The
-#: observer quantizes a continuous severity scalar to one of these with hysteresis
-#: (:func:`tools.ai_sidecar.realtime_observer`), and the resolver keys the manifest on it.
-REGISTERS: tuple[str, ...] = ("calm", "firm", "critical")
+#: Intensity tiers, low -> high (issue #381). Drives the baked *tone* of a clip, never scheduling.
+#: ``calm`` = measured heads-up; ``alert`` = clear attention cue; ``urgent`` = act-now correction;
+#: ``critical`` = alarm. The observer quantizes a continuous severity scalar to one of these with
+#: hysteresis (:func:`tools.ai_sidecar.realtime_observer`), and the resolver keys the manifest on
+#: it.
+REGISTERS: tuple[str, ...] = ("calm", "alert", "urgent", "critical")
+
+#: Backward-compatible input aliases for advisory producers and older tests/log replays. New banks
+#: bake ``urgent``; legacy ``firm`` advisories resolve to that tier instead of going silent.
+REGISTER_ALIASES: dict[str, str] = {"firm": "urgent"}
+
+#: Original/licensed persona metadata folded into every backend ``voice_signature``. This explicitly
+#: documents that the distributed voice is a project-authored race-engineer style, not a real driver
+#: clone.
+VOICE_PERSONA_ID = "race-engineer-original-v1"
+VOICE_PERSONA_LICENSE = "project-authored; no unconsented real-person clone"
+INTENSITY_CHAIN_VERSION = 2
+
+
+def normalize_register(register: object) -> str:
+    """Return the canonical intensity tier for ``register``.
+
+    ``firm`` is accepted as a legacy alias for ``urgent`` so old advisory logs and producers keep
+    speaking after the #381 vocabulary change. Unknown values are returned unchanged; callers still
+    validate against :data:`REGISTERS`.
+    """
+    raw = str(register)
+    return REGISTER_ALIASES.get(raw, raw)
+
+
+REGISTER_RANK: dict[str, int] = {register: rank for rank, register in enumerate(REGISTERS)}
+
+
+def register_rank(register: object, default: int = 0) -> int:
+    """Ordering helper for intensity comparisons, accepting legacy aliases."""
+    return REGISTER_RANK.get(normalize_register(register), default)
+
 
 #: Universal corner numbers we bake (1-based, as spoken). T21+ degrades to the generic clip.
 MAX_CORNER: int = 20
@@ -125,27 +157,34 @@ _STEMS: dict[tuple[str, str, str], str] = {
     # registers ARE the headline — the same control point spoken with a tone that escalates with how
     # late/hot the driver is ("not just 'turn left'").
     ("late_brake", "prepare", "calm"): "Brake point{turn}.",
-    ("late_brake", "act", "firm"): "Brake.",
-    # Critical is the SAME word as firm — the escalation is carried by TONE (louder, brighter,
+    ("late_brake", "act", "alert"): "Brake.",
+    ("late_brake", "act", "urgent"): "Brake.",
+    # Critical is the SAME word as urgent — the escalation is carried by TONE (louder, brighter,
     # faster: the issue #368 headline "even the tone reflects the situation"), kept to one syllable
     # so the alarm lands inside the braking window (≤450 ms). The "!" gives the synthesizer a
-    # sharper intonation than firm's ".".
+    # sharper intonation than urgent's ".".
     ("late_brake", "act", "critical"): "Brake!",
     # brake_release: over-braking past the apex while off-throttle — terse, in-corner (no number).
     ("brake_release", "prepare", "calm"): "Ease off.",
-    ("brake_release", "act", "firm"): "Release.",
+    ("brake_release", "act", "alert"): "Release.",
+    ("brake_release", "act", "urgent"): "Release.",
     # apex_deficit: the text-HUD min-speed verdict. Voice keeps it as a calm heads-up that LOW
     # verbosity suppresses (issue #368 AC e: no post-fact narration in low verbosity).
     ("apex_deficit", "info", "calm"): "More entry speed{turn}.",
     # --- Coach v2: verb-first imperatives, corner-LESS (the cue lands AT the corner, so timing
-    # carries the location — no spoken number). One register each (firm correction / critical
-    # alarm / calm acknowledge); magnitude grading is a later slice. ---
-    ("early_brake", "prepare", "firm"): "Brake later.",
-    ("brake_late", "prepare", "firm"): "Brake earlier.",
-    ("no_trail", "prepare", "firm"): "Trail it.",
-    ("slow_apex", "prepare", "firm"): "Carry more.",
-    ("late_throttle", "act", "firm"): "Power.",
-    # magnitude grading (P2): the SAME word, hotter tone, for a gross miss — second register tier.
+    # carries the location — no spoken number). The same word is baked at alert/urgent/critical so
+    # severity changes tone without changing the coaching command. ---
+    ("early_brake", "prepare", "alert"): "Brake later.",
+    ("brake_late", "prepare", "alert"): "Brake earlier.",
+    ("no_trail", "prepare", "alert"): "Trail it.",
+    ("slow_apex", "prepare", "alert"): "Carry more.",
+    ("late_throttle", "act", "alert"): "Power.",
+    ("early_brake", "prepare", "urgent"): "Brake later.",
+    ("brake_late", "prepare", "urgent"): "Brake earlier.",
+    ("no_trail", "prepare", "urgent"): "Trail it.",
+    ("slow_apex", "prepare", "urgent"): "Carry more.",
+    ("late_throttle", "act", "urgent"): "Power.",
+    # magnitude grading (P2/#381): the SAME word, hotter tone, for a gross miss.
     ("early_brake", "prepare", "critical"): "Brake later.",
     ("brake_late", "prepare", "critical"): "Brake earlier.",
     ("no_trail", "prepare", "critical"): "Trail it.",
@@ -157,16 +196,16 @@ _STEMS: dict[tuple[str, str, str], str] = {
     # numbers ride in the advisory payload for screens/logs, while the voice keeps the hot path
     # short enough to act on.
     ("fuel_status", "info", "calm"): "Fuel check.",
-    ("fuel_save", "act", "firm"): "Save fuel.",
+    ("fuel_save", "act", "urgent"): "Save fuel.",
     ("fuel_save", "act", "critical"): "Lift and coast.",
-    ("tyre_manage", "prepare", "firm"): "Manage tyres.",
-    ("tyre_manage", "act", "firm"): "Save tyres.",
+    ("tyre_manage", "prepare", "alert"): "Manage tyres.",
+    ("tyre_manage", "act", "urgent"): "Save tyres.",
     ("tyre_manage", "act", "critical"): "Save tyres!",
-    ("brake_manage", "prepare", "firm"): "Cool brakes.",
+    ("brake_manage", "prepare", "alert"): "Cool brakes.",
     ("brake_manage", "act", "critical"): "Cool brakes!",
     ("conditions_strategy", "prepare", "calm"): "Track is green.",
-    ("conditions_strategy", "prepare", "firm"): "Adjust to track.",
-    ("conditions_strategy", "act", "firm"): "Smooth inputs.",
+    ("conditions_strategy", "prepare", "alert"): "Adjust to track.",
+    ("conditions_strategy", "act", "urgent"): "Smooth inputs.",
 }
 
 
@@ -221,8 +260,9 @@ def _phrase(kind: str, urgency: str, register: str, corner: int | None) -> Phras
 def iter_vocabulary() -> Iterator[Phrase]:
     """Yield every bakeable :class:`Phrase` exactly once, in a stable, deterministic order.
 
-    Order: kind (KINDS order) -> urgency (info, prepare, act) -> register (calm, firm, critical) ->
-    corner (generic first, then 1..MAX *only* for stems that carry ``{turn}``). Only
+    Order: kind (KINDS order) -> urgency (info, prepare, act) -> register
+    (calm, alert, urgent, critical) -> corner (generic first, then 1..MAX *only* for stems that
+    carry ``{turn}``). Only
     ``(kind, urgency, register)`` triples present in :data:`_STEMS` are emitted. This ordering *is*
     part of the content-addressing contract — :func:`vocabulary_hash` depends on it being stable.
     """


### PR DESCRIPTION
## Summary

Refs #381.

- Promotes the voice register ladder to `calm` / `alert` / `urgent` / `critical`, with legacy `firm` input normalized to `urgent` so old producers and logs still resolve.
- Bumps the phrase-bank manifest to v3 and stamps persona/intensity metadata into every backend `voice_signature` (`race-engineer-original-v1+intensity2`).
- Maps severity through observer, Coach v2, race-management, scheduler, resolver, pyttsx3 fallback, and bake/benchmark tooling so importance changes tone, not just speed.
- Documents the original/licensed race-engineer persona and fixes a Windows codepage-safe benchmark CLI status print found during verification.

## Verification

- `python -m pytest tests/test_voice_vocabulary.py tests/test_voice_manifest.py tests/test_voice_resolver.py tests/test_voice_scheduler.py tests/test_voice_bake.py tests/test_voice_cue.py tests/test_voice_client.py tests/test_realtime_observer_intensity.py tests/test_realtime_observer.py tests/test_coaching_v2.py tests/test_coaching_e2e.py tests/test_race_management.py tests/test_voice_bench_voices.py tests/test_voice_engine.py tests/test_voice_timing_report.py -q` -> 188 passed.
- `python -m ruff check ...changed voice/coaching/tests...` -> all checks passed.
- `$env:FLEET_GOVERNANCE_ROOT=(Resolve-Path .fleet-governance-vendor).Path; make ci-fast` -> 2035 passed, 117 skipped, coverage 85.91%, `ci-fast: OK`.
- `python -m tools.ai_sidecar.voice.bake --backend tone --out .scratch\issue381-voice-bank --samplerate 22050` -> baked 76 clips, manifest v3, signature `tone-v3+race-engineer-original-v1+intensity2`.
- `python -m tools.ai_sidecar.voice.bench_voices --out .scratch\issue381-voice-bench.md --json-out .scratch\issue381-voice-bench.json` -> ToneBackend alert/urgent/critical act cues measured 165.6 ms / 144.0 ms / 126.0 ms.

## Remaining Rig Check

This is draft because #381 explicitly asks for operator-confirmed on-rig A/B listening: critical brake cue should sound urgent and minor apex/coaching cues should sound calm. The hot path remains pre-baked/local and the off-rig bank evidence is ready for that rig pass.
