### PR TITLE
[codex] Fix SimHub launcher detection

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-02T05:15:00Z
+last_updated: 2026-07-02T06:28:31Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/pr-444-atelier-main-dashboard-2026-07-01.md
   - AcCopilotTrainer/03_Investigations/pr-441-voice-signature-gate-2026-07-01.md
@@ -62,6 +62,22 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-07-02 UTC) - Game Point SimHub detection hotfix
+
+Operator reported the Windows Game Point launcher showing `SIMHUB absent` even though SimHub was
+installed. Root cause: `GamePointSupervisor` copied Windows `os.environ` into a plain dict, whose keys
+were uppercase (`PROGRAMFILES(X86)`), then `_simhub_exe()` looked up `ProgramFiles(x86)` exactly.
+`tools/rig_launcher/supervisor.py` now uses a case-insensitive Windows env lookup for SimHub install
+roots, with regression coverage in `tests/test_rig_launcher.py`.
+
+Local proof: `python -m tools.rig_launcher --once --json` and the rebuilt packaged exe both wrote
+`simhub.state=available` with `C:\Program Files (x86)\SimHub\SimHubWPF.exe`. Rebuilt
+`dist\AC-Copilot-Game-Point.exe`, refreshed the Desktop shortcut, and reopened the launcher. Focused
+checks passed (`ruff check`, `ruff format --check`, `pytest tests/test_rig_launcher.py`, plus
+`pytest -k simhub`). `make PYTHON=python ci-fast` was attempted but stopped at repo-wide
+`ci-format`: this checkout has broad unrelated Ruff format drift (227 files), so it was not fixed in
+this hotfix.
 
 ## Delivered (2026-07-02 UTC) — PRs #444/#445/#446 MERGED: Racing Atelier runtime adoption (#432 Parts A2+B, #86 fix)
 

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -668,6 +668,26 @@ def test_simhub_absence_is_visible_but_not_fatal(tmp_path: Path) -> None:
     assert "not found" in result.detail
 
 
+def test_simhub_discovery_treats_windows_env_keys_case_insensitively(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    exe = tmp_path / "SimHub" / "SimHubWPF.exe"
+    exe.parent.mkdir()
+    exe.write_text("", encoding="utf-8")
+    cfg = GamePointConfig(paths=LauncherPaths(tmp_path))
+    monkeypatch.setattr(supervisor_module.os, "name", "nt")
+    sup = GamePointSupervisor(
+        cfg,
+        environ={"PROGRAMFILES(X86)": str(tmp_path)},
+        run=_no_simhub_run,
+    )
+
+    result = sup.probe_simhub(start=False)
+
+    assert result.state == "available"
+    assert result.detail == str(exe)
+
+
 def test_simhub_starts_when_requested_and_executable_exists(tmp_path: Path) -> None:
     exe = tmp_path / "SimHub" / "SimHubWPF.exe"
     exe.parent.mkdir()

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -526,7 +526,7 @@ class GamePointSupervisor:
         if self.config.simhub_exe:
             candidates.append(Path(self.config.simhub_exe))
         for env_key in ("ProgramFiles(x86)", "ProgramFiles"):
-            base = self._environ.get(env_key)
+            base = _env_get(self._environ, env_key)
             if base:
                 candidates.append(Path(base) / "SimHub" / "SimHubWPF.exe")
         for path in candidates:
@@ -739,6 +739,17 @@ def _none_if_blank(value: str | None) -> str | None:
 def _put_if_present(env: MutableMapping[str, str], key: str, value: str | None) -> None:
     if value:
         env[key] = value
+
+
+def _env_get(env: Mapping[str, str], key: str) -> str | None:
+    value = env.get(key)
+    if value is not None or os.name != "nt":
+        return value
+    wanted = key.upper()
+    for actual_key, actual_value in env.items():
+        if actual_key.upper() == wanted:
+            return actual_value
+    return None
 
 
 def _is_loopback(host: str) -> bool:


### PR DESCRIPTION
## Summary

- Fix Game Point SimHub discovery when Windows environment keys are copied into a case-sensitive Python dict.
- Add a regression test covering uppercase `PROGRAMFILES(X86)` lookup.
- Record the local launcher/package verification in the vault handoff.

## Root Cause

`GamePointSupervisor` copied `os.environ` into a plain `dict`. On this Windows launch context the copied keys appeared as uppercase values like `PROGRAMFILES(X86)`, while `_simhub_exe()` looked up `ProgramFiles(x86)` exactly. The launcher therefore reported `SIMHUB absent` even though `C:\Program Files (x86)\SimHub\SimHubWPF.exe` existed.

## Verification

- `python -m ruff check tools/rig_launcher/supervisor.py tests/test_rig_launcher.py`
- `python -m ruff format --check tools/rig_launcher/supervisor.py tests/test_rig_launcher.py`
- `python -m pytest -q tests/test_rig_launcher.py`
- `python -m pytest -q tests/test_rig_launcher.py -k simhub`
- `python -m tools.rig_launcher --once --json` showed `simhub.state=available` at `C:\Program Files (x86)\SimHub\SimHubWPF.exe`.
- Rebuilt `dist\AC-Copilot-Game-Point.exe`, refreshed the Desktop shortcut, reopened the launcher, and confirmed the persisted status row is `simhub: available`.

`make PYTHON=python ci-fast` was attempted but stopped at the repo-wide `ci-format` gate because this checkout has broad unrelated Ruff formatting drift across 227 files. I left that unrelated churn out of this hotfix.