### PR TITLE
feat(evolution): steward-miner-rules gate covers .cursor/rules/learned mirror (gov-hub#231)

### DIFF
--- a/.github/workflows/steward-miner-rules.yml
+++ b/.github/workflows/steward-miner-rules.yml
@@ -12,7 +12,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths:
+      # Both learned-rule mirrors: the authoritative `.claude/.md` side AND the `.cursor/.mdc`
+      # render. A miner PR touches both, but a cursor-only mirror-drift/fixup PR would bypass the
+      # Steward gate entirely if only `.claude/` triggered it (gov-hub#228). The reference wiring a
+      # spoke copies inherits this; the engine de-duplicates the mirror pair so no rule is
+      # double-adjudicated.
       - '.claude/rules/learned/**'
+      - '.cursor/rules/learned/**'
   workflow_dispatch:
     inputs:
       pr:


### PR DESCRIPTION
## What

Adds `.cursor/rules/learned/**` to the `steward-miner-rules.yml` `pull_request` `paths:` trigger, mirroring the hub fix in agorokh/governance-hub#230 (issue #228).

## Why

A miner PR touches both the `.claude/` authoritative side and the `.cursor/` render, so real weekly cycles already trigger. But a **cursor-only** mirror-drift/fixup PR would bypass the Steward gate entirely when only `.claude/` triggered it. This is defense-in-depth for that edge case. The hub engine + action de-duplicate the mirror pair, so once the trigger fires adjudication is correct with no further spoke change.

## Scope

- Trigger-only edit; no engine/action change (hub-canonical).
- One of 10 spoke PRs propagating gov-hub#231.

Refs agorokh/governance-hub#231, agorokh/governance-hub#228, agorokh/governance-hub#197