### PR TITLE
feat(launcher): Game Point photo-parity with the Racing Atelier render (#432 Part B follow-up)

### DIFF
--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -998,6 +998,23 @@ def test_build_pyinstaller_args_collects_optional_rtmixer_when_installed(
     assert _has_option_value(args, "--collect-binaries", "pa_ringbuffer")
 
 
+def test_build_pyinstaller_args_bundles_design_fonts_when_present(tmp_path: Path) -> None:
+    fonts_dir = tmp_path / "src" / "ac_copilot_trainer" / "content" / "fonts"
+    fonts_dir.mkdir(parents=True)
+
+    args = build_pyinstaller_args(tmp_path, onefile=True, windowed=True)
+
+    # Destination "fonts" matches the sys._MEIPASS/fonts lookup in
+    # tools.rig_launcher.fonts.load_private_fonts.
+    assert _has_option_value(args, "--add-data", f"{fonts_dir}{os.pathsep}fonts")
+
+
+def test_build_pyinstaller_args_omits_fonts_when_dir_missing(tmp_path: Path) -> None:
+    args = build_pyinstaller_args(tmp_path, onefile=True, windowed=True)
+
+    assert not any(value.endswith(f"{os.pathsep}fonts") for value in args)
+
+
 def _has_option_value(args: list[str], option: str, value: str) -> bool:
     return any(
         left == option and right == value for left, right in zip(args, args[1:], strict=False)

--- a/tests/test_rig_launcher_fonts.py
+++ b/tests/test_rig_launcher_fonts.py
@@ -1,0 +1,117 @@
+"""Tests for the launcher's private (FR_PRIVATE) design-font loading (epic #432).
+
+All GDI interaction is injected — no test touches the real gdi32, so the suite
+is deterministic on any platform and never mutates the host's font table.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.rig_launcher import fonts
+
+
+class _RecordingAddFont:
+    """Fake gdi32.AddFontResourceExW registrar recording (path, flags) calls."""
+
+    def __init__(self, result: bool = True) -> None:
+        self.calls: list[tuple[str, int]] = []
+        self._result = result
+
+    def __call__(self, path: str, flags: int) -> bool:
+        self.calls.append((path, flags))
+        return self._result
+
+
+def _make_fonts(directory: Path, names: tuple[str, ...]) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (directory / name).write_bytes(b"\x00")
+
+
+def test_loads_every_design_face_with_fr_private_flag(tmp_path: Path) -> None:
+    _make_fonts(tmp_path, fonts.FONT_FILES)
+    add = _RecordingAddFont()
+
+    loaded = fonts.load_private_fonts(font_dirs=[tmp_path], add_font=add)
+
+    assert sorted(loaded) == sorted(fonts.FONT_FILES)
+    assert fonts.FR_PRIVATE == 0x10
+    assert {flags for _path, flags in add.calls} == {fonts.FR_PRIVATE}
+
+
+def test_missing_files_are_tolerated_silently(tmp_path: Path) -> None:
+    present = fonts.FONT_FILES[:2]
+    _make_fonts(tmp_path, present)
+
+    loaded = fonts.load_private_fonts(font_dirs=[tmp_path], add_font=_RecordingAddFont())
+
+    assert loaded == list(present)
+
+
+def test_no_fonts_anywhere_returns_empty_list(tmp_path: Path) -> None:
+    add = _RecordingAddFont()
+
+    loaded = fonts.load_private_fonts(
+        font_dirs=[tmp_path, tmp_path / "does-not-exist"], add_font=add
+    )
+
+    assert loaded == []
+    assert add.calls == []
+
+
+def test_first_directory_with_fonts_wins(tmp_path: Path) -> None:
+    frozen = tmp_path / "frozen" / "fonts"
+    repo = tmp_path / "repo" / "fonts"
+    _make_fonts(frozen, fonts.FONT_FILES[:1])
+    _make_fonts(repo, fonts.FONT_FILES)
+    add = _RecordingAddFont()
+
+    loaded = fonts.load_private_fonts(font_dirs=[frozen, repo], add_font=add)
+
+    assert loaded == [fonts.FONT_FILES[0]]
+    assert all(path.startswith(str(frozen)) for path, _flags in add.calls)
+
+
+def test_failed_gdi_registration_is_dropped_from_result(tmp_path: Path) -> None:
+    _make_fonts(tmp_path, fonts.FONT_FILES)
+
+    loaded = fonts.load_private_fonts(
+        font_dirs=[tmp_path], add_font=_RecordingAddFont(result=False)
+    )
+
+    assert loaded == []
+
+
+def test_noop_when_gdi_is_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _make_fonts(tmp_path, fonts.FONT_FILES)
+    monkeypatch.setattr(fonts, "_resolve_gdi_add_font", lambda: None)
+
+    assert fonts.load_private_fonts(font_dirs=[tmp_path]) == []
+
+
+def test_gdi_resolution_is_none_off_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fonts.sys, "platform", "linux")
+
+    assert fonts._resolve_gdi_add_font() is None
+
+
+def test_default_font_dirs_prefer_frozen_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "_MEIPASS", str(Path("C:/frozen/bundle")), raising=False)
+
+    dirs = fonts._font_dirs()
+
+    assert dirs[0] == Path("C:/frozen/bundle") / "fonts"
+    assert dirs[1].as_posix().endswith("src/ac_copilot_trainer/content/fonts")
+
+
+def test_default_font_dirs_without_frozen_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+    dirs = fonts._font_dirs()
+
+    assert len(dirs) == 1
+    assert dirs[0].as_posix().endswith("src/ac_copilot_trainer/content/fonts")

--- a/tests/test_rig_launcher_theme.py
+++ b/tests/test_rig_launcher_theme.py
@@ -123,6 +123,28 @@ def test_summary_for_other_failure_uses_first_failing_detail() -> None:
     )
 
 
+def test_summary_for_blocking_preflight_outranks_port_copy() -> None:
+    """A failing preflight check must surface before the port-down copy —
+    pressing Start cannot succeed until the blocker clears (PR #445 review)."""
+    status = _status(sidecar=ProbeResult("sidecar", False, "stopped", "—"))
+    status = GamePointStatus(
+        generated_at=status.generated_at,
+        sidecar=status.sidecar,
+        screen=status.screen,
+        hotspot=status.hotspot,
+        voice=status.voice,
+        simhub=status.simhub,
+        log_path=status.log_path,
+        status_path=status.status_path,
+        checks=(ProbeResult("acroot", False, "missing", "AC install not found"),),
+    )
+    assert theme.summary_for(status) == (
+        "PRESS START",
+        "brake",
+        "AC install not found",
+    )
+
+
 def test_summary_for_falls_back_to_state_word_without_detail() -> None:
     status = _status(voice=ProbeResult("voice", False, "DISABLED", ""))
     assert theme.summary_for(status) == ("PRESS START", "brake", "DISABLED")

--- a/tests/test_rig_launcher_theme.py
+++ b/tests/test_rig_launcher_theme.py
@@ -13,6 +13,7 @@ import re
 from pathlib import Path
 
 from tools.rig_launcher import theme
+from tools.rig_launcher.supervisor import GamePointStatus, ProbeResult
 
 _COLORS_CSS = (
     Path(__file__).resolve().parents[1]
@@ -47,8 +48,12 @@ def test_tone_for_maps_states_to_signals() -> None:
     # failures are red unless they are a known in-progress state
     assert theme.tone_for(False, "DISABLED") == "brake"
     assert theme.tone_for(False, "unreachable") == "brake"
-    assert theme.tone_for(False, "waiting") == "lift"
+    # a missing screen peer is a failure to fix, not progress — the render
+    # shows SCREEN WAITING in brake red (issue #432 photo parity)
+    assert theme.tone_for(False, "waiting") == "brake"
+    # genuinely in-progress states stay amber
     assert theme.tone_for(True, "starting") == "lift"
+    assert theme.tone_for(False, "initializing") == "lift"
 
 
 def test_color_for_tone_uses_signal_hex() -> None:
@@ -57,6 +62,86 @@ def test_color_for_tone_uses_signal_hex() -> None:
     assert theme.color_for_tone("brake") == theme.BRAKE
     assert theme.color_for_tone("idle") == theme.DIM
     assert theme.color_for_tone("nonsense") == theme.DIM
+
+
+def test_field_ink_matches_status_field_component() -> None:
+    # StatusField 'go' ink from the design bundle; 'stop' ink is chalk-on-brake.
+    assert theme.FIELD_INK["clear"] == "#06140C"
+    assert theme.FIELD_INK["brake"] == theme.CHALK
+
+
+def _status(**overrides: ProbeResult) -> GamePointStatus:
+    rows: dict[str, ProbeResult] = {
+        "sidecar": ProbeResult("sidecar", True, "healthy", "peers=1 screen_peers=1"),
+        "screen": ProbeResult("screen", True, "connected", "screen_peers=1"),
+        "hotspot": ProbeResult("hotspot", True, "on", "state=On clients=1"),
+        "voice": ProbeResult("voice", True, "enabled", "backend=sounddevice"),
+        "simhub": ProbeResult("simhub", True, "absent", "executable not found"),
+    }
+    rows.update(overrides)
+    return GamePointStatus(
+        generated_at=0.0,
+        log_path="sidecar.log",
+        status_path="status.json",
+        **rows,
+    )
+
+
+def test_summary_for_ready_state() -> None:
+    assert theme.summary_for(_status()) == (
+        "READY TO DRIVE",
+        "clear",
+        "sidecar · screen · hotspot live",
+    )
+
+
+def test_summary_for_stopped_sidecar_names_the_port() -> None:
+    status = _status(
+        sidecar=ProbeResult("sidecar", False, "stopped", "—"),
+        screen=ProbeResult("screen", False, "waiting", "no screen peer"),
+    )
+    assert theme.summary_for(status, port=9876) == (
+        "PRESS START",
+        "brake",
+        "nothing on port 9876 yet",
+    )
+
+
+def test_summary_for_unreachable_sidecar_names_the_default_port() -> None:
+    status = _status(sidecar=ProbeResult("sidecar", False, "unreachable", "connection refused"))
+    assert theme.summary_for(status) == ("PRESS START", "brake", "nothing on port 8765 yet")
+
+
+def test_summary_for_other_failure_uses_first_failing_detail() -> None:
+    status = _status(
+        screen=ProbeResult("screen", False, "waiting", "no ESP32 screen peer connected")
+    )
+    assert theme.summary_for(status) == (
+        "PRESS START",
+        "brake",
+        "no ESP32 screen peer connected",
+    )
+
+
+def test_summary_for_falls_back_to_state_word_without_detail() -> None:
+    status = _status(voice=ProbeResult("voice", False, "DISABLED", ""))
+    assert theme.summary_for(status) == ("PRESS START", "brake", "DISABLED")
+
+
+def test_launcher_buttons_are_uppercase_with_start_emphasis() -> None:
+    from tools.rig_launcher import view
+
+    labels = [label for label, _key, _primary in view._BUTTONS]
+    assert labels == ["▶ START", "REFRESH", "LOGS", "SETTINGS", "SETUP DIFF"]
+    assert [primary for _label, _key, primary in view._BUTTONS] == [
+        True,
+        False,
+        False,
+        False,
+        False,
+    ]
+    # Start is 1.5x each secondary action (1.5fr vs 1fr in the design grid).
+    assert view._BUTTON_WEIGHTS == (3, 2, 2, 2, 2)
 
 
 def test_resolve_font_prefers_available_family() -> None:
@@ -69,3 +154,11 @@ def test_resolve_font_prefers_available_family() -> None:
     assert theme.resolve_font(("saira semi condensed",), {"Saira Semi Condensed"}) == (
         "saira semi condensed"
     )
+
+
+def test_display_ladder_prefers_bundled_semicondensed_family() -> None:
+    # The FR_PRIVATE statics expose the name-table family "Saira SemiCondensed"
+    # (no space); the Google system-install name has the space. Both precede
+    # the Windows fallbacks.
+    assert theme.FONT_DISPLAY[:2] == ("Saira SemiCondensed", "Saira Semi Condensed")
+    assert "Bahnschrift" in theme.FONT_DISPLAY

--- a/tools/rig_launcher/fonts.py
+++ b/tools/rig_launcher/fonts.py
@@ -1,0 +1,90 @@
+"""Private design-font loading for the Game Point launcher (epic #432 photo parity).
+
+Registers the Racing Atelier faces (Saira SemiCondensed statics, Saira Bold,
+Spline Sans Mono Medium) *process-privately* on Windows via GDI's
+``AddFontResourceExW(..., FR_PRIVATE, 0)`` so the launcher renders on-brand
+without a system-wide font install and without leaking the faces to other
+processes. Everything degrades silently: on non-Windows, when GDI is
+unavailable, or when the font files are absent (they ship on the packaging
+branch, not on ``main``), :func:`load_private_fonts` returns what it loaded —
+possibly nothing — and the theme's font ladder falls back to Bahnschrift /
+Consolas.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+#: GDI flag: the font is visible to this process only and never enumerated
+#: system-wide (FR_PRIVATE in wingdi.h).
+FR_PRIVATE = 0x10
+
+#: The design statics the launcher uses (display, read, mono faces).
+FONT_FILES: tuple[str, ...] = (
+    "SairaSemiCondensed-SemiBold.ttf",
+    "SairaSemiCondensed-Bold.ttf",
+    "SairaSemiCondensed-ExtraBold.ttf",
+    "Saira-Bold.ttf",
+    "SplineSansMono-Medium.ttf",
+)
+
+
+def _font_dirs() -> list[Path]:
+    """Candidate font directories, most specific first.
+
+    (a) the PyInstaller onefile extraction dir (``sys._MEIPASS``/fonts, matching
+    the ``--add-data`` destination in ``build_pyinstaller_args``), then
+    (b) the repo checkout's bundled content fonts, located relative to this
+    module so a dev-tree launch finds them without configuration.
+    """
+    dirs: list[Path] = []
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        dirs.append(Path(meipass) / "fonts")
+    repo_root = Path(__file__).resolve().parents[2]
+    dirs.append(repo_root / "src" / "ac_copilot_trainer" / "content" / "fonts")
+    return dirs
+
+
+def _resolve_gdi_add_font() -> Callable[[str, int], bool] | None:
+    """Return a ``(path, flags) -> bool`` GDI registrar, or None off-Windows."""
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        gdi32 = ctypes.windll.gdi32  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 - font loading must never break the launcher
+        return None
+
+    def add_font(path: str, flags: int) -> bool:
+        try:
+            return bool(gdi32.AddFontResourceExW(path, flags, 0))
+        except Exception:  # noqa: BLE001 - a bad TTF must not break the launcher
+            return False
+
+    return add_font
+
+
+def load_private_fonts(
+    *,
+    font_dirs: Sequence[Path] | None = None,
+    add_font: Callable[[str, int], bool] | None = None,
+) -> list[str]:
+    """Register the design TTFs process-privately; return the loaded file names.
+
+    Uses the first candidate directory that contains any of :data:`FONT_FILES`.
+    No-op (empty list) on non-Windows, when GDI is unavailable, or when no font
+    files exist anywhere — missing files are tolerated silently by design.
+    """
+    registrar = add_font if add_font is not None else _resolve_gdi_add_font()
+    if registrar is None:
+        return []
+    for directory in font_dirs if font_dirs is not None else _font_dirs():
+        found = [directory / name for name in FONT_FILES if (directory / name).is_file()]
+        if not found:
+            continue
+        return [path.name for path in found if registrar(str(path), FR_PRIVATE)]
+    return []

--- a/tools/rig_launcher/preview.py
+++ b/tools/rig_launcher/preview.py
@@ -17,6 +17,7 @@ import argparse
 import subprocess
 import time
 
+from tools.rig_launcher.fonts import load_private_fonts
 from tools.rig_launcher.supervisor import GamePointStatus, ProbeResult
 from tools.rig_launcher.view import build_launcher_view
 
@@ -60,6 +61,7 @@ def render(out_path: str, *, status: GamePointStatus | None = None) -> int:
     """Show the themed launcher and save its client rectangle to ``out_path``."""
     import tkinter as tk
 
+    load_private_fonts()  # register design faces so the capture matches the rig
     root = tk.Tk()
     root.title("AC Copilot Game Point")
     root.geometry("660x440+140+140")

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -598,6 +598,12 @@ def build_pyinstaller_args(
         "--hidden-import",
         "pyttsx3.drivers.sapi5",
     ]
+    fonts_dir = project_root / "src" / "ac_copilot_trainer" / "content" / "fonts"
+    if fonts_dir.is_dir():
+        # Racing Atelier design faces, loaded FR_PRIVATE by tools.rig_launcher.fonts
+        # from sys._MEIPASS/fonts. Present only on packaging branches — guarded so
+        # a checkout without the TTFs still builds.
+        args.extend(["--add-data", f"{fonts_dir}{os.pathsep}fonts"])
     _append_optional_pyinstaller_module(args, "rtmixer")
     _append_optional_pyinstaller_module(args, "pa_ringbuffer")
     if onefile:

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -15,6 +15,10 @@ approximation and is intentionally *not* part of the conformance set.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, keeps theme display/runtime free
+    from tools.rig_launcher.supervisor import GamePointStatus
 
 # --- Carbon ground (mirrors colors.css :root) ---
 CARBON = "#0B0C0D"
@@ -44,6 +48,15 @@ DATA = "#49B6C9"
 # Not part of the conformance set (the CSS value is rgba, not hex).
 LINE = "#22262B"
 
+# Tk-only approximation of the stronger --line-2 rgba(255,255,255,0.16) hairline
+# over graphite — the secondary-button border. Not in the conformance set.
+LINE_2 = "#3A3F46"
+
+# Primary-button press state. The design darkens the brass field with a press
+# opacity; Tk has no opacity, so this is a pre-multiplied darker brass. It is
+# deliberately NOT the amber LIFT signal (state colors never double as chrome).
+BRASS_PRESS = "#A87F33"
+
 #: hex tokens validated against colors.css by the conformance test.
 TOKENS: dict[str, str] = {
     "carbon": CARBON,
@@ -68,6 +81,10 @@ TOKENS: dict[str, str] = {
 # with Windows (Bahnschrift is condensed like Saira SC; Consolas is the mono
 # default), so the launcher looks on-brand even before the design fonts install.
 FONT_DISPLAY: tuple[str, ...] = (
+    # Real name-table family of the bundled SemiCondensed statics loaded by
+    # tools.rig_launcher.fonts (note: no space inside "SemiCondensed").
+    "Saira SemiCondensed",
+    # Family name Windows uses when the face is system-installed from Google.
     "Saira Semi Condensed",
     "Bahnschrift",
     "Segoe UI Semibold",
@@ -84,10 +101,18 @@ TONE_COLORS: dict[str, str] = {
     "idle": DIM,
 }
 
+#: StatusField ink-on-fill per tone (mirrors the design StatusField TONES ink).
+FIELD_INK: dict[str, str] = {
+    "clear": "#06140C",
+    "brake": CHALK,
+}
+
 # States that are healthy-but-quiescent (nothing wrong, nothing lit).
 _IDLE_STATES = {"absent", "skipped", "loopback", "available", "stopped"}
-# States that are in-progress / attention-but-not-failure.
-_WARN_STATES = {"waiting", "initializing", "starting", "unavailable", "unknown"}
+# States that are in-progress / attention-but-not-failure. "waiting" is NOT in
+# this set: a missing screen peer is a failure the driver must fix (the render
+# shows SCREEN WAITING in brake red), not progress.
+_WARN_STATES = {"initializing", "starting", "unavailable", "unknown"}
 
 
 def tone_for(ok: bool, state: str) -> str:
@@ -109,6 +134,36 @@ def tone_for(ok: bool, state: str) -> str:
 def color_for_tone(tone: str) -> str:
     """Return the hex for a tone, defaulting to the demoted dim ink."""
     return TONE_COLORS.get(tone, DIM)
+
+
+#: sidecar states that mean "no server on the port yet" (ui-kit recovery state).
+_SIDECAR_DOWN_STATES = {"stopped", "unreachable"}
+
+
+def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, str]:
+    """Map a status snapshot onto the summary StatusField chip + mono caption.
+
+    Returns ``(text, tone, caption)`` — the uppercase chip word, the signal tone
+    keying :data:`TONE_COLORS` / :data:`FIELD_INK`, and the mono caption beside
+    the chip. Mirrors the design ui-kit's two states: ready ("Ready to drive" on
+    the CLEAR field) and recovery ("Press start" on the BRAKE field). Total: it
+    always returns a caption, deriving it from the first failing row when the
+    sidecar itself is up.
+    """
+    if status.ok:
+        return ("READY TO DRIVE", "clear", "sidecar · screen · hotspot live")
+    if (status.sidecar.state or "").strip().lower() in _SIDECAR_DOWN_STATES:
+        return ("PRESS START", "brake", f"nothing on port {port} yet")
+    rows = (status.sidecar, status.screen, status.hotspot, status.voice, status.simhub)
+    caption = next(
+        (
+            row.detail or row.state
+            for row in (*rows, *status.checks)
+            if not row.ok and (row.detail or row.state)
+        ),
+        "needs attention",
+    )
+    return ("PRESS START", "brake", caption)
 
 
 def resolve_font(preferences: Iterable[str], available: Iterable[str]) -> str:

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -152,13 +152,22 @@ def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, st
     """
     if status.ok:
         return ("READY TO DRIVE", "clear", "sidecar · screen · hotspot live")
+    # A failing preflight check outranks the port-down copy: pressing Start
+    # cannot succeed until the blocker is cleared, so the caption must say
+    # what is actually wrong (PR #445 review).
+    blocker = next(
+        (chk for chk in status.checks if not chk.ok and (chk.detail or chk.state)),
+        None,
+    )
+    if blocker is not None:
+        return ("PRESS START", "brake", blocker.detail or blocker.state)
     if (status.sidecar.state or "").strip().lower() in _SIDECAR_DOWN_STATES:
         return ("PRESS START", "brake", f"nothing on port {port} yet")
     rows = (status.sidecar, status.screen, status.hotspot, status.voice, status.simhub)
     caption = next(
         (
             row.detail or row.state
-            for row in (*rows, *status.checks)
+            for row in rows
             if not row.ok and (row.detail or row.state)
         ),
         "needs attention",

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -165,11 +165,7 @@ def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, st
         return ("PRESS START", "brake", f"nothing on port {port} yet")
     rows = (status.sidecar, status.screen, status.hotspot, status.voice, status.simhub)
     caption = next(
-        (
-            row.detail or row.state
-            for row in rows
-            if not row.ok and (row.detail or row.state)
-        ),
+        (row.detail or row.state for row in rows if not row.ok and (row.detail or row.state)),
         "needs attention",
     )
     return ("PRESS START", "brake", caption)

--- a/tools/rig_launcher/view.py
+++ b/tools/rig_launcher/view.py
@@ -7,6 +7,10 @@ diff) is passed in via ``actions`` and the caller drives redraws with
 ``LauncherView.update(status)``. Keeping the view free of supervisor/polling
 logic preserves ``app.run_gui``'s Tk-init fallback contract and lets the palette
 be unit-tested through :mod:`tools.rig_launcher.theme` without a display.
+
+Tk waiver: Tk text has no letter-spacing control, so the design's 0.04-0.12em
+caps tracking is not reproduced. Do NOT fake it by injecting hair-space
+characters — that corrupts copy/paste, accessibility, and text measurement.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from collections.abc import Callable, Mapping
 from tkinter import font as tkfont
 
 from tools.rig_launcher import theme
+from tools.rig_launcher.fonts import load_private_fonts
 from tools.rig_launcher.supervisor import GamePointStatus, ProbeResult
 
 #: (display label, GamePointStatus attribute) for each status row, top to bottom.
@@ -27,14 +32,20 @@ _ROWS: tuple[tuple[str, str], ...] = (
     ("SimHub", "simhub"),
 )
 
-#: (label, action key, is-primary) for each footer button.
+#: (label, action key, is-primary) for each footer button. Labels are uppercase
+#: per the design Button treatment; Setup Diff is functional substance the
+#: design mock omits, kept as a fifth column.
 _BUTTONS: tuple[tuple[str, str, bool], ...] = (
-    ("▶  Start", "start", True),
-    ("Refresh", "refresh", False),
-    ("Logs", "logs", False),
-    ("Settings", "settings", False),
-    ("Setup Diff", "setup_diff", False),
+    ("▶ START", "start", True),
+    ("REFRESH", "refresh", False),
+    ("LOGS", "logs", False),
+    ("SETTINGS", "settings", False),
+    ("SETUP DIFF", "setup_diff", False),
 )
+
+#: grid column weights: Start is 1.5x each secondary action (design
+#: grid-template-columns 1.5fr 1fr 1fr 1fr, extended with the Setup Diff column).
+_BUTTON_WEIGHTS: tuple[int, ...] = (3, 2, 2, 2, 2)
 
 _ARM = 15  # px arm length of the brass corner brackets
 
@@ -52,6 +63,7 @@ class LauncherView:
     ) -> None:
         self._root = root
         self._port = port
+        load_private_fonts()  # register design faces before Tk enumerates families
         families = set(tkfont.families(root))
         self._f_disp = theme.resolve_font(theme.FONT_DISPLAY, families)
         self._f_read = theme.resolve_font(theme.FONT_READ, families)
@@ -61,6 +73,17 @@ class LauncherView:
         if isinstance(root, (tk.Tk, tk.Toplevel)):
             root.configure(bg=theme.CARBON)
 
+        # Debug footer lives on the carbon ground *below* the card — the design
+        # card carries no path line, but the operator info must survive.
+        tk.Label(
+            root,
+            text=status_path,
+            bg=theme.CARBON,
+            fg=theme.FAINT,
+            font=(self._f_mono, 8),
+            anchor="w",
+        ).pack(side="bottom", fill="x", padx=18, pady=(0, 6))
+
         panel = tk.Frame(
             root,
             bg=theme.GRAPHITE,
@@ -69,7 +92,7 @@ class LauncherView:
             highlightthickness=1,
             bd=0,
         )
-        panel.pack(fill="both", expand=True, padx=16, pady=16)
+        panel.pack(fill="both", expand=True, padx=16, pady=(16, 6))
 
         self._build_header(panel)
         tk.Frame(panel, bg=theme.LINE, height=1).pack(fill="x")
@@ -77,19 +100,10 @@ class LauncherView:
 
         body = tk.Frame(panel, bg=theme.GRAPHITE)
         body.pack(fill="both", expand=True, padx=16, pady=(2, 8))
-        for label, key in _ROWS:
-            self._rows[key] = self._build_row(body, label)
+        for index, (label, key) in enumerate(_ROWS):
+            self._rows[key] = self._build_row(body, label, last=index == len(_ROWS) - 1)
 
         self._build_buttons(panel, actions)
-        tk.Label(
-            panel,
-            text=status_path,
-            bg=theme.GRAPHITE,
-            fg=theme.FAINT,
-            font=(self._f_mono, 8),
-            anchor="w",
-        ).pack(fill="x", padx=16, pady=(0, 10))
-
         self._add_corner_brackets(panel)
 
     # -- construction helpers -------------------------------------------------
@@ -113,15 +127,15 @@ class LauncherView:
     def _build_header(self, panel: tk.Frame) -> None:
         header = tk.Frame(panel, bg=theme.GRAPHITE)
         header.pack(fill="x", padx=16, pady=(14, 10))
-        tab = tk.Canvas(header, width=6, height=18, bg=theme.BRASS, highlightthickness=0, bd=0)
+        tab = tk.Canvas(header, width=6, height=16, bg=theme.BRASS, highlightthickness=0, bd=0)
         tab.pack(side="left")
         tk.Label(
             header,
             text="GAME POINT",
             bg=theme.GRAPHITE,
             fg=theme.CHALK,
-            font=(self._f_disp, 15, "bold"),
-        ).pack(side="left", padx=(10, 0))
+            font=(self._f_disp, 14, "bold"),
+        ).pack(side="left", padx=(12, 0))
         tk.Label(
             header,
             text=f":{self._port}",
@@ -132,53 +146,64 @@ class LauncherView:
 
     def _build_summary(self, panel: tk.Frame) -> None:
         row = tk.Frame(panel, bg=theme.GRAPHITE)
-        row.pack(fill="x", padx=16, pady=(12, 10))
-        dot = tk.Canvas(row, width=12, height=12, bg=theme.GRAPHITE, highlightthickness=0, bd=0)
-        oval = dot.create_oval(1, 1, 11, 11, fill=theme.CLEAR, outline="")
-        dot.pack(side="left")
-        text = tk.Label(
-            row, text="Ready to drive", bg=theme.GRAPHITE, fg=theme.CHALK, font=(self._f_read, 13)
+        row.pack(fill="x", padx=16, pady=(14, 10))
+        field = tk.Label(
+            row,
+            text="READY TO DRIVE",
+            bg=theme.CLEAR,
+            fg=theme.FIELD_INK["clear"],
+            font=(self._f_disp, 12, "bold"),
+            padx=9,
+            pady=3,
         )
-        text.pack(side="left", padx=(10, 0))
-        self._summary_dot = dot
-        self._summary_oval = oval
-        self._summary_text = text
+        field.pack(side="left")
+        caption = tk.Label(
+            row,
+            text="sidecar · screen · hotspot live",
+            bg=theme.GRAPHITE,
+            fg=theme.MUTE,
+            font=(self._f_mono, 11),
+        )
+        caption.pack(side="left", padx=(12, 0))
+        self._summary_field = field
+        self._summary_caption = caption
 
-    def _build_row(self, body: tk.Frame, label: str) -> dict[str, object]:
+    def _build_row(self, body: tk.Frame, label: str, *, last: bool = False) -> dict[str, object]:
         row = tk.Frame(body, bg=theme.GRAPHITE)
-        row.pack(fill="x", pady=3)
+        row.pack(fill="x", pady=(8, 8))
         tk.Label(
             row,
             text=label.upper(),
             bg=theme.GRAPHITE,
             fg=theme.MUTE,
-            font=(self._f_disp, 10),
-            width=9,
+            font=(self._f_disp, 12),
+            width=10,
             anchor="w",
         ).pack(side="left")
-        dot = tk.Canvas(row, width=9, height=9, bg=theme.GRAPHITE, highlightthickness=0, bd=0)
-        oval = dot.create_oval(1, 1, 8, 8, fill=theme.DIM, outline="")
-        dot.pack(side="left", padx=(2, 8))
         state = tk.Label(
             row,
             text="—",
             bg=theme.GRAPHITE,
             fg=theme.CHALK,
-            font=(self._f_disp, 11, "bold"),
+            font=(self._f_disp, 13, "bold"),
             width=12,
             anchor="w",
         )
         state.pack(side="left")
         detail = tk.Label(
-            row, text="", bg=theme.GRAPHITE, fg=theme.DIM, font=(self._f_mono, 9), anchor="e"
+            row, text="", bg=theme.GRAPHITE, fg=theme.DIM, font=(self._f_mono, 11), anchor="e"
         )
         detail.pack(side="right")
-        return {"dot": dot, "oval": oval, "state": state, "detail": detail}
+        if not last:
+            tk.Frame(body, bg=theme.LINE, height=1).pack(fill="x")
+        return {"state": state, "detail": detail}
 
     def _build_buttons(self, panel: tk.Frame, actions: Mapping[str, Callable[[], None]]) -> None:
         row = tk.Frame(panel, bg=theme.GRAPHITE)
-        row.pack(fill="x", padx=16, pady=(6, 12))
-        for index, (label, key, primary) in enumerate(_BUTTONS):
+        row.pack(fill="x", padx=16, pady=(10, 14))
+        for column, weight in enumerate(_BUTTON_WEIGHTS):
+            row.columnconfigure(column, weight=weight, uniform="actions")
+        for column, (label, key, primary) in enumerate(_BUTTONS):
             button = tk.Button(
                 row,
                 text=label,
@@ -187,36 +212,38 @@ class LauncherView:
                 relief="flat",
                 bd=0,
                 padx=10,
-                pady=7,
+                pady=11,  # ~40px min height with the 10pt display face
                 font=(self._f_disp, 10, "bold"),
                 bg=theme.BRASS if primary else theme.RAISE,
                 fg=theme.BRASS_INK if primary else theme.CHALK,
-                activebackground=theme.LIFT if primary else theme.SLAB,
+                # Press state: darker brass (press-opacity approximation), never
+                # the amber LIFT signal; secondaries sink to the slab.
+                activebackground=theme.BRASS_PRESS if primary else theme.SLAB,
                 activeforeground=theme.BRASS_INK if primary else theme.CHALK,
-                highlightthickness=0,
+                highlightthickness=0 if primary else 1,
+                highlightbackground=theme.GRAPHITE if primary else theme.LINE_2,
             )
-            button.pack(side="left", expand=True, fill="x", padx=(0 if index == 0 else 6, 0))
+            button.grid(row=0, column=column, sticky="nsew", padx=(0 if column == 0 else 9, 0))
 
     # -- refresh --------------------------------------------------------------
 
     def update(self, status: GamePointStatus) -> None:
-        """Repaint the summary and every status row from a fresh snapshot."""
-        overall_ok = status.ok
-        self._summary_dot.itemconfigure(
-            self._summary_oval, fill=theme.CLEAR if overall_ok else theme.BRAKE
+        """Repaint the summary chip and every status row from a fresh snapshot."""
+        text, tone, caption = theme.summary_for(status, port=self._port)
+        self._summary_field.configure(
+            text=text,
+            bg=theme.color_for_tone(tone),
+            fg=theme.FIELD_INK.get(tone, theme.CHALK),
         )
-        self._summary_text.configure(text="Ready to drive" if overall_ok else "Needs attention")
+        self._summary_caption.configure(text=caption)
         for key, widgets in self._rows.items():
             probe = getattr(status, key, None)
             if not isinstance(probe, ProbeResult):
                 continue
             color = theme.color_for_tone(theme.tone_for(probe.ok, probe.state))
-            dot = widgets["dot"]
-            assert isinstance(dot, tk.Canvas)
-            dot.itemconfigure(widgets["oval"], fill=color)
             state = widgets["state"]
             assert isinstance(state, tk.Label)
-            state.configure(text=probe.state, fg=color)
+            state.configure(text=probe.state.upper(), fg=color)
             detail = widgets["detail"]
             assert isinstance(detail, tk.Label)
             detail.configure(text=probe.detail or "")


### PR DESCRIPTION
## What

Closes the confirmed composition gaps between the merged Part B launcher (#434) and its Racing Atelier targets (`WindowsLauncher.dc.html` healthy / `game_point.png` stopped):

- **Summary band** is now the design's StatusField: a flat signal field (green `READY TO DRIVE` with dark-green ink / red `PRESS START`) + a mono caption (`sidecar · screen · hotspot live` / `nothing on port :N yet`), via a headless-testable `theme.summary_for()`.
- **Status rows** match the StatusRow spec: uppercase tone-colored state words, no per-row dots, 1px hairlines between rows, label column ≈96px, mono 11 details.
- **Buttons** on a weighted grid (3,2,2,2,2): brass `▶ START` at 1.5×, uppercase labels, ~40px height, hairline borders on secondaries, brass press state (`#A87F33`, documented press-opacity approximation — no amber flash). `SETUP DIFF` stays as a fifth column (functional substance; recorded deviation from the 4-button render).
- **`waiting` → brake tone**: a missing screen peer is a failure, not progress — matches the render's red WAITING (tests updated).
- **Private font loading**: new `tools/rig_launcher/fonts.py` registers the bundled design TTFs per-process via `AddFontResourceExW(FR_PRIVATE)` (dir ladder: PyInstaller `_MEIPASS/fonts` → repo fonts; silent partial tolerance). `FONT_DISPLAY` tries the real DirectWrite family `Saira SemiCondensed` first. PyInstaller args bundle the fonts dir when present.
- **status.json path** moved out of the card onto the carbon root (design card carries no debug footer; info preserved).
- Tk letter-spacing is documented as a waiver (no unicode hair-space hacks).

## Verification (observed)

- Rendered the REAL Tk window in both target states via `tools/rig_launcher/preview.py` (GDI pixel capture) and compared against `game_point.png` + `WindowsLauncher.dc.html`: composition, tones, chip, hairlines, buttons and the Saira faces all match; deviations (5th button, Tk tracking) are recorded above.
- `pytest tests/test_rig_launcher_theme.py tests/test_rig_launcher_fonts.py tests/test_rig_launcher.py` → 78 passed; `make ci-fast` → OK; ruff clean.

Part of #432 (Part B acceptance). Font files land with PR #444 (HUD) — the loader tolerates their absence until it merges, falling back to installed/system faces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)