### PR TITLE
docs(vault): record PR #476 timing_report cp1252 fix (#475)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -105,7 +105,12 @@ operator-grade acoustic proof on the **real** intensity3 bank so the human step 
   Evidence comment: [#381#issuecomment-4874323968](https://github.com/agorokh/ac-copilot-trainer/issues/381#issuecomment-4874323968).
   Detail: [[issue-381-intensity-verification-2026-07-03]].
 - **Resume:** operator listens → if critical reads more urgent than the calm cues, **close #381**.
-  Separable trivial find: `timing_report.py` final `print("… → …")` crashes on Windows cp1252 (`→`→`->`).
+- **Delivered (2026-07-03) — PR [#476](https://github.com/agorokh/ac-copilot-trainer/pull/476) MERGED
+  (`a130abb`), issue #475 CLOSED:** the separable `timing_report.py` Windows-cp1252 crash (a literal `→`
+  in the final stdout `print`) is fixed (`→`→`->`); verified exit 0 under `PYTHONIOENCODING=cp1252`
+  with/without a bank, ruff + 12 timing tests green, self-hosted reviewer clean (0 findings). Surfaced
+  during #381 verification, independent of it.
+
 ## Delivered (2026-07-03 UTC) — rig screen WORKING end-to-end over USB (operator-confirmed)
 
 The USB-serial screen shipped across four merged PRs; after real deployment debugging

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-381-intensity-verification-2026-07-03.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-381-intensity-verification-2026-07-03.md
@@ -56,5 +56,7 @@ Human ~15-second confirm. Desk-listenable A/B rendered at native levels under
 `issue381-waveforms.svg` and `issue381-acoustic-ab.json`. Evidence comment:
 [#381#issuecomment-4874323968](https://github.com/agorokh/ac-copilot-trainer/issues/381#issuecomment-4874323968).
 
-**Minor separable find:** `timing_report.py` main() crashes with `UnicodeEncodeError` on its final
-`print("… → …")` under Windows cp1252 stdout (artifact is written first) — trivial `→`→`->` fix.
+**Separable find (FIXED):** `timing_report.py` main() crashed with `UnicodeEncodeError` on its final
+`print("… → …")` under Windows cp1252 stdout (artifact written first) — fixed by PR
+[#476](https://github.com/agorokh/ac-copilot-trainer/pull/476) (merged `a130abb`, issue #475 CLOSED):
+`→`→`->`, verified exit 0 under `PYTHONIOENCODING=cp1252` with/without a bank, ruff + 12 timing tests green.


### PR DESCRIPTION
Vault-only post-merge handoff for PR #476 (the separable timing_report.py Windows-cp1252 crash fix, issue #475, surfaced during #381 verification). Updates the #381 investigation node and Next Session Handoff. Diff strictly under docs/01_Vault/**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)