### PR TITLE
docs(vault): post-merge handoff for #478 Tier-B channel capture (PR #483)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -22,6 +22,23 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
+**Delivered (2026-07-03):** PR [#483](https://github.com/agorokh/ac-copilot-trainer/pull/483)
+**MERGED** at [`28c0fe1`](https://github.com/agorokh/ac-copilot-trainer/commit/28c0fe1b8745cef02d2cf9828502f2c21be58fcf) —
+**[#478](https://github.com/agorokh/ac-copilot-trainer/issues/478) CLOSED** (Capture Tier-B channels
+accG/yaw_rate/wheelsPressure + first-class tyre-set id + weatherType; #266 stretch / #402 residual).
+New `chassis_read.lua` captures measured g-forces (`car.acceleration`, in G) + yaw rate
+(`car.localAngularVelocity.y`); `wheel_read` captures dynamic hot `tyrePressure`; `telemetry.lua`
+persists them (TRACE_FIELDS 23→30, append-only, byte-identical Lua/Python, older archives load as
+blanks; all-zero column = "no live data"). Consume: `corner_attribution` `turn_in_lag` flips
+advisory→verdict only on real heading-trails-steer lag, `grip_limited` on live hot pressure. Lakehouse
+`stints` split on the canonical compound index off the `setup_hash` proxy. Live `telemetry_tick` sends
+real lat/long G. Analysis CSV + MoTeC (G-forces + yaw) export the channels. Review-hardened over 4
+self-hosted-reviewer rounds (all real defects + tests). `make ci-fast` 2357 passed. **Operator-pending
+(not a code AC):** live-CSP in-sim spot-check — deferred, shared rig on `feat/issue-479` + 12
+concurrent worktrees; drive a lap with #478 active and confirm non-zero `accG_*`/`yaw_rate`/
+`wheelsPressure_*` + `tyres` block + a confirmed verdict. Detail:
+[[issue-478-tier-b-channels-2026-07-03]].
+
 **Active focus (2026-07-03):** PR
 [#465](https://github.com/agorokh/ac-copilot-trainer/pull/465) for
 [#461](https://github.com/agorokh/ac-copilot-trainer/issues/461) is review-converged at

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-03T20:00:00Z
+last_updated: 2026-07-03T21:05:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-478-tier-b-channels-2026-07-03.md
   - AcCopilotTrainer/03_Investigations/pr-480-simhub-launcher-toggle-2026-07-03.md
   - AcCopilotTrainer/03_Investigations/issue-432-atelier-insim-reverify-2026-07-03.md
   - AcCopilotTrainer/03_Investigations/issue-381-intensity-verification-2026-07-03.md
@@ -66,6 +67,35 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-07-03 UTC) — PR #483 Tier-B channel capture (#478 CLOSED)
+
+PR [#483](https://github.com/agorokh/ac-copilot-trainer/pull/483) **MERGED** (squash
+[`28c0fe1`](https://github.com/agorokh/ac-copilot-trainer/commit/28c0fe1b8745cef02d2cf9828502f2c21be58fcf))
+closing [#478](https://github.com/agorokh/ac-copilot-trainer/issues/478) — captures the Tier-B channels
+the coaching engine was wired to confirm from but never persisted (successor to #266 / #402). New
+`chassis_read.lua` reads `car.acceleration` (in G) + `car.localAngularVelocity.y` (yaw); `wheel_read`
+reads dynamic hot `tyrePressure`; `telemetry.lua` persists `accG_long/accG_lat/yaw_rate` +
+`wheelsPressure[4]` (TRACE_FIELDS 23→30, append-only, byte-identical Lua/Python, older archives load as
+blanks; all-zero column = "no live data" so a missing signal never fabricates a verdict). Consume:
+`turn_in_lag` flips advisory→verdict only on real heading-trails-steer lag (`_turn_in_yaw_lag`),
+`grip_limited` on live hot pressure. Header gains first-class `tyres` (compoundIndex + name) + Part-D
+`weatherType`; lakehouse `stints` split on the canonical compound index off the `setup_hash` proxy.
+Live `telemetry_tick` now sends real lat/long G. Analysis CSV + MoTeC (G-forces + yaw) export the
+channels. **Review-hardened over 4 self-hosted-reviewer rounds — all real defects, all fixed + tested:**
+zero/healthy-yaw false confirmations, tyre-identity fabrication when compoundIndex unread, ±inf
+compoundIndex ingest crash, stint-key inconsistency. `make ci-fast` 2357 passed. Detail:
+[[issue-478-tier-b-channels-2026-07-03]].
+
+**Operator-pending (not a #478 acceptance criterion): live-CSP in-sim spot-check.** The issue's ACs
+(channels captured, verdicts flip, stints split, byte-identical) are all test-verified — the lupa
+harness drives the real Lua telemetry/wheel_read/chassis_read against a car providing the CSP fields.
+The live-CSP confirmation was **deferred** (shared rig on `feat/issue-479`, AC symlink pointed there, 12
+concurrent worktrees — repointing to force a drive was unsafe; cf.
+[[issue-277-rig-verify-prepped-blocked-concurrency-2026-06-27]]). **Unblock:** with #478 active (primary
+checkout on `main`@`28c0fe1`, or AC symlink at a #478 checkout, + AC relaunch), drive a lap and confirm
+the newest `journal/laps/lap_*.json` carries non-zero `accG_long/accG_lat/yaw_rate/wheelsPressure_*` + a
+real `tyres` block, and a rotation/pressure corner reports a CONFIRMED verdict.
 
 ## Delivered (2026-07-03 UTC) — PR #480 SimHub auto-start toggle (#479 CLOSED)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-478-tier-b-channels-2026-07-03.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-478-tier-b-channels-2026-07-03.md
@@ -1,0 +1,73 @@
+---
+type: investigation
+status: active
+created: 2026-07-03
+updated: 2026-07-03
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/01_Decisions/csp-api-field-safety.md
+---
+
+# #478 Tier-B channel capture (accG, yaw_rate, wheelsPressure) + tyre-set id — PR #483
+
+## Summary
+
+Captured the Tier-B channels the setup-aware coaching engine was already wired to confirm from but
+never persisted. The "capture half" that flips `corner_attribution` rules advisory→verdict. Direct
+successor to #266 (per-wheel omega/slip/temp) and the #402 tyre-set residual. **PR #483 MERGED**
+2026-07-03 at `28c0fe1`; **#478 CLOSED**.
+
+## What shipped
+
+- **Part A — chassis dynamics.** New `chassis_read.lua` (pcall-guarded, single-source like
+  `wheel_read.lua`) reads `car.acceleration` (**already in G**: `.x`=lateral, `.z`=longitudinal) and
+  `car.localAngularVelocity.y` (yaw rate rad/s). `telemetry.lua` persists `accG_long/accG_lat/yaw_rate`.
+  Live `telemetry_tick` now publishes real `lat_g/long_g` (were hardcoded 0 at
+  `ac_copilot_trainer.lua`).
+- **Part B — hot pressure.** `wheel_read.pressure` reads `wheel.tyrePressure` (dynamic, not
+  `tyreStaticPressure`) → `wheelsPressure[4]` columns.
+- **Part C — first-class tyre-set id.** Lap header `tyres` block (`compoundIndex` + `ac.getTyresName`)
+  distinct from `setup.hash`; lakehouse `stints` split on it, canonical on the numeric compound
+  **index** (name is fallback). AC exposes no per-physical-set serial to Lua.
+- **Part D — weatherType** from `sim.weatherType`; flows to lakehouse `weather_type`.
+
+`TRACE_FIELDS` 23→30, append-only after `rpm`; `_TRACE_FIELD_VARIANTS` keeps the 23-col set so older
+archives load & export as blanks. All-zero column = "no live data" (never fabricates a verdict).
+
+## CSP API facts (confirmed from the on-box SDK `ac_apps/lib.lua`)
+
+- `ac.StateCar.acceleration` — vec3 **in G** (`@G-forces, X sideways, Z fwd/back`).
+- `ac.StateCar.localAngularVelocity` — vec3 rad/s local frame; `.y` = yaw.
+- `ac.StateWheel.tyrePressure` — **dynamic** hot pressure; `tyreStaticPressure` = cold.
+- `ac.StateCar.compoundIndex` + `ac.getTyresName(0, idx)` — tyre compound identity.
+- `acceleration`/`localAngularVelocity` NOT on the confirmed-safe list → pcall-guarded, added to
+  `ac_schema.json`.
+
+## Review hardening (4 self-hosted-reviewer rounds — all real defects, all + tests)
+
+r1 zero-yaw false confirm + CSV false-positive + MoTeC channels; r2 turn_in_lag confirmed on *healthy*
+yaw (fixed with `_turn_in_yaw_lag` heading-trails-steer proxy) + tyre-name fabrication when index
+unread; r3 ±inf compoundIndex crashes `int()` ingest; r4 stint-key inconsistency (canonicalize on
+index) + schema doc.
+
+## Verification
+
+- `make ci-fast`: 2357 passed. The lupa harness drives the **real** Lua `telemetry/wheel_read/
+  chassis_read` against a car providing `acceleration/localAngularVelocity/tyrePressure` and confirms
+  the trace columns; consume→verdict path tested; byte-identical Lua/Python asserted.
+- Lone CI red is environmental (rig sets `AC_COPILOT_SIDECAR_SERIAL_PORT=COM6` for the #463 ESP32;
+  passes unset; #478 untouches `server.py` + that test).
+- **PENDING (operator-grade, not a #478 AC): live-CSP in-sim spot-check.** Deferred: the shared rig's
+  AC Lua symlink points at the primary checkout, which was on `feat/issue-479` (no #478), and 12
+  concurrent agent worktrees were active — repointing the shared symlink to force a drive was unsafe.
+  Unblock: with #478 the active Lua (primary checkout on `main`@`28c0fe1`, or symlink at a #478
+  checkout, + AC relaunch), drive a lap and confirm the newest `journal/laps/lap_*.json` carries
+  non-zero `accG_long/accG_lat/yaw_rate/wheelsPressure_*` + a real `tyres` block, and a rotation/
+  pressure corner reports a CONFIRMED (non-advisory) verdict.
+
+## Follow-ups (separable, not filed)
+
+- Prefer measured `accG_lat/long` over the `v²·κ` / `dv/dt` proxies in `lap_dynamics` segmentation
+  (deferred — changes segmentation behavior; own PR).
+- Test-hygiene: `test_external_bind_accepts_env_token` should null `AC_COPILOT_SIDECAR_SERIAL_PORT`
+  (env-leak on the rig).


### PR DESCRIPTION
Post-merge vault handoff for PR #483 (#478 CLOSED). Docs-only under `docs/01_Vault/**`: new investigation node, Current Focus + Next Session Handoff delivered entries, and the operator-pending live-CSP in-sim spot-check (deferred due to shared-rig concurrency). Auto-merge via vault-automerge.yml.