### PR TITLE
fix(launcher): bundle pyserial in the frozen Game Point sidecar (#468)

### DIFF
--- a/tests/test_rig_launcher.py
+++ b/tests/test_rig_launcher.py
@@ -1040,6 +1040,15 @@ def test_build_pyinstaller_args_collects_voice_runtime_floor(tmp_path: Path) -> 
     assert _has_option_value(args, "--hidden-import", "pyttsx3.drivers.sapi5")
 
 
+def test_build_pyinstaller_args_bundles_pyserial_for_serial_transport(tmp_path: Path) -> None:
+    # Issue #463: pyserial is imported lazily by the sidecar, so it must be a
+    # declared hidden-import or the frozen --serial-port sidecar fails at runtime.
+    args = build_pyinstaller_args(tmp_path, onefile=True, windowed=True)
+
+    assert _has_option_value(args, "--hidden-import", "serial")
+    assert _has_option_value(args, "--hidden-import", "serial.tools.list_ports")
+
+
 def test_build_pyinstaller_args_collects_optional_rtmixer_when_installed(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -599,6 +599,14 @@ def build_pyinstaller_args(
         "pyttsx3.drivers",
         "--hidden-import",
         "pyttsx3.drivers.sapi5",
+        # Issue #463: the sidecar imports pyserial lazily (serial_transport.open_serial),
+        # so PyInstaller's static analysis misses it — the frozen --serial-port sidecar
+        # would ModuleNotFoundError without these. serial.tools.list_ports + the win32
+        # backend are pulled transitively by `serial`, but name them for robustness.
+        "--hidden-import",
+        "serial",
+        "--hidden-import",
+        "serial.tools.list_ports",
     ]
     fonts_dir = project_root / "src" / "ac_copilot_trainer" / "content" / "fonts"
     if fonts_dir.is_dir():


### PR DESCRIPTION
Closes #468. Follow-up to #463/#464.

The packaged Game Point launcher couldn't drive the USB-serial screen: `serial_transport.open_serial` imports `pyserial` lazily, so PyInstaller's static analysis missed it and the frozen `--sidecar-child` would `ModuleNotFoundError: No module named 'serial'` under `--serial-port`. Added `serial` + `serial.tools.list_ports` as `--hidden-import` in `build_pyinstaller_args`, with a build-args test asserting it.

**Verified on the rebuilt exe** (hotspot OFF, board on COM6): `AC-Copilot-Game-Point.exe --sidecar-child --port 8798 --serial-port COM6` → `serial transport open port=COM6 (DTR high, RTS low)` → `external hello accepted peer=serial:COM6 class=screen` → **`/health screen_peers=1`**. The deployed exe is in place on the rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)