### PR TITLE
fix(voice): keep neural act cues within timing budget (#381)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/voice-intensity-register-2026-06-28.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/voice-intensity-register-2026-06-28.md
@@ -59,8 +59,9 @@ is offline, every cue is pre-rendered at a tone tier; the hot path stays jitter-
    `critical`; legacy `firm` producer input is normalized to `urgent` so old logs and advisory
    emitters do not go silent. The voice persona is explicitly project-authored:
    `race-engineer-original-v1`, license/source `project-authored; no unconsented real-person clone`.
-   Every backend signature appends `race-engineer-original-v1+intensity2`, so a bank baked before the
-   persona/intensity-chain bump is refused as stale.
+   Every backend signature appends the current `EXPECTED_SIGNATURE_SUFFIX`
+   (`race-engineer-original-v1+prosody2+intensity3` as of #381 timing fix), so a bank baked before a
+   persona/prosody/intensity-chain bump is refused as stale.
 
 ## Reconciliation that mattered
 

--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -18,7 +18,13 @@ import pytest
 
 from tools.ai_sidecar.voice import bake as bake_mod
 from tools.ai_sidecar.voice import vocabulary as vocab
-from tools.ai_sidecar.voice.bake import PiperBackend, ToneBackend, _build_backend, bake_bank
+from tools.ai_sidecar.voice.bake import (
+    KokoroBackend,
+    PiperBackend,
+    ToneBackend,
+    _build_backend,
+    bake_bank,
+)
 from tools.ai_sidecar.voice.manifest import MANIFEST_FILENAME, Manifest, sha256_bytes
 
 
@@ -127,6 +133,22 @@ def test_tone_backend_registers_are_distinct(tmp_path) -> None:
     crit = manifest.clips["late_brake.act.critical.generic"].sha256
     calm = manifest.clips["late_brake.prepare.calm.generic"].sha256
     assert len({alert, urgent, crit, calm}) == 4  # four distinct register clips
+
+
+def test_speech_backends_keep_act_registers_fast() -> None:
+    # Issue #381: the real neural backends must bake terse act registers at an assertive pace.
+    # Otherwise a valid v3 manifest can still fail the runtime brake-alarm timing report.
+    assert KokoroBackend._REGISTER_SPEED["calm"] < KokoroBackend._REGISTER_SPEED["alert"]
+    assert KokoroBackend._REGISTER_SPEED["alert"] < KokoroBackend._REGISTER_SPEED["urgent"]
+    assert KokoroBackend._REGISTER_SPEED["urgent"] < KokoroBackend._REGISTER_SPEED["critical"]
+    assert KokoroBackend._REGISTER_SPEED["critical"] >= 1.4
+
+    assert (
+        PiperBackend._REGISTER_LENGTH_SCALE["calm"] > PiperBackend._REGISTER_LENGTH_SCALE["alert"]
+    )
+    assert PiperBackend._REGISTER_LENGTH_SCALE["alert"] <= 0.75
+    assert PiperBackend._REGISTER_LENGTH_SCALE["urgent"] <= 0.75
+    assert PiperBackend._REGISTER_LENGTH_SCALE["critical"] <= 0.75
 
 
 def test_prosody_shaper_is_run_to_run_deterministic(tmp_path) -> None:
@@ -329,7 +351,7 @@ def test_piper_batch_preserves_register_length_scale(tmp_path, monkeypatch) -> N
     backend.synthesize_many(items, 48000)
 
     assert ("1.05", ["calm one"]) in seen
-    assert ("0.88", ["critical two"]) in seen
+    assert ("0.72", ["critical two"]) in seen
     assert _first_sample(items[0][2]) == 1000
     assert _first_sample(items[1][2]) == 1000
 

--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -146,8 +146,13 @@ def test_speech_backends_keep_act_registers_fast() -> None:
     assert (
         PiperBackend._REGISTER_LENGTH_SCALE["calm"] > PiperBackend._REGISTER_LENGTH_SCALE["alert"]
     )
-    assert PiperBackend._REGISTER_LENGTH_SCALE["alert"] <= 0.75
-    assert PiperBackend._REGISTER_LENGTH_SCALE["urgent"] <= 0.75
+    assert (
+        PiperBackend._REGISTER_LENGTH_SCALE["alert"] > PiperBackend._REGISTER_LENGTH_SCALE["urgent"]
+    )
+    assert (
+        PiperBackend._REGISTER_LENGTH_SCALE["urgent"]
+        > PiperBackend._REGISTER_LENGTH_SCALE["critical"]
+    )
     assert PiperBackend._REGISTER_LENGTH_SCALE["critical"] <= 0.75
 
 
@@ -351,7 +356,7 @@ def test_piper_batch_preserves_register_length_scale(tmp_path, monkeypatch) -> N
     backend.synthesize_many(items, 48000)
 
     assert ("1.05", ["calm one"]) in seen
-    assert ("0.72", ["critical two"]) in seen
+    assert ("0.69", ["critical two"]) in seen
     assert _first_sample(items[0][2]) == 1000
     assert _first_sample(items[1][2]) == 1000
 

--- a/tests/test_voice_engine.py
+++ b/tests/test_voice_engine.py
@@ -76,7 +76,7 @@ def test_disabled_on_signature_drift(tmp_path) -> None:
     mfp = tmp_path / MANIFEST_FILENAME
     data = json.loads(mfp.read_text())
     # Older prosody chain, same persona/intensity/wording — the sharpest form of the gap.
-    data["voice_signature"] = "tone-v3+race-engineer-original-v1+prosody1+intensity2"
+    data["voice_signature"] = "tone-v3+race-engineer-original-v1+prosody1+intensity3"
     mfp.write_text(json.dumps(data))
     pb = RecordingPlayback()
     coach = VoiceCoach.from_bank(tmp_path, VoiceConfig(), playback=pb)

--- a/tests/test_voice_manifest.py
+++ b/tests/test_voice_manifest.py
@@ -51,10 +51,10 @@ def test_validate_detects_signature_drift() -> None:
     # wording keeps vocabulary_hash constant, so the signature suffix is the only stale-bank
     # detector for those changes.
     stale_signatures = [
-        "tone-v3+race-engineer-original-v0+prosody2+intensity2",  # persona swap
-        "tone-v3+race-engineer-original-v1+prosody1+intensity2",  # older prosody chain (codex #441)
-        "tone-v3+race-engineer-original-v1+prosody2+intensity1",  # older intensity chain
-        "tone-v3+race-engineer-original-v1+intensity2",  # pre-prosody suffix shape
+        "tone-v3+race-engineer-original-v0+prosody2+intensity3",  # persona swap
+        "tone-v3+race-engineer-original-v1+prosody1+intensity3",  # older prosody chain (codex #441)
+        "tone-v3+race-engineer-original-v1+prosody2+intensity2",  # older intensity chain
+        "tone-v3+race-engineer-original-v1+intensity3",  # pre-prosody suffix shape
     ]
     for sig in stale_signatures:
         report = build_manifest(voice_signature=sig).validate()
@@ -66,7 +66,7 @@ def test_validate_detects_signature_drift() -> None:
 
 def test_signature_check_is_anchored_at_the_end() -> None:
     # endswith, not equality or substring: the host-varying prefix (backend, voice, ffmpeg major)
-    # must not reject a portable bank, while "…+intensity2" must NOT accept an "…+intensity21"
+    # must not reject a portable bank, while "…+intensity3" must NOT accept an "…+intensity31"
     # bank.
     portable = build_manifest(
         voice_signature=f"kokoro:af_bella+ff8+{vocab.EXPECTED_SIGNATURE_SUFFIX}"

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -292,13 +292,14 @@ class KokoroBackend:
     lazily so the bake module stays importable without it.
     """
 
-    #: per-register synthesis speed (Kokoro renders neutral; the shaper adds tempo for hot tiers
-    #: too, so keep these modest to avoid double-fast unintelligibility on terse cues).
+    #: Per-register synthesis speed. Kokoro renders neutral speech before the shaper adds the
+    #: baked tone. The hot tiers need an assertive base pace so one-word act cues stay inside the
+    #: <=450 ms brake-alarm budget after the full 48 kHz rig bake.
     _REGISTER_SPEED: dict[str, float] = {
         "calm": 0.95,
-        "alert": 0.98,
-        "urgent": 1.02,
-        "critical": 1.05,
+        "alert": 1.26,
+        "urgent": 1.35,
+        "critical": 1.45,
     }
 
     def __init__(
@@ -348,9 +349,9 @@ class PiperBackend:
 
     _REGISTER_LENGTH_SCALE: dict[str, float] = {
         "calm": 1.05,
-        "alert": 1.00,
-        "urgent": 0.93,
-        "critical": 0.88,
+        "alert": 0.72,
+        "urgent": 0.72,
+        "critical": 0.72,
     }
 
     def __init__(self, model_path: str | Path, piper_bin: str = "piper") -> None:

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -349,9 +349,9 @@ class PiperBackend:
 
     _REGISTER_LENGTH_SCALE: dict[str, float] = {
         "calm": 1.05,
-        "alert": 0.72,
+        "alert": 0.75,
         "urgent": 0.72,
-        "critical": 0.72,
+        "critical": 0.69,
     }
 
     def __init__(self, model_path: str | Path, piper_bin: str = "piper") -> None:

--- a/tools/ai_sidecar/voice/manifest.py
+++ b/tools/ai_sidecar/voice/manifest.py
@@ -206,7 +206,7 @@ class Manifest:
           check is ``endswith`` (the suffix is the final signature segment on every backend), NOT
           full equality — ``voice_signature`` also carries host-varying parts (backend id, voice,
           ffmpeg major) that must not reject portable banks — and NOT a plain substring, which
-          would let ``…+intensity2`` accept an ``…+intensity21`` bank.
+          would let the current suffix plus extra trailing characters pass as a valid bank.
         * ``problems`` lists missing clip files and sha256 mismatches when ``bank_dir`` is supplied.
 
         Never raises on content problems — it *reports* them so the caller can degrade per clip.

--- a/tools/ai_sidecar/voice/vocabulary.py
+++ b/tools/ai_sidecar/voice/vocabulary.py
@@ -100,7 +100,7 @@ URGENCIES: tuple[str, ...] = ("info", "prepare", "act")
 #: clone.
 VOICE_PERSONA_ID = "race-engineer-original-v1"
 VOICE_PERSONA_LICENSE = "project-authored; no unconsented real-person clone"
-INTENSITY_CHAIN_VERSION = 2
+INTENSITY_CHAIN_VERSION = 3
 
 #: Bump when the per-register prosody delivery changes: the ffmpeg filter chains in
 #: ``bake._prosody_filter`` (shaped speech backends) or ``bake.ToneBackend``'s register tone table


### PR DESCRIPTION
## Summary

- Increase Kokoro register speeds so schema-v3 neural voice banks keep terse act cues inside the brake-alarm timing budget.
- Tune Piper hot-register pacing into a strict alert > urgent > critical ladder that still clears the act-cue budget.
- Bump the voice intensity-chain signature to invalidate old schema-v3 banks whose baked clips predate the pacing change.
- Add regression guards for speech-backend hot-register pacing and signature drift.

Refs #381. This intentionally does not close #381 until the remaining at-wheel/operator listening confirmation is recorded.

## Verification

- `PYTHONPATH=$PWD pytest tests/test_voice_bake.py tests/test_voice_bench_voices.py tests/test_voice_manifest.py tests/test_voice_engine.py tests/test_voice_timing_report.py -q` -> 54 passed
- `PYTHONPATH=$PWD pytest tests/test_voice_*.py -q` -> 142 passed
- `PYTHONPATH=$PWD make PYTHON=python ci-fast` -> 2205 passed, 117 skipped, `ci-fast: OK`
- `bench_voices` with Piper Lessac medium + Kokoro am_fenrir -> Piper act cues 445.7 / 309.6 / 328.4 ms; Kokoro act cues 428.5 / 379.5 / 365.2 ms; both `act<=450ms`.
- Re-baked `C:\Users\arsen\Projects\ac-copilot-trainer\.scratch\coach-bank-kokoro-fenrir-v3-intensity3-20260702`; manifest validates schema v3 with 76 clips and signature `kokoro:am_fenrir+ff8+race-engineer-original-v1+prosody2+intensity3`.
- Verified stale `intensity2` bank now fails the manifest signature gate with expected suffix `race-engineer-original-v1+prosody2+intensity3`; new `intensity3` bank validates `ok=true`.
- Runtime timing report against the new bank: `late_brake.act.urgent.generic` 379.6 ms; `late_brake.act.critical.generic` 361.4 ms; all boolean assertions true including `brake_alarm_within_450ms`.
- Sidecar smoke on `127.0.0.1:9876` with the new bank + configured reference: `/health.voice.enabled=true`; stderr showed `rtmixer stream open on device index 18 @ 48000 Hz` for `USB Sound Device` / `Windows WASAPI`.
- Updated the user `AC_COPILOT_VOICE_BANK` env var from the invalidated `intensity2` bank to the verified `intensity3` bank path above.