### PR TITLE
fix: harden setup review edge cases (#407)

### DIFF
--- a/scripts/policy_tracked_files.py
+++ b/scripts/policy_tracked_files.py
@@ -14,9 +14,9 @@ POSIX_MAX_ARG_CHARS = 24_000
 WINDOWS_BATCH_SIZE = 25
 WINDOWS_MAX_ARG_CHARS = 4_000
 WINDOWS_COMMAND_HEADROOM = 128
-_HASH_RE = re.compile(r"^[0-9a-f]{40}$")
+_HASH_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 _RAW_SECRET_KEYS = frozenset({"secret", "secret_value", "raw_secret", "value"})
-BASELINE_HASH_EXCLUDE_LINES = r'^\s*"hashed_secret"\s*:\s*"[0-9a-f]{40}",?\s*$'
+BASELINE_HASH_EXCLUDE_LINES = r'^\s*"hashed_secret"\s*:\s*"[0-9a-fA-F]{40}",?\s*$'
 
 
 def _repo_root() -> Path:

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -55,6 +55,8 @@ def _write_setup_lap(
     setup_hash: str,
     lap_ms: int,
     front_bias: int,
+    *,
+    car_id: str = "ks_porsche_911_gt3_r_2016",
 ) -> Path:
     lap_dir.mkdir(parents=True, exist_ok=True)
     path = lap_dir / f"lap_20260616-000000_{name}.json"
@@ -65,7 +67,7 @@ def _write_setup_lap(
                 "lap_uuid": name,
                 "session_uuid": "sess",
                 "exported_at": "2026-06-16T00:00:00Z",
-                "car": {"id": "ks_porsche_911_gt3_r_2016"},
+                "car": {"id": car_id},
                 "track": {"id": "magione"},
                 "conditions": {"trackGripLevel": 0.98},
                 "lap": {"lap_n": 1, "lap_ms": lap_ms, "is_valid": True},
@@ -1177,6 +1179,60 @@ def test_setup_closed_loop_roundtrip_infers_schema_from_records(tmp_path: Path) 
                 await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
                 await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
                 for lap_path in (first, second):
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "v": 1,
+                                "type": "setup.experiment.record",
+                                "archive_path": str(lap_path),
+                            }
+                        )
+                    )
+                    ack = json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+                    assert ack["type"] == ep.TYPE_SETUP_EXPERIMENT_RECORD_ACK
+                    assert ack["ok"] is True
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "setup.closed_loop",
+                            "param": "FRONT_BIAS",
+                            "track_id": "magione",
+                        }
+                    )
+                )
+                return json.loads(await asyncio.wait_for(ws.recv(), timeout=2.0))
+
+    result = asyncio.run(_run())
+    assert result["type"] == ep.TYPE_SETUP_CLOSED_LOOP_RESULT
+    assert result["ok"] is False
+    assert result["status"] == "at_param_bound"
+    assert result["current"] == 70.0
+
+
+def test_setup_closed_loop_roundtrip_ignores_unknown_car_sentinel_for_schema(
+    tmp_path: Path,
+) -> None:
+    async def _run() -> dict:
+        from tools.ai_sidecar import server as srv
+
+        srv._setup_experiment_store_path = None
+        lap_dir = tmp_path / "journal" / "laps"
+        unknown = _write_setup_lap(
+            lap_dir,
+            "lap-u",
+            "unknown",
+            101_000,
+            68,
+            car_id="unknown",
+        )
+        first = _write_setup_lap(lap_dir, "lap-a", "old", 100_000, 69)
+        second = _write_setup_lap(lap_dir, "lap-b", "new", 98_000, 70)
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}/") as ws:
+                await ws.send(json.dumps({"v": 1, "type": "hello", "client": "lua"}))
+                await asyncio.wait_for(ws.recv(), timeout=2.0)  # hello_ack
+                for lap_path in (unknown, first, second):
                     await ws.send(
                         json.dumps(
                             {

--- a/tests/test_policy_tracked_files.py
+++ b/tests/test_policy_tracked_files.py
@@ -117,7 +117,7 @@ def test_audit_baseline_accepts_hashed_findings(tmp_path: Path) -> None:
                     "src/app.py": [
                         {
                             "filename": "src/app.py",
-                            "hashed_secret": "a" * 40,
+                            "hashed_secret": "A" * 40,
                             "type": "Secret",
                         }
                     ]
@@ -128,6 +128,7 @@ def test_audit_baseline_accepts_hashed_findings(tmp_path: Path) -> None:
     )
 
     assert policy_tracked_files._audit_baseline(baseline) == []
+    assert policy_tracked_files._HASH_RE.fullmatch("A" * 40) is not None
 
 
 def test_audit_baseline_rejects_raw_or_malformed_findings(tmp_path: Path) -> None:
@@ -194,3 +195,4 @@ def test_scan_baseline_file_uses_real_path_with_hash_only_metadata_exclusion(
         )
     ]
     assert "type" not in policy_tracked_files.BASELINE_HASH_EXCLUDE_LINES
+    assert "[0-9a-fA-F]" in policy_tracked_files.BASELINE_HASH_EXCLUDE_LINES

--- a/tests/test_setup_optimizer.py
+++ b/tests/test_setup_optimizer.py
@@ -173,16 +173,18 @@ def test_load_lap_archive_wraps_decode_failures_as_json_errors(tmp_path: Path) -
     path = tmp_path / "lap_bad.json"
     path.write_bytes(b"\xff")
 
-    with pytest.raises(SetupExperimentError, match="invalid lap archive JSON"):
+    with pytest.raises(SetupExperimentError, match="invalid lap archive JSON") as excinfo:
         load_lap_archive(path)
+    assert str(path) in str(excinfo.value)
 
 
 def test_load_records_wraps_decode_failures_as_json_errors(tmp_path: Path) -> None:
     store = tmp_path / "experiments.jsonl"
     store.write_bytes(b"\xff\n")
 
-    with pytest.raises(SetupExperimentError, match="invalid experiment store JSON"):
+    with pytest.raises(SetupExperimentError, match="invalid experiment store JSON") as excinfo:
         load_records(store)
+    assert str(store) in str(excinfo.value)
 
 
 def test_candidate_grid_clamps_nonnegative_params() -> None:
@@ -576,6 +578,50 @@ def test_closed_loop_rejects_stale_pair_after_later_setup_change() -> None:
     assert suggestion["changed_params"] == ["WING_2.VALUE"]
     assert suggestion["previous_result"]["from"] == 64.0
     assert suggestion["previous_result"]["to"] == 65.0
+
+
+def test_closed_loop_ignores_later_missing_unrelated_params() -> None:
+    records = [
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-a1",
+                setup_hash="old",
+                setup_name="baseline",
+                lap_ms=100_000,
+                front_bias=64,
+                rear_wing=8,
+            )
+        ),
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-b2",
+                setup_hash="bias-change",
+                setup_name="candidate",
+                lap_ms=98_000,
+                front_bias=65,
+                rear_wing=8,
+            )
+        ),
+        record_from_lap_archive(
+            _lap(
+                lap_uuid="lap-c3",
+                setup_hash="repeat",
+                setup_name="candidate-repeat",
+                lap_ms=97_800,
+                front_bias=65,
+                rear_wing=8,
+            )
+        ),
+    ]
+    records[-1]["setup"]["params"].pop("WING_2.VALUE")
+
+    suggestion = suggest_closed_loop(records, param="FRONT_BIAS")
+
+    assert suggestion["ok"] is True
+    assert suggestion["candidate"]["changed_params"]["FRONT_BIAS.VALUE"] == {
+        "from": 65.0,
+        "to": 66.0,
+    }
 
 
 def test_closed_loop_rejects_ambiguous_car_scope() -> None:

--- a/tools/ai_sidecar/setup_optimizer.py
+++ b/tools/ai_sidecar/setup_optimizer.py
@@ -163,14 +163,18 @@ def is_supported_experiment_store_path(path: str | os.PathLike[str]) -> bool:
 
 def load_lap_archive(path: str | os.PathLike[str]) -> dict[str, Any]:
     try:
-        raw = Path(path).read_text(encoding="utf-8-sig", errors="replace")
+        raw = Path(path).read_text(encoding="utf-8-sig")
     except OSError as exc:
         raise SetupExperimentError(f"cannot read lap archive: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise SetupExperimentError(
+            f"invalid lap archive JSON at {path}: invalid UTF-8 at byte {exc.start}"
+        ) from exc
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise SetupExperimentError(
-            f"invalid lap archive JSON: {exc.msg} at char {exc.pos}"
+            f"invalid lap archive JSON at {path}: {exc.msg} at char {exc.pos}"
         ) from exc
     if not isinstance(data, dict):
         raise SetupExperimentError("lap archive root must be a JSON object")
@@ -256,22 +260,27 @@ def load_records(store_path: str | os.PathLike[str]) -> list[dict[str, Any]]:
     if not path.exists():
         return []
     out: list[dict[str, Any]] = []
-    with path.open("r", encoding="utf-8-sig", errors="replace") as fh:
-        for line_no, line in enumerate(fh, start=1):
-            text = line.strip()
-            if not text:
-                continue
-            try:
-                item = json.loads(text)
-            except json.JSONDecodeError as e:
-                raise SetupExperimentError(
-                    f"invalid experiment store JSON at {path}:{line_no}: {e.msg}"
-                ) from e
-            if not isinstance(item, dict):
-                raise SetupExperimentError(
-                    f"invalid experiment store record at {path}:{line_no}: expected object"
-                )
-            out.append(item)
+    try:
+        with path.open("r", encoding="utf-8-sig") as fh:
+            for line_no, line in enumerate(fh, start=1):
+                text = line.strip()
+                if not text:
+                    continue
+                try:
+                    item = json.loads(text)
+                except json.JSONDecodeError as e:
+                    raise SetupExperimentError(
+                        f"invalid experiment store JSON at {path}:{line_no}: {e.msg}"
+                    ) from e
+                if not isinstance(item, dict):
+                    raise SetupExperimentError(
+                        f"invalid experiment store record at {path}:{line_no}: expected object"
+                    )
+                out.append(item)
+    except UnicodeDecodeError as exc:
+        raise SetupExperimentError(
+            f"invalid experiment store JSON at {path}: invalid UTF-8 at byte {exc.start}"
+        ) from exc
     return out
 
 
@@ -755,12 +764,22 @@ def _finite_setup_params(record: dict[str, Any]) -> dict[str, float]:
 def _changed_param_keys(
     prev_params: dict[str, float],
     curr_params: dict[str, float],
+    *,
+    missing_is_change: bool = True,
 ) -> list[str]:
     changed: list[str] = []
-    for key in sorted(set(prev_params) | set(curr_params)):
+    keys = (
+        set(prev_params) | set(curr_params)
+        if missing_is_change
+        else set(prev_params) & set(curr_params)
+    )
+    for key in sorted(keys):
         before = prev_params.get(key)
         after = curr_params.get(key)
-        if before is None or after is None or abs(after - before) > 1e-9:
+        if before is None or after is None:
+            if missing_is_change:
+                changed.append(key)
+        elif abs(after - before) > 1e-9:
             changed.append(key)
     return changed
 
@@ -793,7 +812,15 @@ def _prior_non_param_changes(
         return []
     prior_params = _finite_setup_params(ordered[prev_index - 1])
     prev_params = _finite_setup_params(prev)
-    return [changed for changed in _changed_param_keys(prior_params, prev_params) if changed != key]
+    return [
+        changed
+        for changed in _changed_param_keys(
+            prior_params,
+            prev_params,
+            missing_is_change=False,
+        )
+        if changed != key
+    ]
 
 
 def _subsequent_non_param_changes(
@@ -809,7 +836,11 @@ def _subsequent_non_param_changes(
         next_params = _finite_setup_params(rec)
         changed.update(
             changed_key
-            for changed_key in _changed_param_keys(prev_params, next_params)
+            for changed_key in _changed_param_keys(
+                prev_params,
+                next_params,
+                missing_is_change=False,
+            )
             if changed_key != key
         )
         prev_params = next_params


### PR DESCRIPTION
Refs #407, #401

## Summary
- fail fast on malformed UTF-8 in setup lap archives and experiment stores instead of replacement-decoding corrupted JSON
- avoid treating later missing/non-finite unrelated setup params as closed-loop confounds
- keep closed-loop schema inference stable when `unknown` car sentinel records coexist with one concrete car
- accept uppercase SHA-1 hashes in `.secrets.baseline` metadata while preserving hash-only scan exclusion

## Verification
- `python -m pytest tests/test_setup_optimizer.py tests/test_ai_sidecar_external.py::test_setup_closed_loop_roundtrip_ignores_unknown_car_sentinel_for_schema tests/test_policy_tracked_files.py`
- `make ci-fast` (2115 passed, 117 skipped, coverage 85.82%)