### PR TITLE
feat: USB-serial rig screen transport — remove Mobile Hotspot (#463)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -82,8 +82,14 @@ evidence: [[usb-serial-screen-transport-2026-07-02]].
 - **Live E2E (hotspot OFF, `AHOME5G` up the whole time, 68%→69%):** `screen_peers=1`,
   bidirectional round-trip (hello → hello_ack → 5 s heartbeat), `coaching.snapshot`
   fanned to the serial peer, 0 send failures. Both firmware envs build.
-- **Next:** open/land the PR; drive review to green. The screen must stay USB-tethered
-  (it already is). WebSocket env `jc3248w535` retained for LAN/CI.
+- **PR [#464](https://github.com/agorokh/ac-copilot-trainer/pull/464): CI fully green**
+  (build/conformance/pip-audit/canonical-docs), `MERGEABLE`/`CLEAN`, 0 unresolved
+  review threads (Qodo endorsed; Gemini/Codex quota-limited). `pyserial>=3.5` added
+  to coaching/launcher/dev extras. **Merge-ready.**
+- **Only unverified piece = operator-visual:** confirm the physical screen pill shows
+  CONNECTED + live hints while driving (needs eyes on the screen; the sidecar-side
+  round-trip + fan-out are proven). The screen must stay USB-tethered (it already is).
+  WebSocket env `jc3248w535` retained for LAN/CI.
 
 ## Delivered (2026-07-02 UTC) — PR #460 MERGED: autonomous harness as a product + setup verify (#459)
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-02T08:20:00Z
+last_updated: 2026-07-02T18:00:00Z
 relates_to:
+  - AcCopilotTrainer/01_Decisions/usb-serial-screen-transport-2026-07-02.md
   - AcCopilotTrainer/03_Investigations/pr-444-atelier-main-dashboard-2026-07-01.md
   - AcCopilotTrainer/03_Investigations/pr-441-voice-signature-gate-2026-07-01.md
   - AcCopilotTrainer/01_Decisions/voice-intensity-register-2026-06-28.md
@@ -62,6 +63,27 @@ relates_to:
 ---
 
 # Next session handoff
+
+## In flight (2026-07-02 UTC) — PR for #463: USB-serial screen transport, hotspot removed
+
+Branch `feat/issue-463-usb-serial-screen` (3 commits). The rig screen now speaks
+protocol v1 over the **native USB CDC** instead of WiFi/WebSocket, so the Windows
+Mobile Hotspot is gone — that hotspot forced a 2.4 GHz SoftAP onto the single-radio
+Intel AC 7260 and dropped the main WiFi (which then would not reconnect). Decision +
+evidence: [[usb-serial-screen-transport-2026-07-02]].
+
+- **Sidecar** `tools/ai_sidecar/serial_transport.py` — `SerialPeer` + read loop on
+  `_handle_external_frame`; `--serial-port` / `AC_COPILOT_SIDECAR_SERIAL_PORT`.
+- **Firmware** `firmware/screen` — `SCREEN_TRANSPORT_SERIAL` flag, env
+  `jc3248w535_serial` (rig default), heartbeat hello. Flashed + live-verified.
+- **Launcher** `tools/rig_launcher` — Mobile Hotspot probe/row/readiness removed.
+- **Hardware trap (durable):** the ESP32-S3 USB CDC needs **DTR asserted** to deliver
+  RX; auto-reset is an **RTS** pulse, not steady DTR. Sidecar opens **DTR high / RTS low**.
+- **Live E2E (hotspot OFF, `AHOME5G` up the whole time, 68%→69%):** `screen_peers=1`,
+  bidirectional round-trip (hello → hello_ack → 5 s heartbeat), `coaching.snapshot`
+  fanned to the serial peer, 0 send failures. Both firmware envs build.
+- **Next:** open/land the PR; drive review to green. The screen must stay USB-tethered
+  (it already is). WebSocket env `jc3248w535` retained for LAN/CI.
 
 ## Delivered (2026-07-02 UTC) — PR #460 MERGED: autonomous harness as a product + setup verify (#459)
 

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/_index.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/_index.md
@@ -17,6 +17,7 @@ Architecture Decision Records for this vault.
 - [screen-firmware-in-trainer-monorepo](screen-firmware-in-trainer-monorepo.md) — `firmware/` lives inside the trainer repo.
 - [screen-firmware-toolchain](screen-firmware-toolchain.md) — Arduino_GFX 1.4.7 + ArduinoWebsockets + ArduinoJson on espressif32@6.13.0.
 - [external-ws-client-protocol-extension](external-ws-client-protocol-extension.md) — sidecar opt-in LAN bind + token + `{v,type}` envelope (issue #81).
+- [usb-serial-screen-transport-2026-07-02](usb-serial-screen-transport-2026-07-02.md) — the rig screen talks protocol v1 over **USB CDC**, not WiFi/hotspot (issue #463); removes the single-radio main-WiFi drop. Key trap: S3 CDC needs **DTR high** for RX, resets on **RTS** pulse.
 - [screen-ui-stack-lvgl-touch](screen-ui-stack-lvgl-touch.md) — LVGL 8.3 + AXS15231B touch + SquareLine for the rig screen UI.
 - [screen-and-csp-apps-integration](screen-and-csp-apps-integration.md) — bridge the rig screen to Pocket Technician + Setup Exchange via same-VM API replication, not cross-VM bridging.
 - [dashboard-visual-design-figma](dashboard-visual-design-figma.md) — Figma file is source of truth for both HUD (shipped) and rig touchscreen (Phase 2); design tokens + cockpit-UX rules captured here.

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/usb-serial-screen-transport-2026-07-02.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/usb-serial-screen-transport-2026-07-02.md
@@ -1,0 +1,65 @@
+---
+type: decision
+status: active
+created: 2026-07-02
+updated: 2026-07-02
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/463
+relates_to:
+  - AcCopilotTrainer/10_Rig/esp32-jc3248w535-screen-v1.md
+  - AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
+  - AcCopilotTrainer/03_Investigations/router-mesh-cross-ap-tcp-block-2026-04-21.md
+  - AcCopilotTrainer/03_Investigations/issue-86-rig-screen-hotspot-autostart-2026-06-28.md
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+---
+
+# Decision: rig screen talks to the sidecar over USB serial, not WiFi/hotspot
+
+## Context
+
+The screen reached the sidecar over WebSocket/TCP. Because the `AHOME5G` mesh
+drops cross-AP TCP ([router-mesh-cross-ap-tcp-block](../03_Investigations/router-mesh-cross-ap-tcp-block-2026-04-21.md)),
+the only working path was a Windows **Mobile Hotspot** on the rig PC. That hotspot
+hosts a 2.4 GHz SoftAP on the PC's **single-radio** Intel AC 7260; while the client
+is on 5 GHz `AHOME5G`, one radio cannot serve both bands, so the main WiFi drops
+and will not reconnect. Physical limitation, not a Windows bug.
+
+## Decision
+
+Move the **screen leg** of the transport from external-WS to the native **USB CDC**
+(the same COM port used to flash). Protocol v1 `{v,type}` frames are carried as
+newline-delimited JSON. The in-game CSP trainer's loopback-WS peer is unchanged;
+only the screen's byte transport changes. This removes WiFi, the hotspot, and the
+mesh cross-AP block from the screen path in one move.
+
+- **Sidecar** (`tools/ai_sidecar/serial_transport.py`): a `SerialPeer` reusing the
+  transport-agnostic `_handle_external_frame` fan-out; `--serial-port` /
+  `AC_COPILOT_SIDECAR_SERIAL_PORT`.
+- **Firmware** (`firmware/screen`): `SCREEN_TRANSPORT_SERIAL` build flag, env
+  `jc3248w535_serial` (now the rig default). Heartbeat `hello` (1 s until linked,
+  5 s after) so a restarted sidecar re-registers the screen without a reboot.
+- **Launcher** (`tools/rig_launcher`): the Mobile Hotspot probe/row/readiness
+  coupling is removed entirely; the screen row derives from `screen_peers`.
+
+## Key hardware finding (the DTR trap)
+
+On the ESP32-S3 native USB CDC, the device only delivers **host→device (RX)** bytes
+to the sketch once the host asserts **DTR**; the auto-reset is an **RTS** pulse, not
+a steady DTR. Opening DTR-low (the intuitive "don't reset" choice) gives *no reset
+but no RX* — the board never sees `hello_ack` and re-`hello`s forever. Correct:
+**DTR high, RTS low**. Verified live on COM6.
+
+## Evidence (live, 2026-07-02)
+
+Mobile Hotspot OFF, main WiFi `AHOME5G` connected throughout (68%→69%, never
+dropped; no `192.168.137.x`): screen registered as a serial screen peer
+(`screen_peers=1`), bidirectional round-trip confirmed (board `hello` → sidecar
+`hello_ack` → board dropped to the 5 s heartbeat), a trainer `coaching.snapshot`
+fanned out to the serial peer with zero send failures. Both firmware envs build.
+
+## Consequences
+
+- The rig no longer needs the Mobile Hotspot; the single-radio main-WiFi drop is
+  gone. The screen must stay USB-tethered to the PC (it already is on the rig).
+- The WebSocket build (`jc3248w535`) is retained for LAN/hotspot deployments and CI.
+- New protocol types still need three sites updated (firmware dispatch, trainer Lua,
+  sidecar allow-list) — transport is orthogonal to that contract.

--- a/firmware/screen/README.md
+++ b/firmware/screen/README.md
@@ -43,11 +43,35 @@ Copy-Item secrets\sidecar.h.example secrets\sidecar.h
 # edit secrets\wifi_secrets.h -> real SSID + password
 # edit secrets\sidecar.h -> LAN IP of the PC + token
 
-# Build + flash + monitor
-pio run -e jc3248w535
+# Build + flash + monitor (USB-serial transport — the rig default)
+pio run                          # default env = jc3248w535_serial
+pio run -t upload
+# NOTE: don't `pio device monitor` in serial mode — the sidecar owns the port
+# (it IS the protocol link). Monitoring would fight it for COM6.
+
+# WebSocket/hotspot variant (LAN deployments, CI build coverage):
 pio run -e jc3248w535 -t upload
-pio device monitor -e jc3248w535
 ```
+
+## Transport: USB serial (default) vs WebSocket (issue #463)
+
+The rig runs the **USB-serial transport**: the screen speaks protocol v1 as
+newline-delimited JSON over the native USB CDC (the same COM port used to flash),
+so it needs **no WiFi and no Windows Mobile Hotspot**. This removes the failure
+mode where hosting a 2.4 GHz SoftAP on the rig PC's single-radio adapter drops the
+main WiFi. Selected by the `SCREEN_TRANSPORT_SERIAL=1` build flag in env
+`jc3248w535_serial` (the default). The screen `secrets/wifi_secrets.h` values are
+unused in this mode (only `CLIENT_ID` from `secrets/sidecar.h` is needed).
+
+Run the sidecar pointed at the screen's COM port:
+
+```powershell
+py -3 -m tools.ai_sidecar --serial-port COM6      # or set AC_COPILOT_SIDECAR_SERIAL_PORT
+```
+
+The launcher auto-forwards `--serial-port` when `AC_COPILOT_SIDECAR_SERIAL_PORT`
+is set in the user environment. The legacy WebSocket build (`jc3248w535`) is kept
+for LAN deployments and CI; it still dials `ws://SIDECAR_HOST:SIDECAR_PORT/`.
 
 ## Before you flash: back up the factory firmware
 
@@ -69,8 +93,12 @@ to force ROM DFU, then `esptool.py ... write_flash 0 <factory.bin>`.
 
 ## Troubleshooting
 
-- **Port open resets the board.** Native-USB CDC on the S3 toggles DTR/RTS on
-  `open`. Don't monitor the port from two processes at once.
+- **Port open resets the board / screen never receives.** Native-USB CDC on the
+  S3 resets on an **RTS** pulse (esptool's reset line), and only delivers RX to
+  the firmware once **DTR** is asserted. The sidecar's serial transport opens with
+  **DTR high, RTS low** — RX works and the board does not reset. A plain
+  `pio device monitor` may toggle both and reset the board; don't run it while the
+  sidecar owns the port.
 - **Backlight never turns on / black screen.** Suspect the pins in
   `include/board/LGFX_JC3248W535.h` first — they are community defaults and
   have not yet been verified on this physical board.
@@ -100,9 +128,11 @@ Optional overrides:
 ```
 
 Restart Content Manager / Assetto Corsa after changing user environment variables.
-For the current rig firmware, `SIDECAR_HOST` in `secrets/sidecar.h` must match
-the Windows Mobile Hotspot gateway address shown on the rig PC, and the screen
-must join the 2.4 GHz hotspot SSID from `secrets/wifi_secrets.h`.
+
+For the **USB-serial** rig firmware (the default) there is no hotspot and no
+`SIDECAR_HOST` to match — set `AC_COPILOT_SIDECAR_SERIAL_PORT` (e.g. `COM6`) so
+the launcher forwards `--serial-port` to the sidecar. `SIDECAR_HOST` / the
+2.4 GHz hotspot only apply to the legacy WebSocket build (`jc3248w535`).
 
 ### Token rotation
 

--- a/firmware/screen/platformio.ini
+++ b/firmware/screen/platformio.ini
@@ -9,7 +9,10 @@
 ; and docs/01_Vault/AcCopilotTrainer/10_Rig/esp32-jc3248w535-screen-v1.md.
 
 [platformio]
-default_envs = jc3248w535
+; The rig runs the USB-serial transport (issue #463) — no Mobile Hotspot. The
+; WebSocket variant (env jc3248w535) is retained for LAN/hotspot deployments and
+; CI build coverage; build it explicitly with `-e jc3248w535`.
+default_envs = jc3248w535_serial
 
 [env:jc3248w535]
 platform       = espressif32@^6.8.0
@@ -67,3 +70,13 @@ upload_port   = ${sysenv.PLATFORMIO_UPLOAD_PORT}
 monitor_speed = 115200
 monitor_port  = ${sysenv.PLATFORMIO_UPLOAD_PORT}
 monitor_filters = esp32_exception_decoder, time
+
+; USB-serial transport variant (issue #463): the screen speaks protocol v1 over
+; the native USB CDC instead of WiFi + WebSocket, so the rig PC never needs the
+; Windows Mobile Hotspot (which drops the single-radio adapter's main WiFi).
+; Same firmware, one added build flag. This is the default env for the rig.
+[env:jc3248w535_serial]
+extends = env:jc3248w535
+build_flags =
+    ${env:jc3248w535.build_flags}
+    -DSCREEN_TRANSPORT_SERIAL=1

--- a/firmware/screen/src/main.cpp
+++ b/firmware/screen/src/main.cpp
@@ -1029,7 +1029,14 @@ static void sweep_rotations() {
 // WebSocket path does.
 static String   serial_rx_line;
 static uint32_t serial_hello_next_ms = 0;
+static uint32_t serial_last_rx_ms = 0;
 static bool     serial_link_up = false;
+// If no frame arrives for this long while linked, treat the link as DOWN. The
+// sidecar answers every heartbeat hello with a hello_ack (~5 s cadence once
+// linked), so this fires only on a real drop (sidecar crash/restart, USB
+// unplug) — 12 s tolerates ~2 missed acks without a false disconnect. This is
+// the serial analogue of the WebSocket `ConnectionClosed` event.
+static constexpr uint32_t SERIAL_RX_TIMEOUT_MS = 12000;
 
 static void serial_send_hello() {
   JsonDocument doc;
@@ -1043,6 +1050,7 @@ static void serial_send_hello() {
 }
 
 static void serial_mark_link_up() {
+  serial_last_rx_ms = millis();  // any inbound frame keeps the link alive
   if (serial_link_up) return;
   serial_link_up = true;
   ws_state = WsState::Open;
@@ -1052,10 +1060,25 @@ static void serial_mark_link_up() {
   app_state_set(APP_LAUNCHER_IDLE);
 }
 
+// Mirror the WebSocket `ConnectionClosed` path: the sidecar went silent, so drop
+// back to CONNECTING, arm the DISCONNECTED grace (the launcher pill flips after
+// WS_DISCONNECT_GRACE_MS), and resume the fast 1 s hello so we re-register the
+// instant it returns. Without this the pill would stay CONNECTED forever after a
+// sidecar crash (self-hosted reviewer HIGH on #464).
+static void serial_mark_link_down(const char* why) {
+  if (!serial_link_up) return;
+  serial_link_up = false;
+  ws_state = WsState::Connecting;
+  Serial.printf("[serial] link down (%s) — re-announcing\n", why);
+  disconnect_grace_arm();
+  serial_hello_next_ms = 0;  // fast re-hello on the next tick
+}
+
 static void serial_transport_begin() {
   ws_state = WsState::Connecting;
   serial_rx_line = "";
   serial_rx_line.reserve(512);
+  serial_last_rx_ms = millis();
   serial_send_hello();               // greet immediately; resent until answered
   serial_hello_next_ms = millis() + 1000;
   Serial.println("[serial] transport begin — hello sent over USB CDC");
@@ -1077,7 +1100,7 @@ static void serial_transport_tick() {
     if (c == '\n') {
       serial_rx_line.trim();  // strip trailing \r / whitespace
       if (serial_rx_line.length() > 0) {
-        serial_mark_link_up();
+        serial_mark_link_up();  // refreshes serial_last_rx_ms
         dispatch_phase2_message(serial_rx_line);
       }
       serial_rx_line = "";
@@ -1089,6 +1112,14 @@ static void serial_transport_tick() {
       }
     }
   }
+  // Down-transition: no frame (not even a heartbeat ack) for the timeout window
+  // means the sidecar is gone. Flip toward DISCONNECTED like the WS path does.
+  if (serial_link_up && (int32_t)(millis() - serial_last_rx_ms) > (int32_t)SERIAL_RX_TIMEOUT_MS) {
+    serial_mark_link_down("rx timeout");
+  }
+  // Surface DISCONNECTED to the launcher pill once the grace window elapses
+  // (mirrors ws_tick()'s call so the armed grace actually fires in serial mode).
+  disconnect_grace_evaluate();
 }
 #endif  // SCREEN_TRANSPORT_SERIAL
 

--- a/firmware/screen/src/main.cpp
+++ b/firmware/screen/src/main.cpp
@@ -32,6 +32,23 @@
 #define PHASE1_FALLBACK 0
 #endif
 
+// ---------------------------------------------------------------------------
+// SCREEN_TRANSPORT_SERIAL (issue #463): 1 → speak protocol v1 over the native
+// USB CDC (COM port) instead of WiFi + WebSocket. This removes the Windows
+// Mobile Hotspot dependency (a 2.4GHz SoftAP on the rig PC's single-radio
+// adapter drops the main WiFi). The same `dispatch_phase2_message` handler and
+// `ws_state` machine are reused; only the byte transport changes — outbound
+// frames are newline-delimited JSON on Serial, inbound frames are read the same
+// way. Default 0 keeps the WebSocket build byte-identical.
+// ---------------------------------------------------------------------------
+#ifndef SCREEN_TRANSPORT_SERIAL
+#define SCREEN_TRANSPORT_SERIAL 0
+#endif
+
+#if SCREEN_TRANSPORT_SERIAL && PHASE1_FALLBACK
+#error "SCREEN_TRANSPORT_SERIAL requires the Phase-2 build (PHASE1_FALLBACK=0)"
+#endif
+
 #if PHASE1_FALLBACK == 0
 #include <lvgl.h>
 #include <esp_heap_caps.h>   // heap_caps_malloc / MALLOC_CAP_SPIRAM
@@ -410,6 +427,19 @@ static void lvgl_tick() {
 
 // -- Network -----------------------------------------------------------------
 
+// Transport-agnostic frame send. In serial mode (issue #463) every protocol
+// frame is one newline-delimited JSON line on the USB CDC; the write is atomic
+// on the single Arduino thread, so interleaved debug prints (their own lines)
+// never split a frame. In WebSocket mode it is the unchanged `ws.send`.
+static void transport_send(const String& out) {
+#if SCREEN_TRANSPORT_SERIAL
+  Serial.print(out);
+  Serial.write('\n');
+#else
+  ws.send(out);
+#endif
+}
+
 static void send_demo_action() {
   if (!ENABLE_DEMO_ACTION) {
     return;
@@ -420,7 +450,7 @@ static void send_demo_action() {
   doc["name"] = "toggleFocusPractice";
   String out;
   serializeJson(doc, out);
-  ws.send(out);
+  transport_send(out);
   Serial.printf("[ws] -> %s\n", out.c_str());
 }
 
@@ -586,7 +616,7 @@ static void phase2_send_setup_load(const char* name, const char* path) {
   if (path && *path) doc["path"] = path;
   String out;
   serializeJson(doc, out);
-  ws.send(out);
+  transport_send(out);
   Serial.printf("[ws] -> %s\n", out.c_str());
 }
 
@@ -836,7 +866,7 @@ static void ws_on_event(WebsocketsEvent ev, String data) {
       doc["client"]  = CLIENT_ID;
       String out;
       serializeJson(doc, out);
-      ws.send(out);
+      transport_send(out);
       demo_next_at = millis() + DEMO_INTERVAL_MS;
       break;
     }
@@ -991,6 +1021,77 @@ static void sweep_rotations() {
 }
 #endif
 
+#if SCREEN_TRANSPORT_SERIAL
+// -- USB-serial transport (issue #463) --------------------------------------
+// The screen speaks the same protocol v1 over the native USB CDC. We reuse the
+// `ws_state`/`app_state` machine: the link is "Open" once the sidecar answers,
+// which drives the CONNECTED pill and the pt/se request drains exactly as the
+// WebSocket path does.
+static String   serial_rx_line;
+static uint32_t serial_hello_next_ms = 0;
+static bool     serial_link_up = false;
+
+static void serial_send_hello() {
+  JsonDocument doc;
+  doc["v"] = 1;
+  doc["type"] = "hello";
+  doc["client"] = CLIENT_ID;
+  doc["client_class"] = "screen";
+  String out;
+  serializeJson(doc, out);
+  transport_send(out);
+}
+
+static void serial_mark_link_up() {
+  if (serial_link_up) return;
+  serial_link_up = true;
+  ws_state = WsState::Open;
+  Serial.println("[serial] link up (sidecar answered)");
+  disconnect_grace_clear();
+  app_state_set(APP_CONNECTED);
+  app_state_set(APP_LAUNCHER_IDLE);
+}
+
+static void serial_transport_begin() {
+  ws_state = WsState::Connecting;
+  serial_rx_line = "";
+  serial_rx_line.reserve(512);
+  serial_send_hello();               // greet immediately; resent until answered
+  serial_hello_next_ms = millis() + 1000;
+  Serial.println("[serial] transport begin — hello sent over USB CDC");
+}
+
+static void serial_transport_tick() {
+  // Heartbeat hello: announce ourselves fast (1 s) until the sidecar answers,
+  // then slowly (5 s) forever. The slow beat lets a *restarted* sidecar — or a
+  // reopened COM port — re-register this screen peer without a board reboot
+  // (`hello` is idempotent server-side). Issue #463.
+  if ((int32_t)(millis() - serial_hello_next_ms) >= 0) {
+    serial_send_hello();
+    serial_hello_next_ms = millis() + (serial_link_up ? 5000 : 1000);
+  }
+  // Pump inbound newline-delimited JSON frames into the shared dispatcher.
+  while (Serial.available() > 0) {
+    int c = Serial.read();
+    if (c < 0) break;
+    if (c == '\n') {
+      serial_rx_line.trim();  // strip trailing \r / whitespace
+      if (serial_rx_line.length() > 0) {
+        serial_mark_link_up();
+        dispatch_phase2_message(serial_rx_line);
+      }
+      serial_rx_line = "";
+    } else if (c != '\r') {
+      if (serial_rx_line.length() < 4096) {
+        serial_rx_line += (char)c;
+      } else {
+        serial_rx_line = "";  // overflow guard: drop a runaway unterminated line
+      }
+    }
+  }
+}
+#endif  // SCREEN_TRANSPORT_SERIAL
+
 void setup() {
   Serial.begin(115200);
   delay(250);
@@ -1086,10 +1187,15 @@ void setup() {
 #endif
 
   // WiFi.
+#if SCREEN_TRANSPORT_SERIAL
+  // Issue #463: USB-serial transport — no WiFi, no WebSocket, no hotspot.
+  serial_transport_begin();
+#else
   wifi_try_begin();
 
   // First WS attempt shortly after WiFi is up; the state machine handles it.
   ws_retry_at = millis() + 500;
+#endif
 }
 
 #if PHASE1_FALLBACK == 0
@@ -1126,7 +1232,7 @@ static void pt_request_drain() {
     }
     String out;
     serializeJson(doc, out);
-    ws.send(out);
+    transport_send(out);
     Serial.printf("[ws] -> %s\n", out.c_str());
   }
 }
@@ -1156,15 +1262,19 @@ static void se_request_drain() {
     }
     String out;
     serializeJson(doc, out);
-    ws.send(out);
+    transport_send(out);
     Serial.printf("[ws] -> %s\n", out.c_str());
   }
 }
 #endif
 
 void loop() {
+#if SCREEN_TRANSPORT_SERIAL
+  serial_transport_tick();
+#else
   wifi_tick();
   ws_tick();
+#endif
 #if PHASE1_FALLBACK == 0
   screen_pocket_technician_set_sidecar_link_up(ws_state == WsState::Open);
   screen_setup_exchange_set_sidecar_link_up(ws_state == WsState::Open);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
   "requests>=2.33.1",
   "websockets>=16.0",
   "lupa>=2.7",  # Lua runtime for HUD smoke tests (issue #66)
+  "pyserial>=3.5",  # USB-serial rig-screen transport (issue #463); lazy-imported by the sidecar
 ]
 mining = [
   # Security floor: requests 2.33.0+ fixes CVE-2026-25645 (surfaced in pip-audit with dev+mining+knowledge).
@@ -51,6 +52,7 @@ coaching = [
     "numpy>=2.4.4",
     "scikit-learn>=1.8.0",
     "shap>=0.51.0",
+    "pyserial>=3.5",  # USB-serial rig-screen transport (issue #463)
 ]
 # Issue #340: in-the-ear phrase-bank playback (lazy-imported in voice/playback.py).
 # Install on the rig to render/play clips: pip install -e ".[voice]".
@@ -90,6 +92,7 @@ launcher = [
   "numpy>=2.4.4",
   "sounddevice>=0.5.1",
   "pyttsx3>=2.90",
+  "pyserial>=3.5",  # sidecar USB-serial rig-screen transport (issue #463)
 ]
 # Issue #368: OFFLINE neural-voice bake (recommended Kokoro-82M backend, Apache-2.0). Used only by
 # the rig/dev bake step (tools/ai_sidecar/voice/bake.py KokoroBackend, lazy-imported); never on the

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -446,6 +446,8 @@ def test_external_bind_accepts_env_token(monkeypatch: pytest.MonkeyPatch) -> Non
         setup_store: str | None,
         setup_exchange_endpoint: str | None,
         user_setups_root: str | None,
+        serial_port: str | None,
+        serial_baud: int,
     ):
         seen.update(
             {
@@ -456,6 +458,8 @@ def test_external_bind_accepts_env_token(monkeypatch: pytest.MonkeyPatch) -> Non
                 "setup_store": setup_store,
                 "setup_exchange_endpoint": setup_exchange_endpoint,
                 "user_setups_root": user_setups_root,
+                "serial_port": serial_port,
+                "serial_baud": serial_baud,
             }
         )
 
@@ -481,6 +485,8 @@ def test_external_bind_accepts_env_token(monkeypatch: pytest.MonkeyPatch) -> Non
         "setup_store": None,
         "setup_exchange_endpoint": None,
         "user_setups_root": None,
+        "serial_port": None,
+        "serial_baud": 115200,
     }
 
 
@@ -498,8 +504,11 @@ def test_main_wires_voice_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         setup_store: str | None,
         setup_exchange_endpoint: str | None,
         user_setups_root: str | None,
+        serial_port: str | None,
+        serial_baud: int,
     ):
         del host, port, reply, token, setup_store, setup_exchange_endpoint, user_setups_root
+        del serial_port, serial_baud
 
     def fake_wire_voice(config: srv.VoiceRuntimeConfig) -> None:
         seen["ref_path"] = config.reference_path

--- a/tests/test_ai_sidecar_serial_transport.py
+++ b/tests/test_ai_sidecar_serial_transport.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import threading
 import time
 
@@ -273,7 +274,9 @@ def test_serial_reassembles_split_frame_and_dispatches_batch() -> None:
     assert asyncio.run(_run()) == 1
 
 
-def test_serial_skips_firmware_traces_and_malformed_frames() -> None:
+def test_serial_skips_firmware_traces_and_malformed_frames(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     async def _run() -> tuple[int, dict]:
         srv._reset_external_state()
         fake = _FakeSerial()
@@ -309,9 +312,15 @@ def test_serial_skips_firmware_traces_and_malformed_frames() -> None:
                 await task
             srv._reset_external_state()
 
-    screens, ack = asyncio.run(_run())
+    with caplog.at_level(logging.DEBUG, logger="tools.ai_sidecar.serial_transport"):
+        screens, ack = asyncio.run(_run())
     assert screens == 1
     assert ack["type"] == "hello_ack"
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    # A `[serial]`-prefixed firmware trace must NOT warn (it starts with '[', not '{').
+    assert not any("link up (sidecar answered)" in m for m in warnings), warnings
+    # A `{`-looking line that fails to parse IS a real malformed frame -> WARNING.
+    assert any("malformed json" in m for m in warnings), warnings
 
 
 def test_serial_disconnect_evicts_peer() -> None:

--- a/tests/test_ai_sidecar_serial_transport.py
+++ b/tests/test_ai_sidecar_serial_transport.py
@@ -132,7 +132,7 @@ def test_serial_peer_send_writes_ndjson() -> None:
     assert not srv._is_loopback_peer(peer)
 
 
-def test_open_serial_holds_dtr_rts_low_before_open() -> None:
+def test_open_serial_asserts_dtr_keeps_rts_low_before_open() -> None:
     import serial
 
     events: list[tuple[str, object]] = []
@@ -175,8 +175,8 @@ def test_open_serial_holds_dtr_rts_low_before_open() -> None:
         serial.Serial = original  # type: ignore[misc]
 
     open_event = next(e for e in events if e[0] == "open")
-    # DTR and RTS must both be LOW at the moment of open (no ESP32 auto-reset).
-    assert open_event[1] == (False, False)
+    # At open: DTR asserted (RX works on the S3 CDC), RTS low (no auto-reset).
+    assert open_event[1] == (True, False)
     assert ser.port == "COM9"
     assert ser.baudrate == 115200
 

--- a/tests/test_ai_sidecar_serial_transport.py
+++ b/tests/test_ai_sidecar_serial_transport.py
@@ -273,7 +273,7 @@ def test_serial_reassembles_split_frame_and_dispatches_batch() -> None:
     assert asyncio.run(_run()) == 1
 
 
-def test_serial_skips_malformed_json_line() -> None:
+def test_serial_skips_firmware_traces_and_malformed_frames() -> None:
     async def _run() -> tuple[int, dict]:
         srv._reset_external_state()
         fake = _FakeSerial()
@@ -288,8 +288,11 @@ def test_serial_skips_malformed_json_line() -> None:
             )
         )
         try:
-            # Garbage line must not kill the transport; a valid hello after it works.
-            fake.feed(b"not json at all\n")
+            # A firmware debug trace (shares the CDC) and a `{`-prefixed malformed
+            # frame must both be skipped without killing the transport; a valid
+            # hello after them still registers the screen (issue #463 demux).
+            fake.feed(b"[serial] link up (sidecar answered)\n")
+            fake.feed(b'{"v":1,"type":\n')  # looks like a frame but is broken
             fake.feed(
                 json.dumps(
                     {"v": 1, "type": "hello", "client": "screen", "client_class": "screen"}

--- a/tests/test_ai_sidecar_serial_transport.py
+++ b/tests/test_ai_sidecar_serial_transport.py
@@ -24,6 +24,8 @@ import json
 import threading
 import time
 
+import pytest
+
 from tools.ai_sidecar import server as srv
 from tools.ai_sidecar.serial_transport import (
     SerialPeer,
@@ -133,7 +135,9 @@ def test_serial_peer_send_writes_ndjson() -> None:
 
 
 def test_open_serial_asserts_dtr_keeps_rts_low_before_open() -> None:
-    import serial
+    # pyserial is an optional runtime dep (lazy-imported by open_serial); skip when
+    # it is not installed, like the duckdb/sentence-transformers tests.
+    serial = pytest.importorskip("serial")
 
     events: list[tuple[str, object]] = []
 

--- a/tests/test_ai_sidecar_serial_transport.py
+++ b/tests/test_ai_sidecar_serial_transport.py
@@ -1,0 +1,344 @@
+"""USB-serial screen transport tests for the AI sidecar (issue #463).
+
+Covers the serial peer adapter that lets the ESP32 screen speak protocol v1 over
+USB CDC instead of WebSocket (removing the Windows Mobile Hotspot dependency):
+
+- ``SerialPeer.send`` writes newline-delimited JSON.
+- ``open_serial`` holds DTR/RTS LOW *before* ``open()`` so the ESP32-S3 does not reset.
+- End-to-end: a ``hello`` read from the port registers a screen peer, a ``hello_ack``
+  is written back, and a hub ``_broadcast_external`` frame reaches the serial peer.
+- Newline framing reassembles a frame split across reads and dispatches two frames
+  from one chunk.
+- A malformed JSON line is skipped without killing the transport.
+- A serial error evicts the peer via ``on_peer_gone``.
+
+Tests use plain ``asyncio.run`` + an injected fake serial — no hardware, no
+pytest-asyncio dependency (matching ``test_ai_sidecar_external.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import threading
+import time
+
+from tools.ai_sidecar import server as srv
+from tools.ai_sidecar.serial_transport import (
+    SerialPeer,
+    open_serial,
+    run_serial_transport,
+)
+
+
+class _FakeSerial:
+    """In-memory pyserial stand-in: ``feed`` inbound bytes, inspect ``written``."""
+
+    def __init__(self, preload: bytes = b"") -> None:
+        self._cond = threading.Condition()
+        self._inbuf = bytearray(preload)
+        self._written = bytearray()
+        self._fail = False
+        self.closed = False
+
+    # --- test-facing API ---
+    def feed(self, data: bytes) -> None:
+        with self._cond:
+            self._inbuf.extend(data)
+            self._cond.notify_all()
+
+    def fail(self) -> None:
+        """Simulate a USB unplug: subsequent reads raise."""
+        with self._cond:
+            self._fail = True
+            self._cond.notify_all()
+
+    def pop_written(self) -> bytes:
+        with self._cond:
+            out = bytes(self._written)
+            self._written.clear()
+            return out
+
+    # --- pyserial-like API used by the transport ---
+    @property
+    def in_waiting(self) -> int:
+        with self._cond:
+            if self._fail:
+                raise OSError("device disconnected")
+            return len(self._inbuf)
+
+    def read(self, size: int = 1) -> bytes:
+        with self._cond:
+            if self._fail:
+                raise OSError("device disconnected")
+            if not self._inbuf:
+                self._cond.wait(timeout=0.05)  # emulate read timeout
+                if self._fail:
+                    raise OSError("device disconnected")
+                if not self._inbuf:
+                    return b""
+            take = min(size, len(self._inbuf))
+            out = bytes(self._inbuf[:take])
+            del self._inbuf[:take]
+            return out
+
+    def write(self, data: bytes) -> int:
+        with self._cond:
+            self._written.extend(data)
+            return len(data)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        with self._cond:
+            self.closed = True
+            self._cond.notify_all()
+
+
+async def _next_frame(fake: _FakeSerial, buf: bytearray, timeout: float = 2.0) -> dict:
+    """Await the next complete NDJSON frame written to ``fake``."""
+    deadline = time.monotonic() + timeout
+    while True:
+        buf.extend(fake.pop_written())
+        nl = buf.find(b"\n")
+        if nl >= 0:
+            line = bytes(buf[:nl])
+            del buf[: nl + 1]
+            return json.loads(line)
+        if time.monotonic() > deadline:
+            raise AssertionError("no NDJSON frame written before timeout")
+        await asyncio.sleep(0.02)
+
+
+async def _wait_for(predicate, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise AssertionError("condition not met before timeout")
+        await asyncio.sleep(0.02)
+
+
+def test_serial_peer_send_writes_ndjson() -> None:
+    written: list[bytes] = []
+    peer = SerialPeer("COM_TEST", written.append)
+
+    asyncio.run(peer.send(json.dumps({"v": 1, "type": "hello_ack"})))
+
+    assert written == [b'{"v": 1, "type": "hello_ack"}\n']
+    # Non-loopback marker so the screen is classified as an external client.
+    assert peer.remote_address == "serial:COM_TEST"
+    assert not srv._is_loopback_peer(peer)
+
+
+def test_open_serial_holds_dtr_rts_low_before_open() -> None:
+    import serial
+
+    events: list[tuple[str, object]] = []
+
+    class _RecordingSerial:
+        def __init__(self) -> None:
+            self._dtr: object = None
+            self._rts: object = None
+            self.port: object = None
+            self.baudrate: object = None
+            self.timeout: object = None
+            self.write_timeout: object = None
+
+        @property
+        def dtr(self) -> object:
+            return self._dtr
+
+        @dtr.setter
+        def dtr(self, value: object) -> None:
+            self._dtr = value
+            events.append(("dtr", value))
+
+        @property
+        def rts(self) -> object:
+            return self._rts
+
+        @rts.setter
+        def rts(self, value: object) -> None:
+            self._rts = value
+            events.append(("rts", value))
+
+        def open(self) -> None:
+            events.append(("open", (self._dtr, self._rts)))
+
+    original = serial.Serial
+    serial.Serial = _RecordingSerial  # type: ignore[misc,assignment]
+    try:
+        ser = open_serial("COM9", 115200)
+    finally:
+        serial.Serial = original  # type: ignore[misc]
+
+    open_event = next(e for e in events if e[0] == "open")
+    # DTR and RTS must both be LOW at the moment of open (no ESP32 auto-reset).
+    assert open_event[1] == (False, False)
+    assert ser.port == "COM9"
+    assert ser.baudrate == 115200
+
+
+def test_serial_hello_registers_screen_peer_and_receives_broadcast() -> None:
+    async def _run() -> tuple[dict, dict, tuple[int, int]]:
+        srv._reset_external_state()
+        fake = _FakeSerial()
+        task = asyncio.create_task(
+            run_serial_transport(
+                port="COM_TEST",
+                baud=115200,
+                handle_frame=srv._handle_external_frame,
+                on_peer_gone=srv._drop_external_peer,
+                serial_factory=lambda _port, _baud: fake,
+                reconnect_delay=0.01,
+            )
+        )
+        try:
+            fake.feed(
+                json.dumps(
+                    {
+                        "v": 1,
+                        "type": "hello",
+                        "client": "ac-copilot-screen-01",
+                        "client_class": "screen",
+                    }
+                ).encode()
+                + b"\n"
+            )
+            buf = bytearray()
+            ack = await _next_frame(fake, buf)
+            await _wait_for(lambda: srv._peer_counts() == (1, 1))
+            counts = srv._peer_counts()
+            await srv._broadcast_external(
+                {
+                    "v": 1,
+                    "type": "state.snapshot",
+                    "topic": "coaching.snapshot",
+                    "payload": {"corner": 3},
+                },
+                exclude=None,
+            )
+            snap = await _next_frame(fake, buf)
+            return ack, snap, counts
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            srv._reset_external_state()
+
+    ack, snap, counts = asyncio.run(_run())
+    assert ack["type"] == "hello_ack"
+    assert counts == (1, 1)
+    assert snap["type"] == "state.snapshot"
+    assert snap["topic"] == "coaching.snapshot"
+    assert snap["payload"] == {"corner": 3}
+
+
+def test_serial_reassembles_split_frame_and_dispatches_batch() -> None:
+    async def _run() -> int:
+        srv._reset_external_state()
+        fake = _FakeSerial()
+        task = asyncio.create_task(
+            run_serial_transport(
+                port="COM_TEST",
+                baud=115200,
+                handle_frame=srv._handle_external_frame,
+                on_peer_gone=srv._drop_external_peer,
+                serial_factory=lambda _p, _b: fake,
+                reconnect_delay=0.01,
+            )
+        )
+        try:
+            hello = json.dumps(
+                {"v": 1, "type": "hello", "client": "screen", "client_class": "screen"}
+            ).encode()
+            # Frame split across two reads: no newline in the first chunk.
+            fake.feed(hello[:10])
+            await asyncio.sleep(0.05)
+            fake.feed(hello[10:] + b"\n")
+            await _wait_for(lambda: srv._peer_counts() == (1, 1))
+            return srv._peer_counts()[1]
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            srv._reset_external_state()
+
+    assert asyncio.run(_run()) == 1
+
+
+def test_serial_skips_malformed_json_line() -> None:
+    async def _run() -> tuple[int, dict]:
+        srv._reset_external_state()
+        fake = _FakeSerial()
+        task = asyncio.create_task(
+            run_serial_transport(
+                port="COM_TEST",
+                baud=115200,
+                handle_frame=srv._handle_external_frame,
+                on_peer_gone=srv._drop_external_peer,
+                serial_factory=lambda _p, _b: fake,
+                reconnect_delay=0.01,
+            )
+        )
+        try:
+            # Garbage line must not kill the transport; a valid hello after it works.
+            fake.feed(b"not json at all\n")
+            fake.feed(
+                json.dumps(
+                    {"v": 1, "type": "hello", "client": "screen", "client_class": "screen"}
+                ).encode()
+                + b"\n"
+            )
+            buf = bytearray()
+            ack = await _next_frame(fake, buf)
+            await _wait_for(lambda: srv._peer_counts() == (1, 1))
+            return srv._peer_counts()[1], ack
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            srv._reset_external_state()
+
+    screens, ack = asyncio.run(_run())
+    assert screens == 1
+    assert ack["type"] == "hello_ack"
+
+
+def test_serial_disconnect_evicts_peer() -> None:
+    async def _run() -> tuple[int, int]:
+        srv._reset_external_state()
+        fake = _FakeSerial()
+        task = asyncio.create_task(
+            run_serial_transport(
+                port="COM_TEST",
+                baud=115200,
+                handle_frame=srv._handle_external_frame,
+                on_peer_gone=srv._drop_external_peer,
+                serial_factory=lambda _p, _b: fake,
+                reconnect_delay=600,  # do not reconnect within the test window
+            )
+        )
+        try:
+            fake.feed(
+                json.dumps(
+                    {"v": 1, "type": "hello", "client": "screen", "client_class": "screen"}
+                ).encode()
+                + b"\n"
+            )
+            await _wait_for(lambda: srv._peer_counts() == (1, 1))
+            before = srv._peer_counts()[0]
+            fake.fail()  # simulate USB unplug
+            await _wait_for(lambda: srv._peer_counts() == (0, 0))
+            return before, srv._peer_counts()[0]
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            srv._reset_external_state()
+
+    before, after = asyncio.run(_run())
+    assert before == 1
+    assert after == 0

--- a/tests/test_ai_sidecar_serial_transport.py
+++ b/tests/test_ai_sidecar_serial_transport.py
@@ -97,9 +97,9 @@ class _FakeSerial:
             self._cond.notify_all()
 
 
-async def _next_frame(fake: _FakeSerial, buf: bytearray, timeout: float = 2.0) -> dict:
+async def _next_frame(fake: _FakeSerial, buf: bytearray, max_wait: float = 2.0) -> dict:
     """Await the next complete NDJSON frame written to ``fake``."""
-    deadline = time.monotonic() + timeout
+    deadline = time.monotonic() + max_wait
     while True:
         buf.extend(fake.pop_written())
         nl = buf.find(b"\n")
@@ -112,8 +112,8 @@ async def _next_frame(fake: _FakeSerial, buf: bytearray, timeout: float = 2.0) -
         await asyncio.sleep(0.02)
 
 
-async def _wait_for(predicate, timeout: float = 2.0) -> None:
-    deadline = time.monotonic() + timeout
+async def _wait_for(predicate, max_wait: float = 2.0) -> None:
+    deadline = time.monotonic() + max_wait
     while not predicate():
         if time.monotonic() > deadline:
             raise AssertionError("condition not met before timeout")

--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -28,7 +28,6 @@ from tools.rig_launcher.install import (
 )
 from tools.rig_launcher.settings import LauncherSettings, ensure_settings_file
 from tools.rig_launcher.supervisor import (
-    _HOTSPOT_PROBE_SCRIPT,
     _WINDOWS_NO_WINDOW,
     GamePointConfig,
     GamePointStatus,
@@ -127,6 +126,24 @@ def test_sidecar_command_uses_env_for_token_and_voice(tmp_path: Path) -> None:
     assert env["AC_COPILOT_REFERENCE_ARCHIVE"] == str((tmp_path / "ref.json").resolve())
     assert env["AC_COPILOT_VOICE_BANK"] == str((tmp_path / "voice-bank").resolve())
     assert env["AC_COPILOT_VOICE_TTS"] == "1"
+
+
+def test_sidecar_command_includes_serial_port_when_configured(tmp_path: Path) -> None:
+    """Issue #463: the launcher forwards --serial-port so the screen uses USB, not hotspot."""
+    cfg = GamePointConfig(serial_port="COM6", paths=LauncherPaths(tmp_path))
+    sup = GamePointSupervisor(cfg, environ={}, python_executable="python")
+
+    command = sup.sidecar_command()
+
+    assert command[-2:] == ["--serial-port", "COM6"]
+
+
+def test_config_reads_serial_port_from_env(tmp_path: Path) -> None:
+    cfg = GamePointConfig.from_env(
+        {"AC_COPILOT_SIDECAR_SERIAL_PORT": "COM6"},
+        paths=LauncherPaths(tmp_path),
+    )
+    assert cfg.serial_port == "COM6"
 
 
 def test_frozen_sidecar_command_uses_bundled_child_mode(tmp_path: Path) -> None:
@@ -1159,53 +1176,6 @@ def test_sidecar_child_entrypoint_rewrites_sys_argv(monkeypatch) -> None:
     assert seen["argv"] == ["ai_sidecar", "--port", "8765"]
 
 
-def test_hotspot_probe_parses_windows_state(tmp_path: Path) -> None:
-    cfg = GamePointConfig(paths=LauncherPaths(tmp_path))
-
-    def fake_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"state":"On","client_count":1}',
-            stderr="",
-        )
-
-    sup = GamePointSupervisor(cfg, run=fake_run)
-    result = sup.probe_hotspot()
-
-    if result.state == "skipped":
-        assert result.ok is True
-    else:
-        assert result.ok is True
-        assert result.state == "on"
-        assert "clients=1" in result.detail
-
-
-def test_hotspot_probe_failure_is_non_blocking(monkeypatch, tmp_path: Path) -> None:
-    cfg = GamePointConfig(paths=LauncherPaths(tmp_path))
-    monkeypatch.setattr(supervisor_module.os, "name", "nt")
-
-    def fake_run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(
-            args=[],
-            returncode=1,
-            stdout="",
-            stderr="Wi-Fi adapter not found",
-        )
-
-    sup = GamePointSupervisor(cfg, run=fake_run)
-    result = sup.probe_hotspot()
-
-    assert result.ok is True
-    assert result.state == "unavailable"
-    assert "Wi-Fi adapter" in result.detail
-
-
-def test_hotspot_probe_falls_back_without_internet_profile() -> None:
-    assert "GetConnectionProfiles() | Select-Object -First 1" in _HOTSPOT_PROBE_SCRIPT
-    assert "No network connection profile found for Mobile Hotspot." in _HOTSPOT_PROBE_SCRIPT
-
-
 def test_run_gui_falls_back_when_tk_init_fails(monkeypatch, capsys) -> None:
     tk_mod = types.ModuleType("tkinter")
     ttk_mod = types.ModuleType("tkinter.ttk")
@@ -1224,7 +1194,6 @@ def test_run_gui_falls_back_when_tk_init_fails(monkeypatch, capsys) -> None:
         generated_at=0.0,
         sidecar=ok,
         screen=ProbeResult("screen", True, "connected"),
-        hotspot=ProbeResult("hotspot", True, "skipped"),
         voice=ProbeResult("voice", True, "skipped"),
         simhub=ProbeResult("simhub", True, "absent"),
         log_path="sidecar.log",

--- a/tests/test_rig_launcher_theme.py
+++ b/tests/test_rig_launcher_theme.py
@@ -39,8 +39,6 @@ def test_tone_for_maps_states_to_signals() -> None:
     assert theme.tone_for(True, "healthy") == "clear"
     assert theme.tone_for(True, "connected") == "clear"
     assert theme.tone_for(True, "enabled") == "clear"
-    # a healthy hotspot "on" is lit green, not amber (matches the design mock)
-    assert theme.tone_for(True, "on") == "clear"
     # present-but-quiescent rows are demoted, not lit green
     assert theme.tone_for(True, "absent") == "idle"
     assert theme.tone_for(True, "skipped") == "idle"
@@ -74,7 +72,6 @@ def _status(**overrides: ProbeResult) -> GamePointStatus:
     rows: dict[str, ProbeResult] = {
         "sidecar": ProbeResult("sidecar", True, "healthy", "peers=1 screen_peers=1"),
         "screen": ProbeResult("screen", True, "connected", "screen_peers=1"),
-        "hotspot": ProbeResult("hotspot", True, "on", "state=On clients=1"),
         "voice": ProbeResult("voice", True, "enabled", "backend=sounddevice"),
         "simhub": ProbeResult("simhub", True, "absent", "executable not found"),
     }
@@ -91,7 +88,7 @@ def test_summary_for_ready_state() -> None:
     assert theme.summary_for(_status()) == (
         "READY TO DRIVE",
         "clear",
-        "sidecar · screen · hotspot live",
+        "sidecar · screen live",
     )
 
 
@@ -131,7 +128,6 @@ def test_summary_for_blocking_preflight_outranks_port_copy() -> None:
         generated_at=status.generated_at,
         sidecar=status.sidecar,
         screen=status.screen,
-        hotspot=status.hotspot,
         voice=status.voice,
         simhub=status.simhub,
         log_path=status.log_path,

--- a/tools/ai_sidecar/serial_transport.py
+++ b/tools/ai_sidecar/serial_transport.py
@@ -146,9 +146,7 @@ def _spawn_reader(
                     if text:
                         _push((text, None))
                 if len(buf) > _MAX_LINE_BYTES:
-                    logger.warning(
-                        "serial %s: dropping %d bytes with no newline", port, len(buf)
-                    )
+                    logger.warning("serial %s: dropping %d bytes with no newline", port, len(buf))
                     buf.clear()
         finally:
             _push((_DISCONNECT, "reader-exit"))

--- a/tools/ai_sidecar/serial_transport.py
+++ b/tools/ai_sidecar/serial_transport.py
@@ -202,10 +202,19 @@ async def run_serial_transport(
                 if item is _DISCONNECT:
                     logger.info("serial %s: disconnect (%s)", port, meta)
                     break
+                # The firmware shares this CDC for both protocol frames and plain-text
+                # debug prints (`[serial] …`, `[boot] …`). Demultiplex: only a line that
+                # looks like a JSON object/array is a protocol frame; anything else is a
+                # firmware trace — log it at DEBUG, never WARNING (issue #463 log-spam fix).
+                if not item.lstrip().startswith(("{", "[")):
+                    logger.debug("serial %s [fw]: %s", port, item[:200])
+                    continue
                 try:
                     data = json.loads(item)
                 except json.JSONDecodeError:
-                    logger.warning("serial %s: invalid json (first 200): %s", port, item[:200])
+                    logger.warning(
+                        "serial %s: malformed json frame (first 200): %s", port, item[:200]
+                    )
                     continue
                 if not isinstance(data, dict):
                     logger.warning(

--- a/tools/ai_sidecar/serial_transport.py
+++ b/tools/ai_sidecar/serial_transport.py
@@ -203,10 +203,12 @@ async def run_serial_transport(
                     logger.info("serial %s: disconnect (%s)", port, meta)
                     break
                 # The firmware shares this CDC for both protocol frames and plain-text
-                # debug prints (`[serial] …`, `[boot] …`). Demultiplex: only a line that
-                # looks like a JSON object/array is a protocol frame; anything else is a
-                # firmware trace — log it at DEBUG, never WARNING (issue #463 log-spam fix).
-                if not item.lstrip().startswith(("{", "[")):
+                # debug prints (`[serial] …`, `[ws] …`, `[boot] …`). Demultiplex: every
+                # protocol v1 frame is a JSON *object* (`{`) — never an array — so a line
+                # that doesn't start with `{` is a firmware trace. (Matching `[` too would
+                # be self-defeating: the debug tags themselves start with `[`.) Log traces
+                # at DEBUG, never WARNING (issue #463 log-spam fix).
+                if not item.lstrip().startswith("{"):
                     logger.debug("serial %s [fw]: %s", port, item[:200])
                     continue
                 try:

--- a/tools/ai_sidecar/serial_transport.py
+++ b/tools/ai_sidecar/serial_transport.py
@@ -1,0 +1,230 @@
+"""USB CDC serial transport for the rig screen (issue #463).
+
+Lets the ESP32 screen speak the **same** protocol-v1 ``{v,type}`` envelope over a
+USB CDC serial link instead of WebSocket, removing the Windows Mobile Hotspot
+dependency. On single-radio WiFi adapters (e.g. the rig PC's Intel AC 7260),
+hosting a 2.4 GHz SoftAP for the ESP32 while the client is on 5 GHz forces one
+radio onto two bands and drops the main WiFi (it will not reconnect). USB has no
+such conflict — the board already enumerates as a native CDC port.
+
+Design: this is a thin **peer adapter**, not a transport refactor. The sidecar's
+:func:`server._handle_external_frame` is already transport-agnostic (it dispatches
+a parsed ``dict`` against any peer object that exposes an async ``send(str)``),
+and :func:`server._broadcast_external` fans out via the same ``send``. So the
+serial path only needs:
+
+* :class:`SerialPeer` — an ``_external_peers``-compatible peer whose ``send``
+  writes newline-delimited JSON to the port, with a non-loopback
+  ``remote_address`` so the screen is classified as an external client (matching
+  the WS screen peer).
+* :func:`run_serial_transport` — opens the port with **DTR/RTS held LOW** (so the
+  ESP32-S3 native USB CDC does not auto-reset on open — verified live on COM6),
+  reads NDJSON frames on a background thread, and feeds each into the injected
+  ``handle_frame(peer, data)`` coroutine. It reconnects on USB drop/replug.
+
+``pyserial`` is imported lazily inside :func:`open_serial` so the sidecar core
+stays dependency-free for users who never enable the serial transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BAUD = 115_200
+# Native USB CDC ignores baud, but pyserial still requires a value.
+_READ_TIMEOUT_S = 0.2
+_WRITE_TIMEOUT_S = 2.0
+_RECONNECT_DELAY_S = 2.0
+# Drop a partial line that never terminates rather than grow unbounded.
+_MAX_LINE_BYTES = 1_000_000
+
+# Pushed onto the inbound queue by the reader thread to signal disconnect.
+_DISCONNECT = object()
+
+FrameHandler = Callable[[Any, dict[str, Any]], Awaitable[None]]
+PeerGoneCallback = Callable[[Any], None]
+SerialFactory = Callable[[str, int], Any]
+
+
+class SerialPeer:
+    """A fan-out peer backed by a serial port.
+
+    Implements only the surface the sidecar hub uses: an async ``send(str)`` and a
+    ``remote_address``. ``remote_address`` is a ``serial:<port>`` marker string —
+    :func:`server._peer_host` returns it verbatim and :func:`server._is_loopback`
+    treats it as non-loopback, so the screen is handled as an external client
+    exactly like the WebSocket screen peer.
+    """
+
+    def __init__(self, port_name: str, write_bytes: Callable[[bytes], None]) -> None:
+        self.remote_address = f"serial:{port_name}"
+        self._write_bytes = write_bytes
+        self._write_lock = asyncio.Lock()
+
+    async def send(self, payload: str) -> None:
+        """Write one NDJSON frame to the port (blocking write offloaded to a thread)."""
+        line = payload.encode("utf-8") + b"\n"
+        async with self._write_lock:
+            await asyncio.to_thread(self._write_bytes, line)
+
+    async def close(self) -> None:  # parity with websocket.close(); the port is owned by the loop
+        return None
+
+
+def open_serial(port: str, baud: int) -> Any:
+    """Open ``port`` with DTR/RTS held LOW so the ESP32-S3 does not reset on open.
+
+    ``pyserial`` asserts DTR/RTS on open by default, which pulses the ESP32 auto-reset
+    circuit. Setting them ``False`` **before** ``open()`` configures the initial line
+    state so the board keeps running across a sidecar (re)connect.
+    """
+    import serial  # lazy: only required when the serial transport is enabled
+
+    ser = serial.Serial()
+    ser.port = port
+    ser.baudrate = baud
+    ser.timeout = _READ_TIMEOUT_S
+    ser.write_timeout = _WRITE_TIMEOUT_S
+    ser.dtr = False
+    ser.rts = False
+    ser.open()
+    # Some drivers only apply line state after open; reassert defensively.
+    try:
+        ser.dtr = False
+        ser.rts = False
+    except OSError:
+        pass
+    return ser
+
+
+def _spawn_reader(
+    ser: Any,
+    loop: asyncio.AbstractEventLoop,
+    inbound: asyncio.Queue,
+    reader_stop: threading.Event,
+    port: str,
+) -> threading.Thread:
+    """Background thread: accumulate bytes, split on newlines, hand lines to the loop.
+
+    Explicit newline framing (not ``readline``) so a read timeout mid-frame cannot
+    fragment a JSON object into two malformed lines.
+    """
+
+    def _push(item: Any) -> None:
+        loop.call_soon_threadsafe(inbound.put_nowait, item)
+
+    def _reader() -> None:
+        buf = bytearray()
+        try:
+            while not reader_stop.is_set():
+                try:
+                    waiting = ser.in_waiting
+                    chunk = ser.read(waiting if waiting and waiting > 0 else 1)
+                except Exception as exc:  # noqa: BLE001 - any serial error ends this session
+                    _push((_DISCONNECT, repr(exc)))
+                    return
+                if not chunk:
+                    continue  # read timeout with no data — keep polling
+                buf.extend(chunk)
+                while True:
+                    nl = buf.find(b"\n")
+                    if nl < 0:
+                        break
+                    line = bytes(buf[:nl])
+                    del buf[: nl + 1]
+                    text = line.decode("utf-8", "replace").strip()
+                    if text:
+                        _push((text, None))
+                if len(buf) > _MAX_LINE_BYTES:
+                    logger.warning(
+                        "serial %s: dropping %d bytes with no newline", port, len(buf)
+                    )
+                    buf.clear()
+        finally:
+            _push((_DISCONNECT, "reader-exit"))
+
+    thread = threading.Thread(target=_reader, name=f"serial-reader-{port}", daemon=True)
+    thread.start()
+    return thread
+
+
+async def run_serial_transport(
+    *,
+    port: str,
+    baud: int = DEFAULT_BAUD,
+    handle_frame: FrameHandler,
+    on_peer_gone: PeerGoneCallback | None = None,
+    serial_factory: SerialFactory = open_serial,
+    reconnect_delay: float = _RECONNECT_DELAY_S,
+) -> None:
+    """Serve the screen over ``port`` until cancelled, reconnecting on USB drop.
+
+    Each inbound NDJSON line is parsed and dispatched through ``handle_frame`` (the
+    sidecar's :func:`server._handle_external_frame`), so the screen registers itself
+    with a ``hello`` frame and receives ``hello_ack`` / fan-out exactly like a WS peer.
+    ``on_peer_gone`` is invoked when the port disconnects so the caller can evict the
+    peer from the fan-out set. ``serial_factory`` is injectable for tests.
+    """
+    loop = asyncio.get_running_loop()
+    while True:
+        try:
+            ser = await asyncio.to_thread(serial_factory, port, baud)
+        except Exception as exc:  # noqa: BLE001 - open failure is retryable, not fatal
+            logger.warning(
+                "serial %s: open failed (%s); retrying in %.1fs", port, exc, reconnect_delay
+            )
+            await asyncio.sleep(reconnect_delay)
+            continue
+
+        logger.info("serial transport open port=%s baud=%s (DTR/RTS low)", port, baud)
+        inbound: asyncio.Queue = asyncio.Queue()
+        reader_stop = threading.Event()
+        _spawn_reader(ser, loop, inbound, reader_stop, port)
+
+        def _write_bytes(data: bytes, _ser: Any = ser) -> None:
+            _ser.write(data)
+            flush = getattr(_ser, "flush", None)
+            if callable(flush):
+                flush()
+
+        peer = SerialPeer(port, _write_bytes)
+        try:
+            while True:
+                item, meta = await inbound.get()
+                if item is _DISCONNECT:
+                    logger.info("serial %s: disconnect (%s)", port, meta)
+                    break
+                try:
+                    data = json.loads(item)
+                except json.JSONDecodeError:
+                    logger.warning("serial %s: invalid json (first 200): %s", port, item[:200])
+                    continue
+                if not isinstance(data, dict):
+                    logger.warning(
+                        "serial %s: json root must be object, got %s", port, type(data).__name__
+                    )
+                    continue
+                try:
+                    await handle_frame(peer, data)
+                except Exception:  # noqa: BLE001 - one bad frame must not kill the transport
+                    logger.exception("serial %s: handle_frame failed", port)
+        finally:
+            reader_stop.set()
+            if on_peer_gone is not None:
+                try:
+                    on_peer_gone(peer)
+                except Exception:  # noqa: BLE001
+                    logger.exception("serial %s: on_peer_gone failed", port)
+            try:
+                await asyncio.to_thread(ser.close)
+            except Exception:  # noqa: BLE001
+                logger.debug("serial %s: close raised", port, exc_info=True)
+
+        await asyncio.sleep(reconnect_delay)

--- a/tools/ai_sidecar/serial_transport.py
+++ b/tools/ai_sidecar/serial_transport.py
@@ -17,9 +17,9 @@ serial path only needs:
   writes newline-delimited JSON to the port, with a non-loopback
   ``remote_address`` so the screen is classified as an external client (matching
   the WS screen peer).
-* :func:`run_serial_transport` — opens the port with **DTR/RTS held LOW** (so the
-  ESP32-S3 native USB CDC does not auto-reset on open — verified live on COM6),
-  reads NDJSON frames on a background thread, and feeds each into the injected
+* :func:`run_serial_transport` — opens the port with **DTR asserted, RTS low** (RX
+  works and the ESP32-S3 does not auto-reset — both verified live on COM6), reads
+  NDJSON frames on a background thread, and feeds each into the injected
   ``handle_frame(peer, data)`` coroutine. It reconnects on USB drop/replug.
 
 ``pyserial`` is imported lazily inside :func:`open_serial` so the sidecar core
@@ -79,11 +79,14 @@ class SerialPeer:
 
 
 def open_serial(port: str, baud: int) -> Any:
-    """Open ``port`` with DTR/RTS held LOW so the ESP32-S3 does not reset on open.
+    """Open ``port`` with DTR asserted and RTS low — RX works, board does not reset.
 
-    ``pyserial`` asserts DTR/RTS on open by default, which pulses the ESP32 auto-reset
-    circuit. Setting them ``False`` **before** ``open()`` configures the initial line
-    state so the board keeps running across a sidecar (re)connect.
+    On the ESP32-S3 native USB CDC, the device only delivers host→device (RX) bytes
+    to the sketch once the host asserts **DTR** ("terminal ready"); with DTR low the
+    board never sees the sidecar's frames (verified live: it kept re-``hello``-ing).
+    The board's auto-reset is driven by the **RTS** line pulse (and pyserial/.NET's
+    default of toggling *both* on open), not by a steady DTR — so DTR=True + RTS=False,
+    applied **before** ``open()`` as a steady state, gives working RX with no reset.
     """
     import serial  # lazy: only required when the serial transport is enabled
 
@@ -92,13 +95,13 @@ def open_serial(port: str, baud: int) -> Any:
     ser.baudrate = baud
     ser.timeout = _READ_TIMEOUT_S
     ser.write_timeout = _WRITE_TIMEOUT_S
-    ser.dtr = False
-    ser.rts = False
+    ser.rts = False  # never pulse RTS -> no ESP32 auto-reset
+    ser.dtr = True  # assert DTR so the S3 CDC delivers RX to the firmware
     ser.open()
     # Some drivers only apply line state after open; reassert defensively.
     try:
-        ser.dtr = False
         ser.rts = False
+        ser.dtr = True
     except OSError:
         pass
     return ser
@@ -183,7 +186,7 @@ async def run_serial_transport(
             await asyncio.sleep(reconnect_delay)
             continue
 
-        logger.info("serial transport open port=%s baud=%s (DTR/RTS low)", port, baud)
+        logger.info("serial transport open port=%s baud=%s (DTR high, RTS low)", port, baud)
         inbound: asyncio.Queue = asyncio.Queue()
         reader_stop = threading.Event()
         _spawn_reader(ser, loop, inbound, reader_stop, port)

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import errno
 import ipaddress
 import json
@@ -853,6 +854,18 @@ def _release_observer_feed(websocket: Any) -> None:
             _coach_runtime.reset()
         if _race_manager is not None:
             _race_manager.reset()
+
+
+def _drop_external_peer(peer: Any) -> None:
+    """Evict a peer from the fan-out set and release any observer feed it owned.
+
+    The WebSocket path evicts inline (send failure in ``_broadcast_targets`` and
+    ``_handler`` teardown). The serial transport (issue #463) has no such loop, so it
+    calls this when the USB link drops.
+    """
+    _external_peers.discard(peer)
+    _external_peer_classes.pop(peer, None)
+    _release_observer_feed(peer)
 
 
 async def _broadcast_targets(frame: dict[str, Any], *, targets: list[Any]) -> None:
@@ -1894,6 +1907,27 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
             await asyncio.gather(*pending_followups, return_exceptions=True)
 
 
+def _maybe_start_serial(serial_port: str | None, serial_baud: int) -> asyncio.Task[Any] | None:
+    """Start the optional USB-serial screen transport (issue #463) on the running loop.
+
+    Returns the task so the caller can cancel it on shutdown. Imported lazily so the
+    sidecar core (and its pyserial dependency) stays optional for WS-only deployments.
+    """
+    if not serial_port:
+        return None
+    from tools.ai_sidecar.serial_transport import run_serial_transport
+
+    logger.info("serial transport enabled port=%s baud=%s", serial_port, serial_baud)
+    return asyncio.create_task(
+        run_serial_transport(
+            port=serial_port,
+            baud=serial_baud,
+            handle_frame=_handle_external_frame,
+            on_peer_gone=_drop_external_peer,
+        )
+    )
+
+
 async def _run(
     host: str,
     port: int,
@@ -1902,6 +1936,8 @@ async def _run(
     setup_store: str | None = None,
     setup_exchange_endpoint: str | None = None,
     user_setups_root: str | None = None,
+    serial_port: str | None = None,
+    serial_baud: int = 115_200,
 ) -> None:
     global _setup_exchange_endpoint, _setup_exchange_user_setups_root
     global _setup_experiment_store_path, _setup_experiment_store_seeded
@@ -1935,7 +1971,14 @@ async def _run(
                     reply_coaching,
                     "set" if token else "unset",
                 )
-                await asyncio.Future()
+                serial_task = _maybe_start_serial(serial_port, serial_baud)
+                try:
+                    await asyncio.Future()
+                finally:
+                    if serial_task is not None:
+                        serial_task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await serial_task
         except OSError as exc:
             # WinError 10048 / errno EADDRINUSE: another sidecar already owns the port. Exit
             # cleanly with a one-line reason instead of a traceback — a frozen --noconsole build
@@ -2403,6 +2446,25 @@ def main() -> None:
             "Falls back to $AC_COPILOT_VOICE_VOLUME."
         ),
     )
+    p.add_argument(
+        "--serial-port",
+        default=os.environ.get("AC_COPILOT_SIDECAR_SERIAL_PORT"),
+        help=(
+            "Issue #463: COM port for the USB-serial rig-screen transport (e.g. COM6). "
+            "When set, the screen speaks protocol v1 over USB CDC instead of WebSocket, "
+            "removing the Windows Mobile Hotspot dependency. "
+            "Falls back to $AC_COPILOT_SIDECAR_SERIAL_PORT. Requires the `pyserial` package."
+        ),
+    )
+    p.add_argument(
+        "--serial-baud",
+        type=int,
+        default=int(os.environ.get("AC_COPILOT_SIDECAR_SERIAL_BAUD") or 115200),
+        help=(
+            "Baud for --serial-port. Native ESP32-S3 USB CDC ignores baud, so the default "
+            "(115200) is fine. Falls back to $AC_COPILOT_SIDECAR_SERIAL_BAUD."
+        ),
+    )
     args = p.parse_args()
     if args.compare_laps:
         _run_compare_laps(args.compare_laps[0], args.compare_laps[1])
@@ -2484,6 +2546,8 @@ def main() -> None:
                 args.setup_store,
                 args.se_endpoint,
                 args.user_setups_root,
+                args.serial_port,
+                args.serial_baud,
             )
         )
     except KeyboardInterrupt:

--- a/tools/rig_launcher/preview.py
+++ b/tools/rig_launcher/preview.py
@@ -32,7 +32,6 @@ def demo_status() -> GamePointStatus:
         generated_at=0.0,
         sidecar=ProbeResult("sidecar", True, "healthy", "peers=1 screen_peers=1"),
         screen=ProbeResult("screen", True, "connected", "screen_peers=1"),
-        hotspot=ProbeResult("hotspot", True, "on", "state=On clients=1"),
         voice=ProbeResult("voice", True, "enabled", "backend=sounddevice"),
         simhub=ProbeResult("simhub", True, "absent", "executable not found"),
         log_path="sidecar.log",

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -134,6 +134,9 @@ class GamePointConfig:
     port: int = DEFAULT_PORT
     external_bind: str | None = None
     token: str | None = None
+    #: COM port for the USB-serial rig-screen transport (issue #463). When set, the
+    #: sidecar serves the screen over USB CDC — no Windows Mobile Hotspot needed.
+    serial_port: str | None = None
     reference_archive: str | None = None
     voice_bank: str | None = None
     voice_tts: bool = False
@@ -173,6 +176,7 @@ class GamePointConfig:
             port=port,
             external_bind=external_bind,
             token=token,
+            serial_port=_none_if_blank(env_map.get("AC_COPILOT_SIDECAR_SERIAL_PORT")),
             reference_archive=_configured_text(
                 env_map.get("AC_COPILOT_REFERENCE_ARCHIVE"),
                 settings.reference_archive,
@@ -196,7 +200,6 @@ class GamePointStatus:
     generated_at: float
     sidecar: ProbeResult
     screen: ProbeResult
-    hotspot: ProbeResult
     voice: ProbeResult
     simhub: ProbeResult
     log_path: str
@@ -205,7 +208,7 @@ class GamePointStatus:
 
     @property
     def ok(self) -> bool:
-        rows = (self.sidecar, self.screen, self.hotspot, self.voice, self.simhub, *self.checks)
+        rows = (self.sidecar, self.screen, self.voice, self.simhub, *self.checks)
         return all(row.ok for row in rows if row.state not in {"skipped", "absent"})
 
     def to_dict(self) -> dict[str, object]:
@@ -214,7 +217,6 @@ class GamePointStatus:
             "ok": self.ok,
             "sidecar": self.sidecar.to_dict(),
             "screen": self.screen.to_dict(),
-            "hotspot": self.hotspot.to_dict(),
             "voice": self.voice.to_dict(),
             "simhub": self.simhub.to_dict(),
             "log_path": self.log_path,
@@ -258,6 +260,8 @@ class GamePointSupervisor:
             args.extend(["--external-bind", self.config.external_bind])
         else:
             args.extend(["--host", self.config.host])
+        if self.config.serial_port:
+            args.extend(["--serial-port", self.config.serial_port])
         if self.config.setup_store:
             setup_store = _resolve_launcher_path(
                 self.config.setup_store,
@@ -411,7 +415,6 @@ class GamePointSupervisor:
             generated_at=time.time(),
             sidecar=sidecar,
             screen=screen,
-            hotspot=self.probe_hotspot(),
             voice=self.probe_voice(health_payload),
             simhub=self.probe_simhub(start=self.config.start_simhub),
             log_path=str(self.paths.sidecar_log_path),
@@ -461,38 +464,6 @@ class GamePointSupervisor:
 
     def _voice_playback_requested(self) -> bool:
         return bool(self.config.voice_bank or self.config.voice_tts)
-
-    def probe_hotspot(self) -> ProbeResult:
-        if os.name != "nt":
-            return ProbeResult("hotspot", True, "skipped", "Windows hotspot probe skipped")
-        command = [
-            "powershell",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            _HOTSPOT_PROBE_SCRIPT,
-        ]
-        try:
-            proc = self._run(
-                command,
-                **_subprocess_kwargs(capture_output=True, text=True, timeout=8),
-            )
-        except Exception as exc:  # noqa: BLE001 - preflight should report, not crash
-            return ProbeResult("hotspot", True, "unavailable", str(exc))
-        if proc.returncode != 0:
-            return ProbeResult("hotspot", True, "unavailable", _short(proc.stderr))
-        try:
-            payload = json.loads(proc.stdout)
-        except json.JSONDecodeError:
-            return ProbeResult("hotspot", True, "unavailable", _short(proc.stdout))
-        state = str(payload.get("state") or "unknown")
-        clients = payload.get("client_count")
-        ok = state.lower() == "on"
-        detail = f"state={state}"
-        if clients is not None:
-            detail += f" clients={clients}"
-        return ProbeResult("hotspot", ok, state.lower(), detail)
 
     def probe_simhub(self, *, start: bool = False) -> ProbeResult:
         exe = self._simhub_exe()
@@ -789,38 +760,12 @@ def _short(text: str | None, limit: int = 240) -> str:
     return cleaned[: limit - 1] + "..."
 
 
-_HOTSPOT_PROBE_SCRIPT = "\n".join(
-    [
-        "$ErrorActionPreference = 'Stop'",
-        "[Windows.Networking.NetworkOperators.NetworkOperatorTetheringManager,"
-        "Windows.Networking.NetworkOperators,ContentType=WindowsRuntime] | Out-Null",
-        "[Windows.Networking.Connectivity.NetworkInformation,"
-        "Windows.Networking.Connectivity,ContentType=WindowsRuntime] | Out-Null",
-        "$profile = "
-        "[Windows.Networking.Connectivity.NetworkInformation]::GetInternetConnectionProfile()",
-        "if ($null -eq $profile) {",
-        "  $profile = [Windows.Networking.Connectivity.NetworkInformation]::"
-        "GetConnectionProfiles() | Select-Object -First 1",
-        "}",
-        "if ($null -eq $profile) { "
-        "throw 'No network connection profile found for Mobile Hotspot.' }",
-        "$mgr = [Windows.Networking.NetworkOperators.NetworkOperatorTetheringManager]"
-        "::CreateFromConnectionProfile($profile)",
-        "[pscustomobject]@{",
-        "  state = $mgr.TetheringOperationalState.ToString()",
-        "  client_count = $mgr.ClientCount",
-        "} | ConvertTo-Json -Compress",
-    ]
-)
-
-
 def render_status_lines(status: GamePointStatus) -> list[str]:
     summary = ProbeResult("overall", status.ok, "ok" if status.ok else "needs_attention")
     rows = [
         summary,
         status.sidecar,
         status.screen,
-        status.hotspot,
         status.voice,
         status.simhub,
         *status.checks,

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -151,7 +151,7 @@ def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, st
     sidecar itself is up.
     """
     if status.ok:
-        return ("READY TO DRIVE", "clear", "sidecar · screen · hotspot live")
+        return ("READY TO DRIVE", "clear", "sidecar · screen live")
     # A failing preflight check outranks the port-down copy: pressing Start
     # cannot succeed until the blocker is cleared, so the caption must say
     # what is actually wrong (PR #445 review).
@@ -163,7 +163,7 @@ def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, st
         return ("PRESS START", "brake", blocker.detail or blocker.state)
     if (status.sidecar.state or "").strip().lower() in _SIDECAR_DOWN_STATES:
         return ("PRESS START", "brake", f"nothing on port {port} yet")
-    rows = (status.sidecar, status.screen, status.hotspot, status.voice, status.simhub)
+    rows = (status.sidecar, status.screen, status.voice, status.simhub)
     caption = next(
         (row.detail or row.state for row in rows if not row.ok and (row.detail or row.state)),
         "needs attention",

--- a/tools/rig_launcher/view.py
+++ b/tools/rig_launcher/view.py
@@ -1,7 +1,7 @@
 """Racing Atelier themed Tk view for the Game Point launcher (epic #432, Part B).
 
 ``build_launcher_view`` renders the carbon/brass status panel that maps 1:1 onto
-``GamePointStatus`` (sidecar / screen / hotspot / voice / simhub). It owns
+``GamePointStatus`` (sidecar / screen / voice / simhub). It owns
 *presentation only*: every behaviour (start, refresh, open logs/settings, setup
 diff) is passed in via ``actions`` and the caller drives redraws with
 ``LauncherView.update(status)``. Keeping the view free of supervisor/polling
@@ -27,7 +27,6 @@ from tools.rig_launcher.supervisor import GamePointStatus, ProbeResult
 _ROWS: tuple[tuple[str, str], ...] = (
     ("Sidecar", "sidecar"),
     ("Screen", "screen"),
-    ("Hotspot", "hotspot"),
     ("Voice", "voice"),
     ("SimHub", "simhub"),
 )
@@ -159,7 +158,7 @@ class LauncherView:
         field.pack(side="left")
         caption = tk.Label(
             row,
-            text="sidecar · screen · hotspot live",
+            text="sidecar · screen live",
             bg=theme.GRAPHITE,
             fg=theme.MUTE,
             font=(self._f_mono, 11),


### PR DESCRIPTION
Closes #463.

## Why

The rig screen reached the sidecar over WebSocket, which only worked through a **Windows Mobile Hotspot** (the `AHOME5G` mesh drops cross-AP TCP). That hotspot hosts a 2.4 GHz SoftAP on the PC's **single-radio** Intel AC 7260 — while the client is on 5 GHz, one radio can't serve both bands, so the **main WiFi drops and won't reconnect**. Physical limitation, not a bug.

This moves the **screen leg** of the transport to the **native USB CDC** (the same COM port used to flash). The in-game CSP trainer's loopback-WS peer is unchanged. Result: no WiFi, no hotspot, no mesh block on the screen path.

## What

- **Sidecar** (`tools/ai_sidecar/serial_transport.py`): a `SerialPeer` that reuses the transport-agnostic `_handle_external_frame` fan-out; newline-delimited JSON; `--serial-port` / `AC_COPILOT_SIDECAR_SERIAL_PORT`; reconnect on USB drop. No WS-path changes.
- **Firmware** (`firmware/screen`): `SCREEN_TRANSPORT_SERIAL` build flag, env `jc3248w535_serial` (now the rig default; WS env `jc3248w535` retained for LAN/CI). `transport_send()` abstracts frame TX; heartbeat `hello` (1 s until linked, 5 s after) so a restarted sidecar re-registers the screen without a reboot.
- **Launcher** (`tools/rig_launcher`): the Mobile Hotspot probe / status row / readiness coupling is **removed entirely**; the screen row derives from the sidecar's `screen_peers`, and the launcher forwards `--serial-port`.

## Hardware trap (durable finding)

On the ESP32-S3 native USB CDC the device only delivers **host→device (RX)** to the sketch once the host asserts **DTR**; the auto-reset is an **RTS** pulse, not steady DTR. Opening DTR-low (the intuitive "don't reset" choice) gave *no reset but no RX* — the board never saw `hello_ack` and re-`hello`d forever. Correct: **DTR high, RTS low**. Captured in the ADR + firmware README.

## Testing

- **Full suite:** `2311 passed, 77 skipped` (skips are pre-existing env gaps: duckdb, sentence-transformers, governance-hub shims).
- **New unit tests:** serial transport framing, DTR-high/RTS-low open, `hello`→screen-peer registration, hub fan-out to the serial peer, malformed-line skip, disconnect eviction; launcher `--serial-port` command + env wiring.
- **Both firmware envs build** (`jc3248w535_serial` and `jc3248w535`; RAM 41%, flash 11%).
- **Live E2E on COM6 — Mobile Hotspot OFF, main WiFi `AHOME5G` connected throughout (68%→69%, never dropped; no `192.168.137.x`):** screen registered as a serial screen peer (`screen_peers=1`); bidirectional round-trip confirmed (board `hello` → sidecar `hello_ack` → board dropped to the 5 s heartbeat); a trainer `coaching.snapshot` fanned out to the serial peer with **zero** send failures.

## Notes

- The screen must stay USB-tethered to the PC (it already is on the rig).
- Final visual check for the operator: with the sidecar on `--serial-port COM6`, the screen pill shows **CONNECTED** and live AC Copilot hints render while driving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
