### PR TITLE
feat(launcher): adopt Racing Atelier design language (#432 Part B)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,4 +176,9 @@ omit = [
   "tools/repo_knowledge/mcp_server.py",
   "tools/ai_sidecar/__main__.py",
   "tools/tt_ingest/__main__.py",
+  # Display-bound launcher GUI + its screenshot dev harness: the testable
+  # tone/palette/font logic lives in tools/rig_launcher/theme.py (100% covered);
+  # the Tk render path needs a display, which headless CI cannot instantiate.
+  "tools/rig_launcher/view.py",
+  "tools/rig_launcher/preview.py",
 ]

--- a/tests/test_rig_launcher_theme.py
+++ b/tests/test_rig_launcher_theme.py
@@ -14,7 +14,10 @@ from pathlib import Path
 
 from tools.rig_launcher import theme
 
-_COLORS_CSS = Path("docs/10_Development/design/racing-atelier/project/tokens/colors.css")
+_COLORS_CSS = (
+    Path(__file__).resolve().parents[1]
+    / "docs/10_Development/design/racing-atelier/project/tokens/colors.css"
+)
 _HEX_TOKEN = re.compile(r"--([a-z0-9-]+):\s*(#[0-9A-Fa-f]{6})\b")
 
 

--- a/tests/test_rig_launcher_theme.py
+++ b/tests/test_rig_launcher_theme.py
@@ -1,0 +1,68 @@
+"""Conformance + logic tests for the Racing Atelier launcher theme (epic #432).
+
+The palette test is the drift guard: it parses the design package's canonical
+``colors.css`` and asserts every hex token the launcher uses matches it, so the
+Python adapter can never silently diverge from the design of record (fleet
+pitfall: *redundant-code-drift*). The tone/font tests cover the presentation
+logic without needing a Tk display, so they run in headless CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tools.rig_launcher import theme
+
+_COLORS_CSS = Path("docs/10_Development/design/racing-atelier/project/tokens/colors.css")
+_HEX_TOKEN = re.compile(r"--([a-z0-9-]+):\s*(#[0-9A-Fa-f]{6})\b")
+
+
+def _css_hex_tokens() -> dict[str, str]:
+    text = _COLORS_CSS.read_text(encoding="utf-8")
+    return {name: value.upper() for name, value in _HEX_TOKEN.findall(text)}
+
+
+def test_palette_matches_design_tokens_single_source_of_truth() -> None:
+    css = _css_hex_tokens()
+    assert css, "no hex tokens parsed from colors.css — path or format drift"
+    for name, value in theme.TOKENS.items():
+        assert name in css, f"token {name!r} is not defined in colors.css"
+        assert value.upper() == css[name], f"{name}: theme={value} but css={css[name]}"
+
+
+def test_tone_for_maps_states_to_signals() -> None:
+    assert theme.tone_for(True, "healthy") == "clear"
+    assert theme.tone_for(True, "connected") == "clear"
+    assert theme.tone_for(True, "enabled") == "clear"
+    # a healthy hotspot "on" is lit green, not amber (matches the design mock)
+    assert theme.tone_for(True, "on") == "clear"
+    # present-but-quiescent rows are demoted, not lit green
+    assert theme.tone_for(True, "absent") == "idle"
+    assert theme.tone_for(True, "skipped") == "idle"
+    assert theme.tone_for(True, "loopback") == "idle"
+    # failures are red unless they are a known in-progress state
+    assert theme.tone_for(False, "DISABLED") == "brake"
+    assert theme.tone_for(False, "unreachable") == "brake"
+    assert theme.tone_for(False, "waiting") == "lift"
+    assert theme.tone_for(True, "starting") == "lift"
+
+
+def test_color_for_tone_uses_signal_hex() -> None:
+    assert theme.color_for_tone("clear") == theme.CLEAR
+    assert theme.color_for_tone("lift") == theme.LIFT
+    assert theme.color_for_tone("brake") == theme.BRAKE
+    assert theme.color_for_tone("idle") == theme.DIM
+    assert theme.color_for_tone("nonsense") == theme.DIM
+
+
+def test_resolve_font_prefers_available_family() -> None:
+    assert (
+        theme.resolve_font(("Saira", "Segoe UI", "Helvetica"), {"Segoe UI", "Arial"}) == "Segoe UI"
+    )
+    # none installed -> last (generic) fallback so the caller always gets a family
+    assert theme.resolve_font(("Saira", "Helvetica"), {"Arial"}) == "Helvetica"
+    # match is case-insensitive
+    assert theme.resolve_font(("saira semi condensed",), {"Saira Semi Condensed"}) == (
+        "saira semi condensed"
+    )

--- a/tools/rig_launcher/app.py
+++ b/tools/rig_launcher/app.py
@@ -287,6 +287,7 @@ def run_gui(supervisor: GamePointSupervisor) -> int:
             "setup_diff": open_setup_diff,
         },
         status_path=str(supervisor.paths.status_path),
+        port=supervisor.config.port,
     )
     refresh()
     root.mainloop()

--- a/tools/rig_launcher/app.py
+++ b/tools/rig_launcher/app.py
@@ -221,7 +221,6 @@ def main(argv: list[str] | None = None) -> int:
 def run_gui(supervisor: GamePointSupervisor) -> int:
     try:
         import tkinter as tk
-        from tkinter import ttk
 
         root = tk.Tk()
     except Exception as exc:  # noqa: BLE001 - fall back to visible CLI status
@@ -230,27 +229,18 @@ def run_gui(supervisor: GamePointSupervisor) -> int:
         print("\n".join(render_status_lines(status)))
         return 1 if not status.ok else 0
 
+    from tools.rig_launcher.view import build_launcher_view
+
     root.title("AC Copilot Game Point")
-    root.geometry("620x360")
-    root.minsize(560, 320)
-
-    frame = ttk.Frame(root, padding=16)
-    frame.pack(fill="both", expand=True)
-    header = ttk.Label(frame, text="AC Copilot Game Point", font=("", 16, "bold"))
-    header.pack(anchor="w")
-    status_var = tk.StringVar(value="Starting")
-    status_label = ttk.Label(frame, textvariable=status_var, justify="left")
-    status_label.pack(anchor="w", fill="x", pady=(12, 8))
-
-    button_row = ttk.Frame(frame)
-    button_row.pack(anchor="w", pady=(8, 0))
+    root.geometry("660x440")
+    root.minsize(620, 400)
 
     last_status: dict[str, GamePointStatus | None] = {"status": None}
 
     def refresh() -> None:
         status = supervisor.poll_status()
         last_status["status"] = status
-        status_var.set("\n".join(render_status_lines(status)))
+        view.update(status)
 
     def start() -> None:
         supervisor.start_sidecar()
@@ -287,13 +277,17 @@ def run_gui(supervisor: GamePointSupervisor) -> int:
         except Exception as exc:  # noqa: BLE001 - surface file/UI errors in the launcher
             messagebox.showerror("Setup Diff", str(exc), parent=root)
 
-    ttk.Button(button_row, text="Start", command=start).pack(side="left", padx=(0, 8))
-    ttk.Button(button_row, text="Refresh", command=refresh).pack(side="left", padx=(0, 8))
-    ttk.Button(button_row, text="Logs", command=open_logs).pack(side="left", padx=(0, 8))
-    ttk.Button(button_row, text="Settings", command=open_settings).pack(side="left", padx=(0, 8))
-    ttk.Button(button_row, text="Setup Diff", command=open_setup_diff).pack(side="left")
-    ttk.Label(frame, text=f"Status: {supervisor.paths.status_path}").pack(anchor="w", pady=(16, 0))
-
+    view = build_launcher_view(
+        root,
+        actions={
+            "start": start,
+            "refresh": refresh,
+            "logs": open_logs,
+            "settings": open_settings,
+            "setup_diff": open_setup_diff,
+        },
+        status_path=str(supervisor.paths.status_path),
+    )
     refresh()
     root.mainloop()
     status = last_status["status"]

--- a/tools/rig_launcher/preview.py
+++ b/tools/rig_launcher/preview.py
@@ -61,9 +61,7 @@ def render(out_path: str, *, status: GamePointStatus | None = None) -> int:
     root = tk.Tk()
     root.title("AC Copilot Game Point")
     root.geometry("660x440+140+140")
-    view = build_launcher_view(
-        root, actions=_NOOP_ACTIONS, status_path=demo_status().status_path
-    )
+    view = build_launcher_view(root, actions=_NOOP_ACTIONS, status_path=demo_status().status_path)
     view.update(status or demo_status())
     root.update_idletasks()
     root.deiconify()

--- a/tools/rig_launcher/preview.py
+++ b/tools/rig_launcher/preview.py
@@ -1,0 +1,95 @@
+"""Render the Racing Atelier launcher to a PNG for visual verification (epic #432).
+
+This is a developer / verification tool, **not** part of the shipped launcher UI:
+it builds the themed view with a representative ``GamePointStatus``, shows the
+window, and grabs the window's client rectangle to a PNG via the Windows GDI
+(``System.Drawing.CopyFromScreen`` through PowerShell — so no Pillow dependency).
+It has no import-time side effects.
+
+Usage::
+
+    python -m tools.rig_launcher.preview --out launcher.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import time
+
+from tools.rig_launcher.supervisor import GamePointStatus, ProbeResult
+from tools.rig_launcher.view import build_launcher_view
+
+_NOOP_ACTIONS = {
+    key: (lambda: None) for key in ("start", "refresh", "logs", "settings", "setup_diff")
+}
+
+
+def demo_status() -> GamePointStatus:
+    """A representative 'all live, SimHub absent' snapshot matching the design mock."""
+    return GamePointStatus(
+        generated_at=0.0,
+        sidecar=ProbeResult("sidecar", True, "healthy", "peers=1 screen_peers=1"),
+        screen=ProbeResult("screen", True, "connected", "screen_peers=1"),
+        hotspot=ProbeResult("hotspot", True, "on", "state=On clients=1"),
+        voice=ProbeResult("voice", True, "enabled", "backend=sounddevice"),
+        simhub=ProbeResult("simhub", True, "absent", "executable not found"),
+        log_path="sidecar.log",
+        status_path=r"%LOCALAPPDATA%\AC Copilot Trainer\GamePoint\status.json",
+    )
+
+
+def _capture_region(x: int, y: int, width: int, height: int, out_path: str) -> None:
+    script = (
+        "Add-Type -AssemblyName System.Drawing;"
+        f"$b=New-Object System.Drawing.Bitmap {width},{height};"
+        "$g=[System.Drawing.Graphics]::FromImage($b);"
+        f"$g.CopyFromScreen({x},{y},0,0,$b.Size);"
+        f"$b.Save('{out_path}',[System.Drawing.Imaging.ImageFormat]::Png);"
+        "$g.Dispose();$b.Dispose()"
+    )
+    subprocess.run(
+        ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+        check=True,
+    )
+
+
+def render(out_path: str, *, status: GamePointStatus | None = None) -> int:
+    """Show the themed launcher and save its client rectangle to ``out_path``."""
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.title("AC Copilot Game Point")
+    root.geometry("660x440+140+140")
+    view = build_launcher_view(
+        root, actions=_NOOP_ACTIONS, status_path=demo_status().status_path
+    )
+    view.update(status or demo_status())
+    root.update_idletasks()
+    root.deiconify()
+    root.lift()
+    root.attributes("-topmost", True)
+    for _ in range(6):
+        root.update()
+        time.sleep(0.08)
+    x, y = root.winfo_rootx(), root.winfo_rooty()
+    width, height = root.winfo_width(), root.winfo_height()
+    time.sleep(0.2)
+    root.update()
+    try:
+        _capture_region(x, y, width, height, out_path)
+    finally:
+        root.destroy()
+    print(f"wrote {out_path} ({width}x{height} at {x},{y})")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render the Racing Atelier launcher to PNG.")
+    parser.add_argument("--out", required=True, help="Output PNG path.")
+    args = parser.parse_args(argv)
+    return render(args.out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/rig_launcher/preview.py
+++ b/tools/rig_launcher/preview.py
@@ -40,12 +40,14 @@ def demo_status() -> GamePointStatus:
 
 
 def _capture_region(x: int, y: int, width: int, height: int, out_path: str) -> None:
+    # Escape single quotes so a path containing one can't break out of the PS string literal.
+    safe_path = out_path.replace("'", "''")
     script = (
         "Add-Type -AssemblyName System.Drawing;"
         f"$b=New-Object System.Drawing.Bitmap {width},{height};"
         "$g=[System.Drawing.Graphics]::FromImage($b);"
         f"$g.CopyFromScreen({x},{y},0,0,$b.Size);"
-        f"$b.Save('{out_path}',[System.Drawing.Imaging.ImageFormat]::Png);"
+        f"$b.Save('{safe_path}',[System.Drawing.Imaging.ImageFormat]::Png);"
         "$g.Dispose();$b.Dispose()"
     )
     subprocess.run(
@@ -61,7 +63,9 @@ def render(out_path: str, *, status: GamePointStatus | None = None) -> int:
     root = tk.Tk()
     root.title("AC Copilot Game Point")
     root.geometry("660x440+140+140")
-    view = build_launcher_view(root, actions=_NOOP_ACTIONS, status_path=demo_status().status_path)
+    view = build_launcher_view(
+        root, actions=_NOOP_ACTIONS, status_path=demo_status().status_path, port=8765
+    )
     view.update(status or demo_status())
     root.update_idletasks()
     root.deiconify()

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -1,0 +1,125 @@
+"""Racing Atelier design tokens for the Game Point launcher (epic #432, Part B).
+
+The single source of truth for the palette is the design package:
+``docs/10_Development/design/racing-atelier/project/tokens/colors.css``.
+``tests/test_rig_launcher_theme.py`` parses that CSS and asserts the hex values
+below match it, so this adapter cannot silently drift from the design of record
+(fleet pitfall: *redundant-code-drift* — do not hand-copy tokens into N runtimes
+without a conformance check binding them back to one source).
+
+Only the hex tokens are mirrored here; the CSS hairline tokens (``--line`` etc.)
+are ``rgba()`` overlays that Tk cannot render, so ``LINE`` is a solid-hex
+approximation and is intentionally *not* part of the conformance set.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# --- Carbon ground (mirrors colors.css :root) ---
+CARBON = "#0B0C0D"
+GRAPHITE = "#141618"
+SLAB = "#191C1F"
+RAISE = "#20242A"
+EDGE = "#2A2F35"
+BLACK = "#000000"
+
+# --- Ink ---
+CHALK = "#EEF1F3"
+MUTE = "#9BA1A8"
+DIM = "#79808A"
+FAINT = "#4A4E55"
+
+# --- Brass: house mark + structure ---
+BRASS = "#C8983E"
+BRASS_INK = "#0B0C0D"
+
+# --- Signal fields (flat, matte; state only) ---
+BRAKE = "#F23B2C"
+LIFT = "#F4A52C"
+CLEAR = "#2FBE6E"
+DATA = "#49B6C9"
+
+# Tk-only approximation of the rgba(255,255,255,0.07) hairline over graphite.
+# Not part of the conformance set (the CSS value is rgba, not hex).
+LINE = "#22262B"
+
+#: hex tokens validated against colors.css by the conformance test.
+TOKENS: dict[str, str] = {
+    "carbon": CARBON,
+    "graphite": GRAPHITE,
+    "slab": SLAB,
+    "raise": RAISE,
+    "edge": EDGE,
+    "black": BLACK,
+    "chalk": CHALK,
+    "mute": MUTE,
+    "dim": DIM,
+    "faint": FAINT,
+    "brass": BRASS,
+    "brass-ink": BRASS_INK,
+    "brake": BRAKE,
+    "lift": LIFT,
+    "clear": CLEAR,
+    "data": DATA,
+}
+
+# Font preference ladders: the bundled design faces first, then faces that ship
+# with Windows (Bahnschrift is condensed like Saira SC; Consolas is the mono
+# default), so the launcher looks on-brand even before the design fonts install.
+FONT_DISPLAY: tuple[str, ...] = (
+    "Saira Semi Condensed",
+    "Bahnschrift",
+    "Segoe UI Semibold",
+    "Segoe UI",
+)
+FONT_READ: tuple[str, ...] = ("Saira", "Segoe UI", "Helvetica")
+FONT_MONO: tuple[str, ...] = ("Spline Sans Mono", "Cascadia Mono", "Consolas", "Courier New")
+
+#: state -> signal tone. ``idle`` is the demoted (dim) tone for absent/skipped rows.
+TONE_COLORS: dict[str, str] = {
+    "clear": CLEAR,
+    "lift": LIFT,
+    "brake": BRAKE,
+    "idle": DIM,
+}
+
+# States that are healthy-but-quiescent (nothing wrong, nothing lit).
+_IDLE_STATES = {"absent", "skipped", "loopback", "available", "stopped"}
+# States that are in-progress / attention-but-not-failure.
+_WARN_STATES = {"waiting", "initializing", "starting", "unavailable", "unknown"}
+
+
+def tone_for(ok: bool, state: str) -> str:
+    """Map a ``ProbeResult`` (ok, state) onto a Racing Atelier signal tone.
+
+    ``clear`` (green) = healthy/lit, ``lift`` (amber) = in-progress/caution,
+    ``brake`` (red) = failure, ``idle`` (dim) = present-but-quiescent.
+    """
+    normalized = (state or "").strip().lower()
+    if normalized in _IDLE_STATES:
+        return "idle"
+    if ok:
+        # A healthy row that is not merely idle reads as lit unless it is a
+        # known in-progress state (e.g. sidecar "starting").
+        return "lift" if normalized in _WARN_STATES else "clear"
+    return "lift" if normalized in _WARN_STATES else "brake"
+
+
+def color_for_tone(tone: str) -> str:
+    """Return the hex for a tone, defaulting to the demoted dim ink."""
+    return TONE_COLORS.get(tone, DIM)
+
+
+def resolve_font(preferences: Iterable[str], available: Iterable[str]) -> str:
+    """Return the first preferred family present in ``available``.
+
+    Falls back to the last preference (a guaranteed-safe generic) when none of
+    the design faces are installed, so callers always get a usable family name.
+    """
+    prefs = list(preferences)
+    available_lower = {name.lower() for name in available}
+    for family in prefs:
+        if family.lower() in available_lower:
+            return family
+    return prefs[-1]

--- a/tools/rig_launcher/view.py
+++ b/tools/rig_launcher/view.py
@@ -48,8 +48,10 @@ class LauncherView:
         *,
         actions: Mapping[str, Callable[[], None]],
         status_path: str,
+        port: int = 8765,
     ) -> None:
         self._root = root
+        self._port = port
         families = set(tkfont.families(root))
         self._f_disp = theme.resolve_font(theme.FONT_DISPLAY, families)
         self._f_read = theme.resolve_font(theme.FONT_READ, families)
@@ -81,7 +83,7 @@ class LauncherView:
         self._build_buttons(panel, actions)
         tk.Label(
             panel,
-            text=f"status.json · {status_path}",
+            text=status_path,
             bg=theme.GRAPHITE,
             fg=theme.FAINT,
             font=(self._f_mono, 8),
@@ -122,7 +124,7 @@ class LauncherView:
         ).pack(side="left", padx=(10, 0))
         tk.Label(
             header,
-            text=":8765",
+            text=f":{self._port}",
             bg=theme.GRAPHITE,
             fg=theme.DIM,
             font=(self._f_mono, 10),
@@ -180,7 +182,7 @@ class LauncherView:
             button = tk.Button(
                 row,
                 text=label,
-                command=actions.get(key),
+                command=actions[key],
                 cursor="hand2",
                 relief="flat",
                 bd=0,
@@ -225,6 +227,7 @@ def build_launcher_view(
     *,
     actions: Mapping[str, Callable[[], None]],
     status_path: str,
+    port: int = 8765,
 ) -> LauncherView:
     """Construct the themed launcher panel inside ``root`` and return its handle."""
-    return LauncherView(root, actions=actions, status_path=status_path)
+    return LauncherView(root, actions=actions, status_path=status_path, port=port)

--- a/tools/rig_launcher/view.py
+++ b/tools/rig_launcher/view.py
@@ -1,0 +1,230 @@
+"""Racing Atelier themed Tk view for the Game Point launcher (epic #432, Part B).
+
+``build_launcher_view`` renders the carbon/brass status panel that maps 1:1 onto
+``GamePointStatus`` (sidecar / screen / hotspot / voice / simhub). It owns
+*presentation only*: every behaviour (start, refresh, open logs/settings, setup
+diff) is passed in via ``actions`` and the caller drives redraws with
+``LauncherView.update(status)``. Keeping the view free of supervisor/polling
+logic preserves ``app.run_gui``'s Tk-init fallback contract and lets the palette
+be unit-tested through :mod:`tools.rig_launcher.theme` without a display.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from collections.abc import Callable, Mapping
+from tkinter import font as tkfont
+
+from tools.rig_launcher import theme
+from tools.rig_launcher.supervisor import GamePointStatus, ProbeResult
+
+#: (display label, GamePointStatus attribute) for each status row, top to bottom.
+_ROWS: tuple[tuple[str, str], ...] = (
+    ("Sidecar", "sidecar"),
+    ("Screen", "screen"),
+    ("Hotspot", "hotspot"),
+    ("Voice", "voice"),
+    ("SimHub", "simhub"),
+)
+
+#: (label, action key, is-primary) for each footer button.
+_BUTTONS: tuple[tuple[str, str, bool], ...] = (
+    ("▶  Start", "start", True),
+    ("Refresh", "refresh", False),
+    ("Logs", "logs", False),
+    ("Settings", "settings", False),
+    ("Setup Diff", "setup_diff", False),
+)
+
+_ARM = 15  # px arm length of the brass corner brackets
+
+
+class LauncherView:
+    """The carbon/brass launcher panel, bound to :class:`GamePointStatus`."""
+
+    def __init__(
+        self,
+        root: tk.Misc,
+        *,
+        actions: Mapping[str, Callable[[], None]],
+        status_path: str,
+    ) -> None:
+        self._root = root
+        families = set(tkfont.families(root))
+        self._f_disp = theme.resolve_font(theme.FONT_DISPLAY, families)
+        self._f_read = theme.resolve_font(theme.FONT_READ, families)
+        self._f_mono = theme.resolve_font(theme.FONT_MONO, families)
+        self._rows: dict[str, dict[str, object]] = {}
+
+        if isinstance(root, (tk.Tk, tk.Toplevel)):
+            root.configure(bg=theme.CARBON)
+
+        panel = tk.Frame(
+            root,
+            bg=theme.GRAPHITE,
+            highlightbackground=theme.EDGE,
+            highlightcolor=theme.EDGE,
+            highlightthickness=1,
+            bd=0,
+        )
+        panel.pack(fill="both", expand=True, padx=16, pady=16)
+
+        self._build_header(panel)
+        tk.Frame(panel, bg=theme.LINE, height=1).pack(fill="x")
+        self._build_summary(panel)
+
+        body = tk.Frame(panel, bg=theme.GRAPHITE)
+        body.pack(fill="both", expand=True, padx=16, pady=(2, 8))
+        for label, key in _ROWS:
+            self._rows[key] = self._build_row(body, label)
+
+        self._build_buttons(panel, actions)
+        tk.Label(
+            panel,
+            text=f"status.json · {status_path}",
+            bg=theme.GRAPHITE,
+            fg=theme.FAINT,
+            font=(self._f_mono, 8),
+            anchor="w",
+        ).pack(fill="x", padx=16, pady=(0, 10))
+
+        self._add_corner_brackets(panel)
+
+    # -- construction helpers -------------------------------------------------
+
+    def _add_corner_brackets(self, panel: tk.Frame) -> None:
+        """Overlay four brass L-brackets at the panel corners (the house mark)."""
+        corners = {
+            "nw": ((0.0, 0.0), [(0, 0, _ARM, 0), (0, 0, 0, _ARM)]),
+            "ne": ((1.0, 0.0), [(15, 0, 15 - _ARM, 0), (15, 0, 15, _ARM)]),
+            "sw": ((0.0, 1.0), [(0, 15, _ARM, 15), (0, 15, 0, 15 - _ARM)]),
+            "se": ((1.0, 1.0), [(15, 15, 15 - _ARM, 15), (15, 15, 15, 15 - _ARM)]),
+        }
+        for anchor, ((relx, rely), segments) in corners.items():
+            canvas = tk.Canvas(
+                panel, width=16, height=16, bg=theme.GRAPHITE, highlightthickness=0, bd=0
+            )
+            for x0, y0, x1, y1 in segments:
+                canvas.create_line(x0, y0, x1, y1, fill=theme.BRASS, width=2)
+            canvas.place(relx=relx, rely=rely, anchor=anchor)
+
+    def _build_header(self, panel: tk.Frame) -> None:
+        header = tk.Frame(panel, bg=theme.GRAPHITE)
+        header.pack(fill="x", padx=16, pady=(14, 10))
+        tab = tk.Canvas(header, width=6, height=18, bg=theme.BRASS, highlightthickness=0, bd=0)
+        tab.pack(side="left")
+        tk.Label(
+            header,
+            text="GAME POINT",
+            bg=theme.GRAPHITE,
+            fg=theme.CHALK,
+            font=(self._f_disp, 15, "bold"),
+        ).pack(side="left", padx=(10, 0))
+        tk.Label(
+            header,
+            text=":8765",
+            bg=theme.GRAPHITE,
+            fg=theme.DIM,
+            font=(self._f_mono, 10),
+        ).pack(side="right")
+
+    def _build_summary(self, panel: tk.Frame) -> None:
+        row = tk.Frame(panel, bg=theme.GRAPHITE)
+        row.pack(fill="x", padx=16, pady=(12, 10))
+        dot = tk.Canvas(row, width=12, height=12, bg=theme.GRAPHITE, highlightthickness=0, bd=0)
+        oval = dot.create_oval(1, 1, 11, 11, fill=theme.CLEAR, outline="")
+        dot.pack(side="left")
+        text = tk.Label(
+            row, text="Ready to drive", bg=theme.GRAPHITE, fg=theme.CHALK, font=(self._f_read, 13)
+        )
+        text.pack(side="left", padx=(10, 0))
+        self._summary_dot = dot
+        self._summary_oval = oval
+        self._summary_text = text
+
+    def _build_row(self, body: tk.Frame, label: str) -> dict[str, object]:
+        row = tk.Frame(body, bg=theme.GRAPHITE)
+        row.pack(fill="x", pady=3)
+        tk.Label(
+            row,
+            text=label.upper(),
+            bg=theme.GRAPHITE,
+            fg=theme.MUTE,
+            font=(self._f_disp, 10),
+            width=9,
+            anchor="w",
+        ).pack(side="left")
+        dot = tk.Canvas(row, width=9, height=9, bg=theme.GRAPHITE, highlightthickness=0, bd=0)
+        oval = dot.create_oval(1, 1, 8, 8, fill=theme.DIM, outline="")
+        dot.pack(side="left", padx=(2, 8))
+        state = tk.Label(
+            row,
+            text="—",
+            bg=theme.GRAPHITE,
+            fg=theme.CHALK,
+            font=(self._f_disp, 11, "bold"),
+            width=12,
+            anchor="w",
+        )
+        state.pack(side="left")
+        detail = tk.Label(
+            row, text="", bg=theme.GRAPHITE, fg=theme.DIM, font=(self._f_mono, 9), anchor="e"
+        )
+        detail.pack(side="right")
+        return {"dot": dot, "oval": oval, "state": state, "detail": detail}
+
+    def _build_buttons(self, panel: tk.Frame, actions: Mapping[str, Callable[[], None]]) -> None:
+        row = tk.Frame(panel, bg=theme.GRAPHITE)
+        row.pack(fill="x", padx=16, pady=(6, 12))
+        for index, (label, key, primary) in enumerate(_BUTTONS):
+            button = tk.Button(
+                row,
+                text=label,
+                command=actions.get(key),
+                cursor="hand2",
+                relief="flat",
+                bd=0,
+                padx=10,
+                pady=7,
+                font=(self._f_disp, 10, "bold"),
+                bg=theme.BRASS if primary else theme.RAISE,
+                fg=theme.BRASS_INK if primary else theme.CHALK,
+                activebackground=theme.LIFT if primary else theme.SLAB,
+                activeforeground=theme.BRASS_INK if primary else theme.CHALK,
+                highlightthickness=0,
+            )
+            button.pack(side="left", expand=True, fill="x", padx=(0 if index == 0 else 6, 0))
+
+    # -- refresh --------------------------------------------------------------
+
+    def update(self, status: GamePointStatus) -> None:
+        """Repaint the summary and every status row from a fresh snapshot."""
+        overall_ok = status.ok
+        self._summary_dot.itemconfigure(
+            self._summary_oval, fill=theme.CLEAR if overall_ok else theme.BRAKE
+        )
+        self._summary_text.configure(text="Ready to drive" if overall_ok else "Needs attention")
+        for key, widgets in self._rows.items():
+            probe = getattr(status, key, None)
+            if not isinstance(probe, ProbeResult):
+                continue
+            color = theme.color_for_tone(theme.tone_for(probe.ok, probe.state))
+            dot = widgets["dot"]
+            assert isinstance(dot, tk.Canvas)
+            dot.itemconfigure(widgets["oval"], fill=color)
+            state = widgets["state"]
+            assert isinstance(state, tk.Label)
+            state.configure(text=probe.state, fg=color)
+            detail = widgets["detail"]
+            assert isinstance(detail, tk.Label)
+            detail.configure(text=probe.detail or "")
+
+
+def build_launcher_view(
+    root: tk.Misc,
+    *,
+    actions: Mapping[str, Callable[[], None]],
+    status_path: str,
+) -> LauncherView:
+    """Construct the themed launcher panel inside ``root`` and return its handle."""
+    return LauncherView(root, actions=actions, status_path=status_path)


### PR DESCRIPTION
## Part B of epic #432 — adopt Racing Atelier in the Windows Game Point launcher

PR #410 (#400) shipped the Racing Atelier design language **docs-only**; the Windows launcher still rendered the old gray `ttk` window. This restyles `tools/rig_launcher/` to the design of record.

**Before → after:** plain gray `ttk` status blob + buttons → carbon/graphite panel, brass corner brackets + header tab, signal-colored per-status rows (Sidecar / Screen / Hotspot / Voice / SimHub), mono detail columns, brass primary **Start**. Realizes the `templates/windows-launcher/WindowsLauncher.dc.html` target.

### What changed
- **`theme.py`** — canonical Racing Atelier palette + font ladders + `tone_for` state→signal mapping. **Single source of truth:** `tests/test_rig_launcher_theme.py` parses the design package's `tokens/colors.css` and asserts every hex token matches, so the Python adapter can't drift from the design (fleet pitfall *redundant-code-drift*).
- **`view.py`** — presentation-only `LauncherView` / `build_launcher_view`. No supervisor/polling logic, so `run_gui`'s Tk-init CLI fallback is unchanged.
- **`app.py`** — `run_gui` renders the themed view; all five actions preserved; the Tk-init fallback contract is intact (`test_run_gui_falls_back_when_tk_init_fails` still green).
- **`preview.py`** — Pillow-free GDI screenshot harness (`python -m tools.rig_launcher.preview --out x.png`) used to verify.

### Verification (operator-grade)
Rendered the **real Tk launcher** and inspected the actual pixels (not a mock): carbon/brass panel, brackets, header, five signal-colored rows, brass Start. Caught + fixed one tone defect (a healthy hotspot `on` was rendering amber instead of green) and re-verified. `ruff` clean; launcher + theme pytest suites green locally; full `make ci-fast` on CI.

### Scope
Launcher only (`tools/rig_launcher/**`). Firmware rig screen = #86 / PR #430 (Part C); in-game HUD = Part A (separate PR). No behavior changes to the supervisor or probes — presentation only.

Refs #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
