### PR TITLE
docs(vault): #466 criterion (a) exhausted - fundamental CSP/CM limit

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-03T21:50:00Z
+last_updated: 2026-07-03T22:35:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-466-setup-drive-rebake-race-2026-07-03.md
@@ -28,11 +28,17 @@ relates_to:
 fast-fail hardening + setup-race diagnosis (built on merged #465). `rig_hijack` short `--hijack-probe-seconds`
 probes detect a stalled "0 seconds" overlay and recycle a fresh launch in ~15 s (not ~32 s); per-cycle
 `[auto-drive]` logs + re-bake stats + `--setup-rebake-interval`; CLI-validated finite/positive float flags.
-**#466 stays OPEN** (criterion a, setup+drive ≥9/10, unmet): the `race.ini` setup re-bake fundamentally
-races CM's immediate-start (aggressive 0.05 s = setup applied but overlay stall; gentle ≥0.1 s = auto-start
-ok but setup missed; no cadence / `SimState.restart` / keypress-nudge fixes it) — needs a different
-injection (candidate: PIT-spawn + pre-hijack in-sim `setup.load`). No-setup drive path is reliable;
-resolve-pr converged in 5 rounds. Detail: [[issue-466-setup-drive-rebake-race-2026-07-03]].
+**#466 criterion (a) EXHAUSTED (2026-07-03, later autonomous session):** reliable `--setup`+drive is a
+**fundamental CSP/CM limitation**, not a missing mechanism. Every setup-injection layer is now closed
+in-sim — race.ini re-bake (no cadence sweet spot); FORCE_START gui.ini (does NOT skip the overlay,
+0/8+, so the #461 "~1/5" does not reproduce); suspend-inject (suspending acs is benign but the race.ini
+WRITE breaks CM immediate-start); read-only race.ini (CM can't launch); CM-native (Quick Drive writes
+`SETUP=` empty, no slot); CSP-Lua `ac.loadSetup` (`isCarResetAllowed` NEVER true on START or PIT
+autonomous launch, 0/152). Root cause: setup application needs a resettable/pre-live state; CM's
+immediate-start (the only reliable overlay-skip) precludes it. **Recommendation:** accept as a
+documented limitation; use `--no-setup` for autonomous drives (setup applies fine when NOT composed
+with a drive). FORCE_START code reverted; criterion (b) fast-fail shipped (#482). No-setup drive path
+reliable. Full table: [[issue-466-setup-drive-rebake-race-2026-07-03]].
 
 **Delivered (2026-07-03):** PR [#483](https://github.com/agorokh/ac-copilot-trainer/pull/483)
 **MERGED** at [`28c0fe1`](https://github.com/agorokh/ac-copilot-trainer/commit/28c0fe1b8745cef02d2cf9828502f2c21be58fcf) —

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-04T01:30:00Z
+last_updated: 2026-07-04T01:45:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-490-tier1-dynamic-channels-2026-07-03.md
   - AcCopilotTrainer/03_Investigations/issue-466-setup-drive-rebake-race-2026-07-03.md
@@ -69,6 +69,26 @@ relates_to:
 ---
 
 # Next session handoff
+
+## #466 criterion (a) EXHAUSTED (2026-07-03 UTC) — reliable `--setup`+drive is a FUNDAMENTAL CSP/CM limit
+
+`/autonomous-deliver 466` continued (operator approved FORCE_START-hygienic, then CSP-Lua). Both
+refuted in-sim. **Every setup-injection layer is now closed** with decisive in-sim evidence — full
+table in [[issue-466-setup-drive-rebake-race-2026-07-03]]:
+- race.ini re-bake (no cadence sweet spot, #482); **FORCE_START gui.ini** (does NOT skip the overlay,
+  0/8+ on CM-launch AND direct-relaunch — the #461 "~1/5" does not reproduce; snapshot/restore
+  hygiene proven correct but reverted with the mechanism); **suspend-inject** (suspending acs is
+  benign, but the race.ini WRITE breaks CM immediate-start); **read-only race.ini** (CM can't launch);
+  **CM-native** (Quick Drive writes `SETUP=` empty, no preset/AppData slot); **CSP-Lua
+  `ac.loadSetup`** (`isCarResetAllowed` NEVER true on START or PIT autonomous launch — 0/152 samples —
+  so loadSetup can't apply on a live car).
+- **Root cause:** setup application needs a resettable/pre-live state; CM's immediate-start (the only
+  reliable overlay-skip) precludes it. Mutually exclusive at every layer.
+- **State:** FORCE_START code reverted to origin/main (no code shipped this session). Criterion (b)
+  fast-fail already merged (#482). Setup applies fine when NOT composed with a drive (fuel-verified).
+- **Recommendation for #466:** accept as a documented CSP/CM limitation; use `--no-setup` for reliable
+  autonomous drives. A real fix needs an upstream CSP/CM change (a QuickDrive setup slot, or a
+  resettable autonomous state) — out of harness scope. #466 commented with the full characterization.
 
 ## Delivered (2026-07-04 UTC) — PR #492 MERGED (`73ebe82`): #490 Tier-1 base-AC dynamic channels, RIG-VERIFIED
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-466-setup-drive-rebake-race-2026-07-03.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-466-setup-drive-rebake-race-2026-07-03.md
@@ -49,9 +49,31 @@ launch. This is the fundamental #461/#465 timing race, now characterized (not a 
   not ~32 s (#466 criterion b). Per-cycle `[auto-drive]` logs + re-bake stats + `--setup-rebake-interval`.
 - **No-setup DRIVE path reliable.** Keypress nudge kept opt-out (`--no-overlay-nudge`), documented ineffective.
 
-## Remaining on #466 (criterion a: setup+drive ≥9/10)
-Needs a different setup-injection mechanism. Top candidate: **PIT-spawn + pre-hijack in-sim
-`setup.load`** (CSP `ac.setSetupSpinnerValue`) while `ac.isCarResetAllowed()` is true in the pit box —
-the "must be in pits" refusal was seen at a START spawn / while a hijack held the car, and is untested
-for a PIT-spawn pre-hijack load. Needs the trainer app as a loopback Lua peer. Larger than the
-overlay-skip scope, so #466 stays open for it.
+## Criterion (a) is a FUNDAMENTAL limitation - every setup-injection layer closed (2026-07-03)
+
+`/autonomous-deliver 466` continued: operator approved trying FORCE_START (hygienic), then CSP-Lua.
+Both refuted in-sim. Criterion (a) (reliable `--setup` + drive) is a **fundamental limitation** of
+this AC/CSP/CM stack, not a missing mechanism. The setup-injection half works (fuel-verified
+repeatedly); the overlay-skip half works (no-setup). They **cannot coexist**: setup application needs
+a PRE-LIVE / resettable state, and CM's immediate-start (the only reliable overlay-skip) precludes it.
+Every layer, verified in-sim:
+
+| Layer / mechanism | Result | Evidence |
+|---|---|---|
+| race.ini re-bake (cadence sweep) | No sweet spot | 0.05s applies setup but breaks auto-start; >=0.1s preserves auto-start but misses setup (#482) |
+| race.ini + CSP `[BASIC] FORCE_START` (install-tree gui.ini) | **FORCE_START does NOT skip the overlay** | 0/8+ across CM-launch AND direct-acs-relaunch; `FORCE_START=1` confirmed present through acs startup + setup applied (fuel=45), overlay still stalled. The #461 "~1/5" does NOT reproduce (why #465 removed it). Snapshot/restore/self-heal hygiene proven correct but reverted with the refuted mechanism |
+| race.ini suspend-inject (freeze acs, inject, resume) | suspend BENIGN, the WRITE breaks immediate-start | suspend-only (no write) -> hijack OK; suspend+write -> setup applied (fuel=45) but overlay stalled. CM reacts to the race.ini change during launch, regardless of acs being frozen |
+| Read-only race.ini (block CM's wipe) | CM can't launch | LIVE=False: CM must write race.ini to launch |
+| CM-native setup (cmpreset / AppData) | Dead | CM Quick Drive writes `[CAR_0] SETUP=` **empty**; no preset setup field (verified real presets); no per-car AppData setup key |
+| CSP-Lua `ac.loadSetup` at car init | Blocked | `ac.isCarResetAllowed()` polled continuously 45s on START **and** PIT -> **NEVER true** (0 OK / 152 "must be in pits"). `ac.loadSetup` needs a resettable state (CSP docs + PT usage + the #91 gate); an autonomous car never has one |
+
+**Root cause (ironclad):** setup application needs a resettable/pre-live state; CM's immediate-start
+precludes it. A race.ini WRITE during the immediate-start window breaks it (CM watches the file);
+CSP `ac.loadSetup` needs `isCarResetAllowed` which is never true on an autonomous launch; CM has no
+native setup slot; FORCE_START does not skip the overlay on this CSP.
+
+**Recommendation:** treat criterion (a) as a documented CSP/CM limitation. Shipped value: criterion
+(b) fast-fail is merged (#482); the setup applies fine when NOT composed with a drive (`--setup`
+alone is fuel-verified); use `--no-setup` for reliable autonomous drives. A real fix needs an
+upstream CSP/CM change (a QuickDrive setup slot, or a resettable autonomous state) - out of harness
+scope. Probes preserved: `.scratch/issue-466/{suspend_inject,readonly_race,reset_allowed_timeline}_probe.py`.


### PR DESCRIPTION
Vault characterization: **#466 criterion (a)** (reliable `--setup`+drive) is a **fundamental CSP/CM limitation**, documented after exhausting every setup-injection layer in-sim during the continued `/autonomous-deliver 466` session.

**Scope:** `docs/01_Vault/**` only — the #466 investigation node (full mechanism table + root cause) + `Next Session Handoff` + `Current Focus`.

**Why:** the operator approved trying FORCE_START (hygienic) and then CSP-Lua setup-at-init; both were refuted in-sim. Every layer is now closed with decisive evidence (FORCE_START gui.ini 0/8+; suspend-inject write breaks CM immediate-start; read-only race.ini stops CM launching; CM has no setup slot; CSP `ac.loadSetup` needs `isCarResetAllowed` which is never true on an autonomous launch, 0/152). The FORCE_START code was **reverted to origin/main** (no code change ships from this session). Criterion (b) fast-fail remains shipped (#482).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
