### PR TITLE
docs(vault): USB CDC RX-buffer deploy fix + handoff (#470)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -64,6 +64,21 @@ relates_to:
 
 # Next session handoff
 
+## Delivered (2026-07-03 UTC) — rig screen WORKING end-to-end over USB (operator-confirmed)
+
+The USB-serial screen shipped across four merged PRs; after real deployment debugging
+the operator confirmed **"finally works"** (device screen CONNECTED). Chain:
+- [#464](https://github.com/agorokh/ac-copilot-trainer/pull/464) — transport + hotspot removal (see below).
+- [#468](https://github.com/agorokh/ac-copilot-trainer/issues/468)/[#469](https://github.com/agorokh/ac-copilot-trainer/pull/469) — bundle `pyserial` as a PyInstaller hidden-import (frozen `.exe` sidecar).
+- [#470](https://github.com/agorokh/ac-copilot-trainer/issues/470)/[#471](https://github.com/agorokh/ac-copilot-trainer/pull/471) — **the real deploy fix: 256→8192 B USB CDC RX buffer.**
+
+**Durable gotcha (cost hours):** `screen_peers=1` in the launcher only means the sidecar
+heard the board's small `hello` — NOT that the screen works. The board's RX ring
+(256 B default) overflowed on the 326 B `hello_ack`, dropping the newline, so the board
+never linked (re-`hello`d forever) while the launcher showed CONNECTED. Full write-up in
+[[usb-serial-screen-transport-2026-07-02]] § "Second trap". Rig board is flashed with the fix;
+`AC_COPILOT_SIDECAR_SERIAL_PORT=COM6` is set in the user env; the deployed `.exe` is the rebuilt one.
+
 ## Delivered (2026-07-03 UTC) — MERGED #463: USB-serial screen transport, hotspot removed
 
 PR [#464](https://github.com/agorokh/ac-copilot-trainer/pull/464) squash-merged to `main`

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/usb-serial-screen-transport-2026-07-02.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/usb-serial-screen-transport-2026-07-02.md
@@ -48,6 +48,25 @@ a steady DTR. Opening DTR-low (the intuitive "don't reset" choice) gives *no res
 but no RX* — the board never sees `hello_ack` and re-`hello`s forever. Correct:
 **DTR high, RTS low**. Verified live on COM6.
 
+## Second trap (the deploy killer): the 256-byte USB CDC RX ring (#470)
+
+After the launcher shipped, the rig showed `screen_peers=1` **but the physical
+screen stayed DISCONNECTED**. That asymmetry is the whole diagnosis: `screen_peers`
+only proves the sidecar heard the board's (small) `hello`; it says nothing about
+the board receiving the reply. The ESP32-S3 USB CDC **RX ring defaults to 256 bytes**.
+The real `hello_ack` (with capabilities) is **326 bytes**, and `coaching.snapshot`
+is larger — a frame >256 B arrives as one USB burst and overflows the ring before
+`loop()` (LVGL render, tens of ms) drains it, so the trailing `\n` is dropped, the
+line never completes, and the board never links (re-`hello`s forever). Bisected: a
+~60 B ack links the board; the 326 B ack does not. Fix: `Serial.setRxBufferSize(8192)`
+before `Serial.begin()` (firmware, serial mode). **Rule: `screen_peers=1` is NOT a
+"screen works" signal — it only means the board's hello was heard.**
+
+Two more deploy facts worth keeping: (1) the packaged `.exe` needs `pyserial` as an
+explicit PyInstaller `--hidden-import` (it's lazy-imported, so static analysis misses
+it — #468); (2) the launcher's sidecar picks up `--serial-port` from
+`AC_COPILOT_SIDECAR_SERIAL_PORT` (set it in the user env) or via the launcher forwarding it.
+
 ## Evidence (live, 2026-07-02)
 
 Mobile Hotspot OFF, main WiFi `AHOME5G` connected throughout (68%→69%, never


### PR DESCRIPTION
Vault SAVE for the serial-screen deployment debugging: the 256→8192 B RX-buffer root cause (#470/#471), the `screen_peers=1`≠working gotcha, and the pyserial/env deploy facts. Diff strictly under docs/01_Vault/**; auto-merged by the vault-only workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)