### PR TITLE
fix(voice): ASCII arrow in timing_report stdout for Windows cp1252 (#475)

### DIFF
--- a/tools/ai_sidecar/voice/timing_report.py
+++ b/tools/ai_sidecar/voice/timing_report.py
@@ -396,7 +396,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.out:
         Path(args.out).write_text(text, encoding="utf-8")
         print(
-            f"wrote timing report → {args.out} ({report.covered_corners} covered corners, "
+            f"wrote timing report -> {args.out} ({report.covered_corners} covered corners, "
             f"{report.assertions['cues_spoken']} cues spoken)"
         )
     else:


### PR DESCRIPTION
Closes #475.

`tools/ai_sidecar/voice/timing_report.py` `main()` printed a literal `→` (U+2192) in its success line. On Windows cp1252 stdout that raised `UnicodeEncodeError` **after** the report artifact was already written, so the tool exited non-zero with a traceback (seen running `python -m tools.ai_sidecar.voice.timing_report --bank <dir> --out <file>`).

**Change:** one line — swap `→` for ASCII `->`. The other non-ASCII characters in the file are in comments/docstrings (UTF-8 source, never printed to stdout) and are deliberately untouched.

**Verification**
- `PYTHONIOENCODING=cp1252` run **with** a bank: prints `wrote timing report -> …`, exit 0 (was crashing).
- `PYTHONIOENCODING=cp1252` run **without** a bank (JSON to stdout): exit 0.
- `ruff check` clean; `pytest -k timing_report` 12 passed.

No change to report content or behavior. Surfaced during #381 verification, independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)