### PR TITLE
ci(vault-automerge): bump to @0db3755 (gov-hub#187 orphan-race fix)

### DIFF
--- a/.github/workflows/vault-automerge.yml
+++ b/.github/workflows/vault-automerge.yml
@@ -1,16 +1,19 @@
 name: Vault auto-merge
 
-# Thin caller. The vault-only scope guard (`docs/01_Vault/**` only) + `gh pr merge --auto`
-# logic -- including the #506 confirmation-race handling and the #855 `allow_auto_merge`-off
-# benign-downgrade -- lives ONCE in the governance-hub `vault-automerge` composite action
-# (agent-factory#863, gov-hub#122/#123), instead of a per-repo vendored copy. This repo keeps
-# only the trigger, the `vault-only` label gate, and permissions; the action operates on the PR
-# via `gh` (no checkout) and re-arms auto-merge only when scope passes (the gov-hub#123
-# disarm-first fix). SHA-pinned (reference-not-vendor; roll new versions canary -> fleet).
+# Thin caller. The vault-only scope guard (`docs/01_Vault/**` only) + the head-bound SYNCHRONOUS
+# merge (gov-hub#187/#190 -- never native `--auto`, so no standing server-side order can fire on
+# a stale head and orphan a follow-up commit) live ONCE in the governance-hub `vault-automerge`
+# composite action (agent-factory#863, gov-hub#122/#123), instead of a per-repo vendored copy.
+# This repo keeps only the trigger, the `vault-only` label gate, and permissions; the action
+# operates on the PR via `gh` (no checkout). SHA-pinned (reference-not-vendor; roll canary -> fleet).
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: vault-automerge-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -20,7 +23,7 @@ jobs:
   guard-and-automerge:
     if: contains(github.event.pull_request.labels.*.name, 'vault-only') && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 8
     steps:
       # The composite action lives in the PRIVATE governance-hub repo. A cross-repo `uses:` of a
       # private action does NOT resolve with the default GITHUB_TOKEN ("Unable to resolve action
@@ -39,7 +42,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: agorokh/governance-hub
-          ref: 0939d4724bd1e89515d4abd89d676c750580b028  # pragma: allowlist secret (git SHA, not a secret)
+          ref: 0db37554f20e8ddbbfdc6f8a622ce845faf4dd06  # pragma: allowlist secret (git SHA, not a secret)
           token: ${{ steps.app-token.outputs.token }}
           path: .governance-hub
       - uses: ./.governance-hub/.github/actions/vault-automerge


### PR DESCRIPTION
Rolls the #187/#190 vault-automerge orphan-race fix to this spoke (gov-hub#192).

- Bump the composite action pin to `@0db3755` — merges SYNCHRONOUSLY bound to the exact head via `--match-head-commit`, never arms native `--auto`, so a follow-up commit on a `vault-only` PR can no longer be orphaned.
- Raise `timeout-minutes` above the action's synchronous `merge-timeout-seconds` wait (the old action armed `--auto` and returned fast; the new one WAITS in-run, so a 3-minute job would be hard-killed mid-merge).
- Add `concurrency: cancel-in-progress: true` (this caller had no concurrency block) to cancel a stale in-run merge waiter when a new commit arrives.

Closes part of agorokh/governance-hub#192.