### PR TITLE
feat(telemetry): #488 Part B tyre identity & specs — live capture + ACD tyres.ini reader + car-true window

### DIFF
--- a/src/ac_copilot_trainer/modules/lap_archive.lua
+++ b/src/ac_copilot_trainer/modules/lap_archive.lua
@@ -282,6 +282,36 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
     end)
   end
 
+  -- Tyre compound LONG name (issue #488 Part B) — e.g. "Toyo R888R" via ac.getTyresLongName. Same
+  -- unread-index guard as tyreName: only claim it when the compound index was actually read, so the
+  -- lakehouse never keys on an identity the capture couldn't confirm.
+  local tyreLongName = nil
+  if tyreCompoundIndex ~= nil then
+    pcall(function()
+      if ac and type(ac.getTyresLongName) == "function" then
+        local n = ac.getTyresLongName(0, tyreCompoundIndex)
+        if type(n) == "string" and n ~= "" then
+          tyreLongName = n
+        end
+      end
+    end)
+  end
+
+  -- Car-true optimal tyre CORE temperature (°C, issue #488 Part B) — CSP
+  -- `wheel.tyreOptimumTemperature` (the PERFORMANCE_CURVE peak the game itself uses), so the tyre
+  -- model can interpret core temps against the CAR-true window instead of a generic per-compound
+  -- bucket. Read wheel 0 (0-indexed per ac.Wheel; constant per compound), pcall + finite-guarded so
+  -- an unreadable field is honestly absent (nil). Rejects 0/negative (unread/invalid).
+  local tyreOptimalTempC = nil
+  pcall(function()
+    local wheels = opts.car and opts.car.wheels
+    local w0 = wheels and wheels[0]
+    local t = tonumber(w0 and w0.tyreOptimumTemperature)
+    if t ~= nil and t == t and t ~= math.huge and t ~= -math.huge and t > 0 then
+      tyreOptimalTempC = t
+    end
+  end)
+
   -- Tier-2 availability confound (issue #488 Part A): whether CSP extended car physics was active
   -- (`ac.StateCar.extendedPhysics`). The Tier-2 force/slip trace channels are populated by AC's tyre
   -- solver regardless, but this per-lap flag tells ML whether the advanced physics model was in
@@ -373,6 +403,8 @@ local function buildRecordEnvelope(opts, samplesColumnar, samplesCount)
     tyres = {
       compoundIndex = tyreCompoundIndex,
       name = tyreName,
+      longName = tyreLongName,
+      optimalTempC = tyreOptimalTempC,
     },
     trace = {
       samples_count = samplesCount,

--- a/tests/test_setup_model.py
+++ b/tests/test_setup_model.py
@@ -239,3 +239,30 @@ def test_diff_handles_added_and_removed_knobs():
     cand = from_snapshot({"FRONT_BIAS.VALUE": "66", "TRACTION_CONTROL.VALUE": "5"})
     d = cand.diff(base)
     assert d["TRACTION_CONTROL"] == {"from": None, "to": 5.0}
+
+
+def test_resolve_tyre_spec_from_setup_compound(monkeypatch):
+    # #488 Part B: a setup's [TYRES] compound index resolves the car-true tyre spec (ACD-aware).
+    from types import SimpleNamespace
+
+    from tools.ai_sidecar import setup_model
+
+    setup = from_snapshot({"TYRES.VALUE": "0", "PRESSURE_LF.VALUE": "27.5"})
+    captured = {}
+
+    def _fake(car_dir, compound_index):
+        captured["ci"] = compound_index
+        return SimpleNamespace(name="Slick Soft", optimal_temp_c=70.0, pressure_ideal_psi=26.0)
+
+    monkeypatch.setattr(setup_model, "read_tyre_specs", _fake)
+    spec = setup_model.resolve_tyre_spec(setup, "/fake/car/dir")
+    assert captured["ci"] == 0  # the [TYRES] VALUE index was passed through
+    assert spec is not None
+    assert spec.name == "Slick Soft"
+
+
+def test_resolve_tyre_spec_none_without_compound():
+    from tools.ai_sidecar import setup_model
+
+    setup = from_snapshot({"PRESSURE_LF.VALUE": "27.5"})  # no [TYRES] compound index
+    assert setup_model.resolve_tyre_spec(setup, "/fake/car/dir") is None

--- a/tests/test_tyre_model.py
+++ b/tests/test_tyre_model.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from tools.ai_sidecar.tyre_model import (
     COMPOUND_WINDOWS,
     CRITICAL_C,
+    OPTIMAL_BAND_ABOVE_C,
+    OPTIMAL_BAND_BELOW_C,
+    OPTIMAL_CRITICAL_MARGIN_C,
     analyze_tyres,
     tyres_from_lap_archive,
 )
@@ -203,6 +206,85 @@ def test_tyres_from_lap_archive_averages_core_and_reads_pressure():
 def test_tyres_from_lap_archive_none_without_temp_channels():
     archive = {"trace": {"fields": ["spline", "speed", "eMs"], "samples": [[0, 1, 2], [0.5, 1, 3]]}}
     assert tyres_from_lap_archive(archive) is None
+
+
+def test_optimal_temp_recenters_window_on_car_true_peak():
+    # #488 Part B: a captured car-true optimum re-centers the window on the real peak. peak=90 ->
+    # window (70, 100), critical 115. AT the peak = in-window; well above peak+ABOVE = overheat.
+    peak = 90.0
+    r = analyze_tyres(_core(peak, peak, peak, peak), compound="soft", optimal_temp_c=peak)
+    assert r.window == (peak - OPTIMAL_BAND_BELOW_C, peak + OPTIMAL_BAND_ABOVE_C)
+    assert all(s == "in_window" for s in r.status.values())
+    hot = analyze_tyres(
+        _core(peak + OPTIMAL_BAND_ABOVE_C + 5, peak, peak, peak), optimal_temp_c=peak
+    )
+    assert hot.status["fl"] == "overheat"
+    crit = analyze_tyres(
+        _core(peak + OPTIMAL_CRITICAL_MARGIN_C + 1, peak, peak, peak), optimal_temp_c=peak
+    )
+    assert crit.status["fl"] == "critical"
+
+
+def test_optimal_temp_overrides_generic_bucket():
+    # Same core, different optimum: with optimal_temp_c the window is the CAR-true band, not the
+    # generic per-compound bucket (which would be soft's (70, 100)).
+    generic = analyze_tyres(_core(90, 90, 90, 90), compound="soft")
+    car_true = analyze_tyres(_core(90, 90, 90, 90), compound="soft", optimal_temp_c=105.0)
+    assert generic.window == COMPOUND_WINDOWS["soft"]
+    assert car_true.window == (105.0 - OPTIMAL_BAND_BELOW_C, 105.0 + OPTIMAL_BAND_ABOVE_C)
+    assert car_true.window != generic.window
+
+
+def test_tyres_from_lap_archive_uses_car_true_optimum_and_longname():
+    # #488 Part B: the tyres header's optimalTempC drives a car-true window; longName is the label.
+    archive = _archive_with_temps(_core(85, 85, 83, 83))
+    archive["tyres"] = {
+        "compoundIndex": 4,
+        "name": "R888R",
+        "longName": "Toyo R888R",
+        "optimalTempC": 88.0,
+    }
+    r = tyres_from_lap_archive(archive)
+    assert r is not None
+    assert r.window == (88.0 - OPTIMAL_BAND_BELOW_C, 88.0 + OPTIMAL_BAND_ABOVE_C)
+    assert r.compound == "toyo r888r"  # long-name display label (lowercased)
+
+
+def test_tyres_from_lap_archive_without_optimum_falls_back_to_generic():
+    # Back-compat: a pre-#488 archive with no tyres.optimalTempC uses the generic slick window.
+    r = tyres_from_lap_archive(_archive_with_temps(_core(92, 92, 88, 88)))
+    assert r is not None
+    assert r.window == COMPOUND_WINDOWS["slick"]
+
+
+def test_tyres_from_lap_archive_acd_fallback_resolves_optimum(monkeypatch):
+    # #488 Part B: a pre-#488 archive (compoundIndex only, no live optimum/name) resolves the
+    # car-true optimum + compound name from the car's tyres.ini (ACD) when car_data_dir is given.
+    from types import SimpleNamespace
+
+    from tools.ai_sidecar import tyre_model
+
+    archive = _archive_with_temps(_core(72, 72, 70, 70))
+    archive["tyres"] = {"compoundIndex": 0}  # index only — the pre-#488 capture shape
+
+    def _fake_specs(car_dir, compound_index):
+        assert compound_index == 0
+        return SimpleNamespace(optimal_temp_c=70.0, name="Slick Soft")
+
+    monkeypatch.setattr(tyre_model, "read_tyre_specs", _fake_specs)
+    r = tyres_from_lap_archive(archive, car_data_dir="/fake/car/dir")
+    assert r is not None
+    assert r.window == (70.0 - OPTIMAL_BAND_BELOW_C, 70.0 + OPTIMAL_BAND_ABOVE_C)
+    assert r.compound == "slick soft"
+
+
+def test_tyres_from_lap_archive_no_car_dir_skips_acd():
+    # Without car_data_dir the ACD reader is never touched (no side effects, generic fallback).
+    archive = _archive_with_temps(_core(92, 92, 88, 88))
+    archive["tyres"] = {"compoundIndex": 0}
+    r = tyres_from_lap_archive(archive)
+    assert r is not None
+    assert r.window == COMPOUND_WINDOWS["slick"]
 
 
 def test_archive_zero_temps_are_unread_sentinel():

--- a/tests/test_tyre_specs.py
+++ b/tests/test_tyre_specs.py
@@ -217,6 +217,33 @@ def test_prefers_unpacked_data_dir(tmp_path: Path) -> None:
     assert spec.optimal_temp_c == 85.0
 
 
+def test_unpacked_data_dir_is_case_insensitive(tmp_path: Path) -> None:
+    """AC mods ship TYRES.INI / Tyres.ini and .LUT in mixed case; the reader must still resolve them
+    (a case-exact lookup would miss them on a case-sensitive FS) — gemini HIGH on PR #500."""
+    car_dir = tmp_path / "mixed_case_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "TYRES.INI").write_text(_SYNTH_TYRES_INI, encoding="utf-8")
+    (data_dir / "TCurve_R888.LUT").write_text(_SYNTH_R888_LUT, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.name == "Toyo R888R"
+    assert spec.optimal_temp_c == 85.0  # the mixed-case .lut still resolves
+
+
+def test_acd_member_names_are_case_insensitive(tmp_path: Path) -> None:
+    """A data.acd whose member is packed as TYRES.INI (mod author's case) still resolves."""
+    folder = "mixed_case_acd_car"
+    car_dir = tmp_path / folder
+    car_dir.mkdir(parents=True)
+    acd = _build_acd(folder, {"TYRES.INI": _SYNTH_TYRES_INI, "TCURVE_R888.LUT": _SYNTH_R888_LUT})
+    (car_dir / "data.acd").write_bytes(acd)
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.name == "Toyo R888R"
+    assert spec.optimal_temp_c == 85.0
+
+
 # --------------------------------------------------------------------------------------------------
 # Tolerant parsing + graceful degradation
 # --------------------------------------------------------------------------------------------------
@@ -330,3 +357,22 @@ def test_caches_archive_per_car_dir(synth_car: Path, monkeypatch: pytest.MonkeyP
     spec = read_tyre_specs(synth_car, 1)
     assert spec is not None
     assert spec.name == "Slick Medium"
+
+
+def test_archive_cache_is_bounded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-car archive cache evicts oldest entries at capacity (Qodo reliability finding): a
+    long-lived process reading many cars never grows the cache without limit."""
+    import tools.ai_sidecar.tyre_specs as mod
+
+    monkeypatch.setattr(mod, "_ARCHIVE_CACHE", {})
+    monkeypatch.setattr(mod, "_ARCHIVE_CACHE_MAX", 2)
+    for i in range(4):
+        folder = f"car_{i}"
+        cd = tmp_path / folder
+        cd.mkdir()
+        acd = _build_acd(
+            folder, {"tyres.ini": _SYNTH_TYRES_INI, "tcurve_r888.lut": _SYNTH_R888_LUT}
+        )
+        (cd / "data.acd").write_bytes(acd)
+        assert read_tyre_specs(cd, 0) is not None
+    assert len(mod._ARCHIVE_CACHE) <= 2

--- a/tests/test_tyre_specs.py
+++ b/tests/test_tyre_specs.py
@@ -356,6 +356,27 @@ def test_non_finite_values_degrade_to_none(tmp_path: Path) -> None:
     assert spec.pressure_ideal_psi == 26.0  # the one finite field survives
 
 
+def test_performance_curve_with_path_prefix_resolves(tmp_path: Path) -> None:
+    """A PERFORMANCE_CURVE written with a folder prefix (`data/tcurve.lut`) resolves via its
+    basename against the archive's basename keys (gemini #500)."""
+    ini = (
+        "[FRONT]\n"
+        "NAME=Path Prefix Tyre\n"
+        "WIDTH=0.25\n"
+        "RADIUS=0.32\n"
+        "[THERMAL_FRONT]\n"
+        "PERFORMANCE_CURVE=data/tcurve_r888.lut\n"
+    )
+    car_dir = tmp_path / "path_prefix_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tyres.ini").write_text(ini, encoding="utf-8")
+    (data_dir / "tcurve_r888.lut").write_text(_SYNTH_R888_LUT, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.optimal_temp_c == 85.0  # basename lookup found the .lut despite the path prefix
+
+
 def test_rear_fallback_for_missing_front_key(tmp_path: Path) -> None:
     """A key present only in [REAR_N] is used when [FRONT_N] omits it."""
     ini = (

--- a/tests/test_tyre_specs.py
+++ b/tests/test_tyre_specs.py
@@ -1,0 +1,332 @@
+"""Hermetic tests for ``tools.ai_sidecar.tyre_specs``.
+
+No dependency on the Steam install: a tiny synthetic ``data.acd`` is built in-test with the SAME
+obfuscation the reader reverses (encode = ``(char + key_ord[i % len]) & 0xFF``, the inverse of the
+reader's subtraction), so the round-trip proves both the container layout and the de-obfuscation.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from tools.ai_sidecar.tyre_specs import (
+    TyreSpec,
+    _acd_key,
+    read_tyre_specs,
+)
+
+# --------------------------------------------------------------------------------------------------
+# Synthetic ACD encoder (mirror-image of the reader's decrypt path)
+# --------------------------------------------------------------------------------------------------
+
+
+def _acd_encode_content(text: str, key: str) -> bytes:
+    """Obfuscate one member's bytes: each char -> a little-endian int32 whose low byte is
+    ``(char + key_ord[i % len]) & 0xFF`` (upper 3 bytes zero). Inverse of the reader's subtract."""
+    key_ord = [ord(c) for c in key]
+    klen = len(key_ord)
+    raw = text.encode("utf-8")
+    out = bytearray()
+    for i, ch in enumerate(raw):
+        low = (ch + key_ord[i % klen]) & 0xFF
+        out += struct.pack("<I", low)
+    return bytes(out)
+
+
+def _build_acd(folder_name: str, members: dict[str, str], with_version: bool = True) -> bytes:
+    """Assemble a synthetic ``data.acd`` for ``folder_name`` containing ``members``.
+
+    Layout: optional ``[-1111][version]`` prefix, then per member
+    ``[name_len:uint32][name][content_len:uint32][content int32s]``.
+    """
+    key = _acd_key(folder_name)
+    blob = bytearray()
+    if with_version:
+        blob += struct.pack("<l", -1111)
+        blob += struct.pack("<l", 42)  # arbitrary version int
+    for name, text in members.items():
+        name_bytes = name.encode("utf-8")
+        blob += struct.pack("<I", len(name_bytes))
+        blob += name_bytes
+        blob += struct.pack("<I", len(text.encode("utf-8")))
+        blob += _acd_encode_content(text, key)
+    return bytes(blob)
+
+
+# A compact but realistic tyres.ini: bare [FRONT]/[REAR] == compound 0, plus a [FRONT_1].
+_SYNTH_TYRES_INI = """\
+[HEADER]
+VERSION=7
+
+[COMPOUND_DEFAULT]
+INDEX=0
+
+; ---- compound 0 ----
+[FRONT]
+NAME=Toyo R888R          ; road-legal semi-slick
+SHORT_NAME=R
+WIDTH=0.255
+RADIUS=0.318
+RIM_RADIUS=0.2286
+PRESSURE_STATIC=24 ; cold
+PRESSURE_IDEAL=30  ; hot
+DX_REF=1.44
+DY_REF=1.42
+
+[REAR]
+NAME=Toyo R888R
+WIDTH=0.275
+RADIUS=0.320
+RIM_RADIUS=0.2286
+PRESSURE_STATIC=24
+PRESSURE_IDEAL=30
+DX_REF=1.44
+DY_REF=1.42
+
+[THERMAL_FRONT]
+PERFORMANCE_CURVE=tcurve_r888.lut
+COOL_FACTOR=1.9
+
+[THERMAL_REAR]
+PERFORMANCE_CURVE=tcurve_r888.lut
+
+; ---- compound 1 (duplicate NAME key exercises last-write-wins) ----
+[FRONT_1]
+NAME=PLACEHOLDER
+NAME=Slick Medium
+WIDTH=0.300
+RADIUS=0.330
+RIM_RADIUS=0.2413
+DX_REF=1.60
+DY_REF=1.58
+
+[THERMAL_FRONT_1]
+PERFORMANCE_CURVE=tcurve_slick.lut
+"""
+
+# 3-point curve: peak grip 1.0 at 85 C (a clear single max, not on the endpoints).
+_SYNTH_R888_LUT = "60|0.85\n85|1.00\n110|0.92\n"
+# Compound-1 curve peaks at 95 C.
+_SYNTH_SLICK_LUT = "70|0.80\n95|1.00\n130|0.88\n"
+
+
+@pytest.fixture
+def synth_car(tmp_path: Path) -> Path:
+    """A car dir whose only tyre source is a synthetic encrypted ``data.acd``."""
+    folder = "synth_test_car"
+    car_dir = tmp_path / folder
+    car_dir.mkdir()
+    acd = _build_acd(
+        folder,
+        {
+            "tyres.ini": _SYNTH_TYRES_INI,
+            "tcurve_r888.lut": _SYNTH_R888_LUT,
+            "tcurve_slick.lut": _SYNTH_SLICK_LUT,
+        },
+    )
+    (car_dir / "data.acd").write_bytes(acd)
+    return car_dir
+
+
+# --------------------------------------------------------------------------------------------------
+# ACD decrypt + parse round-trip
+# --------------------------------------------------------------------------------------------------
+
+
+def test_acd_roundtrip_compound0(synth_car: Path) -> None:
+    """Decrypt a synthetic data.acd and parse compound 0 end-to-end."""
+    spec = read_tyre_specs(synth_car, 0)
+    assert spec is not None
+    assert spec == TyreSpec(
+        compound_index=0,
+        name="Toyo R888R",
+        width_m=0.255,
+        radius_m=0.318,
+        rim_radius_m=0.2286,
+        size_label="255/R31.8 (rim R22.9)",
+        pressure_static_psi=24.0,
+        pressure_ideal_psi=30.0,
+        dx_ref=1.44,
+        dy_ref=1.42,
+        optimal_temp_c=85.0,  # peak of the 3-point PERFORMANCE_CURVE
+        version=7,
+    )
+
+
+def test_acd_roundtrip_compound1(synth_car: Path) -> None:
+    """Compound 1 resolves the ``_1`` sections and its own thermal curve (peak 95 C)."""
+    spec = read_tyre_specs(synth_car, 1)
+    assert spec is not None
+    assert spec.name == "Slick Medium"  # last-write-wins over the PLACEHOLDER duplicate key
+    assert spec.width_m == 0.300
+    assert spec.dx_ref == 1.60
+    assert spec.optimal_temp_c == 95.0
+    # PRESSURE_* absent in the compound-1 section -> None, not fabricated.
+    assert spec.pressure_static_psi is None
+    assert spec.pressure_ideal_psi is None
+
+
+def test_acd_no_version_prefix(tmp_path: Path) -> None:
+    """A container whose leading int is already the first filename length (no -1111) parses too."""
+    folder = "no_version_car"
+    car_dir = tmp_path / folder
+    car_dir.mkdir()
+    acd = _build_acd(
+        folder,
+        {"tyres.ini": _SYNTH_TYRES_INI, "tcurve_r888.lut": _SYNTH_R888_LUT},
+        with_version=False,
+    )
+    (car_dir / "data.acd").write_bytes(acd)
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.name == "Toyo R888R"
+    assert spec.optimal_temp_c == 85.0
+
+
+def test_key_is_folder_name_dependent(synth_car: Path) -> None:
+    """The key is derived from the folder name: a data.acd built for a DIFFERENT folder name must
+    NOT decrypt to a readable tyres.ini (guards against a folder-name-independent regression)."""
+    wrong = _build_acd("some_other_folder", {"tyres.ini": _SYNTH_TYRES_INI})
+    (synth_car / "data.acd").write_bytes(wrong)
+    # Wrong key -> either no readable "tyres.ini" member (None) or a garbled one whose fields
+    # do not match. Either way it must not yield the correct spec.
+    spec = read_tyre_specs(synth_car, 0)
+    assert spec is None or spec.name != "Toyo R888R"
+
+
+# --------------------------------------------------------------------------------------------------
+# Unpacked data/ source preference
+# --------------------------------------------------------------------------------------------------
+
+
+def test_prefers_unpacked_data_dir(tmp_path: Path) -> None:
+    """When an unpacked ``data/tyres.ini`` exists it is used directly (no decryption needed), and
+    its ``.lut`` is resolved from the same folder."""
+    car_dir = tmp_path / "unpacked_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tyres.ini").write_text(_SYNTH_TYRES_INI, encoding="utf-8")
+    (data_dir / "tcurve_r888.lut").write_text(_SYNTH_R888_LUT, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.name == "Toyo R888R"
+    assert spec.radius_m == 0.318
+    assert spec.optimal_temp_c == 85.0
+
+
+# --------------------------------------------------------------------------------------------------
+# Tolerant parsing + graceful degradation
+# --------------------------------------------------------------------------------------------------
+
+
+def test_missing_car_returns_none(tmp_path: Path) -> None:
+    """No data.acd and no data/ -> None (never raises)."""
+    assert read_tyre_specs(tmp_path / "does_not_exist", 0) is None
+
+
+def test_out_of_range_compound_returns_none(synth_car: Path) -> None:
+    """A compound index with no matching section -> None."""
+    assert read_tyre_specs(synth_car, 9) is None
+
+
+def test_missing_fields_degrade_to_none(tmp_path: Path) -> None:
+    """A section present but missing individual keys yields None for those fields, not a crash.
+    Also: comments and a missing THERMAL section leave optimal_temp_c None (never fabricated)."""
+    ini = (
+        "[HEADER]\n"
+        "; no VERSION key here\n"
+        "[FRONT]\n"
+        "NAME=Sparse Compound  ; only a name\n"
+        "WIDTH=0.2\n"
+        "; RADIUS intentionally omitted -> radius_m None, so size_label None\n"
+    )
+    car_dir = tmp_path / "sparse_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tyres.ini").write_text(ini, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.name == "Sparse Compound"
+    assert spec.width_m == 0.2
+    assert spec.radius_m is None
+    assert spec.rim_radius_m is None
+    assert spec.size_label is None  # needs width AND radius
+    assert spec.pressure_static_psi is None
+    assert spec.dx_ref is None
+    assert spec.optimal_temp_c is None  # no THERMAL section / curve
+    assert spec.version is None
+
+
+def test_inline_comment_and_whitespace_stripping(tmp_path: Path) -> None:
+    """`KEY=VALUE ; comment` and stray whitespace are handled; numeric parse ignores the comment."""
+    ini = (
+        "[FRONT]\n"
+        "NAME = Spaced Name \t ; trailing comment\n"
+        "WIDTH= 0.245\t; width with tab+comment\n"
+        "RADIUS =0.315 # hash comment style\n"
+        "RIM_RADIUS=0.22\n"
+    )
+    car_dir = tmp_path / "commenty_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tyres.ini").write_text(ini, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.name == "Spaced Name"
+    assert spec.width_m == 0.245
+    assert spec.radius_m == 0.315
+    assert spec.size_label == "245/R31.5 (rim R22.0)"
+
+
+def test_rear_fallback_for_missing_front_key(tmp_path: Path) -> None:
+    """A key present only in [REAR_N] is used when [FRONT_N] omits it."""
+    ini = (
+        "[FRONT]\n"
+        "NAME=Front Only Name\n"
+        "WIDTH=0.28\n"
+        "RADIUS=0.33\n"
+        "[REAR]\n"
+        "NAME=Front Only Name\n"
+        "WIDTH=0.30\n"
+        "RADIUS=0.34\n"
+        "PRESSURE_STATIC=21 ; only defined on REAR\n"
+    )
+    car_dir = tmp_path / "rear_fallback_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tyres.ini").write_text(ini, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    # FRONT value wins where present...
+    assert spec.width_m == 0.28
+    # ...REAR fills the key FRONT omits.
+    assert spec.pressure_static_psi == 21.0
+
+
+def test_corrupt_acd_returns_none(tmp_path: Path) -> None:
+    """Random bytes named data.acd must degrade to None, never raise."""
+    car_dir = tmp_path / "corrupt_car"
+    car_dir.mkdir()
+    (car_dir / "data.acd").write_bytes(b"\x00\x01\x02\x03not a real acd" * 8)
+    assert read_tyre_specs(car_dir, 0) is None
+
+
+def test_caches_archive_per_car_dir(synth_car: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The decrypted archive is cached per car_dir: a second read for another compound does not
+    re-read data.acd from disk."""
+    import tools.ai_sidecar.tyre_specs as mod
+
+    # Prime the cache.
+    assert read_tyre_specs(synth_car, 0) is not None
+
+    # Now make any further disk read explode; a cached second call must still succeed.
+    def _boom(*_args: object, **_kwargs: object) -> bytes:
+        raise AssertionError("data.acd should not be re-read when cached")
+
+    monkeypatch.setattr(mod.Path, "read_bytes", _boom)
+    spec = read_tyre_specs(synth_car, 1)
+    assert spec is not None
+    assert spec.name == "Slick Medium"

--- a/tests/test_tyre_specs.py
+++ b/tests/test_tyre_specs.py
@@ -308,6 +308,54 @@ def test_inline_comment_and_whitespace_stripping(tmp_path: Path) -> None:
     assert spec.size_label == "245/R31.5 (rim R22.0)"
 
 
+def test_section_header_with_inline_comment(tmp_path: Path) -> None:
+    """A section header with a trailing comment (`[FRONT] ; x`) still parses; the comment is
+    stripped before the anchored section-header regex runs (gemini #500)."""
+    ini = (
+        "[FRONT] ; road-legal semi-slick\n"
+        "NAME=Commented Header\n"
+        "WIDTH=0.25\n"
+        "RADIUS=0.32\n"
+        "[THERMAL_FRONT]  # hash comment on header\n"
+        "PERFORMANCE_CURVE=60|0.9,80|1.0,100|0.9\n"
+    )
+    car_dir = tmp_path / "header_comment_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tyres.ini").write_text(ini, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None
+    assert spec.name == "Commented Header"
+    assert spec.width_m == 0.25
+    assert spec.optimal_temp_c == 80.0  # inline curve resolved despite the header comment
+
+
+def test_non_finite_values_degrade_to_none(tmp_path: Path) -> None:
+    """NaN/inf in the INI degrade to None, never crashing size/int formatting (gemini #500)."""
+    ini = (
+        "[HEADER]\n"
+        "VERSION=inf\n"
+        "[FRONT]\n"
+        "NAME=Corrupt Dims\n"
+        "WIDTH=nan\n"
+        "RADIUS=inf\n"
+        "RIM_RADIUS=-inf\n"
+        "PRESSURE_IDEAL=26\n"
+    )
+    car_dir = tmp_path / "corrupt_car"
+    data_dir = car_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "tyres.ini").write_text(ini, encoding="utf-8")
+    spec = read_tyre_specs(car_dir, 0)
+    assert spec is not None  # never raises
+    assert spec.name == "Corrupt Dims"
+    assert spec.width_m is None
+    assert spec.radius_m is None
+    assert spec.version is None  # inf VERSION -> None, not an OverflowError
+    assert spec.size_label is None  # needs finite width + radius
+    assert spec.pressure_ideal_psi == 26.0  # the one finite field survives
+
+
 def test_rear_fallback_for_missing_front_key(tmp_path: Path) -> None:
     """A key present only in [REAR_N] is used when [FRONT_N] omits it."""
     ini = (

--- a/tools/ai_sidecar/setup_model.py
+++ b/tools/ai_sidecar/setup_model.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from tools.ai_sidecar.tyre_specs import TyreSpec, read_tyre_specs
+
 # --- categories -------------------------------------------------------------
 BRAKES = "brakes"
 TIRES = "tires"
@@ -504,3 +506,18 @@ def from_spinners(
     if schema:
         out.spinner_schema = schema
     return out
+
+
+def resolve_tyre_spec(setup: CarSetup, car_data_dir: str | Path) -> TyreSpec | None:
+    """Resolve the CAR-true tyre specs for a setup's compound from the car's ``tyres.ini``.
+
+    The setup-side feed of the #488 Part B tyre-identity reader: a garage setup carries the
+    ``[TYRES] VALUE`` compound index, so given the car's data dir this surfaces the real compound
+    identity + specs (name, ideal cold/hot pressures, peak mu, optimal temp, size), letting the
+    coaching layer reason against car-true numbers instead of a generic bucket. ``None`` when the
+    compound index or the car's tyre data is unresolvable (ACD-aware; never raises).
+    """
+    ci = setup.compound_index
+    if ci is None or ci != ci or ci in (float("inf"), float("-inf")):
+        return None
+    return read_tyre_specs(car_data_dir, int(ci))

--- a/tools/ai_sidecar/tyre_model.py
+++ b/tools/ai_sidecar/tyre_model.py
@@ -19,7 +19,10 @@ red-team corrections are encoded here and must NOT be "simplified" away:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+
+from tools.ai_sidecar.tyre_specs import read_tyre_specs
 
 _WHEELS = ("fl", "fr", "rl", "rr")
 #: Our front-corner wheel key (fl) → AC setup INI's side-corner key (LF). AC uses LF/RF/LR/RR.
@@ -47,6 +50,21 @@ COMPOUND_CRITICAL_C: dict[str, float] = {
     "slick": 120.0,
 }
 CRITICAL_C = COMPOUND_CRITICAL_C["soft"]  # back-compat default (most conservative)
+
+#: Car-true window from the live PERFORMANCE_CURVE peak (`wheel.tyreOptimumTemperature`, #488).
+#: When the optimum is known we re-center the window on the real peak, not a generic per-compound
+#: bucket. Grip rolls off asymmetrically (faster above than below, red-team-verified), so the band
+#: is wider below; reuses the generic 30C span + +25C critical margin, anchored on the true peak.
+OPTIMAL_BAND_BELOW_C = 20.0
+OPTIMAL_BAND_ABOVE_C = 10.0
+OPTIMAL_CRITICAL_MARGIN_C = 25.0
+
+
+def _window_from_optimal(optimal_c: float) -> tuple[tuple[float, float], float]:
+    """``(window, critical_c)`` centered on the car-true optimal core temp (the curve peak)."""
+    window = (optimal_c - OPTIMAL_BAND_BELOW_C, optimal_c + OPTIMAL_BAND_ABOVE_C)
+    return window, optimal_c + OPTIMAL_CRITICAL_MARGIN_C
+
 
 # pressure↔core coupling (ideal gas, constant V): ~+1 psi per 10 °C at GT3 pressures
 PRESSURE_PSI_PER_DEGC = 0.12
@@ -144,18 +162,28 @@ def analyze_tyres(
     cold_pressure: dict[str, float] | None = None,
     *,
     compound: str | None = None,
+    optimal_temp_c: float | None = None,
     prev_core: dict[str, float] | None = None,
     laps_since_start: int | None = None,
 ) -> TyreReport:
     """Analyze a lap's per-wheel core temps (+ optional cold pressures, compound, previous lap).
 
     ``core``/``cold_pressure`` are ``{fl,fr,rl,rr: value}`` (missing wheels tolerated). ``compound``
-    is one of COMPOUND_WINDOWS keys; unknown → generic ``slick``. ``prev_core`` +
+    is a display label (a COMPOUND_WINDOWS key, or a car-authored name like "Toyo R888R").
+    ``optimal_temp_c`` is the CAR-true optimal core temp (the PERFORMANCE_CURVE peak, live via
+    ``wheel.tyreOptimumTemperature`` or resolved from ``tyres.ini``, #488 Part B): when given, the
+    window is re-centered on the real peak instead of a generic per-compound bucket. ``prev_core`` +
     ``laps_since_start`` drive warm-up vs steady classification. Returns a :class:`TyreReport`.
     """
     comp = (compound or "slick").lower()
-    window = COMPOUND_WINDOWS.get(comp, COMPOUND_WINDOWS["slick"])
-    critical_c = COMPOUND_CRITICAL_C.get(comp, COMPOUND_CRITICAL_C["slick"])
+    # Prefer the CAR-true window (curve peak) when the optimum was captured; else the generic
+    # per-compound bucket only when it wasn't (older archive / unreadable field).
+    opt = _num(optimal_temp_c)
+    if opt is not None and opt > 0:
+        window, critical_c = _window_from_optimal(opt)
+    else:
+        window = COMPOUND_WINDOWS.get(comp, COMPOUND_WINDOWS["slick"])
+        critical_c = COMPOUND_CRITICAL_C.get(comp, COMPOUND_CRITICAL_C["slick"])
     core = {w: float(core[w]) for w in _WHEELS if w in core and core[w] is not None}
     status = {w: _status_for(core[w], window, critical_c) for w in core}
     present = list(core.values())
@@ -358,12 +386,15 @@ def _build_findings(
     return out
 
 
-def tyres_from_lap_archive(archive: dict) -> TyreReport | None:
+def tyres_from_lap_archive(
+    archive: dict, *, car_data_dir: str | Path | None = None
+) -> TyreReport | None:
     """Build a :class:`TyreReport` from a lap archive's per-wheel ``tyreCoreTemp_*`` trace columns.
 
     Averages each wheel's core temp over the lap (the trace carries per-sample core temps, #266).
-    Returns None if the archive has no per-wheel temp channels. Compound/cold-pressure are read from
-    the setup snapshot when present (compound index → unknown name, so falls back to generic slick).
+    Returns None if the archive has no per-wheel temp channels. The car-true optimum + compound name
+    come from the archive ``tyres`` header (live, #488); when ``car_data_dir`` is given and the
+    archive lacks them, they are resolved offline from the car's ``tyres.ini`` (ACD-aware).
     """
     trace = archive.get("trace") if isinstance(archive, dict) else None
     if not isinstance(trace, dict):
@@ -404,4 +435,24 @@ def tyres_from_lap_archive(archive: dict) -> TyreReport | None:
     lap = archive.get("lap") if isinstance(archive.get("lap"), dict) else {}
     lap_num = _num(lap.get("lap_n"))  # _num rejects NaN/±inf so int() below never crashes
     laps_since = int(lap_num) if lap_num is not None else None
-    return analyze_tyres(core, cold or None, laps_since_start=laps_since)
+    # Car-true optimal core temp + compound identity from the archive tyres header (#488 Part B).
+    # Prefer the LONG compound name ("Toyo R888R") as the debrief label; else the short name.
+    tyres = archive.get("tyres") if isinstance(archive.get("tyres"), dict) else {}
+    optimal = _num(tyres.get("optimalTempC"))
+    label = tyres.get("longName") or tyres.get("name")
+    compound = label if isinstance(label, str) and label else None
+    # Offline enrichment (#488 Part B): a pre-#488 archive has no live optimum/name. When the car's
+    # data dir is available, resolve them from the car's tyres.ini (ACD-aware). A bad or
+    # absent ACD leaves the live values (or None → generic bucket), never raises.
+    if (optimal is None or compound is None) and car_data_dir is not None:
+        ci = _num(tyres.get("compoundIndex"))
+        if ci is not None:
+            spec = read_tyre_specs(car_data_dir, int(ci))
+            if spec is not None:
+                if optimal is None:
+                    optimal = _num(spec.optimal_temp_c)
+                if compound is None and isinstance(spec.name, str) and spec.name:
+                    compound = spec.name
+    return analyze_tyres(
+        core, cold or None, compound=compound, optimal_temp_c=optimal, laps_since_start=laps_since
+    )

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -281,10 +281,13 @@ def _parse_ini_sections(text: str) -> dict[str, dict[str, str]]:
     sections: dict[str, dict[str, str]] = {}
     current: dict[str, str] | None = None
     for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith((";", "#")):
+        # Strip an inline comment (';'/'#') from the WHOLE line first, so a section header or key
+        # with a trailing comment (e.g. "[FRONT] ; road tyre") still parses — the anchored
+        # _SECTION_RE would otherwise fail to match the raw line.
+        stripped = re.split(r"[;#]", line, maxsplit=1)[0].strip()
+        if not stripped:
             continue
-        m = _SECTION_RE.match(line)
+        m = _SECTION_RE.match(stripped)
         if m:
             name = m.group(1).strip().upper()
             current = sections.setdefault(name, {})
@@ -292,8 +295,7 @@ def _parse_ini_sections(text: str) -> dict[str, dict[str, str]]:
         if current is None or "=" not in stripped:
             continue
         key, _, value = stripped.partition("=")
-        # strip inline comment (';' or '#') and surrounding whitespace/quotes
-        value = re.split(r"[;#]", value, maxsplit=1)[0].strip().strip('"').strip("'")
+        value = value.strip().strip('"').strip("'")
         current[key.strip().upper()] = value
     return sections
 
@@ -302,18 +304,17 @@ def _to_float(value: str | None) -> float | None:
     if value is None:
         return None
     try:
-        return float(value.strip())
+        f = float(value.strip())
     except (ValueError, AttributeError):
         return None
+    # Reject NaN/±inf so a corrupt INI can't propagate a non-finite into size-label formatting,
+    # window math, or int() (which raises OverflowError on inf) downstream.
+    return f if f == f and f not in (float("inf"), float("-inf")) else None
 
 
 def _to_int(value: str | None) -> int | None:
-    if value is None:
-        return None
-    try:
-        return int(float(value.strip()))
-    except (ValueError, AttributeError):
-        return None
+    f = _to_float(value)  # inherits the non-finite guard; int() on a finite float is safe
+    return int(f) if f is not None else None
 
 
 def _section_for(

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -1,0 +1,473 @@
+"""Car-true tyre compound specs, resolved from Assetto Corsa car data (``tyres.ini``).
+
+This is the *identity* side of the tyre story. ``tyre_model.py`` consumes **live** core
+temperature and can only *infer* a compound window because "compound identity is NOT in the
+telemetry feed" (see that module's docstring). This reader closes that gap: it reads the car's
+own ``tyres.ini`` — the ground-truth `NAME`, physical size, cold/hot ideal pressures, peak-mu
+references, and the car-specific optimal core temperature baked into the thermal
+`PERFORMANCE_CURVE` — so downstream coaching can key off the *actual* compound the driver
+selected (``ac.getCar().compoundIndex`` / setup ``[TYRES] VALUE``) instead of a generic guess.
+
+On this rig every stock/Kunos car ships **only** ``data.acd`` (no unpacked ``data/`` folder), so
+this module must decrypt the packed+obfuscated ACD container itself. Pure stdlib, Windows-safe.
+
+ACD format (confirmed by decrypting the real ``ks_porsche_911_gt3_r_2016/data.acd`` — see the
+Part-B investigation note). Canonical reference: the ``bovis/acd_extractor`` Ruby implementation
+and aluigi's ZenHAX writeup (``zenhax.com/viewtopic.php?t=90``).
+
+* **Key** — derived from the CAR FOLDER NAME string via 8 small integer algorithms, then rendered
+  as the dash-joined decimal string ``"p1-p2-...-p8"``. The *string* is the key material, so its
+  length is variable (25 chars for the 911), and de-obfuscation indexes byte-by-byte into it.
+* **Container** — leading ``int32``: if it equals ``-1111`` a version ``int32`` follows, otherwise
+  it is already the first filename length. Then repeating records:
+  ``[name_len:uint32][name bytes][content_len:uint32][content]`` where content is stored as
+  ``content_len`` little-endian ``int32``s — only each int's low byte carries the obfuscated char.
+* **De-obfuscation** — ``char = (stored_low_byte - key_ord[i % len(key)]) mod 256`` (subtraction,
+  NOT XOR; empirically verified — XOR yields garbage).
+
+Everything is wrapped so a malformed / renamed / missing car degrades to ``None`` (or None-fields)
+and never raises — the sidecar must not crash on one bad car.
+"""
+
+from __future__ import annotations
+
+import re
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+_ACD_DUMMY_LEADING = -1111
+#: Compound index N maps to sections ``[FRONT_N]`` / ``[REAR_N]``; N==0 also matches bare
+#: ``[FRONT]`` / ``[REAR]`` (AC treats the unsuffixed section as compound 0). Thermal curve lives in
+#: the sibling ``[THERMAL_FRONT*]`` section.
+
+
+@dataclass(frozen=True)
+class TyreSpec:
+    """Resolved specs for one tyre compound of one car. Every field may be ``None`` if the source
+    car is missing that key (we never fabricate)."""
+
+    compound_index: int
+    name: str | None  # [FRONT_N] NAME, e.g. "Slick Soft" / "Toyo R888R"
+    width_m: float | None  # WIDTH (metres)
+    radius_m: float | None  # RADIUS (metres)
+    rim_radius_m: float | None  # RIM_RADIUS (metres)
+    size_label: (
+        str | None
+    )  # human size string derived from width/radius/rim; None if inputs missing
+    pressure_static_psi: float | None  # PRESSURE_STATIC (ideal cold)
+    pressure_ideal_psi: float | None  # PRESSURE_IDEAL (ideal hot)
+    dx_ref: float | None  # DX_REF (peak longitudinal mu)
+    dy_ref: float | None  # DY_REF (peak lateral mu)
+    optimal_temp_c: float | None  # x at max y of the [THERMAL_*] PERFORMANCE_CURVE LUT
+    version: int | None  # [HEADER] VERSION
+
+
+# --------------------------------------------------------------------------------------------------
+# ACD decryption (folder-name key + container unpack)
+# --------------------------------------------------------------------------------------------------
+
+
+def _acd_key(folder_name: str) -> str:
+    """Derive the ACD obfuscation key string from the car folder name.
+
+    Verbatim port of the 8-part integer algorithm from the canonical ``bovis/acd_extractor``
+    ``Cipher.get_key``. Returns the dash-joined decimal string used as key material.
+    """
+    o = [ord(c) for c in folder_name]
+    n = len(o)
+
+    # PART 1: sum of all ordinals
+    p1 = 0
+    for i in range(n):
+        p1 += o[i]
+    p1 &= 0xFF
+
+    # PART 2: alternating multiply / subtract over pairs
+    p2 = 0
+    i = 0
+    while i < n - 1:
+        p2 = p2 * o[i]
+        i += 1
+        p2 = p2 - o[i]
+        i += 1
+    p2 &= 0xFF
+
+    # PART 3: multiply / integer-divide / subtract with +0x1b offset (truncate-toward-zero divide)
+    p3 = 0
+    i = 1
+    while i < n - 3:
+        p3 = p3 * o[i]
+        i += 1
+        if p3 < 0:
+            p3 = -(abs(p3) // (o[i] + 0x1B))
+        else:
+            p3 = p3 // (o[i] + 0x1B)
+        i -= 2
+        p3 = p3 + (-(0x1B) - o[i])
+        i += 4
+    p3 &= 0xFF
+
+    # PART 4: 0x1683 minus ordinals from index 1
+    p4 = 0x1683
+    i = 1
+    while i < n:
+        p4 = p4 - o[i]
+        i += 1
+    p4 &= 0xFF
+
+    # PART 5: 0x42 seeded multiply/add chain with 0xf / 0x16 offsets, stride 4
+    p5 = 0x42
+    i = 1
+    while i < n - 4:
+        a = p5 * (o[i] + 0xF)
+        i -= 1
+        b = o[i]
+        i += 1
+        b = b + 0xF
+        b = b * a
+        b = b + 0x16
+        p5 = b
+        i += 4
+    p5 &= 0xFF
+
+    # PART 6: 0x65 minus every other ordinal
+    p6 = 0x65
+    i = 0
+    while i < n - 2:
+        p6 = p6 - o[i]
+        i += 2
+    p6 &= 0xFF
+
+    # PART 7: 0xab modulo every other ordinal
+    p7 = 0xAB
+    i = 0
+    while i < n - 2:
+        p7 = p7 % o[i]
+        i += 2
+    p7 &= 0xFF
+
+    # PART 8: 0xab alternating integer-divide / add
+    p8 = 0xAB
+    i = 0
+    while i < n - 1:
+        p8 = p8 // o[i]
+        i += 1
+        p8 = p8 + o[i]
+    p8 &= 0xFF
+
+    return f"{p1}-{p2}-{p3}-{p4}-{p5}-{p6}-{p7}-{p8}"
+
+
+def _acd_unpack(data: bytes, folder_name: str) -> dict[str, bytes]:
+    """De-obfuscate a raw ``data.acd`` blob into ``{filename: content_bytes}``.
+
+    Raises on truncation/format errors; callers wrap this and degrade to ``None``.
+    """
+    key = _acd_key(folder_name)
+    key_ord = [ord(c) for c in key]
+    klen = len(key_ord)
+    if klen == 0:  # empty folder name -> unusable key
+        raise ValueError("empty ACD key")
+
+    files: dict[str, bytes] = {}
+    pos = 0
+    total = len(data)
+
+    # Leading int: -1111 => a version int follows; otherwise it IS the first filename length.
+    (lead,) = struct.unpack_from("<l", data, pos)
+    if lead == _ACD_DUMMY_LEADING:
+        pos += 4  # consume the -1111 marker
+        pos += 4  # consume the version int (not needed for extraction)
+
+    while pos < total:
+        (name_len,) = struct.unpack_from("<I", data, pos)
+        pos += 4
+        # A bogus length (obfuscation drift / trailing padding) would overrun — bail cleanly.
+        if name_len == 0 or pos + name_len > total:
+            break
+        name = data[pos : pos + name_len].decode("utf-8", "replace")
+        pos += name_len
+
+        (content_len,) = struct.unpack_from("<I", data, pos)
+        pos += 4
+        content_span = content_len * 4
+        if pos + content_span > total:
+            break
+
+        out = bytearray(content_len)
+        base = pos
+        for j in range(content_len):
+            low = data[base + j * 4]  # low byte of each int32 carries the obfuscated char
+            out[j] = (low - key_ord[j % klen]) & 0xFF
+        pos += content_span
+
+        files[name] = bytes(out)
+
+    return files
+
+
+# --------------------------------------------------------------------------------------------------
+# tyres.ini resolution + tolerant INI parsing
+# --------------------------------------------------------------------------------------------------
+
+#: Per-car_dir cache of ``{archive_member_name: text}`` so repeated compound reads decrypt once.
+_ARCHIVE_CACHE: dict[str, dict[str, str] | None] = {}
+
+_SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+
+
+def _decode_text(raw: bytes) -> str:
+    """Best-effort text decode of an INI/LUT member (AC data is ASCII/latin-1 in practice)."""
+    for enc in ("utf-8", "cp1252", "latin-1"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("utf-8", "replace")
+
+
+def _load_archive(car_dir: Path) -> dict[str, str] | None:
+    """Return ``{member_name: text}`` for the car, or ``None`` if no source is readable.
+
+    Prefers an unpacked ``data/`` folder (any car that has been extracted); otherwise decrypts
+    ``data.acd`` using the car FOLDER NAME as the key. Result cached per ``car_dir``.
+    """
+    cache_key = str(car_dir)
+    if cache_key in _ARCHIVE_CACHE:
+        return _ARCHIVE_CACHE[cache_key]
+
+    archive: dict[str, str] | None = None
+    try:
+        data_dir = car_dir / "data"
+        tyres_unpacked = data_dir / "tyres.ini"
+        if tyres_unpacked.is_file():
+            # Unpacked car: lazily read members from data/ on demand via a dict-like snapshot of
+            # the files we might need (tyres.ini + any .lut). Read all small files up front.
+            members: dict[str, str] = {}
+            for child in data_dir.iterdir():
+                if child.is_file() and child.suffix.lower() in (".ini", ".lut"):
+                    try:
+                        members[child.name] = _decode_text(child.read_bytes())
+                    except OSError:
+                        continue
+            archive = members if "tyres.ini" in members else None
+        else:
+            acd_path = car_dir / "data.acd"
+            if acd_path.is_file():
+                raw = acd_path.read_bytes()
+                folder_name = car_dir.name  # the key is derived from THIS folder's name
+                unpacked = _acd_unpack(raw, folder_name)
+                if "tyres.ini" in unpacked:
+                    archive = {name: _decode_text(blob) for name, blob in unpacked.items()}
+    except (OSError, ValueError, struct.error, IndexError):
+        archive = None
+
+    _ARCHIVE_CACHE[cache_key] = archive
+    return archive
+
+
+def _parse_ini_sections(text: str) -> dict[str, dict[str, str]]:
+    """Tolerant AC-INI parser: last-write-wins on duplicate keys, strips ``;`` inline comments,
+    ignores blank/comment lines and stray junk. Section names are upper-cased for lookup."""
+    sections: dict[str, dict[str, str]] = {}
+    current: dict[str, str] | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith((";", "#")):
+            continue
+        m = _SECTION_RE.match(line)
+        if m:
+            name = m.group(1).strip().upper()
+            current = sections.setdefault(name, {})
+            continue
+        if current is None or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        # strip inline comment (';' or '#') and surrounding whitespace/quotes
+        value = re.split(r"[;#]", value, maxsplit=1)[0].strip().strip('"').strip("'")
+        current[key.strip().upper()] = value
+    return sections
+
+
+def _to_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _to_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(float(value.strip()))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _section_for(
+    sections: dict[str, dict[str, str]], prefix: str, compound_index: int
+) -> dict[str, str] | None:
+    """Resolve ``[<PREFIX>_<N>]`` with N==0 falling back to the bare ``[<PREFIX>]`` alias."""
+    exact = sections.get(f"{prefix}_{compound_index}")
+    if exact is not None:
+        return exact
+    if compound_index == 0:
+        return sections.get(prefix)
+    return None
+
+
+def _get(section: dict[str, str] | None, key: str) -> str | None:
+    if section is None:
+        return None
+    return section.get(key.upper())
+
+
+def _size_label(
+    width_m: float | None, radius_m: float | None, rim_radius_m: float | None
+) -> str | None:
+    """Human tyre-size string derived from physical dims, e.g. ``"300/R34.0 (rim R24.1)"``.
+
+    Width is rendered in millimetres (AC width is metres); radius/rim in centimetre-precision ``R``
+    notation. Returns ``None`` unless at least width and radius are known.
+    """
+    if width_m is None or radius_m is None:
+        return None
+    width_mm = round(width_m * 1000)
+    radius_label = f"R{radius_m * 100:.1f}"
+    if rim_radius_m is not None:
+        return f"{width_mm}/{radius_label} (rim R{rim_radius_m * 100:.1f})"
+    return f"{width_mm}/{radius_label}"
+
+
+_LUT_PAIR_RE = re.compile(r"^\s*([-+0-9.eE]+)\s*\|\s*([-+0-9.eE]+)\s*$")
+
+
+def _parse_lut_pairs(text: str) -> list[tuple[float, float]]:
+    """Parse a ``.lut`` (or inline) ``x|y`` table, tolerant of comments/blank lines."""
+    pairs: list[tuple[float, float]] = []
+    for line in text.splitlines():
+        stripped = re.split(r"[;#]", line, maxsplit=1)[0].strip()
+        if not stripped:
+            continue
+        m = _LUT_PAIR_RE.match(stripped)
+        if not m:
+            continue
+        try:
+            pairs.append((float(m.group(1)), float(m.group(2))))
+        except ValueError:
+            continue
+    return pairs
+
+
+def _optimal_temp_from_curve(
+    performance_curve: str | None, archive: dict[str, str]
+) -> float | None:
+    """Resolve the PERFORMANCE_CURVE (a ``.lut`` filename in the same archive, or an inline table)
+    and return the temperature (x) at peak grip (max y). Ties resolve to the first (lowest) x that
+    reaches the max — the temperature at which peak grip is first achieved. ``None`` if it cannot be
+    resolved.
+    """
+    if not performance_curve:
+        return None
+    curve_text: str | None = None
+    candidate = performance_curve.strip()
+    if candidate.lower().endswith(".lut"):
+        # Filename reference into the same decrypted archive (match case-insensitively).
+        curve_text = archive.get(candidate)
+        if curve_text is None:
+            lowered = candidate.lower()
+            for name, body in archive.items():
+                if name.lower() == lowered:
+                    curve_text = body
+                    break
+    else:
+        # Inline curve: AC allows the LUT written directly, sometimes wrapped in parentheses.
+        curve_text = candidate.replace("(", "\n").replace(")", "\n").replace(",", "\n")
+
+    if not curve_text:
+        return None
+    pairs = _parse_lut_pairs(curve_text)
+    if not pairs:
+        return None
+    max_y = max(y for _, y in pairs)
+    for x, y in pairs:
+        if y == max_y:
+            return x
+    return None
+
+
+# --------------------------------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------------------------------
+
+
+def read_tyre_specs(car_dir: str | Path, compound_index: int) -> TyreSpec | None:
+    """Resolve ``tyres.ini`` for ``car_dir``; return the :class:`TyreSpec` for ``compound_index``.
+
+    Source preference: unpacked ``data/tyres.ini`` if present, else decrypt ``data.acd`` (folder
+    name is the key). Parses ``[FRONT_<N>]`` (bare ``[FRONT]`` for N==0), falling back to
+    ``[REAR_<N>]`` for any key the front section omits. Optimal core temp is the peak of the
+    matching ``[THERMAL_FRONT_<N>]`` (or ``[THERMAL_REAR_<N>]``) ``PERFORMANCE_CURVE``.
+
+    Returns ``None`` if neither source is readable / has no ``tyres.ini``. Never raises on a
+    malformed car — unreadable individual fields degrade to ``None``.
+    """
+    try:
+        car_path = Path(car_dir)
+    except (TypeError, ValueError):
+        return None
+
+    archive = _load_archive(car_path)
+    if archive is None:
+        return None
+
+    tyres_text = archive.get("tyres.ini")
+    if not tyres_text:
+        return None
+
+    try:
+        sections = _parse_ini_sections(tyres_text)
+
+        front = _section_for(sections, "FRONT", compound_index)
+        rear = _section_for(sections, "REAR", compound_index)
+        if front is None and rear is None:
+            # Compound index out of range for this car.
+            return None
+
+        def field(key: str) -> str | None:
+            # Prefer FRONT; fall back to REAR for keys the front section omits.
+            return _get(front, key) if _get(front, key) is not None else _get(rear, key)
+
+        width_m = _to_float(field("WIDTH"))
+        radius_m = _to_float(field("RADIUS"))
+        rim_radius_m = _to_float(field("RIM_RADIUS"))
+
+        thermal_front = _section_for(sections, "THERMAL_FRONT", compound_index)
+        thermal_rear = _section_for(sections, "THERMAL_REAR", compound_index)
+        perf_curve = _get(thermal_front, "PERFORMANCE_CURVE")
+        if perf_curve is None:
+            perf_curve = _get(thermal_rear, "PERFORMANCE_CURVE")
+
+        header = sections.get("HEADER")
+
+        return TyreSpec(
+            compound_index=compound_index,
+            name=field("NAME"),
+            width_m=width_m,
+            radius_m=radius_m,
+            rim_radius_m=rim_radius_m,
+            size_label=_size_label(width_m, radius_m, rim_radius_m),
+            pressure_static_psi=_to_float(field("PRESSURE_STATIC")),
+            pressure_ideal_psi=_to_float(field("PRESSURE_IDEAL")),
+            dx_ref=_to_float(field("DX_REF")),
+            dy_ref=_to_float(field("DY_REF")),
+            optimal_temp_c=_optimal_temp_from_curve(perf_curve, archive),
+            version=_to_int(_get(header, "VERSION")),
+        )
+    except Exception:
+        # Absolute backstop: a malformed car must never crash the sidecar.
+        return None

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -213,6 +213,9 @@ def _acd_unpack(data: bytes, folder_name: str) -> dict[str, bytes]:
 
 #: Per-car_dir cache of ``{archive_member_name: text}`` so repeated compound reads decrypt once.
 _ARCHIVE_CACHE: dict[str, dict[str, str] | None] = {}
+#: Bound the per-car archive cache. Distinct car dirs are few in practice, but a long-lived process
+#: (a batch lake rebuild over many cars) must never grow it without limit (Qodo reliability nit).
+_ARCHIVE_CACHE_MAX = 64
 
 _SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
 
@@ -239,30 +242,35 @@ def _load_archive(car_dir: Path) -> dict[str, str] | None:
 
     archive: dict[str, str] | None = None
     try:
+        # Prefer an unpacked data/ folder. Read the small data files (tyres.ini + any .lut) up
+        # front, lowercasing member names so every downstream lookup is case-insensitive — AC mods
+        # ship TYRES.INI / Tyres.ini too, and a case-exact check misses them on a case-sensitive FS.
         data_dir = car_dir / "data"
-        tyres_unpacked = data_dir / "tyres.ini"
-        if tyres_unpacked.is_file():
-            # Unpacked car: lazily read members from data/ on demand via a dict-like snapshot of
-            # the files we might need (tyres.ini + any .lut). Read all small files up front.
-            members: dict[str, str] = {}
+        members: dict[str, str] = {}
+        if data_dir.is_dir():
             for child in data_dir.iterdir():
                 if child.is_file() and child.suffix.lower() in (".ini", ".lut"):
                     try:
-                        members[child.name] = _decode_text(child.read_bytes())
+                        members[child.name.lower()] = _decode_text(child.read_bytes())
                     except OSError:
                         continue
-            archive = members if "tyres.ini" in members else None
+        if "tyres.ini" in members:
+            archive = members
         else:
             acd_path = car_dir / "data.acd"
             if acd_path.is_file():
                 raw = acd_path.read_bytes()
-                folder_name = car_dir.name  # the key is derived from THIS folder's name
-                unpacked = _acd_unpack(raw, folder_name)
-                if "tyres.ini" in unpacked:
-                    archive = {name: _decode_text(blob) for name, blob in unpacked.items()}
+                unpacked = _acd_unpack(raw, car_dir.name)  # key derived from THIS folder's name
+                # Lowercase member names for the same case-insensitive lookups downstream.
+                lowered = {name.lower(): blob for name, blob in unpacked.items()}
+                if "tyres.ini" in lowered:
+                    archive = {name: _decode_text(blob) for name, blob in lowered.items()}
     except (OSError, ValueError, struct.error, IndexError):
         archive = None
 
+    # Bounded insert: evict the oldest entry (dict preserves insertion order) when at capacity.
+    if cache_key not in _ARCHIVE_CACHE and len(_ARCHIVE_CACHE) >= _ARCHIVE_CACHE_MAX:
+        _ARCHIVE_CACHE.pop(next(iter(_ARCHIVE_CACHE)))
     _ARCHIVE_CACHE[cache_key] = archive
     return archive
 

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -385,9 +385,11 @@ def _optimal_temp_from_curve(
     curve_text: str | None = None
     candidate = performance_curve.strip()
     if candidate.lower().endswith(".lut"):
-        # Filename reference into the same archive. Archive keys are lowercased by _load_archive, so
-        # a single lowercased lookup is case-insensitive and O(1) (no linear scan needed).
-        curve_text = archive.get(candidate.lower())
+        # Filename reference into the same archive. Use the lowercased BASENAME (some mods write a
+        # path prefix like `data/tcurve.lut` or `data\tcurve.lut`) — archive keys are lowercased
+        # basenames, so this stays a case-insensitive O(1) lookup.
+        base = candidate.replace("\\", "/").rsplit("/", 1)[-1].lower()
+        curve_text = archive.get(base)
     else:
         # Inline curve: AC allows the LUT written directly, sometimes wrapped in parentheses.
         curve_text = candidate.replace("(", "\n").replace(")", "\n").replace(",", "\n")

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -384,14 +384,9 @@ def _optimal_temp_from_curve(
     curve_text: str | None = None
     candidate = performance_curve.strip()
     if candidate.lower().endswith(".lut"):
-        # Filename reference into the same decrypted archive (match case-insensitively).
-        curve_text = archive.get(candidate)
-        if curve_text is None:
-            lowered = candidate.lower()
-            for name, body in archive.items():
-                if name.lower() == lowered:
-                    curve_text = body
-                    break
+        # Filename reference into the same archive. Archive keys are lowercased by _load_archive, so
+        # a single lowercased lookup is case-insensitive and O(1) (no linear scan needed).
+        curve_text = archive.get(candidate.lower())
     else:
         # Inline curve: AC allows the LUT written directly, sometimes wrapped in parentheses.
         curve_text = candidate.replace("(", "\n").replace(")", "\n").replace(",", "\n")


### PR DESCRIPTION
## What

Delivers **Part B** of EPIC #488 — **tyre identity & specs**: resolve the compound identity and the **car-true optimal-temp window** (`PERFORMANCE_CURVE` peak) instead of `tyre_model`'s hard-coded generic per-compound bucket.

## How

**Live capture** (`lap_archive.lua` `tyres` header — no ACD, header-only so the byte-identical trace contract is untouched):
- `longName` via `ac.getTyresLongName` (e.g. "Toyo R888R")
- `optimalTempC` via `wheel.tyreOptimumTemperature` — the `PERFORMANCE_CURVE` peak the game itself uses

**New `tools/ai_sidecar/tyre_specs.py`** — pure-stdlib `data.acd` reader:
- `data.acd` **decryptor** (grounded via aluigi/ZenHAX + `bovis/acd_extractor`): **subtraction** cipher (not XOR), key = decimal-string of 8 folder-name sub-algorithms indexed `% len(key)`; container `-1111`/version handling
- tolerant `tyres.ini` parser → `TyreSpec` (name, size, `PRESSURE_STATIC/IDEAL`, `DX/DY_REF` peak μ, `PERFORMANCE_CURVE`-peak `optimal_temp_c`, `VERSION`), keyed by `(car_dir, compound_index)`, cached per car; prefers unpacked `data/tyres.ini`, else decrypts `data.acd`; handles the Kunos bare `[FRONT]` == compound 0 layout
- **hermetic tests** (synthetic ACD built in-test — no dependency on the Steam install)

**Feeds:**
- `tyre_model.analyze_tyres(optimal_temp_c=)` re-centers the window on the car-true peak (asymmetric roll-off, red-team-grounded); `tyres_from_lap_archive` reads the live optimum + compound name, with an offline `car_data_dir` ACD fallback for pre-#488 archives
- `setup_model.resolve_tyre_spec(setup, car_dir)` surfaces the car-true specs for a setup's `[TYRES]` compound

## Verified

- `make ci-fast`: **OK**. `tyre_specs` verified against the **real 911 GT3 R** `data.acd`: compound 0 = **"Slick Soft"**, `optimal_temp_c` **70 °C** (vs the generic slick bucket 75–105), `PRESSURE_IDEAL` 26, `DX/DY_REF` 1.58, version 10.
- **Rig lap verification** of the live `longName` + `optimalTempC` in a real archive (+ `tyre_model` using the car-true window) **to follow** — draft until then.

## Scope

**Advances** EPIC #488 (Part B). Part A merged in #497. Parts C (grain + serialization), D (setup⟷outcome linkage) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)