### PR TITLE
fix(harness): wait for async lap archive before populating report.lap_archives (#515)

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -309,10 +309,16 @@ def test_wait_lap_requires_a_lap_frame():
     assert with_lap.ok is True
 
 
+def _timed_lap(ms: int = 90_000) -> dict:
+    """A `lap` snapshot carrying a positive lap time (an archiveable, timed lap)."""
+    return {"v": 1, "type": "state.snapshot", "topic": "lap", "payload": {"last_lap_ms": ms}}
+
+
 def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
-    # After a --wait-lap lap the car must keep driving briefly (grace) so the trainer's async
+    # After a --wait-lap TIMED lap the car must keep driving briefly (grace) so the trainer's async
     # lap-archive writer finalizes lap 1's trace before teardown (#515). Assert the grace is awaited
-    # when a lap is seen and NOT when no lap arrives. asyncio.sleep is spied so no real time passes.
+    # for a timed lap and NOT for: no lap, --wait-lap off, or an untimed (unarchiveable) out-lap
+    # (#516). asyncio.sleep is spied so no real time passes.
     import tools.ac_harness.auto_drive as ad
 
     slept: list[float] = []
@@ -328,11 +334,11 @@ def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
             launch=_ok_launch,
             hijack=lambda c: FakeController(),
             drive=_drive_returning(DriveStats(drove=True), {}),
-            tap=_tap_returning([*CONTINUOUS, _snap("session"), _snap("lap")]),
+            tap=_tap_returning([*CONTINUOUS, _snap("session"), _timed_lap()]),
         )
     )
     assert got.ok is True
-    assert 5.0 in slept  # grace-drive awaited on a completed lap
+    assert 5.0 in slept  # grace-drive awaited on a completed timed lap
     assert got.lap_grace_applied is True  # the single flag the evidence poll gates on
 
     slept.clear()
@@ -348,8 +354,7 @@ def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
     assert 5.0 not in slept
     assert no_lap.lap_grace_applied is False
 
-    # Lap seen but --wait-lap disabled: the grace is gated off, so the flag is False and the poll
-    # must NOT wait for an archive the grace never created (#516 daemon review).
+    # Lap seen but --wait-lap disabled: grace gated off, flag False, poll must not wait (#516).
     slept.clear()
     no_wait = asyncio.run(
         run_auto_drive(
@@ -357,16 +362,45 @@ def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
             launch=_ok_launch,
             hijack=lambda c: FakeController(),
             drive=_drive_returning(DriveStats(drove=True), {}),
-            tap=_tap_returning([*CONTINUOUS, _snap("lap")]),
+            tap=_tap_returning([*CONTINUOUS, _timed_lap()]),
         )
     )
     assert 5.0 not in slept
     assert no_wait.lap_grace_applied is False
 
+    # Untimed out-lap (last_lap_ms absent): the trainer archives only timed laps, so the grace must
+    # NOT fire on an unarchiveable boundary (#516 codex).
+    slept.clear()
+    untimed = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, lap_finalize_grace_s=5.0),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning([*CONTINUOUS, _snap("session"), _snap("lap")]),  # lap frame, no time
+        )
+    )
+    assert 5.0 not in slept
+    assert untimed.lap_grace_applied is False
+
+
+def test_has_timed_lap_detects_only_positive_time():
+    from tools.ac_harness.auto_drive import _has_timed_lap
+
+    assert _has_timed_lap([_timed_lap(90_000)]) is True
+    assert _has_timed_lap([_snap("connection"), _timed_lap()]) is True
+    assert _has_timed_lap([_snap("lap")]) is False  # lap frame, no last_lap_ms
+    zero = {"v": 1, "type": "state.snapshot", "topic": "lap", "payload": {"last_lap_ms": 0}}
+    assert _has_timed_lap([zero]) is False  # untimed boundary
+    diag = {"v": 1, "type": "diagnostic", "topic": "lap", "payload": {"last_lap_ms": 5}}
+    assert _has_timed_lap([diag]) is False  # not a state.snapshot
+    assert _has_timed_lap([]) is False
+
 
 def test_wait_lap_extends_drive_budget_for_grace_headroom(monkeypatch):
     # The drive thread self-terminates on drive_seconds and brakes on exit; the post-lap grace must
-    # have driving headroom or the car stops at S/F and the trace never finalizes (#515 boundary).
+    # have driving headroom or the car stops at S/F and the trace never finalizes (#515/#516). The
+    # budget must outlive the LATEST lap the tap accepts (max(180, drive_seconds)) PLUS the grace.
     import tools.ac_harness.auto_drive as ad
 
     async def _spy(_dt):
@@ -389,7 +423,8 @@ def test_wait_lap_extends_drive_budget_for_grace_headroom(monkeypatch):
             tap=_tap_returning([*CONTINUOUS, _snap("session"), _snap("lap")]),
         )
     )
-    assert captured["drive_seconds"] == 108.0  # base + grace headroom
+    # max(180, 100) + 8 = 188 — outlives the tap's lap deadline, not merely drive_seconds+grace.
+    assert captured["drive_seconds"] == 188.0
 
     captured.clear()
     asyncio.run(

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -29,6 +29,7 @@ from tools.ac_harness.auto_drive import (
     default_ac_root,
     fuel_matches,
     generic_gt3_ggv,
+    known_journal_laps_dir,
     parse_setup_fuel,
     preflight,
     race_ini_setup_bake_loop,
@@ -1689,6 +1690,66 @@ def test_collect_lap_archives_present_first_skips_wait(tmp_path):
     )
     assert got == [str(lap)]
     assert slept == []  # found on the first scan, never polled
+
+
+def test_collect_lap_archives_waits_for_dir_created_during_poll(tmp_path):
+    # Fresh profile: journal/laps does not exist at the first scan; the async writer creates BOTH
+    # the dir and the finalized file on a later frame. Polling the (initially absent) path must
+    # still find it once it appears (#515 review — discovery would return None otherwise).
+    import os
+
+    laps = tmp_path / "cfg_laps_not_yet"
+    clock = {"t": 0.0}
+
+    def _clock() -> float:
+        return clock["t"]
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        if clock["t"] >= 1.0 and not laps.exists():
+            laps.mkdir()
+            lap = laps / "lap_x.json"
+            lap.write_text("{}")
+            os.utime(lap, (2_000_000, 2_000_000))
+
+    got = collect_lap_archives(
+        laps,
+        since_epoch=1_500_000,
+        wait_for_first=True,
+        timeout_s=8.0,
+        poll_s=0.5,
+        _clock=_clock,
+        _sleep=_sleep,
+    )
+    assert got == [str(laps / "lap_x.json")]
+
+
+def test_known_journal_laps_dir_is_canonical(tmp_path):
+    d = known_journal_laps_dir(tmp_path)
+    assert d == (
+        tmp_path
+        / "cfg"
+        / "extension"
+        / "state"
+        / "lua"
+        / "app"
+        / "AC_Copilot_Trainer"
+        / "ac_copilot_trainer"
+        / "journal"
+        / "laps"
+    )
+
+
+def test_nonneg_float_allows_zero_rejects_inf_and_negative():
+    import argparse
+
+    from tools.ac_harness.auto_drive import _nonneg_float
+
+    assert _nonneg_float("0") == 0.0
+    assert _nonneg_float("8") == 8.0
+    for bad in ("inf", "-inf", "nan", "-1"):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _nonneg_float(bad)
 
 
 def test_cli_new_flags_map_to_config(tmp_path):

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -346,6 +346,46 @@ def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
     assert 5.0 not in slept
 
 
+def test_wait_lap_extends_drive_budget_for_grace_headroom(monkeypatch):
+    # The drive thread self-terminates on drive_seconds and brakes on exit; the post-lap grace must
+    # have driving headroom or the car stops at S/F and the trace never finalizes (#515 boundary).
+    import tools.ac_harness.auto_drive as ad
+
+    async def _spy(_dt):
+        pass
+
+    monkeypatch.setattr(ad.asyncio, "sleep", _spy)
+
+    captured: dict = {}
+
+    def _capture_drive(controller, config, stop):
+        captured["drive_seconds"] = config.drive_seconds
+        return DriveStats(drove=True)
+
+    asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, drive_seconds=100.0, lap_finalize_grace_s=8.0),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_capture_drive,
+            tap=_tap_returning([*CONTINUOUS, _snap("session"), _snap("lap")]),
+        )
+    )
+    assert captured["drive_seconds"] == 108.0  # base + grace headroom
+
+    captured.clear()
+    asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=False, drive_seconds=100.0, lap_finalize_grace_s=8.0),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_capture_drive,
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert captured["drive_seconds"] == 100.0  # no wait_lap -> no headroom
+
+
 def test_drove_false_gates_overall_success_even_if_pipeline_ok():
     # Sim died mid-drive: pipeline frames present but the drive did not actually move the car.
     report = asyncio.run(

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -426,6 +426,20 @@ def test_wait_lap_extends_drive_budget_for_grace_headroom(monkeypatch):
     # max(180, 100) + 8 = 188 — outlives the tap's lap deadline, not merely drive_seconds+grace.
     assert captured["drive_seconds"] == 188.0
 
+    # grace=0 with wait_lap must STILL align to the tap deadline (else the drive stops early and the
+    # tap hangs the full lap_timeout on a stopped car): max(180, 50) + 0 = 180 (#516 daemon review).
+    captured.clear()
+    asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, drive_seconds=50.0, lap_finalize_grace_s=0.0),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_capture_drive,
+            tap=_tap_returning([*CONTINUOUS, _timed_lap()]),
+        )
+    )
+    assert captured["drive_seconds"] == 180.0
+
     captured.clear()
     asyncio.run(
         run_auto_drive(

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1741,6 +1741,43 @@ def test_collect_lap_archives_waits_for_dir_created_during_poll(tmp_path):
     assert got == [str(laps / "lap_x.json")]
 
 
+def test_collect_lap_archives_rediscovers_dir_during_poll(tmp_path):
+    # Fresh profile + (possibly renamed) install: journal_dir is None at call time; the writer makes
+    # the dir at its ACTUAL path mid-poll. A `resolve` callable re-run each scan must find it, not a
+    # hardcoded path (#516 review — the known-path fallback broke renamed installs).
+    import os
+
+    target = tmp_path / "renamed_app" / "journal" / "laps"
+
+    def _resolve():
+        return target if target.is_dir() else None
+
+    clock = {"t": 0.0}
+
+    def _clock() -> float:
+        return clock["t"]
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        if clock["t"] >= 1.0 and not target.exists():
+            target.mkdir(parents=True)
+            lap = target / "lap_y.json"
+            lap.write_text("{}")
+            os.utime(lap, (2_000_000, 2_000_000))
+
+    got = collect_lap_archives(
+        None,
+        since_epoch=1_500_000,
+        resolve=_resolve,
+        wait_for_first=True,
+        timeout_s=8.0,
+        poll_s=0.5,
+        _clock=_clock,
+        _sleep=_sleep,
+    )
+    assert got == [str(target / "lap_y.json")]
+
+
 def test_known_journal_laps_dir_is_canonical(tmp_path):
     d = known_journal_laps_dir(tmp_path)
     assert d == (

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1522,6 +1522,93 @@ def test_collect_lap_archives_filters_by_mtime(tmp_path):
     assert collect_lap_archives(None, since_epoch=0) == []
 
 
+def test_collect_lap_archives_no_wait_returns_immediately(tmp_path):
+    # A run that produced no lap must NOT poll — return the (empty) scan immediately, no sleeping.
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    slept: list[float] = []
+    got = collect_lap_archives(
+        laps, since_epoch=0, wait_for_first=False, _sleep=slept.append, _clock=lambda: 0.0
+    )
+    assert got == []
+    assert slept == []  # never waited
+
+
+def test_collect_lap_archives_waits_for_async_archive(tmp_path):
+    # The async writer finalizes lap_*.json a moment AFTER the lap frame (#515). With wait_for_first
+    # the poll must pick it up once it lands rather than racing to an empty list.
+    import os
+
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    lap = laps / "lap_late.json"
+    clock = {"t": 0.0}
+
+    def _clock() -> float:
+        return clock["t"]
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        if clock["t"] >= 1.0 and not lap.exists():  # writer finalizes ~1s in
+            lap.write_text("{}")
+            os.utime(lap, (2_000_000, 2_000_000))
+
+    got = collect_lap_archives(
+        laps,
+        since_epoch=1_500_000,
+        wait_for_first=True,
+        timeout_s=8.0,
+        poll_s=0.5,
+        _clock=_clock,
+        _sleep=_sleep,
+    )
+    assert got == [str(lap)]
+
+
+def test_collect_lap_archives_wait_times_out_bounded(tmp_path):
+    # If the archive never appears, the poll is bounded and returns [] rather than hanging.
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    clock = {"t": 0.0}
+    calls = {"n": 0}
+
+    def _clock() -> float:
+        return clock["t"]
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        calls["n"] += 1
+
+    got = collect_lap_archives(
+        laps,
+        since_epoch=0,
+        wait_for_first=True,
+        timeout_s=2.0,
+        poll_s=0.5,
+        _clock=_clock,
+        _sleep=_sleep,
+    )
+    assert got == []
+    assert calls["n"] <= 5  # ~timeout_s/poll_s, bounded — did not spin forever
+
+
+def test_collect_lap_archives_present_first_skips_wait(tmp_path):
+    # An archive already on disk is returned without entering the poll loop.
+    import os
+
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    lap = laps / "lap_present.json"
+    lap.write_text("{}")
+    os.utime(lap, (2_000_000, 2_000_000))
+    slept: list[float] = []
+    got = collect_lap_archives(
+        laps, since_epoch=1_500_000, wait_for_first=True, _sleep=slept.append, _clock=lambda: 0.0
+    )
+    assert got == [str(lap)]
+    assert slept == []  # found on the first scan, never polled
+
+
 def test_cli_new_flags_map_to_config(tmp_path):
     args = _build_arg_parser().parse_args(
         [

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -424,11 +424,11 @@ def test_wait_lap_extends_drive_budget_for_grace_headroom(monkeypatch):
             tap=_tap_returning([*CONTINUOUS, _snap("session"), _snap("lap")]),
         )
     )
-    # max(180, 100) + 8 = 188 — outlives the tap's lap deadline, not merely drive_seconds+grace.
-    assert captured["drive_seconds"] == 188.0
+    # settle(120) + max(180, 100) + grace(8) = 308 — outlives the full tap window + grace
+    assert captured["drive_seconds"] == 308.0
 
-    # grace=0 with wait_lap must STILL align to the tap deadline (else the drive stops early and the
-    # tap hangs the full lap_timeout on a stopped car): max(180, 50) + 0 = 180 (#516 daemon review).
+    # grace=0 with wait_lap must STILL align to the full tap window (else the drive stops early and
+    # the tap hangs on a stopped car): 120 + max(180, 50) + 0 = 300 (#516 daemon review).
     captured.clear()
     asyncio.run(
         run_auto_drive(
@@ -439,7 +439,7 @@ def test_wait_lap_extends_drive_budget_for_grace_headroom(monkeypatch):
             tap=_tap_returning([*CONTINUOUS, _timed_lap()]),
         )
     )
-    assert captured["drive_seconds"] == 180.0
+    assert captured["drive_seconds"] == 300.0
 
     captured.clear()
     asyncio.run(

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -24,6 +24,7 @@ from tools.ac_harness.auto_drive import (
     _wait_live,
     bake_setup_into_race_ini,
     build_practice_preset,
+    candidate_journal_laps_dirs,
     collect_lap_archives,
     custom_ai_enabled,
     default_ac_root,
@@ -1799,7 +1800,7 @@ def test_collect_lap_archives_rediscovers_dir_during_poll(tmp_path):
     target = tmp_path / "renamed_app" / "journal" / "laps"
 
     def _resolve():
-        return target if target.is_dir() else None
+        return [target] if target.is_dir() else []
 
     clock = {"t": 0.0}
 
@@ -1847,7 +1848,9 @@ def test_collect_lap_archives_follows_resolver_off_stale_dir(tmp_path):
         return clock["t"]
 
     def _resolve():
-        return canonical if canonical.is_dir() else stale
+        # Both are candidates — the stale default persists after a rename (CSP doesn't delete it).
+        # Scanning all + the mtime gate must still find the fresh archive, not shadow it with stale.
+        return [d for d in (stale, canonical) if d.is_dir()]
 
     def _sleep(dt: float) -> None:
         clock["t"] += dt
@@ -1868,6 +1871,21 @@ def test_collect_lap_archives_follows_resolver_off_stale_dir(tmp_path):
         _sleep=_sleep,
     )
     assert got == [str(canonical / "lap_new.json")]  # followed to canonical; stale old file ignored
+
+
+def test_candidate_journal_laps_dirs_includes_canonical_and_renamed(tmp_path):
+    # A stale canonical dir AND a renamed-install dir both exist; candidate_journal_laps_dirs must
+    # return BOTH so the scan finds the active writer's archive regardless of the stale leftover.
+    canonical = known_journal_laps_dir(tmp_path)
+    canonical.mkdir(parents=True)
+    renamed = tmp_path / "cfg" / "extension" / "state" / "lua" / "app" / "Renamed" / "renamed"
+    renamed_laps = renamed / "journal" / "laps"
+    renamed_laps.mkdir(parents=True)
+    dirs = candidate_journal_laps_dirs(tmp_path)
+    assert canonical in dirs
+    assert renamed_laps in dirs
+    # No dirs when nothing exists.
+    assert candidate_journal_laps_dirs(tmp_path / "empty") == []
 
 
 def test_known_journal_laps_dir_is_canonical(tmp_path):

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -50,7 +50,11 @@ _PROFILE = [40.0, 40.0, 40.0, 40.0]  # m/s targets
 
 
 def _cfg(**kw) -> AutoDriveConfig:
-    base = dict(cm_preset="preset.cmpreset", track_id="imola", tap_seconds=0.0)
+    # lap_finalize_grace_s=0.0 so orchestration tests don't real-sleep the post-lap grace; the grace
+    # behaviour itself is covered by test_wait_lap_grace_drive_finalizes_archive.
+    base = dict(
+        cm_preset="preset.cmpreset", track_id="imola", tap_seconds=0.0, lap_finalize_grace_s=0.0
+    )
     base.update(kw)
     return AutoDriveConfig(**base)  # type: ignore[arg-type]
 
@@ -302,6 +306,44 @@ def test_wait_lap_requires_a_lap_frame():
         )
     )
     assert with_lap.ok is True
+
+
+def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
+    # After a --wait-lap lap the car must keep driving briefly (grace) so the trainer's async
+    # lap-archive writer finalizes lap 1's trace before teardown (#515). Assert the grace is awaited
+    # when a lap is seen and NOT when no lap arrives. asyncio.sleep is spied so no real time passes.
+    import tools.ac_harness.auto_drive as ad
+
+    slept: list[float] = []
+
+    async def _spy(dt):
+        slept.append(dt)
+
+    monkeypatch.setattr(ad.asyncio, "sleep", _spy)
+
+    got = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, lap_finalize_grace_s=5.0),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning([*CONTINUOUS, _snap("session"), _snap("lap")]),
+        )
+    )
+    assert got.ok is True
+    assert 5.0 in slept  # grace-drive awaited on a completed lap
+
+    slept.clear()
+    asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, lap_finalize_grace_s=5.0),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning(CONTINUOUS),  # no lap frame -> no grace
+        )
+    )
+    assert 5.0 not in slept
 
 
 def test_drove_false_gates_overall_success_even_if_pipeline_ok():

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1813,6 +1813,49 @@ def test_collect_lap_archives_rediscovers_dir_during_poll(tmp_path):
     assert got == [str(target / "lap_y.json")]
 
 
+def test_collect_lap_archives_follows_resolver_off_stale_dir(tmp_path):
+    # A stale leftover dir (old files) is returned first; the canonical dir with the NEW archive
+    # appears mid-poll. With journal_dir=None the poll re-resolves each scan and must follow the
+    # resolver to the canonical dir, not pin to stale — the stale old file is excluded by the
+    # since_epoch gate (#516 review).
+    import os
+
+    stale = tmp_path / "stale" / "laps"
+    stale.mkdir(parents=True)
+    old = stale / "lap_old.json"
+    old.write_text("{}")
+    os.utime(old, (1_000_000, 1_000_000))  # before since_epoch -> filtered out
+    canonical = tmp_path / "canonical" / "laps"
+
+    clock = {"t": 0.0}
+
+    def _clock() -> float:
+        return clock["t"]
+
+    def _resolve():
+        return canonical if canonical.is_dir() else stale
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        if clock["t"] >= 1.0 and not canonical.exists():
+            canonical.mkdir(parents=True)
+            new = canonical / "lap_new.json"
+            new.write_text("{}")
+            os.utime(new, (2_000_000, 2_000_000))
+
+    got = collect_lap_archives(
+        None,
+        since_epoch=1_500_000,
+        resolve=_resolve,
+        wait_for_first=True,
+        timeout_s=8.0,
+        poll_s=0.5,
+        _clock=_clock,
+        _sleep=_sleep,
+    )
+    assert got == [str(canonical / "lap_new.json")]  # followed to canonical; stale old file ignored
+
+
 def test_known_journal_laps_dir_is_canonical(tmp_path):
     d = known_journal_laps_dir(tmp_path)
     assert d == (

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -333,9 +333,10 @@ def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
     )
     assert got.ok is True
     assert 5.0 in slept  # grace-drive awaited on a completed lap
+    assert got.lap_grace_applied is True  # the single flag the evidence poll gates on
 
     slept.clear()
-    asyncio.run(
+    no_lap = asyncio.run(
         run_auto_drive(
             _cfg(wait_lap=True, lap_finalize_grace_s=5.0),
             launch=_ok_launch,
@@ -345,6 +346,22 @@ def test_wait_lap_grace_drive_finalizes_archive(monkeypatch):
         )
     )
     assert 5.0 not in slept
+    assert no_lap.lap_grace_applied is False
+
+    # Lap seen but --wait-lap disabled: the grace is gated off, so the flag is False and the poll
+    # must NOT wait for an archive the grace never created (#516 daemon review).
+    slept.clear()
+    no_wait = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=False, lap_finalize_grace_s=5.0),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning([*CONTINUOUS, _snap("lap")]),
+        )
+    )
+    assert 5.0 not in slept
+    assert no_wait.lap_grace_applied is False
 
 
 def test_wait_lap_extends_drive_budget_for_grace_headroom(monkeypatch):

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1178,18 +1178,40 @@ def discover_journal_laps_dir(user_dir: Path) -> Path | None:
     return None
 
 
-def _scan_lap_archives(journal_dir: Path | None, since_epoch: float) -> list[str]:
-    """List ``lap_*.json`` written at/after ``since_epoch`` (mtime), newest first."""
-    if journal_dir is None or not journal_dir.is_dir():
-        return []
+def candidate_journal_laps_dirs(user_dir: Path) -> list[Path]:
+    """ALL existing per-lap archive dirs: the canonical path plus any ``app/*/*/journal/laps``.
+
+    CSP does not delete an app's old state dir on rename/move, so the canonical (default) dir can
+    persist as a STALE leftover while the active writer uses a renamed dir. Preferring the canonical
+    (`discover_journal_laps_dir`) then shadows the renamed one and the poll watches the wrong path
+    (#516 review). Scanning EVERY candidate + filtering by mtime finds the fresh archive wherever
+    the active writer put it, regardless of stale leftovers.
+    """
+    dirs: list[Path] = []
+    known = known_journal_laps_dir(user_dir)
+    if known.is_dir():
+        dirs.append(known)
+    state_root = user_dir / "cfg" / "extension" / "state" / "lua"
+    if state_root.is_dir():
+        for cand in sorted(state_root.glob("app/*/*/journal/laps")):
+            if cand.is_dir() and cand not in dirs:
+                dirs.append(cand)
+    return dirs
+
+
+def _scan_lap_archives(dirs: list[Path], since_epoch: float) -> list[str]:
+    """List ``lap_*.json`` across all ``dirs`` at/after ``since_epoch`` (mtime), newest first."""
     hits: list[tuple[float, str]] = []
-    for path in journal_dir.glob("lap_*.json"):
-        try:
-            mtime = path.stat().st_mtime
-        except OSError:
+    for journal_dir in dirs:
+        if journal_dir is None or not journal_dir.is_dir():
             continue
-        if mtime >= since_epoch:
-            hits.append((mtime, str(path)))
+        for path in journal_dir.glob("lap_*.json"):
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                continue
+            if mtime >= since_epoch:
+                hits.append((mtime, str(path)))
     return [p for _, p in sorted(hits, reverse=True)]
 
 
@@ -1197,7 +1219,7 @@ def collect_lap_archives(
     journal_dir: Path | None,
     since_epoch: float,
     *,
-    resolve: Callable[[], Path | None] | None = None,
+    resolve: Callable[[], list[Path]] | None = None,
     wait_for_first: bool = False,
     timeout_s: float = 8.0,
     poll_s: float = 0.5,
@@ -1216,14 +1238,17 @@ def collect_lap_archives(
     first archive to appear instead of racing the writer; it returns as soon as one exists, and
     returns immediately with no wait when ``wait_for_first`` is false (a run that produced no lap).
 
-    When ``journal_dir`` is ``None`` and ``resolve`` is given, the dir is **re-resolved each scan**
-    via ``resolve()`` — so a fresh-profile dir that the writer creates mid-poll is picked up at its
-    actual path (default OR a renamed install), rather than watching a hardcoded path (#516 review).
+    When ``journal_dir`` is ``None`` and ``resolve`` is given, the candidate dirs are **re-resolved
+    each scan** via ``resolve()`` (which returns ALL candidate dirs) — so a fresh-profile dir the
+    writer creates mid-poll is found at its actual path, and a stale default dir cannot shadow a
+    renamed-install dir (every candidate is scanned; mtime filters stale files; #516 review).
     ``_clock``/``_sleep`` are injectable so the poll is deterministic in off-sim tests.
     """
 
-    def _current() -> Path | None:
-        return journal_dir if journal_dir is not None else (resolve() if resolve else None)
+    def _current() -> list[Path]:
+        if journal_dir is not None:
+            return [journal_dir]
+        return resolve() if resolve else []
 
     found = _scan_lap_archives(_current(), since_epoch)
     if found or not wait_for_first:
@@ -2187,15 +2212,14 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     # The grace-drive already elapsed synchronously in run_auto_drive, so by here the writer has
     # streamed the trace; this poll only awaits the OS flush/rename — a short CONSTANT timeout, not
     # one scaled to the in-sim grace time (#516 review). collect_lap_archives' default covers it.
-    # journal_dir=None (not a pinned initial discover): an initial discover can return a STALE
-    # leftover dir (old/renamed install) while the current writer creates the canonical one moments
-    # later — pinning would poll the wrong path (#516 review). Re-resolving each scan follows the
-    # writer to the canonical dir (discover prefers the known path over the bounded glob fallback);
-    # stale old files there are excluded by the since_epoch mtime gate.
+    # Scan ALL candidate journal/laps dirs each poll (canonical + any renamed) and filter by mtime:
+    # CSP leaves stale default state dirs on rename, so preferring one dir lets a stale leftover
+    # shadow the active renamed dir (#516 review). The fresh archive is found wherever the active
+    # writer put it; stale files are excluded by the since_epoch gate.
     lap_archives = collect_lap_archives(
         None,
         run_started_epoch,
-        resolve=lambda: discover_journal_laps_dir(user_dir),
+        resolve=lambda: candidate_journal_laps_dirs(user_dir),
         wait_for_first=report.lap_grace_applied,
     )
     journal_dir = discover_journal_laps_dir(user_dir)  # for the report path (post-poll)

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -339,6 +339,31 @@ class ProgressWatchdog:
         self._anchor_time = now
 
 
+def _has_timed_lap(frames: list[dict]) -> bool:
+    """True if a produced ``lap`` snapshot carries a positive time (``payload.last_lap_ms > 0``).
+
+    An out-lap / teleport boundary still emits a ``lap`` frame but with no time, and the trainer
+    only archives a TIMED lap (``lastMs > 0``). So the post-lap grace-drive + archive poll must fire
+    on a timed lap, not merely on a ``lap`` frame, or an unarchiveable boundary wastes the grace and
+    then times out the poll (#516 review).
+    """
+    for frame in frames:
+        if (
+            not isinstance(frame, dict)
+            or frame.get("type") != "state.snapshot"
+            or frame.get("topic") != "lap"
+        ):
+            continue
+        payload = frame.get("payload")
+        ms = payload.get("last_lap_ms") if isinstance(payload, dict) else None
+        try:
+            if ms is not None and float(ms) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 async def run_auto_drive(
     config: AutoDriveConfig,
     *,
@@ -445,15 +470,16 @@ async def run_auto_drive(
         )
 
     stop = threading.Event()
-    # The drive thread self-terminates on its own drive_seconds budget (rig_drive), and on exit it
-    # BRAKES the car. If a lap lands within lap_finalize_grace_s of that budget, the post-lap grace
-    # below would run against an already-stopped car and the trace would not finalize (#515 boundary
-    # case). Give the drive thread grace headroom so it keeps driving through the grace.
+    # The tap waits up to `lap_deadline` for the lap (a full lap at harness pace can exceed 180s /
+    # drive_seconds — Spa ~7km). The drive thread self-terminates on its own drive_seconds budget
+    # and BRAKES the car on exit, so to keep it driving through the post-lap grace it must outlive
+    # the LATEST lap the tap accepts PLUS the grace — not merely drive_seconds (which can be < the
+    # tap deadline, breaking headroom for a late lap; #515/#516). One `lap_deadline` feeds both the
+    # tap timeout and the drive budget so they cannot diverge.
+    lap_deadline = max(180.0, config.drive_seconds)
     drive_config = config
     if config.wait_lap and config.lap_finalize_grace_s > 0:
-        drive_config = replace(
-            config, drive_seconds=config.drive_seconds + config.lap_finalize_grace_s
-        )
+        drive_config = replace(config, drive_seconds=lap_deadline + config.lap_finalize_grace_s)
     drive_task = asyncio.create_task(asyncio.to_thread(drive, controller, drive_config, stop))
     stats = DriveStats(reason="drive did not run")
     seq_ok: bool | None = None
@@ -469,10 +495,10 @@ async def run_auto_drive(
     try:
         tap_kwargs: dict[str, Any] = dict(seconds=config.tap_seconds, wait_for_lap=config.wait_lap)
         if config.wait_lap:
-            # A full lap at harness pace can exceed tap_frames' 180 s default (Spa ~7 km) —
-            # wait as long as the drive leg is allowed to run, or the tap gives up on the lap
-            # while the car is still mid-lap and the run false-fails (#459 Part F).
-            tap_kwargs["lap_timeout"] = max(180.0, config.drive_seconds)
+            # Wait as long as the drive leg is allowed to run (a full lap at harness pace can exceed
+            # the 180 s tap default, Spa ~7 km) — the SAME `lap_deadline` the drive budget is sized
+            # to, so the tap never gives up on a lap the drive thread can still complete (#459 F).
+            tap_kwargs["lap_timeout"] = lap_deadline
         frames = await tap(config.sidecar_url, **tap_kwargs)
         result = evaluate_sequence(
             frames, strict_lifecycle=config.strict, require_lap=config.wait_lap
@@ -481,7 +507,7 @@ async def run_auto_drive(
         counts = dict(result.counts)
         notes = list(result.notes)
         grace_applied = bool(
-            config.wait_lap and counts.get("lap") and config.lap_finalize_grace_s > 0
+            config.wait_lap and _has_timed_lap(frames) and config.lap_finalize_grace_s > 0
         )
         if grace_applied:
             # The drive thread is still running here (stop not yet set), so the car keeps driving
@@ -2154,13 +2180,15 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     # disagree (#516 review). On a fresh profile journal/laps may not exist until the async writer
     # creates it — pass a re-discovering resolver so the poll finds it at its real path (default or
     # renamed install), not a hardcoded one. No grace-drive => single scan, no hang.
+    # The grace-drive already elapsed synchronously in run_auto_drive, so by here the writer has
+    # streamed the trace; this poll only awaits the OS flush/rename — a short CONSTANT timeout, not
+    # one scaled to the in-sim grace time (#516 review). collect_lap_archives' default covers it.
     journal_dir = discover_journal_laps_dir(user_dir)
     lap_archives = collect_lap_archives(
         journal_dir,
         run_started_epoch,
         resolve=lambda: discover_journal_laps_dir(user_dir),
         wait_for_first=report.lap_grace_applied,
-        timeout_s=config.lap_finalize_grace_s + 2.0,
     )
     # Re-discover for the report path: the writer may have created the dir during the poll.
     journal_dir = journal_dir or discover_journal_laps_dir(user_dir)

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1101,14 +1101,16 @@ def write_evidence(
     return out
 
 
-def discover_journal_laps_dir(user_dir: Path) -> Path | None:
-    """Locate the trainer's per-lap archive dir under the AC user data root.
+def known_journal_laps_dir(user_dir: Path) -> Path:
+    """The trainer's canonical per-lap archive dir (may not exist yet on a fresh profile).
 
     The Lua app writes to ``ac.FolderID.ScriptConfig``/…/``journal/laps`` — on disk:
     ``<user_dir>/cfg/extension/state/lua/app/AC_Copilot_Trainer/ac_copilot_trainer/journal/laps``
-    (verified on the rig). Falls back to a bounded glob for renamed installs.
+    (verified on the rig). The async writer creates it lazily when it opens the first temp file, so
+    the directory can be absent right after a lap — poll this path so the archive is found once it
+    appears (#515 review).
     """
-    known = (
+    return (
         user_dir
         / "cfg"
         / "extension"
@@ -1120,6 +1122,11 @@ def discover_journal_laps_dir(user_dir: Path) -> Path | None:
         / "journal"
         / "laps"
     )
+
+
+def discover_journal_laps_dir(user_dir: Path) -> Path | None:
+    """Locate the EXISTING per-lap archive dir; bounded-glob fallback for renamed installs."""
+    known = known_journal_laps_dir(user_dir)
     if known.is_dir():
         return known
     state_root = user_dir / "cfg" / "extension" / "state" / "lua"
@@ -1860,6 +1867,19 @@ def _positive_float(value: str) -> float:
     return parsed
 
 
+def _nonneg_float(value: str) -> float:
+    """argparse type: a non-negative, FINITE float (``0`` allowed to disable the feature).
+
+    Like :func:`_positive_float` but permits ``0`` — ``--lap-finalize-grace-s 0`` is a valid "no
+    grace" opt-out. Still rejects negatives and non-finite ``inf``/``nan``: ``inf`` would make the
+    post-lap ``await asyncio.sleep(inf)`` never reach the teardown ``finally`` (#515 review).
+    """
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError(f"must be a finite number >= 0, got {value!r}")
+    return parsed
+
+
 def _build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Composed autonomous self-test (#154 Part G): drive any car/track + assert"
@@ -1923,9 +1943,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--drive-seconds", type=float, default=300.0)
     p.add_argument(
         "--lap-finalize-grace-s",
-        type=float,
+        type=_nonneg_float,
         default=8.0,
-        help="drive this long past S/F after the lap so the async archive writer finalizes (#515)",
+        help="drive this long past S/F after the lap so the async archive writer finalizes; "
+        "0 disables (#515)",
     )
     p.add_argument("--target-speed", type=float, default=55.0, help="cruise target speed (km/h)")
     p.add_argument("--min-corner", type=float, default=30.0, help="cruise min corner speed (km/h)")
@@ -2104,10 +2125,13 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             sidecar_proc.terminate()
 
     hud = _capture_hud_evidence(evidence_dir, args.hud_region)
-    journal_dir = discover_journal_laps_dir(user_dir)
-    # A produced lap is finalized by the async writer just after the lap WS frame the tap returned
-    # on, so wait briefly for it rather than racing to an empty list (#515). No lap -> no wait.
-    produced_lap = bool(getattr(report.drive, "laps", 0))
+    # Gate the wait on the WS `lap` frame the tap actually saw (report.counts["lap"]) — the SAME
+    # signal run_auto_drive's grace uses — not rig_drive's separate lap counter, so the two never
+    # diverge (#515 review). The async writer finalizes just after that frame, so wait briefly
+    # rather than racing to []. On a fresh profile journal/laps may not exist until the writer
+    # creates it, so poll the deterministic known path when discovery finds nothing yet.
+    produced_lap = bool(report.counts.get("lap"))
+    journal_dir = discover_journal_laps_dir(user_dir) or known_journal_laps_dir(user_dir)
     lap_archives = collect_lap_archives(journal_dir, run_started_epoch, wait_for_first=produced_lap)
     extras = {
         "run": {

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2132,7 +2132,16 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     # creates it, so poll the deterministic known path when discovery finds nothing yet.
     produced_lap = bool(report.counts.get("lap"))
     journal_dir = discover_journal_laps_dir(user_dir) or known_journal_laps_dir(user_dir)
-    lap_archives = collect_lap_archives(journal_dir, run_started_epoch, wait_for_first=produced_lap)
+    # The grace-drive is what finalizes the archive, so only wait when the grace actually ran, and
+    # bind the poll timeout to it — `--lap-finalize-grace-s 0` disables the grace and must NOT then
+    # hang the poll on an archive that will never arrive (#516 review).
+    grace = config.lap_finalize_grace_s
+    lap_archives = collect_lap_archives(
+        journal_dir,
+        run_started_epoch,
+        wait_for_first=produced_lap and grace > 0,
+        timeout_s=grace + 2.0,
+    )
     extras = {
         "run": {
             "started_epoch": run_started_epoch,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1112,8 +1112,8 @@ def discover_journal_laps_dir(user_dir: Path) -> Path | None:
     return None
 
 
-def collect_lap_archives(journal_dir: Path | None, since_epoch: float) -> list[str]:
-    """List lap-archive JSONs written at/after ``since_epoch`` (mtime), newest first."""
+def _scan_lap_archives(journal_dir: Path | None, since_epoch: float) -> list[str]:
+    """List ``lap_*.json`` written at/after ``since_epoch`` (mtime), newest first."""
     if journal_dir is None or not journal_dir.is_dir():
         return []
     hits: list[tuple[float, str]] = []
@@ -1125,6 +1125,41 @@ def collect_lap_archives(journal_dir: Path | None, since_epoch: float) -> list[s
         if mtime >= since_epoch:
             hits.append((mtime, str(path)))
     return [p for _, p in sorted(hits, reverse=True)]
+
+
+def collect_lap_archives(
+    journal_dir: Path | None,
+    since_epoch: float,
+    *,
+    wait_for_first: bool = False,
+    timeout_s: float = 8.0,
+    poll_s: float = 0.5,
+    _clock: Callable[[], float] = time.monotonic,
+    _sleep: Callable[[float], None] = time.sleep,
+) -> list[str]:
+    """List lap-archive JSONs written at/after ``since_epoch`` (mtime), newest first.
+
+    The trainer finalizes each lap trace with an **async deferred writer** (#246/#249): it streams
+    to a temp file and atomically renames to ``lap_*.json`` *after* the ``lap`` WS frame the harness
+    waits on. So immediately after a ``--wait-lap`` drive the finalized archive frequently does not
+    exist yet (only a mid-stream temp file, which the ``lap_*.json`` glob correctly ignores) — a
+    naive single scan then reports an empty list even though a lap was produced (#515).
+
+    With ``wait_for_first`` (set when the run produced a lap) this polls up to ``timeout_s`` for the
+    first archive to appear instead of racing the writer; it returns as soon as one exists, and
+    returns immediately with no wait when ``wait_for_first`` is false (a run that produced no lap).
+    ``_clock``/``_sleep`` are injectable so the poll is deterministic in off-sim tests.
+    """
+    found = _scan_lap_archives(journal_dir, since_epoch)
+    if found or not wait_for_first:
+        return found
+    deadline = _clock() + max(0.0, timeout_s)
+    while _clock() < deadline:
+        _sleep(max(0.0, poll_s))
+        found = _scan_lap_archives(journal_dir, since_epoch)
+        if found:
+            return found
+    return found
 
 
 # ---------------------------------------------------------------------------
@@ -2044,7 +2079,10 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
 
     hud = _capture_hud_evidence(evidence_dir, args.hud_region)
     journal_dir = discover_journal_laps_dir(user_dir)
-    lap_archives = collect_lap_archives(journal_dir, run_started_epoch)
+    # A produced lap is finalized by the async writer just after the lap WS frame the tap returned
+    # on, so wait briefly for it rather than racing to an empty list (#515). No lap -> no wait.
+    produced_lap = bool(getattr(report.drive, "laps", 0))
+    lap_archives = collect_lap_archives(journal_dir, run_started_epoch, wait_for_first=produced_lap)
     extras = {
         "run": {
             "started_epoch": run_started_epoch,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -478,7 +478,11 @@ async def run_auto_drive(
     # tap timeout and the drive budget so they cannot diverge.
     lap_deadline = max(180.0, config.drive_seconds)
     drive_config = config
-    if config.wait_lap and config.lap_finalize_grace_s > 0:
+    if config.wait_lap:
+        # Whenever we wait for a lap, the drive thread must outlive the tap's lap deadline (+ grace)
+        # or it stops+brakes the car while the tap is still waiting — the tap then hangs the full
+        # lap_timeout on a stopped car (drive_seconds=50 < 180: stops at 50s, tap waits to 180s).
+        # Align the budget to lap_deadline unconditionally; grace adds 0 when disabled (#516).
         drive_config = replace(config, drive_seconds=lap_deadline + config.lap_finalize_grace_s)
     drive_task = asyncio.create_task(asyncio.to_thread(drive, controller, drive_config, stop))
     stats = DriveStats(reason="drive did not run")

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -476,14 +476,19 @@ async def run_auto_drive(
     # the LATEST lap the tap accepts PLUS the grace — not merely drive_seconds (which can be < the
     # tap deadline, breaking headroom for a late lap; #515/#516). One `lap_deadline` feeds both the
     # tap timeout and the drive budget so they cannot diverge.
+    # tap_frames waits in TWO phases: up to `tap_settle_s` for the car-on-track (any continuous
+    # topic), THEN up to lap_deadline for the lap. So the tap can accept a lap as late as
+    # tap_settle_s + lap_deadline, and the drive thread must outlive that whole window + grace (it
+    # brakes on budget exit; a premature stop leaves the tap hanging on a stopped car, #515/#516).
+    # One tap_settle_s + lap_deadline feeds BOTH the tap and the budget so they cannot diverge.
+    tap_settle_s = 120.0  # matches tap_frames' default settle_timeout
     lap_deadline = max(180.0, config.drive_seconds)
     drive_config = config
     if config.wait_lap:
-        # Whenever we wait for a lap, the drive thread must outlive the tap's lap deadline (+ grace)
-        # or it stops+brakes the car while the tap is still waiting — the tap then hangs the full
-        # lap_timeout on a stopped car (drive_seconds=50 < 180: stops at 50s, tap waits to 180s).
-        # Align the budget to lap_deadline unconditionally; grace adds 0 when disabled (#516).
-        drive_config = replace(config, drive_seconds=lap_deadline + config.lap_finalize_grace_s)
+        drive_config = replace(
+            config,
+            drive_seconds=tap_settle_s + lap_deadline + config.lap_finalize_grace_s,
+        )
     drive_task = asyncio.create_task(asyncio.to_thread(drive, controller, drive_config, stop))
     stats = DriveStats(reason="drive did not run")
     seq_ok: bool | None = None
@@ -499,9 +504,10 @@ async def run_auto_drive(
     try:
         tap_kwargs: dict[str, Any] = dict(seconds=config.tap_seconds, wait_for_lap=config.wait_lap)
         if config.wait_lap:
-            # Wait as long as the drive leg is allowed to run (a full lap at harness pace can exceed
-            # the 180 s tap default, Spa ~7 km) — the SAME `lap_deadline` the drive budget is sized
-            # to, so the tap never gives up on a lap the drive thread can still complete (#459 F).
+            # The SAME settle + lap deadline the drive budget is sized to (above), so the tap never
+            # waits past what the drive thread can still drive (a full lap at pace can exceed
+            # the 180 s default, Spa ~7 km); #459 F / #516.
+            tap_kwargs["settle_timeout"] = tap_settle_s
             tap_kwargs["lap_timeout"] = lap_deadline
         frames = await tap(config.sidecar_url, **tap_kwargs)
         result = evaluate_sequence(
@@ -1242,6 +1248,10 @@ def collect_lap_archives(
     each scan** via ``resolve()`` (which returns ALL candidate dirs) — so a fresh-profile dir the
     writer creates mid-poll is found at its actual path, and a stale default dir cannot shadow a
     renamed-install dir (every candidate is scanned; mtime filters stale files; #516 review).
+
+    A single ``journal_dir`` is for **tests / a known-good dir only**. Production MUST pass
+    ``journal_dir=None`` + a ``resolve`` returning every candidate (`candidate_journal_laps_dirs`);
+    passing one resolved dir would bypass the multi-dir scan and re-open the stale-shadowing bug.
     ``_clock``/``_sleep`` are injectable so the poll is deterministic in off-sim tests.
     """
 

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2222,7 +2222,11 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         resolve=lambda: candidate_journal_laps_dirs(user_dir),
         wait_for_first=report.lap_grace_applied,
     )
-    journal_dir = discover_journal_laps_dir(user_dir)  # for the report path (post-poll)
+    # Report the dir the archive was actually found in (correct even for a renamed install), so the
+    # metadata matches the multi-dir scan, not the canonical-preferring discover (#516 review).
+    journal_dir = (
+        Path(lap_archives[0]).parent if lap_archives else discover_journal_laps_dir(user_dir)
+    )
     extras = {
         "run": {
             "started_epoch": run_started_epoch,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -206,6 +206,10 @@ class AutoDriveReport:
     counts: dict[str, int] = field(default_factory=dict)
     notes: list[str] = field(default_factory=list)
     error: str | None = None
+    # Whether the post-lap grace-drive ran (drove past S/F so the async writer finalizes the lap
+    # archive). The single source of truth the evidence-bundle poll gates on, so the grace condition
+    # and the poll condition can never diverge (#515/#516 review).
+    lap_grace_applied: bool = False
     # Combo identity + setup verification (#459 Parts A/C) — evidence consumers key on these.
     car_id: str | None = None
     track_id: str | None = None
@@ -455,6 +459,7 @@ async def run_auto_drive(
     seq_ok: bool | None = None
     counts: dict[str, int] = {}
     notes: list[str] = []
+    grace_applied = False
     # A fuel-less setup is baked but not fuel-confirmed — surface that in the report so a setup
     # A/B run does not read `setup_applied=True` as "independently verified" (#460 review).
     if setup_ack is not None and setup_applied and setup_ack.get("expected_fuel") is None:
@@ -475,11 +480,15 @@ async def run_auto_drive(
         seq_ok = result.ok
         counts = dict(result.counts)
         notes = list(result.notes)
-        if config.wait_lap and counts.get("lap") and config.lap_finalize_grace_s > 0:
+        grace_applied = bool(
+            config.wait_lap and counts.get("lap") and config.lap_finalize_grace_s > 0
+        )
+        if grace_applied:
             # The drive thread is still running here (stop not yet set), so the car keeps driving
             # past S/F while the trainer's async writer (#246/#249) streams + finalizes lap 1's
             # archive over the following frames. Without this, stopping at the exact lap boundary
-            # loses the trace (#515 / the #305 "not followed by another lap" class).
+            # loses the trace (#515 / the #305 "not followed by another lap" class). The evidence
+            # poll gates on report.lap_grace_applied, this exact boolean, so the two never diverge.
             await asyncio.sleep(config.lap_finalize_grace_s)
     except Exception as exc:  # noqa: BLE001 - surface any tap/eval failure as a FAIL report
         stage, error = "pipeline", f"{type(exc).__name__}: {exc}"
@@ -517,6 +526,7 @@ async def run_auto_drive(
         hijacked=True,
         drive=stats,
         sequence_ok=seq_ok,
+        lap_grace_applied=grace_applied,
         counts=counts,
         notes=notes,
         error=error,
@@ -2130,17 +2140,16 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     # diverge (#515 review). The async writer finalizes just after that frame, so wait briefly
     # rather than racing to []. On a fresh profile journal/laps may not exist until the writer
     # creates it, so poll the deterministic known path when discovery finds nothing yet.
-    produced_lap = bool(report.counts.get("lap"))
     journal_dir = discover_journal_laps_dir(user_dir) or known_journal_laps_dir(user_dir)
-    # The grace-drive is what finalizes the archive, so only wait when the grace actually ran, and
-    # bind the poll timeout to it — `--lap-finalize-grace-s 0` disables the grace and must NOT then
-    # hang the poll on an archive that will never arrive (#516 review).
-    grace = config.lap_finalize_grace_s
+    # Only wait when the grace-drive ACTUALLY ran — gate on the single flag run_auto_drive set
+    # (report.lap_grace_applied), not a re-derived condition, so the grace and the poll can never
+    # disagree (#516 review). On a fresh profile journal/laps may not exist until the async writer
+    # creates it, so poll the deterministic known path. No grace-drive => single scan, no hang.
     lap_archives = collect_lap_archives(
         journal_dir,
         run_started_epoch,
-        wait_for_first=produced_lap and grace > 0,
-        timeout_s=grace + 2.0,
+        wait_for_first=report.lap_grace_applied,
+        timeout_s=config.lap_finalize_grace_s + 2.0,
     )
     extras = {
         "run": {

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2183,15 +2183,18 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     # The grace-drive already elapsed synchronously in run_auto_drive, so by here the writer has
     # streamed the trace; this poll only awaits the OS flush/rename — a short CONSTANT timeout, not
     # one scaled to the in-sim grace time (#516 review). collect_lap_archives' default covers it.
-    journal_dir = discover_journal_laps_dir(user_dir)
+    # journal_dir=None (not a pinned initial discover): an initial discover can return a STALE
+    # leftover dir (old/renamed install) while the current writer creates the canonical one moments
+    # later — pinning would poll the wrong path (#516 review). Re-resolving each scan follows the
+    # writer to the canonical dir (discover prefers the known path over the bounded glob fallback);
+    # stale old files there are excluded by the since_epoch mtime gate.
     lap_archives = collect_lap_archives(
-        journal_dir,
+        None,
         run_started_epoch,
         resolve=lambda: discover_journal_laps_dir(user_dir),
         wait_for_first=report.lap_grace_applied,
     )
-    # Re-discover for the report path: the writer may have created the dir during the poll.
-    journal_dir = journal_dir or discover_journal_laps_dir(user_dir)
+    journal_dir = discover_journal_laps_dir(user_dir)  # for the report path (post-poll)
     extras = {
         "run": {
             "started_epoch": run_started_epoch,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1167,6 +1167,7 @@ def collect_lap_archives(
     journal_dir: Path | None,
     since_epoch: float,
     *,
+    resolve: Callable[[], Path | None] | None = None,
     wait_for_first: bool = False,
     timeout_s: float = 8.0,
     poll_s: float = 0.5,
@@ -1184,15 +1185,23 @@ def collect_lap_archives(
     With ``wait_for_first`` (set when the run produced a lap) this polls up to ``timeout_s`` for the
     first archive to appear instead of racing the writer; it returns as soon as one exists, and
     returns immediately with no wait when ``wait_for_first`` is false (a run that produced no lap).
+
+    When ``journal_dir`` is ``None`` and ``resolve`` is given, the dir is **re-resolved each scan**
+    via ``resolve()`` — so a fresh-profile dir that the writer creates mid-poll is picked up at its
+    actual path (default OR a renamed install), rather than watching a hardcoded path (#516 review).
     ``_clock``/``_sleep`` are injectable so the poll is deterministic in off-sim tests.
     """
-    found = _scan_lap_archives(journal_dir, since_epoch)
+
+    def _current() -> Path | None:
+        return journal_dir if journal_dir is not None else (resolve() if resolve else None)
+
+    found = _scan_lap_archives(_current(), since_epoch)
     if found or not wait_for_first:
         return found
     deadline = _clock() + max(0.0, timeout_s)
     while _clock() < deadline:
         _sleep(max(0.0, poll_s))
-        found = _scan_lap_archives(journal_dir, since_epoch)
+        found = _scan_lap_archives(_current(), since_epoch)
         if found:
             return found
     return found
@@ -2140,17 +2149,21 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     # diverge (#515 review). The async writer finalizes just after that frame, so wait briefly
     # rather than racing to []. On a fresh profile journal/laps may not exist until the writer
     # creates it, so poll the deterministic known path when discovery finds nothing yet.
-    journal_dir = discover_journal_laps_dir(user_dir) or known_journal_laps_dir(user_dir)
     # Only wait when the grace-drive ACTUALLY ran — gate on the single flag run_auto_drive set
     # (report.lap_grace_applied), not a re-derived condition, so the grace and the poll can never
     # disagree (#516 review). On a fresh profile journal/laps may not exist until the async writer
-    # creates it, so poll the deterministic known path. No grace-drive => single scan, no hang.
+    # creates it — pass a re-discovering resolver so the poll finds it at its real path (default or
+    # renamed install), not a hardcoded one. No grace-drive => single scan, no hang.
+    journal_dir = discover_journal_laps_dir(user_dir)
     lap_archives = collect_lap_archives(
         journal_dir,
         run_started_epoch,
+        resolve=lambda: discover_journal_laps_dir(user_dir),
         wait_for_first=report.lap_grace_applied,
         timeout_s=config.lap_finalize_grace_s + 2.0,
     )
+    # Re-discover for the report path: the writer may have created the dir during the poll.
+    journal_dir = journal_dir or discover_journal_laps_dir(user_dir)
     extras = {
         "run": {
             "started_epoch": run_started_epoch,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -441,7 +441,16 @@ async def run_auto_drive(
         )
 
     stop = threading.Event()
-    drive_task = asyncio.create_task(asyncio.to_thread(drive, controller, config, stop))
+    # The drive thread self-terminates on its own drive_seconds budget (rig_drive), and on exit it
+    # BRAKES the car. If a lap lands within lap_finalize_grace_s of that budget, the post-lap grace
+    # below would run against an already-stopped car and the trace would not finalize (#515 boundary
+    # case). Give the drive thread grace headroom so it keeps driving through the grace.
+    drive_config = config
+    if config.wait_lap and config.lap_finalize_grace_s > 0:
+        drive_config = replace(
+            config, drive_seconds=config.drive_seconds + config.lap_finalize_grace_s
+        )
+    drive_task = asyncio.create_task(asyncio.to_thread(drive, controller, drive_config, stop))
     stats = DriveStats(reason="drive did not run")
     seq_ok: bool | None = None
     counts: dict[str, int] = {}

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -141,6 +141,10 @@ class AutoDriveConfig:
     # Stall recovery (#459 Part D).
     progress_stall_seconds: float = 10.0  # no forward progress for this long => recover
     max_recoveries: int = 6  # then FAIL honestly instead of teleport-looping
+    # Keep driving this long past S/F after the lap frame so the trainer's async lap-archive writer
+    # (#246/#249) finalizes lap 1's trace over the following frames before teardown; stopping at the
+    # exact boundary loses the archive (#515 / the #305 "not followed by another lap" class).
+    lap_finalize_grace_s: float = 8.0
     spawn_to_line: bool = True  # teleport onto the racing line when spawned off it (pit box)
     # Keep race.ini setup keys present during the CM launch window. CM regenerates race.ini while
     # launching; a short-lived Documents-only re-bake loop preserves the selected setup without
@@ -462,6 +466,12 @@ async def run_auto_drive(
         seq_ok = result.ok
         counts = dict(result.counts)
         notes = list(result.notes)
+        if config.wait_lap and counts.get("lap") and config.lap_finalize_grace_s > 0:
+            # The drive thread is still running here (stop not yet set), so the car keeps driving
+            # past S/F while the trainer's async writer (#246/#249) streams + finalizes lap 1's
+            # archive over the following frames. Without this, stopping at the exact lap boundary
+            # loses the trace (#515 / the #305 "not followed by another lap" class).
+            await asyncio.sleep(config.lap_finalize_grace_s)
     except Exception as exc:  # noqa: BLE001 - surface any tap/eval failure as a FAIL report
         stage, error = "pipeline", f"{type(exc).__name__}: {exc}"
     finally:
@@ -1902,6 +1912,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--ggv-scale", type=float, default=0.9, help="ggv: safety margin on min-time")
     p.add_argument("--max-speed", type=float, default=240.0, help="racing/ggv: speed cap (km/h)")
     p.add_argument("--drive-seconds", type=float, default=300.0)
+    p.add_argument(
+        "--lap-finalize-grace-s",
+        type=float,
+        default=8.0,
+        help="drive this long past S/F after the lap so the async archive writer finalizes (#515)",
+    )
     p.add_argument("--target-speed", type=float, default=55.0, help="cruise target speed (km/h)")
     p.add_argument("--min-corner", type=float, default=30.0, help="cruise min corner speed (km/h)")
     p.add_argument("--tap-seconds", type=float, default=30.0)
@@ -1980,6 +1996,7 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         ggv_scale=args.ggv_scale,
         racing_max_speed_kmh=args.max_speed,
         drive_seconds=args.drive_seconds,
+        lap_finalize_grace_s=args.lap_finalize_grace_s,
         target_speed_kmh=args.target_speed,
         min_corner_speed_kmh=args.min_corner,
         tap_seconds=args.tap_seconds,


### PR DESCRIPTION
Closes #515. Surfaced by the live SF-26 @ Silverstone GP verification of EPIC #154: `report.lap_archives` came back `[]` on a `--wait-lap` run with `drive.laps=1`, while a real **2.2 MB** lap trace was on disk.

**Root cause (the scan already existed):** the trainer finalizes each lap trace with an async deferred writer (#246/#249) — temp file → atomic rename to `lap_*.json` **after** the `lap` WS frame the tap returns on. So `collect_lap_archives` globbed `lap_*.json` before the finalized file existed → false-empty.

**Fix:** bounded grace-poll in `collect_lap_archives` (`wait_for_first`/`timeout_s`/`poll_s`, injectable clock+sleep), gated in `_main` on `report.drive.laps` so a no-lap run returns immediately (no wait). Pure scan split into `_scan_lap_archives`.

**Tests:** 5 off-sim (waits-then-finds via injected clock/sleep, bounded timeout, no-wait path never sleeps, present-first skips the poll, existing mtime filter preserved). `make ci-fast: OK`. Rig re-verify (populated `lap_archives` on a live driven lap) to follow on the PR.