### PR TITLE
feat(harness): false-green-rate KPI shadow-mode report (#512, EPIC #154 Part G)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -137,10 +137,34 @@ launch, probe outcome, and re-bake stats so a recycle's timing is visible.
 | Two agents, one rig | **Yield**: a single AC instance cannot serve two autonomous sessions (see the issue-277 investigation). Check for a running `acs.exe`/peer sidecar before launching |
 | Sidecar port already in use | That's usually the Game Point launcher's supervised sidecar — the harness reuses it; don't spawn a second |
 
+## Trusting the harness — the false-green KPI (EPIC #154 Part G)
+
+A harness is only worth its PASS if that PASS is *honest*. The ADR bar is **false-green rate vs
+human reality < 5%** — a false green is the harness reporting the pipeline healthy when a human at
+the wheel would see it broken. Two arms measure it:
+
+- **Live arm (rig-gated):** the `self_test` / `auto_drive` run itself, live-verified with no human
+  at the wheel — the ground truth against real physics.
+- **CI arm (off-sim, deterministic):** `python -m tools.ac_harness.false_green_kpi` — a shadow-mode
+  report that runs a **labeled corpus** of the real failure classes tied to historical bugs
+  (#170 missing peer, #180 tire-temps, #182 lap-before-session, #191 lap-timeout, #459/#460
+  sim-death, schema-gate, HUD blank/frozen, envelope spoof, **report-path swallowing**) through the
+  **real** production oracles (`evaluate_sequence`, `load_schema`, `PhysicsStallDetector`,
+  `liveness_score`, and the full `run_self_test` report path). It prints per-class results and
+  `false_green_rate`, exits non-zero if any broken class leaks (`--json OUT` for the full report).
+  It is honest about its boundary: an `out_of_scope` list names the human-perceptible classes it
+  cannot see (semantic coaching validity, audio, render correctness, long-run perf, persistence) —
+  those stay the live arm's job.
+
+**Fold real failures into the corpus.** When a live drive surfaces a false green, dump the WS tap to
+JSONL and load it with `sequence_probe.frames_from_jsonl(path)` as a new corpus scenario — that
+anchors the CI arm to observed reality and turns every escape into a permanent regression guard.
+
 ## Layers underneath (when you need less than the full loop)
 
 `auto_drive` composes the primitives; they remain individually usable:
 `entry_launcher` (launch only) · `custom_ai` (carcsw actuation) · `sequence_probe` (WS assert
 only, `--skip-launch` style) · `hud_capture` (render liveness) · `self_test` (producer contract
-without motion) · `daemon` (persistent rig service with `/session/start`).
+without motion) · `false_green_kpi` (off-sim discrimination KPI) · `daemon` (persistent rig service
+with `/session/start`).
 Architecture decision record: vault `01_Decisions/autonomous-self-test-harness.md`.

--- a/tests/test_false_green_kpi.py
+++ b/tests/test_false_green_kpi.py
@@ -1,0 +1,154 @@
+"""Meta-validation of the false-green-rate KPI (`false_green_kpi.py`, EPIC #154 Part G).
+
+The KPI measures the harness detector layer's discrimination against a labeled corpus of the real
+failure classes the harness exists to catch. These tests assert it is (1) green on the shipped
+corpus, (2) NON-vacuous — a defanged oracle visibly leaks false greens above the gate — and (3)
+faithful — it drives the same oracle symbols the harness uses, propagates through the real
+`run_self_test` report path, and exercises the real `PhysicsStallDetector`. All off-sim.
+"""
+
+from __future__ import annotations
+
+from tools.ac_harness import false_green_kpi, self_test
+from tools.ac_harness.auto_drive import PhysicsStallDetector
+from tools.ac_harness.false_green_kpi import (
+    BROKEN_CLASSES,
+    GATE_THRESHOLD,
+    OUT_OF_SCOPE,
+    _report_path_ok,
+    _snap,
+    build_corpus,
+    run_kpi,
+)
+
+
+# --------------------------------------------------------------------------- shipped corpus passes
+def test_kpi_passes_on_shipped_corpus():
+    r = run_kpi()
+    assert r.false_green_rate == 0.0  # zero broken scenarios leak -> well under the 5% gate
+    assert r.false_red_rate == 0.0  # no healthy scenario false-fails
+    assert r.ok is True
+    assert r.broken_total >= 12  # a broad broken corpus, not a token one
+    assert r.healthy_total >= 6
+
+
+def test_every_declared_broken_class_is_covered():
+    r = run_kpi()
+    assert r.missing_classes == []
+    for cls in BROKEN_CLASSES:
+        assert cls in r.covered_classes, f"declared class {cls} not represented in the corpus"
+
+
+def test_report_is_deterministic():
+    assert run_kpi().to_dict() == run_kpi().to_dict()
+
+
+def test_out_of_scope_is_surfaced():
+    # The report must name what it cannot see, so it never implies full human-reality coverage.
+    r = run_kpi()
+    assert r.out_of_scope == list(OUT_OF_SCOPE)
+    assert len(r.out_of_scope) >= 3
+
+
+# --------------------------------------------------------------------------- anti-vacuity (teeth)
+def test_weakening_the_sequence_oracle_trips_the_gate():
+    # Defang the richest oracle; every sequence-broken scenario must now leak as a false green,
+    # pushing the rate well above the gate. Proves the KPI is sensitive to oracle strength.
+    weak = run_kpi(weaken="sequence")
+    assert weak.false_green_rate > GATE_THRESHOLD
+    assert weak.ok is False
+    assert weak.broken_false_green >= 5
+
+
+def test_weakening_the_render_oracle_also_leaks():
+    weak = run_kpi(weaken="render")
+    assert weak.broken_false_green >= 2  # hud_blank + hud_uniform leak
+    assert weak.false_green_rate > GATE_THRESHOLD
+
+
+def test_dropping_required_topic_is_red_but_optional_is_green():
+    # Granularity: dropping a REQUIRED continuous topic must flag broken; dropping the OPTIONAL
+    # `delta` (needs a reference lap) must stay healthy. Both are in the shipped corpus.
+    r = run_kpi()
+    assert "healthy_dropped_optional_delta" not in r.false_reds
+    assert "broken_missing_tire_temps" not in r.false_greens
+
+
+# --------------------------------------------------------------------------- faithful to production
+def test_kpi_uses_the_same_sequence_oracle_symbol_as_self_test():
+    # No divergent codepath: the KPI and the live self-test evaluate the identical function object.
+    assert false_green_kpi.evaluate_sequence is self_test.evaluate_sequence
+
+
+def test_report_path_propagates_broken_verdict():
+    # An oracle FAIL must reach SelfTestReport.ok through the full orchestration (no swallowing).
+    assert _report_path_ok([_snap("connection"), _snap("coaching.snapshot")]) is False
+
+
+def test_report_path_propagates_healthy_verdict():
+    assert (
+        _report_path_ok(
+            [
+                _snap("connection"),
+                _snap("session"),
+                _snap("lap"),
+                _snap("tire_temps"),
+                _snap("coaching.snapshot"),
+            ]
+        )
+        is True
+    )
+
+
+def test_corpus_expected_labels_and_oracles_are_valid():
+    for sc in build_corpus():
+        assert sc.expected in ("GREEN", "RED")
+        assert sc.oracle in ("sequence", "schema", "sim_death", "render", "report_path")
+        assert callable(sc.run)
+
+
+# ------------------------------------------------------------------- extracted sim-death oracle
+def test_physics_stall_advancing_never_trips():
+    det = PhysicsStallDetector(sim_dead_seconds=1.0)
+    tripped = [det.update(i * 0.1, i + 1) for i in range(25)]
+    assert not any(tripped)
+
+
+def test_physics_stall_frozen_packet_trips():
+    det = PhysicsStallDetector(sim_dead_seconds=1.0)
+    assert det.update(0.0, 5) is False
+    assert det.update(0.5, 5) is False
+    assert det.update(1.6, 5) is True  # frozen > sim_dead_seconds
+
+
+def test_physics_stall_none_does_not_reset_timer():
+    # A None (physics mmap gone) must NOT reset the death timer (#460 review).
+    det = PhysicsStallDetector(sim_dead_seconds=1.0)
+    assert det.update(0.0, 5) is False
+    assert det.update(0.5, None) is False
+    assert det.update(1.7, None) is True
+
+
+def test_physics_stall_real_advance_resets_timer():
+    det = PhysicsStallDetector(sim_dead_seconds=1.0)
+    det.update(0.0, 5)
+    assert det.update(0.9, 6) is False  # advance just before the deadline resets it
+    assert det.update(1.8, 6) is False  # 0.9s since the reset -> still alive
+
+
+# --------------------------------------------------------------------------- CLI
+def test_main_returns_zero_on_pass():
+    assert false_green_kpi._main([]) == 0
+
+
+def test_main_writes_json(tmp_path):
+    out = tmp_path / "kpi.json"
+    rc = false_green_kpi._main(["--json", str(out)])
+    assert rc == 0
+    import json
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["ok"] is True
+    assert data["false_green_rate"] == 0.0
+    assert data["kpi"] == "known_failure_discrimination"
+    assert "out_of_scope" in data

--- a/tests/test_false_green_kpi.py
+++ b/tests/test_false_green_kpi.py
@@ -66,6 +66,25 @@ def test_weakening_the_render_oracle_also_leaks():
     assert weak.false_green_rate > GATE_THRESHOLD
 
 
+def test_gate_is_zero_leaks_not_a_rate():
+    # Deterministic arm: a single leaked broken scenario must FAIL even when a large caught corpus
+    # dilutes the rate below 5% (the gate must not be diluteable as the corpus grows). Predicate
+    # tested directly to isolate it from coverage (workflow review finding on #513).
+    from tools.ac_harness.false_green_kpi import KpiReport
+
+    r = KpiReport(
+        false_green_rate=1 / 21,  # 4.76% — under the reported 5% bar
+        false_red_rate=0.0,
+        broken_total=21,
+        broken_false_green=1,  # ...but one broken scenario genuinely leaked
+        healthy_total=8,
+        healthy_false_red=0,
+        missing_classes=[],
+    )
+    assert r.false_green_rate < GATE_THRESHOLD
+    assert r.ok is False  # zero-leak gate fails despite the sub-threshold rate
+
+
 def test_dropping_required_topic_is_red_but_optional_is_green():
     # Granularity: dropping a REQUIRED continuous topic must flag broken; dropping the OPTIONAL
     # `delta` (needs a reference lap) must stay healthy. Both are in the shipped corpus.
@@ -134,6 +153,32 @@ def test_physics_stall_real_advance_resets_timer():
     det.update(0.0, 5)
     assert det.update(0.9, 6) is False  # advance just before the deadline resets it
     assert det.update(1.8, 6) is False  # 0.9s since the reset -> still alive
+
+
+def test_physics_stall_anchored_at_start_trips_on_late_none():
+    # Sim already dead at loop start, packet mmap gone: the first sample arrives after the deadline.
+    # Anchored at construction (now=0.0) the veto must fire, not be delayed a full window (codex on
+    # #513) — the inline rig watchdog started its timer at loop begin; this restores that.
+    det = PhysicsStallDetector(sim_dead_seconds=1.0, now=0.0)
+    assert det.update(1.5, None) is True
+
+
+def test_physics_stall_default_anchors_on_first_update():
+    # Without a start anchor the timer begins at the first sample (the KPI oracle's per-sample mode)
+    det = PhysicsStallDetector(sim_dead_seconds=1.0)
+    assert det.update(1.5, None) is False
+
+
+def test_coverage_counts_only_broken_scenarios():
+    # A declared broken class present ONLY as a mislabeled GREEN scenario must read as NOT covered,
+    # so the gate can never pass on a hollowed-out failure class (codex on #513).
+    from tools.ac_harness.false_green_kpi import Scenario
+
+    hollow = [Scenario("mislabeled", "missing_connection", "-", "GREEN", "sequence", lambda: True)]
+    r = run_kpi(hollow)
+    assert "missing_connection" not in r.covered_classes
+    assert "missing_connection" in r.missing_classes
+    assert r.ok is False
 
 
 # --------------------------------------------------------------------------- CLI

--- a/tests/test_false_green_kpi.py
+++ b/tests/test_false_green_kpi.py
@@ -186,14 +186,22 @@ def test_main_returns_zero_on_pass():
     assert false_green_kpi._main([]) == 0
 
 
-def test_main_writes_json(tmp_path):
-    out = tmp_path / "kpi.json"
-    rc = false_green_kpi._main(["--json", str(out)])
+def test_main_writes_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # outputs are contained under cwd (#204 convention)
+    rc = false_green_kpi._main(["--json", "kpi.json"])
     assert rc == 0
     import json
 
-    data = json.loads(out.read_text(encoding="utf-8"))
+    data = json.loads((tmp_path / "kpi.json").read_text(encoding="utf-8"))
     assert data["ok"] is True
     assert data["false_green_rate"] == 0.0
     assert data["kpi"] == "known_failure_discrimination"
     assert "out_of_scope" in data
+
+
+def test_main_rejects_json_path_escaping_cwd(tmp_path, monkeypatch):
+    # --json must not write outside cwd (qodo on #513): a `..` traversal is refused with exit 2.
+    monkeypatch.chdir(tmp_path)
+    rc = false_green_kpi._main(["--json", "../escape.json"])
+    assert rc == 2
+    assert not (tmp_path.parent / "escape.json").exists()

--- a/tests/test_false_green_kpi.py
+++ b/tests/test_false_green_kpi.py
@@ -51,19 +51,32 @@ def test_out_of_scope_is_surfaced():
 
 
 # --------------------------------------------------------------------------- anti-vacuity (teeth)
-def test_weakening_the_sequence_oracle_trips_the_gate():
-    # Defang the richest oracle; every sequence-broken scenario must now leak as a false green,
-    # pushing the rate well above the gate. Proves the KPI is sensitive to oracle strength.
-    weak = run_kpi(weaken="sequence")
-    assert weak.false_green_rate > GATE_THRESHOLD
-    assert weak.ok is False
+class _AlwaysHealthy:
+    """A defanged sequence oracle: every stream 'passes' regardless of content."""
+
+    ok = True
+
+
+def test_weakening_the_sequence_oracle_trips_the_gate(monkeypatch):
+    # Defang the REAL sequence oracle (patch the symbol build_corpus resolves at call time); every
+    # sequence-broken scenario must now leak as a false green. Proves the KPI is sensitive to oracle
+    # strength without any test-only knob in the production API.
+    monkeypatch.setattr(false_green_kpi, "evaluate_sequence", lambda *a, **k: _AlwaysHealthy())
+    weak = run_kpi()
     assert weak.broken_false_green >= 5
+    assert weak.ok is False
 
 
-def test_weakening_the_render_oracle_also_leaks():
-    weak = run_kpi(weaken="render")
+def test_weakening_the_render_oracle_also_leaks(monkeypatch):
+    # Defang the render oracle: a black/uniform frame now reads as rendering -> hud_* leak.
+    class _Live:
+        def is_rendering(self, **kw):
+            return True
+
+    monkeypatch.setattr(false_green_kpi, "liveness_score", lambda bgra: _Live())
+    weak = run_kpi()
     assert weak.broken_false_green >= 2  # hud_blank + hud_uniform leak
-    assert weak.false_green_rate > GATE_THRESHOLD
+    assert weak.ok is False
 
 
 def test_gate_is_zero_leaks_not_a_rate():

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1515,6 +1515,40 @@ def _teleport_onto_line(  # pragma: no cover - rig-only
     return landed <= 25.0
 
 
+class PhysicsStallDetector:
+    """Sim-death detector: the main ``acpmf_physics`` packet_id stagnant for
+    ``sim_dead_seconds`` means ``acs.exe`` died (#459/#460).
+
+    Feed one ``(monotonic now, main packet_id)`` sample per frame via :meth:`update`.
+    A real packet advance resets the death timer; a ``None`` packet (physics mmap
+    gone) does **not** — sustained ``None`` or a frozen packet both trip, which is
+    exactly the crash/freeze case the watchdog exists to catch (resetting on every
+    ``None`` would disable it, #460 review). The Car0 (Custom-AI) packet is *not*
+    used: CSP holds it constant for a stationary car, so it false-fired at the start
+    line (#459 review).
+
+    Extracted from :func:`rig_drive` so the rule is one source of truth and is
+    unit-testable off-rig — it is the sim-death oracle the EPIC #154 Part-G
+    false-green KPI (``false_green_kpi.py``) exercises.
+    """
+
+    def __init__(self, sim_dead_seconds: float) -> None:
+        self.sim_dead_seconds = sim_dead_seconds
+        self._last_pkt: int | None = None
+        self._last_change: float | None = None
+
+    def update(self, now: float, packet_id: int | None) -> bool:
+        """Record one sample; return ``True`` once the packet has been stagnant
+        longer than ``sim_dead_seconds`` (sim-death), else ``False``."""
+        if self._last_change is None:
+            self._last_change = now
+        if packet_id is not None and (self._last_pkt is None or packet_id != self._last_pkt):
+            self._last_pkt = packet_id
+            self._last_change = now
+            return False
+        return (now - self._last_change) > self.sim_dead_seconds
+
+
 def rig_drive(  # pragma: no cover - rig-only
     controller: Controller, config: AutoDriveConfig, stop: threading.Event
 ) -> DriveStats:
@@ -1615,8 +1649,7 @@ def rig_drive(  # pragma: no cover - rig-only
         return p.packet_id if p is not None else None
 
     prev_plane: tuple[float, float] | None = None
-    last_pkt: int | None = None
-    last_pkt_change = time.monotonic()
+    stall = PhysicsStallDetector(config.sim_dead_seconds)
     t0 = time.monotonic()
     try:
         while not stop.is_set() and time.monotonic() - t0 < config.drive_seconds:
@@ -1624,15 +1657,10 @@ def rig_drive(  # pragma: no cover - rig-only
             if not cd:
                 time.sleep(0.02)
                 continue
-            pkt = _main_packet_id()
-            # Reset the death timer ONLY on a real packet advance. A None (physics mmap gone) must
-            # NOT reset it — that is exactly the crash/freeze case the watchdog exists to catch, and
-            # resetting on every None would disable it (#460 review). Sustained None or a frozen
-            # packet both let the timer run out and trip sim_dead.
-            if pkt is not None and (last_pkt is None or pkt != last_pkt):
-                last_pkt = pkt
-                last_pkt_change = time.monotonic()
-            elif time.monotonic() - last_pkt_change > config.sim_dead_seconds:
+            # Sim-death: the main acpmf_physics packet_id stagnant for sim_dead_seconds means
+            # acs.exe died. A None (physics mmap gone) does NOT reset the timer (#460 review) —
+            # sustained None or a frozen packet both trip. Rule owned by PhysicsStallDetector.
+            if stall.update(time.monotonic(), _main_packet_id()):
                 stats.sim_dead = True
                 stats.reason = "acpmf_physics packet_id stagnant (acs.exe died)"
                 break

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1532,10 +1532,13 @@ class PhysicsStallDetector:
     false-green KPI (``false_green_kpi.py``) exercises.
     """
 
-    def __init__(self, sim_dead_seconds: float) -> None:
+    def __init__(self, sim_dead_seconds: float, *, now: float | None = None) -> None:
         self.sim_dead_seconds = sim_dead_seconds
         self._last_pkt: int | None = None
-        self._last_change: float | None = None
+        # Anchor the death timer at construction when ``now`` is given (the drive-loop start), so a
+        # sim already dead before the first packet sample still trips after sim_dead_seconds — the
+        # inline watchdog's behaviour. Without ``now`` the timer anchors on the first update sample.
+        self._last_change: float | None = now
 
     def update(self, now: float, packet_id: int | None) -> bool:
         """Record one sample; return ``True`` once the packet has been stagnant
@@ -1649,8 +1652,10 @@ def rig_drive(  # pragma: no cover - rig-only
         return p.packet_id if p is not None else None
 
     prev_plane: tuple[float, float] | None = None
-    stall = PhysicsStallDetector(config.sim_dead_seconds)
     t0 = time.monotonic()
+    # Anchor the sim-death timer at the loop start (not the first packet sample) so a sim that is
+    # already dead trips once stale car data appears, even on a short/ending run (codex on #513).
+    stall = PhysicsStallDetector(config.sim_dead_seconds, now=t0)
     try:
         while not stop.is_set() and time.monotonic() - t0 < config.drive_seconds:
             cd = controller.read_car_data()

--- a/tools/ac_harness/false_green_kpi.py
+++ b/tools/ac_harness/false_green_kpi.py
@@ -1,0 +1,508 @@
+"""False-green-rate KPI — the CI-measurable arm of EPIC #154 Part-G's ``< 5%`` gate.
+
+A **false green** is the failure this whole harness exists to prevent: the self-test reports
+the coaching pipeline *healthy* (PASS) when a human at the wheel would see it *broken* — no
+coaching on screen, a frozen HUD, absent/zeroed tire temps, no lap registered, a ``lap`` before
+its ``session``, stale/frozen telemetry, an out-of-schema read. The ADR
+(`autonomous-self-test-harness.md`, L2) states the acceptance bar as *"false-green rate vs human
+reality (<5%), not coverage."*
+
+**Scope (honest by construction).** Full *"vs human reality"* fidelity is the rig-gated live
+`self_test.py` run (already live-verified, no human at the wheel). This module measures the
+**off-sim, deterministic** half: the harness **detector layer's discrimination** against a
+labeled corpus of the real failure classes tied to historical bugs (#170/#180/#182/#191/#459).
+It is *known-failure discrimination* — each broken scenario is a class the harness was built to
+catch, evaluated by the **real production oracle** for that class (imported, never
+reimplemented):
+
+* stream presence + ``session→lap`` ordering — `sequence_probe.evaluate_sequence`
+* out-of-schema field read (mock-fallacy / L0 schema gate) — `trace_replay.load_schema`
+* sim-death / frozen telemetry — `auto_drive.PhysicsStallDetector`
+* HUD render-liveness (black/uniform frame) — `hud_capture.liveness_score`
+* **report-path integrity** — `self_test.run_self_test` driven end-to-end with injected
+  transports, so an oracle FAIL is proven to propagate to ``SelfTestReport.ok`` (catches the
+  "detector works but the harness swallows the failure" false green)
+
+The report is explicit about what it *cannot* see (`OUT_OF_SCOPE`) so it never implies full
+human-reality coverage. Recorded live WS taps can be folded in as extra scenarios via
+`sequence_probe.frames_from_jsonl` to anchor the corpus to reality over time.
+
+CLI: ``python -m tools.ac_harness.false_green_kpi [--json OUT]`` — exits ``0`` iff
+``false_green_rate < 0.05`` **and** ``false_red_rate == 0`` **and** every declared class is covered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from tools.ac_harness.auto_drive import PhysicsStallDetector
+from tools.ac_harness.hud_capture import liveness_score
+from tools.ac_harness.self_test import SelfTestConfig, run_self_test
+from tools.ac_harness.sequence_probe import evaluate_sequence
+from tools.ac_harness.trace_replay import load_schema
+
+GATE_THRESHOLD = 0.05
+
+# The broken failure classes the corpus MUST cover — every one is a real historical false-green
+# risk. `run_kpi` fails if any is absent, so the gate can never pass on a hollowed-out corpus.
+BROKEN_CLASSES: tuple[str, ...] = (
+    "missing_connection",  # #170 — trainer never registers as a v1 WS peer
+    "missing_tire_temps",  # #180 — tire-temp stream absent / 0-index shift
+    "dead_coaching",  # coaching.snapshot stream never produced
+    "lap_before_session",  # #182 — lap emitted before its session (ordering)
+    "envelope_spoof",  # non-state.snapshot frame masquerading as a topic
+    "require_lap_timeout",  # #191 — waited for a lap, none arrived
+    "empty_stream",  # nothing published at all
+    "out_of_schema_field",  # mock-fallacy — reading a field not in ac_schema.json
+    "sim_death_frozen",  # acpmf_physics packet_id frozen (acs.exe died)
+    "sim_death_physics_gone",  # #460 — physics mmap gone; None must not reset the timer
+    "hud_blank",  # black HUD frame
+    "hud_uniform",  # frozen/uniform HUD frame (almost no distinct values)
+    "report_path_swallow",  # oracle FAIL must reach SelfTestReport.ok (no swallowing)
+)
+
+# Human-perceptible false greens this OFF-SIM detector layer genuinely cannot see. Named in every
+# report so it never implies full human-reality coverage — these stay the live rig arm's job.
+OUT_OF_SCOPE: tuple[str, ...] = (
+    "semantic coaching validity (right cue at the right place) — needs the live coach + a judge",
+    "audio path (a voice cue actually audible at the wheel) — rig-gated at-wheel A/B audit",
+    "render correctness beyond liveness (clipping / colour / position) — needs pixel/OCR judgement",
+    "performance degradation / memory growth over a full session — needs a long live run",
+    "lap persistence across a save/load or restart — needs live state round-trip",
+)
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One labeled corpus entry: an input run through a real oracle with a known ground truth."""
+
+    id: str
+    failure_class: str
+    issue_ref: str
+    expected: str  # "GREEN" (healthy — oracle must PASS) or "RED" (broken — oracle must catch)
+    oracle: str  # which detector: sequence | schema | sim_death | render | report_path
+    run: Callable[[], bool]  # the oracle verdict: True = looks healthy, False = flagged broken
+
+
+@dataclass
+class KpiReport:
+    """Outcome of running the corpus through the real oracles."""
+
+    false_green_rate: float
+    false_red_rate: float
+    broken_total: int
+    broken_false_green: int
+    healthy_total: int
+    healthy_false_red: int
+    per_class: dict[str, dict] = field(default_factory=dict)
+    covered_classes: list[str] = field(default_factory=list)
+    missing_classes: list[str] = field(default_factory=list)
+    false_greens: list[str] = field(default_factory=list)
+    false_reds: list[str] = field(default_factory=list)
+    out_of_scope: list[str] = field(default_factory=lambda: list(OUT_OF_SCOPE))
+    gate_threshold: float = GATE_THRESHOLD
+
+    @property
+    def ok(self) -> bool:
+        """The Part-G gate: low enough false-green rate, zero false reds, full class coverage."""
+        return (
+            self.false_green_rate < self.gate_threshold
+            and self.false_red_rate == 0.0
+            and not self.missing_classes
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "kpi": "known_failure_discrimination",
+            "gate_threshold": self.gate_threshold,
+            "ok": self.ok,
+            "false_green_rate": round(self.false_green_rate, 4),
+            "false_red_rate": round(self.false_red_rate, 4),
+            "broken_total": self.broken_total,
+            "broken_false_green": self.broken_false_green,
+            "healthy_total": self.healthy_total,
+            "healthy_false_red": self.healthy_false_red,
+            "false_greens": self.false_greens,
+            "false_reds": self.false_reds,
+            "covered_classes": self.covered_classes,
+            "missing_classes": self.missing_classes,
+            "per_class": self.per_class,
+            "out_of_scope": self.out_of_scope,
+        }
+
+    def summary(self) -> str:
+        head = "PASS" if self.ok else "FAIL"
+        pct = self.false_green_rate * 100
+        lines = [
+            f"{head}: false-green KPI (known-failure discrimination) -- "
+            f"false_green_rate={pct:.1f}% (gate < {self.gate_threshold * 100:.0f}%)",
+            f"  broken: {self.broken_total} scenarios, "
+            f"{self.broken_false_green} leaked (false green)",
+            f"  healthy: {self.healthy_total} scenarios, "
+            f"{self.healthy_false_red} false-failed (false red)",
+        ]
+        for cls in self.covered_classes:
+            pc = self.per_class[cls]
+            mark = "ok" if pc["false_green"] == 0 and pc["false_red"] == 0 else "XX"
+            lines.append(f"  [{mark}] {cls}: {pc['total']} scenario(s)")
+        if self.missing_classes:
+            lines.append(f"  MISSING classes (corpus hollowed out): {self.missing_classes}")
+        if self.false_greens:
+            lines.append(f"  FALSE GREENS: {self.false_greens}")
+        lines.append(
+            "  out-of-scope (rig-gated, NOT measured here): "
+            + str(len(self.out_of_scope))
+            + " class(es)"
+        )
+        return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- frame builders
+def _snap(topic: str) -> dict:
+    """A produced topic frame as the tap receives it (ws_bridge.publishTopic envelope)."""
+    return {"v": 1, "type": "state.snapshot", "topic": topic, "payload": {}}
+
+
+def _nonsnap(topic: str) -> dict:
+    """A non-snapshot frame that merely carries a topic key — must NOT satisfy the contract."""
+    return {"v": 1, "type": "diagnostic", "topic": topic}
+
+
+def _healthy_stream() -> list[dict]:
+    return [
+        _snap("connection"),
+        _snap("session"),
+        _snap("delta"),
+        _snap("tire_temps"),
+        _snap("coaching.snapshot"),
+        _snap("lap"),
+        _snap("tire_temps"),
+    ]
+
+
+# --------------------------------------------------------------------------- oracle adapters
+def _verdict(oracle: str, weaken: str | None, real: Callable[[], bool]) -> bool:
+    """Return the real oracle verdict, or (when weakening this oracle for the anti-vacuity guard)
+    an unconditional "healthy" — so a defanged oracle visibly leaks its broken scenarios."""
+    if weaken == oracle:
+        return True
+    return real()
+
+
+def _sim_alive(samples: list[tuple[float, int | None]], *, sim_dead_seconds: float) -> bool:
+    """Run (now, packet_id) samples through the REAL PhysicsStallDetector; alive = never tripped."""
+    det = PhysicsStallDetector(sim_dead_seconds)
+    for now, pkt in samples:
+        if det.update(now, pkt):
+            return False
+    return True
+
+
+def _report_path_ok(frames: list[dict]) -> bool:
+    """Drive the FULL self_test orchestration with injected transports; return SelfTestReport.ok.
+
+    Proves an oracle verdict propagates end-to-end (session -> sidecar -> tap -> evaluate ->
+    report): a broken ``frames`` stream must surface as ``ok is False`` rather than being
+    swallowed into a green report.
+    """
+    import asyncio
+
+    def _http(method, url, *, token, timeout=30.0):  # noqa: ANN001, ANN202 - injected stub
+        # Every daemon step succeeds; the only signal under test is the tapped stream's verdict.
+        return 200, {"ok": True, "outcome": "driving", "reason": "injected"}
+
+    async def _tap(url, *, seconds=20.0, wait_for_lap=False):  # noqa: ANN001, ANN202 - injected
+        return frames
+
+    config = SelfTestConfig(token="kpi", tap_seconds=0.0)
+    report = asyncio.run(run_self_test(config, http=_http, tap=_tap))
+    return report.ok
+
+
+# --------------------------------------------------------------------------- corpus
+def build_corpus(*, weaken: str | None = None) -> list[Scenario]:
+    """The labeled scenario corpus. ``weaken`` defangs one oracle (anti-vacuity guard only)."""
+    live_bgra = bytes(range(256)) * 40  # non-uniform: mean ~127, 256 distinct -> renders
+    black_bgra = bytes(4 * 200)  # all-zero -> black frame
+    uniform_bgra = bytes([50]) * 800  # one distinct value -> frozen/uniform frame
+
+    def seq(frames: list[dict], **kw) -> bool:
+        return _verdict("sequence", weaken, lambda: evaluate_sequence(frames, **kw).ok)
+
+    def schema(field_name: str) -> bool:
+        return _verdict("schema", weaken, lambda: field_name in load_schema().car_fields)
+
+    def sim(samples, *, sim_dead_seconds=1.0) -> bool:
+        def real() -> bool:
+            return _sim_alive(samples, sim_dead_seconds=sim_dead_seconds)
+
+        return _verdict("sim_death", weaken, real)
+
+    def render(bgra: bytes) -> bool:
+        return _verdict("render", weaken, lambda: liveness_score(bgra).is_rendering())
+
+    def report_path(frames: list[dict]) -> bool:
+        return _verdict("report_path", weaken, lambda: _report_path_ok(frames))
+
+    # advancing packet ids (alive) vs frozen / gone (dead)
+    advancing = [(i * 0.1, i + 1) for i in range(25)]
+    frozen = [(0.0, 5), (0.5, 5), (1.6, 5)]
+    physics_gone = [(0.0, 5), (0.5, None), (1.7, None)]
+
+    return [
+        # ---- HEALTHY (must PASS; a fail here is a false RED) ----
+        Scenario(
+            "healthy_nominal_drive",
+            "healthy",
+            "-",
+            "GREEN",
+            "sequence",
+            lambda: seq(_healthy_stream()),
+        ),
+        Scenario(
+            "healthy_mid_session_tap",
+            "healthy",
+            "#190",
+            "GREEN",
+            "sequence",
+            lambda: seq(
+                [_snap("connection"), _snap("lap"), _snap("tire_temps"), _snap("coaching.snapshot")]
+            ),
+        ),
+        Scenario(
+            "healthy_no_reference_no_delta",
+            "healthy",
+            "#173",
+            "GREEN",
+            "sequence",
+            lambda: seq(
+                [
+                    _snap("connection"),
+                    _snap("session"),
+                    _snap("lap"),
+                    _snap("tire_temps"),
+                    _snap("coaching.snapshot"),
+                ],
+                strict_lifecycle=True,
+            ),
+        ),
+        Scenario(
+            "healthy_dropped_optional_delta",
+            "healthy",
+            "#173",
+            "GREEN",
+            "sequence",
+            lambda: seq([f for f in _healthy_stream() if f["topic"] != "delta"]),
+        ),
+        Scenario(
+            "healthy_schema_known_field",
+            "healthy",
+            "-",
+            "GREEN",
+            "schema",
+            lambda: schema("speedKmh"),
+        ),
+        Scenario(
+            "healthy_sim_advancing", "healthy", "#459", "GREEN", "sim_death", lambda: sim(advancing)
+        ),
+        Scenario(
+            "healthy_render_live", "healthy", "-", "GREEN", "render", lambda: render(live_bgra)
+        ),
+        Scenario(
+            "healthy_report_path_pass",
+            "healthy",
+            "-",
+            "GREEN",
+            "report_path",
+            lambda: report_path(_healthy_stream()),
+        ),
+        # ---- BROKEN (must be CAUGHT; a pass here is a FALSE GREEN) ----
+        Scenario(
+            "broken_missing_connection",
+            "missing_connection",
+            "#170",
+            "RED",
+            "sequence",
+            lambda: seq(
+                [_snap("session"), _snap("tire_temps"), _snap("coaching.snapshot"), _snap("lap")]
+            ),
+        ),
+        Scenario(
+            "broken_missing_tire_temps",
+            "missing_tire_temps",
+            "#180",
+            "RED",
+            "sequence",
+            lambda: seq(
+                [_snap("connection"), _snap("session"), _snap("lap"), _snap("coaching.snapshot")]
+            ),
+        ),
+        Scenario(
+            "broken_dead_coaching",
+            "dead_coaching",
+            "-",
+            "RED",
+            "sequence",
+            lambda: seq([_snap("connection"), _snap("session"), _snap("lap"), _snap("tire_temps")]),
+        ),
+        Scenario(
+            "broken_lap_before_session",
+            "lap_before_session",
+            "#182",
+            "RED",
+            "sequence",
+            lambda: seq(
+                [
+                    _snap("connection"),
+                    _snap("lap"),
+                    _snap("session"),
+                    _snap("tire_temps"),
+                    _snap("coaching.snapshot"),
+                ]
+            ),
+        ),
+        Scenario(
+            "broken_envelope_spoof",
+            "envelope_spoof",
+            "-",
+            "RED",
+            "sequence",
+            lambda: seq(
+                [
+                    _snap("connection"),
+                    _snap("coaching.snapshot"),
+                    _nonsnap("tire_temps"),
+                    _nonsnap("lap"),
+                ]
+            ),
+        ),
+        Scenario(
+            "broken_require_lap_timeout",
+            "require_lap_timeout",
+            "#191",
+            "RED",
+            "sequence",
+            lambda: seq(
+                [_snap("connection"), _snap("tire_temps"), _snap("coaching.snapshot")],
+                require_lap=True,
+            ),
+        ),
+        Scenario("broken_empty_stream", "empty_stream", "-", "RED", "sequence", lambda: seq([])),
+        Scenario(
+            "broken_schema_out_of_field",
+            "out_of_schema_field",
+            "-",
+            "RED",
+            "schema",
+            lambda: schema("totallyBogusFieldNotInSchema"),
+        ),
+        Scenario(
+            "broken_sim_frozen_packet",
+            "sim_death_frozen",
+            "#459",
+            "RED",
+            "sim_death",
+            lambda: sim(frozen),
+        ),
+        Scenario(
+            "broken_sim_physics_gone",
+            "sim_death_physics_gone",
+            "#460",
+            "RED",
+            "sim_death",
+            lambda: sim(physics_gone),
+        ),
+        Scenario(
+            "broken_render_black", "hud_blank", "-", "RED", "render", lambda: render(black_bgra)
+        ),
+        Scenario(
+            "broken_render_uniform",
+            "hud_uniform",
+            "-",
+            "RED",
+            "render",
+            lambda: render(uniform_bgra),
+        ),
+        Scenario(
+            "broken_report_path_swallow",
+            "report_path_swallow",
+            "-",
+            "RED",
+            "report_path",
+            lambda: report_path([_snap("connection"), _snap("coaching.snapshot")]),
+        ),
+    ]
+
+
+def run_kpi(scenarios: list[Scenario] | None = None, *, weaken: str | None = None) -> KpiReport:
+    """Run the corpus through the real oracles and compute the false-green / false-red KPI."""
+    corpus = scenarios if scenarios is not None else build_corpus(weaken=weaken)
+    per_class: dict[str, dict] = {}
+    broken_total = broken_fg = healthy_total = healthy_fr = 0
+    false_greens: list[str] = []
+    false_reds: list[str] = []
+
+    for sc in corpus:
+        healthy_verdict = sc.run()  # True = oracle says healthy
+        pc = per_class.setdefault(sc.failure_class, {"total": 0, "false_green": 0, "false_red": 0})
+        pc["total"] += 1
+        if sc.expected == "RED":
+            broken_total += 1
+            if healthy_verdict:  # broken input the oracle called healthy -> FALSE GREEN
+                broken_fg += 1
+                pc["false_green"] += 1
+                false_greens.append(sc.id)
+        else:  # GREEN
+            healthy_total += 1
+            if not healthy_verdict:  # healthy input the oracle called broken -> FALSE RED
+                healthy_fr += 1
+                pc["false_red"] += 1
+                false_reds.append(sc.id)
+
+    covered = sorted(c for c in per_class if c != "healthy")
+    missing = [c for c in BROKEN_CLASSES if c not in per_class]
+    return KpiReport(
+        false_green_rate=(broken_fg / broken_total) if broken_total else 0.0,
+        false_red_rate=(healthy_fr / healthy_total) if healthy_total else 0.0,
+        broken_total=broken_total,
+        broken_false_green=broken_fg,
+        healthy_total=healthy_total,
+        healthy_false_red=healthy_fr,
+        per_class=per_class,
+        covered_classes=covered,
+        missing_classes=missing,
+        false_greens=false_greens,
+        false_reds=false_reds,
+    )
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="False-green-rate KPI shadow-mode report (EPIC #154 Part G)"
+    )
+    parser.add_argument("--json", default=None, help="Write the full report as JSON to this path")
+    return parser
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    report = run_kpi()
+    print(report.summary())
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump(report.to_dict(), fh, indent=2)
+        print(f"  wrote {args.json}")
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+
+    _repo_root = str(Path(__file__).resolve().parents[2])
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
+    raise SystemExit(_main())

--- a/tools/ac_harness/false_green_kpi.py
+++ b/tools/ac_harness/false_green_kpi.py
@@ -27,8 +27,9 @@ The report is explicit about what it *cannot* see (`OUT_OF_SCOPE`) so it never i
 human-reality coverage. Recorded live WS taps can be folded in as extra scenarios via
 `sequence_probe.frames_from_jsonl` to anchor the corpus to reality over time.
 
-CLI: ``python -m tools.ac_harness.false_green_kpi [--json OUT]`` — exits ``0`` iff
-``false_green_rate < 0.05`` **and** ``false_red_rate == 0`` **and** every declared class is covered.
+CLI: ``python -m tools.ac_harness.false_green_kpi [--json OUT]`` — exits ``0`` iff **no broken
+scenario leaks** (``broken_false_green == 0``; the deterministic bar, stricter than the reported
+``< 5%``) **and** ``false_red_rate == 0`` **and** every declared class is covered.
 """
 
 from __future__ import annotations
@@ -107,11 +108,13 @@ class KpiReport:
 
     @property
     def ok(self) -> bool:
-        """The Part-G gate: low enough false-green rate, zero false reds, full class coverage."""
+        """The Part-G gate. This OFF-SIM arm is DETERMINISTIC (no noise), so the bar is **zero
+        leaked broken scenarios**, not merely ``< 5%``: a single un-caught broken class must fail
+        and can never be diluted below the rate threshold as the corpus grows (the module invites
+        folding recorded taps in). The ``< 5%`` rate stays the *reported* KPI and the live
+        "vs human reality" arm's bar. Also requires zero false reds and full class coverage."""
         return (
-            self.false_green_rate < self.gate_threshold
-            and self.false_red_rate == 0.0
-            and not self.missing_classes
+            self.broken_false_green == 0 and self.false_red_rate == 0.0 and not self.missing_classes
         )
 
     def to_dict(self) -> dict:
@@ -138,7 +141,8 @@ class KpiReport:
         pct = self.false_green_rate * 100
         lines = [
             f"{head}: false-green KPI (known-failure discrimination) -- "
-            f"false_green_rate={pct:.1f}% (gate < {self.gate_threshold * 100:.0f}%)",
+            f"false_green_rate={pct:.1f}% "
+            f"(gate: 0 leaks; reported bar < {self.gate_threshold * 100:.0f}%)",
             f"  broken: {self.broken_total} scenarios, "
             f"{self.broken_false_green} leaked (false green)",
             f"  healthy: {self.healthy_total} scenarios, "
@@ -441,6 +445,7 @@ def run_kpi(scenarios: list[Scenario] | None = None, *, weaken: str | None = Non
     """Run the corpus through the real oracles and compute the false-green / false-red KPI."""
     corpus = scenarios if scenarios is not None else build_corpus(weaken=weaken)
     per_class: dict[str, dict] = {}
+    red_classes: set[str] = set()
     broken_total = broken_fg = healthy_total = healthy_fr = 0
     false_greens: list[str] = []
     false_reds: list[str] = []
@@ -451,6 +456,7 @@ def run_kpi(scenarios: list[Scenario] | None = None, *, weaken: str | None = Non
         pc["total"] += 1
         if sc.expected == "RED":
             broken_total += 1
+            red_classes.add(sc.failure_class)
             if healthy_verdict:  # broken input the oracle called healthy -> FALSE GREEN
                 broken_fg += 1
                 pc["false_green"] += 1
@@ -462,8 +468,11 @@ def run_kpi(scenarios: list[Scenario] | None = None, *, weaken: str | None = Non
                 pc["false_red"] += 1
                 false_reds.append(sc.id)
 
-    covered = sorted(c for c in per_class if c != "healthy")
-    missing = [c for c in BROKEN_CLASSES if c not in per_class]
+    # Coverage counts ONLY classes exercised by a broken (RED) scenario: a declared class present
+    # solely as a mislabeled GREEN scenario is NOT covered, so the gate cannot pass on a hollow
+    # failure class (codex on #513).
+    covered = sorted(red_classes)
+    missing = [c for c in BROKEN_CLASSES if c not in red_classes]
     return KpiReport(
         false_green_rate=(broken_fg / broken_total) if broken_total else 0.0,
         false_red_rate=(healthy_fr / healthy_total) if healthy_total else 0.0,

--- a/tools/ac_harness/false_green_kpi.py
+++ b/tools/ac_harness/false_green_kpi.py
@@ -38,6 +38,7 @@ import argparse
 import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from tools.ac_harness.auto_drive import PhysicsStallDetector
 from tools.ac_harness.hud_capture import liveness_score
@@ -496,20 +497,37 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_output_path(path: str) -> Path:
+    """Resolve ``--json`` under the current working directory and reject any escape.
+
+    Tool outputs stay contained under cwd (repo convention, e.g. ``lap_archive_export`` / #204): an
+    absolute path outside cwd or a ``..`` traversal is refused, not written as an arbitrary file.
+    """
+    root = Path.cwd().resolve()
+    resolved = (root / path).resolve()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError(f"--json path {path!r} escapes the working directory {root}")
+    return resolved
+
+
 def _main(argv: list[str] | None = None) -> int:
     args = _build_arg_parser().parse_args(argv)
     report = run_kpi()
     print(report.summary())
     if args.json:
-        with open(args.json, "w", encoding="utf-8") as fh:
+        try:
+            out = _resolve_output_path(args.json)
+        except ValueError as exc:
+            print(f"  error: {exc}")
+            return 2
+        with open(out, "w", encoding="utf-8") as fh:
             json.dump(report.to_dict(), fh, indent=2)
-        print(f"  wrote {args.json}")
+        print(f"  wrote {out}")
     return 0 if report.ok else 1
 
 
 if __name__ == "__main__":
     import sys
-    from pathlib import Path
 
     _repo_root = str(Path(__file__).resolve().parents[2])
     if _repo_root not in sys.path:

--- a/tools/ac_harness/false_green_kpi.py
+++ b/tools/ac_harness/false_green_kpi.py
@@ -189,14 +189,6 @@ def _healthy_stream() -> list[dict]:
 
 
 # --------------------------------------------------------------------------- oracle adapters
-def _verdict(oracle: str, weaken: str | None, real: Callable[[], bool]) -> bool:
-    """Return the real oracle verdict, or (when weakening this oracle for the anti-vacuity guard)
-    an unconditional "healthy" — so a defanged oracle visibly leaks its broken scenarios."""
-    if weaken == oracle:
-        return True
-    return real()
-
-
 def _sim_alive(samples: list[tuple[float, int | None]], *, sim_dead_seconds: float) -> bool:
     """Run (now, packet_id) samples through the REAL PhysicsStallDetector; alive = never tripped."""
     det = PhysicsStallDetector(sim_dead_seconds)
@@ -228,29 +220,30 @@ def _report_path_ok(frames: list[dict]) -> bool:
 
 
 # --------------------------------------------------------------------------- corpus
-def build_corpus(*, weaken: str | None = None) -> list[Scenario]:
-    """The labeled scenario corpus. ``weaken`` defangs one oracle (anti-vacuity guard only)."""
+def build_corpus() -> list[Scenario]:
+    """The labeled scenario corpus, each scenario a thunk over the REAL oracle for its class.
+
+    Anti-vacuity ("would a defanged oracle leak?") is proven in the test suite by patching an
+    oracle symbol — no test-only knob is plumbed through this production API.
+    """
     live_bgra = bytes(range(256)) * 40  # non-uniform: mean ~127, 256 distinct -> renders
     black_bgra = bytes(4 * 200)  # all-zero -> black frame
     uniform_bgra = bytes([50]) * 800  # one distinct value -> frozen/uniform frame
 
     def seq(frames: list[dict], **kw) -> bool:
-        return _verdict("sequence", weaken, lambda: evaluate_sequence(frames, **kw).ok)
+        return evaluate_sequence(frames, **kw).ok
 
     def schema(field_name: str) -> bool:
-        return _verdict("schema", weaken, lambda: field_name in load_schema().car_fields)
+        return field_name in load_schema().car_fields
 
     def sim(samples, *, sim_dead_seconds=1.0) -> bool:
-        def real() -> bool:
-            return _sim_alive(samples, sim_dead_seconds=sim_dead_seconds)
-
-        return _verdict("sim_death", weaken, real)
+        return _sim_alive(samples, sim_dead_seconds=sim_dead_seconds)
 
     def render(bgra: bytes) -> bool:
-        return _verdict("render", weaken, lambda: liveness_score(bgra).is_rendering())
+        return liveness_score(bgra).is_rendering()
 
     def report_path(frames: list[dict]) -> bool:
-        return _verdict("report_path", weaken, lambda: _report_path_ok(frames))
+        return _report_path_ok(frames)
 
     # advancing packet ids (alive) vs frozen / gone (dead)
     advancing = [(i * 0.1, i + 1) for i in range(25)]
@@ -442,9 +435,9 @@ def build_corpus(*, weaken: str | None = None) -> list[Scenario]:
     ]
 
 
-def run_kpi(scenarios: list[Scenario] | None = None, *, weaken: str | None = None) -> KpiReport:
+def run_kpi(scenarios: list[Scenario] | None = None) -> KpiReport:
     """Run the corpus through the real oracles and compute the false-green / false-red KPI."""
-    corpus = scenarios if scenarios is not None else build_corpus(weaken=weaken)
+    corpus = scenarios if scenarios is not None else build_corpus()
     per_class: dict[str, dict] = {}
     red_classes: set[str] = set()
     broken_total = broken_fg = healthy_total = healthy_fr = 0


### PR DESCRIPTION
Closes #512. Delivers the **last open residual** on EPIC #154's Closure Criterion — the Part-G
formal gate — so #154 can close.

## What & why

The ADR (`autonomous-self-test-harness.md`, L2) sets the acceptance bar as **"false-green rate vs
human reality (<5%), not coverage."** A *false green* is the failure this whole harness exists to
prevent: the self-test reports the coaching pipeline healthy when a human at the wheel would see it
broken. This PR ships the **CI-measurable arm** of that gate (the live "vs human reality" arm is the
already-live-verified rig `self_test`).

`tools/ac_harness/false_green_kpi.py` runs a **labeled corpus** of the real failure classes the
harness was built to catch — each tied to a historical bug — through the **real production oracle**
for its class (imported, never reimplemented), and asserts `false_green_rate < 5%` with zero false
reds and full class coverage:

| Oracle (real, imported) | Failure classes covered |
|---|---|
| `sequence_probe.evaluate_sequence` | #170 missing peer, #180 tire-temps, dead coaching, #182 lap-before-session, envelope spoof, #191 lap-timeout, empty stream |
| `trace_replay.load_schema` (allow-set) | out-of-schema field read (mock-fallacy / L0 gate) |
| `auto_drive.PhysicsStallDetector` | sim-death frozen packet, #460 physics-gone (None ≠ reset) |
| `hud_capture.liveness_score` | HUD blank, HUD frozen/uniform |
| `self_test.run_self_test` (full path) | **report-path swallowing** — an oracle FAIL must reach `SelfTestReport.ok` |

## Honest scope (Council-reviewed)

The design was adversarially pressure-tested by the Council (gemini/mistral/kimi) before
implementation. Their strongest points are folded in:

- **Reframed honestly** — this is the *known-failure discrimination* arm, not a sole "human reality"
  measure. The report carries an explicit `out_of_scope` list of the human-perceptible classes only
  the rig arm can see (semantic coaching validity, audio, render correctness beyond liveness,
  long-run perf, save/load persistence), so it never implies full coverage.
- **Report-path integrity** closes the "detector works but harness swallows the failure" gap by
  driving the full `run_self_test` with injected transports.
- **Strengthened anti-vacuity** — a test proves a *defanged* oracle raises the false-green rate above
  the gate (teeth), plus granularity checks (dropping a required topic → RED, an optional one → GREEN).
- The KPI asserts it imports the **same** `evaluate_sequence` object the live harness uses (no
  divergent codepath).

## Refactor

Extracts the sim-death rule (`acpmf_physics` packet_id stagnation) from the rig-only `rig_drive`
loop into a tested `PhysicsStallDetector` — single source of truth, and it adds unit coverage to
logic that was previously `# pragma: no cover` rig-only. Behaviour-preserving.

## Verification (local)

- `make ci-fast: OK` (full suite).
- 115 harness tests (`test_false_green_kpi` + `test_ac_harness_auto_drive` + `test_sequence_probe`)
  green; 17 new KPI tests.
- KPI CLI: **PASS — `false_green_rate=0.0%`**, 13 broken scenarios all caught, 8 healthy all pass,
  all 13 declared classes covered, exit 0.
- `PYTHONIOENCODING=cp1252` stdout smoke exits 0 (no `UnicodeEncodeError`; the #476-class hazard).

## Files

- `tools/ac_harness/false_green_kpi.py` (new) · `tests/test_false_green_kpi.py` (new)
- `tools/ac_harness/auto_drive.py` (extract `PhysicsStallDetector`)
- `docs/10_Development/18_Autonomous_Harness.md` (KPI section + primitives list)

Pure-stdlib, off-sim, no new deps.
