### PR TITLE
Add reference library selection to session review (#408)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-02T05:15:00Z
+last_updated: 2026-07-02T07:05:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/pr-444-atelier-main-dashboard-2026-07-01.md
@@ -21,6 +21,17 @@ relates_to:
 # Current focus
 
 **Repo:** ac-copilot-trainer.
+
+**In flight (2026-07-02):** branch `codex/issue-408-reference-library` completes the remaining
+[#408](https://github.com/agorokh/ac-copilot-trainer/issues/408) reference-library selection slice
+after PR [#418](https://github.com/agorokh/ac-copilot-trainer/pull/418) delivered sectors/SuperLap
+and [#353](https://github.com/agorokh/ac-copilot-trainer/issues/353) closed Track Titan curriculum.
+Session Review now tags/selects `your-best` / `pro` / `tt` / `generated` / `imported` / `none`,
+CLI accepts `--reference-source` / `--reference-path`, and loopback `session.review.generate`
+accepts `reference_source` / `reference_file` while external broadcasts keep host paths redacted.
+Focused proof: 78 tests passing plus scratch CLI JSON/HTML proof selecting `lap_tt.json`. Local
+`make ci-fast` still trips on repo-wide Windows CRLF/LF drift across untouched files; touched-file
+Ruff checks and `git diff --check` are clean.
 
 **Delivered (2026-07-02):** Racing Atelier **runtime adoption complete on all three surfaces**
 ([#432](https://github.com/agorokh/ac-copilot-trainer/issues/432) Parts A2+B; #86 conformance fix):

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-02T05:15:00Z
+last_updated: 2026-07-02T07:05:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/pr-444-atelier-main-dashboard-2026-07-01.md
   - AcCopilotTrainer/03_Investigations/pr-441-voice-signature-gate-2026-07-01.md
@@ -62,6 +62,24 @@ relates_to:
 ---
 
 # Next session handoff
+
+## In flight (2026-07-02 UTC) - #408 reference-library selection
+
+Branch `codex/issue-408-reference-library` from `origin/main` completes the remaining
+[#408](https://github.com/agorokh/ac-copilot-trainer/issues/408) Part D scope after PR
+[#418](https://github.com/agorokh/ac-copilot-trainer/pull/418) delivered sectors/SuperLap and
+[#353](https://github.com/agorokh/ac-copilot-trainer/issues/353) is closed. The report builder now
+classifies reference archives as `your-best`, `pro`, `tt`, `generated`, `imported`, or `none`;
+`tools.session_review` accepts `--reference-source` / `--reference-path`; sidecar
+`session.review.generate` accepts `reference_source` / basename-only `reference_file`; broadcasts
+keep local paths redacted while preserving `reference` / `reference_selection` metadata.
+
+Proof so far: `ruff check` + `ruff format --check` on touched Python files, `git diff --check`,
+`pytest tests/test_session_review.py tests/test_ai_sidecar_external.py tests/test_lap_archive_source_structure.py tests/test_ws_bridge_hello_handshake.py -q`
+(78 passed), and scratch CLI proof selecting Track Titan `lap_tt.json` with JSON + self-contained HTML.
+`make ci-fast` still stops at repo-wide `ruff format --check src tests tools scripts` because this
+Windows checkout has broad CRLF/LF drift across untouched files; do not fold that 226-file formatting
+churn into this PR unless the operator explicitly chooses a separate hygiene pass.
 
 ## Delivered (2026-07-02 UTC) — PRs #444/#445/#446 MERGED: Racing Atelier runtime adoption (#432 Parts A2+B, #86 fix)
 

--- a/docs/10_Development/12_WS_Sidecar_Protocol.md
+++ b/docs/10_Development/12_WS_Sidecar_Protocol.md
@@ -122,6 +122,21 @@ python -m tools.ai_sidecar --setup-store "<...>/experiments.jsonl" --host 127.0.
 
 See [13_Setup_Experiments.md](13_Setup_Experiments.md) for data location, reset, and rebuild.
 
+## Session Review Reports
+
+Loopback Lua/client -> sidecar: `{"v":1,"type":"session.review.generate","lap_dir":".../journal/laps"}` writes a derived post-session review to the sibling `journal/reports` directory.
+
+Optional fields:
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `session` | string | Session UUID to review, or omit for latest. |
+| `driver_id` | string | Driver profile key; defaults to `local-driver`. |
+| `reference_source` | string | `auto`, `your-best`, `pro`, `tt`, `generated`, `imported`, or `none`; aliases such as `track-titan` are accepted. |
+| `reference_file` | string | Basename under the same `journal/laps` directory to pin one same-car/track/layout reference archive. |
+
+The loopback ack is `session.review.result` with local `markdown_path`, `json_path`, and `html_path` plus `reference` / `reference_selection` metadata. External `session.review` snapshots and `coaching.cue` details redact host paths to `markdown_file`, `json_file`, and `html_file` basenames while preserving the reference metadata.
+
 ## Tests
 
 `tests/test_ai_sidecar_protocol.py` — `prepare_outbound_message` unit tests and asyncio WebSocket round-trip (requires `websockets`). `tests/test_llm_coach.py` — Ollama debrief helpers with mocked HTTP (issue **#46**).

--- a/docs/10_Development/17_Session_Review.md
+++ b/docs/10_Development/17_Session_Review.md
@@ -1,7 +1,9 @@
 # Session Review Reports
 
-Issue #404 Part A adds a saved post-session debrief artifact over the immutable
-lap archive corpus.
+Issue #404 adds a saved post-session review surface over the immutable lap
+archive corpus. The artifact is derived and regenerable: source laps stay under
+`journal/laps/lap_*.json`, while review products are written under
+`journal/reports/`.
 
 Generate the latest session report:
 
@@ -9,12 +11,15 @@ Generate the latest session report:
 python -m tools.session_review --lap-dir journal/laps
 ```
 
-The command writes two derived files under `journal/reports/`:
+The command writes three derived files under `journal/reports/`:
 
 - `session_<session>_<car>_<track>.md` - driver-readable Markdown.
 - `session_<session>_<car>_<track>.json` - machine-readable report with
-  `spoken_summary`, `screen_summary`, ranked corner problems, and next-session
-  prep items.
+  `spoken_summary`, `screen_summary`, ranked corner problems, next-session prep
+  items, history/trend rows, and downsampled comparison traces.
+- `session_<session>_<car>_<track>.html` - self-contained local report for
+  browsing session history, lap-time trends, corner-speed trends, and lap A/B
+  telemetry traces without SQL or a running server.
 
 Review a specific session:
 
@@ -22,9 +27,26 @@ Review a specific session:
 python -m tools.session_review --lap-dir journal/laps --session <session_uuid>
 ```
 
+Choose the comparison reference source:
+
+```bash
+python -m tools.session_review --lap-dir journal/laps --reference-source tt
+python -m tools.session_review --lap-dir journal/laps --reference-source none
+python -m tools.session_review --lap-dir journal/laps --reference-path journal/laps/lap_reference.json
+```
+
+Reference sources are `auto`, `your-best`, `pro`, `tt`, `generated`,
+`imported`, or `none`. `auto` picks the fastest valid same-car/track/layout
+lap in the corpus. Specific sources filter to that reference kind; `none`
+keeps trend/history output but disables reference comparison. `--reference-path`
+pins one same-car/track/layout `lap_*.json` archive when the operator wants an
+exact library entry instead of the fastest candidate.
+
 The report compares the selected session against the fastest known valid lap for
-the same car/track/layout in the supplied corpus. It never mutates
-`journal/laps/lap_*.json`; reports are derived products and may be regenerated.
+the same car/track/layout in the supplied corpus. If the selected session owns
+the fastest lap, the compare picker falls back to the next fastest same-combo
+lap. It never mutates `journal/laps/lap_*.json`; reports are derived products
+and may be regenerated.
 
 Use JSON output when a launcher or rig surface needs the paths:
 
@@ -37,10 +59,16 @@ Runtime integration:
 - When the Lua trainer reaches the main menu after a driven session, it drains
   pending lap archive jobs, then sends `session.review.generate` to the loopback
   sidecar with the current lap archive directory and session UUID.
-- The sidecar writes the same Markdown and JSON reports to the sibling
+- The loopback request may include `reference_source` and `reference_file`
+  (`reference_file` is a basename under the same `journal/laps` directory) to
+  select an exact reference-library entry for the generated report.
+- The sidecar writes the same Markdown, JSON, and HTML reports to the sibling
   `journal/reports/` directory, publishes a `session.review` state snapshot for
   screens, and emits a `coaching.cue` with the `spoken_summary` for the voice
   client.
 - Generation is loopback-only. External screens subscribe to the derived
   `session.review` / `coaching.cue` topics; they do not request report writes
   directly.
+- Loopback acks include full local `markdown_path`, `json_path`, and
+  `html_path` values. External `session.review` and `coaching.cue` broadcasts
+  expose only `markdown_file`, `json_file`, and `html_file` basenames.

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -1239,8 +1239,10 @@ end
 --- Ask the Python sidecar to generate a saved post-session review artifact.
 ---@param lapDir string|nil
 ---@param sessionUuid string|nil
+---@param referenceSource string|nil
+---@param referenceFile string|nil
 ---@return boolean
-function M.sendSessionReviewGenerate(lapDir, sessionUuid)
+function M.sendSessionReviewGenerate(lapDir, sessionUuid, referenceSource, referenceFile)
   if type(lapDir) ~= "string" or lapDir == "" then return false end
   if not (sock and externalHelloAcked) then return false end
   if not localPathFramesAllowed() then return false end
@@ -1252,6 +1254,12 @@ function M.sendSessionReviewGenerate(lapDir, sessionUuid)
   }
   if type(sessionUuid) == "string" and sessionUuid ~= "" then
     payload.session = sessionUuid
+  end
+  if type(referenceSource) == "string" and referenceSource ~= "" then
+    payload.reference_source = referenceSource
+  end
+  if type(referenceFile) == "string" and referenceFile ~= "" then
+    payload.reference_file = referenceFile
   end
   return M.sendJson(payload)
 end

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -233,6 +233,8 @@ def test_validate_inbound_accepts_known_types() -> None:
                 "type": "session.review.generate",
                 "lap_dir": "journal/laps",
                 "session": "sess",
+                "reference_source": "track-titan",
+                "reference_file": "lap_tt.json",
             }
         )
         is None
@@ -350,6 +352,28 @@ def test_validate_inbound_rejects_invalid() -> None:
                 "type": "session.review.generate",
                 "lap_dir": "journal/laps",
                 "output_dir": "journal/reports",
+            }
+        )
+        or ""
+    )
+    assert "reference_source" in (
+        ep.validate_inbound(
+            {
+                "v": 1,
+                "type": "session.review.generate",
+                "lap_dir": "journal/laps",
+                "reference_source": "aliens",
+            }
+        )
+        or ""
+    )
+    assert "reference_file" in (
+        ep.validate_inbound(
+            {
+                "v": 1,
+                "type": "session.review.generate",
+                "lap_dir": "journal/laps",
+                "reference_file": "../lap_tt.json",
             }
         )
         or ""
@@ -1517,6 +1541,8 @@ def test_session_review_generate_publishes_result_snapshot_and_voice_cue(
         session: str,
         driver_id: str,
         output_dir: str | None = None,
+        reference_source: str = "auto",
+        reference_file: str | None = None,
     ) -> dict[str, object]:
         calls.append(
             {
@@ -1524,6 +1550,8 @@ def test_session_review_generate_publishes_result_snapshot_and_voice_cue(
                 "session": session,
                 "driver_id": driver_id,
                 "output_dir": output_dir,
+                "reference_source": reference_source,
+                "reference_file": reference_file,
             }
         )
         report_dir = tmp_path / "journal" / "reports"
@@ -1531,6 +1559,7 @@ def test_session_review_generate_publishes_result_snapshot_and_voice_cue(
             "ok": True,
             "markdown_path": str(report_dir / "session_sess.md"),
             "json_path": str(report_dir / "session_sess.json"),
+            "html_path": str(report_dir / "session_sess.html"),
             "session_uuid": "sess",
             "car_id": "ks_porsche_911_gt3_r_2016",
             "track_id": "magione",
@@ -1539,6 +1568,14 @@ def test_session_review_generate_publishes_result_snapshot_and_voice_cue(
             "screen_summary": ["T1: 0.74s - technique"],
             "problems": [],
             "next_session_prep": [],
+            "reference": {"source_file": "lap_tt.json", "kind": "tt", "lap_ms": 97_000},
+            "reference_selection": {
+                "requested_source": "tt",
+                "active": True,
+                "active_source": "tt",
+                "source_file": "lap_tt.json",
+                "reason": "fastest valid same car/track tt reference",
+            },
             "source": {"lap_dirs": [lap_dir]},
         }
 
@@ -1568,6 +1605,8 @@ def test_session_review_generate_publishes_result_snapshot_and_voice_cue(
                             "type": ep.TYPE_SESSION_REVIEW_GENERATE,
                             "lap_dir": str(lap_dir),
                             "session": "sess",
+                            "reference_source": "tt",
+                            "reference_file": "lap_tt.json",
                         }
                     )
                 )
@@ -1601,25 +1640,38 @@ def test_session_review_generate_publishes_result_snapshot_and_voice_cue(
             "session": "sess",
             "driver_id": "local-driver",
             "output_dir": None,
+            "reference_source": "tt",
+            "reference_file": "lap_tt.json",
         }
     ]
     assert ack["type"] == ep.TYPE_SESSION_REVIEW_RESULT
     assert ack["ok"] is True
     assert ack["markdown_path"].endswith("session_sess.md")
+    assert ack["html_path"].endswith("session_sess.html")
+    assert ack["reference"]["kind"] == "tt"
+    assert ack["reference_selection"]["requested_source"] == "tt"
     review = next(frame for frame in frames if frame.get("topic") == ep.TOPIC_SESSION_REVIEW)
     cue = next(frame for frame in frames if frame.get("topic") == ep.TOPIC_COACHING_CUE)
     assert review["type"] == ep.TYPE_STATE_SNAPSHOT
     assert review["payload"]["session_uuid"] == "sess"
     assert "markdown_path" not in review["payload"]
     assert "json_path" not in review["payload"]
+    assert "html_path" not in review["payload"]
     assert review["payload"]["markdown_file"] == "session_sess.md"
     assert review["payload"]["json_file"] == "session_sess.json"
+    assert review["payload"]["html_file"] == "session_sess.html"
+    assert review["payload"]["reference"]["kind"] == "tt"
+    assert review["payload"]["reference_selection"]["active_source"] == "tt"
     assert cue["payload"]["kind"] == "session_review"
     assert cue["payload"]["message"] == "Session debrief for Magione: focus T1."
     assert "markdown_path" not in cue["payload"]["detail"]
     assert "json_path" not in cue["payload"]["detail"]
+    assert "html_path" not in cue["payload"]["detail"]
     assert cue["payload"]["detail"]["markdown_file"] == "session_sess.md"
     assert cue["payload"]["detail"]["json_file"] == "session_sess.json"
+    assert cue["payload"]["detail"]["html_file"] == "session_sess.html"
+    assert cue["payload"]["detail"]["reference"]["kind"] == "tt"
+    assert cue["payload"]["detail"]["reference_selection"]["active_source"] == "tt"
     assert cached == review
     assert voice.messages == ["Session debrief for Magione: focus T1."]
 
@@ -1670,8 +1722,10 @@ def test_failed_session_review_replaces_cached_snapshot_with_error(
         session: str,
         driver_id: str,
         output_dir: str | None = None,
+        reference_source: str = "auto",
+        reference_file: str | None = None,
     ) -> dict[str, object]:
-        del driver_id, output_dir
+        del driver_id, output_dir, reference_source, reference_file
         if mode[0] == "fail":
             raise ValueError("session has no valid timed laps")
         report_dir = tmp_path / "journal" / "reports"
@@ -1679,6 +1733,7 @@ def test_failed_session_review_replaces_cached_snapshot_with_error(
             "ok": True,
             "markdown_path": str(report_dir / "session_good.md"),
             "json_path": str(report_dir / "session_good.json"),
+            "html_path": str(report_dir / "session_good.html"),
             "session_uuid": session,
             "car_id": "ks_porsche_911_gt3_r_2016",
             "track_id": "magione",
@@ -1752,6 +1807,7 @@ def test_failed_session_review_replaces_cached_snapshot_with_error(
     assert fail_snapshot["payload"]["ok"] is False
     assert fail_snapshot["payload"]["session_uuid"] == "sess-empty"
     assert "markdown_path" not in fail_snapshot["payload"]
+    assert "html_path" not in fail_snapshot["payload"]
     assert cached == fail_snapshot
 
 
@@ -1767,8 +1823,10 @@ def test_session_review_generate_returns_structured_error_on_unexpected_exceptio
         session: str,
         driver_id: str,
         output_dir: str | None = None,
+        reference_source: str = "auto",
+        reference_file: str | None = None,
     ) -> dict[str, object]:
-        del lap_dir, session, driver_id, output_dir
+        del lap_dir, session, driver_id, output_dir, reference_source, reference_file
         raise RuntimeError("analysis worker exploded")
 
     monkeypatch.setattr(srv, "_generate_session_review_safe", _boom)

--- a/tests/test_lap_archive_source_structure.py
+++ b/tests/test_lap_archive_source_structure.py
@@ -83,6 +83,8 @@ def test_session_review_bridge_uses_generic_local_path_gate() -> None:
     body = match.group(0)
     assert "localPathFramesAllowed()" in body
     assert "setupExperimentPathFramesAllowed" not in body
+    assert "reference_source" in body
+    assert "reference_file" in body
 
 
 def test_lap_boundary_queues_archive_instead_of_sync_write() -> None:

--- a/tests/test_session_review.py
+++ b/tests/test_session_review.py
@@ -10,6 +10,7 @@ from tools.session_review.report import (
     SessionReviewError,
     build_session_report,
     main,
+    render_markdown,
     report_dir_for_lap_dir,
     write_session_report,
 )
@@ -22,6 +23,9 @@ def _corner_archive(
     lap_n: int,
     exported_at: str,
     degrade: float = 0.0,
+    source: str = "in_game",
+    import_format: str | None = None,
+    generator: dict | None = None,
 ) -> dict:
     radius, ds, n_pre, n_arc, n_post = 30.0, 2.0, 40, 30, 40
     n = n_pre + n_arc + n_post
@@ -57,9 +61,9 @@ def _corner_archive(
         [spline[i], v[i] * 3.6, t_ms[i], throttle[i], brake[i], steer[i], 4, xs[i], 0.0, zs[i]]
         for i in range(n)
     ]
-    return {
+    payload = {
         "schema_version": 1,
-        "source": "in_game",
+        "source": source,
         "lap_uuid": lap_uuid,
         "session_uuid": session_uuid,
         "exported_at": exported_at,
@@ -82,7 +86,19 @@ def _corner_archive(
             ],
             "samples": samples,
         },
+        "corners": [
+            {
+                "label": "T1",
+                "minSpeed": min(v) * 3.6,
+                "exitSpeed": max(v[apex_i:]) * 3.6,
+            }
+        ],
     }
+    if import_format is not None:
+        payload["import_format"] = import_format
+    if generator is not None:
+        payload["generator"] = generator
+    return payload
 
 
 def _write_lap(root: Path, name: str, payload: dict) -> Path:
@@ -137,8 +153,17 @@ def test_build_session_report_selects_latest_and_ranks_corner_problem(
 ) -> None:
     report = build_session_report([session_corpus], grip_ceiling_g=2.5, generated_at="stamp")
 
+    assert report["schema_version"] == 2
     assert report["session"]["session_uuid"] == "sess-latest"
     assert report["reference"]["source_file"] == "lap_ref.json"
+    assert report["reference"]["kind"] == "your-best"
+    assert report["reference_selection"] == {
+        "requested_source": "auto",
+        "active": True,
+        "active_source": "your-best",
+        "source_file": "lap_ref.json",
+        "reason": "fastest valid same car/track reference",
+    }
     assert report["problems"]
     top = report["problems"][0]
     assert top["label"] == "T1"
@@ -147,6 +172,108 @@ def test_build_session_report_selects_latest_and_ranks_corner_problem(
     assert report["source"]["selected_lap_files"] == ["lap_latest-1.json", "lap_latest-2.json"]
     assert report["screen_summary"][0].startswith("T1:")
     assert report["next_session_prep"][0].startswith("T1:")
+    assert [row["session_uuid"] for row in report["history"]["trend"]["sessions"]] == [
+        "sess-reference",
+        "sess-latest",
+    ]
+    assert report["history"]["trend"]["corner_speed"][0]["points"]
+    assert report["comparison"]["default_pair"]["a"] == "lap-latest-2"
+    assert report["comparison"]["default_pair"]["b"] == "lap-ref"
+    assert report["comparison"]["laps"][0]["trace"]["points"]
+
+
+def test_reference_source_selects_track_titan_over_faster_candidate(
+    session_corpus: Path,
+) -> None:
+    _write_lap(
+        session_corpus,
+        "tt",
+        _corner_archive(
+            lap_uuid="lap-tt",
+            session_uuid="sess-tt",
+            lap_n=1,
+            exported_at="2026-06-29T11:00:00Z",
+            degrade=3.0,
+            source="imported",
+            import_format="track_titan_reference_v1",
+            generator={"tt_reference": {"partial": False}},
+        ),
+    )
+    _write_lap(
+        session_corpus,
+        "pro",
+        _corner_archive(
+            lap_uuid="lap-pro",
+            session_uuid="sess-pro",
+            lap_n=1,
+            exported_at="2026-06-29T11:10:00Z",
+            degrade=0.0,
+            source="imported",
+            import_format="motec_csv",
+        ),
+    )
+
+    report = build_session_report(
+        [session_corpus],
+        session="sess-latest",
+        reference_source="tt",
+        grip_ceiling_g=2.5,
+        generated_at="stamp",
+    )
+
+    assert report["reference"]["source_file"] == "lap_tt.json"
+    assert report["reference"]["kind"] == "tt"
+    assert report["reference_selection"]["requested_source"] == "tt"
+    assert report["reference_selection"]["active_source"] == "tt"
+    assert any(row["reference_kind"] == "tt" for row in report["history"]["laps"])
+
+
+def test_reference_source_none_disables_reference_comparison(session_corpus: Path) -> None:
+    report = build_session_report(
+        [session_corpus],
+        reference_source="none",
+        grip_ceiling_g=2.5,
+        generated_at="stamp",
+    )
+
+    assert report["reference"] is None
+    assert report["reference_selection"] == {
+        "requested_source": "none",
+        "active": False,
+        "active_source": None,
+        "source_file": None,
+        "reason": "reference comparison disabled by request",
+    }
+    assert "Reference: none (reference comparison disabled by request)" in render_markdown(report)
+
+
+def test_reference_path_pins_generated_reference(session_corpus: Path) -> None:
+    generated_path = _write_lap(
+        session_corpus,
+        "generated",
+        _corner_archive(
+            lap_uuid="lap-generated",
+            session_uuid="sess-generated",
+            lap_n=1,
+            exported_at="2026-06-29T11:20:00Z",
+            degrade=4.0,
+            source="imported",
+            import_format="generated_reference_v1",
+            generator={"name": "tools.ac_harness.reference_lap.synthetic"},
+        ),
+    )
+
+    report = build_session_report(
+        [session_corpus],
+        session="sess-latest",
+        reference_path=generated_path,
+        grip_ceiling_g=2.5,
+        generated_at="stamp",
+    )
+
+    assert report["reference"]["source_file"] == "lap_generated.json"
+    assert report["reference"]["kind"] == "generated"
+    assert report["reference_selection"]["reason"] == "explicit reference file selected"
 
 
 def test_missing_exported_at_does_not_break_latest_selection(session_corpus: Path) -> None:
@@ -207,12 +334,19 @@ def test_write_session_report_saves_markdown_and_json_under_reports(
 
     assert written.markdown_path.is_file()
     assert written.json_path.is_file()
+    assert written.html_path.is_file()
     assert written.markdown_path.parent.name == "reports"
     markdown = written.markdown_path.read_text(encoding="utf-8")
     assert "## Problem List" in markdown
     assert "## Next Session Prep" in markdown
+    assert "## Lap History" in markdown
     payload = json.loads(written.json_path.read_text(encoding="utf-8"))
     assert payload["spoken_summary"] == report["spoken_summary"]
+    assert payload["reference_selection"]["active"] is True
+    html = written.html_path.read_text(encoding="utf-8")
+    assert "Lap Compare" in html
+    assert 'id="review-data"' in html
+    assert "https://" not in html
 
 
 def test_report_output_must_stay_under_journal_reports(session_corpus: Path) -> None:
@@ -230,6 +364,7 @@ def test_absolute_sibling_report_dir_for_lap_dir_is_allowed(session_corpus: Path
 
     assert written.markdown_path.parent == output_dir
     assert written.json_path.parent == output_dir
+    assert written.html_path.parent == output_dir
 
 
 def test_cli_generates_json_result(
@@ -241,7 +376,10 @@ def test_cli_generates_json_result(
     payload = json.loads(capsys.readouterr().out)
     assert Path(payload["markdown"]).is_file()
     assert Path(payload["json"]).is_file()
+    assert Path(payload["html"]).is_file()
     assert payload["screen_summary"]
+    assert payload["reference"]["kind"] == "your-best"
+    assert payload["reference_selection"]["requested_source"] == "auto"
 
 
 def test_session_without_valid_laps_fails_closed(

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -78,6 +78,26 @@ TYPE_SETUP_CLOSED_LOOP = "setup.closed_loop"
 TYPE_SETUP_EXCHANGE_SEARCH = "se.search"
 TYPE_SETUP_EXCHANGE_DOWNLOAD = "se.download"
 TYPE_SESSION_REVIEW_GENERATE = "session.review.generate"
+SESSION_REVIEW_REFERENCE_SOURCES: frozenset[str] = frozenset(
+    {
+        "auto",
+        "your-best",
+        "pro",
+        "tt",
+        "generated",
+        "imported",
+        "none",
+        "pb",
+        "personal",
+        "personal-best",
+        "your-best-lap",
+        "your-best-reference",
+        "track-titan",
+        "tracktitan",
+        "disabled",
+        "off",
+    }
+)
 
 # Server → client.
 TYPE_HELLO_ACK = "hello_ack"
@@ -663,10 +683,26 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
             return "session.review.generate requires non-empty 'lap_dir'"
         if "output_dir" in frame:
             return "session.review.generate does not accept 'output_dir'"
-        for key in ("session", "driver_id"):
+        for key in ("session", "driver_id", "reference_source", "referenceSource"):
             err = _validate_optional_string(frame, key)
             if err is not None:
                 return err
+        for key in ("reference_file", "referenceFile"):
+            err = _validate_optional_string(frame, key)
+            if err is not None:
+                return err
+            value = frame.get(key)
+            if isinstance(value, str) and ("/" in value or "\\" in value or value in {".", ".."}):
+                return f"{key} must be a file name under journal/laps"
+        source_key = "reference_source" if "reference_source" in frame else "referenceSource"
+        source = frame.get(source_key)
+        if isinstance(source, str):
+            normalized = source.strip().lower().replace("_", "-")
+            if normalized not in SESSION_REVIEW_REFERENCE_SOURCES:
+                return (
+                    "reference_source must be one of: auto, your-best, pro, tt, "
+                    "generated, imported, none"
+                )
         return None
     if t in (
         TYPE_SETUP_LIST_RESULT,

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -543,6 +543,8 @@ def _generate_session_review_safe(
     session: str = SESSION_REVIEW_DEFAULT_SESSION,
     driver_id: str = "local-driver",
     output_dir: str | None = None,
+    reference_source: str = "auto",
+    reference_file: str | None = None,
 ) -> dict[str, Any]:
     from tools.session_review import (
         build_session_report,
@@ -559,13 +561,32 @@ def _generate_session_review_safe(
         )
         if requested_output_dir != target_dir:
             raise ValueError("output_dir must be the sibling journal/reports for lap_dir")
-    report = build_session_report([safe_lap_dir], session=session, driver_id=driver_id)
+    reference_path = None
+    if reference_file:
+        reference_file = reference_file.strip()
+        ref_name = Path(reference_file)
+        if (
+            not reference_file
+            or reference_file in {".", ".."}
+            or ref_name.name != reference_file
+            or ref_name.is_absolute()
+        ):
+            raise ValueError("reference_file must be a file name under journal/laps")
+        reference_path = safe_lap_dir / reference_file
+    report = build_session_report(
+        [safe_lap_dir],
+        session=session,
+        driver_id=driver_id,
+        reference_source=reference_source,
+        reference_path=reference_path,
+    )
     written = write_session_report(report, output_dir=target_dir)
     session_meta = report.get("session") if isinstance(report.get("session"), dict) else {}
     return {
         "ok": True,
         "markdown_path": str(written.markdown_path),
         "json_path": str(written.json_path),
+        "html_path": str(written.html_path),
         "session_uuid": session_meta.get("session_uuid"),
         "car_id": session_meta.get("car_id"),
         "track_id": session_meta.get("track_id"),
@@ -574,6 +595,8 @@ def _generate_session_review_safe(
         "screen_summary": report.get("screen_summary"),
         "problems": report.get("problems"),
         "next_session_prep": report.get("next_session_prep"),
+        "reference": report.get("reference"),
+        "reference_selection": report.get("reference_selection"),
         "source": report.get("source"),
     }
 
@@ -1365,7 +1388,11 @@ def _cache_sidecar_snapshot(frame: dict[str, Any]) -> None:
 def _sanitize_session_review_result(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop host-local paths before broadcasting session-review results to clients."""
     sanitized = dict(payload)
-    for path_key, file_key in (("markdown_path", "markdown_file"), ("json_path", "json_file")):
+    for path_key, file_key in (
+        ("markdown_path", "markdown_file"),
+        ("json_path", "json_file"),
+        ("html_path", "html_file"),
+    ):
         path = sanitized.pop(path_key, None)
         if isinstance(path, str) and path:
             sanitized[file_key] = Path(path).name
@@ -1377,10 +1404,20 @@ def _session_review_cue_payload(result: dict[str, Any]) -> dict[str, Any] | None
     if not isinstance(message, str) or not message.strip():
         return None
     detail: dict[str, Any] = {"session_uuid": result.get("session_uuid")}
-    for path_key, file_key in (("markdown_path", "markdown_file"), ("json_path", "json_file")):
+    for path_key, file_key in (
+        ("markdown_path", "markdown_file"),
+        ("json_path", "json_file"),
+        ("html_path", "html_file"),
+    ):
         path = result.get(path_key)
         if isinstance(path, str) and path:
             detail[file_key] = Path(path).name
+    reference = result.get("reference")
+    if isinstance(reference, dict):
+        detail["reference"] = reference
+    reference_selection = result.get("reference_selection")
+    if isinstance(reference_selection, dict):
+        detail["reference_selection"] = reference_selection
     return {
         "kind": "session_review",
         "corner": None,
@@ -1410,12 +1447,17 @@ async def _handle_session_review_frame(websocket: Any, data: dict[str, Any]) -> 
     lap_dir = str(data.get("lap_dir") or "")
     session = str(data.get("session") or SESSION_REVIEW_DEFAULT_SESSION)
     driver_id = str(data.get("driver_id") or "local-driver")
+    reference_source = str(data.get("reference_source") or data.get("referenceSource") or "auto")
+    reference_file_raw = data.get("reference_file") or data.get("referenceFile")
+    reference_file = reference_file_raw if isinstance(reference_file_raw, str) else None
     try:
         result = await asyncio.to_thread(
             _generate_session_review_safe,
             lap_dir,
             session=session,
             driver_id=driver_id,
+            reference_source=reference_source,
+            reference_file=reference_file,
         )
     except Exception as e:
         error = str(e)

--- a/tools/session_review/report.py
+++ b/tools/session_review/report.py
@@ -19,6 +19,7 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from html import escape as html_escape
 from pathlib import Path
 from statistics import median
 from typing import Any, TextIO
@@ -26,10 +27,24 @@ from typing import Any, TextIO
 from tools.ai_sidecar.coach_report import build_structured_debrief
 from tools.lap_archive_export import iter_lap_archive_paths, lap_is_valid, load_lap_archive
 
-REPORT_SCHEMA_VERSION = 1
+REPORT_SCHEMA_VERSION = 2
 DEFAULT_OUTPUT_DIR = Path("journal/reports")
 DEFAULT_SESSION = "latest"
 _LOSS_THRESHOLD_S = 0.03
+_MAX_COMPARE_LAPS = 40
+_MAX_TRACE_POINTS = 240
+REFERENCE_SOURCE_CHOICES = ("auto", "your-best", "pro", "tt", "generated", "imported", "none")
+_REFERENCE_SOURCE_ALIASES = {
+    "pb": "your-best",
+    "personal": "your-best",
+    "personal-best": "your-best",
+    "your-best-lap": "your-best",
+    "your-best-reference": "your-best",
+    "track-titan": "tt",
+    "tracktitan": "tt",
+    "disabled": "none",
+    "off": "none",
+}
 
 
 class SessionReviewError(ValueError):
@@ -50,6 +65,19 @@ class LoadedLap:
     lap_ms: int | None
     exported_at: str | None
     is_valid: bool
+    source: str | None
+    import_format: str | None
+    reference_kind: str
+
+
+@dataclass(frozen=True)
+class ReferenceSelection:
+    """Reference-source selection result for one session report."""
+
+    requested_source: str
+    reference: LoadedLap | None
+    reason: str
+    reference_file: str | None = None
 
 
 @dataclass(frozen=True)
@@ -58,6 +86,7 @@ class WrittenSessionReport:
 
     markdown_path: Path
     json_path: Path
+    html_path: Path
     report: dict[str, Any]
 
 
@@ -101,6 +130,49 @@ def _slug(value: Any, *, fallback: str = "unknown") -> str:
     return text.strip("-") or fallback
 
 
+def _clean_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def normalize_reference_source(value: str | None) -> str:
+    """Normalize a user-facing reference source selector."""
+    raw = (value or "auto").strip().lower().replace("_", "-")
+    source = _REFERENCE_SOURCE_ALIASES.get(raw, raw)
+    if source not in REFERENCE_SOURCE_CHOICES:
+        choices = ", ".join(REFERENCE_SOURCE_CHOICES)
+        raise SessionReviewError(f"reference_source must be one of: {choices}")
+    return source
+
+
+def _reference_kind(record: Mapping[str, Any]) -> str:
+    source = _clean_text(record.get("source"))
+    import_format = _clean_text(record.get("import_format"))
+    generator = record.get("generator") if isinstance(record.get("generator"), Mapping) else {}
+    generator_name = _clean_text(generator.get("name")) if isinstance(generator, Mapping) else None
+    tt_reference = generator.get("tt_reference") if isinstance(generator, Mapping) else None
+    if import_format == "track_titan_reference_v1" or isinstance(tt_reference, Mapping):
+        return "tt"
+    if import_format == "generated_reference_v1" or (
+        generator_name is not None
+        and (
+            generator_name.startswith("ac_harness.reference_lap")
+            or generator_name.startswith("tools.ac_harness.reference_lap")
+            or generator_name.startswith("trace_replay:")
+        )
+    ):
+        return "generated"
+    if source == "in_game":
+        return "your-best"
+    if source == "imported" and import_format == "motec_csv":
+        return "pro"
+    if source == "imported":
+        return "imported"
+    return "unknown"
+
+
 def _loaded_lap(path: Path, record: dict[str, Any]) -> LoadedLap:
     lap = record.get("lap") if isinstance(record.get("lap"), Mapping) else {}
     car = record.get("car") if isinstance(record.get("car"), Mapping) else {}
@@ -119,6 +191,9 @@ def _loaded_lap(path: Path, record: dict[str, Any]) -> LoadedLap:
         if isinstance(record.get("exported_at"), str)
         else None,
         is_valid=lap_is_valid(record),
+        source=_clean_text(record.get("source")),
+        import_format=_clean_text(record.get("import_format")),
+        reference_kind=_reference_kind(record),
     )
 
 
@@ -181,21 +256,91 @@ def _valid_laps(laps: Iterable[LoadedLap]) -> list[LoadedLap]:
     return [lap for lap in laps if lap.is_valid and lap.lap_ms is not None]
 
 
-def _select_reference(laps: list[LoadedLap], selected: list[LoadedLap]) -> LoadedLap | None:
+def _reference_sort_key(lap: LoadedLap) -> tuple[int, datetime, str]:
+    return (
+        lap.lap_ms if lap.lap_ms is not None else 999_999_999,
+        _parse_dt(lap.exported_at) or datetime.max.replace(tzinfo=UTC),
+        lap.path.name,
+    )
+
+
+def _reference_matches_source(lap: LoadedLap, source: str) -> bool:
+    if source == "auto":
+        return True
+    if source == "imported":
+        return lap.source == "imported"
+    return lap.reference_kind == source
+
+
+def _select_reference(
+    laps: list[LoadedLap],
+    selected: list[LoadedLap],
+    *,
+    reference_source: str = "auto",
+    reference_path: str | Path | None = None,
+) -> ReferenceSelection:
+    requested_source = normalize_reference_source(reference_source)
+    if requested_source == "none":
+        return ReferenceSelection(
+            requested_source=requested_source,
+            reference=None,
+            reason="reference comparison disabled by request",
+        )
     valid_selected = _valid_laps(selected)
     if not valid_selected:
-        return None
+        return ReferenceSelection(
+            requested_source=requested_source,
+            reference=None,
+            reason="selected session has no valid timed laps",
+        )
     combo = _combo_key(valid_selected[0])
     candidates = [lap for lap in _valid_laps(laps) if _combo_key(lap) == combo]
     if not candidates:
-        return None
-    return min(
-        candidates,
-        key=lambda lap: (
-            lap.lap_ms if lap.lap_ms is not None else 999_999_999,
-            _parse_dt(lap.exported_at) or datetime.max.replace(tzinfo=UTC),
-            lap.path.name,
-        ),
+        return ReferenceSelection(
+            requested_source=requested_source,
+            reference=None,
+            reason="no valid same car/track reference candidates found",
+        )
+    if reference_path is not None:
+        requested_path = Path(reference_path)
+        try:
+            resolved = requested_path.resolve()
+        except (OSError, RuntimeError) as exc:
+            raise SessionReviewError(
+                f"{requested_path}: reference path cannot be resolved"
+            ) from exc
+        for candidate in candidates:
+            if candidate.path.resolve() == resolved:
+                return ReferenceSelection(
+                    requested_source=requested_source,
+                    reference=candidate,
+                    reason="explicit reference file selected",
+                    reference_file=candidate.path.name,
+                )
+        raise SessionReviewError(
+            f"{requested_path}: reference file is not a valid same car/track lap archive"
+        )
+
+    source_candidates = [
+        lap for lap in candidates if _reference_matches_source(lap, requested_source)
+    ]
+    if not source_candidates:
+        return ReferenceSelection(
+            requested_source=requested_source,
+            reference=None,
+            reason=f"no valid same car/track reference candidates for {requested_source}",
+        )
+    reason = (
+        "fastest valid same car/track reference"
+        if requested_source == "auto"
+        else f"fastest valid same car/track {requested_source} reference"
+    )
+    reference = min(source_candidates, key=_reference_sort_key)
+    return ReferenceSelection(
+        requested_source=requested_source,
+        reference=reference,
+        reason=reason,
+        reference_file=reference.path.name,
     )
 
 
@@ -441,6 +586,8 @@ def build_session_report(
     driver_id: str = "local-driver",
     grip_ceiling_g: float | None = None,
     generated_at: str | None = None,
+    reference_source: str = "auto",
+    reference_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Build a JSON-serializable session review report."""
     laps, load_skipped = _load_laps(inputs)
@@ -448,7 +595,13 @@ def build_session_report(
     stats = _session_stats(selected_session, selected)
     if not stats["valid_laps"]:
         raise SessionReviewError(f"session {selected_session!r} has no valid timed laps")
-    reference = _select_reference(laps, selected)
+    reference_selection = _select_reference(
+        laps,
+        selected,
+        reference_source=reference_source,
+        reference_path=reference_path,
+    )
+    reference = reference_selection.reference
     problems, analysis_skipped, analyzed = _aggregate_problems(
         selected,
         reference=reference,
@@ -459,14 +612,24 @@ def build_session_report(
             f"session {selected_session!r} has no valid laps with usable trace"
         )
     prep = _prep_items(problems)
+    history = _history_payload(laps, selected)
+    comparison = _comparison_payload(laps, selected, reference=reference)
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at or _iso_now(),
         "driver_id": driver_id,
         "session": stats,
-        "reference": _reference_struct(reference),
+        "reference": _reference_struct(reference, reference_selection),
+        "reference_selection": _reference_selection_struct(reference_selection),
         "problems": problems,
         "next_session_prep": prep,
+        "history": history,
+        "comparison": comparison,
+        "share": {
+            "formats": ["html", "markdown", "json"],
+            "self_contained_html": True,
+            "host_paths_in_broadcasts": False,
+        },
         "spoken_summary": _spoken_summary(stats, problems),
         "screen_summary": _screen_summary(problems),
         "source": {
@@ -481,7 +644,19 @@ def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def _reference_struct(reference: LoadedLap | None) -> dict[str, Any] | None:
+def _reference_selection_struct(selection: ReferenceSelection) -> dict[str, Any]:
+    return {
+        "requested_source": selection.requested_source,
+        "active": selection.reference is not None,
+        "active_source": selection.reference.reference_kind if selection.reference else None,
+        "source_file": selection.reference_file,
+        "reason": selection.reason,
+    }
+
+
+def _reference_struct(
+    reference: LoadedLap | None, selection: ReferenceSelection
+) -> dict[str, Any] | None:
     if reference is None:
         return None
     return {
@@ -492,6 +667,280 @@ def _reference_struct(reference: LoadedLap | None) -> dict[str, Any] | None:
         "car_id": reference.car_id,
         "track_id": reference.track_id,
         "track_layout": reference.track_layout,
+        "source": reference.source,
+        "import_format": reference.import_format,
+        "kind": reference.reference_kind,
+        "selection_source": selection.requested_source,
+        "selection_reason": selection.reason,
+    }
+
+
+def _lap_uuid(lap: LoadedLap | None) -> str | None:
+    if lap is None:
+        return None
+    value = lap.record.get("lap_uuid")
+    return str(value) if value is not None else lap.path.stem
+
+
+def _best_valid_lap(laps: Iterable[LoadedLap]) -> LoadedLap | None:
+    valid = _valid_laps(laps)
+    if not valid:
+        return None
+    return min(
+        valid,
+        key=lambda lap: (
+            lap.lap_ms if lap.lap_ms is not None else 999_999_999,
+            _parse_dt(lap.exported_at) or datetime.max.replace(tzinfo=UTC),
+            lap.path.name,
+        ),
+    )
+
+
+def _same_combo_laps(laps: Iterable[LoadedLap], selected: list[LoadedLap]) -> list[LoadedLap]:
+    anchor = _best_valid_lap(selected) or (selected[0] if selected else None)
+    if anchor is None:
+        return []
+    combo = _combo_key(anchor)
+    return [lap for lap in laps if _combo_key(lap) == combo]
+
+
+def _lap_browser_row(lap: LoadedLap, *, include_trace: bool = False) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "lap_uuid": _lap_uuid(lap),
+        "session_uuid": lap.session_uuid,
+        "source_file": lap.path.name,
+        "car_id": lap.car_id,
+        "track_id": lap.track_id,
+        "track_layout": lap.track_layout,
+        "lap_n": lap.lap_n,
+        "lap_ms": lap.lap_ms,
+        "is_valid": lap.is_valid,
+        "exported_at": lap.exported_at,
+        "source": lap.source,
+        "import_format": lap.import_format,
+        "reference_kind": lap.reference_kind,
+    }
+    if include_trace:
+        row["trace"] = _trace_payload(lap)
+    return row
+
+
+def _session_history(laps: list[LoadedLap]) -> list[dict[str, Any]]:
+    rows = [
+        _session_stats(session_uuid, sorted(grouped, key=_lap_sort_key))
+        for session_uuid, grouped in _session_candidates(laps).items()
+    ]
+    return sorted(
+        rows,
+        key=lambda row: (
+            str(row.get("last_exported_at") or ""),
+            str(row.get("session_uuid") or ""),
+        ),
+    )
+
+
+def _trend_sessions(same_combo: list[LoadedLap]) -> list[dict[str, Any]]:
+    rows = [
+        _session_stats(session_uuid, sorted(grouped, key=_lap_sort_key))
+        for session_uuid, grouped in _session_candidates(same_combo).items()
+    ]
+    return sorted(
+        rows,
+        key=lambda row: (
+            str(row.get("last_exported_at") or ""),
+            str(row.get("session_uuid") or ""),
+        ),
+    )
+
+
+def _corner_value(corner: Mapping[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _as_float(corner.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _corner_trends(same_combo: list[LoadedLap]) -> list[dict[str, Any]]:
+    by_corner: dict[int, dict[str, Any]] = {}
+    grouped: dict[tuple[int, str], dict[str, Any]] = {}
+    session_dates = {
+        row["session_uuid"]: row.get("last_exported_at") for row in _trend_sessions(same_combo)
+    }
+    for lap in _valid_laps(same_combo):
+        corners = lap.record.get("corners")
+        if not isinstance(corners, list):
+            continue
+        for fallback_index, corner_raw in enumerate(corners):
+            if not isinstance(corner_raw, Mapping):
+                continue
+            corner_index = corner_raw.get("index")
+            index = (
+                int(corner_index)
+                if isinstance(corner_index, int) and not isinstance(corner_index, bool)
+                else fallback_index
+            )
+            label = str(corner_raw.get("label") or f"T{index + 1}")
+            by_corner.setdefault(index, {"corner": index, "label": label})
+            key = (index, lap.session_uuid)
+            bucket = grouped.setdefault(
+                key,
+                {
+                    "session_uuid": lap.session_uuid,
+                    "last_exported_at": session_dates.get(lap.session_uuid),
+                    "min_speeds": [],
+                    "exit_speeds": [],
+                },
+            )
+            min_speed = _corner_value(corner_raw, "minSpeed", "min_speed")
+            exit_speed = _corner_value(corner_raw, "exitSpeed", "exit_speed")
+            if min_speed is not None:
+                bucket["min_speeds"].append(min_speed)
+            if exit_speed is not None:
+                bucket["exit_speeds"].append(exit_speed)
+
+    results: list[dict[str, Any]] = []
+    for index, meta in sorted(by_corner.items()):
+        points = []
+        for (corner_index, _session_uuid), bucket in grouped.items():
+            if corner_index != index:
+                continue
+            min_values = bucket["min_speeds"]
+            exit_values = bucket["exit_speeds"]
+            if not min_values and not exit_values:
+                continue
+            points.append(
+                {
+                    "session_uuid": bucket["session_uuid"],
+                    "last_exported_at": bucket["last_exported_at"],
+                    "avg_min_speed_kmh": (
+                        round(sum(min_values) / len(min_values), 1) if min_values else None
+                    ),
+                    "avg_exit_speed_kmh": (
+                        round(sum(exit_values) / len(exit_values), 1) if exit_values else None
+                    ),
+                    "laps": max(len(min_values), len(exit_values)),
+                }
+            )
+        points.sort(
+            key=lambda row: (
+                str(row.get("last_exported_at") or ""),
+                str(row.get("session_uuid") or ""),
+            )
+        )
+        if points:
+            results.append({**meta, "points": points})
+    return results
+
+
+def _sample_indices(count: int, limit: int = _MAX_TRACE_POINTS) -> list[int]:
+    if count <= 0:
+        return []
+    if count <= limit:
+        return list(range(count))
+    step = (count - 1) / max(limit - 1, 1)
+    indexes = {0, count - 1}
+    indexes.update(int(round(i * step)) for i in range(limit))
+    return sorted(index for index in indexes if 0 <= index < count)
+
+
+def _trace_payload(lap: LoadedLap) -> dict[str, Any]:
+    trace = lap.record.get("trace")
+    if not isinstance(trace, Mapping):
+        return {"sample_count": 0, "sampled_points": 0, "points": []}
+    fields = trace.get("fields")
+    samples = trace.get("samples")
+    if not isinstance(fields, list) or not isinstance(samples, list):
+        return {"sample_count": 0, "sampled_points": 0, "points": []}
+    field_index = {str(name): i for i, name in enumerate(fields)}
+
+    def sample_value(sample: Any, field: str) -> float | None:
+        index = field_index.get(field)
+        if index is None or not isinstance(sample, (list, tuple)) or index >= len(sample):
+            return None
+        return _as_float(sample[index])
+
+    points = []
+    denominator = max(len(samples) - 1, 1)
+    for sample_index in _sample_indices(len(samples)):
+        sample = samples[sample_index]
+        spline = sample_value(sample, "spline")
+        point = {
+            "x": round(spline if spline is not None else sample_index / denominator, 5),
+            "speed_kmh": _round_or_none(sample_value(sample, "speed"), 2),
+            "brake": _round_or_none(sample_value(sample, "brake"), 4),
+            "throttle": _round_or_none(sample_value(sample, "throttle"), 4),
+            "steer": _round_or_none(sample_value(sample, "steer"), 4),
+            "e_ms": _round_or_none(sample_value(sample, "eMs"), 1),
+        }
+        points.append(point)
+    return {
+        "sample_count": len(samples),
+        "sampled_points": len(points),
+        "points": points,
+    }
+
+
+def _round_or_none(value: float | None, digits: int) -> float | None:
+    return round(value, digits) if value is not None else None
+
+
+def _history_payload(laps: list[LoadedLap], selected: list[LoadedLap]) -> dict[str, Any]:
+    same_combo = _same_combo_laps(laps, selected)
+    anchor = _best_valid_lap(selected) or (selected[0] if selected else None)
+    combo = (
+        {
+            "car_id": anchor.car_id,
+            "track_id": anchor.track_id,
+            "track_layout": anchor.track_layout,
+        }
+        if anchor
+        else None
+    )
+    return {
+        "sessions": _session_history(laps),
+        "laps": [_lap_browser_row(lap) for lap in sorted(same_combo, key=_lap_sort_key)],
+        "trend": {
+            "combo": combo,
+            "sessions": _trend_sessions(same_combo),
+            "corner_speed": _corner_trends(same_combo),
+        },
+    }
+
+
+def _comparison_payload(
+    laps: list[LoadedLap],
+    selected: list[LoadedLap],
+    *,
+    reference: LoadedLap | None,
+) -> dict[str, Any]:
+    same_combo = sorted(_valid_laps(_same_combo_laps(laps, selected)), key=_lap_sort_key)
+    best_selected = _best_valid_lap(selected)
+    best_path = best_selected.path if best_selected is not None else None
+    default_b = reference if reference is not None and reference.path != best_path else None
+    if default_b is None:
+        default_b = next(
+            (
+                lap
+                for lap in sorted(same_combo, key=lambda item: item.lap_ms or 999_999_999)
+                if lap.path != best_path
+            ),
+            None,
+        )
+
+    included: dict[Path, LoadedLap] = {}
+    for lap in same_combo[-_MAX_COMPARE_LAPS:]:
+        included[lap.path] = lap
+    for lap in (best_selected, default_b, reference):
+        if lap is not None:
+            included[lap.path] = lap
+    compare_laps = sorted(included.values(), key=_lap_sort_key)
+    return {
+        "default_pair": {
+            "a": _lap_uuid(best_selected),
+            "b": _lap_uuid(default_b),
+        },
+        "laps": [_lap_browser_row(lap, include_trace=True) for lap in compare_laps],
     }
 
 
@@ -562,9 +1011,19 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         f"- Consistency: {_format_ms(session.get('consistency_ms'))}",
     ]
     if reference:
+        kind = reference.get("kind") or reference.get("source") or "reference"
         lines.append(
-            f"- Reference: `{reference.get('source_file')}` ({_format_ms(reference.get('lap_ms'))})"
+            f"- Reference: `{reference.get('source_file')}` "
+            f"({_format_ms(reference.get('lap_ms'))}, {kind})"
         )
+    else:
+        selection = (
+            report.get("reference_selection")
+            if isinstance(report.get("reference_selection"), Mapping)
+            else None
+        )
+        if selection:
+            lines.append(f"- Reference: none ({selection.get('reason')})")
     lines.extend(["", "## Problem List"])
     problems = report.get("problems") if isinstance(report.get("problems"), list) else []
     if problems:
@@ -585,8 +1044,521 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     lines.extend(["", "## Next Session Prep"])
     for item in report.get("next_session_prep") or []:
         lines.append(f"- {item}")
+    history = report.get("history") if isinstance(report.get("history"), Mapping) else {}
+    trend = history.get("trend") if isinstance(history.get("trend"), Mapping) else {}
+    trend_sessions = trend.get("sessions") if isinstance(trend.get("sessions"), list) else []
+    if trend_sessions:
+        lines.extend(["", "## Lap History"])
+        for row in trend_sessions[-5:]:
+            lines.append(
+                "- "
+                f"{row.get('session_uuid')}: best {_format_ms(row.get('best_lap_ms'))}, "
+                f"median {_format_ms(row.get('median_lap_ms'))}, "
+                f"valid {row.get('valid_laps')} / {row.get('lap_count')}"
+            )
+    comparison = report.get("comparison") if isinstance(report.get("comparison"), Mapping) else {}
+    pair = (
+        comparison.get("default_pair")
+        if isinstance(comparison.get("default_pair"), Mapping)
+        else {}
+    )
+    if pair.get("a") or pair.get("b"):
+        lines.extend(
+            [
+                "",
+                "## Lap Compare",
+                f"- Lap A: `{pair.get('a') or 'n/a'}`",
+                f"- Lap B: `{pair.get('b') or 'n/a'}`",
+            ]
+        )
     lines.extend(["", "## Spoken Summary", "", str(report.get("spoken_summary") or "")])
     return "\n".join(lines).rstrip() + "\n"
+
+
+def _html(value: Any) -> str:
+    return html_escape("" if value is None else str(value), quote=True)
+
+
+def _html_ms(value: Any) -> str:
+    return _html(_format_ms(value))
+
+
+def _trend_svg(points: list[Mapping[str, Any]]) -> str:
+    values = [
+        _as_float(point.get("best_lap_ms"))
+        for point in points
+        if _as_float(point.get("best_lap_ms")) is not None
+    ]
+    if len(values) < 2:
+        return '<p class="empty">Need at least two sessions for a lap-time trend.</p>'
+    width, height, pad = 720, 180, 28
+    min_value = min(values)
+    max_value = max(values)
+    span = max(max_value - min_value, 1.0)
+    trend_points = []
+    value_points = [point for point in points if _as_float(point.get("best_lap_ms")) is not None]
+    for index, point in enumerate(value_points):
+        value = _as_float(point.get("best_lap_ms")) or 0.0
+        x = pad + (width - 2 * pad) * index / max(len(value_points) - 1, 1)
+        y = height - pad - (height - 2 * pad) * (max_value - value) / span
+        trend_points.append((x, y, value, point))
+    polyline = " ".join(f"{x:.1f},{y:.1f}" for x, y, _value, _point in trend_points)
+    circles = "\n".join(
+        f'<circle cx="{x:.1f}" cy="{y:.1f}" r="4"><title>'
+        f"{_html(point.get('session_uuid'))}: {_html_ms(value)}</title></circle>"
+        for x, y, value, point in trend_points
+    )
+    start_label = _html_ms(trend_points[0][2])
+    end_label = _html_ms(trend_points[-1][2])
+    return f"""
+<svg class="trend-svg" viewBox="0 0 {width} {height}" role="img" aria-label="Best lap trend">
+  <line class="axis" x1="{pad}" y1="{height - pad}" x2="{width - pad}" y2="{height - pad}" />
+  <line class="axis" x1="{pad}" y1="{pad}" x2="{pad}" y2="{height - pad}" />
+  <polyline class="lap-line" points="{polyline}" />
+  {circles}
+  <text x="{pad}" y="{height - 6}" class="chart-label">{start_label}</text>
+  <text x="{width - pad}" y="{height - 6}" class="chart-label" text-anchor="end">{end_label}</text>
+</svg>
+""".strip()
+
+
+def _history_rows_html(rows: list[Mapping[str, Any]]) -> str:
+    if not rows:
+        return '<tr><td colspan="6">No history rows.</td></tr>'
+    rendered = []
+    for row in rows[-12:]:
+        rendered.append(
+            "<tr>"
+            f"<td>{_html(row.get('session_uuid'))}</td>"
+            f"<td>{_html(row.get('last_exported_at'))}</td>"
+            f"<td>{_html_ms(row.get('best_lap_ms'))}</td>"
+            f"<td>{_html_ms(row.get('median_lap_ms'))}</td>"
+            f"<td>{_html_ms(row.get('consistency_ms'))}</td>"
+            f"<td>{_html(row.get('valid_laps'))}/{_html(row.get('lap_count'))}</td>"
+            "</tr>"
+        )
+    return "\n".join(rendered)
+
+
+def _problem_rows_html(problems: list[Mapping[str, Any]]) -> str:
+    if not problems:
+        return '<tr><td colspan="5">No repeated corner loss above threshold.</td></tr>'
+    rendered = []
+    for rank, problem in enumerate(problems[:8], start=1):
+        rendered.append(
+            "<tr>"
+            f"<td>{rank}</td>"
+            f"<td>{_html(problem.get('label'))}</td>"
+            f"<td>{_html(problem.get('primary_cause'))}</td>"
+            f"<td>{_html(problem.get('total_time_loss_s'))}s</td>"
+            f"<td>{_html(problem.get('recommended_fix'))}</td>"
+            "</tr>"
+        )
+    return "\n".join(rendered)
+
+
+def _corner_trend_html(corners: list[Mapping[str, Any]]) -> str:
+    if not corners:
+        return '<p class="empty">No corner trend rows in this corpus yet.</p>'
+    rendered = []
+    for corner in corners[:8]:
+        points = corner.get("points") if isinstance(corner.get("points"), list) else []
+        latest = points[-1] if points else {}
+        rendered.append(
+            "<tr>"
+            f"<td>{_html(corner.get('label'))}</td>"
+            f"<td>{_html(latest.get('avg_min_speed_kmh'))}</td>"
+            f"<td>{_html(latest.get('avg_exit_speed_kmh'))}</td>"
+            f"<td>{_html(len(points))}</td>"
+            "</tr>"
+        )
+    return (
+        "<table><thead><tr><th>Corner</th><th>Apex km/h</th><th>Exit km/h</th>"
+        "<th>Sessions</th></tr></thead><tbody>" + "\n".join(rendered) + "</tbody></table>"
+    )
+
+
+def _json_for_script(report: Mapping[str, Any]) -> str:
+    return json.dumps(report, sort_keys=True, separators=(",", ":")).replace("</", "<\\/")
+
+
+def render_html(report: Mapping[str, Any]) -> str:
+    """Render a self-contained session review HTML report."""
+    session = report.get("session") if isinstance(report.get("session"), Mapping) else {}
+    history = report.get("history") if isinstance(report.get("history"), Mapping) else {}
+    trend = history.get("trend") if isinstance(history.get("trend"), Mapping) else {}
+    trend_sessions = trend.get("sessions") if isinstance(trend.get("sessions"), list) else []
+    corners = trend.get("corner_speed") if isinstance(trend.get("corner_speed"), list) else []
+    problems = report.get("problems") if isinstance(report.get("problems"), list) else []
+    prep_items = (
+        report.get("next_session_prep") if isinstance(report.get("next_session_prep"), list) else []
+    )
+    reference = report.get("reference") if isinstance(report.get("reference"), Mapping) else None
+    reference_selection = (
+        report.get("reference_selection")
+        if isinstance(report.get("reference_selection"), Mapping)
+        else None
+    )
+    title = f"{session.get('car_id') or 'car'} at {session.get('track_id') or 'track'}"
+    prep_html = "\n".join(f"<li>{_html(item)}</li>" for item in prep_items)
+    if not prep_html:
+        prep_html = "<li>Keep banking comparable laps.</li>"
+    data_json = _json_for_script(report)
+    if reference:
+        reference_meta = (
+            f"Reference {_html(reference.get('source_file'))} "
+            f"({_html_ms(reference.get('lap_ms'))}, {_html(reference.get('kind') or 'reference')})"
+        )
+    elif reference_selection:
+        reference_meta = f"Reference none ({_html(reference_selection.get('reason'))})"
+    else:
+        reference_meta = "Reference none"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Session Review - {_html(title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --ink: #182126;
+      --muted: #60717a;
+      --paper: #f8f7f2;
+      --line: #d7d2c4;
+      --panel: #ffffff;
+      --teal: #167c80;
+      --red: #d1495b;
+      --amber: #e3a12f;
+      --blue: #2f6fbb;
+      --green: #3a8b5c;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font: 15px/1.45 "Segoe UI", Arial, sans-serif;
+      letter-spacing: 0;
+    }}
+    header {{
+      padding: 28px clamp(18px, 5vw, 56px) 22px;
+      border-bottom: 1px solid var(--line);
+      background: #fffdf7;
+    }}
+    main {{
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 24px clamp(16px, 4vw, 36px) 48px;
+    }}
+    h1, h2, h3 {{ margin: 0; line-height: 1.1; letter-spacing: 0; }}
+    h1 {{ font-size: clamp(30px, 4vw, 48px); }}
+    h2 {{ font-size: 22px; margin-bottom: 14px; }}
+    h3 {{
+      font-size: 15px;
+      color: var(--muted);
+      text-transform: uppercase;
+      margin-bottom: 8px;
+    }}
+    .meta {{ margin-top: 10px; color: var(--muted); }}
+    section {{ padding: 22px 0; border-bottom: 1px solid var(--line); }}
+    .kpis {{
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }}
+    .kpi {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      padding: 14px;
+      border-radius: 8px;
+    }}
+    .kpi strong {{ display: block; font-size: 24px; color: var(--teal); }}
+    .grid {{
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(280px, .8fr);
+      gap: 22px;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+      border: 1px solid var(--line);
+    }}
+    th, td {{
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }}
+    th {{ color: var(--muted); font-size: 12px; text-transform: uppercase; }}
+    ul {{ margin: 0; padding-left: 20px; }}
+    .trend-svg {{
+      width: 100%;
+      min-height: 180px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+    }}
+    .axis {{ stroke: var(--line); stroke-width: 1; }}
+    .lap-line {{ fill: none; stroke: var(--red); stroke-width: 3; }}
+    circle {{ fill: var(--red); }}
+    .chart-label {{ fill: var(--muted); font-size: 12px; }}
+    .controls {{
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 14px;
+    }}
+    label {{
+      display: grid;
+      gap: 6px;
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+    }}
+    select {{
+      width: 100%;
+      min-height: 38px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 8px;
+      background: white;
+      color: var(--ink);
+    }}
+    #compare-chart {{
+      width: 100%;
+      min-height: 260px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      display: block;
+    }}
+    .legend {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      color: var(--muted);
+      font-size: 13px;
+      margin-top: 10px;
+    }}
+    .swatch {{
+      display: inline-block;
+      width: 20px;
+      height: 3px;
+      margin-right: 6px;
+      vertical-align: middle;
+    }}
+    .empty {{
+      color: var(--muted);
+      background: var(--panel);
+      border: 1px solid var(--line);
+      padding: 14px;
+      margin: 0;
+    }}
+    @media (max-width: 760px) {{
+      .kpis, .grid, .controls {{ grid-template-columns: 1fr; }}
+      th, td {{ padding: 8px; }}
+    }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{_html(title)}</h1>
+    <div class="meta">
+      Session {_html(session.get("session_uuid"))} - generated {_html(report.get("generated_at"))}
+    </div>
+    <div class="meta">{reference_meta}</div>
+  </header>
+  <main>
+    <section class="kpis" aria-label="Session summary">
+      <div class="kpi">
+        <h3>Best Lap</h3><strong>{_html_ms(session.get("best_lap_ms"))}</strong>
+      </div>
+      <div class="kpi">
+        <h3>Median</h3><strong>{_html_ms(session.get("median_lap_ms"))}</strong>
+      </div>
+      <div class="kpi">
+        <h3>Consistency</h3><strong>{_html_ms(session.get("consistency_ms"))}</strong>
+      </div>
+      <div class="kpi">
+        <h3>Valid Laps</h3>
+        <strong>{_html(session.get("valid_laps"))}/{_html(session.get("lap_count"))}</strong>
+      </div>
+    </section>
+    <section class="grid">
+      <div>
+        <h2>Debrief</h2>
+        <table>
+          <thead><tr><th>Rank</th><th>Corner</th><th>Cause</th><th>Loss</th><th>Fix</th></tr></thead>
+          <tbody>{_problem_rows_html(problems)}</tbody>
+        </table>
+      </div>
+      <div>
+        <h2>Next Session</h2>
+        <ul>{prep_html}</ul>
+      </div>
+    </section>
+    <section>
+      <h2>History</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Session</th><th>Last Lap</th><th>Best</th>
+            <th>Median</th><th>Consistency</th><th>Valid</th>
+          </tr>
+        </thead>
+        <tbody>{_history_rows_html(trend_sessions)}</tbody>
+      </table>
+    </section>
+    <section class="grid">
+      <div>
+        <h2>Lap-Time Trend</h2>
+        {_trend_svg(trend_sessions)}
+      </div>
+      <div>
+        <h2>Corner Trends</h2>
+        {_corner_trend_html(corners)}
+      </div>
+    </section>
+    <section>
+      <h2>Lap Compare</h2>
+      <div class="controls">
+        <label>Lap A<select id="lap-a"></select></label>
+        <label>Lap B<select id="lap-b"></select></label>
+      </div>
+      <svg id="compare-chart" viewBox="0 0 900 300" role="img"
+        aria-label="Telemetry trace comparison"></svg>
+      <div class="legend">
+        <span><span class="swatch" style="background:var(--red)"></span>Speed A/B</span>
+        <span><span class="swatch" style="background:var(--blue)"></span>Throttle</span>
+        <span><span class="swatch" style="background:var(--amber)"></span>Brake</span>
+        <span><span class="swatch" style="background:var(--green)"></span>Steer</span>
+      </div>
+    </section>
+  </main>
+  <script id="review-data" type="application/json">{data_json}</script>
+  <script>
+    const report = JSON.parse(document.getElementById("review-data").textContent);
+    const laps = (report.comparison && report.comparison.laps) || [];
+    const pair = (report.comparison && report.comparison.default_pair) || {{}};
+    const selectA = document.getElementById("lap-a");
+    const selectB = document.getElementById("lap-b");
+    const chart = document.getElementById("compare-chart");
+    const colors = {{
+      speed_kmh: "#d1495b",
+      throttle: "#2f6fbb",
+      brake: "#e3a12f",
+      steer: "#3a8b5c"
+    }};
+    function labelFor(lap) {{
+      const n = lap.lap_n === null || lap.lap_n === undefined ? "?" : lap.lap_n;
+      const time = lap.lap_ms ? (lap.lap_ms / 1000).toFixed(3) + "s" : "n/a";
+      return "L" + n + " - " + time + " - " + lap.session_uuid;
+    }}
+    function fillSelect(select, preferred) {{
+      select.textContent = "";
+      for (const lap of laps) {{
+        const option = document.createElement("option");
+        option.value = lap.lap_uuid;
+        option.textContent = labelFor(lap);
+        select.appendChild(option);
+      }}
+      if (preferred) select.value = preferred;
+    }}
+    function lapById(id) {{
+      return laps.find((lap) => lap.lap_uuid === id) || laps[0];
+    }}
+    function maxSpeed() {{
+      let value = 1;
+      for (const lap of laps) {{
+        for (const point of ((lap.trace && lap.trace.points) || [])) {{
+          if (Number.isFinite(point.speed_kmh)) {{
+            value = Math.max(value, point.speed_kmh);
+          }}
+        }}
+      }}
+      return value;
+    }}
+    function norm(point, key, speedMax) {{
+      const value = point[key];
+      if (!Number.isFinite(value)) return null;
+      if (key === "speed_kmh") return value / speedMax;
+      if (key === "steer") return (Math.max(-1, Math.min(1, value)) + 1) / 2;
+      return Math.max(0, Math.min(1, value));
+    }}
+    function pathFor(points, key, speedMax, yBase, yScale) {{
+      const coords = [];
+      for (const point of points) {{
+        const yNorm = norm(point, key, speedMax);
+        if (yNorm === null) continue;
+        const x = 32 + point.x * 836;
+        const y = yBase - yNorm * yScale;
+        coords.push(x.toFixed(1) + "," + y.toFixed(1));
+      }}
+      return coords.join(" ");
+    }}
+    function draw() {{
+      const a = lapById(selectA.value);
+      const b = lapById(selectB.value);
+      const speedMax = maxSpeed();
+      const aPoints = (a && a.trace && a.trace.points) || [];
+      const bPoints = (b && b.trace && b.trace.points) || [];
+      chart.textContent = "";
+      const ns = "http://www.w3.org/2000/svg";
+      function add(tag, attrs) {{
+        const node = document.createElementNS(ns, tag);
+        for (const [key, value] of Object.entries(attrs)) {{
+          node.setAttribute(key, value);
+        }}
+        chart.appendChild(node);
+        return node;
+      }}
+      add("line", {{x1: 32, y1: 260, x2: 868, y2: 260, stroke: "#d7d2c4"}});
+      add("line", {{x1: 32, y1: 40, x2: 32, y2: 260, stroke: "#d7d2c4"}});
+      for (const key of ["speed_kmh", "throttle", "brake", "steer"]) {{
+        const pathA = pathFor(aPoints, key, speedMax, 260, 210);
+        const pathB = pathFor(bPoints, key, speedMax, 260, 210);
+        const width = key === "speed_kmh" ? 3 : 1.8;
+        if (pathA) {{
+          add("polyline", {{
+            points: pathA,
+            fill: "none",
+            stroke: colors[key],
+            "stroke-width": width
+          }});
+        }}
+        if (pathB) {{
+          add("polyline", {{
+            points: pathB,
+            fill: "none",
+            stroke: colors[key],
+            "stroke-width": width,
+            "stroke-dasharray": "7 5"
+          }});
+        }}
+      }}
+      add("text", {{
+        x: 32,
+        y: 286,
+        fill: "#60717a",
+        "font-size": 12
+      }}).textContent = a ? labelFor(a) : "No lap";
+      add("text", {{
+        x: 868,
+        y: 286,
+        fill: "#60717a",
+        "font-size": 12,
+        "text-anchor": "end"
+      }}).textContent = b ? labelFor(b) : "No lap";
+    }}
+    fillSelect(selectA, pair.a);
+    fillSelect(selectB, pair.b);
+    selectA.addEventListener("change", draw);
+    selectB.addEventListener("change", draw);
+    draw();
+  </script>
+</body>
+</html>
+"""
 
 
 def write_session_report(
@@ -594,15 +1566,20 @@ def write_session_report(
     *,
     output_dir: str | Path = DEFAULT_OUTPUT_DIR,
 ) -> WrittenSessionReport:
-    """Write Markdown and JSON report files under ``journal/reports``."""
+    """Write Markdown, JSON, and HTML report files under ``journal/reports``."""
     resolved_dir = _resolve_output_dir(output_dir)
     basename = _report_basename(report)
     markdown_path = resolved_dir / f"{basename}.md"
     json_path = resolved_dir / f"{basename}.json"
+    html_path = resolved_dir / f"{basename}.html"
     _atomic_write(markdown_path, render_markdown(report))
     _atomic_write(json_path, json.dumps(report, indent=2, sort_keys=True) + "\n")
+    _atomic_write(html_path, render_html(report))
     return WrittenSessionReport(
-        markdown_path=markdown_path, json_path=json_path, report=dict(report)
+        markdown_path=markdown_path,
+        json_path=json_path,
+        html_path=html_path,
+        report=dict(report),
     )
 
 
@@ -623,6 +1600,21 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--driver-id", default="local-driver")
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
     parser.add_argument("--grip-ceiling-g", type=float, default=None)
+    parser.add_argument(
+        "--reference-source",
+        choices=REFERENCE_SOURCE_CHOICES,
+        default="auto",
+        help=(
+            "Reference selector for same-car/track comparison: auto, your-best, pro, "
+            "tt, generated, imported, or none."
+        ),
+    )
+    parser.add_argument(
+        "--reference-path",
+        type=Path,
+        default=None,
+        help="Optional explicit lap_*.json archive to use as the reference.",
+    )
     parser.add_argument("--json", action="store_true", help="Print machine-readable result paths.")
     return parser
 
@@ -645,6 +1637,8 @@ def main(
             session=args.session,
             driver_id=args.driver_id,
             grip_ceiling_g=args.grip_ceiling_g,
+            reference_source=args.reference_source,
+            reference_path=args.reference_path,
         )
         written = write_session_report(report, output_dir=args.output_dir)
     except SessionReviewError as exc:
@@ -656,6 +1650,9 @@ def main(
                 {
                     "markdown": str(written.markdown_path),
                     "json": str(written.json_path),
+                    "html": str(written.html_path),
+                    "reference": report.get("reference"),
+                    "reference_selection": report.get("reference_selection"),
                     "spoken_summary": report["spoken_summary"],
                     "screen_summary": report["screen_summary"],
                 },
@@ -666,5 +1663,6 @@ def main(
     else:
         print(f"session-review: wrote {written.markdown_path}", file=out)
         print(f"session-review: wrote {written.json_path}", file=out)
+        print(f"session-review: wrote {written.html_path}", file=out)
         print(report["spoken_summary"], file=out)
     return 0


### PR DESCRIPTION
## Summary
- Add source-aware reference selection for session review reports (`auto`, `your-best`, `pro`, `tt`, `generated`, `imported`, `none`) plus explicit `--reference-path` pinning.
- Surface `reference` and `reference_selection` metadata through CLI JSON, Markdown/HTML reports, sidecar `session.review.generate`, state snapshots, and voice cue details while keeping host paths redacted.
- Extend the Lua WS bridge and docs so loopback clients can pass `reference_source` / basename-only `reference_file`.

## Verification
- `python -m ruff check tools\session_review\report.py tools\ai_sidecar\server.py tools\ai_sidecar\external_protocol.py tests\test_session_review.py tests\test_ai_sidecar_external.py tests\test_lap_archive_source_structure.py`
- `python -m ruff format --check tools\session_review\report.py tools\ai_sidecar\server.py tools\ai_sidecar\external_protocol.py tests\test_session_review.py tests\test_ai_sidecar_external.py tests\test_lap_archive_source_structure.py`
- `python -m pytest tests\test_session_review.py tests\test_ai_sidecar_external.py tests\test_lap_archive_source_structure.py tests\test_ws_bridge_hello_handshake.py -q`
- Scratch CLI proof: `python -m tools.session_review --lap-dir .scratch\session-review-reference-proof\journal\laps --session sess-latest --reference-source tt --output-dir .scratch\session-review-reference-proof\journal\reports --json --grip-ceiling-g 2.5` selected `lap_tt.json`, wrote JSON/HTML, and embedded `review-data`.

## Notes
- `make ci-fast` was attempted locally and currently stops at repo-wide `ruff format --check src tests tools scripts` because this Windows checkout has broad CRLF/LF drift across untouched files. Touched-file Ruff checks and `git diff --check` pass.

Closes #408