### PR TITLE
feat(telemetry): Tier-2 CSP force/slip channels + handling-balance verdict (#488 Part A)

### DIFF
--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -84,6 +84,18 @@ local TRACE_FIELDS = {
   "suspTravel_fl", "suspTravel_fr", "suspTravel_rl", "suspTravel_rr",
   "damperVel_fl", "damperVel_fr", "damperVel_rl", "damperVel_rr",
   "rideHeightFront", "rideHeightRear", "brakeBias", "turboBoost", "fuel", "accG_vert",
+  -- Tier-2 CSP force/slip channels (issue #488 Part A): per-wheel FL/FR/RL/RR. Appended AFTER
+  -- accG_vert so every older column position stays byte-stable; older (<=76-col) archives export
+  -- these as blanks. slipRatio unitless (longitudinal — NOT the AC-ndSlip `wheelSlip` above);
+  -- slipAngle DEGREES (lateral); mz Nm (self-aligning torque); fx/fy N (contact forces); dy peak mu.
+  -- Populated by AC's tyre solver via CSP `ac.StateWheel`; the per-lap header `extendedPhysics`
+  -- flag records whether the advanced physics model was active. Byte-identical to reference_lap.py.
+  "slipRatio_fl", "slipRatio_fr", "slipRatio_rl", "slipRatio_rr",
+  "slipAngle_fl", "slipAngle_fr", "slipAngle_rl", "slipAngle_rr",
+  "mz_fl", "mz_fr", "mz_rl", "mz_rr",
+  "fx_fl", "fx_fr", "fx_rl", "fx_rr",
+  "fy_fl", "fy_fr", "fy_rl", "fy_rr",
+  "dy_fl", "dy_fr", "dy_rl", "dy_rr",
 }
 
 local function lapArchiveDir()
@@ -270,6 +282,18 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
     end)
   end
 
+  -- Tier-2 availability confound (issue #488 Part A): whether CSP extended car physics was active
+  -- (`ac.StateCar.extendedPhysics`). The Tier-2 force/slip trace channels are populated by AC's tyre
+  -- solver regardless, but this per-lap flag tells ML whether the advanced physics model was in
+  -- effect. Kept boolean|nil so an unreadable field is honestly absent (nil), never a false negative.
+  local extendedPhysics = nil
+  pcall(function()
+    local v = opts.car and opts.car.extendedPhysics
+    if type(v) == "boolean" then
+      extendedPhysics = v
+    end
+  end)
+
   samplesColumnar = samplesColumnar or {}
   samplesCount = tonumber(samplesCount) or #samplesColumnar
   local cornersOut = {}
@@ -319,6 +343,7 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
     car = {
       id = carId,
       displayName = nil,
+      extendedPhysics = extendedPhysics,
     },
     track = {
       id = trackId,

--- a/src/ac_copilot_trainer/modules/telemetry.lua
+++ b/src/ac_copilot_trainer/modules/telemetry.lua
@@ -107,6 +107,31 @@ local MAX_LAP_TRACE = 2000
 ---@field turboBoost number|nil
 ---@field fuel number|nil
 ---@field accG_vert number|nil
+--- issue #488 Tier-2 CSP extended-physics force/slip channels (per-wheel FL/FR/RL/RR)
+---@field slipRatio_fl number|nil
+---@field slipRatio_fr number|nil
+---@field slipRatio_rl number|nil
+---@field slipRatio_rr number|nil
+---@field slipAngle_fl number|nil
+---@field slipAngle_fr number|nil
+---@field slipAngle_rl number|nil
+---@field slipAngle_rr number|nil
+---@field mz_fl number|nil
+---@field mz_fr number|nil
+---@field mz_rl number|nil
+---@field mz_rr number|nil
+---@field fx_fl number|nil
+---@field fx_fr number|nil
+---@field fx_rl number|nil
+---@field fx_rr number|nil
+---@field fy_fl number|nil
+---@field fy_fr number|nil
+---@field fy_rl number|nil
+---@field fy_rr number|nil
+---@field dy_fl number|nil
+---@field dy_fr number|nil
+---@field dy_rl number|nil
+---@field dy_rr number|nil
 
 local Telemetry = {}
 Telemetry.__index = Telemetry
@@ -357,6 +382,33 @@ function Telemetry:update(dt, car, sim)
       turboBoost = chassis.turboBoost,
       fuel = chassis.fuel,
       accG_vert = chassis.accG_vert,
+      -- issue #488 Tier-2 CSP extended-physics force/slip channels (per-wheel FL/FR/RL/RR), read via
+      -- wheel_read. slipRatio unitless (longitudinal, NOT the legacy AC-ndSlip `wheelSlip`); slipAngle
+      -- DEGREES (lateral); mz Nm (self-aligning torque); fx/fy N (contact-patch forces); dy peak mu.
+      slipRatio_fl = w.slipRatioLong.fl,
+      slipRatio_fr = w.slipRatioLong.fr,
+      slipRatio_rl = w.slipRatioLong.rl,
+      slipRatio_rr = w.slipRatioLong.rr,
+      slipAngle_fl = w.slipAngle.fl,
+      slipAngle_fr = w.slipAngle.fr,
+      slipAngle_rl = w.slipAngle.rl,
+      slipAngle_rr = w.slipAngle.rr,
+      mz_fl = w.mz.fl,
+      mz_fr = w.mz.fr,
+      mz_rl = w.mz.rl,
+      mz_rr = w.mz.rr,
+      fx_fl = w.fx.fl,
+      fx_fr = w.fx.fr,
+      fx_rl = w.fx.rl,
+      fx_rr = w.fx.rr,
+      fy_fl = w.fy.fl,
+      fy_fr = w.fy.fr,
+      fy_rl = w.fy.rl,
+      fy_rr = w.fy.rr,
+      dy_fl = w.dy.fl,
+      dy_fr = w.dy.fr,
+      dy_rl = w.dy.rl,
+      dy_rr = w.dy.rr,
     }
     self.lapBuf[self.lapN] = lp
     if self.lapN > MAX_LAP_RAW then

--- a/src/ac_copilot_trainer/modules/wheel_read.lua
+++ b/src/ac_copilot_trainer/modules/wheel_read.lua
@@ -85,6 +85,11 @@ end
 
 --- Brake disc temperature (degC). CSP `discTemperature` — brake heat into the tyre; brake-bias /
 --- duct attribution + braking-abuse. nil if unreadable.
+--- CAVEAT (#488, rig-verified 2026-07-04): `discTemperature` reads a flat ambient (~26 °C) when the
+--- car's brake-thermal model is inactive — reproduced on the 911 GT3 R across a hard-braking lap
+--- even with `car.extendedPhysics == true`. So it is CAR-physics-dependent, NOT extended-physics-
+--- gated; it stays a Tier-1 base-AC channel (it heats in sessions where the model is active). Treat
+--- a flat 26 °C as "not modelled for this car", not a capture bug.
 function M.brakeTemp(one)
   return finite(M.field(one, "discTemperature"))
 end

--- a/src/ac_copilot_trainer/modules/wheel_read.lua
+++ b/src/ac_copilot_trainer/modules/wheel_read.lua
@@ -121,6 +121,55 @@ function M.suspTravel(one)
   return finite(M.field(one, "suspensionTravel"))
 end
 
+-- Tier-2 CSP force/slip channels (issue #488 Part A) — the dynamic tyre FORCE + SLIP state: the
+-- ground-truth grip labels ML needs and the earliest understeer-onset signal (Mz collapses before
+-- lateral force saturates). CSP field names verified against THIS rig's lua-sdk `ac.StateWheel`
+-- stubs (extension/internal/lua-sdk/*/lib.lua, class ac.StateWheel): `slipRatio` (unitless
+-- longitudinal), `slipAngle` (DEGREES lateral — "angle between desired and actual direction"),
+-- `mz` (self-aligning torque), `fx`/`fy` (contact-patch forces, N), `dy` (lateral friction
+-- coefficient / peak mu). AC's Pacejka solver populates these via CSP Lua; the car-level
+-- `extendedPhysics` flag (recorded in the lap header, not per-wheel) is the confound telling ML
+-- whether the advanced tyre model was active. Every read is pcall-guarded + finite-filtered, so an
+-- absent field degrades to nil (serialized as 0 downstream) — it never throws out of the hot loop
+-- nor fails the archive, satisfying the "gate/record availability, never fail" contract.
+
+--- Longitudinal slip ratio (unitless; CSP `slipRatio`). Traction-limit + frictional-heat driver.
+--- Reads ONLY the explicit longitudinal ratio — distinct from `M.slip`/`wheelSlip` (AC ndSlip
+--- fallback). nil if unreadable.
+function M.slipRatioLong(one)
+  return finite(M.field(one, "slipRatio"))
+end
+
+--- Lateral slip angle (DEGREES; CSP `slipAngle`). Cornering grip usage + lateral heat input; the
+--- front-vs-rear slip-angle balance is the direct under/oversteer signal. nil if unreadable.
+function M.slipAngle(one)
+  return finite(M.field(one, "slipAngle"))
+end
+
+--- Self-aligning torque Mz (Nm; CSP `mz`). Collapses BEFORE lateral force saturates → earliest
+--- understeer-onset signal. nil if unreadable.
+function M.mz(one)
+  return finite(M.field(one, "mz"))
+end
+
+--- Longitudinal contact-patch force Fx (N; CSP `fx`). Ground-truth traction/braking force label.
+--- nil if unreadable.
+function M.fx(one)
+  return finite(M.field(one, "fx"))
+end
+
+--- Lateral contact-patch force Fy (N; CSP `fy`). Ground-truth cornering-force label. nil if
+--- unreadable.
+function M.fy(one)
+  return finite(M.field(one, "fy"))
+end
+
+--- Lateral friction coefficient Dy / peak mu (unitless; CSP `dy`). Supervised grip-model label —
+--- the friction the tyre is actually delivering. nil if unreadable.
+function M.dy(one)
+  return finite(M.field(one, "dy"))
+end
+
 --- Read all four wheels into {omega={fl,fr,rl,rr}, slip={...}, temp={...}, pressure={...}, and the
 --- issue #490 Tier-1 channels tyreTempInner/Mid/Outer, brakeTemp, load, wear, dirty, camber,
 --- suspTravel} (each value number|nil). pcall-guards the `car.wheels` access and every per-wheel read.
@@ -142,6 +191,13 @@ function M.readPerWheel(car)
     dirty = {},
     camber = {},
     suspTravel = {},
+    -- issue #488 Tier-2 CSP force/slip channels
+    slipRatioLong = {},
+    slipAngle = {},
+    mz = {},
+    fx = {},
+    fy = {},
+    dy = {},
   }
   if car == nil then
     return out
@@ -172,6 +228,13 @@ function M.readPerWheel(car)
       out.dirty[k] = M.dirty(one)
       out.camber[k] = M.camber(one)
       out.suspTravel[k] = M.suspTravel(one)
+      -- issue #488 Tier-2 CSP force/slip channels
+      out.slipRatioLong[k] = M.slipRatioLong(one)
+      out.slipAngle[k] = M.slipAngle(one)
+      out.mz[k] = M.mz(one)
+      out.fx[k] = M.fx(one)
+      out.fy[k] = M.fy(one)
+      out.dy[k] = M.dy(one)
     end
   end
   return out

--- a/tests/test_corner_attribution.py
+++ b/tests/test_corner_attribution.py
@@ -284,6 +284,67 @@ def test_corner_live_signals_emits_cross_tread_gradient():
     assert extra["tyreCrossGradient"]["fl"] == 17.0
 
 
+def test_corner_live_signals_emits_slip_angle_balance():
+    # #488 Part A: corner_live_signals derives the front-vs-rear slip-angle balance marker (plus mz,
+    # grip-mu, slip-ratio) from the persisted Tier-2 columns, so a lap carrying them graduates the
+    # handling_balance rule to a verdict without a caller supplying extra.
+    n = 12
+    # front axle (idx 0,1) at ~5°, rear axle (idx 2,3) at ~2° -> +3° balance = understeer.
+    slip_angle = [[5.0, 5.0, 2.0, 2.0] for _ in range(n)]
+    mz = [[40.0, 40.0, 30.0, 30.0] for _ in range(n)]
+    dy = [[1.45, 1.44, 1.50, 1.49] for _ in range(n)]
+    slip_ratio = [[0.02, 0.02, 0.06, 0.06] for _ in range(n)]
+    lap = LapTrace(
+        spline=[i / (n - 1) for i in range(n)],
+        t_s=[i * 0.1 for i in range(n)],
+        v_ms=[40.0] * n,
+        brake=[0.0] * n,
+        throttle=[0.0] * n,
+        steer=[0.1] * n,
+        gear=[3] * n,
+        x=[float(i) for i in range(n)],
+        z=[0.0] * n,
+        slip_angle=slip_angle,
+        mz=mz,
+        dy=dy,
+        slip_ratio=slip_ratio,
+    )
+    extra = corner_live_signals(lap, _sig(index=0, entry_i=2, apex_i=5, exit_i=9))
+    assert extra["slipAngle"]["front"] == 5.0
+    assert extra["slipAngle"]["rear"] == 2.0
+    assert extra["slipAngle"]["balance"] == 3.0  # front - rear > 0 -> understeer
+    assert extra["mz"] == 40.0  # front-axle peak self-aligning torque
+    assert extra["gripMu"] == 1.5  # peak lateral friction coefficient (any wheel)
+    assert extra["slipRatio"] == 0.06  # peak |longitudinal slip| (any wheel)
+
+
+def test_handling_balance_is_a_verdict_with_slip_angle_balance():
+    # #488 Part A: a front-vs-rear slip-angle imbalance yields an under/oversteer VERDICT (not
+    # advisory), routed to setup. Without the slipAngle channel the rule stays silent — the archive
+    # has no proxy for the handling balance, so the diagnosis exists only once the channel is here.
+    sig = _sig()
+    silent = [
+        a
+        for a in attribute_corner(CornerContext(sig=sig, setup=SETUP))
+        if a.key == "handling_balance"
+    ]
+    assert silent == []  # no slip-angle channel -> the rule does not fire
+    verdict = next(
+        a
+        for a in attribute_corner(
+            CornerContext(
+                sig=sig,
+                setup=SETUP,
+                extra={"slipAngle": {"front": 5.0, "rear": 2.0, "balance": 3.0}},
+            )
+        )
+        if a.key == "handling_balance"
+    )
+    assert verdict.advisory is False  # channel present -> verdict
+    assert any("UNDERSTEER" in c for c in verdict.setup_causes)
+    assert "understeer" in verdict.coaching.lower()
+
+
 def test_camber_pressure_imbalance_is_a_verdict_with_cross_tread_gradient():
     # #490 acceptance: an inner/outer cross-tread imbalance yields a camber/pressure VERDICT (not
     # advisory), routed to setup. Without the gradient channel the rule stays silent — there is no

--- a/tests/test_lap_archive_export.py
+++ b/tests/test_lap_archive_export.py
@@ -148,7 +148,7 @@ def test_tier1_dynamic_columns_in_csv_and_match_trace_fields() -> None:
     # export locations — CSV_COLUMNS, _TIER1_DYNAMIC_TRACE_FIELDS, _TRACE_TO_CSV — must not drift).
     from tools.ac_harness.reference_lap import TRACE_FIELDS
 
-    tier1 = TRACE_FIELDS[30:]
+    tier1 = TRACE_FIELDS[30:76]
     assert len(tier1) == 46
     assert lap_archive_export._TIER1_DYNAMIC_TRACE_FIELDS == tier1
     for name in tier1:
@@ -156,6 +156,20 @@ def test_tier1_dynamic_columns_in_csv_and_match_trace_fields() -> None:
         assert name in lap_archive_export._TRACE_TO_CSV, f"{name} missing from trace->CSV map"
     # every trace column maps to a CSV column (no silent drops on export)
     assert set(TRACE_FIELDS) <= set(lap_archive_export._TRACE_TO_CSV)
+
+
+def test_tier2_dynamic_columns_in_csv_and_match_trace_fields() -> None:
+    # #488 Part A: the generic analysis CSV carries every Tier-2 CSP force/slip trace column, and
+    # the export's Tier-2 field group stays in lock-step with reference_lap.TRACE_FIELDS[76:]
+    # (CSV_COLUMNS, _TIER2_DYNAMIC_TRACE_FIELDS, _TRACE_TO_CSV must not drift).
+    from tools.ac_harness.reference_lap import TRACE_FIELDS
+
+    tier2 = TRACE_FIELDS[76:]
+    assert len(tier2) == 24
+    assert lap_archive_export._TIER2_DYNAMIC_TRACE_FIELDS == tier2
+    for name in tier2:
+        assert name in lap_archive_export.CSV_COLUMNS, f"{name} missing from generic CSV export"
+        assert name in lap_archive_export._TRACE_TO_CSV, f"{name} missing from trace->CSV map"
 
 
 def test_motec_csv_uses_trace_elapsed_when_lap_ms_is_missing(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_reference_lap.py
+++ b/tests/test_reference_lap.py
@@ -68,9 +68,9 @@ def test_generated_archive_carries_per_wheel_channels() -> None:
     for name in ("wheelAngularSpeed_fl", "wheelSlip_rr", "tyreCoreTemp_fl"):
         assert name in fields
     assert "rpm" in fields
-    # #490 Tier-1 dynamic channels append AFTER the #478 pressure block (append-only), so the last
-    # column is now accG_vert (was wheelsPressure_rr after #478, rpm before that).
-    assert fields[-1] == "accG_vert"
+    # Append-only history: #478 pressure block, then #490 Tier-1 (last was accG_vert at idx 75),
+    # then #488 Part A Tier-2 force/slip — so the final column is now dy_rr.
+    assert fields[-1] == "dy_rr"
     frames = archive_trace_to_object_trace(record)
     f0 = frames[0]
     speed_ms = f0["speed"] / 3.6
@@ -143,7 +143,8 @@ def test_generated_archive_carries_tier1_dynamic_channels() -> None:
         "accG_vert",
     ):
         assert name in fields
-    assert fields[-1] == "accG_vert"
+    # accG_vert is the last Tier-1 column (index 75); #488 Part A appends Tier-2 after it.
+    assert fields[75] == "accG_vert"
     f0 = archive_trace_to_object_trace(record)[0]
     for name in ("tyreTempInner_fl", "camber_rr", "rideHeightFront", "fuel", "accG_vert"):
         assert f0[name] == pytest.approx(0.0)
@@ -161,6 +162,47 @@ def test_validator_accepts_pre_490_30_field_trace() -> None:
     assert "wheelsPressure_rr" in frames[0]
     assert "tyreTempInner_fl" not in frames[0]
     assert "accG_vert" not in frames[0]
+
+
+def test_generated_archive_carries_tier2_dynamic_channels() -> None:
+    # #488 Part A: a generated reference archive includes the Tier-2 CSP force/slip columns. The
+    # synthetic generator does not model them, so they are 0.0 -> the all-zero guard treats a
+    # generated reference as honestly having no measured force/slip signal.
+    record = build_archive_record_from_scenario("brake_too_late")
+    fields = record["trace"]["fields"]
+    for name in (
+        "slipRatio_fl",
+        "slipRatio_rr",
+        "slipAngle_fl",
+        "slipAngle_rr",
+        "mz_fl",
+        "mz_rr",
+        "fx_fl",
+        "fy_rr",
+        "dy_fl",
+        "dy_rr",
+    ):
+        assert name in fields
+    assert fields[-1] == "dy_rr"
+    assert len(fields) == 100
+    f0 = archive_trace_to_object_trace(record)[0]
+    for name in ("slipRatio_fl", "slipAngle_rr", "mz_fl", "fx_rr", "dy_rr"):
+        assert f0[name] == pytest.approx(0.0)
+
+
+def test_validator_accepts_pre_488_76_field_trace() -> None:
+    # #488 Part A: the Tier-2 force/slip channels append AFTER the #490 Tier-1 block; a lap captured
+    # between #490 and #488 declares 76 columns and stays schema-v1-valid, converting without the
+    # Tier-2 keys.
+    record = build_archive_record_from_scenario("brake_too_late")
+    fields = record["trace"]["fields"]
+    record["trace"]["fields"] = list(fields[:76])
+    record["trace"]["samples"] = [[row[i] for i in range(76)] for row in record["trace"]["samples"]]
+    validate_lap_archive_record(record)  # must not raise
+    frames = archive_trace_to_object_trace(record)
+    assert "accG_vert" in frames[0]
+    assert "slipRatio_fl" not in frames[0]
+    assert "dy_rr" not in frames[0]
 
 
 def test_validator_accepts_pre_478_23_field_trace() -> None:

--- a/tools/ac_harness/reference_lap.py
+++ b/tools/ac_harness/reference_lap.py
@@ -115,6 +115,36 @@ TRACE_FIELDS: tuple[str, ...] = (
     "turboBoost",
     "fuel",
     "accG_vert",
+    # Tier-2 CSP force/slip channels (issue #488 Part A) — per-wheel FL/FR/RL/RR, appended AFTER
+    # accG_vert so every older column position stays byte-stable and <=76-col archives keep loading.
+    # slipRatio unitless (longitudinal, NOT the AC-ndSlip `wheelSlip` above); slipAngle DEGREES
+    # (lateral); mz Nm (self-aligning torque); fx/fy N (contact forces); dy peak mu. Populated by
+    # AC's tyre solver via CSP `ac.StateWheel`; the lap header `car.extendedPhysics` flag records
+    # whether the advanced physics model was active. Byte-identical to lap_archive.lua.
+    "slipRatio_fl",
+    "slipRatio_fr",
+    "slipRatio_rl",
+    "slipRatio_rr",
+    "slipAngle_fl",
+    "slipAngle_fr",
+    "slipAngle_rl",
+    "slipAngle_rr",
+    "mz_fl",
+    "mz_fr",
+    "mz_rl",
+    "mz_rr",
+    "fx_fl",
+    "fx_fr",
+    "fx_rl",
+    "fx_rr",
+    "fy_fl",
+    "fy_fr",
+    "fy_rl",
+    "fy_rr",
+    "dy_fl",
+    "dy_fr",
+    "dy_rl",
+    "dy_rr",
 )
 
 _LEGACY_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[:10]
@@ -128,13 +158,21 @@ _PRE_TIER_B_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[:23]
 # archives keep loading and validating.
 _PRE_TIER1_DYNAMIC_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[:30]
 # The 46 Tier-1 base-AC dynamic channels appended by #490 (per-wheel bands + car scalars).
-_TIER1_DYNAMIC_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[30:]
+_TIER1_DYNAMIC_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[30:76]
+# The pre-#488 full set (30 + 46 Tier-1 = 76 cols). #488 Part A appends the Tier-2 CSP force/slip
+# channels AFTER accG_vert, so this 76-col set stays a valid prefix and existing archives keep
+# loading and validating.
+_PRE_TIER2_DYNAMIC_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[:76]
+# The 24 Tier-2 CSP force/slip channels appended by #488 Part A (per-wheel slipRatio/slipAngle/mz/
+# fx/fy/dy).
+_TIER2_DYNAMIC_TRACE_FIELDS: tuple[str, ...] = TRACE_FIELDS[76:]
 _TRACE_FIELD_VARIANTS: tuple[tuple[str, ...], ...] = (
     _LEGACY_TRACE_FIELDS,
     _LEGACY_RPM_TRACE_FIELDS,
     _LEGACY_TRACE_FIELDS + _PER_WHEEL_TRACE_FIELDS,
     _PRE_TIER_B_TRACE_FIELDS,
     _PRE_TIER1_DYNAMIC_TRACE_FIELDS,
+    _PRE_TIER2_DYNAMIC_TRACE_FIELDS,
     TRACE_FIELDS,
 )
 

--- a/tools/ai_sidecar/corner_attribution.py
+++ b/tools/ai_sidecar/corner_attribution.py
@@ -928,6 +928,47 @@ def corner_live_signals(
         if grads:
             extra["tyreCrossGradient"] = grads
 
+    # --- Tier-2 CSP force/slip (#488 Part A): front-vs-rear slip-angle balance confirms handling
+    # balance (under/oversteer) directly, with Mz / grip-mu / longitudinal-slip as corroborating
+    # context. Each block is gated on the channel being persisted AND non-zero IN this corner (a 0.0
+    # among readings is the unread sentinel), so the marker never outruns the data. ---
+    if lap.slip_angle is not None:
+        front_sa = [
+            abs(lap.slip_angle[k][i]) for k in seg for i in (0, 1) if lap.slip_angle[k][i] != 0.0
+        ]
+        rear_sa = [
+            abs(lap.slip_angle[k][i]) for k in seg for i in (2, 3) if lap.slip_angle[k][i] != 0.0
+        ]
+        if front_sa and rear_sa:
+            fsa = sum(front_sa) / len(front_sa)
+            rsa = sum(rear_sa) / len(rear_sa)
+            # balance > 0 = front at a higher slip angle than rear = understeer; < 0 = oversteer.
+            extra["slipAngle"] = {
+                "front": round(fsa, 2),
+                "rear": round(rsa, 2),
+                "balance": round(fsa - rsa, 2),
+            }
+    if lap.mz is not None:
+        # Front-axle self-aligning torque peak (Nm): its collapse is the earliest understeer-onset
+        # cue; recorded as corroboration for the slip-angle balance verdict.
+        front_mz = [abs(lap.mz[k][i]) for k in seg for i in (0, 1) if lap.mz[k][i] != 0.0]
+        if front_mz:
+            extra["mz"] = round(max(front_mz), 1)
+    if lap.dy is not None:
+        # Peak lateral friction coefficient actually delivered (μ) over the corner, any wheel — the
+        # ground-truth grip label.
+        mus = [lap.dy[k][i] for k in seg for i in range(4) if lap.dy[k][i] != 0.0]
+        if mus:
+            extra["gripMu"] = round(max(mus), 3)
+    if lap.slip_ratio is not None:
+        # Peak |longitudinal slip ratio| over the corner, any wheel — traction usage on power,
+        # corroborating the wheelspin/lock signals.
+        srs = [
+            abs(lap.slip_ratio[k][i]) for k in seg for i in range(4) if lap.slip_ratio[k][i] != 0.0
+        ]
+        if srs:
+            extra["slipRatio"] = round(max(srs), 3)
+
     return extra
 
 
@@ -1323,6 +1364,66 @@ def _camber_pressure_coaching(ctx: CornerContext) -> str:
     )
 
 
+# --- handling balance under/oversteer (#488 Part A: CSP slip-angle balance) ------------------
+#: A meaningful front-vs-rear mean |slip angle| split (degrees). Below this, the axles are working
+#: evenly enough that calling it under/oversteer would outrun the signal.
+_HANDLING_BALANCE_MIN_DEG = 1.0
+
+
+def _r_handling_balance(ctx: CornerContext) -> float:
+    # Confidence scales with the front-vs-rear slip-angle imbalance. Advisory (no verdict) until the
+    # slipAngle channel is persisted — apply_rules gates that via channels_needed=("slipAngle",).
+    sa = ctx.extra.get("slipAngle")
+    if not isinstance(sa, dict):
+        return 0.0
+    balance = sa.get("balance")
+    if not isinstance(balance, (int, float)):
+        return 0.0
+    mag = abs(float(balance))
+    if mag < _HANDLING_BALANCE_MIN_DEG:
+        return 0.0
+    return min(0.8, 0.3 + (mag - _HANDLING_BALANCE_MIN_DEG) / 8.0)
+
+
+def _handling_balance_setup_causes(ctx: CornerContext) -> list[str]:
+    sa = ctx.extra.get("slipAngle")
+    if not isinstance(sa, dict):
+        return []
+    balance = float(sa.get("balance", 0.0))
+    front, rear = sa.get("front"), sa.get("rear")
+    mz = ctx.extra.get("mz")
+    mz_txt = (
+        f" (front self-aligning torque peaked at {mz} Nm then bled off)" if mz is not None else ""
+    )
+    if balance > 0:  # front slip angle higher -> understeer
+        return [
+            f"CONFIRMED mid-corner UNDERSTEER: front runs {balance:.1f}° more slip than rear "
+            f"(front {front}° vs rear {rear}°){mz_txt} → free the front: soften ARB_FRONT, add "
+            "front wing / drop rear wing, or bring rear pressures toward the hot window.",
+        ]
+    return [  # rear slip angle higher -> oversteer
+        f"CONFIRMED mid-corner OVERSTEER: rear runs {-balance:.1f}° more slip than front "
+        f"(rear {rear}° vs front {front}°) → steady the rear: soften ARB_REAR, add rear wing, "
+        "or ease DIFF_POWER / add rear pressure.",
+    ]
+
+
+def _handling_balance_coaching(ctx: CornerContext) -> str:
+    sa = ctx.extra.get("slipAngle")
+    if not isinstance(sa, dict):
+        return "Supply live slip-angle telemetry to confirm the mid-corner balance."
+    balance = float(sa.get("balance", 0.0))
+    if balance > 0:
+        return (
+            f"Front running {balance:.1f}° more slip than rear — understeer at the limit; free the "
+            "front (ARB/wing/pressure) rather than chasing the line."
+        )
+    return (
+        f"Rear running {-balance:.1f}° more slip than front — oversteer at the limit; steady the "
+        "rear (ARB/wing/diff) and ease the throttle pickup."
+    )
+
+
 RULES: list[DiagnosticRule] = [
     DiagnosticRule(
         key="grip_limited",
@@ -1513,5 +1614,22 @@ RULES: list[DiagnosticRule] = [
             "release can lower peak edge temps once the setup is already close.",
         ),
         coaching=_camber_pressure_coaching,
+    ),
+    DiagnosticRule(
+        key="handling_balance",
+        symptom="mid-corner handling balance (under/oversteer)",
+        phase="mid",
+        tier="A",
+        # 'slipAngle' is the COMPUTED front-vs-rear slip-angle balance (#488 Part A CSP force/slip),
+        # present only when slip angle was read IN this corner — so confirmation never outruns the
+        # data. This is the direct under/oversteer verdict the archive alone cannot produce.
+        channels_needed=("slipAngle",),
+        test=_r_handling_balance,
+        setup_causes=_handling_balance_setup_causes,
+        technique_causes=(
+            "Balance also responds to technique: an earlier, smoother brake release frees a "
+            "pushing front; a gentler throttle pickup settles a loose rear.",
+        ),
+        coaching=_handling_balance_coaching,
     ),
 ]

--- a/tools/ai_sidecar/lap_dynamics.py
+++ b/tools/ai_sidecar/lap_dynamics.py
@@ -57,6 +57,12 @@ class LapTrace:
     tyre_temp_mid: list[list[float]] | None = None  # tread middle temp, °C
     tyre_temp_outer: list[list[float]] | None = None  # tread outer temp, °C
     camber: list[list[float]] | None = None  # dynamic (running) camber, DEGREES (CSP `camber`)
+    # optional Tier-2 CSP force/slip channels (issue #488 Part A); per sample, 4 wheels [FL, FR, RL,
+    # RR]; None when not persisted OR present-but-all-zero (the unreadable sentinel — _wheel_cols).
+    slip_ratio: list[list[float]] | None = None  # CSP slipRatio, unitless (longitudinal)
+    slip_angle: list[list[float]] | None = None  # CSP slipAngle, DEGREES (lateral)
+    mz: list[list[float]] | None = None  # CSP mz, self-aligning torque (Nm)
+    dy: list[list[float]] | None = None  # CSP dy, lateral friction coefficient (peak mu)
     # lazily derived
     _kappa: list[float] | None = field(default=None, repr=False)
     _lat_g: list[float] | None = field(default=None, repr=False)
@@ -254,6 +260,11 @@ def lap_trace_from_archive(archive: dict[str, Any]) -> LapTrace:
     tyre_temp_mid = _wheel_cols(fields, samples, "tyreTempMid", n)
     tyre_temp_outer = _wheel_cols(fields, samples, "tyreTempOuter", n)
     camber = _wheel_cols(fields, samples, "camber", n)
+    # optional Tier-2 CSP force/slip channels (issue #488 Part A); present only when persisted
+    slip_ratio = _wheel_cols(fields, samples, "slipRatio", n)
+    slip_angle = _wheel_cols(fields, samples, "slipAngle", n)
+    mz = _wheel_cols(fields, samples, "mz", n)
+    dy = _wheel_cols(fields, samples, "dy", n)
 
     car = archive.get("car") if isinstance(archive.get("car"), dict) else {}
     track = archive.get("track") if isinstance(archive.get("track"), dict) else {}
@@ -276,6 +287,10 @@ def lap_trace_from_archive(archive: dict[str, Any]) -> LapTrace:
         tyre_temp_mid=tyre_temp_mid,
         tyre_temp_outer=tyre_temp_outer,
         camber=camber,
+        slip_ratio=slip_ratio,
+        slip_angle=slip_angle,
+        mz=mz,
+        dy=dy,
         x=x_col,
         z=z_col,
         lap_ms=_finite(lap.get("lap_ms")),

--- a/tools/lap_archive_export.py
+++ b/tools/lap_archive_export.py
@@ -112,6 +112,32 @@ CSV_COLUMNS: tuple[str, ...] = (
     "turboBoost",
     "fuel",
     "accG_vert",
+    # Tier-2 CSP force/slip channels (issue #488 Part A) — blank for archives that lack them.
+    # Identity CSV names; in sync with reference_lap.TRACE_FIELDS[76:] (test_lap_archive_export).
+    "slipRatio_fl",
+    "slipRatio_fr",
+    "slipRatio_rl",
+    "slipRatio_rr",
+    "slipAngle_fl",
+    "slipAngle_fr",
+    "slipAngle_rl",
+    "slipAngle_rr",
+    "mz_fl",
+    "mz_fr",
+    "mz_rl",
+    "mz_rr",
+    "fx_fl",
+    "fx_fr",
+    "fx_rl",
+    "fx_rr",
+    "fy_fl",
+    "fy_fr",
+    "fy_rl",
+    "fy_rr",
+    "dy_fl",
+    "dy_fr",
+    "dy_rl",
+    "dy_rr",
 )
 
 _PER_WHEEL_TRACE_FIELDS: tuple[str, ...] = (
@@ -191,6 +217,35 @@ _TIER1_DYNAMIC_TRACE_FIELDS: tuple[str, ...] = (
     "accG_vert",
 )
 
+# Tier-2 CSP force/slip channels (issue #488 Part A); blank for archives that lack them. MUST stay
+# in sync with reference_lap.TRACE_FIELDS[76:] — asserted by test_lap_archive_export.
+_TIER2_DYNAMIC_TRACE_FIELDS: tuple[str, ...] = (
+    "slipRatio_fl",
+    "slipRatio_fr",
+    "slipRatio_rl",
+    "slipRatio_rr",
+    "slipAngle_fl",
+    "slipAngle_fr",
+    "slipAngle_rl",
+    "slipAngle_rr",
+    "mz_fl",
+    "mz_fr",
+    "mz_rl",
+    "mz_rr",
+    "fx_fl",
+    "fx_fr",
+    "fx_rl",
+    "fx_rr",
+    "fy_fl",
+    "fy_fr",
+    "fy_rl",
+    "fy_rr",
+    "dy_fl",
+    "dy_fr",
+    "dy_rl",
+    "dy_rr",
+)
+
 _TRACE_TO_CSV: dict[str, str] = {
     "eMs": "elapsed_ms",
     "spline": "spline",
@@ -209,6 +264,8 @@ _TRACE_TO_CSV: dict[str, str] = {
     **{name: name for name in _TIER_B_TRACE_FIELDS},
     # Tier-1 base-AC dynamic channels (issue #490) map to identically-named CSV columns
     **{name: name for name in _TIER1_DYNAMIC_TRACE_FIELDS},
+    # Tier-2 CSP force/slip channels (issue #488 Part A) map to identically-named CSV columns
+    **{name: name for name in _TIER2_DYNAMIC_TRACE_FIELDS},
 }
 
 _MOTEC_CHANNELS: tuple[tuple[str, str, str], ...] = (


### PR DESCRIPTION
## What

Delivers **Part A** of EPIC #488 — the **Tier-2 CSP extended-physics force/slip channels** (Tier-1 base-AC channels shipped in #490 / PR #492). Appends **24 append-only per-wheel trace columns (76 → 100)**:

| Channel | Source (`ac.StateWheel`) | Unit | ML value |
|---|---|---|---|
| `slipRatio_*` | `slipRatio` | unitless | longitudinal traction limit + frictional heat |
| `slipAngle_*` | `slipAngle` | **degrees** | cornering grip usage; front-vs-rear = under/oversteer |
| `mz_*` | `mz` | Nm | self-aligning torque — collapses before lateral saturation ⇒ earliest understeer onset |
| `fx_*`,`fy_*` | `fx`,`fy` | N | ground-truth contact-patch force labels |
| `dy_*` | `dy` | μ | ground-truth lateral friction coefficient |

Field names grounded against **this rig's on-disk CSP lua-sdk `ac.StateWheel` stubs** (`extension/internal/lua-sdk`), not docs.

## How (the byte-identical trace contract)

- `wheel_read.lua` — 6 new pcall-guarded + finite-filtered accessors; extends `readPerWheel`.
- `telemetry.lua` — assembles the 24 new sample keys (+ `---@field` types).
- `lap_archive.lua` — appends to `TRACE_FIELDS` **after `accG_vert`**; records the car-level **`extendedPhysics`** availability flag in the lap header (`car.extendedPhysics`) — the confound telling ML whether the advanced tyre model was active. Channels degrade to `0` when unreadable, so the archive **never fails**.
- `reference_lap.py` — byte-identical Python mirror; new **76-col pre-#488 trace variant** so older archives keep loading; parity test asserts Lua == Python.
- `lap_archive_export.py` — CSV/`_TRACE_TO_CSV` extended + sync test.

## Analysis wiring (advisory → verdict)

- `lap_dynamics.py` loads the new per-wheel columns.
- `corner_attribution.py` derives the **front-vs-rear slip-angle balance** (+ `mz` / `gripMu` / `slipRatio` corroboration) and a **new `handling_balance` rule** (`channels_needed=("slipAngle",)`) that flips advisory→verdict — a direct **under/oversteer** diagnosis the archive alone cannot produce. Each marker is gated on the channel being persisted AND non-zero in the corner (never outruns the data).

## Tests / CI

- `make ci-fast`: **OK** (2390 passed, 73 skipped; ruff, bandit, CSP API + UI-safety, policy all green).
- New tests: Tier-2 trace-carry + 76-col back-compat variant (`test_reference_lap`), export sync (`test_lap_archive_export`), slip-angle balance marker + `handling_balance` verdict (`test_corner_attribution`).

## Verification (in progress)

Rig-verification on a real Magione lap (live channel values + resolving the operator's **brakeTemp Tier-boundary** question from the #488 comment) follows — mirrors the #490 evidence bundle. Draft until that lands.

## Scope

**Advances** EPIC #488 (Part A) — does **not** close it; Parts B (tyre identity), C (serialization grain), D (setup⟷outcome linkage) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)