### PR TITLE
fix(harness): #466 Part B — setup-resolution + race.ini concurrency hardening

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1624,6 +1624,7 @@ local function resetRuntimeAfterLeavingTrack()
   renderDiag.reset()
   realtimeCoaching.reset()
   lifecyclePublisher.reset()  -- #180: re-emit `session` after a reset (else stale key suppresses it)
+  setupReader.resetRaceIniCache()  -- #466 B1: a fresh session may bake a different setup into race.ini
   telemetryPublisher.reset()  -- #180: reset delta/tire_temps rate-limiters
   state.realtimeActiveHint = nil
   state._cachedRealtimeView = nil
@@ -1664,6 +1665,7 @@ local function resetRollingDrivingState()
   hud.reset()
   realtimeCoaching.reset()
   lifecyclePublisher.reset()  -- #180: same-session/stint restart must re-emit `session`
+  setupReader.resetRaceIniCache()  -- #466 B1: a stint restart may re-bake a different setup into race.ini
   telemetryPublisher.reset()  -- #180: reset delta/tire_temps rate-limiters
   state.deltaRefStale = true  -- #180/#185: clock reset; delta silent until the next clean lap boundary
   state.pendingWrapResetLapCount = nil

--- a/src/ac_copilot_trainer/modules/setup_reader.lua
+++ b/src/ac_copilot_trainer/modules/setup_reader.lua
@@ -79,16 +79,18 @@ end
 --- non-existent `setups/<car>/<track>/race.ini` (live-found #461). Returns the absolute INI path
 --- only when it resolves to a readable file, else nil.
 ---@param doc string
----@return string|nil
+---@return string|false|nil value  path | RACE_INI_NO_SETUP (confirmed none) | nil (vanilla folder-guess)
+---@return boolean transient  true when race.ini could not be opened/read this call — momentarily
+---  missing or locked while CM rewrites it; the caller must retry, NOT folder-guess (#466 B2).
 local function readActiveSetupPathFromRaceIni(doc)
   local f = io.open(doc .. "/Assetto Corsa/cfg/race.ini", "r")
   if not f then
-    return nil
+    return nil, true
   end
   local text = f:read("*a")
   f:close()
   if not text then
-    return nil
+    return nil, true
   end
   local section = ""
   local ext_setup_filename = nil
@@ -108,14 +110,17 @@ local function readActiveSetupPathFromRaceIni(doc)
   end
   if ext_setup_filename then
     if ext_setup_filename == "" then
-      return RACE_INI_NO_SETUP
+      return RACE_INI_NO_SETUP, false
     end
-    return readablePath(ext_setup_filename) or RACE_INI_NO_SETUP
+    return (readablePath(ext_setup_filename) or RACE_INI_NO_SETUP), false
   end
   if setup_val and setup_val ~= "" then
-    return nil
+    -- Vanilla `SETUP=<name>` without `_EXT_SETUP_FILENAME`: a real (readable) race.ini that simply
+    -- does not name an absolute setup path. NOT transient — let the caller fall through to the
+    -- legacy folder guess (preserves the vanilla-setup fallback added in 927b07ed for #461).
+    return nil, false
   end
-  return RACE_INI_NO_SETUP
+  return RACE_INI_NO_SETUP, false
 end
 
 local raceIniSetupCache = { key = nil, path = RACE_INI_NO_SETUP }
@@ -136,28 +141,42 @@ local function raceIniSetupCacheKey(sim)
   return table.concat(parts, "|"), doc
 end
 
+---@return string|false|nil value  path | RACE_INI_NO_SETUP | nil (vanilla folder-guess this call)
+---@return boolean transient  true when race.ini was momentarily unreadable (retry, no folder guess)
 local function activeSetupPathFromRaceIni(sim)
   local key, doc = raceIniSetupCacheKey(sim)
   if not key or not doc then
-    return nil
+    return nil, false
   end
   if raceIniSetupCache.key == key then
-    return raceIniSetupCache.path
+    return raceIniSetupCache.path, false
   end
-  local path = readActiveSetupPathFromRaceIni(doc)
+  local path, transient = readActiveSetupPathFromRaceIni(doc)
+  if transient then
+    -- race.ini momentarily missing/locked while CM rewrites it: do NOT cache and do NOT let the
+    -- caller folder-guess (that can archive the wrong setup). Signal retry (#466 B2).
+    return nil, true
+  end
   if path == nil then
-    return nil
+    -- Vanilla `SETUP=` (no `_EXT_SETUP_FILENAME`): caller folder-guesses; not cached (the guess is
+    -- cheap and a later launch may bake an absolute `_EXT_SETUP_FILENAME` this session should pick up).
+    return nil, false
   end
-  -- Cache confirmed negative reads too: once Lua successfully reads race.ini in acs.exe, a missing
-  -- setup pointer for the current session should not become per-frame disk IO. Transient read
-  -- failures return nil above and are retried rather than cached as "no setup".
+  -- Cache confirmed reads (a path or a confirmed no-setup) so a stable race.ini within one spawn is
+  -- not re-parsed per frame. A new spawn/stint refreshes the cache via M.resetRaceIniCache() (#466 B1).
   raceIniSetupCache.key = key
-  if path then
-    raceIniSetupCache.path = path
-  else
-    raceIniSetupCache.path = RACE_INI_NO_SETUP
-  end
-  return path
+  raceIniSetupCache.path = path or RACE_INI_NO_SETUP
+  return path, false
+end
+
+--- Reset the per-spawn race.ini setup cache. The trainer calls this on a new session/stint (a real
+--- car re-spawn) so a long-lived acs.exe that REUSES a Quick-Drive session index with a different
+--- baked setup re-reads race.ini instead of serving the prior spawn's setup (#466 B1). Within one
+--- spawn the cache holds — the applied setup is a spawn-time fact, so an in-place race.ini edit the
+--- car has not re-read must not flap the archived setup, and resolution stays off the per-frame IO path.
+function M.resetRaceIniCache()
+  raceIniSetupCache.key = nil
+  raceIniSetupCache.path = RACE_INI_NO_SETUP
 end
 
 ---@param car ac.StateCar|nil
@@ -173,13 +192,21 @@ local function guessSetupIniPath(car, sim)
   end
   -- The active setup baked/selected into race.ini beats a folder guess: it names the actual applied
   -- setup file (e.g. Realistic_BB_v3.ini), so the lap archive records that setup, not an empty snap.
-  local fromRace = activeSetupPathFromRaceIni(sim)
+  local fromRace, transient = activeSetupPathFromRaceIni(sim)
+  if transient then
+    -- race.ini momentarily missing/locked (#466 B2): archive nothing this call and retry rather
+    -- than attributing a legacy folder guess (which can be the WRONG setup). NOT confirmed-no-setup,
+    -- so callers keep the prior spawn's snapshot instead of clearing it.
+    return nil, false
+  end
   if fromRace == RACE_INI_NO_SETUP then
     return nil, true
   end
   if fromRace then
     return fromRace, false
   end
+  -- fromRace == nil and not transient → vanilla `SETUP=` without `_EXT_SETUP_FILENAME`: fall through
+  -- to the folder guess below (the intended resolution for a vanilla-selected setup).
   local doc = documentsRoot()
   if not doc then
     return nil, false

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -801,6 +801,50 @@ def test_write_setup_baked_race_ini_cleans_temp_on_replace_failure(tmp_path, mon
     assert not tmp.exists()
 
 
+def test_write_setup_baked_race_ini_skips_torn_read_and_preserves_cm_keys(tmp_path, monkeypatch):
+    """#466 B3: a torn read (race.ini changing under us mid-CM-write) must never be baked back — an
+    atomic replace derived from a truncated read would silently drop the CM-owned sections. Two
+    non-identical back-to-back reads are detected as unstable and nothing is written."""
+    from pathlib import Path as _P
+
+    race_ini = tmp_path / "Assetto Corsa" / "cfg" / "race.ini"
+    race_ini.parent.mkdir(parents=True)
+    cm_content = "[RACE]\nMODEL=cm_owned\n[CAR_0]\nSKIN=brg\n[SESSION_0]\nTYPE=1\n"
+    race_ini.write_text(cm_content, encoding="utf-8")
+    setup = _P("/home/x/Documents/Assetto Corsa/setups/car/spa/Realistic_BB_v3.ini")
+    # Two consecutive reads return different bytes → CM is rewriting the file right now.
+    reads = iter([cm_content, "[CAR_0]\nSKIN=brg\n"])  # second read caught mid-truncation
+    monkeypatch.setattr(pathlib.Path, "read_text", lambda self, *a, **k: next(reads))
+
+    assert write_setup_baked_race_ini(race_ini, setup) == "unstable"
+
+    monkeypatch.undo()
+    # On-disk file is byte-for-byte the CM content — the truncation was never persisted.
+    assert race_ini.read_text(encoding="utf-8") == cm_content
+    assert not (race_ini.parent / ".race.ini.ac_copilot_setup.tmp").exists()
+
+
+def test_write_setup_baked_race_ini_skips_unparseable_snapshot(tmp_path, monkeypatch):
+    """#466 B3: a STABLE but unparseable read (torn such that two reads agree yet the content is not
+    valid INI) is treated as a no-op instead of atomically replacing race.ini with a bad bake."""
+    from pathlib import Path as _P
+
+    race_ini = tmp_path / "Assetto Corsa" / "cfg" / "race.ini"
+    race_ini.parent.mkdir(parents=True)
+    cm_content = "[CAR_0]\nSKIN=brg\n"
+    race_ini.write_text(cm_content, encoding="utf-8")
+    setup = _P("/home/x/Documents/Assetto Corsa/setups/car/spa/Realistic_BB_v3.ini")
+    # Key=value before any [section] → MissingSectionHeaderError (a configparser.Error).
+    garbage = "torn=1\nno_section_header=2\n"
+    monkeypatch.setattr(pathlib.Path, "read_text", lambda self, *a, **k: garbage)
+
+    assert write_setup_baked_race_ini(race_ini, setup) == "unstable"
+
+    monkeypatch.undo()
+    assert race_ini.read_text(encoding="utf-8") == cm_content
+    assert not (race_ini.parent / ".race.ini.ac_copilot_setup.tmp").exists()
+
+
 def test_race_ini_setup_bake_loop_rejects_non_positive_interval(tmp_path):
     from pathlib import Path as _P
 

--- a/tests/test_setup_reader_race_ini.py
+++ b/tests/test_setup_reader_race_ini.py
@@ -219,3 +219,78 @@ def test_confirmed_no_race_ini_setup_blocks_legacy_folder_guess(tmp_path):
         ".. tostring(no_setup)"
     )
     assert out == "nil||true", out
+
+
+def test_race_ini_setup_cache_resets_on_new_spawn_with_reused_session_index(tmp_path):
+    """#466 B1: a new Quick-Drive spawn that REUSES the session index but bakes a different setup
+    must archive the NEW setup once the trainer signals the spawn via ``resetRaceIniCache()``.
+
+    The reset is the spawn discriminator the session index alone cannot provide: without it the
+    cache holds the spawn-time setup (``test_race_ini_setup_resolution_is_cached_within_session`` —
+    the same-spawn in-place-edit case that must NOT flap the archive), and the trainer calls the
+    reset only on a real re-spawn (``resetSessionState`` / ``resetRollingDrivingState``).
+    """
+    setup_ini = _write_setup_combo(tmp_path, "{setup_ini}")  # Realistic_BB_v3.ini
+    rt = _runtime(str(tmp_path).replace("\\", "/"))
+    rt.execute('sr = require("setup_reader")')
+    first = rt.execute("return sr.activeSetupIniPath({}, { currentSessionIndex = 1 })")
+    assert first == str(setup_ini), first
+
+    other = setup_ini.with_name("OtherSetup.ini")
+    other.write_text("[FUEL]\nVALUE=15\n", encoding="utf-8")
+    race_ini = tmp_path / "Assetto Corsa" / "cfg" / "race.ini"
+    race_ini.write_text(f"[CAR_0]\n_EXT_SETUP_FILENAME={other}\n", encoding="utf-8")
+
+    rt.execute("sr.resetRaceIniCache()")  # the trainer's new-spawn hook
+    out = rt.execute("return sr.activeSetupIniPath({}, { currentSessionIndex = 1 })")
+
+    assert out == str(other), out
+
+
+def test_transient_race_ini_miss_does_not_folder_guess(tmp_path):
+    """#466 B2: a momentarily missing/locked ``cfg/race.ini`` must yield nil (retry) rather than a
+    legacy ``setups/<car>/<track>/`` folder guess, which can archive the WRONG setup. A later real
+    read then resolves the applied setup — the transient miss is not negative-cached.
+    """
+    ac_root = tmp_path / "Assetto Corsa"
+    (ac_root / "cfg").mkdir(parents=True)
+    # A folder-guess candidate (lupa car/track ids resolve to "unknown") that must NOT be attributed
+    # while race.ini is momentarily unreadable.
+    guess = ac_root / "setups" / "unknown" / "unknown" / "race.ini"
+    guess.parent.mkdir(parents=True)
+    guess.write_text("[FUEL]\nVALUE=99\n", encoding="utf-8")
+    rt = _runtime(str(tmp_path).replace("\\", "/"))
+    rt.execute('sr = require("setup_reader")')
+
+    # cfg/race.ini absent → transient → nil, NOT the folder guess.
+    miss = rt.execute("return sr.activeSetupIniPath({}, { currentSessionIndex = 1 })")
+    assert miss != str(guess), miss
+    assert miss is None, f"expected nil on a transient race.ini miss, got {miss!r}"
+
+    # CM writes race.ini naming the applied setup → resolves it (retry after the transient miss).
+    applied = ac_root / "setups" / "unknown" / "unknown" / "Applied.ini"
+    applied.write_text("[FUEL]\nVALUE=45\n", encoding="utf-8")
+    (ac_root / "cfg" / "race.ini").write_text(
+        f"[CAR_0]\n_EXT_SETUP_FILENAME={applied}\n", encoding="utf-8"
+    )
+    out = rt.execute("return sr.activeSetupIniPath({}, { currentSessionIndex = 1 })")
+    assert out == str(applied), out
+
+
+def test_vanilla_setup_without_ext_filename_still_folder_guesses(tmp_path):
+    """#466 B2 guard: a readable race.ini with vanilla ``SETUP=<name>`` and no
+    ``_EXT_SETUP_FILENAME`` must still resolve via the legacy folder guess — the
+    transient-miss fix must not re-break the vanilla-setup fallback (927b07ed, #461).
+    """
+    ac_root = tmp_path / "Assetto Corsa"
+    (ac_root / "cfg").mkdir(parents=True)
+    guess = ac_root / "setups" / "unknown" / "unknown" / "race.ini"
+    guess.parent.mkdir(parents=True)
+    guess.write_text("[FUEL]\nVALUE=45\n", encoding="utf-8")
+    (ac_root / "cfg" / "race.ini").write_text(
+        "[CAR_0]\nSETUP=Realistic_BB_v3.ini\n", encoding="utf-8"
+    )
+    rt = _runtime(str(tmp_path).replace("\\", "/"))
+    out = rt.execute('local sr = require("setup_reader"); return sr.activeSetupIniPath({}, nil)')
+    # The Lua folder guess builds paths with forward slashes; normalize for the Windows comparison.
+    assert out == str(guess).replace("\\", "/"), out

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -663,6 +663,7 @@ class RaceIniBakeState:
 
     ready: int = 0
     writes: int = 0
+    unstable: int = 0  # #466 B3: ticks skipped because race.ini was mid-write (torn/locked read)
     last_error: str | None = None
 
 
@@ -683,16 +684,39 @@ def validate_race_ini_write_target(race_ini: Path) -> Path:
 def write_setup_baked_race_ini(race_ini: Path, setup_ini: Path) -> str:
     """Bake ``setup_ini`` into ``race.ini`` with an atomic same-directory replace.
 
-    Returns ``"missing"`` when ``race.ini`` is not present yet, ``"unchanged"`` when it already
-    names the requested setup/spawn, and ``"written"`` after an atomic replace. Content Manager
-    often creates or rewrites the file during launch. The only accepted target is
-    ``Documents/Assetto Corsa/cfg/race.ini``.
+    Returns ``"missing"`` when ``race.ini`` is not present yet, ``"unstable"`` when the file is
+    being rewritten by CM right now (see torn-read safety), ``"unchanged"`` when it already names
+    the requested setup/spawn, and ``"written"`` after an atomic replace. The only accepted target
+    is ``Documents/Assetto Corsa/cfg/race.ini``.
+
+    Torn-read safety (#466 B3): the 50 ms re-bake loop runs concurrently with CM, which rewrites
+    ``race.ini`` non-atomically during launch. A single ``read_text`` can capture a truncated file;
+    baking that back through ``configparser`` and atomically replacing it would make the truncation
+    permanent — silently dropping the CM-owned sections/keys that were cut off. Two guards prevent
+    that: (1) require a STABLE snapshot — two identical back-to-back reads — before trusting the
+    content, and (2) treat an unparseable snapshot as a no-op. Either guard failing returns
+    ``"unstable"`` and writes nothing; the loop retries on its next tick once CM's write settles.
     """
     race_ini = validate_race_ini_write_target(race_ini)
     if not race_ini.is_file():
         return "missing"
-    original = race_ini.read_text(encoding="utf-8", errors="surrogateescape")
-    baked = bake_setup_into_race_ini(original, setup_ini)
+    try:
+        first = race_ini.read_text(encoding="utf-8", errors="surrogateescape")
+        second = race_ini.read_text(encoding="utf-8", errors="surrogateescape")
+    except OSError:
+        # Momentarily unreadable (locked) mid-write; retry next tick rather than write a
+        # partial file.
+        return "unstable"
+    if first != second:
+        # The file changed between two back-to-back reads → CM is writing it now. Skip this tick.
+        return "unstable"
+    original = first
+    try:
+        baked = bake_setup_into_race_ini(original, setup_ini)
+    except configparser.Error:
+        # A stable but unparseable snapshot (e.g. a torn read halted mid-section). Never atomically
+        # replace race.ini with a bake derived from it — that would drop CM's sections/keys.
+        return "unstable"
     if baked == original:
         return "unchanged"
     tmp = race_ini.with_name(f".{race_ini.name}.ac_copilot_setup.tmp")
@@ -724,10 +748,12 @@ def race_ini_setup_bake_loop(
         while not stop.is_set():
             try:
                 result = write_setup_baked_race_ini(race_ini, setup_ini)
-                if result != "missing":
+                if result not in ("missing", "unstable"):
                     state.ready += 1
                 if result == "written":
                     state.writes += 1
+                elif result == "unstable":
+                    state.unstable += 1  # #466 B3: torn/locked read dodged (no partial write)
             except Exception as exc:  # noqa: BLE001 - CM can expose half-written race.ini briefly.
                 state.last_error = f"{type(exc).__name__}: {exc}"
             stop.wait(interval)


### PR DESCRIPTION
## What & why

Delivers **Part B of #466** — the 3 self-hosted-daemon (cursor) `[MEDIUM]` findings captured on the issue against merged #461/#465 code. These are **separable from the criterion-(a) fundamental CSP/CM limit** (documented as exhausted in #482/#495): they harden the setup **archival/resolution** path — which works today, including `--setup` alone and manual play — plus `race.ini` write-integrity. All three acceptance criteria are **off-rig testable** (lupa + pytest), so this is verified without the physical rig.

Reconciliation (live, not the stale body): criterion (b) shipped in #482 (MERGED); criterion (a) is a documented fundamental limit (#495 MERGED). Part B's three checkboxes were still unaddressed — `git log` confirms no commit after #482 touched `setup_reader.lua` / `auto_drive.py`.

## Findings addressed

### B1 — session-cache staleness (`setup_reader.lua`)
A long-lived `acs.exe` that **reuses** a Quick-Drive session index with a different baked setup kept serving the *first* spawn's setup path. Fix: add `M.resetRaceIniCache()` and call it from the trainer's `resetSessionState` / `resetRollingDrivingState` (the real re-spawn signal, next to `lifecyclePublisher.reset()`).

The **spawn signal — not the session index — is the discriminator**: a same-spawn in-place `race.ini` edit still holds the spawn-time setup (must not flap the archive mid-stint — preserved by `test_race_ini_setup_resolution_is_cached_within_session`); a real re-spawn refreshes it. This resolves the finding **without weakening** the existing cache test.

### B2 — transient `race.ini` miss vs vanilla fallback (`setup_reader.lua`)
`readActiveSetupPathFromRaceIni` now returns a `transient` flag, so a momentarily missing/locked `cfg/race.ini` yields `nil` (retry) instead of falling through to the legacy `setups/<car>/<track>/…` folder guess (which could archive the **wrong** setup). The vanilla `SETUP=` (no `_EXT_SETUP_FILENAME`) folder-guess fallback added in `927b07ed` is **preserved**.

### B3 — continuous `race.ini` read contention (`auto_drive.py`)
`write_setup_baked_race_ini` now requires a **stable two-read snapshot** and treats an **unparseable read as a no-op**, so a torn CM write (the 50 ms re-bake loop races CM's non-atomic rewrite) can never be baked back and atomically **drop CM-owned sections/keys**. Returns a new `"unstable"` status; adds an `unstable` counter to `RaceIniBakeState` for observability. `bake.ready` no longer counts unstable ticks (defers to fuel verification exactly as before).

## Tests → acceptance criteria
- **B1:** `test_race_ini_setup_cache_resets_on_new_spawn_with_reused_session_index` — same session index, reset between = the spawn signal → archives the new setup.
- **B2:** `test_transient_race_ini_miss_does_not_folder_guess` (nil, retry, no wrong guess) + `test_vanilla_setup_without_ext_filename_still_folder_guesses` (fallback preserved).
- **B3:** `test_write_setup_baked_race_ini_skips_torn_read_and_preserves_cm_keys` + `test_write_setup_baked_race_ini_skips_unparseable_snapshot` — both assert `race.ini` stays **byte-for-byte** intact.

`make ci-fast` green locally (format, lint, full test suite, bandit, secrets, policy, CSP API/UI safety).

Refs #466 (Part B). Criterion (a) remains a characterized CSP/CM limitation (separate; not touched here).