### PR TITLE
fix(post-merge): guard $HOME under set -u in hub-root lookup (governance-hub#241)

### DIFF
--- a/scripts/post_merge_sync.sh
+++ b/scripts/post_merge_sync.sh
@@ -157,7 +157,7 @@ phase_sync() {
       echo "Deleting local branch $HEAD_REF (PR head; squash merges usually need -D)..."
       # governance-hub#209: tear down the merged head's ephemeral agent worktree first,
       # so the `git branch -D` below actually succeeds instead of silently failing (|| true).
-      python3 "${FLEET_GOVERNANCE_ROOT:-$HOME/.fleet-governance}/scripts/remove_worktree.py" --branch "$HEAD_REF" 2>/dev/null || true
+      python3 "${FLEET_GOVERNANCE_ROOT:-${HOME:-}/.fleet-governance}/scripts/remove_worktree.py" --branch "$HEAD_REF" 2>/dev/null || true
       git branch -d "$HEAD_REF" 2>/dev/null || git branch -D "$HEAD_REF" 2>/dev/null || true
     fi
   fi


### PR DESCRIPTION
Guards `${FLEET_GOVERNANCE_ROOT:-$HOME/.fleet-governance}` with `${HOME:-}` (1 site(s)) so `post_merge_sync.sh` does not abort with `HOME: unbound variable` under `set -euo pipefail` on HOME-less hosts. Mechanical fix; pilot + regression test merged in agent-factory#1233. Part of the governance-hub#241 fleet fan-out (operator-approved, Council architect sign-off).