### PR TITLE
feat(telemetry): capture Tier-B channels (accG, yaw_rate, wheelsPressure) + first-class tyre-set id (#478)

### DIFF
--- a/docs/10_Development/13_Lap_Archive_Export.md
+++ b/docs/10_Development/13_Lap_Archive_Export.md
@@ -43,7 +43,9 @@ speed_kmh, brake, throttle, steering, gear,
 position_x_m, position_y_m, position_z_m,
 wheelAngularSpeed_fl, wheelAngularSpeed_fr, wheelAngularSpeed_rl, wheelAngularSpeed_rr,
 wheelSlip_fl, wheelSlip_fr, wheelSlip_rl, wheelSlip_rr,
-tyreCoreTemp_fl, tyreCoreTemp_fr, tyreCoreTemp_rl, tyreCoreTemp_rr
+tyreCoreTemp_fl, tyreCoreTemp_fr, tyreCoreTemp_rl, tyreCoreTemp_rr,
+accG_long, accG_lat, yaw_rate,
+wheelsPressure_fl, wheelsPressure_fr, wheelsPressure_rl, wheelsPressure_rr
 ```
 
 `brake`, `throttle`, and `steering` preserve the normalized CSP values from the
@@ -64,6 +66,25 @@ gracefully (they export as blank cells). The setup-coaching engine
 *suspicion* to a *confirmed* axle-level verdict (which axle locks → brake bias; rear
 wheelspin → traction/TC/diff). The trace field set is a hard contract kept byte-identical
 between `lap_archive.lua::TRACE_FIELDS` and `reference_lap.py::TRACE_FIELDS`.
+
+### Optional Tier-B chassis + hot-pressure channels (#478)
+
+When present, the trace also carries measured chassis dynamics and dynamic HOT tyre pressure:
+`accG_long` / `accG_lat` (longitudinal / lateral g-force from CSP `car.acceleration`, already in G),
+`yaw_rate` (rad/s, from `car.localAngularVelocity.y`), and `wheelsPressure_{fl,fr,rl,rr}` (psi — the
+DYNAMIC hot pressure from `wheel.tyrePressure`, not the cold set pressure). Like the #266 per-wheel
+channels they are **optional** and **append-only** after `rpm`: older archives omit them and export
+as blank cells. The setup-coaching engine consumes `yaw_rate` to confirm turn-in lag / the
+under-vs-oversteer direction and `wheelsPressure` to confirm pressure/compound attribution, upgrading
+those rules from a *suspicion* to a *confirmed verdict*. A lap whose chassis/pressure was unreadable
+persists zeros; the analysis loader treats an all-zero column as "no live data" so a missing signal
+never fabricates a verdict.
+
+The lap **header** also gains (issue #478): `conditions.weatherType` (the `ac.WeatherType` enum,
+Part D) and a first-class `tyres` block (`compoundIndex` + `name` via `ac.getTyresName`, Part C) — the
+tyre identity the coaching lakehouse now keys stints on instead of the `setup.hash` proxy. AC does not
+expose a per-physical-set serial to Lua, so `tyres` identifies the compound, not a same-compound
+fresh-rubber swap.
 
 ## MoTeC-Shaped CSV
 

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -39,6 +39,7 @@ local shiftProfile = require("shift_profile")
 local coachingPublisher = require("coaching_publisher")
 local lifecyclePublisher = require("lifecycle_publisher")
 local telemetryPublisher = require("telemetry_publisher")
+local chassisRead = require("chassis_read")
 local setupLibrary = require("setup_library")
 
 --- Pixel sizes per window title; must match ``manifest.ini`` WINDOW_* ``SIZE=``.
@@ -2456,12 +2457,16 @@ function script.update(dt)
       temps = currentTireTemps,
       wsBridge = wsBridge,
     })
+    -- Real measured g-forces (issue #478): CSP `car.acceleration` is in G (.x lateral, .z long).
+    -- Was hardcoded 0/0; chassis_read pcall-guards the read and degrades to nil (→ 0 in the
+    -- publisher) off-rig, so the live coaching path now sees true lateral/longitudinal load.
+    local liveChassis = chassisRead.read(car)
     telemetryPublisher.publishTelemetryTickIfDue({
       dt = dt,
       car = car,
       wsBridge = wsBridge,
-      lat_g = 0,
-      long_g = 0,
+      lat_g = liveChassis.accG_lat,
+      long_g = liveChassis.accG_long,
       temps = currentTireTemps,
     })
   end)

--- a/src/ac_copilot_trainer/modules/chassis_read.lua
+++ b/src/ac_copilot_trainer/modules/chassis_read.lua
@@ -1,0 +1,68 @@
+-- Shared chassis-dynamics accessors (issue #478 Part A).
+--
+-- Single source of truth for the measured g-force + yaw-rate channels the coaching brain's balance
+-- and rotation rules confirm from (corner_attribution `turn_in_lag` / under-vs-oversteer direction),
+-- so the trace capture (telemetry.lua) and the live telemetry_tick publish (ac_copilot_trainer.lua)
+-- cannot drift on the finicky parts:
+--   * CSP `car.acceleration` is a vec3 already in **G** (NOT m/s^2): `.x` = lateral (sideways,
+--     relative to the car), `.z` = longitudinal (forwards/backwards). Confirmed from the CSP Lua SDK
+--     (`ac_apps/lib.lua`: "@G-forces, X for sideways relative to car, Z for forwards/backwards").
+--   * CSP `car.localAngularVelocity` is a vec3 in rad/s in the car's local frame; `.y` (the vertical
+--     axis) is the yaw rate — the clean rotation signal.
+--   * Neither field is on the CSP "confirmed valid" list (see csp-api-field-safety), so a struct that
+--     lacks them THROWS on access rather than returning nil. Every read is pcall-guarded and degrades
+--     to nil — mirroring wheel_read.lua so the two accessors behave identically.
+--   * Non-finite reads (NaN / +-inf) are rejected to nil so they never serialize as invalid JSON
+--     downstream (a CSP field can be present-but-non-finite; NaN ~= itself, +-inf == math.huge).
+
+local M = {}
+
+local function finite(n)
+  n = tonumber(n)
+  if n == nil or n ~= n or n == math.huge or n == -math.huge then
+    return nil
+  end
+  return n
+end
+
+--- Read `obj[key]`, pcall-guarded (an unknown CSP struct field throws instead of returning nil).
+function M.field(obj, key)
+  local ok, v = pcall(function()
+    return obj[key]
+  end)
+  if ok and v ~= nil then
+    return v
+  end
+  return nil
+end
+
+--- Read a vec3 component (`.x`/`.y`/`.z`), pcall-guarded and finite-filtered. nil if unreadable.
+local function component(vec, axis)
+  if vec == nil then
+    return nil
+  end
+  return finite(M.field(vec, axis))
+end
+
+--- Read chassis dynamics into {accG_long, accG_lat, yaw_rate} (each value number|nil).
+--- pcall-guards `car.acceleration` and `car.localAngularVelocity` and every component read.
+---@param car any
+---@return table
+function M.read(car)
+  local out = { accG_long = nil, accG_lat = nil, yaw_rate = nil }
+  if car == nil then
+    return out
+  end
+  local accel = M.field(car, "acceleration")
+  if accel ~= nil then
+    out.accG_lat = component(accel, "x")   -- sideways (lateral) G
+    out.accG_long = component(accel, "z")  -- forwards/backwards (longitudinal) G
+  end
+  local angVel = M.field(car, "localAngularVelocity")
+  if angVel ~= nil then
+    out.yaw_rate = component(angVel, "y")  -- rotation about the vertical axis = yaw rate (rad/s)
+  end
+  return out
+end
+
+return M

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -233,15 +233,25 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
   -- set serial to Lua, so this identifies the compound, not a same-compound fresh-rubber swap.
   local tyreCompoundIndex = nil
   pcall(function() tyreCompoundIndex = tonumber(opts.car and opts.car.compoundIndex) end)
+  -- Reject a non-finite read (NaN) so a garbage index can't seed a bogus identity.
+  if tyreCompoundIndex ~= nil and tyreCompoundIndex ~= tyreCompoundIndex then
+    tyreCompoundIndex = nil
+  end
   local tyreName = nil
-  pcall(function()
-    if ac and type(ac.getTyresName) == "function" then
-      local n = ac.getTyresName(0, tyreCompoundIndex or -1)
-      if type(n) == "string" and n ~= "" then
-        tyreName = n
+  -- Only claim a tyre identity when the compound index was actually read. Calling
+  -- ac.getTyresName(0, -1) on an UNREAD index would return the current tyre name with compoundIndex
+  -- still nil, letting build_analytics key stints on a name the capture couldn't confirm (cursor
+  -- #483). When the index is unread, leave BOTH fields nil so the lakehouse falls back to setup_hash.
+  if tyreCompoundIndex ~= nil then
+    pcall(function()
+      if ac and type(ac.getTyresName) == "function" then
+        local n = ac.getTyresName(0, tyreCompoundIndex)
+        if type(n) == "string" and n ~= "" then
+          tyreName = n
+        end
       end
-    end
-  end)
+    end)
+  end
 
   samplesColumnar = samplesColumnar or {}
   samplesCount = tonumber(samplesCount) or #samplesColumnar

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -64,6 +64,11 @@ local TRACE_FIELDS = {
   "wheelSlip_fl", "wheelSlip_fr", "wheelSlip_rl", "wheelSlip_rr",
   "tyreCoreTemp_fl", "tyreCoreTemp_fr", "tyreCoreTemp_rl", "tyreCoreTemp_rr",
   "rpm",
+  -- Chassis dynamics (issue #478 Part A): measured g-forces (accG_long/accG_lat, in G) + yaw_rate
+  -- (rad/s), then dynamic HOT tyre pressure per wheel (Part B, psi). Appended AFTER rpm so every
+  -- older column position stays stable; older archives lacking them export as blanks.
+  "accG_long", "accG_lat", "yaw_rate",
+  "wheelsPressure_fl", "wheelsPressure_fr", "wheelsPressure_rl", "wheelsPressure_rr",
 }
 
 local function lapArchiveDir()

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -223,6 +223,25 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
   pcall(function() ambient = tonumber(sim and sim.ambientTemperature) end)
   local trackTemp = nil
   pcall(function() trackTemp = tonumber(sim and sim.trackTemperature) end)
+  local weatherType = nil
+  -- CSP sim.weatherType is an ac.WeatherType enum (integer-valued); capture it as a number so the
+  -- conditions model can consume it (issue #478 Part D). pcall-guarded like the other sim reads.
+  pcall(function() weatherType = tonumber(sim and sim.weatherType) end)
+
+  -- First-class tyre-set identity (issue #478 Part C), distinct from setup.hash: the tyre COMPOUND
+  -- AC exposes (compoundIndex + short name via ac.getTyresName). AC does not surface a per-physical-
+  -- set serial to Lua, so this identifies the compound, not a same-compound fresh-rubber swap.
+  local tyreCompoundIndex = nil
+  pcall(function() tyreCompoundIndex = tonumber(opts.car and opts.car.compoundIndex) end)
+  local tyreName = nil
+  pcall(function()
+    if ac and type(ac.getTyresName) == "function" then
+      local n = ac.getTyresName(0, tyreCompoundIndex or -1)
+      if type(n) == "string" and n ~= "" then
+        tyreName = n
+      end
+    end
+  end)
 
   samplesColumnar = samplesColumnar or {}
   samplesCount = tonumber(samplesCount) or #samplesColumnar
@@ -283,7 +302,7 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
       trackGripLevel = trackGrip,
       ambientTempC = ambient,
       trackTempC = trackTemp,
-      weatherType = nil,
+      weatherType = weatherType,
     },
     lap = {
       lap_n = tonumber(opts.lap_n) or 0,
@@ -298,6 +317,10 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
       -- is usually basename-only from `readIniSnapshot` (codex P1 on PR #91).
       path = archiveSetupPath,
       snapshot = flattenSetupSnapshot(opts.setup_snap),
+    },
+    tyres = {
+      compoundIndex = tyreCompoundIndex,
+      name = tyreName,
     },
     trace = {
       samples_count = samplesCount,
@@ -574,6 +597,7 @@ function M.createWriteJob(opts, capMB)
       { "conditions", self._rec.conditions },
       { "lap", self._rec.lap },
       { "setup", self._rec.setup },
+      { "tyres", self._rec.tyres },
     }
     for i = 1, #fields do
       ok, err = self:_writeField(fields[i][1], fields[i][2])

--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -233,8 +233,10 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
   -- set serial to Lua, so this identifies the compound, not a same-compound fresh-rubber swap.
   local tyreCompoundIndex = nil
   pcall(function() tyreCompoundIndex = tonumber(opts.car and opts.car.compoundIndex) end)
-  -- Reject a non-finite read (NaN) so a garbage index can't seed a bogus identity.
-  if tyreCompoundIndex ~= nil and tyreCompoundIndex ~= tyreCompoundIndex then
+  -- Reject a non-finite read (NaN or +/-inf) so a garbage index can't seed a bogus identity or crash
+  -- lakehouse ingest — build_analytics does int(compoundIndex), which raises on inf (qodo #483).
+  if tyreCompoundIndex ~= nil and (tyreCompoundIndex ~= tyreCompoundIndex
+      or tyreCompoundIndex == math.huge or tyreCompoundIndex == -math.huge) then
     tyreCompoundIndex = nil
   end
   local tyreName = nil

--- a/src/ac_copilot_trainer/modules/telemetry.lua
+++ b/src/ac_copilot_trainer/modules/telemetry.lua
@@ -2,6 +2,7 @@
 
 local ch = require("csp_helpers")
 local wheel_read = require("wheel_read")
+local chassis_read = require("chassis_read")
 
 local M = {}
 
@@ -40,6 +41,25 @@ local MAX_LAP_TRACE = 2000
 ---@field px number
 ---@field py number
 ---@field pz number
+---@field wheelAngularSpeed_fl number|nil
+---@field wheelAngularSpeed_fr number|nil
+---@field wheelAngularSpeed_rl number|nil
+---@field wheelAngularSpeed_rr number|nil
+---@field wheelSlip_fl number|nil
+---@field wheelSlip_fr number|nil
+---@field wheelSlip_rl number|nil
+---@field wheelSlip_rr number|nil
+---@field tyreCoreTemp_fl number|nil
+---@field tyreCoreTemp_fr number|nil
+---@field tyreCoreTemp_rl number|nil
+---@field tyreCoreTemp_rr number|nil
+---@field accG_long number|nil
+---@field accG_lat number|nil
+---@field yaw_rate number|nil
+---@field wheelsPressure_fl number|nil
+---@field wheelsPressure_fr number|nil
+---@field wheelsPressure_rl number|nil
+---@field wheelsPressure_rr number|nil
 
 local Telemetry = {}
 Telemetry.__index = Telemetry
@@ -183,6 +203,11 @@ function Telemetry:update(dt, car, sim)
     -- Python loader treats an all-zero omega column as "no live wheel data" so it never confirms a
     -- false lockup when wheels are unreadable.
     local w = wheel_read.readPerWheel(car)
+    -- Chassis dynamics (issue #478): measured g-forces (accG, in G) + yaw rate (rad/s) confirm the
+    -- balance/rotation rules; dynamic hot tyre pressure (per wheel) confirms the pressure rule. nil
+    -- reads serialize as 0 via traceSampleToColumnRow; the analysis layer treats an all-zero column
+    -- as "no live data" so an unreadable field never fabricates a verdict.
+    local chassis = chassis_read.read(car)
     ---@type LapTraceSample
     local lp = {
       spline = car.splinePosition or 0,
@@ -208,6 +233,13 @@ function Telemetry:update(dt, car, sim)
       tyreCoreTemp_fr = w.temp.fr,
       tyreCoreTemp_rl = w.temp.rl,
       tyreCoreTemp_rr = w.temp.rr,
+      accG_long = chassis.accG_long,
+      accG_lat = chassis.accG_lat,
+      yaw_rate = chassis.yaw_rate,
+      wheelsPressure_fl = w.pressure.fl,
+      wheelsPressure_fr = w.pressure.fr,
+      wheelsPressure_rl = w.pressure.rl,
+      wheelsPressure_rr = w.pressure.rr,
     }
     self.lapBuf[self.lapN] = lp
     if self.lapN > MAX_LAP_RAW then

--- a/src/ac_copilot_trainer/modules/wheel_read.lua
+++ b/src/ac_copilot_trainer/modules/wheel_read.lua
@@ -56,12 +56,19 @@ function M.omega(one)
   return finite(M.field(one, "angularSpeed") or M.field(one, "wheelAngularSpeed"))
 end
 
---- Read all four wheels into {omega={fl,fr,rl,rr}, slip={...}, temp={...}} (each value number|nil).
---- pcall-guards the `car.wheels` access and every per-wheel read.
+--- Dynamic (HOT) tyre pressure (psi). CSP `tyrePressure` is the live/dynamic value the pressure
+--- attribution rule confirms from; `tyreStaticPressure` is the cold set value (not this). nil if
+--- unreadable (issue #478 Part B).
+function M.pressure(one)
+  return finite(M.field(one, "tyrePressure") or M.field(one, "dynamicPressure"))
+end
+
+--- Read all four wheels into {omega={fl,fr,rl,rr}, slip={...}, temp={...}, pressure={...}} (each
+--- value number|nil). pcall-guards the `car.wheels` access and every per-wheel read.
 ---@param car any
 ---@return table
 function M.readPerWheel(car)
-  local out = { omega = {}, slip = {}, temp = {} }
+  local out = { omega = {}, slip = {}, temp = {}, pressure = {} }
   if car == nil then
     return out
   end
@@ -80,6 +87,7 @@ function M.readPerWheel(car)
       out.omega[k] = M.omega(one)
       out.slip[k] = M.slip(one)
       out.temp[k] = M.temp(one)
+      out.pressure[k] = M.pressure(one)
     end
   end
   return out

--- a/tests/test_coaching_lake.py
+++ b/tests/test_coaching_lake.py
@@ -161,6 +161,25 @@ def test_session_and_stint_rollups_are_queryable(lake_cwd):
     assert stint_a[cols.index("lap_count")] == 3
 
 
+def test_stints_split_on_first_class_tyre_set(lake_cwd):
+    # #478 Part C AC3: two laps in one session on DIFFERENT tyre sets (identical setup_hash) split
+    # into two stints keyed on the tyre-set identity, not the setup_hash proxy.
+    laps = lake_cwd / "laps"
+    laps.mkdir()
+    a = _archive("ta", "bmw_z4_gt3", "spa", 110000, session_uuid="sess-t", setup_hash="same-setup")
+    a["tyres"] = {"compoundIndex": 1, "name": "Soft (S)"}
+    a["lap"]["lap_n"] = 1
+    b = _archive("tb", "bmw_z4_gt3", "spa", 109000, session_uuid="sess-t", setup_hash="same-setup")
+    b["tyres"] = {"compoundIndex": 2, "name": "Medium (M)"}
+    b["lap"]["lap_n"] = 2
+    _write(laps, "ta", a)
+    _write(laps, "tb", b)
+    summary = build_lake(laps, _db_path())
+    assert summary.stints == 2  # split on tyre-set id despite identical setup_hash
+    cols, rows = run_report(_db_path(), "stints")
+    assert sorted(r[cols.index("tyre_set_key")] for r in rows) == ["Medium (M)", "Soft (S)"]
+
+
 def test_corner_speed_report_is_corner_grain(lake_cwd):
     db, _ = _build(lake_cwd)
     cols, rows = run_report(db, "corner-speed")

--- a/tests/test_coaching_lake.py
+++ b/tests/test_coaching_lake.py
@@ -161,6 +161,19 @@ def test_session_and_stint_rollups_are_queryable(lake_cwd):
     assert stint_a[cols.index("lap_count")] == 3
 
 
+def test_tyre_set_key_rejects_non_finite_compound_index():
+    # qodo #483: a non-finite compoundIndex (e.g. +inf leaking from a bad CSP read) must not crash
+    # the lakehouse — _tyre_set_key falls back to None (→ setup_hash) instead of int(inf) raising.
+    from tools.coaching_lake.build_analytics import _tyre_set_key
+
+    assert _tyre_set_key({"compoundIndex": float("inf")}) is None
+    assert _tyre_set_key({"compoundIndex": float("-inf")}) is None
+    assert _tyre_set_key({"compoundIndex": float("nan")}) is None
+    assert _tyre_set_key({"compoundIndex": 2}) == "compound:2"
+    assert _tyre_set_key({"name": "Soft (S)"}) == "Soft (S)"
+    assert _tyre_set_key({}) is None
+
+
 def test_stints_split_on_first_class_tyre_set(lake_cwd):
     # #478 Part C AC3: two laps in one session on DIFFERENT tyre sets (identical setup_hash) split
     # into two stints keyed on the tyre-set identity, not the setup_hash proxy.

--- a/tests/test_coaching_lake.py
+++ b/tests/test_coaching_lake.py
@@ -190,7 +190,8 @@ def test_stints_split_on_first_class_tyre_set(lake_cwd):
     summary = build_lake(laps, _db_path())
     assert summary.stints == 2  # split on tyre-set id despite identical setup_hash
     cols, rows = run_report(_db_path(), "stints")
-    assert sorted(r[cols.index("tyre_set_key")] for r in rows) == ["Medium (M)", "Soft (S)"]
+    # keyed on the canonical compound INDEX (stable), not the intermittent name (cursor #483).
+    assert sorted(r[cols.index("tyre_set_key")] for r in rows) == ["compound:1", "compound:2"]
 
 
 def test_corner_speed_report_is_corner_grain(lake_cwd):

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -256,6 +256,29 @@ def test_corner_live_signals_emits_chassis_and_pressure_markers():
     assert extra["wheelsPressure"]["fl"] == 27.0
 
 
+def test_corner_live_signals_zero_yaw_through_turn_in_does_not_confirm():
+    # cursor #483: a lap that carries yaw data but whose peak |yaw| through THIS corner's turn-in is
+    # ~0 must NOT emit the yaw_rate marker (which would falsely confirm turn_in_lag at "0.0 rad/s").
+    n = 12
+    yaw = [0.0] * n
+    yaw[n - 1] = 0.5  # rotation only well AFTER this corner's window
+    lap = LapTrace(
+        spline=[i / (n - 1) for i in range(n)],
+        t_s=[i * 0.1 for i in range(n)],
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        steer=[0.1] * n,
+        gear=[3] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+        yaw_rate=yaw,
+    )
+    # entry_i..apex_i covers only the zero region -> no rotation observed here -> no marker.
+    extra = corner_live_signals(lap, _sig(index=0, entry_i=1, apex_i=4, exit_i=6))
+    assert "yaw_rate" not in extra
+
+
 def test_entry_speed_left_is_technique_verdict():
     ctx = CornerContext(
         sig=_sig(peak_lat_g=1.1),

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -210,6 +210,52 @@ def test_grip_limited_confirmed_with_live_pressure():
     assert grip.advisory is False  # live pressure present -> verdict
 
 
+def test_turn_in_lag_advisory_without_yaw_then_verdict_with_live_yaw():
+    # #478 AC2: turn_in_lag is advisory without yaw_rate and a verdict once the measured yaw-rate
+    # channel is supplied.
+    sig = _sig(max_abs_steer=0.5)  # high steer + no grip ceiling -> the rule fires
+    advisory = next(
+        a for a in attribute_corner(CornerContext(sig=sig, setup=SETUP)) if a.key == "turn_in_lag"
+    )
+    assert advisory.advisory is True  # yaw_rate not supplied
+    confirmed = next(
+        a
+        for a in attribute_corner(CornerContext(sig=sig, setup=SETUP, extra={"yaw_rate": 0.3}))
+        if a.key == "turn_in_lag"
+    )
+    assert confirmed.advisory is False  # live yaw-rate present -> verdict
+    assert "0.3" in confirmed.coaching or "yaw-rate" in confirmed.coaching.lower()
+
+
+def test_corner_live_signals_emits_chassis_and_pressure_markers():
+    # #478: corner_live_signals derives the confirming yaw_rate + wheelsPressure markers (and accG)
+    # from the persisted trace columns, so a lap carrying them graduates the turn_in_lag /
+    # grip_limited rules to a verdict without a caller supplying extra by hand.
+    n = 12
+    lap = LapTrace(
+        spline=[i / (n - 1) for i in range(n)],
+        t_s=[i * 0.1 for i in range(n)],
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        steer=[0.1] * n,
+        gear=[3] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+        yaw_rate=[0.30] * n,
+        accg_lat=[1.2] * n,
+        accg_long=[-0.4] * n,
+        wheel_pressure=[[27.0, 27.1, 26.5, 26.6] for _ in range(n)],
+    )
+    assert lap.has_tier_b_data is True
+    extra = corner_live_signals(lap, _sig(index=0, entry_i=2, apex_i=5, exit_i=9))
+    assert extra["yaw_rate"] == 0.3
+    assert extra["accG_lat"] == 1.2
+    assert extra["accG_long"] == -0.4
+    assert set(extra["wheelsPressure"]) == {"fl", "fr", "rl", "rr"}
+    assert extra["wheelsPressure"]["fl"] == 27.0
+
+
 def test_entry_speed_left_is_technique_verdict():
     ctx = CornerContext(
         sig=_sig(peak_lat_g=1.1),

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -249,11 +249,37 @@ def test_corner_live_signals_emits_chassis_and_pressure_markers():
     )
     assert lap.has_tier_b_data is True
     extra = corner_live_signals(lap, _sig(index=0, entry_i=2, apex_i=5, exit_i=9))
-    assert extra["yaw_rate"] == 0.3
+    # constant yaw tracks the (constant) steer -> responsive front, NOT lag -> no yaw_rate marker.
+    assert "yaw_rate" not in extra
     assert extra["accG_lat"] == 1.2
     assert extra["accG_long"] == -0.4
     assert set(extra["wheelsPressure"]) == {"fl", "fr", "rl", "rr"}
     assert extra["wheelsPressure"]["fl"] == 27.0
+
+
+def test_turn_in_yaw_lag_confirms_only_when_heading_trails_steer():
+    # cursor #483: turn_in_lag is confirmed by yaw ONLY when the heading TRAILS the steer input
+    # through turn-in. A responsive front (yaw tracks steer) must NOT flip to a verdict.
+    n = 12
+    base = dict(
+        spline=[i / (n - 1) for i in range(n)],
+        t_s=[i * 0.1 for i in range(n)],
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        gear=[3] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+    )
+    sig = _sig(index=0, entry_i=0, apex_i=8, exit_i=11)
+    steer = [0.5] * 9 + [0.3] * 3  # committed early, high through entry
+    # LAGGING: yaw stays near-zero while steer is committed, builds only near the apex.
+    yaw_lag = [0.02] * 6 + [0.1, 0.2, 0.3] + [0.3] * 3
+    extra_lag = corner_live_signals(LapTrace(steer=steer, yaw_rate=yaw_lag, **base), sig)
+    assert "yaw_rate" in extra_lag  # heading trailed steer -> confirmed lag
+    # RESPONSIVE: yaw is already high when steer commits (tracks steer).
+    extra_ok = corner_live_signals(LapTrace(steer=steer, yaw_rate=[0.3] * n, **base), sig)
+    assert "yaw_rate" not in extra_ok  # yaw tracks steer -> not lag, stays advisory
 
 
 def test_corner_live_signals_zero_yaw_through_turn_in_does_not_confirm():

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -165,6 +165,14 @@ def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.P
         "tyreCoreTemp_rl",
         "tyreCoreTemp_rr",
         "rpm",
+        # chassis dynamics + hot pressure (issue #478)
+        "accG_long",
+        "accG_lat",
+        "yaw_rate",
+        "wheelsPressure_fl",
+        "wheelsPressure_fr",
+        "wheelsPressure_rl",
+        "wheelsPressure_rr",
     ]
     assert record["setup"]["hash"] == "hash1234"
     assert record["coaching"]["rules_hints"] == ["Brake earlier at T1"]

--- a/tests/test_lap_archive_export.py
+++ b/tests/test_lap_archive_export.py
@@ -131,6 +131,17 @@ def test_motec_csv_export_writes_quoted_header_units_and_rows(tmp_path: Path, mo
     assert rows[12][3] == "70"
 
 
+def test_tier_b_columns_in_generic_csv_and_motec_chassis_channels() -> None:
+    # #478 + #483 review: the generic analysis CSV carries every Tier-B trace column, and the
+    # MoTeC-shaped export carries the single-value chassis channels (G-forces + yaw). Per-wheel
+    # arrays (omega/slip/temp/pressure) stay in the analysis CSV only (curated MoTeC subset).
+    for name in lap_archive_export._TIER_B_TRACE_FIELDS:
+        assert name in lap_archive_export.CSV_COLUMNS, f"{name} missing from generic CSV export"
+    motec_keys = {key for _, _, key in lap_archive_export._MOTEC_CHANNELS}
+    for name in ("accG_long", "accG_lat", "yaw_rate"):
+        assert name in motec_keys, f"{name} missing from MoTeC channels"
+
+
 def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     monkeypatch.chdir(tmp_path)
     first = tmp_path / "lap_001.json"

--- a/tests/test_lap_dynamics.py
+++ b/tests/test_lap_dynamics.py
@@ -293,3 +293,45 @@ def test_spline_derived_from_positions_when_channel_missing():
     assert lap.spline[-1] == pytest.approx(1.0)
     assert all(lap.spline[i] <= lap.spline[i + 1] + 1e-9 for i in range(len(lap) - 1))
     assert max(lap.spline) - min(lap.spline) > 0.5  # not collapsed
+
+
+_TIER_B_COLS = [
+    "accG_long",
+    "accG_lat",
+    "yaw_rate",
+    "wheelsPressure_fl",
+    "wheelsPressure_fr",
+    "wheelsPressure_rl",
+    "wheelsPressure_rr",
+]
+
+
+def test_lap_trace_reads_chassis_and_pressure_channels():
+    # #478: lap_trace_from_archive reads accG/yaw/pressure columns when the trace carries them.
+    arch = _make_corner_archive()
+    arch["trace"]["fields"].extend(_TIER_B_COLS)
+    for row in arch["trace"]["samples"]:
+        row.extend([-0.5, 1.1, 0.25, 27.0, 27.1, 26.5, 26.6])
+    lap = lap_trace_from_archive(arch)
+    assert lap.has_chassis_data is True
+    assert lap.has_pressure_data is True
+    assert lap.has_tier_b_data is True
+    assert lap.accg_lat is not None and lap.accg_lat[0] == pytest.approx(1.1)
+    assert lap.accg_long is not None and lap.accg_long[0] == pytest.approx(-0.5)
+    assert lap.yaw_rate is not None and lap.yaw_rate[0] == pytest.approx(0.25)
+    assert lap.wheel_pressure is not None
+    assert lap.wheel_pressure[0] == [27.0, 27.1, 26.5, 26.6]
+
+
+def test_all_zero_chassis_and_pressure_columns_read_as_no_data():
+    # #478: an all-zero chassis/pressure column (unreadable on a real lap) reads as "no data" so a
+    # missing signal never fabricates a verdict — the same guard as the per-wheel omega column.
+    arch = _make_corner_archive()
+    arch["trace"]["fields"].extend(_TIER_B_COLS)
+    for row in arch["trace"]["samples"]:
+        row.extend([0.0] * len(_TIER_B_COLS))
+    lap = lap_trace_from_archive(arch)
+    assert lap.accg_lat is None and lap.accg_long is None and lap.yaw_rate is None
+    assert lap.wheel_pressure is None
+    assert lap.has_chassis_data is False
+    assert lap.has_pressure_data is False

--- a/tests/test_lua_trace_replay.py
+++ b/tests/test_lua_trace_replay.py
@@ -35,6 +35,7 @@ from tools.ac_harness.trace_replay import (  # noqa: E402 - after importorskip
     SchemaViolationError,
     TraceReplayHarness,
     available_scenarios,
+    car_chassis_from_frame,
     load_schema,
     synthesize_trace,
     wheels_from_frame,
@@ -470,6 +471,65 @@ def test_wheels_from_frame_maps_corner_order() -> None:
     assert wheels_from_frame({})[2] == {}
 
 
+def test_telemetry_captures_chassis_and_pressure_channels(harness: TraceReplayHarness) -> None:
+    """#478: telemetry.lua captures measured g-forces (car.acceleration, in G), yaw rate
+    (car.localAngularVelocity.y) and dynamic HOT pressure (wheel.tyrePressure) into the trace
+    columns. car.acceleration.x is lateral, .z is longitudinal; localAngularVelocity.y is yaw."""
+    wheels = [
+        {"angularSpeed": 100.0, "tyrePressure": 27.5},
+        {"angularSpeed": 101.0, "tyrePressure": 27.6},
+        {"angularSpeed": 102.0, "tyrePressure": 26.8},
+        {"angularSpeed": 103.0, "tyrePressure": 26.9},
+    ]
+    frames = [
+        {
+            "speedKmh": 180.0,
+            "splinePosition": 0.10 + i * 0.01,
+            "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+            "acceleration": {"x": 1.2, "y": 0.0, "z": -0.8},
+            "localAngularVelocity": {"x": 0.0, "y": 0.35, "z": 0.0},
+            "wheels": wheels,
+        }
+        for i in range(5)
+    ]
+    lap_trace = _ingest_lap(harness, frames, with_wheels=True)
+
+    def col(name: str) -> float:
+        return harness.lua.eval(f"function(tr) return tr[1].{name} end")(lap_trace)
+
+    assert col("accG_lat") == pytest.approx(1.2)  # car.acceleration.x
+    assert col("accG_long") == pytest.approx(-0.8)  # car.acceleration.z
+    assert col("yaw_rate") == pytest.approx(0.35)  # localAngularVelocity.y
+    assert col("wheelsPressure_fl") == pytest.approx(27.5)
+    assert col("wheelsPressure_rr") == pytest.approx(26.9)
+
+
+def test_car_chassis_from_frame_maps_axes() -> None:
+    """#478: car_chassis_from_frame maps accG_lat->acceleration.x, accG_long->acceleration.z,
+    yaw_rate->localAngularVelocity.y, and omits a vec3 whose columns are all absent (unreadable,
+    not a fabricated zero)."""
+    out = car_chassis_from_frame({"accG_lat": 1.1, "accG_long": -0.9, "yaw_rate": 0.4})
+    assert out["acceleration"] == {"x": 1.1, "y": 0.0, "z": -0.9}
+    assert out["localAngularVelocity"] == {"x": 0.0, "y": 0.4, "z": 0.0}
+    assert car_chassis_from_frame({}) == {}
+    assert "localAngularVelocity" not in car_chassis_from_frame({"accG_lat": 1.0})
+
+
+def test_wheels_from_frame_maps_hot_pressure() -> None:
+    """#478: wheels_from_frame carries wheelsPressure_{corner} -> tyrePressure per wheel, and omits
+    it when absent (a synthetic 0.0 and an unreadable nil are different signals)."""
+    frame = {
+        "wheelsPressure_fl": 27.0,
+        "wheelsPressure_fr": 27.1,
+        "wheelsPressure_rl": 26.5,
+        "wheelsPressure_rr": 26.6,
+    }
+    wheels = wheels_from_frame(frame)
+    assert wheels[0] == {"tyrePressure": 27.0}
+    assert wheels[3] == {"tyrePressure": 26.6}
+    assert wheels_from_frame({})[0] == {}
+
+
 def test_make_car_wheels_are_zero_indexed_for_wheel_read(harness: TraceReplayHarness) -> None:
     """L0-22: make_car(wheels=...) builds a 0-indexed car.wheels that wheel_read.readPerWheel
     reads with the correct FL/FR/RL/RR mapping (it iterates `for i = 0, 3`). A 1-based array
@@ -604,6 +664,14 @@ def test_synthesize_trace_scenarios_have_expected_shape(harness: TraceReplayHarn
         "tyreCoreTemp_fr",
         "tyreCoreTemp_rl",
         "tyreCoreTemp_rr",
+        # chassis dynamics + hot pressure (issue #478)
+        "accG_long",
+        "accG_lat",
+        "yaw_rate",
+        "wheelsPressure_fl",
+        "wheelsPressure_fr",
+        "wheelsPressure_rl",
+        "wheelsPressure_rr",
     }
     for scenario in available_scenarios():
         frames = synthesize_trace(scenario)

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -65,7 +65,9 @@ def test_generated_archive_carries_per_wheel_channels() -> None:
     fields = record["trace"]["fields"]
     for name in ("wheelAngularSpeed_fl", "wheelSlip_rr", "tyreCoreTemp_fl"):
         assert name in fields
-    assert fields[-1] == "rpm"
+    assert "rpm" in fields
+    # #478 chassis + pressure channels append AFTER rpm (append-only), so rpm is no longer last.
+    assert fields[-1] == "wheelsPressure_rr"
     frames = archive_trace_to_object_trace(record)
     f0 = frames[0]
     speed_ms = f0["speed"] / 3.6
@@ -73,6 +75,48 @@ def test_generated_archive_carries_per_wheel_channels() -> None:
     assert f0["wheelSlip_fl"] == pytest.approx(0.0)
     assert f0["tyreCoreTemp_rr"] == pytest.approx(80.0)
     assert f0["rpm"] == pytest.approx(0.0)
+
+
+def test_generated_archive_carries_tier_b_chassis_channels() -> None:
+    # #478: a generated reference archive includes the chassis + hot-pressure columns. The synthetic
+    # generator does not model them, so they are 0.0 -> the analysis layer's all-zero guard treats a
+    # generated reference as honestly having no measured chassis/pressure signal.
+    record = build_archive_record_from_scenario("brake_too_late")
+    fields = record["trace"]["fields"]
+    for name in (
+        "accG_long",
+        "accG_lat",
+        "yaw_rate",
+        "wheelsPressure_fl",
+        "wheelsPressure_fr",
+        "wheelsPressure_rl",
+        "wheelsPressure_rr",
+    ):
+        assert name in fields
+    f0 = archive_trace_to_object_trace(record)[0]
+    for name in ("accG_long", "accG_lat", "yaw_rate", "wheelsPressure_fl", "wheelsPressure_rr"):
+        assert f0[name] == pytest.approx(0.0)
+
+
+def test_validator_accepts_pre_478_23_field_trace() -> None:
+    # #478: chassis/pressure append AFTER rpm; a lap captured between #442 and #478 declares 23
+    # columns (legacy + per-wheel + rpm) and stays schema-v1-valid, converting without #478 keys.
+    record = build_archive_record_from_scenario("brake_too_late")
+    fields = record["trace"]["fields"]
+    record["trace"]["fields"] = list(fields[:23])
+    record["trace"]["samples"] = [[row[i] for i in range(23)] for row in record["trace"]["samples"]]
+    validate_lap_archive_record(record)  # must not raise
+    frames = archive_trace_to_object_trace(record)
+    assert "rpm" in frames[0]
+    assert "accG_long" not in frames[0]
+    assert "wheelsPressure_fl" not in frames[0]
+
+
+def test_generated_archive_carries_tyres_header() -> None:
+    # #478 Part C: the header carries a first-class tyres block (None for a generated reference,
+    # which has no real tyre set -> the lakehouse falls back to the setup-hash proxy).
+    record = build_archive_record_from_scenario("brake_too_late")
+    assert record["tyres"] == {"compoundIndex": None, "name": None}
 
 
 def test_validator_accepts_old_22_field_schema_v1_trace() -> None:

--- a/tools/ac_harness/ac_schema.json
+++ b/tools/ac_harness/ac_schema.json
@@ -84,10 +84,11 @@
       "fields": {
         "angularSpeed": "number",
         "slipRatio": "number",
-        "tyreCoreTemperature": "number"
+        "tyreCoreTemperature": "number",
+        "tyrePressure": "number"
       },
       "read_by": ["wheel_read.lua (via telemetry.lua / tire_monitor.lua)"],
-      "note": "0-indexed array of per-wheel objects (ac.Wheel): FrontLeft=0, FrontRight=1, RearLeft=2, RearRight=3 -- see wheel_read.WHEEL_KEYS; a 1-based read shifts every corner and reads RR=0 (the #180 regression). wheel_read.lua reads angularSpeed (omega), slipRatio (slip) and tyreCoreTemperature (temp) off each wheel, every access pcall-guarded with CSP field-name fallbacks (wheelAngularSpeed / slip,ndSlip / temperature,tyreTemperature). telemetry.lua persists them as the wheelAngularSpeed_/wheelSlip_/tyreCoreTemp_ {fl,fr,rl,rr} trace columns (issue #266). The trace_replay mock synthesizes car.wheels[i] from a frame's per-wheel fields so the off-sim lupa replay exercises this capture path (issue #278). load_schema only special-cases type:vec3, so this entry's `fields` are documentation; only `wheels` being a declared car field matters to the gate."
+      "note": "0-indexed array of per-wheel objects (ac.Wheel): FrontLeft=0, FrontRight=1, RearLeft=2, RearRight=3 -- see wheel_read.WHEEL_KEYS; a 1-based read shifts every corner and reads RR=0 (the #180 regression). wheel_read.lua reads angularSpeed (omega), slipRatio (slip), tyreCoreTemperature (temp) and tyrePressure (dynamic HOT pressure, issue #478) off each wheel, every access pcall-guarded with CSP field-name fallbacks (wheelAngularSpeed / slip,ndSlip / temperature,tyreTemperature / dynamicPressure). telemetry.lua persists them as the wheelAngularSpeed_/wheelSlip_/tyreCoreTemp_ (issue #266) and wheelsPressure_ (issue #478) {fl,fr,rl,rr} trace columns. The trace_replay mock synthesizes car.wheels[i] from a frame's per-wheel fields so the off-sim lupa replay exercises this capture path (issue #278). load_schema only special-cases type:vec3, so this entry's `fields` are documentation; only `wheels` being a declared car field matters to the gate."
     },
     "acceleration": {
       "type": "vec3",

--- a/tools/ac_harness/ac_schema.json
+++ b/tools/ac_harness/ac_schema.json
@@ -83,6 +83,26 @@
       },
       "read_by": ["wheel_read.lua (via telemetry.lua / tire_monitor.lua)"],
       "note": "0-indexed array of per-wheel objects (ac.Wheel): FrontLeft=0, FrontRight=1, RearLeft=2, RearRight=3 -- see wheel_read.WHEEL_KEYS; a 1-based read shifts every corner and reads RR=0 (the #180 regression). wheel_read.lua reads angularSpeed (omega), slipRatio (slip) and tyreCoreTemperature (temp) off each wheel, every access pcall-guarded with CSP field-name fallbacks (wheelAngularSpeed / slip,ndSlip / temperature,tyreTemperature). telemetry.lua persists them as the wheelAngularSpeed_/wheelSlip_/tyreCoreTemp_ {fl,fr,rl,rr} trace columns (issue #266). The trace_replay mock synthesizes car.wheels[i] from a frame's per-wheel fields so the off-sim lupa replay exercises this capture path (issue #278). load_schema only special-cases type:vec3, so this entry's `fields` are documentation; only `wheels` being a declared car field matters to the gate."
+    },
+    "acceleration": {
+      "type": "vec3",
+      "fields": {
+        "x": "number",
+        "y": "number",
+        "z": "number"
+      },
+      "read_by": ["chassis_read.lua (via telemetry.lua / entry)"],
+      "note": "CSP car.acceleration is in G (NOT m/s^2): x=lateral (sideways relative to car), z=longitudinal (forwards/backwards). chassis_read reads accG_lat=.x, accG_long=.z; telemetry persists them as the accG_lat/accG_long trace columns (issue #478). Not historically on the confirmed-safe list, so every read is pcall-guarded."
+    },
+    "localAngularVelocity": {
+      "type": "vec3",
+      "fields": {
+        "x": "number",
+        "y": "number",
+        "z": "number"
+      },
+      "read_by": ["chassis_read.lua (via telemetry.lua / entry)"],
+      "note": "CSP local-frame angular velocity (rad/s); .y is the yaw rate (rotation about the vertical axis). chassis_read reads yaw_rate=.y, persisted as the yaw_rate trace column (issue #478). pcall-guarded."
     }
   },
   "sim": {

--- a/tools/ac_harness/ac_schema.json
+++ b/tools/ac_harness/ac_schema.json
@@ -44,6 +44,11 @@
       "read_by": ["telemetry.lua", "brake_detection.lua", "entry"],
       "note": "Normalized track position 0..1."
     },
+    "compoundIndex": {
+      "type": "number",
+      "read_by": ["lap_archive.lua"],
+      "note": "0-based index of the currently selected tyre compound. lap_archive captures it (+ ac.getTyresName) as the first-class tyre-set identity in the lap header (issue #478 Part C). pcall-guarded."
+    },
     "look": {
       "type": "vec3",
       "fields": {
@@ -140,6 +145,11 @@
       "type": "number",
       "read_by": ["lap_archive.lua"],
       "note": "Track temp (session metadata)."
+    },
+    "weatherType": {
+      "type": "number",
+      "read_by": ["lap_archive.lua"],
+      "note": "CSP sim.weatherType is an ac.WeatherType enum (integer-valued); lap_archive captures tonumber(sim.weatherType) into conditions.weatherType (issue #478 Part D)."
     }
   }
 }

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -52,15 +52,31 @@ TRACE_FIELDS: tuple[str, ...] = (
     "tyreCoreTemp_rl",
     "tyreCoreTemp_rr",
     "rpm",
+    # Chassis dynamics (issue #478 Part A) — measured g-forces + yaw rate, appended AFTER rpm so every
+    # older column position stays byte-stable. accG_long/accG_lat are in G (CSP car.acceleration:
+    # x=lateral, z=longitudinal); yaw_rate is rad/s (CSP car.localAngularVelocity.y).
+    "accG_long",
+    "accG_lat",
+    "yaw_rate",
+    # Dynamic HOT tyre pressure per wheel (issue #478 Part B), psi (CSP wheel.tyrePressure). Order FL,
+    # FR, RL, RR — matches the #266 per-wheel channels.
+    "wheelsPressure_fl",
+    "wheelsPressure_fr",
+    "wheelsPressure_rl",
+    "wheelsPressure_rr",
 )
 
 _LEGACY_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[:10]
 _LEGACY_RPM_TRACE_FIELDS: tuple[str, ...] = _LEGACY_TRACE_FIELDS + ("rpm",)
 _PER_WHEEL_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[10:22]
+# The pre-#478 full set (10 legacy + 12 per-wheel + rpm). #478 appends the chassis + pressure
+# channels AFTER rpm, so this stays a valid prefix and older 23-column archives keep loading.
+_PRE_TIER_B_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[:23]
 _TRACE_FIELD_VARIANTS: tuple[tuple[str, ...], ...] = (
     _LEGACY_TRACE_FIELDS,
     _LEGACY_RPM_TRACE_FIELDS,
     _LEGACY_TRACE_FIELDS + _PER_WHEEL_TRACE_FIELDS,
+    _PRE_TIER_B_TRACE_FIELDS,
     TRACE_FIELDS,
 )
 
@@ -93,8 +109,8 @@ def _iso_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-#: The original required trace columns. Fields beyond these (the per-wheel #266 channels and
-#: #442 rpm) are OPTIONAL and default to 0.0 when a frame omits them.
+#: The original required trace columns. Fields beyond these (the per-wheel #266 channels, #442 rpm,
+#: and the #478 chassis/pressure channels) are OPTIONAL and default to 0.0 when a frame omits them.
 _REQUIRED_TRACE_FIELDS: tuple[str, ...] = _LEGACY_TRACE_FIELDS
 
 
@@ -284,7 +300,7 @@ def validate_lap_archive_record(record: Mapping[str, Any]) -> None:
     if not isinstance(trace, Mapping):
         raise LapArchiveSchemaError("trace must be an object")
     fields = trace.get("fields")
-    # Accept pre-#266 10-field, importer 10+rpm, #266 22-field, and full #442 traces:
+    # Accept pre-#266 10-field, importer 10+rpm, #266 22-field, #442 23-field, and full #478 traces:
     # SCHEMA_VERSION is still 1 and existing archives carry older column sets.
     allowed_fields = [list(variant) for variant in _TRACE_FIELD_VARIANTS]
     if fields not in allowed_fields:

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -52,13 +52,13 @@ TRACE_FIELDS: tuple[str, ...] = (
     "tyreCoreTemp_rl",
     "tyreCoreTemp_rr",
     "rpm",
-    # Chassis dynamics (issue #478 Part A) — measured g-forces + yaw rate, appended AFTER rpm so every
+    # Chassis dynamics (#478 Part A) — measured g-forces + yaw rate, appended AFTER rpm so every
     # older column position stays byte-stable. accG_long/accG_lat are in G (CSP car.acceleration:
     # x=lateral, z=longitudinal); yaw_rate is rad/s (CSP car.localAngularVelocity.y).
     "accG_long",
     "accG_lat",
     "yaw_rate",
-    # Dynamic HOT tyre pressure per wheel (issue #478 Part B), psi (CSP wheel.tyrePressure). Order FL,
+    # Dynamic HOT tyre pressure per wheel (#478 Part B), psi (wheel.tyrePressure). Order FL,
     # FR, RL, RR — matches the #266 per-wheel channels.
     "wheelsPressure_fl",
     "wheelsPressure_fr",

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -231,6 +231,9 @@ def build_archive_record(
             "is_valid": True,
         },
         "setup": {"hash": "", "path": None, "snapshot": {}},
+        # First-class tyre identity (issue #478 Part C). A generated reference has no real tyre set,
+        # so both fields are None (the lakehouse then falls back to the setup-hash proxy).
+        "tyres": {"compoundIndex": None, "name": None},
         "trace": {
             "samples_count": len(rows),
             "fields": list(TRACE_FIELDS),

--- a/tools/ac_harness/trace_replay.py
+++ b/tools/ac_harness/trace_replay.py
@@ -361,7 +361,7 @@ def _base_frame(
         "tyreCoreTemp_fr": _SYNTH_TYRE_TEMP_C,
         "tyreCoreTemp_rl": _SYNTH_TYRE_TEMP_C,
         "tyreCoreTemp_rr": _SYNTH_TYRE_TEMP_C,
-        # Chassis dynamics + hot pressure (issue #478) are NOT modeled by the synthetic generator, so
+        # Chassis dynamics + hot pressure (#478) are NOT modeled by the synthetic generator, so
         # they default to 0.0 — the analysis layer's all-zero-column guard then treats them as "no
         # live data" (a generated reference honestly has no measured g / yaw / pressure). The lupa
         # round-trip test drives non-zero values through make_car to exercise the capture path.

--- a/tools/ac_harness/trace_replay.py
+++ b/tools/ac_harness/trace_replay.py
@@ -361,6 +361,17 @@ def _base_frame(
         "tyreCoreTemp_fr": _SYNTH_TYRE_TEMP_C,
         "tyreCoreTemp_rl": _SYNTH_TYRE_TEMP_C,
         "tyreCoreTemp_rr": _SYNTH_TYRE_TEMP_C,
+        # Chassis dynamics + hot pressure (issue #478) are NOT modeled by the synthetic generator, so
+        # they default to 0.0 — the analysis layer's all-zero-column guard then treats them as "no
+        # live data" (a generated reference honestly has no measured g / yaw / pressure). The lupa
+        # round-trip test drives non-zero values through make_car to exercise the capture path.
+        "accG_long": 0.0,
+        "accG_lat": 0.0,
+        "yaw_rate": 0.0,
+        "wheelsPressure_fl": 0.0,
+        "wheelsPressure_fr": 0.0,
+        "wheelsPressure_rl": 0.0,
+        "wheelsPressure_rr": 0.0,
     }
 
 
@@ -518,11 +529,39 @@ def wheels_from_frame(frame: TraceFrame) -> list[dict[str, float]]:
         omega = frame.get(f"wheelAngularSpeed_{corner}")
         slip = frame.get(f"wheelSlip_{corner}")
         temp = frame.get(f"tyreCoreTemp_{corner}")
+        pressure = frame.get(f"wheelsPressure_{corner}")
         if omega is not None:
             spec["angularSpeed"] = omega
         if slip is not None:
             spec["slipRatio"] = slip
         if temp is not None:
             spec["tyreCoreTemperature"] = temp
+        if pressure is not None:
+            # CSP ac.Wheel.tyrePressure is the DYNAMIC (hot) pressure wheel_read.pressure reads
+            # first; telemetry persists it as the wheelsPressure_{corner} column (issue #478).
+            spec["tyrePressure"] = pressure
         wheels.append(spec)
     return wheels
+
+
+def car_chassis_from_frame(frame: TraceFrame) -> dict[str, Any]:
+    """Map a frame's chassis columns into :meth:`TraceReplayHarness.make_car` kwargs (issue #478).
+
+    Returns ``{"acceleration": {...}, "localAngularVelocity": {...}}`` built from the frame's
+    ``accG_lat`` / ``accG_long`` / ``yaw_rate`` columns, ready to splat into ``make_car`` so the
+    off-sim lupa replay exercises the ``chassis_read`` capture path (the analogue of
+    :func:`wheels_from_frame` for the chassis channels). CSP ``car.acceleration`` is in G with
+    ``x`` = lateral and ``z`` = longitudinal; ``localAngularVelocity.y`` is the yaw rate. A column
+    absent from the frame omits the whole vec3 (mirroring an unreadable CSP struct → chassis_read
+    degrades to nil), rather than fabricating a zero the analysis layer can't distinguish from a
+    real reading.
+    """
+    out: dict[str, Any] = {}
+    accg_lat = frame.get("accG_lat")
+    accg_long = frame.get("accG_long")
+    if accg_lat is not None or accg_long is not None:
+        out["acceleration"] = {"x": accg_lat or 0.0, "y": 0.0, "z": accg_long or 0.0}
+    yaw = frame.get("yaw_rate")
+    if yaw is not None:
+        out["localAngularVelocity"] = {"x": 0.0, "y": yaw, "z": 0.0}
+    return out

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -580,10 +580,10 @@ def coach_lap(
             consistency_sample_count=len(history_matches.get(sig.index, [sig])),
             history_laps_loaded=len(history_laps),
         )
-        # explicit caller-supplied signals win; else auto-compute Tier-B signals from per-wheel data
+        # explicit caller-supplied signals win; else auto-compute Tier-B signals from live channels
         extra = (extra_by_corner or {}).get(sig.index)
         if extra is None:
-            extra = corner_live_signals(lap, sig) if lap.has_wheel_data else {}
+            extra = corner_live_signals(lap, sig) if lap.has_tier_b_data else {}
         extra = {
             "exit_road_usage": diagnostics["exit_road_usage"],
             "consistency": diagnostics["consistency"],
@@ -772,6 +772,7 @@ def _grip_used_frac(ctx: CornerContext) -> float | None:
 
 # --- Tier-B live signals: turn per-wheel data into CONFIRMED attribution ------
 WHEEL_RADIUS_M = 0.347  # GT3 R effective rolling radius (session plant-ID)
+_WHEEL_LABELS = ("fl", "fr", "rl", "rr")  # #266 per-wheel order (matches wheel_read.WHEEL_KEYS)
 
 
 def _slip(omega: float, r: float, v: float) -> float:
@@ -789,56 +790,96 @@ def corner_live_signals(
     lock_thresh: float = -0.06,
     spin_thresh: float = 0.10,
 ) -> dict[str, Any]:
-    """Per-corner Tier-B signals from ``wheelAngularSpeed`` — which axle locks, exit wheelspin.
+    """Per-corner Tier-B signals that turn live telemetry into CONFIRMED attribution.
 
-    Returns ``{}`` when the lap has no per-wheel data. When present, returns a dict carrying the
-    confirming channel marker(s) plus ``lock_axle`` ('front'|'rear'|'both'|None) and ``wheelspin``,
-    so the braking/exit rules graduate from a suspicion to a confirmed verdict. Slip is computed
-    from angular speed (the canonical longitudinal signal), not AC's combined ``wheelSlip``.
+    For each Tier-B channel actually persisted in ``lap``, emits the confirming channel marker the
+    rule table keys on (so a suspicion graduates to a verdict) plus the derived signal:
+
+    * ``wheelAngularSpeed`` (#266) → ``lock_axle`` ('front'|'rear'|'both'|None) under braking and
+      ``wheelspin`` on exit. Slip is computed from angular speed (the canonical longitudinal signal),
+      not AC's combined ``wheelSlip``.
+    * ``yaw_rate`` (#478 Part A) → the measured rotation signal confirming turn-in lag / the
+      under-vs-oversteer direction, as the peak |yaw| through turn-in (rad/s). ``accG_lat`` /
+      ``accG_long`` ride along (peak lateral load, peak braking decel) for the balance rules.
+    * ``wheelsPressure`` (#478 Part B) → the mean per-wheel dynamic HOT pressure over the corner
+      (psi), confirming the pressure/compound attribution.
+
+    Returns ``{}`` when the lap persists no Tier-B channel at all. Each block is independently gated,
+    so a lap with only some channels still confirms the rules those channels back.
     """
-    if lap.wheel_omega is None:
-        return {}
-    extra: dict[str, Any] = {"wheelAngularSpeed": True}
-    if lap.wheel_slip is not None:
-        extra["wheelSlip"] = True
+    extra: dict[str, Any] = {}
 
-    def _axle_slip(om: list[float], a: int, b: int, v: float) -> float | None:
-        # A 0.0 omega among real readings is the "unread wheel" sentinel (telemetry serializes a nil
-        # read as 0), NOT a lock — a truly locked wheel at speed still has a small POSITIVE omega.
-        # Exclude unread wheels so one failed corner can't fake a lockup (codex partial-read guard).
-        vals = [_slip(om[i], wheel_radius_m, v) for i in (a, b) if om[i] > 0.0]
-        return min(vals) if vals else None
+    # --- per-wheel angular speed (#266): which axle locks under braking / exit wheelspin ---
+    if lap.wheel_omega is not None:
+        extra["wheelAngularSpeed"] = True
+        if lap.wheel_slip is not None:
+            extra["wheelSlip"] = True
 
-    # braking phase (turn-in..apex with brake on): which axle reaches lock first?
-    front, rear = [], []
-    for k in range(sig.entry_i, sig.apex_i + 1):
-        if lap.brake[k] > brake_thresh:
-            v, om = lap.v_ms[k], lap.wheel_omega[k]
-            f = _axle_slip(om, 0, 1, v)
-            r = _axle_slip(om, 2, 3, v)
-            if f is not None:
-                front.append(f)
-            if r is not None:
-                rear.append(r)
-    if front and rear:
-        fl, rl = min(front), min(rear)
-        extra["front_lock"], extra["rear_lock"] = round(fl, 3), round(rl, 3)
-        if min(fl, rl) <= lock_thresh:
-            extra["lock_axle"] = "front" if fl < rl - 0.02 else "rear" if rl < fl - 0.02 else "both"
-        else:
-            extra["lock_axle"] = None
-    # exit phase (apex..exit with throttle on): rear wheelspin?
-    spins = []
-    for k in range(sig.apex_i, sig.exit_i + 1):
-        if lap.throttle[k] > throttle_thresh:
-            v, om = lap.v_ms[k], lap.wheel_omega[k]
-            rear_spin = [_slip(om[i], wheel_radius_m, v) for i in (2, 3) if om[i] > 0.0]
-            if rear_spin:
-                spins.append(max(rear_spin))
-    if spins:
-        rmax = max(spins)
-        extra["rear_exit_slip"] = round(rmax, 3)
-        extra["wheelspin"] = rmax >= spin_thresh
+        def _axle_slip(om: list[float], a: int, b: int, v: float) -> float | None:
+            # A 0.0 omega among real readings is the "unread wheel" sentinel (telemetry serializes a
+            # nil read as 0), NOT a lock — a truly locked wheel at speed still has a small POSITIVE
+            # omega. Exclude unread wheels so one failed corner can't fake a lockup (codex guard).
+            vals = [_slip(om[i], wheel_radius_m, v) for i in (a, b) if om[i] > 0.0]
+            return min(vals) if vals else None
+
+        # braking phase (turn-in..apex with brake on): which axle reaches lock first?
+        front, rear = [], []
+        for k in range(sig.entry_i, sig.apex_i + 1):
+            if lap.brake[k] > brake_thresh:
+                v, om = lap.v_ms[k], lap.wheel_omega[k]
+                f = _axle_slip(om, 0, 1, v)
+                r = _axle_slip(om, 2, 3, v)
+                if f is not None:
+                    front.append(f)
+                if r is not None:
+                    rear.append(r)
+        if front and rear:
+            fl, rl = min(front), min(rear)
+            extra["front_lock"], extra["rear_lock"] = round(fl, 3), round(rl, 3)
+            if min(fl, rl) <= lock_thresh:
+                extra["lock_axle"] = (
+                    "front" if fl < rl - 0.02 else "rear" if rl < fl - 0.02 else "both"
+                )
+            else:
+                extra["lock_axle"] = None
+        # exit phase (apex..exit with throttle on): rear wheelspin?
+        spins = []
+        for k in range(sig.apex_i, sig.exit_i + 1):
+            if lap.throttle[k] > throttle_thresh:
+                v, om = lap.v_ms[k], lap.wheel_omega[k]
+                rear_spin = [_slip(om[i], wheel_radius_m, v) for i in (2, 3) if om[i] > 0.0]
+                if rear_spin:
+                    spins.append(max(rear_spin))
+        if spins:
+            rmax = max(spins)
+            extra["rear_exit_slip"] = round(rmax, 3)
+            extra["wheelspin"] = rmax >= spin_thresh
+
+    # --- chassis dynamics (#478 Part A): measured yaw rate + g-forces confirm rotation/balance ---
+    seg = range(sig.entry_i, sig.exit_i + 1)
+    if lap.yaw_rate is not None:
+        entry_yaw = [abs(lap.yaw_rate[k]) for k in range(sig.entry_i, sig.apex_i + 1)]
+        # Peak |yaw| through turn-in is the confirming rotation magnitude; its presence flips the
+        # turn_in_lag / balance-direction rules from a suspicion to a verdict.
+        extra["yaw_rate"] = round(max(entry_yaw), 3) if entry_yaw else 0.0
+    if lap.accg_lat is not None:
+        extra["accG_lat"] = round(max(abs(lap.accg_lat[k]) for k in seg), 3)
+    if lap.accg_long is not None:
+        # Most-negative longitudinal g over the corner = peak braking decel (the braking-decel
+        # ceiling / ABS-too-high signal named in setup_knowledge TIER_B_CHANNELS).
+        extra["accG_long"] = round(min(lap.accg_long[k] for k in seg), 3)
+
+    # --- dynamic hot pressure (#478 Part B): confirms the pressure/compound attribution ---
+    if lap.wheel_pressure is not None:
+        means: list[float | None] = []
+        for wi in range(4):
+            vals = [lap.wheel_pressure[k][wi] for k in seg if lap.wheel_pressure[k][wi] > 0.0]
+            means.append(round(sum(vals) / len(vals), 2) if vals else None)
+        # Only confirm when pressure was actually observed IN this corner (mirrors the lock_axle
+        # guard) — the marker must never outrun the data.
+        if any(m is not None for m in means):
+            extra["wheelsPressure"] = dict(zip(_WHEEL_LABELS, means, strict=False))
+
     return extra
 
 
@@ -1144,6 +1185,38 @@ def _consistency_coaching(ctx: CornerContext) -> str:
     )
 
 
+def _grip_limited_coaching(ctx: CornerContext) -> str:
+    press = ctx.extra.get("wheelsPressure") if isinstance(ctx.extra, dict) else None
+    if isinstance(press, dict):
+        shown = ", ".join(
+            f"{k.upper()} {v}" for k, v in press.items() if isinstance(v, (int, float))
+        )
+        return (
+            "Car's at the limit mid-corner; to go faster change the setup (pressures/compound/wing), "
+            f"not the line. Live hot pressures ({shown} psi) confirm it — check them against the "
+            "compound's optimal window and move pressures toward it."
+        )
+    return (
+        "Car's at the limit mid-corner; to go faster change the setup (pressures/compound/wing), not "
+        "the line. Confirm pressure/compound with live hot-pressure + core-temp."
+    )
+
+
+def _turn_in_lag_coaching(ctx: CornerContext) -> str:
+    yaw = ctx.extra.get("yaw_rate") if isinstance(ctx.extra, dict) else None
+    if isinstance(yaw, (int, float)):
+        return (
+            f"Sluggish turn-in CONFIRMED by live yaw-rate (peak {yaw} rad/s through entry) — the car "
+            "rotates late for the steering input. Load the front on entry (trail-brake, quicker "
+            "initial input); cold or under-pressure fronts are the next suspect, before caster / "
+            "front springs. Front toe-out is a last, small lever."
+        )
+    return (
+        "Sluggish turn-in (heading lags steer) — likely technique or front load, not necessarily "
+        "toe. Confirm with live yaw-rate."
+    )
+
+
 RULES: list[DiagnosticRule] = [
     DiagnosticRule(
         key="grip_limited",
@@ -1163,10 +1236,7 @@ RULES: list[DiagnosticRule] = [
             + ", or more wing for fast corners.",
         ],
         technique_causes=("Driver is already using the available grip — little to gain here.",),
-        coaching=lambda c: (
-            "Car's at the limit mid-corner; to go faster change the setup (pressures/compound/"
-            "wing), not the line. Confirm pressure/compound with live hot-pressure + core-temp."
-        ),
+        coaching=_grip_limited_coaching,
     ),
     DiagnosticRule(
         key="entry_speed_left",
@@ -1232,10 +1302,7 @@ RULES: list[DiagnosticRule] = [
         technique_causes=(
             "Trail-brake to load the front on entry and use a quicker, deliberate initial input.",
         ),
-        coaching=lambda c: (
-            "Sluggish turn-in (heading lags steer) — likely technique or front load, not "
-            "necessarily toe. Confirm with live yaw-rate."
-        ),
+        coaching=_turn_in_lag_coaching,
     ),
     DiagnosticRule(
         key="steering_aggression",

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -773,6 +773,7 @@ def _grip_used_frac(ctx: CornerContext) -> float | None:
 # --- Tier-B live signals: turn per-wheel data into CONFIRMED attribution ------
 WHEEL_RADIUS_M = 0.347  # GT3 R effective rolling radius (session plant-ID)
 _WHEEL_LABELS = ("fl", "fr", "rl", "rr")  # #266 per-wheel order (matches wheel_read.WHEEL_KEYS)
+_YAW_RATE_EPS = 1e-3  # rad/s: peak turn-in |yaw| at/below this = "no rotation observed here" (#483)
 
 
 def _slip(omega: float, r: float, v: float) -> float:
@@ -859,9 +860,13 @@ def corner_live_signals(
     seg = range(sig.entry_i, sig.exit_i + 1)
     if lap.yaw_rate is not None:
         entry_yaw = [abs(lap.yaw_rate[k]) for k in range(sig.entry_i, sig.apex_i + 1)]
-        # Peak |yaw| through turn-in is the confirming rotation magnitude; its presence flips the
-        # turn_in_lag / balance-direction rules from a suspicion to a verdict.
-        extra["yaw_rate"] = round(max(entry_yaw), 3) if entry_yaw else 0.0
+        peak_yaw = max(entry_yaw) if entry_yaw else 0.0
+        # Only confirm when rotation was actually OBSERVED through turn-in (mirrors the lock_axle /
+        # wheelspin "observed here" guard): a 0.0 peak — an all-zero turn-in window, or an empty
+        # entry window — must never fabricate a turn_in_lag verdict claiming "0.0 rad/s" just
+        # because the lap carries yaw data elsewhere (cursor #483).
+        if peak_yaw > _YAW_RATE_EPS:
+            extra["yaw_rate"] = round(peak_yaw, 3)
     if lap.accg_lat is not None:
         extra["accG_lat"] = round(max(abs(lap.accg_lat[k]) for k in seg), 3)
     if lap.accg_long is not None:

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -781,6 +781,35 @@ def _slip(omega: float, r: float, v: float) -> float:
     return 0.0 if v < 0.5 else (omega * r - v) / v
 
 
+def _turn_in_yaw_lag(lap: LapTrace, sig: CornerSignature) -> float | None:
+    """Turn-in lag score in (0, 1] when heading TRAILS the steer input through entry, else None.
+
+    'Sluggish turn-in' means the wheel is loaded but the car has not started rotating. We measure
+    that reference-free from the SAME lap: at the sample where steering first commits (>=60% of its
+    entry-window peak), how far has yaw developed toward its entry-window peak? A responsive front
+    already has yaw near its peak when steer commits (high ratio) -> NOT lag. A lagging front is
+    still near-zero yaw at steer commit -> return 1 - that ratio (bigger = laggier). This — not
+    mere yaw presence — is what confirms turn_in_lag (cursor #483).
+    """
+    if lap.yaw_rate is None:
+        return None
+    steer_abs = [abs(lap.steer[k]) for k in range(sig.entry_i, sig.apex_i + 1)]
+    yaw_abs = [abs(lap.yaw_rate[k]) for k in range(sig.entry_i, sig.apex_i + 1)]
+    if len(steer_abs) < 3:
+        return None
+    steer_pk = max(steer_abs)
+    yaw_pk = max(yaw_abs)
+    if steer_pk < 0.05 or yaw_pk <= _YAW_RATE_EPS:
+        return None  # no real steering demand, or no rotation signal at all
+    commit = next((j for j, s in enumerate(steer_abs) if s >= 0.6 * steer_pk), None)
+    if commit is None:
+        return None
+    yaw_frac_at_commit = yaw_abs[commit] / yaw_pk
+    if yaw_frac_at_commit >= 0.6:
+        return None  # yaw already tracking steer -> responsive front, not a lag
+    return round(1.0 - yaw_frac_at_commit, 3)
+
+
 def corner_live_signals(
     lap: LapTrace,
     sig: CornerSignature,
@@ -859,14 +888,13 @@ def corner_live_signals(
     # --- chassis dynamics (#478 Part A): measured yaw rate + g-forces confirm rotation/balance ---
     seg = range(sig.entry_i, sig.exit_i + 1)
     if lap.yaw_rate is not None:
-        entry_yaw = [abs(lap.yaw_rate[k]) for k in range(sig.entry_i, sig.apex_i + 1)]
-        peak_yaw = max(entry_yaw) if entry_yaw else 0.0
-        # Only confirm when rotation was actually OBSERVED through turn-in (mirrors the lock_axle /
-        # wheelspin "observed here" guard): a 0.0 peak — an all-zero turn-in window, or an empty
-        # entry window — must never fabricate a turn_in_lag verdict claiming "0.0 rad/s" just
-        # because the lap carries yaw data elsewhere (cursor #483).
-        if peak_yaw > _YAW_RATE_EPS:
-            extra["yaw_rate"] = round(peak_yaw, 3)
+        # Confirm turn_in_lag ONLY when the measured yaw actually TRAILS the steer input through
+        # turn-in (heading lags steer). Healthy rotation (yaw tracks steer) is NOT lag, so we leave
+        # the rule advisory rather than flip a false "rotates late" verdict on any observed yaw
+        # (cursor #483). accG rides along below for the balance rules regardless.
+        lag = _turn_in_yaw_lag(lap, sig)
+        if lag is not None:
+            extra["yaw_rate"] = lag
     if lap.accg_lat is not None:
         extra["accG_lat"] = round(max(abs(lap.accg_lat[k]) for k in seg), 3)
     if lap.accg_long is not None:
@@ -1212,13 +1240,13 @@ def _grip_limited_coaching(ctx: CornerContext) -> str:
 
 
 def _turn_in_lag_coaching(ctx: CornerContext) -> str:
-    yaw = ctx.extra.get("yaw_rate") if isinstance(ctx.extra, dict) else None
-    if isinstance(yaw, (int, float)):
+    lag = ctx.extra.get("yaw_rate") if isinstance(ctx.extra, dict) else None
+    if isinstance(lag, (int, float)):
         return (
-            f"Sluggish turn-in CONFIRMED by live yaw-rate (peak {yaw} rad/s) — the car "
-            "rotates late for the steering input. Load the front on entry (trail-brake, quicker "
-            "initial input); cold or under-pressure fronts are the next suspect, before caster / "
-            "front springs. Front toe-out is a last, small lever."
+            "Sluggish turn-in CONFIRMED by live yaw-rate — the heading trails the steering through "
+            f"turn-in (lag {lag}). Load the front on entry (trail-brake, quicker initial input); "
+            "cold or under-pressure fronts are the next suspect, before caster / front springs. "
+            "Front toe-out is a last, small lever."
         )
     return (
         "Sluggish turn-in (heading lags steer) — likely technique or front load, not necessarily "

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -796,7 +796,7 @@ def corner_live_signals(
     rule table keys on (so a suspicion graduates to a verdict) plus the derived signal:
 
     * ``wheelAngularSpeed`` (#266) → ``lock_axle`` ('front'|'rear'|'both'|None) under braking and
-      ``wheelspin`` on exit. Slip is computed from angular speed (the canonical longitudinal signal),
+      ``wheelspin`` on exit. Slip is from angular speed (the canonical longitudinal signal),
       not AC's combined ``wheelSlip``.
     * ``yaw_rate`` (#478 Part A) → the measured rotation signal confirming turn-in lag / the
       under-vs-oversteer direction, as the peak |yaw| through turn-in (rad/s). ``accG_lat`` /
@@ -804,7 +804,7 @@ def corner_live_signals(
     * ``wheelsPressure`` (#478 Part B) → the mean per-wheel dynamic HOT pressure over the corner
       (psi), confirming the pressure/compound attribution.
 
-    Returns ``{}`` when the lap persists no Tier-B channel at all. Each block is independently gated,
+    Returns ``{}`` when the lap persists no Tier-B channel. Each block is independently gated,
     so a lap with only some channels still confirms the rules those channels back.
     """
     extra: dict[str, Any] = {}
@@ -1187,17 +1187,21 @@ def _consistency_coaching(ctx: CornerContext) -> str:
 
 def _grip_limited_coaching(ctx: CornerContext) -> str:
     press = ctx.extra.get("wheelsPressure") if isinstance(ctx.extra, dict) else None
+    shown: str | None = None
     if isinstance(press, dict):
         shown = ", ".join(
             f"{k.upper()} {v}" for k, v in press.items() if isinstance(v, (int, float))
         )
+    elif isinstance(press, (list, tuple)):
+        shown = ", ".join(f"{v}" for v in press if isinstance(v, (int, float)))
+    if shown:
         return (
-            "Car's at the limit mid-corner; to go faster change the setup (pressures/compound/wing), "
+            "Car's at the limit mid-corner; to go faster change setup (pressures/compound/wing), "
             f"not the line. Live hot pressures ({shown} psi) confirm it — check them against the "
             "compound's optimal window and move pressures toward it."
         )
     return (
-        "Car's at the limit mid-corner; to go faster change the setup (pressures/compound/wing), not "
+        "Car's at the limit mid-corner; to go faster change setup (pressures/compound/wing), not "
         "the line. Confirm pressure/compound with live hot-pressure + core-temp."
     )
 
@@ -1206,7 +1210,7 @@ def _turn_in_lag_coaching(ctx: CornerContext) -> str:
     yaw = ctx.extra.get("yaw_rate") if isinstance(ctx.extra, dict) else None
     if isinstance(yaw, (int, float)):
         return (
-            f"Sluggish turn-in CONFIRMED by live yaw-rate (peak {yaw} rad/s through entry) — the car "
+            f"Sluggish turn-in CONFIRMED by live yaw-rate (peak {yaw} rad/s) — the car "
             "rotates late for the steering input. Load the front on entry (trail-brake, quicker "
             "initial input); cold or under-pressure fronts are the next suspect, before caster / "
             "front springs. Front toe-out is a last, small lever."

--- a/tools/ai_sidecar/lap_dynamics.py
+++ b/tools/ai_sidecar/lap_dynamics.py
@@ -90,10 +90,8 @@ class LapTrace:
 
     @property
     def has_chassis_data(self) -> bool:
-        """True when measured chassis dynamics (accG / yaw_rate) are persisted in this lap (#478)."""
-        return (
-            self.yaw_rate is not None or self.accg_lat is not None or self.accg_long is not None
-        )
+        """True when measured chassis dynamics (accG / yaw_rate) are persisted in this lap."""
+        return self.yaw_rate is not None or self.accg_lat is not None or self.accg_long is not None
 
     @property
     def has_pressure_data(self) -> bool:

--- a/tools/ai_sidecar/lap_dynamics.py
+++ b/tools/ai_sidecar/lap_dynamics.py
@@ -45,6 +45,12 @@ class LapTrace:
     # optional Tier-B live channels (per sample, 4 wheels [FL, FR, RL, RR]); None when not persisted
     wheel_omega: list[list[float]] | None = None  # wheelAngularSpeed rad/s
     wheel_slip: list[list[float]] | None = None  # AC wheelSlip (Pacejka NDslip; secondary)
+    # optional Tier-B chassis + hot-pressure channels (issue #478); None when not persisted OR
+    # present-but-all-zero (the "unreadable" sentinel — see _scalar_col / _wheel_cols).
+    accg_long: list[float] | None = None  # measured longitudinal g (accG_long, in G; -ve = braking)
+    accg_lat: list[float] | None = None  # measured lateral g (accG_lat, in G)
+    yaw_rate: list[float] | None = None  # measured yaw rate (rad/s), CSP localAngularVelocity.y
+    wheel_pressure: list[list[float]] | None = None  # dynamic HOT pressure psi [FL, FR, RL, RR]
     # lazily derived
     _kappa: list[float] | None = field(default=None, repr=False)
     _lat_g: list[float] | None = field(default=None, repr=False)
@@ -82,6 +88,23 @@ class LapTrace:
         """True when per-wheel angular speed (the Tier-B channel) is persisted in this lap."""
         return self.wheel_omega is not None
 
+    @property
+    def has_chassis_data(self) -> bool:
+        """True when measured chassis dynamics (accG / yaw_rate) are persisted in this lap (#478)."""
+        return (
+            self.yaw_rate is not None or self.accg_lat is not None or self.accg_long is not None
+        )
+
+    @property
+    def has_pressure_data(self) -> bool:
+        """True when dynamic HOT tyre pressure is persisted in this lap (issue #478)."""
+        return self.wheel_pressure is not None
+
+    @property
+    def has_tier_b_data(self) -> bool:
+        """True when ANY Tier-B live channel (per-wheel, chassis, or pressure) is persisted."""
+        return self.has_wheel_data or self.has_chassis_data or self.has_pressure_data
+
 
 def _idx(fields: list[str], *names: str) -> int | None:
     for n in names:
@@ -117,6 +140,30 @@ def _wheel_cols(fields: list[str], samples: list, base: str, n: int) -> list[lis
                 any_nonzero = True
             vals.append(v)
         out.append(vals)
+    return out if any_nonzero else None
+
+
+def _scalar_col(fields: list[str], samples: list, name: str) -> list[float] | None:
+    """Read a single channel column by ``name`` into N floats, or None.
+
+    Same all-zero guard as :func:`_wheel_cols`: #478 makes these chassis fields ALWAYS present in a
+    new trace, so a real lap whose chassis was unreadable persists zeros. A zero must read as "no
+    live data" (not a real 0 g / 0 yaw), so the confirming channel marker is never emitted off an
+    absent signal. Returns None when the column is absent OR present-but-all-zero.
+    """
+    i = _idx(fields, name)
+    if i is None:
+        return None
+    out: list[float] = []
+    any_nonzero = False
+    for row in samples:
+        try:
+            v = float(row[i])
+        except (TypeError, ValueError, IndexError):
+            v = 0.0
+        if v != 0.0:
+            any_nonzero = True
+        out.append(v)
     return out if any_nonzero else None
 
 
@@ -179,6 +226,11 @@ def lap_trace_from_archive(archive: dict[str, Any]) -> LapTrace:
     # optional Tier-B per-wheel channels (FL, FR, RL, RR); present only when persisted (#266)
     wheel_omega = _wheel_cols(fields, samples, "wheelAngularSpeed", n)
     wheel_slip = _wheel_cols(fields, samples, "wheelSlip", n)
+    # optional Tier-B chassis + hot-pressure channels; present only when persisted (#478)
+    accg_long = _scalar_col(fields, samples, "accG_long")
+    accg_lat = _scalar_col(fields, samples, "accG_lat")
+    yaw_rate = _scalar_col(fields, samples, "yaw_rate")
+    wheel_pressure = _wheel_cols(fields, samples, "wheelsPressure", n)
 
     car = archive.get("car") if isinstance(archive.get("car"), dict) else {}
     track = archive.get("track") if isinstance(archive.get("track"), dict) else {}
@@ -193,6 +245,10 @@ def lap_trace_from_archive(archive: dict[str, Any]) -> LapTrace:
         gear=col(i_g),
         wheel_omega=wheel_omega,
         wheel_slip=wheel_slip,
+        accg_long=accg_long,
+        accg_lat=accg_lat,
+        yaw_rate=yaw_rate,
+        wheel_pressure=wheel_pressure,
         x=x_col,
         z=z_col,
         lap_ms=_finite(lap.get("lap_ms")),

--- a/tools/coaching_lake/build_analytics.py
+++ b/tools/coaching_lake/build_analytics.py
@@ -145,7 +145,10 @@ def _create_schema(con) -> None:  # noqa: ANN001
             lap_n INTEGER, lap_ms BIGINT, lap_s DOUBLE, is_pb BOOLEAN, is_valid BOOLEAN,
             weather_type TEXT, track_grip DOUBLE, ambient_temp_c DOUBLE, track_temp_c DOUBLE,
             setup_hash TEXT, setup_path TEXT, n_setup_params INTEGER,
-            n_corners INTEGER, sample_count INTEGER, exported_at TEXT
+            n_corners INTEGER, sample_count INTEGER, exported_at TEXT,
+            -- First-class tyre identity from the lap header (issue #478 Part C), distinct from
+            -- setup_hash; NULL for archives written before the tyres block existed.
+            tyre_set TEXT
         )
         """
     )
@@ -216,6 +219,23 @@ def _iter_setup_items(snapshot: Any):
                     yield k, item[1]
 
 
+def _tyre_set_key(tyres: Any) -> str | None:
+    """First-class tyre identity for a lap (issue #478 Part C).
+
+    Prefers the human tyre-set name (``ac.getTyresName``), else the compound index, else None so the
+    lakehouse falls back to the setup-hash proxy for archives written before the tyres block existed.
+    """
+    if not isinstance(tyres, dict):
+        return None
+    name = tyres.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    idx = tyres.get("compoundIndex")
+    if isinstance(idx, (int, float)) and not isinstance(idx, bool):
+        return f"compound:{int(idx)}"
+    return None
+
+
 def _lap_row(rec: dict, path: Path) -> tuple:
     car = rec.get("car") or {}
     track = rec.get("track") or {}
@@ -226,6 +246,7 @@ def _lap_row(rec: dict, path: Path) -> tuple:
     lap_ms = lap.get("lap_ms")
     lap_ms_i = int(lap_ms) if isinstance(lap_ms, (int, float)) else None
     n_setup = sum(1 for _ in _iter_setup_items(setup.get("snapshot")))
+    tyre_set = _tyre_set_key(rec.get("tyres"))
     return (
         rec.get("lap_uuid"),
         rec.get("session_uuid"),
@@ -251,6 +272,7 @@ def _lap_row(rec: dict, path: Path) -> tuple:
         len(rec.get("corners") or []),
         trace.get("samples_count") or len(trace.get("samples") or []),
         rec.get("exported_at"),
+        tyre_set,
     )
 
 
@@ -296,11 +318,14 @@ def _materialize_session_tables(con) -> None:  # noqa: ANN001
         INSERT INTO stints
         WITH ordered AS (
             SELECT *,
+                   -- A stint boundary is a change in the tyre-set identity (issue #478 Part C) OR
+                   -- the setup; keying on both promotes stints off the raw setup_hash proxy while
+                   -- still splitting when only the setup changed.
                    CASE
-                     WHEN lag(coalesce(setup_hash, '')) OVER (
+                     WHEN lag(coalesce(tyre_set, '') || '|' || coalesce(setup_hash, '')) OVER (
                          PARTITION BY session_uuid
                          ORDER BY lap_n ASC NULLS LAST, exported_at ASC NULLS LAST, file ASC
-                     ) IS NOT DISTINCT FROM coalesce(setup_hash, '')
+                     ) IS NOT DISTINCT FROM (coalesce(tyre_set, '') || '|' || coalesce(setup_hash, ''))
                      THEN 0 ELSE 1
                    END AS stint_start
             FROM laps
@@ -320,7 +345,8 @@ def _materialize_session_tables(con) -> None:  # noqa: ANN001
                any_value(car_id),
                any_value(track_id),
                nullif(any_value(setup_hash), ''),
-               coalesce(nullif(any_value(setup_hash), ''), 'unknown-tyre-set'),
+               coalesce(nullif(any_value(tyre_set), ''), nullif(any_value(setup_hash), ''),
+                        'unknown-tyre-set'),
                min(lap_n),
                max(lap_n),
                count(*)::INTEGER,
@@ -424,7 +450,7 @@ def build_lake(
                 car = (rec.get("car") or {}).get("id")
                 track = (rec.get("track") or {}).get("id")
                 con.execute(
-                    "INSERT INTO laps VALUES (" + ", ".join("?" for _ in range(24)) + ")",
+                    "INSERT INTO laps VALUES (" + ", ".join("?" for _ in range(25)) + ")",
                     _lap_row(rec, path),
                 )
                 summary.laps += 1

--- a/tools/coaching_lake/build_analytics.py
+++ b/tools/coaching_lake/build_analytics.py
@@ -227,14 +227,16 @@ def _tyre_set_key(tyres: Any) -> str | None:
     """
     if not isinstance(tyres, dict):
         return None
+    # Canonicalize on the numeric compound INDEX whenever it is a finite number: the index is stable
+    # across laps, whereas the human name can be intermittent (getTyresName may fail on some laps),
+    # so preferring name would split one physical set into multiple stints (cursor #483). Guard
+    # non-finite (inf/NaN): int(inf) raises OverflowError and would break ingest (qodo #483).
+    idx = tyres.get("compoundIndex")
+    if isinstance(idx, (int, float)) and not isinstance(idx, bool) and math.isfinite(idx):
+        return f"compound:{int(idx)}"
     name = tyres.get("name")
     if isinstance(name, str) and name.strip():
         return name.strip()
-    idx = tyres.get("compoundIndex")
-    # Guard non-finite (inf/NaN): int(inf) raises OverflowError and would break ingest for any
-    # archive that slipped a bad index through (qodo #483). Fall back to setup_hash instead.
-    if isinstance(idx, (int, float)) and not isinstance(idx, bool) and math.isfinite(idx):
-        return f"compound:{int(idx)}"
     return None
 
 

--- a/tools/coaching_lake/build_analytics.py
+++ b/tools/coaching_lake/build_analytics.py
@@ -231,7 +231,9 @@ def _tyre_set_key(tyres: Any) -> str | None:
     if isinstance(name, str) and name.strip():
         return name.strip()
     idx = tyres.get("compoundIndex")
-    if isinstance(idx, (int, float)) and not isinstance(idx, bool):
+    # Guard non-finite (inf/NaN): int(inf) raises OverflowError and would break ingest for any
+    # archive that slipped a bad index through (qodo #483). Fall back to setup_hash instead.
+    if isinstance(idx, (int, float)) and not isinstance(idx, bool) and math.isfinite(idx):
         return f"compound:{int(idx)}"
     return None
 

--- a/tools/coaching_lake/build_analytics.py
+++ b/tools/coaching_lake/build_analytics.py
@@ -223,7 +223,7 @@ def _tyre_set_key(tyres: Any) -> str | None:
     """First-class tyre identity for a lap (issue #478 Part C).
 
     Prefers the human tyre-set name (``ac.getTyresName``), else the compound index, else None so the
-    lakehouse falls back to the setup-hash proxy for archives written before the tyres block existed.
+    lakehouse falls back to the setup-hash proxy for archives written before the tyres block.
     """
     if not isinstance(tyres, dict):
         return None
@@ -325,7 +325,9 @@ def _materialize_session_tables(con) -> None:  # noqa: ANN001
                      WHEN lag(coalesce(tyre_set, '') || '|' || coalesce(setup_hash, '')) OVER (
                          PARTITION BY session_uuid
                          ORDER BY lap_n ASC NULLS LAST, exported_at ASC NULLS LAST, file ASC
-                     ) IS NOT DISTINCT FROM (coalesce(tyre_set, '') || '|' || coalesce(setup_hash, ''))
+                     ) IS NOT DISTINCT FROM (
+                         coalesce(tyre_set, '') || '|' || coalesce(setup_hash, '')
+                     )
                      THEN 0 ELSE 1
                    END AS stint_start
             FROM laps

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -126,6 +126,12 @@ _MOTEC_CHANNELS: tuple[tuple[str, str, str], ...] = (
     ("Lap Number", "none", "lap_n"),
     ("Lap Time", "s", "lap_time_s"),
     ("Valid Lap", "none", "valid_lap"),
+    # Chassis dynamics (issue #478) — APPENDED so existing MoTeC column positions stay stable.
+    # G-forces + yaw rate are prime MoTeC analysis channels; the per-wheel arrays (#266 omega/slip/
+    # temp, #478 wheelsPressure) stay out of the curated MoTeC subset and ride the analysis CSV.
+    ("G Force Long", "G", "accG_long"),
+    ("G Force Lat", "G", "accG_lat"),
+    ("Yaw Rate", "rad/s", "yaw_rate"),
 )
 
 

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -56,6 +56,14 @@ CSV_COLUMNS: tuple[str, ...] = (
     "tyreCoreTemp_fr",
     "tyreCoreTemp_rl",
     "tyreCoreTemp_rr",
+    # chassis dynamics + hot pressure (issue #478) — blank for archives that lack them
+    "accG_long",
+    "accG_lat",
+    "yaw_rate",
+    "wheelsPressure_fl",
+    "wheelsPressure_fr",
+    "wheelsPressure_rl",
+    "wheelsPressure_rr",
 )
 
 _PER_WHEEL_TRACE_FIELDS: tuple[str, ...] = (
@@ -73,6 +81,17 @@ _PER_WHEEL_TRACE_FIELDS: tuple[str, ...] = (
     "tyreCoreTemp_rr",
 )
 
+# Chassis dynamics + dynamic hot pressure (issue #478); blank for archives that lack them.
+_TIER_B_TRACE_FIELDS: tuple[str, ...] = (
+    "accG_long",
+    "accG_lat",
+    "yaw_rate",
+    "wheelsPressure_fl",
+    "wheelsPressure_fr",
+    "wheelsPressure_rl",
+    "wheelsPressure_rr",
+)
+
 _TRACE_TO_CSV: dict[str, str] = {
     "eMs": "elapsed_ms",
     "spline": "spline",
@@ -87,6 +106,8 @@ _TRACE_TO_CSV: dict[str, str] = {
     "pz": "position_z_m",
     # per-wheel channels map to identically-named CSV columns
     **{name: name for name in _PER_WHEEL_TRACE_FIELDS},
+    # chassis + hot-pressure channels (issue #478) map to identically-named CSV columns
+    **{name: name for name in _TIER_B_TRACE_FIELDS},
 }
 
 _MOTEC_CHANNELS: tuple[tuple[str, str, str], ...] = (


### PR DESCRIPTION
## What

Captures the **Tier-B channels** the setup-aware coaching engine was already wired to confirm from but that were **read live and never persisted** — measured g-forces, yaw rate, and dynamic hot tyre pressure — plus a first-class tyre-set identity and the weather type. The engine's attribution rules already key on `rule.channels_needed`; this is the "capture half" that flips them from *advisory* to *verdict*.

Direct successor to **#266** (persisted `wheelSlip[4]`+`wheelAngularSpeed[4]`) and the **#402** tyre-set residual. Same append-only, byte-identical-trace shape.

Closes #478.

## Parts

**A — Chassis dynamics (`accG_long`, `accG_lat`, `yaw_rate`).** New `chassis_read.lua` (pcall-guarded, single source of truth like `wheel_read.lua`) reads `car.acceleration` (already in **G**: `.x` lateral, `.z` longitudinal) and `car.localAngularVelocity.y` (yaw rate, rad/s) — both confirmed against the on-box CSP SDK (`ac_apps/lib.lua`). `telemetry.lua` writes them into the trace; `corner_attribution.corner_live_signals` emits the `yaw_rate` (+`accG`) markers so `turn_in_lag` reports a **verdict**. As the same reader was added, the live `telemetry_tick` publish (`ac_copilot_trainer.lua`) now sends real `lat_g`/`long_g` (were hardcoded `0`).

**B — `wheelsPressure[4]` (dynamic hot pressure).** `wheel_read.pressure` reads `wheel.tyrePressure` (the *dynamic* hot value, not `tyreStaticPressure`); persisted per wheel and consumed so `grip_limited` reports a **verdict**.

**C — First-class tyre-set id.** Lap header gains a `tyres` block (`compoundIndex` + `ac.getTyresName`), distinct from `setup.hash`. The lakehouse `stints` now split on this identity (falling back to `setup_hash` for old archives) and `tyre_set_key` is promoted off the raw `setup_hash` proxy. *AC exposes no per-physical-set serial to Lua*, so this identifies the **compound**, not a same-compound fresh-rubber swap.

**D — `conditions.weatherType`.** Populated from `sim.weatherType` (was a `nil` stub); already flows into the lakehouse `weather_type` column.

## Acceptance criteria

- [x] **Trace carries the new channels; older archives still load & export as blanks.** `TRACE_FIELDS` 23→30, appended **after** `rpm`; `_TRACE_FIELD_VARIANTS` keeps the 23-col set (new tests: pre-#478 23-col load + blank export).
- [x] **A rotation-lag / pressure corner reports a verdict on a lap carrying the channels.** `corner_live_signals` auto-derives the `yaw_rate`/`wheelsPressure` markers; `turn_in_lag` and `grip_limited` flip advisory→verdict (tested).
- [x] **Stints split on the first-class tyre-set id.** `build_analytics` keys stints on the tyre identity; tested with two compounds under one identical `setup_hash`.
- [x] **`test_reference_lap` still asserts the Lua/Python `TRACE_FIELDS` agree** (record fields == `TRACE_FIELDS`; the lupa round-trip drives the real `lap_archive.lua`/`telemetry.lua`).

## Pitfalls honored

- **Byte-identical, append-only trace** — `lap_archive.lua::TRACE_FIELDS` and `reference_lap.py::TRACE_FIELDS` stay identical; new columns appended after `rpm` so older column positions are load-bearing-stable.
- **All-zero = "no live data"** — a lap whose chassis/pressure was unreadable persists zeros; `_scalar_col`/`_wheel_cols` treat an all-zero column as absent so a missing signal never fabricates a verdict (mirrors the #266 omega guard).
- **CSP field safety** — `acceleration`/`localAngularVelocity` are not on the confirmed-safe list, so every read is pcall-guarded and declared in `ac_schema.json`.
- **Data-immutability** — capture only writes new archives.

## Reconciled against the evolved code (not the issue text)

- The hardcoded `lat_g/long_g=0` is at `ac_copilot_trainer.lua:2463` (issue said `:2278` — **line drift**; trusted code).
- `setup_optimizer.py:205` uses `setup_hash` as the **setup-experiment** identity (correct — not a tyre-set proxy), so left unchanged. The real proxy was `build_analytics.stints`.
- `tyreCoreTemp[4]` / `rpm` / `conditions` header were already shipped (#266/#442) — not re-scoped.

## Verification

`make ci-fast`: **2357 passed**. The lone red is environmental, not from this change: `test_ai_sidecar_external::test_external_bind_accepts_env_token` asserts `serial_port=None`, but this rig sets `AC_COPILOT_SIDECAR_SERIAL_PORT=COM6` (the #463 ESP32 screen) which leaks into the test's argparse default. It **passes with the var unset**, and this branch touches neither `server.py` nor that test — CI runs clean.

**Pending: operator-grade in-sim verification** — drive a lap on the rig, confirm the archive columns carry non-zero `accG_*`/`yaw_rate`/`wheelsPressure_*` and a real `tyres` block, and that a rotation/pressure corner reports a confirmed verdict. (Off-rig the CSP fields degrade to `nil`→blank, by design.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
