### PR TITLE
fix(post-merge): tear down merged head's ephemeral worktree before branch -D (gov-hub#209)

### DIFF
--- a/scripts/post_merge_sync.sh
+++ b/scripts/post_merge_sync.sh
@@ -155,6 +155,9 @@ phase_sync() {
   if [[ -n "$HEAD_REF" && "$HEAD_REF" != "main" ]]; then
     if git show-ref --verify --quiet "refs/heads/$HEAD_REF"; then
       echo "Deleting local branch $HEAD_REF (PR head; squash merges usually need -D)..."
+      # governance-hub#209: tear down the merged head's ephemeral agent worktree first,
+      # so the `git branch -D` below actually succeeds instead of silently failing (|| true).
+      python3 "${FLEET_GOVERNANCE_ROOT:-$HOME/.fleet-governance}/scripts/remove_worktree.py" --branch "$HEAD_REF" 2>/dev/null || true
       git branch -d "$HEAD_REF" 2>/dev/null || git branch -D "$HEAD_REF" 2>/dev/null || true
     fi
   fi


### PR DESCRIPTION
## What
Wire the hub-canonical `remove_worktree.py` teardown into `scripts/post_merge_sync.sh`, immediately **before** the merged PR head is deleted with `git branch -d/-D "$HEAD_REF"`.

## Why (the bug)
`post_merge_sync.sh` deletes the merged head with `git branch -D ... || true`, but the head is **still checked out in the agent's ephemeral worktree** (`.claude/`/`.codex/`/`.agentctl/worktrees/…`). Git refuses to delete a branch checked out in a worktree, so `git branch -D` fails and is **swallowed by `|| true`** — leaving BOTH the worktree and the branch behind forever (~430 stale branches / ~160 worktrees on one host, 2026-07-05).

## The fix (one line, additive, inert-until-deployed)
```sh
python3 "${FLEET_GOVERNANCE_ROOT:-$HOME/.fleet-governance}/scripts/remove_worktree.py" --branch "$HEAD_REF" 2>/dev/null || true
```
Calls the hub-canonical primitive (governance-hub#210, reachable fleet-wide via `~/.fleet-governance`) to remove the ephemeral worktree first; then the existing `git branch -D` succeeds. Its safety ladder (ephemeral-path-only, never primary/current/locked/service-pinned, tracked-dirty gate that does not deadlock on `.venv`, recovery manifest) governs the removal. `|| true` keeps it a safe no-op until the primitive is deployed to a host — same inert-until-wired acceptance as `create_worktree.py` (#63).

## Verification
`bash -n` clean; the primitive was verified end-to-end on the fleet host (governance-hub#210, `9e94734`) — removing a merged head's ephemeral worktree unblocks the previously-silently-failing `git branch -D`. Pilot spoke agent-factory#1198 is CI-green.

Fan-out spoke for governance-hub#209 (epic #197 actuation gap). Refs agorokh/governance-hub#209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
