### PR TITLE
feat(hud): adopt Racing Atelier design language in the in-game HUD (#432 Part A)

### DIFF
--- a/src/ac_copilot_trainer/modules/coaching_overlay.lua
+++ b/src/ac_copilot_trainer/modules/coaching_overlay.lua
@@ -24,10 +24,9 @@ local COLOR_RED          = T.color("brake")         -- danger / warning
 local COLOR_AMBER        = T.color("lift")          -- caution / approaching
 local COLOR_BAR_BG       = T.color("raise", 0.85)   -- progress bar trough
 local COLOR_BAR_FILL     = T.color("brake", 0.95)   -- braking-urgency fill
-local COLOR_BAR_GLOW     = T.color("brake", 0.35)   -- glow
 local COLOR_BRAND        = T.color("dim")           -- branding
 
-local PANEL_ROUNDING = 12
+local PANEL_ROUNDING = 0  -- Racing Atelier: square corners (--r: 0px)
 local PANEL_PAD_X    = 24
 local PANEL_PAD_Y    = 20
 
@@ -81,11 +80,6 @@ local function drawProgressBar(x, y, w, h, pct)
   -- Fill
   local fillW = math.max(0, math.min(1, pct)) * w
   if fillW > 1 then
-    -- Glow layer behind fill (subtle wider bar for bloom effect)
-    if fillW > 4 then
-      ui.drawRectFilled(vec2(x, y - 1), vec2(x + fillW, y + h + 1), COLOR_BAR_GLOW, h / 2)
-    end
-    -- Fill layer on top
     ui.drawRectFilled(p0, vec2(x + fillW, y + h), COLOR_BAR_FILL, h / 2)
   end
 end
@@ -325,7 +319,7 @@ function M.drawApproachPanel(approachData)
   drawProgressBar(padX, barY, barW, barH, progressPct or 0)
 
   ------------------------------------------------------------------
-  -- Footer: AG PORSCHE ACADEMY (Syncopate brand)
+  -- Footer: RACING ATELIER (brand)
   ------------------------------------------------------------------
   local divY = barY + barH + 14
   ui.drawRectFilled(

--- a/src/ac_copilot_trainer/modules/coaching_overlay.lua
+++ b/src/ac_copilot_trainer/modules/coaching_overlay.lua
@@ -2,6 +2,7 @@
 -- Approach telemetry panel: polished structured data display (issue #57 Part C).
 
 local fontMod = require("coaching_font")
+local T = require("design_tokens")
 
 local M = {}
 
@@ -9,20 +10,22 @@ local M = {}
 -- Design tokens (Figma design brief, issue #57 Part C)
 -- ---------------------------------------------------------------------------
 
-local COLOR_BG           = rgbm(0.067, 0.067, 0.067, 0.60)   -- rgba(17,17,17,0.6)
-local COLOR_BG_BORDER    = rgbm(0.30, 0.32, 0.38, 0.40)
-local COLOR_LABEL        = rgbm(0.55, 0.58, 0.65, 1.0)       -- muted labels (legacy)
-local COLOR_LABEL_GREY   = rgbm(0.549, 0.565, 0.612, 1.0)    -- #8C909C small caps labels
-local COLOR_BRAND_GREY   = rgbm(0.435, 0.459, 0.522, 1.0)    -- #6F7585 footer branding
-local COLOR_TITLE        = rgbm(0.35, 0.82, 0.95, 1.0)       -- accent cyan (legacy)
-local COLOR_WHITE        = rgbm(0.949, 0.949, 0.960, 1.0)    -- #F2F2F5 primary text
-local COLOR_GREEN        = rgbm(0.20, 0.85, 0.35, 1.0)       -- speed OK
-local COLOR_RED          = rgbm(0.937, 0.267, 0.267, 1.0)    -- #EF4444 warning
-local COLOR_AMBER        = rgbm(1.000, 0.769, 0.239, 1.0)    -- #FFC43D secondary hint
-local COLOR_BAR_BG       = rgbm(0.15, 0.15, 0.18, 0.85)      -- progress bar background
-local COLOR_BAR_FILL     = rgbm(0.937, 0.267, 0.267, 0.95)   -- #EF4444 red progress fill
-local COLOR_BAR_GLOW     = rgbm(0.937, 0.267, 0.267, 0.35)   -- red glow
-local COLOR_BRAND        = rgbm(0.45, 0.48, 0.52, 1.0)       -- legacy branding
+-- Racing Atelier palette (epic #432 Part A) — sourced from design_tokens.lua (single source of
+-- truth, validated against the design colors.css). Carbon ground, brass accent, signal fields.
+local COLOR_BG           = T.color("carbon", 0.78)  -- carbon panel ground
+local COLOR_BG_BORDER    = T.color("edge", 0.60)    -- structural edge
+local COLOR_LABEL        = T.color("mute")          -- muted labels
+local COLOR_LABEL_GREY   = T.color("mute")          -- small-caps labels
+local COLOR_BRAND_GREY   = T.color("dim")           -- footer branding
+local COLOR_TITLE        = T.color("brass")         -- house accent (was legacy cyan)
+local COLOR_WHITE        = T.color("chalk")         -- primary text
+local COLOR_GREEN        = T.color("clear")         -- on line / faster
+local COLOR_RED          = T.color("brake")         -- danger / warning
+local COLOR_AMBER        = T.color("lift")          -- caution / approaching
+local COLOR_BAR_BG       = T.color("raise", 0.85)   -- progress bar trough
+local COLOR_BAR_FILL     = T.color("brake", 0.95)   -- braking-urgency fill
+local COLOR_BAR_GLOW     = T.color("brake", 0.35)   -- glow
+local COLOR_BRAND        = T.color("dim")           -- branding
 
 local PANEL_ROUNDING = 12
 local PANEL_PAD_X    = 24
@@ -333,7 +336,7 @@ function M.drawApproachPanel(approachData)
   )
 
   do
-    local footerStr = "AG PORSCHE ACADEMY"
+    local footerStr = "RACING ATELIER"
     local fontPx = 12
     local footerSize = _measureDW(footerStr, fontPx)
     local footerX = math.floor(w * 0.5 - footerSize.x * 0.5)

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -5,9 +5,9 @@
 -- values match, so this adapter cannot silently drift from the design of record (fleet pitfall:
 -- redundant-code-drift — do not hand-copy tokens into N runtimes without a conformance check).
 --
--- HEX is kept as plain strings so the conformance test needs no Lua runtime. M.color() builds a
--- CSP rgbm when invoked; hud.lua and coaching_overlay.lua call T.color() at module scope, which is
--- safe in the CSP Lua host because rgbm is available before app modules load.
+-- HEX is kept as plain strings so the conformance test needs no Lua runtime. M.color()
+-- builds a CSP rgbm on demand; hud.lua and coaching_overlay.lua call it at require
+-- time to define module-level COLOR_* constants (rgbm is available when AC loads Lua apps).
 
 local M = {}
 
@@ -37,6 +37,7 @@ local function _rgb(hexstr, a)
 end
 
 local colorCache = {}
+local _warnedUnknown = {}
 
 --- Build a CSP rgbm from a token name at the given alpha (default opaque).
 ---@param name string  a key in M.HEX
@@ -44,7 +45,13 @@ local colorCache = {}
 function M.color(name, a)
   local hex = M.HEX[name]
   if hex == nil then
-    error("Unknown design token: " .. tostring(name))
+    if not _warnedUnknown[name] then
+      _warnedUnknown[name] = true
+      if ac and type(ac.log) == "function" then
+        ac.log("[COPILOT][design_tokens] unknown token: " .. tostring(name))
+      end
+    end
+    hex = M.HEX.chalk
   end
   local alpha = a or 1.0
   local nameCache = colorCache[name]

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -1,0 +1,49 @@
+-- Racing Atelier design tokens for the in-game HUD (CSP Lua) — epic #432 Part A.
+--
+-- Canonical source of truth: docs/10_Development/design/racing-atelier/project/tokens/colors.css.
+-- tests/test_hud_design_tokens.py parses both this file and colors.css and asserts the hex
+-- values match, so this adapter cannot silently drift from the design of record (fleet pitfall:
+-- redundant-code-drift — do not hand-copy tokens into N runtimes without a conformance check).
+--
+-- HEX is kept as plain strings so the conformance test needs no Lua runtime; M.color() builds a
+-- CSP rgbm on demand (rgbm is a CSP global, only referenced at render time, never at require).
+
+local M = {}
+
+--- Canonical hex, mirroring colors.css :root.
+M.HEX = {
+  carbon = "#0B0C0D",   -- base ground (near-black; OLED off)
+  graphite = "#141618", -- panel
+  slab = "#191C1F",     -- raised band
+  raise = "#20242A",    -- control trough / inactive
+  edge = "#2A2F35",     -- structural border
+  chalk = "#EEF1F3",    -- primary text / lit
+  mute = "#9BA1A8",     -- labels
+  dim = "#79808A",      -- meta / demoted
+  faint = "#4A4E55",    -- disabled
+  brass = "#C8983E",    -- house accent / structure
+  brake = "#F23B2C",    -- danger / too hot / loss
+  lift = "#F4A52C",     -- caution / approaching
+  clear = "#2FBE6E",    -- on line / faster / gain
+  data = "#49B6C9",     -- neutral telemetry highlight
+}
+
+local function _rgb(hexstr, a)
+  local r = tonumber(hexstr:sub(2, 3), 16)
+  local g = tonumber(hexstr:sub(4, 5), 16)
+  local b = tonumber(hexstr:sub(6, 7), 16)
+  return rgbm(r / 255, g / 255, b / 255, a or 1.0)
+end
+
+--- Build a CSP rgbm from a token name at the given alpha (default opaque).
+---@param name string  a key in M.HEX
+---@param a number|nil  alpha 0..1 (default 1.0)
+function M.color(name, a)
+  local hex = M.HEX[name]
+  if hex == nil then
+    return rgbm(1, 0, 1, 1) -- magenta = "unknown token" tell
+  end
+  return _rgb(hex, a)
+end
+
+return M

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -43,7 +43,7 @@ end
 function M.color(name, a)
   local hex = M.HEX[name]
   if hex == nil then
-    error("[COPILOT][design_tokens] unknown token: " .. tostring(name))
+    error("[COPILOT][design_tokens] unknown token: " .. tostring(name), 2)
   end
   return _rgb(hex, a or 1.0)
 end

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -36,7 +36,6 @@ local function _rgb(hexstr, a)
   return rgbm(r / 255, g / 255, b / 255, a or 1.0)
 end
 
-local colorCache = {}
 
 --- Build a CSP rgbm from a token name at the given alpha (default opaque).
 ---@param name string  a key in M.HEX
@@ -46,18 +45,7 @@ function M.color(name, a)
   if hex == nil then
     error("[COPILOT][design_tokens] unknown token: " .. tostring(name))
   end
-  local alpha = a or 1.0
-  local nameCache = colorCache[name]
-  if not nameCache then
-    nameCache = {}
-    colorCache[name] = nameCache
-  end
-  local cached = nameCache[alpha]
-  if not cached then
-    cached = _rgb(hex, alpha)
-    nameCache[alpha] = cached
-  end
-  return cached
+  return _rgb(hex, a or 1.0)
 end
 
 return M

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -35,6 +35,8 @@ local function _rgb(hexstr, a)
   return rgbm(r / 255, g / 255, b / 255, a or 1.0)
 end
 
+local colorCache = {}
+
 --- Build a CSP rgbm from a token name at the given alpha (default opaque).
 ---@param name string  a key in M.HEX
 ---@param a number|nil  alpha 0..1 (default 1.0)
@@ -43,7 +45,18 @@ function M.color(name, a)
   if hex == nil then
     error("Unknown design token: " .. tostring(name))
   end
-  return _rgb(hex, a)
+  local alpha = a or 1.0
+  local nameCache = colorCache[name]
+  if not nameCache then
+    nameCache = {}
+    colorCache[name] = nameCache
+  end
+  local cached = nameCache[alpha]
+  if not cached then
+    cached = _rgb(hex, alpha)
+    nameCache[alpha] = cached
+  end
+  return cached
 end
 
 return M

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -41,7 +41,7 @@ end
 function M.color(name, a)
   local hex = M.HEX[name]
   if hex == nil then
-    return rgbm(1, 0, 1, 1) -- magenta = "unknown token" tell
+    error("Unknown design token: " .. tostring(name))
   end
   return _rgb(hex, a)
 end

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -5,8 +5,9 @@
 -- values match, so this adapter cannot silently drift from the design of record (fleet pitfall:
 -- redundant-code-drift — do not hand-copy tokens into N runtimes without a conformance check).
 --
--- HEX is kept as plain strings so the conformance test needs no Lua runtime; M.color() builds a
--- CSP rgbm on demand (rgbm is a CSP global, only referenced at render time, never at require).
+-- HEX is kept as plain strings so the conformance test needs no Lua runtime. M.color() builds a
+-- CSP rgbm when invoked; hud.lua and coaching_overlay.lua call T.color() at module scope, which is
+-- safe in the CSP Lua host because rgbm is available before app modules load.
 
 local M = {}
 

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -37,7 +37,6 @@ local function _rgb(hexstr, a)
 end
 
 local colorCache = {}
-local _warnedUnknown = {}
 
 --- Build a CSP rgbm from a token name at the given alpha (default opaque).
 ---@param name string  a key in M.HEX
@@ -45,13 +44,7 @@ local _warnedUnknown = {}
 function M.color(name, a)
   local hex = M.HEX[name]
   if hex == nil then
-    if not _warnedUnknown[name] then
-      _warnedUnknown[name] = true
-      if ac and type(ac.log) == "function" then
-        ac.log("[COPILOT][design_tokens] unknown token: " .. tostring(name))
-      end
-    end
-    hex = M.HEX.chalk
+    error("[COPILOT][design_tokens] unknown token: " .. tostring(name))
   end
   local alpha = a or 1.0
   local nameCache = colorCache[name]

--- a/src/ac_copilot_trainer/modules/hud.lua
+++ b/src/ac_copilot_trainer/modules/hud.lua
@@ -24,7 +24,7 @@ local COLOR_GREEN     = T.color("clear")         -- #2FBE6E on line / faster
 local COLOR_WHITE     = T.color("chalk")         -- #EEF1F3 primary text
 local COLOR_TEXT_GREY = T.color("mute")          -- #9BA1A8 labels
 
-local PANEL_ROUNDING = 8
+local PANEL_ROUNDING = 0  -- Racing Atelier: square corners (--r: 0px)
 local PANEL_PAD_Y    = 14
 
 --- CSP: `ui.dwriteDrawText` is often a cdata callable, not `type(...) == "function"`.

--- a/src/ac_copilot_trainer/modules/hud.lua
+++ b/src/ac_copilot_trainer/modules/hud.lua
@@ -5,6 +5,7 @@
 -- Always renders panel chrome + title even in the empty state — never blank.
 
 local fontMod = require("coaching_font")
+local T = require("design_tokens")
 
 local M = {}
 
@@ -12,14 +13,16 @@ local M = {}
 -- Design tokens (Figma CoachingHUD.tsx — see issue #72)
 -- ---------------------------------------------------------------------------
 
-local COLOR_BG_DARK   = rgbm(17 / 255, 17 / 255, 17 / 255, 0.60)
-local COLOR_BG_BORDER = rgbm(0.30, 0.32, 0.38, 0.40)  -- grey, matches coaching_overlay (round 5: user reverted to grey)
-local COLOR_RED       = rgbm(239 / 255, 68 / 255, 68 / 255, 1.0)   -- #EF4444 (per spec)
-local COLOR_RED_HARD  = COLOR_RED                                  -- back-compat alias
-local COLOR_AMBER     = rgbm(251 / 255, 191 / 255, 36 / 255, 1.0)  -- amber-400
-local COLOR_GREEN     = rgbm(74 / 255, 222 / 255, 128 / 255, 1.0)
-local COLOR_WHITE     = rgbm(255 / 255, 255 / 255, 255 / 255, 1.0)
-local COLOR_TEXT_GREY = rgbm(212 / 255, 212 / 255, 212 / 255, 1.0) -- neutral-300
+-- Racing Atelier palette (epic #432 Part A) — sourced from design_tokens.lua (single source of
+-- truth, validated against the design colors.css).
+local COLOR_BG_DARK   = T.color("carbon", 0.78)  -- carbon panel ground
+local COLOR_BG_BORDER = T.color("edge", 0.60)    -- structural edge
+local COLOR_RED       = T.color("brake")         -- #F23B2C danger
+local COLOR_RED_HARD  = COLOR_RED                -- back-compat alias
+local COLOR_AMBER     = T.color("lift")          -- #F4A52C caution
+local COLOR_GREEN     = T.color("clear")         -- #2FBE6E on line / faster
+local COLOR_WHITE     = T.color("chalk")         -- #EEF1F3 primary text
+local COLOR_TEXT_GREY = T.color("mute")          -- #9BA1A8 labels
 
 local PANEL_ROUNDING = 8
 local PANEL_PAD_Y    = 14

--- a/tests/lua_text_helpers.py
+++ b/tests/lua_text_helpers.py
@@ -1,0 +1,30 @@
+"""Shared Lua source-text helpers for static conformance tests."""
+
+from __future__ import annotations
+
+
+def strip_lua_comments(text: str) -> str:
+    """Drop Lua ``--`` line comments, honoring string literals (PR #173 pattern).
+
+    A ``--`` inside a string is not a comment, and an escaped quote does not end
+    one. Block comments (``--[[ ]]``) are out of scope — no producer wraps live
+    code in one.
+    """
+    out: list[str] = []
+    for line in text.splitlines():
+        i, in_str, cut = 0, None, None
+        while i < len(line):
+            c = line[i]
+            if in_str is not None:
+                if c == "\\":
+                    i += 1
+                elif c == in_str:
+                    in_str = None
+            elif c in ("'", '"'):
+                in_str = c
+            elif c == "-" and line[i + 1 : i + 2] == "-":
+                cut = i
+                break
+            i += 1
+        out.append(line if cut is None else line[:cut])
+    return "\n".join(out)

--- a/tests/test_design_conformance.py
+++ b/tests/test_design_conformance.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from tests.lua_text_helpers import strip_lua_comments
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULES = REPO_ROOT / "src" / "ac_copilot_trainer" / "modules"
 ENTRY = REPO_ROOT / "src" / "ac_copilot_trainer" / "ac_copilot_trainer.lua"
@@ -27,28 +29,6 @@ MANIFEST = REPO_ROOT / "src" / "ac_copilot_trainer" / "manifest.ini"
 def _lua_text(name: str) -> str:
     """Return full text of a module under ``src/ac_copilot_trainer/modules/``."""
     return (MODULES / name).read_text(encoding="utf-8")
-
-
-def _strip_lua_comments(text: str) -> str:
-    """Drop Lua ``--`` line comments, honoring string literals (PR #173 pattern)."""
-    out: list[str] = []
-    for line in text.splitlines():
-        i, in_str, cut = 0, None, None
-        while i < len(line):
-            c = line[i]
-            if in_str is not None:
-                if c == "\\":
-                    i += 1
-                elif c == in_str:
-                    in_str = None
-            elif c in ("'", '"'):
-                in_str = c
-            elif c == "-" and line[i + 1 : i + 2] == "-":
-                cut = i
-                break
-            i += 1
-        out.append(line if cut is None else line[:cut])
-    return "\n".join(out)
 
 
 def _manifest_text() -> str:
@@ -387,7 +367,7 @@ class TestApproachPanel:
 
     def test_approach_panel_design_tokens(self) -> None:
         """PC-04: Racing Atelier design tokens (epic #432)."""
-        src = _strip_lua_comments(_lua_text("coaching_overlay.lua"))
+        src = strip_lua_comments(_lua_text("coaching_overlay.lua"))
         assert re.search(
             r'^\s*local\s+T\s*=\s*require\(["\']design_tokens["\']\)',
             src,

--- a/tests/test_design_conformance.py
+++ b/tests/test_design_conformance.py
@@ -364,11 +364,16 @@ class TestApproachPanel:
         )
 
     def test_approach_panel_design_tokens(self) -> None:
-        """PC-04: design tokens match Figma brief."""
+        """PC-04: Racing Atelier design tokens (epic #432)."""
         src = _lua_text("coaching_overlay.lua")
-        assert "COLOR_RED" in src, "Must define COLOR_RED design token"
-        assert re.search(r'COLOR_BG\s*=\s*T\.color\("carbon",\s*0\.78\)', src), (
-            "COLOR_BG must use carbon token at 0.78 alpha (Racing Atelier panel ground)"
+        assert 'require("design_tokens")' in src or "require('design_tokens')" in src, (
+            "coaching_overlay must require design_tokens"
+        )
+        assert re.search(r'COLOR_BG\s*=\s*T\.color\("carbon"', src), (
+            'COLOR_BG must use T.color("carbon")'
+        )
+        assert re.search(r"PANEL_ROUNDING\s*=\s*0", src), (
+            "PANEL_ROUNDING must be 0 (square corners)"
         )
 
     def test_window_coaching_calls_approach_panel(self) -> None:

--- a/tests/test_design_conformance.py
+++ b/tests/test_design_conformance.py
@@ -29,6 +29,28 @@ def _lua_text(name: str) -> str:
     return (MODULES / name).read_text(encoding="utf-8")
 
 
+def _strip_lua_comments(text: str) -> str:
+    """Drop Lua ``--`` line comments, honoring string literals (PR #173 pattern)."""
+    out: list[str] = []
+    for line in text.splitlines():
+        i, in_str, cut = 0, None, None
+        while i < len(line):
+            c = line[i]
+            if in_str is not None:
+                if c == "\\":
+                    i += 1
+                elif c == in_str:
+                    in_str = None
+            elif c in ("'", '"'):
+                in_str = c
+            elif c == "-" and line[i + 1 : i + 2] == "-":
+                cut = i
+                break
+            i += 1
+        out.append(line if cut is None else line[:cut])
+    return "\n".join(out)
+
+
 def _manifest_text() -> str:
     return MANIFEST.read_text(encoding="utf-8")
 
@@ -365,16 +387,22 @@ class TestApproachPanel:
 
     def test_approach_panel_design_tokens(self) -> None:
         """PC-04: Racing Atelier design tokens (epic #432)."""
-        src = _lua_text("coaching_overlay.lua")
-        assert 'require("design_tokens")' in src or "require('design_tokens')" in src, (
-            "coaching_overlay must require design_tokens"
-        )
-        assert re.search(r'COLOR_BG\s*=\s*T\.color\("carbon"', src), (
-            'COLOR_BG must use T.color("carbon")'
-        )
-        assert re.search(r"PANEL_ROUNDING\s*=\s*0", src), (
-            "PANEL_ROUNDING must be 0 (square corners)"
-        )
+        src = _strip_lua_comments(_lua_text("coaching_overlay.lua"))
+        assert re.search(
+            r'^\s*local\s+T\s*=\s*require\(["\']design_tokens["\']\)',
+            src,
+            re.M,
+        ), "coaching_overlay must require design_tokens"
+        assert re.search(
+            r'^\s*local\s+COLOR_BG\s*=\s*T\.color\(["\']carbon["\']',
+            src,
+            re.M,
+        ), 'COLOR_BG must use T.color("carbon")'
+        assert re.search(
+            r"^\s*local\s+PANEL_ROUNDING\s*=\s*0\s*(?:--.*)?$",
+            src,
+            re.M,
+        ), "PANEL_ROUNDING must be exactly 0 (square corners)"
 
     def test_window_coaching_calls_approach_panel(self) -> None:
         """PC-07: windowCoaching in entry script calls drawApproachPanel.

--- a/tests/test_design_conformance.py
+++ b/tests/test_design_conformance.py
@@ -367,8 +367,8 @@ class TestApproachPanel:
         """PC-04: design tokens match Figma brief."""
         src = _lua_text("coaching_overlay.lua")
         assert "COLOR_RED" in src, "Must define COLOR_RED design token"
-        assert re.search(r"COLOR_BG\s*=\s*rgbm\([^)]+0\.60\)", src), (
-            "COLOR_BG must use 0.60 alpha (Figma: rgba(17,17,17,0.6))"
+        assert re.search(r'COLOR_BG\s*=\s*T\.color\("carbon",\s*0\.78\)', src), (
+            "COLOR_BG must use carbon token at 0.78 alpha (Racing Atelier panel ground)"
         )
 
     def test_window_coaching_calls_approach_panel(self) -> None:

--- a/tests/test_hud_design_tokens.py
+++ b/tests/test_hud_design_tokens.py
@@ -26,9 +26,11 @@ def _css_tokens() -> dict[str, str]:
 
 
 def _lua_tokens() -> dict[str, str]:
-    return {
-        n: v.upper() for n, v in _LUA_HEX.findall(_DESIGN_TOKENS_LUA.read_text(encoding="utf-8"))
-    }
+    text = _DESIGN_TOKENS_LUA.read_text(encoding="utf-8")
+    hex_block = re.search(r"M\.HEX\s*=\s*\{(.*?)\}", text, re.DOTALL)
+    if not hex_block:
+        return {}
+    return {n: v.upper() for n, v in _LUA_HEX.findall(hex_block.group(1))}
 
 
 def test_hud_design_tokens_match_colors_css() -> None:

--- a/tests/test_hud_design_tokens.py
+++ b/tests/test_hud_design_tokens.py
@@ -1,0 +1,47 @@
+"""Conformance: the in-game HUD palette must match the Racing Atelier design colors.css.
+
+Drift guard (fleet pitfall *redundant-code-drift*): the CSP-Lua HUD adapter
+``src/ac_copilot_trainer/modules/design_tokens.lua`` mirrors the Racing Atelier palette that the
+in-game HUD (`hud.lua`, `coaching_overlay.lua`) renders. This test parses both that adapter and
+the canonical ``colors.css`` and asserts every hex matches, so the HUD palette cannot silently
+diverge from the design of record — the same single-source-of-truth check the launcher's
+``theme.py`` gets in ``test_rig_launcher_theme.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_COLORS_CSS = _ROOT / "docs/10_Development/design/racing-atelier/project/tokens/colors.css"
+_DESIGN_TOKENS_LUA = _ROOT / "src/ac_copilot_trainer/modules/design_tokens.lua"
+
+_CSS_HEX = re.compile(r"--([a-z0-9-]+):\s*(#[0-9A-Fa-f]{6})\b")
+_LUA_HEX = re.compile(r'(\w+)\s*=\s*"(#[0-9A-Fa-f]{6})"')
+
+
+def _css_tokens() -> dict[str, str]:
+    return {n: v.upper() for n, v in _CSS_HEX.findall(_COLORS_CSS.read_text(encoding="utf-8"))}
+
+
+def _lua_tokens() -> dict[str, str]:
+    return {
+        n: v.upper() for n, v in _LUA_HEX.findall(_DESIGN_TOKENS_LUA.read_text(encoding="utf-8"))
+    }
+
+
+def test_hud_design_tokens_match_colors_css() -> None:
+    css = _css_tokens()
+    lua = _lua_tokens()
+    assert lua, "no hex tokens parsed from design_tokens.lua"
+    assert css, "no hex tokens parsed from colors.css"
+    for name, value in lua.items():
+        assert name in css, f"HUD token {name!r} is not defined in colors.css"
+        assert value == css[name], f"{name}: design_tokens.lua={value} but colors.css={css[name]}"
+
+
+def test_hud_design_tokens_cover_the_signal_palette() -> None:
+    lua = _lua_tokens()
+    for required in ("carbon", "edge", "chalk", "mute", "brass", "brake", "lift", "clear"):
+        assert required in lua, f"HUD palette missing required token {required!r}"

--- a/tests/test_hud_design_tokens.py
+++ b/tests/test_hud_design_tokens.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from tests.lua_text_helpers import strip_lua_comments
+
 _ROOT = Path(__file__).resolve().parents[1]
 _COLORS_CSS = _ROOT / "docs/10_Development/design/racing-atelier/project/tokens/colors.css"
 _DESIGN_TOKENS_LUA = _ROOT / "src/ac_copilot_trainer/modules/design_tokens.lua"
@@ -26,7 +28,7 @@ def _css_tokens() -> dict[str, str]:
 
 
 def _lua_tokens() -> dict[str, str]:
-    text = _DESIGN_TOKENS_LUA.read_text(encoding="utf-8")
+    text = strip_lua_comments(_DESIGN_TOKENS_LUA.read_text(encoding="utf-8"))
     hex_block = re.search(r"M\.HEX\s*=\s*\{(.*?)\}", text, re.DOTALL)
     if not hex_block:
         return {}

--- a/tests/test_hud_design_tokens.py
+++ b/tests/test_hud_design_tokens.py
@@ -17,8 +17,8 @@ _ROOT = Path(__file__).resolve().parents[1]
 _COLORS_CSS = _ROOT / "docs/10_Development/design/racing-atelier/project/tokens/colors.css"
 _DESIGN_TOKENS_LUA = _ROOT / "src/ac_copilot_trainer/modules/design_tokens.lua"
 
-_CSS_HEX = re.compile(r"--([a-z0-9-]+):\s*(#[0-9A-Fa-f]{6})\b")
-_LUA_HEX = re.compile(r'(\w+)\s*=\s*"(#[0-9A-Fa-f]{6})"')
+_CSS_HEX = re.compile(r"--([a-zA-Z0-9-]+)\s*:\s*(#[0-9A-Fa-f]{6})\b")
+_LUA_HEX = re.compile(r'(\w+)\s*=\s*["\'](#[0-9A-Fa-f]{6})["\']')
 
 
 def _css_tokens() -> dict[str, str]:

--- a/tests/test_phase5_rebuild_ete.py
+++ b/tests/test_phase5_rebuild_ete.py
@@ -809,12 +809,12 @@ def test_ete08c_coaching_overlay_bottom_tile_always_renders(lua):
     approachData is nil. Today it returns false and renders nothing."""
     overlay = lua.execute('local m = require("coaching_overlay"); return m')
     lua.execute("_reset_recorders()")
-    # nil approach data — should still render chrome + AG PORSCHE ACADEMY footer
+    # nil approach data — should still render chrome + RACING ATELIER footer
     overlay["drawApproachPanel"](None)
     rects = lua.execute("return #_draw_rect_filled_calls")
     assert rects >= 1, "drawApproachPanel(nil) must still render panel chrome"
-    assert lua.execute('return _count_dwrite_text("AG PORSCHE ACADEMY")') >= 1, (
-        "drawApproachPanel(nil) must render 'AG PORSCHE ACADEMY' footer"
+    assert lua.execute('return _count_dwrite_text("RACING ATELIER")') >= 1, (
+        "drawApproachPanel(nil) must render 'RACING ATELIER' footer"
     )
 
 

--- a/tests/test_ws_topic_allowlist.py
+++ b/tests/test_ws_topic_allowlist.py
@@ -24,6 +24,7 @@ import re
 
 import pytest
 
+from tests.lua_text_helpers import strip_lua_comments
 from tools.ai_sidecar.external_protocol import (
     ENVELOPE_KEY,
     ENVELOPE_VERSION,
@@ -49,37 +50,10 @@ _DEF_RE = re.compile(r"\bfunction\s+[\w.]*\w$")
 _STR_RE = re.compile(r"\"[^\"]*\"|'[^']*'")
 
 
-def _strip_lua_comments(text: str) -> str:
-    """Drop Lua `--` line comments, honoring string literals (a `--` inside a string
-    is not a comment, and an escaped quote doesn't end one). This is done ONCE up
-    front so neither a commented-out call nor a commented-out `NAME = "..."` decoy
-    assignment can be mistaken for live code. Block comments (`--[[ ]]`) are out of
-    scope — no producer wraps a publishTopic call in one.
-    """
-    out: list[str] = []
-    for line in text.splitlines():
-        i, in_str, cut = 0, None, None
-        while i < len(line):
-            c = line[i]
-            if in_str is not None:
-                if c == "\\":
-                    i += 1  # skip the escaped char
-                elif c == in_str:
-                    in_str = None
-            elif c in ("'", '"'):
-                in_str = c
-            elif c == "-" and line[i + 1 : i + 2] == "-":
-                cut = i
-                break
-            i += 1
-        out.append(line if cut is None else line[:cut])
-    return "\n".join(out)
-
-
 def _resolve_calls(text: str) -> tuple[set[str], list[str]]:
     """Return ({topics}, [unresolved]) for `.publishTopic(` CALLS in one Lua blob.
 
-    Comments are stripped first (`_strip_lua_comments`), so commented calls and
+    Comments are stripped first (`strip_lua_comments`), so commented calls and
     commented decoy assignments are gone before parsing. Each call's first arg is
     resolved to a string literal: direct ('"coaching.snapshot"') or via a
     `local NAME = "..."` / `NAME = "..."` assignment in the same blob (covers
@@ -89,7 +63,7 @@ def _resolve_calls(text: str) -> tuple[set[str], list[str]]:
     cannot be resolved to a literal is reported as unresolved so the guard fails
     loud rather than silently passing a producer it can't verify.
     """
-    text = _strip_lua_comments(text)
+    text = strip_lua_comments(text)
     topics: set[str] = set()
     unresolved: list[str] = []
     for m in _CALL_RE.finditer(text):


### PR DESCRIPTION
## Part A of epic #432 — adopt Racing Atelier in the in-game HUD

PR #410 (#400) shipped the Racing Atelier design **docs-only**; the in-game coaching HUD still rendered the old Figma palette and — visibly, in-cockpit — the **"AG PORSCHE ACADEMY"** footer brand. This restyles it and retires that branding.

### What changed
- **`design_tokens.lua`** (new) — canonical Racing Atelier palette for the CSP-Lua HUD (carbon/brass/signal). Hex is kept as a plain `M.HEX` table so a conformance test validates it against the design `colors.css` **without** a Lua runtime; `M.color(name, alpha)` builds the CSP `rgbm` on demand.
- **`hud.lua`** ("Active Suggestion" tile) + **`coaching_overlay.lua`** (approach panel) — source their `COLOR_*` tokens from `design_tokens` instead of hand-coded `rgbm` literals (single source of truth, no drift), and the footer brand changes **"AG PORSCHE ACADEMY" → "RACING ATELIER"**.
- **`test_hud_design_tokens.py`** — drift guard: asserts every HUD hex matches `colors.css` (fleet pitfall *redundant-code-drift*), mirroring the launcher's `theme.py` conformance test.

### Verified IN-SIM (not a mock)
Launched AC via the harness daemon (`/session/start`, cm mode), drove **autonomously** at Magione (Audi R8 LMS, no human at the wheel), and captured the live cockpit HUD with `tools.ac_harness.hud_capture`:
- **before** — the approach panel read "AG PORSCHE ACADEMY";
- **after** — it reads "RACING ATELIER", panels rendering the carbon/signal palette.

CSP API + UI-safety guards pass (32 Lua files, 0 warnings); the conformance test passes.

**Honest note:** the color delta is moderate — the old HUD was already a dark red/amber theme close to Racing Atelier's carbon/signal, so the headline changes are the **retired branding removed** + **all HUD colors now traceable to one design source**. Inline `rgbm()` literals deeper in `coaching_overlay.lua`'s render functions are left for a follow-up polish pass; the dominant panel / label / title / signal colors are the named tokens migrated here.

### Scope
In-game HUD only (`src/ac_copilot_trainer/modules/{design_tokens,hud,coaching_overlay}.lua` + test). Launcher = merged #434 (Part B); firmware rig screen = #430 (Part C).

Refs #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
