### PR TITLE
feat(voice): tablet coaching-audio endpoint over USB + audible-latency harness (#511 Part D, #381)

### DIFF
--- a/docs/10_Development/12_WS_Sidecar_Protocol.md
+++ b/docs/10_Development/12_WS_Sidecar_Protocol.md
@@ -137,6 +137,27 @@ Optional fields:
 
 The loopback ack is `session.review.result` with local `markdown_path`, `json_path`, and `html_path` plus `reference` / `reference_selection` metadata. External `session.review` snapshots and `coaching.cue` details redact host paths to `markdown_file`, `json_file`, and `html_file` basenames while preserving the reference metadata.
 
+## Tablet voice endpoint (issue #511 Part D)
+
+Additive surface for a remote coaching-audio endpoint (7" tablet page over `adb reverse`):
+
+- Topic `coaching.voice` (sidecar-produced, subscribable like `coaching.cue`): one
+  `state.snapshot` frame per clip the in-process VoiceCoach scheduler **actually dispatched**
+  (post cooldown/dedup/barge-in), payload
+  `{seq, clip_id, kind, urgency, register, corner, text, duration_ms, t_wall_ms, t_mono_ms}`.
+  A remote endpoint plays exactly what the in-ear coach speaks — it never re-arbitrates.
+- client → sidecar `{"v":1,"type":"voice.echo","seq":N,"clip_id":"…","t_dispatch_ms":…,"t_receive_ms":…}`
+  (optional `t_play_ms`, `buffer_state` ∈ preloaded/decoded/missing, `audio_armed`): per-cue
+  client timestamps, recorded server-side for the audible-latency harness. Never relayed.
+- loopback-only `{"v":1,"type":"voice.demo","kind":"late_brake","urgency":"act","register":"critical"}`
+  (optional `corner`, `message`): injects one synthetic advisory through the REAL voice path
+  (scheduler → dispatch tap → `coaching.voice`). Bench entrypoint for #381 timeliness runs.
+- HTTP on the same port (read-only, ungated like `/health`): `/tablet/voice` (self-contained
+  page), `/voice/manifest.json`, `/voice/clips/<file>` (exact-match against the bank manifest
+  allow-list — no traversal), `/voice/dispatches`, `/voice/echoes` (bounded ring buffers).
+
+Full runbook + measurement methodology: [19_Tablet_Voice_Endpoint.md](19_Tablet_Voice_Endpoint.md).
+
 ## Tests
 
-`tests/test_ai_sidecar_protocol.py` — `prepare_outbound_message` unit tests and asyncio WebSocket round-trip (requires `websockets`). `tests/test_llm_coach.py` — Ollama debrief helpers with mocked HTTP (issue **#46**).
+`tests/test_ai_sidecar_protocol.py` — `prepare_outbound_message` unit tests and asyncio WebSocket round-trip (requires `websockets`). `tests/test_llm_coach.py` — Ollama debrief helpers with mocked HTTP (issue **#46**). `tests/test_voice_tablet_endpoint.py` — coaching.voice/voice.echo/voice.demo protocol, dispatch tap, and tablet HTTP routes. `tests/test_audible_latency.py` — matched-filter + clock-map math on synthetic room recordings.

--- a/docs/10_Development/19_Tablet_Voice_Endpoint.md
+++ b/docs/10_Development/19_Tablet_Voice_Endpoint.md
@@ -1,0 +1,87 @@
+# Tablet voice endpoint + audible-latency harness
+
+**Status:** Active
+**Owns:** the remote coaching-audio endpoint (issue [#511](https://github.com/agorokh/ac-copilot-trainer/issues/511) Part D) and the end-to-end audible-timeliness measurement (issue [#381](https://github.com/agorokh/ac-copilot-trainer/issues/381) verification).
+**Protocol reference:** [12_WS_Sidecar_Protocol.md](12_WS_Sidecar_Protocol.md) § Tablet voice endpoint.
+
+## Why
+
+The in-ear coach's hot path is proven off-sim (emit→dispatch asserted in CI), but "how timely
+is it *in the ear*" needs a real room: WS hop + endpoint audio stack + speaker→ear. The rig PC
+has no microphone; the 7" Android dashboard tablet (PRITOM P7, #511) provides both halves over
+one USB cable — its **mic** becomes the PC's room capture (scrcpy), and its **audio jack**
+becomes the coaching output (earpiece), which also separates coaching from PC-speaker
+engine/game noise.
+
+## Architecture (one paragraph)
+
+The sidecar's `VoiceCoach` playback is wrapped in a dispatch tap
+(`tools/ai_sidecar/voice/dispatch.py`): every clip the scheduler actually dispatches is
+broadcast as a `coaching.voice` frame stamped `t_wall_ms` at dispatch. The tablet opens
+`http://127.0.0.1:8765/tablet/voice` (reached over `adb reverse`), preloads every bank clip
+into WebAudio buffers, plays each `coaching.voice` frame (seq-based barge-in, silent-loop HAL
+keep-warm), and reports `voice.echo` timestamps back. The tablet never re-arbitrates cues —
+the PC scheduler stays the single arbiter (pre-baked-bank + one-arbiter invariants hold).
+
+## Runbook — coaching in the earpiece (operator)
+
+1. Tablet plugged into the rig PC via USB, USB debugging ON (one-time "Allow" tap).
+2. On the PC (adb from `Google.PlatformTools` winget package):
+
+   ```powershell
+   adb reverse tcp:8765 tcp:8765
+   ```
+
+3. Start the sidecar with voice configured as usual (Game Point launcher or harness;
+   `AC_COPILOT_VOICE_BANK` + `AC_COPILOT_REFERENCE_ARCHIVE`).
+4. On the tablet open `http://127.0.0.1:8765/tablet/voice` (Chrome or Fully Kiosk start URL).
+5. Plug the earpiece into the tablet, tap **TAP TO ARM AUDIO** once.
+6. Drive. Status pills show WS/audio/clip state; the big tile shows the last spoken cue.
+
+No WiFi is involved — `adb reverse` carries the socket over the cable, which sidesteps both
+the mesh cross-AP TCP block and the tablet's 2.4 GHz/CGNAT limitation (#511).
+
+## Runbook — audible-latency measurement (#381)
+
+The harness records the room via the tablet mic, anchors the recording to the PC wall clock
+with start/end chirps (5→15 kHz, DAC-stamped via PortAudio callback), matched-filters each
+dispatched clip's own waveform out of the recording, and reports
+`audible_latency_ms = acoustic onset − dispatch stamp` per cue with P50/P95/max.
+
+For the measurement run play the tablet on its **speaker** (the mic must hear the cues);
+switch to the earpiece for the operator run.
+
+```powershell
+# bench burst — full path, no sim needed (voice.demo cues through the real scheduler)
+python -m tools.ai_sidecar.voice.audible_latency run `
+  --bank $env:AC_COPILOT_VOICE_BANK --out-dir .scratch\audible-latency `
+  --burst 12 --scrcpy <path-to-scrcpy.exe>
+
+# drive mode — passive window while the autonomous harness (18_Autonomous_Harness.md) drives
+python -m tools.ai_sidecar.voice.audible_latency run `
+  --bank $env:AC_COPILOT_VOICE_BANK --out-dir .scratch\audible-latency-drive `
+  --observe-seconds 300 --scrcpy <path-to-scrcpy.exe>
+```
+
+Artifacts land in `--out-dir`: `room_capture.wav`, `dispatches.json`, `echoes.json`,
+`chirps.json`, `audible_latency.json` + `audible_latency.md` (per-cue table + assertions).
+Exit code 0 iff the clock map anchored, every dispatched cue was acoustically located, and
+act cues (+ stated systematic uncertainty) fit the 450 ms budget.
+
+### Honesty notes
+
+- The chirp anchor carries the PC output-path estimate; the report states the systematic
+  uncertainty (±15 ms with DAC stamps, ±60 ms without) rather than hiding it.
+- Cross-device clocks are never subtracted: tablet-clock intervals (`t_play − t_receive`) and
+  server-clock intervals (echo RTT) are reported separately.
+- An unmatched cue is a FAILED assertion, not a dropped row — silence must never read as
+  timely.
+
+## Known limits (v1)
+
+- The tablet page assumes a no-token loopback WS (the `adb reverse` deployment); a token gate
+  on a non-loopback bind would need a page-side token input (browser WS cannot set headers).
+- WebAudio output latency on the P7 is measured, not assumed; if the drive-mode median audio
+  stack exceeds ~150 ms or σ > 40 ms, the fallback is Fully Kiosk's native player (council
+  recommendation, 2026-07-11).
+- scrcpy audio capture needs Android 11+ (P7 is Android 13 Go).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,8 @@ include = ["ac_copilot_trainer*", "tools*"]
 [tool.setuptools.package-data]
 # Ship the native-OCR PowerShell helper so TrackTitanScreenOracle resolves it in wheel/non-editable installs.
 "tools.ai_sidecar" = ["*.ps1"]
+# Ship the tablet voice endpoint page so /tablet/voice works in wheel/non-editable installs (#511 Part D).
+"tools.ai_sidecar.voice" = ["web/*.html"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_audible_latency.py
+++ b/tests/test_audible_latency.py
@@ -169,6 +169,128 @@ def test_unmatched_cue_fails_assertions_not_silently(tmp_path: Path) -> None:
     assert not report.assertions["act_cues_within_budget"]
 
 
+def test_same_clip_repeats_do_not_cross_assign_onsets(tmp_path: Path) -> None:
+    """Two dispatches of the SAME clip inside one search window must each match their own
+    acoustic instance (onset consumption), never both lock onto the later/louder one
+    (PR #519 adversarial review)."""
+    bake_bank(tmp_path, ToneBackend())
+    manifest = Manifest.load(tmp_path / MANIFEST_FILENAME)
+    bank = Bank.from_manifest(manifest, tmp_path)
+    clip_id = "late_brake.act.critical.generic"
+    clip = np.asarray(bank.get(clip_id), dtype=np.float64)
+
+    chirp = al.make_chirp(SR, np)
+    recording = 0.04 * RNG.standard_normal(SR * 10)
+    w0 = 100_000.0
+    _place(recording, chirp, SR)
+    # Two acoustic instances of the SAME clip, 1.5 s apart; the second slightly louder.
+    a_at = SR + 2 * SR
+    b_at = a_at + int(1.5 * SR)
+    _place(recording, clip, a_at, gain=0.5)
+    _place(recording, clip, b_at, gain=0.7)
+    rec_path = tmp_path / "room.wav"
+    _write_wav(rec_path, recording)
+
+    dispatches = [
+        {
+            "seq": 1,
+            "clip_id": clip_id,
+            "kind": "late_brake",
+            "urgency": "act",
+            "register": "critical",
+            "t_wall_ms": w0 + 2_000.0 - 150.0,
+        },
+        {
+            "seq": 2,
+            "clip_id": clip_id,
+            "kind": "late_brake",
+            "urgency": "act",
+            "register": "critical",
+            "t_wall_ms": w0 + 3_500.0 - 150.0,
+        },
+    ]
+    report = al.analyze(
+        recording_path=rec_path,
+        bank_dir=tmp_path,
+        dispatches=dispatches,
+        chirps=[al.ChirpMark("start", w0, w0, 10.0)],
+    )
+    lats = [c.audible_latency_ms for c in report.cues]
+    assert all(c.matched for c in report.cues), lats
+    # Each cue matched its OWN instance: ~150 ms each, not ~1650 ms for the first.
+    assert lats[0] == pytest.approx(150.0, abs=20.0)
+    assert lats[1] == pytest.approx(150.0, abs=20.0)
+
+
+def test_missed_end_chirp_fails_drift_assertion(tmp_path: Path) -> None:
+    """When two chirps were played but only one is locatable, the run must FAIL loudly
+    (clock_map_drift_corrected=False), never silently fall back (PR #519 review)."""
+    bake_bank(tmp_path, ToneBackend())
+    chirp = al.make_chirp(SR, np)
+    recording = 0.04 * RNG.standard_normal(SR * 8)
+    w0 = 50_000.0
+    _place(recording, chirp, SR)  # start chirp only — the end chirp never made it
+    rec_path = tmp_path / "room.wav"
+    _write_wav(rec_path, recording)
+    report = al.analyze(
+        recording_path=rec_path,
+        bank_dir=tmp_path,
+        dispatches=[],
+        chirps=[
+            al.ChirpMark("start", w0, w0, 10.0),
+            al.ChirpMark("end", w0 + 6_000.0, w0 + 6_000.0, 10.0),
+        ],
+    )
+    assert report.clock_map["anchors_used"] == 1
+    assert report.assertions["clock_map_drift_corrected"] is False
+
+
+def test_burst_count_assertion_fails_on_suppressed_cues(tmp_path: Path) -> None:
+    """Burst mode must assert every injected cue was dispatched — scheduler suppression
+    silently shrinking the sample is a FAIL, not a smaller PASS (PR #519 review)."""
+    bake_bank(tmp_path, ToneBackend())
+    manifest = Manifest.load(tmp_path / MANIFEST_FILENAME)
+    bank = Bank.from_manifest(manifest, tmp_path)
+    clip_id = "late_brake.act.critical.generic"
+    clip = np.asarray(bank.get(clip_id), dtype=np.float64)
+    chirp = al.make_chirp(SR, np)
+    recording = 0.04 * RNG.standard_normal(SR * 8)
+    w0 = 70_000.0
+    _place(recording, chirp, SR)
+    _place(recording, clip, 3 * SR)
+    rec_path = tmp_path / "room.wav"
+    _write_wav(rec_path, recording)
+    dispatches = [
+        {
+            "seq": 1,
+            "clip_id": clip_id,
+            "kind": "late_brake",
+            "urgency": "act",
+            "register": "critical",
+            "t_wall_ms": w0 + 2_000.0 - 150.0,
+        },
+    ]
+    report = al.analyze(
+        recording_path=rec_path,
+        bank_dir=tmp_path,
+        dispatches=dispatches,
+        chirps=[al.ChirpMark("start", w0, w0, 10.0)],
+        expected_dispatches=3,  # 3 injected, only 1 dispatched
+    )
+    assert report.assertions["all_burst_cues_dispatched"] is False
+
+
+def test_http_get_json_rejects_lookalike_loopback_hosts() -> None:
+    for bad in [
+        "http://127.0.0.1.evil.example/voice/dispatches",
+        "http://localhost.evil.example/voice/dispatches",
+        "https://127.0.0.1:8765/voice/dispatches",  # https ≠ the loopback sidecar
+        "http://192.168.1.10:8765/voice/dispatches",
+    ]:
+        with pytest.raises(ValueError):
+            al._http_get_json(bad)
+
+
 def test_filter_dispatches_to_window() -> None:
     """Only cues dispatched inside THIS run's chirp-bounded window are analyzed — the ring
     buffer spans the whole sidecar process (PR #519 review)."""

--- a/tests/test_audible_latency.py
+++ b/tests/test_audible_latency.py
@@ -1,0 +1,235 @@
+"""Audible-latency harness math tests (issue #381 verification / #511 Part D).
+
+All synthetic: a fabricated room recording (noise + known chirp + known clip waveform at
+known offsets) must yield a clock map and per-cue onsets within tight tolerance, and the
+matched filter must REFUSE to invent onsets that are not there. No audio hardware, no
+scrcpy — the capture orchestration is exercised live on the rig, not in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import wave
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from tools.ai_sidecar.voice import audible_latency as al  # noqa: E402
+from tools.ai_sidecar.voice.bake import ToneBackend, bake_bank  # noqa: E402
+from tools.ai_sidecar.voice.manifest import MANIFEST_FILENAME, Manifest  # noqa: E402
+from tools.ai_sidecar.voice.playback import Bank  # noqa: E402
+
+SR = 48_000
+RNG = np.random.default_rng(20260711)
+
+
+def _write_wav(path: Path, signal: np.ndarray, sr: int = SR) -> None:
+    pcm = (np.clip(signal, -1.0, 1.0) * 32767.0).astype("<i2")
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        wf.writeframes(pcm.tobytes())
+
+
+def _place(recording: np.ndarray, signal: np.ndarray, at: int, gain: float = 0.6) -> None:
+    recording[at : at + len(signal)] += gain * signal[: len(recording) - at]
+
+
+def test_chirp_is_locatable_in_noise() -> None:
+    chirp = al.make_chirp(SR, np)
+    recording = 0.05 * RNG.standard_normal(SR * 6)
+    _place(recording, chirp, 2 * SR)
+    onset, score, prom = al.find_onset(recording, chirp, np)
+    assert onset is not None
+    assert abs(onset - 2 * SR) <= 48  # within 1 ms
+    assert score > 0.5
+    assert prom > al.MATCH_MIN_PROMINENCE
+
+
+def test_find_onset_refuses_absent_template() -> None:
+    chirp = al.make_chirp(SR, np)
+    noise = 0.05 * RNG.standard_normal(SR * 4)
+    onset, _score, _prom = al.find_onset(noise, chirp, np)
+    assert onset is None
+
+
+def test_clock_map_two_anchor_drift_fit() -> None:
+    chirp = al.make_chirp(SR, np)
+    recording = 0.03 * RNG.standard_normal(SR * 14)
+    _place(recording, chirp, SR)
+    _place(recording, chirp, 12 * SR)
+    w0 = 1_000_000.0
+    marks = [
+        al.ChirpMark("start", w0, w0, 10.0),
+        al.ChirpMark("end", w0 + 11_000.0, w0 + 11_000.0, 10.0),
+    ]
+    clock_map, detail = al.build_clock_map(recording, SR, marks, np)
+    assert {d["label"] for d in detail} == {"start", "end"}
+    # 11 s of wall clock over exactly 11 s of samples -> nominal slope.
+    assert clock_map.wall_ms(SR) == pytest.approx(w0, abs=2.0)
+    assert clock_map.wall_ms(12 * SR) == pytest.approx(w0 + 11_000.0, abs=2.0)
+
+
+def test_clock_map_requires_a_chirp() -> None:
+    with pytest.raises(ValueError):
+        al.build_clock_map(0.01 * RNG.standard_normal(SR), SR, [al.ChirpMark("start", 0, 0, 0)], np)
+
+
+def test_end_to_end_analysis_on_synthetic_room(tmp_path: Path) -> None:
+    bake_bank(tmp_path, ToneBackend())
+    manifest = Manifest.load(tmp_path / MANIFEST_FILENAME)
+    bank = Bank.from_manifest(manifest, tmp_path)
+    clip_id = "late_brake.act.critical.generic"
+    clip = np.asarray(bank.get(clip_id), dtype=np.float64)
+    assert bank.samplerate == SR, "test assumes the baked bank is 48 kHz"
+
+    chirp = al.make_chirp(SR, np)
+    recording = 0.04 * RNG.standard_normal(SR * 10)
+    w0 = 5_000_000.0
+    chirp_at = SR  # 1 s in -> wall w0
+    _place(recording, chirp, chirp_at)
+    # True acoustic onset 3.0 s after the chirp -> wall w0 + 3000 ms.
+    clip_at = chirp_at + 3 * SR
+    _place(recording, clip, clip_at)
+    rec_path = tmp_path / "room.wav"
+    _write_wav(rec_path, recording)
+
+    # Dispatch stamped 180 ms before the acoustic onset -> expected latency ~180 ms.
+    dispatches = [
+        {
+            "seq": 1,
+            "clip_id": clip_id,
+            "kind": "late_brake",
+            "urgency": "act",
+            "register": "critical",
+            "t_wall_ms": w0 + 3_000.0 - 180.0,
+        }
+    ]
+    echoes = [
+        {
+            "seq": 1,
+            "clip_id": clip_id,
+            "t_dispatch_ms": w0 + 2_820.0,
+            "t_receive_ms": 42.0,
+            "t_play_ms": 54.0,
+            "t_server_ms": w0 + 2_828.0,
+        }
+    ]
+    report = al.analyze(
+        recording_path=rec_path,
+        bank_dir=tmp_path,
+        dispatches=dispatches,
+        chirps=[al.ChirpMark("start", w0, w0, 12.0)],
+        echoes=echoes,
+    )
+    assert report.assertions["clock_map_anchored"]
+    cue = report.cues[0]
+    assert cue.matched, f"cue unmatched (score={cue.match_score}, prom={cue.match_prominence})"
+    assert cue.audible_latency_ms == pytest.approx(180.0, abs=15.0)
+    assert cue.rtt_ms == pytest.approx(8.0, abs=0.1)
+    assert cue.js_play_ms == pytest.approx(12.0, abs=0.1)
+    assert report.assertions["all_dispatched_cues_matched"]
+    assert report.assertions["act_cues_within_budget"]
+    assert report.stats["act_latency_ms"]["n"] == 1
+
+    md = al.render_markdown(report)
+    assert clip_id in md
+    assert "Systematic uncertainty" in md
+
+
+def test_unmatched_cue_fails_assertions_not_silently(tmp_path: Path) -> None:
+    bake_bank(tmp_path, ToneBackend())
+    chirp = al.make_chirp(SR, np)
+    recording = 0.04 * RNG.standard_normal(SR * 6)
+    w0 = 1_000.0
+    _place(recording, chirp, SR)
+    rec_path = tmp_path / "room.wav"
+    _write_wav(rec_path, recording)
+    dispatches = [
+        {
+            "seq": 1,
+            "clip_id": "late_brake.act.critical.generic",
+            "kind": "late_brake",
+            "urgency": "act",
+            "register": "critical",
+            "t_wall_ms": w0 + 2_000.0,  # dispatched, but the clip never sounded
+        }
+    ]
+    report = al.analyze(
+        recording_path=rec_path,
+        bank_dir=tmp_path,
+        dispatches=dispatches,
+        chirps=[al.ChirpMark("start", w0, w0, 12.0)],
+    )
+    assert not report.cues[0].matched
+    assert not report.assertions["all_dispatched_cues_matched"]
+    assert not report.assertions["act_cues_within_budget"]
+
+
+def test_analyze_cmd_round_trip(tmp_path: Path) -> None:
+    """The CLI analyze path parses the run artifacts it writes (shape contract)."""
+    bake_bank(tmp_path, ToneBackend())
+    manifest = Manifest.load(tmp_path / MANIFEST_FILENAME)
+    bank = Bank.from_manifest(manifest, tmp_path)
+    clip_id = "late_brake.act.critical.generic"
+    clip = np.asarray(bank.get(clip_id), dtype=np.float64)
+    chirp = al.make_chirp(SR, np)
+    recording = 0.04 * RNG.standard_normal(SR * 8)
+    w0 = 9_000.0
+    _place(recording, chirp, SR)
+    _place(recording, clip, SR + 2 * SR)
+    rec = tmp_path / "room.wav"
+    _write_wav(rec, recording)
+    (tmp_path / "dispatches.json").write_text(
+        json.dumps(
+            {
+                "dispatches": [
+                    {
+                        "seq": 1,
+                        "clip_id": clip_id,
+                        "kind": "late_brake",
+                        "urgency": "act",
+                        "register": "critical",
+                        "t_wall_ms": w0 + 2_000.0 - 150.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "chirps.json").write_text(
+        json.dumps(
+            [
+                {
+                    "label": "start",
+                    "t_wall_ms": w0,
+                    "t_dac_wall_ms": w0,
+                    "output_latency_ms": 10.0,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "out"
+    rc = al.main(
+        [
+            "analyze",
+            "--bank",
+            str(tmp_path),
+            "--out-dir",
+            str(out_dir),
+            "--recording",
+            str(rec),
+            "--dispatches",
+            str(tmp_path / "dispatches.json"),
+            "--chirps",
+            str(tmp_path / "chirps.json"),
+        ]
+    )
+    assert rc == 0
+    report = json.loads((out_dir / "audible_latency.json").read_text(encoding="utf-8"))
+    assert report["cues"][0]["matched"] is True
+    assert (out_dir / "audible_latency.md").exists()

--- a/tests/test_audible_latency.py
+++ b/tests/test_audible_latency.py
@@ -169,6 +169,26 @@ def test_unmatched_cue_fails_assertions_not_silently(tmp_path: Path) -> None:
     assert not report.assertions["act_cues_within_budget"]
 
 
+def test_filter_dispatches_to_window() -> None:
+    """Only cues dispatched inside THIS run's chirp-bounded window are analyzed — the ring
+    buffer spans the whole sidecar process (PR #519 review)."""
+    chirps = [
+        al.ChirpMark("start", 10_000.0, 10_000.0, 5.0),
+        al.ChirpMark("end", 40_000.0, 40_000.0, 5.0),
+    ]
+    dispatches = [
+        {"seq": 1, "t_wall_ms": 5_000.0},  # earlier sidecar activity — dropped
+        {"seq": 2, "t_wall_ms": 10_100.0},  # in window — kept
+        {"seq": 3, "t_wall_ms": 39_900.0},  # in window — kept
+        {"seq": 4, "t_wall_ms": 55_000.0},  # after the capture — dropped
+        {"seq": 5},  # no stamp — dropped
+    ]
+    kept = al.filter_dispatches_to_window(dispatches, chirps)
+    assert [d["seq"] for d in kept] == [2, 3]
+    # No chirps (analysis-only edge) -> passthrough rather than dropping everything.
+    assert al.filter_dispatches_to_window(dispatches, []) == dispatches
+
+
 def test_analyze_cmd_round_trip(tmp_path: Path) -> None:
     """The CLI analyze path parses the run artifacts it writes (shape contract)."""
     bake_bank(tmp_path, ToneBackend())

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -306,12 +306,15 @@ def test_wire_voice_bank_uses_env_audio_routing(tmp_path, monkeypatch):
         def start(self) -> None:
             seen["started"] = True
 
-    def fake_from_bank(bank_dir, config, *, backend):  # noqa: ANN001
+    def fake_from_bank(bank_dir, config, *, backend, dispatch_listener=None):  # noqa: ANN001
         seen["bank_dir"] = bank_dir
         seen["backend"] = backend
         seen["device_name"] = config.device_name
         seen["host_api"] = config.host_api
         seen["verbosity"] = config.verbosity.name.lower()
+        # Issue #511 Part D: the server wires its dispatch listener so remote voice
+        # endpoints receive coaching.voice broadcasts.
+        seen["dispatch_listener"] = dispatch_listener is server._on_voice_dispatch
         return _Coach()
 
     server.set_voice_coach(None)
@@ -335,6 +338,7 @@ def test_wire_voice_bank_uses_env_audio_routing(tmp_path, monkeypatch):
         "device_name": "USB Sound Device",
         "host_api": "Windows DirectSound",
         "verbosity": "high",
+        "dispatch_listener": True,
         "started": True,
     }
 

--- a/tests/test_voice_tablet_endpoint.py
+++ b/tests/test_voice_tablet_endpoint.py
@@ -162,6 +162,22 @@ def test_dispatch_tap_listener_fault_never_breaks_audio() -> None:
     assert len(inner.played) == 1  # audio path wins
 
 
+def test_dispatch_tap_suppresses_event_for_bank_skipped_clip() -> None:
+    """A bank-backed backend silently skips a missing/sha-bad clip; the tap must not
+    broadcast a dispatch for audio that never sounded (PR #519 review). A tap WITHOUT a
+    duration lookup (injected test double) keeps emitting — it has no bank to consult."""
+    inner = RecordingPlayback()
+    events: list[VoiceDispatch] = []
+    tap = DispatchTapPlayback(inner, events.append, duration_lookup=lambda _cid: None)
+    tap.play(_utterance())
+    assert len(inner.played) == 1  # playback path untouched (backend logs its own skip)
+    assert events == []  # but nothing is broadcast for silence
+
+    bare = DispatchTapPlayback(RecordingPlayback(), events.append)
+    bare.play(_utterance())
+    assert len(events) == 1  # no lookup -> no bank knowledge -> emit as before
+
+
 def test_dispatch_tap_no_event_when_backend_raises() -> None:
     class _Boom:
         current = None

--- a/tests/test_voice_tablet_endpoint.py
+++ b/tests/test_voice_tablet_endpoint.py
@@ -308,6 +308,29 @@ def test_http_dispatch_and_echo_logs() -> None:
     assert e["echoes"][-1]["seq"] == 9
 
 
+def test_rewire_disarms_stale_bank_but_serve_start_reset_does_not(tmp_path: Path) -> None:
+    """PR #519 review (self-hosted MEDIUM): a re-wire with voice disabled must stop serving
+    the previous bank's clips. The fix lives in ``_wire_voice`` (+ ``_run`` teardown), NOT in
+    ``_reset_external_state`` — main() wires voice BEFORE the serve loop runs the reset, so a
+    reset-side clear would disarm a freshly-armed endpoint (the ordering trap)."""
+    bake_bank(tmp_path, ToneBackend())
+    server._set_voice_web_bank(tmp_path)
+    assert server._voice_bank_dir == tmp_path
+    assert server._voice_clip_files
+
+    # Serve-start reset keeps the armed endpoint (arm happens pre-serve in main()).
+    _reset_external_state()
+    assert server._voice_bank_dir == tmp_path
+    assert server._voice_clip_files
+
+    # A re-wire with voice fully disabled disarms it (no stale bank serving).
+    server._wire_voice(server.VoiceRuntimeConfig(reference_path=None, bank_dir=None))
+    assert server._voice_bank_dir is None
+    assert server._voice_clip_files == frozenset()
+    assert _get("/voice/manifest.json").status == HTTPStatus.NOT_FOUND
+    assert _get("/voice/clips/anything.wav").status == HTTPStatus.NOT_FOUND
+
+
 # --------------------------------------------------------------------------------------------
 # Server: WS voice.echo / voice.demo flows (real sockets, loopback)
 # --------------------------------------------------------------------------------------------

--- a/tests/test_voice_tablet_endpoint.py
+++ b/tests/test_voice_tablet_endpoint.py
@@ -342,8 +342,9 @@ async def _running_sidecar() -> AsyncIterator[int]:
 
 
 async def _hello(ws, client: str = "test-client", client_class: str = "voice") -> None:
-    await ws.send(json.dumps({"v": 1, "type": "hello", "client": client,
-                              "client_class": client_class}))
+    await ws.send(
+        json.dumps({"v": 1, "type": "hello", "client": client, "client_class": client_class})
+    )
     ack = json.loads(await ws.recv())
     assert ack["type"] == "hello_ack"
 

--- a/tests/test_voice_tablet_endpoint.py
+++ b/tests/test_voice_tablet_endpoint.py
@@ -98,6 +98,7 @@ def test_validate_voice_echo_accepts_valid_and_rejects_bad() -> None:
         ({"seq": -1}, "seq"),
         ({"seq": True}, "seq"),
         ({"clip_id": ""}, "clip_id"),
+        ({"clip_id": "evil\nCUE-ECHO forged=1"}, "clip_id"),  # log-forging guard
         ({"t_dispatch_ms": "x"}, "t_dispatch_ms"),
         ({"buffer_state": "weird"}, "buffer_state"),
         ({"audio_armed": "yes"}, "audio_armed"),
@@ -160,6 +161,41 @@ def test_dispatch_tap_listener_fault_never_breaks_audio() -> None:
     tap = DispatchTapPlayback(inner, _boom)
     tap.play(_utterance())
     assert len(inner.played) == 1  # audio path wins
+
+
+def test_dispatch_tap_stamps_clocks_before_backend_play() -> None:
+    """t_wall_ms anchors the audible-latency measurement at the scheduler's dispatch
+    DECISION. Stamping after inner.play() would exclude the sounddevice fallback's
+    stream-open time (tens of ms on WASAPI) — a one-sided bias toward false PASS on the
+    450 ms act budget (PR #519 adversarial review)."""
+    order: list[str] = []
+
+    class _SlowInner:
+        current = None
+
+        def play(self, _utt: Utterance) -> None:
+            order.append("play")
+
+        def cancel(self) -> None:  # pragma: no cover - interface completeness
+            pass
+
+        def close(self) -> None:  # pragma: no cover
+            pass
+
+    def _wall() -> float:
+        order.append("wall")
+        return 100.0
+
+    def _mono() -> float:
+        order.append("mono")
+        return 5.0
+
+    events: list[VoiceDispatch] = []
+    tap = DispatchTapPlayback(_SlowInner(), events.append, wall_clock=_wall, mono_clock=_mono)
+    tap.play(_utterance())
+    assert order.index("wall") < order.index("play")
+    assert order.index("mono") < order.index("play")
+    assert events and events[0].t_wall_ms == 100.0 * 1000.0
 
 
 def test_dispatch_tap_suppresses_event_for_bank_skipped_clip() -> None:
@@ -275,14 +311,14 @@ class _FakeConnection:
 
 
 class _FakeRequest:
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, headers: dict[str, str] | None = None) -> None:
         self.path = path
-        self.headers: dict[str, str] = {}
+        self.headers: dict[str, str] = headers or {}
 
 
-def _get(path: str):
-    handler = make_process_request(None)
-    return handler(_FakeConnection(), _FakeRequest(path))
+def _get(path: str, *, token: str | None = None, headers: dict[str, str] | None = None):
+    handler = make_process_request(token)
+    return handler(_FakeConnection(), _FakeRequest(path, headers))
 
 
 def test_http_tablet_page_served() -> None:
@@ -309,10 +345,34 @@ def test_http_clip_serving_is_allowlisted(tmp_path: Path) -> None:
     assert ok.headers.get("Content-Type") == "audio/wav"
     assert ok.headers.get("Content-Length") == str(len(ok.body))
     assert ok.body[:4] == b"RIFF"
-    # Traversal / non-manifest names never resolve, even when the file exists on disk.
+    # The page URL-encodes filenames; the server must decode before the allow-list so the
+    # cross-boundary contract holds for any manifest name (PR #519 review, cursor HIGH).
+    encoded = entry["file"].replace(".", "%2E", 1)
+    assert _get(f"/voice/clips/{encoded}").status == HTTPStatus.OK
+    # Traversal / non-manifest names never resolve, even when the file exists on disk —
+    # including AFTER percent-decoding.
     assert _get("/voice/clips/../manifest.json").status == HTTPStatus.NOT_FOUND
     assert _get("/voice/clips/manifest.json").status == HTTPStatus.NOT_FOUND
     assert _get("/voice/clips/..%2Fmanifest.json").status == HTTPStatus.NOT_FOUND
+
+
+def test_http_voice_routes_token_gated_for_non_loopback(tmp_path: Path) -> None:
+    """With a token configured, non-loopback clients need X-AC-Copilot-Token for the voice
+    routes (the fake connection has no remote_address → treated as non-loopback); /health
+    stays ungated (PR #519 review, Codex P2)."""
+    bake_bank(tmp_path, ToneBackend())
+    server._set_voice_web_bank(tmp_path)
+    assert _get("/tablet/voice", token="sekret").status == HTTPStatus.UNAUTHORIZED
+    assert _get("/voice/manifest.json", token="sekret").status == HTTPStatus.UNAUTHORIZED
+    assert _get("/voice/dispatches", token="sekret").status == HTTPStatus.UNAUTHORIZED
+    ok = _get("/tablet/voice", token="sekret", headers={"X-AC-Copilot-Token": "sekret"})
+    assert ok.status == HTTPStatus.OK
+    assert (
+        _get("/voice/manifest.json", token="sekret", headers={"X-AC-Copilot-Token": "sekret"})
+    ).status == HTTPStatus.OK
+    assert _get("/health", token="sekret").status == HTTPStatus.OK  # unchanged trust model
+    # No token configured (loopback-only bind is enforced at startup) -> unchanged.
+    assert _get("/tablet/voice").status == HTTPStatus.OK
 
 
 def test_http_dispatch_and_echo_logs() -> None:

--- a/tests/test_voice_tablet_endpoint.py
+++ b/tests/test_voice_tablet_endpoint.py
@@ -1,0 +1,424 @@
+"""Tablet coaching-audio endpoint tests (issue #511 Part D).
+
+Covers the additive protocol surface (``coaching.voice`` topic, ``voice.echo`` /
+``voice.demo`` inbound types), the dispatch tap (post-scheduler broadcast seam), the engine
+wiring, and the sidecar's static/JSON HTTP routes — all without audio hardware, per the
+repo's injectable-playback test discipline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+
+from tools.ai_sidecar import external_protocol as ep
+from tools.ai_sidecar import server
+from tools.ai_sidecar.server import _reset_external_state, make_process_request
+from tools.ai_sidecar.voice.bake import ToneBackend, bake_bank
+from tools.ai_sidecar.voice.config import VoiceConfig
+from tools.ai_sidecar.voice.dispatch import DispatchTapPlayback, VoiceDispatch
+from tools.ai_sidecar.voice.engine import VoiceCoach
+from tools.ai_sidecar.voice.playback import RecordingPlayback
+from tools.ai_sidecar.voice.utterance import Utterance
+
+
+@pytest.fixture(autouse=True)
+def _isolated_sidecar_state():
+    server.set_realtime_observer(None)
+    server.set_voice_coach(None)
+    _reset_external_state()
+    server._voice_bank_dir = None
+    server._voice_clip_files = frozenset()
+    yield
+    server.set_realtime_observer(None)
+    server.set_voice_coach(None)
+    _reset_external_state()
+    server._voice_bank_dir = None
+    server._voice_clip_files = frozenset()
+
+
+def _utterance(clip_id: str = "late_brake.act.urgent.generic") -> Utterance:
+    return Utterance(
+        clip_id=clip_id,
+        kind="late_brake",
+        urgency="act",
+        register="urgent",
+        corner=None,
+        text="Brake!",
+        dedup_key="late_brake:None:urgent",
+    )
+
+
+# --------------------------------------------------------------------------------------------
+# Protocol
+# --------------------------------------------------------------------------------------------
+
+
+def test_coaching_voice_topic_is_sidecar_produced_and_subscribable() -> None:
+    assert ep.TOPIC_COACHING_VOICE in ep.SIDECAR_PRODUCED_TOPICS
+    assert ep.TOPIC_COACHING_VOICE in ep.KNOWN_TOPICS
+    assert ep.topics_are_sidecar_only([ep.TOPIC_COACHING_VOICE])
+    err = ep.validate_inbound(
+        {"v": 1, "type": ep.TYPE_STATE_SUBSCRIBE, "topics": [ep.TOPIC_COACHING_VOICE]}
+    )
+    assert err is None
+
+
+def test_make_coaching_voice_shape() -> None:
+    payload = {"seq": 1, "clip_id": "late_brake.act.critical.generic", "t_wall_ms": 123.0}
+    frame = ep.make_coaching_voice(payload)
+    assert frame["v"] == 1
+    assert frame["type"] == ep.TYPE_STATE_SNAPSHOT
+    assert frame["topic"] == ep.TOPIC_COACHING_VOICE
+    assert frame["payload"] is payload
+    assert frame["source"] == "sidecar.voice"
+
+
+def test_validate_voice_echo_accepts_valid_and_rejects_bad() -> None:
+    good = {
+        "v": 1,
+        "type": ep.TYPE_VOICE_ECHO,
+        "seq": 3,
+        "clip_id": "late_brake.act.urgent.generic",
+        "t_dispatch_ms": 1000.0,
+        "t_receive_ms": 1010.0,
+        "t_play_ms": 1015.0,
+        "buffer_state": "preloaded",
+        "audio_armed": True,
+    }
+    assert ep.validate_inbound(good) is None
+    for mutation, expect in [
+        ({"seq": -1}, "seq"),
+        ({"seq": True}, "seq"),
+        ({"clip_id": ""}, "clip_id"),
+        ({"t_dispatch_ms": "x"}, "t_dispatch_ms"),
+        ({"buffer_state": "weird"}, "buffer_state"),
+        ({"audio_armed": "yes"}, "audio_armed"),
+    ]:
+        frame = dict(good)
+        frame.update(mutation)
+        err = ep.validate_inbound(frame)
+        assert err is not None and expect in err, (mutation, err)
+
+
+def test_validate_voice_demo() -> None:
+    good = {"v": 1, "type": ep.TYPE_VOICE_DEMO, "kind": "late_brake", "urgency": "act"}
+    assert ep.validate_inbound(good) is None
+    assert ep.validate_inbound({**good, "urgency": "loud"}) is not None
+    assert ep.validate_inbound({**good, "kind": ""}) is not None
+    assert ep.validate_inbound({**good, "corner": 99}) is not None
+    assert ep.validate_inbound({**good, "corner": 5, "register": "critical"}) is None
+
+
+# --------------------------------------------------------------------------------------------
+# Dispatch tap
+# --------------------------------------------------------------------------------------------
+
+
+def test_dispatch_tap_emits_and_forwards() -> None:
+    inner = RecordingPlayback()
+    events: list[VoiceDispatch] = []
+    wall = iter([100.0, 101.0]).__next__
+    mono = iter([5.0, 6.0]).__next__
+    tap = DispatchTapPlayback(
+        inner,
+        events.append,
+        duration_lookup=lambda cid: 361.4,
+        wall_clock=wall,
+        mono_clock=mono,
+    )
+    utt = _utterance()
+    tap.play(utt)
+    assert inner.played == [utt]
+    assert tap.current is utt
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.seq == 1
+    assert ev.clip_id == utt.clip_id
+    assert ev.duration_ms == 361.4
+    assert ev.t_wall_ms == 100.0 * 1000.0
+    assert ev.t_mono_ms == 5.0 * 1000.0
+    tap.cancel()
+    assert inner.cancelled == [utt]
+    tap.play(_utterance("apex_deficit.info.calm.t01"))
+    assert events[-1].seq == 2
+
+
+def test_dispatch_tap_listener_fault_never_breaks_audio() -> None:
+    inner = RecordingPlayback()
+
+    def _boom(_ev: VoiceDispatch) -> None:
+        raise RuntimeError("listener bug")
+
+    tap = DispatchTapPlayback(inner, _boom)
+    tap.play(_utterance())
+    assert len(inner.played) == 1  # audio path wins
+
+
+def test_dispatch_tap_no_event_when_backend_raises() -> None:
+    class _Boom:
+        current = None
+
+        def play(self, _utt: Utterance) -> None:
+            raise RuntimeError("device gone")
+
+        def cancel(self) -> None:  # pragma: no cover - interface completeness
+            pass
+
+        def close(self) -> None:  # pragma: no cover
+            pass
+
+    events: list[VoiceDispatch] = []
+    tap = DispatchTapPlayback(_Boom(), events.append)
+    with pytest.raises(RuntimeError):
+        tap.play(_utterance())
+    assert events == []
+
+
+def test_engine_wires_dispatch_listener_through_real_scheduler(tmp_path: Path) -> None:
+    bake_bank(tmp_path, ToneBackend())
+    events: list[VoiceDispatch] = []
+    coach = VoiceCoach.from_bank(
+        tmp_path,
+        VoiceConfig(),
+        playback=RecordingPlayback(),
+        dispatch_listener=events.append,
+    )
+    assert coach.enabled
+    coach.start()
+    try:
+        import time as _time
+
+        from _voice_support import make_advisory
+
+        coach.subscribe(make_advisory(kind="late_brake", urgency="act", corner=2))
+        t0 = _time.perf_counter()
+        while not events and _time.perf_counter() - t0 < 2.0:
+            _time.sleep(0.002)
+    finally:
+        coach.stop()
+    assert events, "dispatch listener never fired through the real scheduler"
+    assert events[0].clip_id == "late_brake.act.urgent.generic"
+    assert events[0].t_wall_ms > 0
+    assert events[0].seq == 1
+
+
+# --------------------------------------------------------------------------------------------
+# Server: dispatch listener + HTTP routes
+# --------------------------------------------------------------------------------------------
+
+
+def test_on_voice_dispatch_records_without_event_loop() -> None:
+    ev = VoiceDispatch(
+        seq=1,
+        clip_id="late_brake.act.critical.generic",
+        kind="late_brake",
+        urgency="act",
+        register="critical",
+        corner=None,
+        text="Brake!",
+        duration_ms=361.4,
+        t_wall_ms=1.0,
+        t_mono_ms=2.0,
+    )
+    server._on_voice_dispatch(ev)
+    assert list(server._voice_dispatch_log)[-1]["clip_id"] == ev.clip_id
+
+
+class _FakeHeaders:
+    def __init__(self) -> None:
+        self._data: dict[str, str] = {"Content-Type": "text/plain; charset=utf-8"}
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self._data[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._data[key]
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._data.get(key, default)
+
+
+class _FakeResponse:
+    def __init__(self, status: HTTPStatus, text: str) -> None:
+        self.status = status
+        self.headers = _FakeHeaders()
+        self.body = text.encode("utf-8")
+
+
+class _FakeConnection:
+    def respond(self, status: HTTPStatus, text: str) -> _FakeResponse:
+        return _FakeResponse(status, text)
+
+
+class _FakeRequest:
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.headers: dict[str, str] = {}
+
+
+def _get(path: str):
+    handler = make_process_request(None)
+    return handler(_FakeConnection(), _FakeRequest(path))
+
+
+def test_http_tablet_page_served() -> None:
+    resp = _get("/tablet/voice")
+    assert resp.status == HTTPStatus.OK
+    assert "text/html" in resp.headers.get("Content-Type", "")
+    assert b"coaching.voice" in resp.body
+
+
+def test_http_voice_routes_404_without_bank() -> None:
+    assert _get("/voice/manifest.json").status == HTTPStatus.NOT_FOUND
+    assert _get("/voice/clips/anything.wav").status == HTTPStatus.NOT_FOUND
+
+
+def test_http_clip_serving_is_allowlisted(tmp_path: Path) -> None:
+    bake_bank(tmp_path, ToneBackend())
+    server._set_voice_web_bank(tmp_path)
+    manifest_resp = _get("/voice/manifest.json")
+    assert manifest_resp.status == HTTPStatus.OK
+    manifest = json.loads(manifest_resp.body.decode("utf-8"))
+    entry = next(iter(manifest["clips"].values()))
+    ok = _get(f"/voice/clips/{entry['file']}")
+    assert ok.status == HTTPStatus.OK
+    assert ok.headers.get("Content-Type") == "audio/wav"
+    assert ok.headers.get("Content-Length") == str(len(ok.body))
+    assert ok.body[:4] == b"RIFF"
+    # Traversal / non-manifest names never resolve, even when the file exists on disk.
+    assert _get("/voice/clips/../manifest.json").status == HTTPStatus.NOT_FOUND
+    assert _get("/voice/clips/manifest.json").status == HTTPStatus.NOT_FOUND
+    assert _get("/voice/clips/..%2Fmanifest.json").status == HTTPStatus.NOT_FOUND
+
+
+def test_http_dispatch_and_echo_logs() -> None:
+    server._voice_dispatch_log.append({"seq": 9, "clip_id": "x"})
+    server._voice_echo_log.append({"seq": 9, "clip_id": "x", "t_server_ms": 1.0})
+    d = json.loads(_get("/voice/dispatches").body.decode("utf-8"))
+    e = json.loads(_get("/voice/echoes").body.decode("utf-8"))
+    assert d["dispatches"][-1]["seq"] == 9
+    assert e["echoes"][-1]["seq"] == 9
+
+
+# --------------------------------------------------------------------------------------------
+# Server: WS voice.echo / voice.demo flows (real sockets, loopback)
+# --------------------------------------------------------------------------------------------
+
+websockets = pytest.importorskip("websockets")
+from websockets.asyncio.client import connect as ws_connect  # noqa: E402
+from websockets.asyncio.server import serve as ws_serve  # noqa: E402
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+@asynccontextmanager
+async def _running_sidecar() -> AsyncIterator[int]:
+    port = _free_port()
+    _reset_external_state()
+    try:
+        async with ws_serve(
+            lambda ws: server._handler(ws, reply_coaching=True),
+            "127.0.0.1",
+            port,
+        ):
+            yield port
+    finally:
+        _reset_external_state()
+
+
+async def _hello(ws, client: str = "test-client", client_class: str = "voice") -> None:
+    await ws.send(json.dumps({"v": 1, "type": "hello", "client": client,
+                              "client_class": client_class}))
+    ack = json.loads(await ws.recv())
+    assert ack["type"] == "hello_ack"
+
+
+def test_ws_voice_echo_recorded() -> None:
+    async def _t() -> list[dict]:
+        async with _running_sidecar() as port:
+            async with ws_connect(f"ws://127.0.0.1:{port}") as ws:
+                await _hello(ws)
+                await ws.send(
+                    json.dumps(
+                        {
+                            "v": 1,
+                            "type": "voice.echo",
+                            "seq": 7,
+                            "clip_id": "late_brake.act.critical.generic",
+                            "t_dispatch_ms": 100.0,
+                            "t_receive_ms": 110.0,
+                            "t_play_ms": 118.0,
+                            "buffer_state": "preloaded",
+                            "audio_armed": True,
+                        }
+                    )
+                )
+                # voice.echo is fire-and-forget; poll the log briefly. Capture INSIDE the
+                # context — sidecar teardown clears the ring buffers by design.
+                for _ in range(100):
+                    if server._voice_echo_log:
+                        break
+                    await asyncio.sleep(0.01)
+                return list(server._voice_echo_log)
+
+    echoes = asyncio.run(_t())
+    assert echoes, "echo was not recorded"
+    rec = echoes[-1]
+    assert rec["seq"] == 7
+    assert rec["t_server_ms"] > 0
+
+
+def test_ws_voice_demo_feeds_coach_and_broadcasts_cue() -> None:
+    class _FakeCoach:
+        def __init__(self) -> None:
+            self.spoken: list = []
+
+        def subscribe(self, advisory) -> None:
+            self.spoken.append(advisory)
+
+    coach = _FakeCoach()
+
+    async def _t() -> list:
+        async with _running_sidecar() as port:
+            server.set_voice_coach(coach)
+            async with ws_connect(f"ws://127.0.0.1:{port}") as listener:
+                await _hello(listener, client="listener")
+                await listener.send(
+                    json.dumps({"v": 1, "type": "state.subscribe", "topics": ["coaching.cue"]})
+                )
+                async with ws_connect(f"ws://127.0.0.1:{port}") as producer:
+                    await _hello(producer, client="bench")
+                    await producer.send(
+                        json.dumps(
+                            {
+                                "v": 1,
+                                "type": "voice.demo",
+                                "kind": "late_brake",
+                                "urgency": "act",
+                                "register": "critical",
+                            }
+                        )
+                    )
+                    frame = json.loads(await asyncio.wait_for(listener.recv(), timeout=5.0))
+                    return [frame]
+
+    frames = asyncio.run(_t())
+    assert coach.spoken, "voice.demo never reached the coach"
+    assert coach.spoken[0].register == "critical"
+    assert frames[0]["topic"] == "coaching.cue"
+    assert frames[0]["payload"]["kind"] == "late_brake"

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -78,6 +78,16 @@ TYPE_SETUP_CLOSED_LOOP = "setup.closed_loop"
 TYPE_SETUP_EXCHANGE_SEARCH = "se.search"
 TYPE_SETUP_EXCHANGE_DOWNLOAD = "se.download"
 TYPE_SESSION_REVIEW_GENERATE = "session.review.generate"
+# Issue #511 Part D: a remote voice endpoint (tablet page) reports per-cue client-side
+# timestamps back to the sidecar so the audible-latency harness can decompose network-hop
+# vs audio-stack delay. Accepted from any authenticated peer; never relayed.
+TYPE_VOICE_ECHO = "voice.echo"
+# Issue #511 Part D / #381 verification: inject one synthetic advisory into the REAL
+# in-process voice path (scheduler arbitration + dispatch + coaching.voice broadcast).
+# Loopback-only — a bench/measurement entrypoint, never a remote control surface.
+TYPE_VOICE_DEMO = "voice.demo"
+VOICE_DEMO_URGENCIES: frozenset[str] = frozenset({"info", "prepare", "act"})
+VOICE_ECHO_BUFFER_STATES: frozenset[str] = frozenset({"preloaded", "decoded", "missing"})
 SESSION_REVIEW_REFERENCE_SOURCES: frozenset[str] = frozenset(
     {
         "auto",
@@ -208,10 +218,18 @@ KNOWN_ACTIONS: frozenset[str] = frozenset(
 #: Lua `publishTopic` drift-guard does not cover it — it is listed here so a `voice`-class client
 #: can legitimately subscribe.
 TOPIC_COACHING_CUE = "coaching.cue"
+#: Topic the sidecar publishes actually-DISPATCHED voice clips on (issue #511 Part D). Unlike
+#: ``coaching.cue`` (every advisory the observer emits), ``coaching.voice`` carries only what the
+#: in-process VoiceCoach scheduler decided to SPEAK (post cooldown/dedup/barge-in arbitration),
+#: stamped at dispatch time. A remote audio endpoint (the tablet page) mirrors exactly what the
+#: in-ear coach says without re-implementing the arbitration client-side.
+TOPIC_COACHING_VOICE = "coaching.voice"
 TOPIC_SESSION_REVIEW = "session.review"
 # Topics the sidecar produces directly (no loopback Lua relay). Voice/offline clients may
 # state.subscribe to these without a Lua peer connected.
-SIDECAR_PRODUCED_TOPICS: frozenset[str] = frozenset({TOPIC_COACHING_CUE, TOPIC_SESSION_REVIEW})
+SIDECAR_PRODUCED_TOPICS: frozenset[str] = frozenset(
+    {TOPIC_COACHING_CUE, TOPIC_COACHING_VOICE, TOPIC_SESSION_REVIEW}
+)
 KNOWN_TOPICS: frozenset[str] = frozenset(
     {
         # Declared topics (EPIC #154 Part D wires producers for these).
@@ -225,6 +243,8 @@ KNOWN_TOPICS: frozenset[str] = frozenset(
         "setup.active",
         # Sidecar-originated live coaching cues (issue #341).
         TOPIC_COACHING_CUE,
+        # Sidecar-originated dispatched-voice-clip events (issue #511 Part D).
+        TOPIC_COACHING_VOICE,
         # Sidecar-originated post-session debrief report (issue #404 Part A).
         TOPIC_SESSION_REVIEW,
     }
@@ -294,6 +314,25 @@ def make_coaching_cue(payload: dict[str, Any], *, ts_sim: float | None = None) -
     if ts_sim is not None:
         frame["ts_sim"] = ts_sim
     return frame
+
+
+def make_coaching_voice(payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a ``coaching.voice`` topic frame for one DISPATCHED clip (issue #511 Part D).
+
+    Emitted by the sidecar at the moment the in-process VoiceCoach scheduler dispatches a
+    clip to playback — i.e. after cooldown/dedup/barge-in arbitration, so a remote audio
+    endpoint plays exactly what the in-ear coach speaks. ``payload`` carries
+    ``seq``/``clip_id``/``kind``/``urgency``/``register``/``corner``/``duration_ms`` plus the
+    dispatch timestamps ``t_wall_ms`` (Unix epoch ms) and ``t_mono_ms`` (server monotonic ms)
+    the audible-latency harness anchors on.
+    """
+    return {
+        ENVELOPE_KEY: ENVELOPE_VERSION,
+        TYPE_KEY: TYPE_STATE_SNAPSHOT,
+        "topic": TOPIC_COACHING_VOICE,
+        "payload": payload,
+        "source": "sidecar.voice",
+    }
 
 
 def make_error(message: str, *, ref_type: str | None = None) -> dict[str, Any]:
@@ -728,6 +767,50 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
         return _validate_telemetry_tick(frame)
     if t == TYPE_HAPTIC_EVENT:
         return _validate_haptic_event(frame)
+    if t == TYPE_VOICE_ECHO:
+        seq = frame.get("seq")
+        if isinstance(seq, bool) or not isinstance(seq, int) or seq < 0:
+            return "voice.echo requires non-negative integer 'seq'"
+        clip_id = frame.get("clip_id")
+        if not isinstance(clip_id, str) or not clip_id or len(clip_id) > 128:
+            return "voice.echo requires non-empty 'clip_id' (<=128 chars)"
+        for key in ("t_dispatch_ms", "t_receive_ms"):
+            err = _validate_number(frame, key, min_value=0)
+            if err is not None:
+                return err
+        err = _validate_optional_number(frame, "t_play_ms", min_value=0)
+        if err is not None:
+            return err
+        buffer_state = frame.get("buffer_state")
+        if buffer_state is not None and (
+            not isinstance(buffer_state, str) or buffer_state not in VOICE_ECHO_BUFFER_STATES
+        ):
+            return "voice.echo optional 'buffer_state' must be one of: " + ", ".join(
+                sorted(VOICE_ECHO_BUFFER_STATES)
+            )
+        audio_armed = frame.get("audio_armed")
+        if audio_armed is not None and not isinstance(audio_armed, bool):
+            return "voice.echo optional 'audio_armed' must be a boolean"
+        return None
+    if t == TYPE_VOICE_DEMO:
+        kind = frame.get("kind")
+        if not isinstance(kind, str) or not kind or len(kind) > 64:
+            return "voice.demo requires non-empty 'kind' (<=64 chars)"
+        urgency = frame.get("urgency")
+        if not isinstance(urgency, str) or urgency not in VOICE_DEMO_URGENCIES:
+            return "voice.demo requires 'urgency' in: " + ", ".join(sorted(VOICE_DEMO_URGENCIES))
+        register = frame.get("register")
+        if register is not None and not isinstance(register, str):
+            return "voice.demo optional 'register' must be a string"
+        corner = frame.get("corner")
+        if corner is not None and (
+            isinstance(corner, bool) or not isinstance(corner, int) or corner < 0 or corner > 40
+        ):
+            return "voice.demo optional 'corner' must be an integer between 0 and 40"
+        err = _validate_optional_string(frame, "message")
+        if err is not None:
+            return err
+        return None
     if t in (TYPE_STATE_SUBSCRIBE, TYPE_STATE_UNSUBSCRIBE):
         topics = frame.get("topics")
         if not isinstance(topics, list) or not topics:

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from typing import Any
 
 # Envelope key that identifies a v1 external-client frame.
@@ -88,6 +89,9 @@ TYPE_VOICE_ECHO = "voice.echo"
 TYPE_VOICE_DEMO = "voice.demo"
 VOICE_DEMO_URGENCIES: frozenset[str] = frozenset({"info", "prepare", "act"})
 VOICE_ECHO_BUFFER_STATES: frozenset[str] = frozenset({"preloaded", "decoded", "missing"})
+# Clip ids are `kind.urgency.register.suffix` — restrict echo clip_id to that shape so a
+# client-supplied value can never smuggle newlines/control chars into server log lines.
+VOICE_CLIP_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 SESSION_REVIEW_REFERENCE_SOURCES: frozenset[str] = frozenset(
     {
         "auto",
@@ -774,6 +778,8 @@ def validate_inbound(frame: dict[str, Any]) -> str | None:
         clip_id = frame.get("clip_id")
         if not isinstance(clip_id, str) or not clip_id or len(clip_id) > 128:
             return "voice.echo requires non-empty 'clip_id' (<=128 chars)"
+        if not VOICE_CLIP_ID_RE.fullmatch(clip_id):
+            return "voice.echo 'clip_id' must match [A-Za-z0-9._-]+"
         for key in ("t_dispatch_ms", "t_receive_ms"):
             err = _validate_number(frame, key, min_value=0)
             if err is not None:

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -22,6 +22,7 @@ import os
 import re
 import secrets
 import time
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -86,7 +87,10 @@ from tools.ai_sidecar.external_protocol import (
     TYPE_STATE_SUBSCRIBE,
     TYPE_STATE_UNSUBSCRIBE,
     TYPE_TELEMETRY_TICK,
+    TYPE_VOICE_DEMO,
+    TYPE_VOICE_ECHO,
     make_coaching_cue,
+    make_coaching_voice,
     make_error,
     make_hello_ack,
     topics_are_sidecar_only,
@@ -179,6 +183,22 @@ _voice_runtime_status: dict[str, object] = {
     "disabled_reason": "",
 }
 _ABSOLUTE_PATH_RE = re.compile(r"(?:(?:[A-Za-z]:[\\/]|/)[^\s'\"<>]+)")
+
+# Issue #511 Part D — remote voice endpoint state. ``_voice_dispatch_log`` records every clip
+# the scheduler actually dispatched (mirrors the ``coaching.voice`` broadcast); the tablet page
+# posts ``voice.echo`` frames into ``_voice_echo_log``. Both are bounded ring buffers exposed
+# read-only over HTTP for the #381 audible-latency harness. ``_event_loop`` is the running
+# asyncio loop captured by ``_run`` so the scheduler worker thread can hand dispatch events
+# across to async fan-out via ``call_soon_threadsafe``.
+_VOICE_EVENT_LOG_MAX = 512
+_voice_dispatch_log: deque[dict[str, Any]] = deque(maxlen=_VOICE_EVENT_LOG_MAX)
+_voice_echo_log: deque[dict[str, Any]] = deque(maxlen=_VOICE_EVENT_LOG_MAX)
+_event_loop: asyncio.AbstractEventLoop | None = None
+# Static-serving allow-list for the tablet page: the bank dir plus the EXACT clip file names
+# listed in its manifest. ``/voice/clips/<name>`` serves only names in this set, so no path
+# traversal is possible regardless of what the URL contains.
+_voice_bank_dir: Path | None = None
+_voice_clip_files: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -345,6 +365,9 @@ CLIENT_TO_SERVER_TYPES = frozenset(
         TYPE_SETUP_EXCHANGE_SEARCH,
         TYPE_SETUP_EXCHANGE_DOWNLOAD,
         TYPE_SESSION_REVIEW_GENERATE,
+        # Issue #511 Part D: remote voice endpoint timestamps + loopback demo-cue injection.
+        TYPE_VOICE_ECHO,
+        TYPE_VOICE_DEMO,
     }
 )
 SERVER_TO_CLIENT_TYPES = frozenset(
@@ -418,6 +441,8 @@ def _reset_external_state() -> None:
     _external_peer_classes.clear()
     _sidecar_state_cache.clear()
     _peripheral_rate_limiter.reset()
+    _voice_dispatch_log.clear()
+    _voice_echo_log.clear()
     if _race_manager is not None:
         _race_manager.reset()
     # The single-producer observer feed is external-peer state: a full reset (server (re)start or
@@ -768,6 +793,84 @@ def make_token_check(token: str | None):
     return _check
 
 
+def _on_voice_dispatch(dispatch: Any) -> None:
+    """Listener for the voice dispatch tap (issue #511 Part D).
+
+    Runs on the SCHEDULER WORKER THREAD, so it must stay cheap and thread-safe: append the
+    record to the bounded ring buffer (deque append is atomic) and hand the async fan-out to
+    the event loop via ``call_soon_threadsafe``. Any fault is contained — the audio path and
+    the scheduler never see an exception from here (the tap also guards, belt-and-braces).
+    """
+    try:
+        payload = dispatch.to_payload()
+        _voice_dispatch_log.append(payload)
+        loop = _event_loop
+        if loop is None or loop.is_closed():
+            return
+        frame = make_coaching_voice(payload)
+
+        def _schedule() -> None:
+            task = asyncio.ensure_future(_broadcast_external(frame, exclude=None))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+
+        loop.call_soon_threadsafe(_schedule)
+    except RuntimeError:
+        # Loop shut down between the check and the call — a teardown race, not an error.
+        logger.debug("voice: dispatch broadcast skipped (event loop closed)")
+    except Exception:  # noqa: BLE001 — never propagate into the scheduler thread
+        logger.exception("voice: failed to record/broadcast dispatch")
+
+
+def _set_voice_web_bank(bank_dir: Path) -> None:
+    """Arm the tablet-page static routes for ``bank_dir`` (issue #511 Part D).
+
+    Loads the manifest once to build the EXACT-filename allow-list for ``/voice/clips/<name>``
+    — serving is impossible for any file the manifest does not list, so no traversal or
+    sibling-file exposure regardless of URL contents. On any manifest fault the routes stay
+    disarmed (404) and the coach itself is unaffected.
+    """
+    global _voice_bank_dir, _voice_clip_files
+    try:
+        from tools.ai_sidecar.voice.manifest import MANIFEST_FILENAME, Manifest
+
+        manifest = Manifest.load(bank_dir / MANIFEST_FILENAME)
+        files = frozenset(
+            entry.file
+            for entry in manifest.clips.values()
+            if isinstance(entry.file, str)
+            and entry.file
+            and "/" not in entry.file
+            and "\\" not in entry.file
+            and entry.file not in {".", ".."}
+        )
+        _voice_bank_dir = bank_dir
+        _voice_clip_files = files
+        logger.info(
+            "voice: tablet endpoint armed — %d clips servable from %s", len(files), bank_dir
+        )
+    except Exception:  # noqa: BLE001 — web serving is optional; never break voice wiring
+        _voice_bank_dir = None
+        _voice_clip_files = frozenset()
+        logger.exception("voice: failed to arm tablet endpoint from %s", bank_dir)
+
+
+_TABLET_PAGE_PATH = Path(__file__).resolve().parent / "voice" / "web" / "tablet_voice.html"
+_tablet_page_cache: str | None = None
+
+
+def _tablet_voice_page() -> str | None:
+    """Read (and cache) the self-contained tablet voice page shipped with the package."""
+    global _tablet_page_cache
+    if _tablet_page_cache is None:
+        try:
+            _tablet_page_cache = _TABLET_PAGE_PATH.read_text(encoding="utf-8")
+        except OSError:
+            logger.exception("voice: tablet page missing at %s", _TABLET_PAGE_PATH)
+            return None
+    return _tablet_page_cache
+
+
 def _http_response(connection: Any, status: HTTPStatus, body: str, content_type: str) -> Any:
     """Build a plain HTTP response on the WS connection with a SINGLE, correct
     Content-Type.
@@ -784,6 +887,26 @@ def _http_response(connection: Any, status: HTTPStatus, body: str, content_type:
     except KeyError:  # pragma: no cover - defensive across websockets versions
         pass
     response.headers["Content-Type"] = content_type
+    return response
+
+
+def _http_response_bytes(
+    connection: Any, status: HTTPStatus, body: bytes, content_type: str
+) -> Any:
+    """Binary variant of :func:`_http_response` (WAV clips for the tablet page).
+
+    ``connection.respond`` only takes text, so build from an empty response and replace the
+    body — Content-Length must be rewritten to match or strict clients truncate/over-read.
+    """
+    response = connection.respond(status, "")
+    for header in ("Content-Type", "Content-Length"):
+        try:
+            del response.headers[header]
+        except KeyError:  # pragma: no cover - defensive across websockets versions
+            pass
+    response.headers["Content-Type"] = content_type
+    response.headers["Content-Length"] = str(len(body))
+    response.body = body
     return response
 
 
@@ -820,6 +943,58 @@ def make_process_request(token: str | None):
                 HTTPStatus.OK,
                 observability.build_metrics_text(connected_peers, screen_peers=screen_peers),
                 observability.PROM_CONTENT_TYPE,
+            )
+        # Issue #511 Part D — tablet voice endpoint. Same trust model as /health: read-only,
+        # no secrets (the page, the bank manifest, baked clip audio, and bounded event logs),
+        # so not token-gated; the WS upgrade below keeps the gate. Clip serving is exact-match
+        # against the manifest allow-list — no traversal surface.
+        if path == "/tablet/voice":
+            page = _tablet_voice_page()
+            if page is None:
+                return _http_response(
+                    connection, HTTPStatus.NOT_FOUND, "tablet page unavailable\n", "text/plain"
+                )
+            return _http_response(connection, HTTPStatus.OK, page, "text/html; charset=utf-8")
+        if path == "/voice/manifest.json":
+            bank_dir = _voice_bank_dir
+            if bank_dir is None:
+                return _http_response(
+                    connection, HTTPStatus.NOT_FOUND, "no voice bank configured\n", "text/plain"
+                )
+            try:
+                body = (bank_dir / "manifest.json").read_text(encoding="utf-8")
+            except OSError:
+                return _http_response(
+                    connection, HTTPStatus.NOT_FOUND, "manifest unavailable\n", "text/plain"
+                )
+            return _http_response(connection, HTTPStatus.OK, body, "application/json")
+        if path.startswith("/voice/clips/"):
+            bank_dir = _voice_bank_dir
+            name = path[len("/voice/clips/") :]
+            if bank_dir is None or name not in _voice_clip_files:
+                return _http_response(
+                    connection, HTTPStatus.NOT_FOUND, "unknown clip\n", "text/plain"
+                )
+            try:
+                data = (bank_dir / name).read_bytes()
+            except OSError:
+                return _http_response(
+                    connection, HTTPStatus.NOT_FOUND, "clip unavailable\n", "text/plain"
+                )
+            return _http_response_bytes(connection, HTTPStatus.OK, data, "audio/wav")
+        if path == "/voice/dispatches":
+            return _http_response(
+                connection,
+                HTTPStatus.OK,
+                json.dumps({"dispatches": list(_voice_dispatch_log)}),
+                "application/json",
+            )
+        if path == "/voice/echoes":
+            return _http_response(
+                connection,
+                HTTPStatus.OK,
+                json.dumps({"echoes": list(_voice_echo_log)}),
+                "application/json",
             )
         # A rig-screen sighting rides on the WS upgrade (the client header is on
         # the upgrade request), then the token gate applies if one is configured.
@@ -1654,6 +1829,43 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
     if t in SIDECAR_LOCAL_TYPES:
         await _handle_setup_experiment_frame(websocket, data)
         return
+    if t == TYPE_VOICE_ECHO:
+        # Issue #511 Part D: per-cue client timestamps from a remote voice endpoint. Recorded
+        # for the audible-latency harness (/voice/echoes); never relayed to other peers.
+        record = {
+            "seq": data.get("seq"),
+            "clip_id": data.get("clip_id"),
+            "t_dispatch_ms": data.get("t_dispatch_ms"),
+            "t_receive_ms": data.get("t_receive_ms"),
+            "t_play_ms": data.get("t_play_ms"),
+            "buffer_state": data.get("buffer_state"),
+            "audio_armed": data.get("audio_armed"),
+            "t_server_ms": time.time() * 1000.0,
+        }
+        _voice_echo_log.append(record)
+        # rtt_ms is dispatch→echo-receipt on the SERVER clock (valid interval); js_ms is
+        # receive→play on the TABLET clock (valid interval). t_receive - t_dispatch would mix
+        # the two clocks, so it is never logged as a latency.
+        logger.info(
+            "CUE-ECHO seq=%s clip=%s rtt_ms=%s js_ms=%s",
+            record["seq"],
+            record["clip_id"],
+            _echo_interval(record, "t_dispatch_ms", "t_server_ms"),
+            _echo_interval(record, "t_receive_ms", "t_play_ms"),
+        )
+        return
+    if t == TYPE_VOICE_DEMO:
+        # Issue #511 Part D / #381: loopback-only synthetic advisory through the REAL voice
+        # path (scheduler arbitration → dispatch tap → coaching.voice broadcast). Bench
+        # entrypoint for the audible-latency harness; never a remote control surface.
+        if not _is_loopback_peer(websocket):
+            await _safe_send(
+                websocket,
+                make_error("voice.demo is accepted only from loopback peers", ref_type=t),
+            )
+            return
+        await _handle_voice_demo(websocket, data)
+        return
     if t in SERVER_TO_CLIENT_TYPES and not _is_loopback_peer(websocket):
         await _safe_send(
             websocket,
@@ -1733,6 +1945,44 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
         len(_external_peers),
     )
     await _broadcast_external(data, exclude=websocket)
+
+
+def _echo_interval(record: dict[str, Any], start_key: str, end_key: str) -> str:
+    start = record.get(start_key)
+    end = record.get(end_key)
+    if not isinstance(start, int | float) or not isinstance(end, int | float):
+        return "?"
+    return f"{float(end) - float(start):.1f}"
+
+
+async def _handle_voice_demo(websocket: Any, data: dict[str, Any]) -> None:
+    """Feed one validated ``voice.demo`` frame into the in-process coach + cue fan-out."""
+    from tools.ai_sidecar.registers import REGISTERS, normalize_register
+
+    raw_register = data.get("register")
+    register = normalize_register(raw_register) if isinstance(raw_register, str) else "calm"
+    if register not in REGISTERS:
+        register = "calm"
+    corner = data.get("corner")
+    advisory = SimpleNamespace(
+        kind=data["kind"],
+        urgency=data["urgency"],
+        register=register,
+        corner=corner if isinstance(corner, int) else None,
+        intensity=0.0,
+        message=data.get("message") or f"demo {data['kind']}",
+        spline=None,
+        detail={"demo": True},
+    )
+    coach = _voice_coach
+    if coach is not None:
+        try:
+            coach.subscribe(advisory)
+        except Exception:
+            logger.exception("voice coach subscribe failed for voice.demo")
+    cue_payload = _advisory_to_payload(advisory)
+    if cue_payload is not None:
+        await _broadcast_external(make_coaching_cue(cue_payload), exclude=websocket)
 
 
 async def _handler(websocket: Any, reply_coaching: bool) -> None:
@@ -1940,7 +2190,7 @@ async def _run(
     serial_baud: int = 115_200,
 ) -> None:
     global _setup_exchange_endpoint, _setup_exchange_user_setups_root
-    global _setup_experiment_store_path, _setup_experiment_store_seeded
+    global _setup_experiment_store_path, _setup_experiment_store_seeded, _event_loop
     try:
         import websockets
     except ImportError as e:
@@ -1948,6 +2198,9 @@ async def _run(
 
     process_request = make_process_request(token)
     _reset_external_state()
+    # Issue #511 Part D: the voice scheduler's worker thread hands dispatch broadcasts to this
+    # loop via call_soon_threadsafe; captured here (the one place the serve loop is known).
+    _event_loop = asyncio.get_running_loop()
     _setup_experiment_store_path = Path(setup_store) if setup_store else None
     _setup_experiment_store_seeded = setup_store is not None
     _setup_exchange_endpoint = setup_exchange_endpoint or os.environ.get(
@@ -1992,6 +2245,7 @@ async def _run(
                 ) from exc
             raise
     finally:
+        _event_loop = None
         _reset_external_state()
 
 
@@ -2140,7 +2394,9 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                     or "low"
                 ),
             )
-            coach = VoiceCoach.from_bank(bank_dir, config, backend=backend)
+            coach = VoiceCoach.from_bank(
+                bank_dir, config, backend=backend, dispatch_listener=_on_voice_dispatch
+            )
             if not coach.enabled:
                 set_voice_coach(coach)
                 set_voice_runtime_status(
@@ -2159,6 +2415,7 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
             else:
                 coach.start()
                 set_voice_coach(coach)
+                _set_voice_web_bank(Path(bank_dir))
                 set_voice_runtime_status(
                     configured=True,
                     enabled=True,

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -822,6 +822,20 @@ def _on_voice_dispatch(dispatch: Any) -> None:
         logger.exception("voice: failed to record/broadcast dispatch")
 
 
+def _disarm_voice_web_bank() -> None:
+    """Clear the tablet-endpoint serving state (no bank routes; /voice/* return 404).
+
+    Called at the START of ``_wire_voice`` (so a re-wire with voice disabled or a different
+    bank can never keep serving the previous bank's clips — self-hosted reviewer finding on
+    PR #519) and at ``_run`` teardown. Deliberately NOT part of ``_reset_external_state``:
+    that reset runs at serve START, *after* ``main()`` has already wired voice, so clearing
+    there would disarm a freshly-armed endpoint (verified live — arm happens pre-serve).
+    """
+    global _voice_bank_dir, _voice_clip_files
+    _voice_bank_dir = None
+    _voice_clip_files = frozenset()
+
+
 def _set_voice_web_bank(bank_dir: Path) -> None:
     """Arm the tablet-page static routes for ``bank_dir`` (issue #511 Part D).
 
@@ -2247,6 +2261,9 @@ async def _run(
     finally:
         _event_loop = None
         _reset_external_state()
+        # Teardown-only (never at serve start — voice is wired BEFORE _run): stop serving
+        # bank clips once the server is gone so an embedded/test re-serve starts disarmed.
+        _disarm_voice_web_bank()
 
 
 def _is_loopback(host: str) -> bool:
@@ -2267,6 +2284,10 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
     are imported lazily here (only when ``--voice-bank`` is supplied), so the sidecar core stays
     dep-free for users who never enable voice.
     """
+    # Re-wiring is authoritative for the tablet-endpoint serving state: disarm first so a
+    # voice-disabled (or different-bank) configuration can never keep serving stale clips;
+    # the enabled path below re-arms via _set_voice_web_bank (PR #519 review).
+    _disarm_voice_web_bank()
     reference_path = voice_settings.reference_path
     bank_dir = voice_settings.bank_dir
     bank_backend = (

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -22,6 +22,7 @@ import os
 import re
 import secrets
 import time
+import urllib.parse
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -365,9 +366,9 @@ CLIENT_TO_SERVER_TYPES = frozenset(
         TYPE_SETUP_EXCHANGE_SEARCH,
         TYPE_SETUP_EXCHANGE_DOWNLOAD,
         TYPE_SESSION_REVIEW_GENERATE,
-        # Issue #511 Part D: remote voice endpoint timestamps + loopback demo-cue injection.
-        TYPE_VOICE_ECHO,
-        TYPE_VOICE_DEMO,
+        # NOTE: TYPE_VOICE_ECHO / TYPE_VOICE_DEMO are deliberately NOT listed here — they
+        # are handled explicitly (and early-return) in _handle_external_frame before the
+        # type-set routing runs, so membership would be dead configuration (PR #519 review).
     }
 )
 SERVER_TO_CLIENT_TYPES = frozenset(
@@ -958,10 +959,22 @@ def make_process_request(token: str | None):
                 observability.build_metrics_text(connected_peers, screen_peers=screen_peers),
                 observability.PROM_CONTENT_TYPE,
             )
-        # Issue #511 Part D — tablet voice endpoint. Same trust model as /health: read-only,
-        # no secrets (the page, the bank manifest, baked clip audio, and bounded event logs),
-        # so not token-gated; the WS upgrade below keeps the gate. Clip serving is exact-match
+        # Issue #511 Part D — tablet voice endpoint. Read-only and secret-free, but unlike
+        # /health it carries product content (bank audio, dispatch/echo logs), so on an
+        # authenticated external bind these routes honor the same token as the WS upgrade:
+        # loopback (the USB `adb reverse` deployment) passes untokened; a LAN client needs
+        # the X-AC-Copilot-Token header (PR #519 review). Clip serving stays exact-match
         # against the manifest allow-list — no traversal surface.
+        if path == "/tablet/voice" or path.startswith("/voice/"):
+            if token and not _is_loopback_peer(connection):
+                supplied = request.headers.get(AUTH_HEADER)
+                if supplied is None or not secrets.compare_digest(supplied, token):
+                    return _http_response(
+                        connection,
+                        HTTPStatus.UNAUTHORIZED,
+                        "missing or invalid X-AC-Copilot-Token\n",
+                        "text/plain",
+                    )
         if path == "/tablet/voice":
             page = _tablet_voice_page()
             if page is None:
@@ -984,7 +997,11 @@ def make_process_request(token: str | None):
             return _http_response(connection, HTTPStatus.OK, body, "application/json")
         if path.startswith("/voice/clips/"):
             bank_dir = _voice_bank_dir
-            name = path[len("/voice/clips/") :]
+            # The page requests encodeURIComponent(file); decode before the allow-list so
+            # the cross-boundary contract holds for any manifest filename. Exact-match
+            # against manifest entries (which never contain separators) still forbids
+            # traversal — a decoded "../x" simply isn't in the set (PR #519 review).
+            name = urllib.parse.unquote(path[len("/voice/clips/") :])
             if bank_dir is None or name not in _voice_clip_files:
                 return _http_response(
                     connection, HTTPStatus.NOT_FOUND, "unknown clip\n", "text/plain"

--- a/tools/ai_sidecar/voice/audible_latency.py
+++ b/tools/ai_sidecar/voice/audible_latency.py
@@ -233,9 +233,9 @@ def normalized_match(recording: Any, template: Any, np: Any) -> Any:
     size = 1
     while size < n + length:
         size *= 2
-    corr = np.fft.irfft(
-        np.fft.rfft(rec, size) * np.conj(np.fft.rfft(tmpl, size)), size
-    )[: n - length + 1]
+    corr = np.fft.irfft(np.fft.rfft(rec, size) * np.conj(np.fft.rfft(tmpl, size)), size)[
+        : n - length + 1
+    ]
     energy = np.concatenate(([0.0], np.cumsum(rec * rec)))
     window_energy = energy[length:] - energy[: n - length + 1]
     tmpl_norm = float(np.sqrt(np.sum(tmpl * tmpl)))
@@ -621,8 +621,10 @@ def run(args: argparse.Namespace) -> int:
         )
 
         chirps.append(play_chirp("end", device=args.chirp_device, host_api=args.chirp_host_api))
-        _log.info("cue phase complete (%d coaching.voice frames); waiting for capture to close",
-                  len(collected))
+        _log.info(
+            "cue phase complete (%d coaching.voice frames); waiting for capture to close",
+            len(collected),
+        )
         try:
             proc.wait(timeout=total_s + 30)
         except subprocess.TimeoutExpired:

--- a/tools/ai_sidecar/voice/audible_latency.py
+++ b/tools/ai_sidecar/voice/audible_latency.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import json
 import logging
 import statistics
@@ -521,6 +522,31 @@ def render_markdown(report: AudibleLatencyReport) -> str:
 # --------------------------------------------------------------------------------------------
 
 
+def filter_dispatches_to_window(
+    dispatches: list[dict[str, Any]],
+    chirps: list[ChirpMark],
+    *,
+    margin_ms: float = 250.0,
+) -> list[dict[str, Any]]:
+    """Keep only dispatches whose stamp lies inside this run's chirp-bounded window."""
+    if not chirps:
+        return dispatches
+    start = min(c.anchor_wall_ms() for c in chirps) - margin_ms
+    end = max(c.anchor_wall_ms() for c in chirps) + margin_ms
+    kept: list[dict[str, Any]] = []
+    for d in dispatches:
+        t = d.get("t_wall_ms")
+        if isinstance(t, int | float) and start <= float(t) <= end:
+            kept.append(d)
+    dropped = len(dispatches) - len(kept)
+    if dropped:
+        _log.info(
+            "ignoring %d dispatch(es) outside this capture window (earlier sidecar activity)",
+            dropped,
+        )
+    return kept
+
+
 def _http_get_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
     if not url.startswith(("http://127.0.0.1", "http://localhost")):
         raise ValueError(f"refusing non-loopback sidecar URL: {url}")
@@ -632,12 +658,25 @@ def run(args: argparse.Namespace) -> int:
             proc.wait(timeout=10)
     finally:
         if proc.poll() is None:
+            # Failure path: wait after terminate (kill on timeout) so a dying scrcpy cannot
+            # keep writing the WAV or hold the log handle into the next run (PR #519 review).
             proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=5)
         scrcpy_log.close()
 
     http_base = args.http_url.rstrip("/")
     dispatches = _http_get_json(f"{http_base}/voice/dispatches").get("dispatches", [])
     echoes = _http_get_json(f"{http_base}/voice/echoes").get("echoes", [])
+    # The ring buffers span the whole sidecar process, not this run. Keep only cues
+    # dispatched between the two sync chirps — anything earlier/later is outside the
+    # recording and would be reported UNMATCHED, failing a perfectly good run (PR #519
+    # review). The chirps bound the capture by construction.
+    dispatches = filter_dispatches_to_window(dispatches, chirps)
     (out_dir / "dispatches.json").write_text(json.dumps(dispatches, indent=2), encoding="utf-8")
     (out_dir / "echoes.json").write_text(json.dumps(echoes, indent=2), encoding="utf-8")
     (out_dir / "chirps.json").write_text(

--- a/tools/ai_sidecar/voice/audible_latency.py
+++ b/tools/ai_sidecar/voice/audible_latency.py
@@ -44,6 +44,7 @@ import logging
 import statistics
 import subprocess
 import time
+import urllib.parse
 import urllib.request
 import wave
 from dataclasses import asdict, dataclass, field
@@ -61,6 +62,11 @@ CHIRP_AMPLITUDE = 0.7
 #: with a specific speech waveform; validated by the synthetic-noise unit tests).
 MATCH_MIN_SCORE = 0.20
 MATCH_MIN_PROMINENCE = 3.0
+#: A candidate region counts as a real instance only when its peak reaches this fraction of
+#: the window's global max — separates a genuinely earlier same-clip instance (normalized
+#: score is gain-invariant, so comparable) from the match's own correlation sidelobes
+#: (structurally ~-13 dB / ~4x lower for the log chirp).
+_REGION_DOMINANCE = 0.6
 #: How long after a dispatch stamp the clip onset is searched for. Covers WS hop + a slow
 #: Android audio stack with margin; anything later is reported unmatched rather than guessed.
 SEARCH_WINDOW_MS = 3_000.0
@@ -262,22 +268,51 @@ def find_onset(
     scores = normalized_match(segment, template, np)
     if len(scores) == 0:
         return None, 0.0, 0.0
-    peak_idx = int(np.argmax(scores))
-    peak = float(scores[peak_idx])
     median = float(np.median(scores))
+    peak_idx = int(np.argmax(scores))
+    if float(scores[peak_idx]) < MATCH_MIN_SCORE:
+        peak = float(scores[peak_idx])
+        return None, peak, peak / max(median, 1e-9)
+    # EARLIEST comparable instance, not the loudest: with two instances of the same clip in
+    # one window, a bare argmax locks onto the louder LATER one and reports an absurd
+    # latency for the earlier cue (PR #519 adversarial review). An earlier candidate counts
+    # as a distinct instance only when it is (a) separated from the current peak by more
+    # than one template length — the same instance's own correlation ramp/sidelobes span
+    # +/-L by construction (periodic tone clips ramp for the full overlap range; a chirp's
+    # -13 dB sidelobes hug the main lobe) — and (b) comparable in normalized score
+    # (gain-invariant, so a true instance scores near the max while noise does not).
+    length = len(template)
+    while True:
+        cutoff = peak_idx - length
+        if cutoff <= 0:
+            break
+        earlier = scores[:cutoff]
+        candidate = int(np.argmax(earlier))
+        if float(earlier[candidate]) < max(
+            MATCH_MIN_SCORE, _REGION_DOMINANCE * float(scores[peak_idx])
+        ):
+            break
+        peak_idx = candidate
+    peak = float(scores[peak_idx])
     prominence = peak / max(median, 1e-9)
-    if peak < MATCH_MIN_SCORE or prominence < MATCH_MIN_PROMINENCE:
+    if prominence < MATCH_MIN_PROMINENCE:
         return None, peak, prominence
     return start + peak_idx, peak, prominence
 
 
 @dataclass
 class ClockMap:
-    """Linear map recording-sample → PC wall ms, anchored on one or two chirps."""
+    """Linear map recording-sample → PC wall ms, anchored on one or two chirps.
+
+    ``anchors_used`` records whether the slope came from a two-chirp drift fit (2) or the
+    nominal samplerate (1) — the report asserts on it so a missed end chirp can never
+    silently downgrade a drift-corrected run (PR #519 adversarial review).
+    """
 
     anchor_sample: int
     anchor_wall_ms: float
     ms_per_sample: float
+    anchors_used: int = 1
 
     def wall_ms(self, sample: int) -> float:
         return self.anchor_wall_ms + (sample - self.anchor_sample) * self.ms_per_sample
@@ -302,11 +337,18 @@ def build_clock_map(
     third = len(recording) // 3
     found: list[tuple[ChirpMark, int]] = []
     detail: list[dict[str, Any]] = []
+    start_onset: int | None = None
     for mark in chirps:
         if mark.label == "start":
             onset, score, prom = find_onset(recording, template, np, start=0, end=2 * third)
+            if onset is not None:
+                start_onset = onset
         else:
-            onset, score, prom = find_onset(recording, template, np, start=third)
+            # Search for the END chirp strictly AFTER the located start chirp — the naive
+            # overlapping regions could lock both anchors onto the SAME chirp instance on a
+            # short run, degenerating the pair (PR #519 adversarial review).
+            search_from = start_onset + 2 * len(template) if start_onset is not None else third
+            onset, score, prom = find_onset(recording, template, np, start=search_from)
         detail.append(
             {
                 "label": mark.label,
@@ -327,7 +369,7 @@ def build_clock_map(
             slope = (m1.anchor_wall_ms() - m0.anchor_wall_ms()) / (s1 - s0)
             # A capture clock more than 5% off nominal means a mis-located chirp, not drift.
             if abs(slope - nominal) / nominal < 0.05:
-                return ClockMap(s0, m0.anchor_wall_ms(), slope), detail
+                return ClockMap(s0, m0.anchor_wall_ms(), slope, anchors_used=2), detail
             _log.warning(
                 "chirp-pair slope %.6f ms/sample deviates >5%% from nominal %.6f — "
                 "falling back to single-anchor map",
@@ -335,7 +377,7 @@ def build_clock_map(
                 nominal,
             )
     mark, sample = found[0]
-    return ClockMap(sample, mark.anchor_wall_ms(), nominal), detail
+    return ClockMap(sample, mark.anchor_wall_ms(), nominal, anchors_used=1), detail
 
 
 def _load_wav_mono(path: Path, np: Any) -> tuple[Any, int]:
@@ -376,8 +418,14 @@ def analyze(
     chirps: list[ChirpMark],
     echoes: list[dict[str, Any]] | None = None,
     act_budget_ms: float = DEFAULT_ACT_BUDGET_MS,
+    expected_dispatches: int | None = None,
 ) -> AudibleLatencyReport:
-    """Locate every dispatched clip in the room recording and build the timeliness report."""
+    """Locate every dispatched clip in the room recording and build the timeliness report.
+
+    ``expected_dispatches`` (burst mode) asserts the scheduler actually spoke every injected
+    cue — without it, scheduler suppression would silently shrink the sample and a partial
+    run could read as a full PASS (PR #519 adversarial review).
+    """
     import numpy as np
 
     from tools.ai_sidecar.voice.manifest import MANIFEST_FILENAME, Manifest
@@ -391,6 +439,11 @@ def analyze(
     echo_by_seq = {e.get("seq"): e for e in (echoes or [])}
 
     cues: list[CueResult] = []
+    # Same-clip repeats inside one search window must not cross-assign onsets: process in
+    # dispatch order and start each same-clip search after the previous match (PR #519
+    # adversarial review).
+    next_allowed_start: dict[str, int] = {}
+    dispatches = sorted(dispatches, key=lambda d: float(d.get("t_wall_ms", 0.0)))
     for d in dispatches:
         seq = int(d.get("seq", -1))
         clip_id = str(d.get("clip_id", ""))
@@ -422,14 +475,20 @@ def analyze(
             continue
         template = _resample_linear(np.asarray(pcm, dtype=np.float64), bank.samplerate, rec_sr, np)
         # Search from the dispatch stamp forward; a small negative margin absorbs clock-map
-        # uncertainty without letting a pre-dispatch sound masquerade as the cue.
+        # uncertainty without letting a pre-dispatch sound masquerade as the cue. The end is
+        # extended by the template length: normalized_match only scores FULL alignments, so
+        # without the extension an onset near the window edge could never match and the
+        # effective window would silently shrink by the clip duration (PR #519 review).
         start_wall = t_dispatch - 100.0
         start_sample = clock_map.anchor_sample + int(
             (start_wall - clock_map.anchor_wall_ms) / clock_map.ms_per_sample
         )
-        end_sample = start_sample + int((SEARCH_WINDOW_MS + 100.0) / clock_map.ms_per_sample)
+        start_sample = max(0, start_sample, next_allowed_start.get(clip_id, 0))
+        end_sample = (
+            start_sample + int((SEARCH_WINDOW_MS + 100.0) / clock_map.ms_per_sample) + len(template)
+        )
         onset, score, prom = find_onset(
-            recording, template, np, start=max(0, start_sample), end=max(0, end_sample)
+            recording, template, np, start=start_sample, end=max(0, end_sample)
         )
         cue.match_score = round(score, 4)
         cue.match_prominence = round(prom, 2)
@@ -437,6 +496,7 @@ def analyze(
             cue.matched = True
             cue.onset_wall_ms = clock_map.wall_ms(onset)
             cue.audible_latency_ms = cue.onset_wall_ms - t_dispatch
+            next_allowed_start[clip_id] = onset + len(template) // 2
         cues.append(cue)
 
     matched = [c for c in cues if c.matched and c.audible_latency_ms is not None]
@@ -463,10 +523,15 @@ def analyze(
 
     assertions = {
         "clock_map_anchored": True,
+        # A missed/degenerate end chirp must FAIL loudly, never silently drop the drift fit.
+        "clock_map_drift_corrected": clock_map.anchors_used >= 2 if len(chirps) >= 2 else True,
         "all_dispatched_cues_matched": len(matched) == len(cues) and len(cues) > 0,
         "act_cues_within_budget": bool(act_latencies)
         and max(act_latencies) + systematic <= act_budget_ms,
     }
+    if expected_dispatches is not None:
+        # Burst mode: every injected cue must have actually been dispatched by the scheduler.
+        assertions["all_burst_cues_dispatched"] = len(cues) == expected_dispatches
     return AudibleLatencyReport(
         recording=str(recording_path),
         recording_samplerate=rec_sr,
@@ -548,7 +613,10 @@ def filter_dispatches_to_window(
 
 
 def _http_get_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
-    if not url.startswith(("http://127.0.0.1", "http://localhost")):
+    # Parse the actual host — a prefix check would accept e.g. 127.0.0.1.evil.example
+    # (PR #519 adversarial review).
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
         raise ValueError(f"refusing non-loopback sidecar URL: {url}")
     with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 - loopback-only
         return json.loads(resp.read().decode("utf-8"))
@@ -691,6 +759,7 @@ def run(args: argparse.Namespace) -> int:
         chirps=chirps,
         echoes=echoes,
         act_budget_ms=args.act_budget_ms,
+        expected_dispatches=args.burst if args.burst > 0 else None,
     )
     return _emit_report(report, out_dir)
 

--- a/tools/ai_sidecar/voice/audible_latency.py
+++ b/tools/ai_sidecar/voice/audible_latency.py
@@ -1,0 +1,735 @@
+"""End-to-end audible-latency harness — how timely is the coach IN THE ROOM (issue #381).
+
+The CI timing report (:mod:`timing_report`) proves emit→dispatch with an injected clock; this
+harness measures the half nothing else can: **dispatch → acoustic onset at a real microphone**,
+covering the WS hop to a remote audio endpoint (the tablet page, issue #511 Part D), the
+endpoint's audio stack, and the speaker→mic path.
+
+Method (council-reviewed, 2026-07-11):
+
+* **Room capture** — the Android tablet's microphone is recorded ON THE PC over USB via
+  ``scrcpy --no-video --audio-source=mic* --audio-codec=raw --record=<wav>``. No mic hardware
+  on the PC is needed.
+* **Clock sync** — the PC plays a 5→15 kHz log chirp at the START and END of the capture,
+  wall-stamped at the DAC via the PortAudio callback ``time_info``. Matched-filtering the known
+  chirp in the recording maps recording samples ↔ PC wall clock; two anchors correct linear
+  drift. The residual systematic uncertainty (PC output path estimate) is REPORTED, not hidden.
+* **Cue onsets** — every dispatched clip's own baked waveform (the bank is the template
+  library) is matched-filtered inside a search window after its ``t_wall_ms`` dispatch stamp
+  (from the ``coaching.voice`` stream / ``/voice/dispatches``), which stays robust under game
+  noise. ``audible_latency_ms = onset_wall - t_wall_ms``.
+* **Decomposition** — when the tablet page's ``voice.echo`` records are available
+  (``/voice/echoes``), the report also splits server→tablet round-trip (server clock) and
+  receive→play JS time (tablet clock). Cross-device clock differences are never subtracted.
+
+Two subcommands::
+
+    python -m tools.ai_sidecar.voice.audible_latency run --bank <dir> --out-dir <dir> \
+        [--burst N | --observe-seconds S] [--sidecar-url ws://127.0.0.1:8765] ...
+    python -m tools.ai_sidecar.voice.audible_latency analyze --recording rec.wav \
+        --bank <dir> --dispatches dispatches.json --chirps chirps.json --out-dir <dir>
+
+``run`` orchestrates capture + cue injection + scraping and then runs ``analyze``. Heavy deps
+(``numpy``, ``sounddevice``, ``websockets``) are imported lazily inside the functions that
+need them, so importing this module stays stdlib-only (repo dependency discipline, #340).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import statistics
+import subprocess
+import time
+import urllib.request
+import wave
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+_log = logging.getLogger("ai_sidecar.voice.audible_latency")
+
+CHIRP_F0_HZ = 5_000.0
+CHIRP_F1_HZ = 15_000.0
+CHIRP_DURATION_S = 0.3
+CHIRP_AMPLITUDE = 0.7
+#: Matched-filter acceptance: normalized correlation peak must clear this floor AND stand
+#: this many times above the window's median score (engine noise never correlates this well
+#: with a specific speech waveform; validated by the synthetic-noise unit tests).
+MATCH_MIN_SCORE = 0.20
+MATCH_MIN_PROMINENCE = 3.0
+#: How long after a dispatch stamp the clip onset is searched for. Covers WS hop + a slow
+#: Android audio stack with margin; anything later is reported unmatched rather than guessed.
+SEARCH_WINDOW_MS = 3_000.0
+DEFAULT_ACT_BUDGET_MS = 450.0
+
+_BURST_CUES: tuple[dict[str, Any], ...] = (
+    {"kind": "late_brake", "urgency": "act", "register": "critical"},
+    {"kind": "apex_deficit", "urgency": "info", "register": "calm", "corner": 2},
+    {"kind": "late_brake", "urgency": "act", "register": "urgent"},
+    {"kind": "late_brake", "urgency": "prepare", "register": "alert", "corner": 4},
+    {"kind": "apex_deficit", "urgency": "info", "register": "calm", "corner": 6},
+    {"kind": "late_brake", "urgency": "act", "register": "critical", "corner": 8},
+)
+
+
+@dataclass
+class ChirpMark:
+    """One sync chirp: what the PC believes about when it hit the DAC (wall clock, ms)."""
+
+    label: str
+    t_wall_ms: float
+    t_dac_wall_ms: float | None
+    output_latency_ms: float | None
+
+    def anchor_wall_ms(self) -> float:
+        return self.t_dac_wall_ms if self.t_dac_wall_ms is not None else self.t_wall_ms
+
+
+@dataclass
+class CueResult:
+    seq: int
+    clip_id: str
+    kind: str
+    urgency: str
+    register: str
+    t_dispatch_wall_ms: float
+    matched: bool
+    onset_wall_ms: float | None = None
+    audible_latency_ms: float | None = None
+    match_score: float | None = None
+    match_prominence: float | None = None
+    rtt_ms: float | None = None
+    js_play_ms: float | None = None
+    buffer_state: str | None = None
+
+
+@dataclass
+class AudibleLatencyReport:
+    recording: str
+    recording_samplerate: int
+    chirps: list[dict[str, Any]]
+    clock_map: dict[str, Any]
+    cues: list[CueResult]
+    stats: dict[str, Any] = field(default_factory=dict)
+    assertions: dict[str, bool] = field(default_factory=dict)
+    systematic_uncertainty_ms: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = asdict(self)
+        out["cues"] = [asdict(c) for c in self.cues]
+        return out
+
+
+# --------------------------------------------------------------------------------------------
+# Chirp generation + DAC-stamped playback
+# --------------------------------------------------------------------------------------------
+
+
+def make_chirp(samplerate: int, np: Any) -> Any:
+    """Log-frequency chirp 5→15 kHz — cuts through engine roar (low/mid dominant)."""
+    n = int(CHIRP_DURATION_S * samplerate)
+    t = np.arange(n, dtype=np.float64) / samplerate
+    k = (CHIRP_F1_HZ / CHIRP_F0_HZ) ** (1.0 / CHIRP_DURATION_S)
+    phase = 2.0 * np.pi * CHIRP_F0_HZ * (k**t - 1.0) / np.log(k)
+    sig = np.sin(phase)
+    # 10 ms raised-cosine edges: no click transient to smear the matched-filter peak.
+    edge = max(1, int(0.010 * samplerate))
+    ramp = 0.5 * (1.0 - np.cos(np.pi * np.arange(edge) / edge))
+    sig[:edge] *= ramp
+    sig[-edge:] *= ramp[::-1]
+    return (CHIRP_AMPLITUDE * sig).astype(np.float32)
+
+
+def play_chirp(label: str, *, device: str | None, host_api: str | None) -> ChirpMark:
+    """Play the sync chirp on the PC output and wall-stamp its first sample at the DAC.
+
+    Uses the PortAudio callback's ``outputBufferDacTime`` to map the first callback buffer to
+    the wall clock — collapsing most of the "when did the speaker actually move" uncertainty
+    that a naive pre-play stamp carries.
+    """
+    import numpy as np
+    import sounddevice as sd
+
+    device_index: int | None = None
+    if device:
+        from tools.ai_sidecar.voice.playback import resolve_output_device
+
+        device_index = resolve_output_device(
+            device,
+            host_api,
+            devices=list(sd.query_devices()),
+            host_apis=list(sd.query_hostapis()),
+        )
+    samplerate = 48_000
+    chirp = make_chirp(samplerate, np)
+    state: dict[str, Any] = {"pos": 0, "dac_wall_ms": None, "latency_ms": None}
+    done = __import__("threading").Event()
+
+    def _callback(outdata: Any, frames: int, time_info: Any, status: Any) -> None:
+        if state["dac_wall_ms"] is None:
+            now_wall = time.time()
+            try:
+                stream_now = stream.time
+                dac = time_info.outputBufferDacTime
+                state["dac_wall_ms"] = (now_wall + (dac - stream_now)) * 1000.0
+                state["latency_ms"] = float(stream.latency) * 1000.0
+            except Exception:  # noqa: BLE001 — DAC stamping is best-effort refinement
+                state["dac_wall_ms"] = None
+        pos = state["pos"]
+        chunk = chirp[pos : pos + frames]
+        outdata[: len(chunk), 0] = chunk
+        if len(chunk) < frames:
+            outdata[len(chunk) :, 0] = 0.0
+            done.set()
+            raise sd.CallbackStop
+        state["pos"] = pos + frames
+
+    t_wall_ms = time.time() * 1000.0
+    stream = sd.OutputStream(
+        samplerate=samplerate,
+        channels=1,
+        dtype="float32",
+        device=device_index,
+        callback=_callback,
+    )
+    with stream:
+        done.wait(timeout=CHIRP_DURATION_S + 2.0)
+    mark = ChirpMark(
+        label=label,
+        t_wall_ms=t_wall_ms,
+        t_dac_wall_ms=state["dac_wall_ms"],
+        output_latency_ms=state["latency_ms"],
+    )
+    _log.info(
+        "chirp %s: wall=%.1f dac_wall=%s latency=%s",
+        label,
+        mark.t_wall_ms,
+        f"{mark.t_dac_wall_ms:.1f}" if mark.t_dac_wall_ms else "n/a",
+        f"{mark.output_latency_ms:.1f}ms" if mark.output_latency_ms else "n/a",
+    )
+    return mark
+
+
+# --------------------------------------------------------------------------------------------
+# Matched filter + clock mapping (pure numpy; unit-tested on synthetic signals)
+# --------------------------------------------------------------------------------------------
+
+
+def normalized_match(recording: Any, template: Any, np: Any) -> Any:
+    """Normalized cross-correlation score in [0, 1] for every alignment (FFT-based).
+
+    ``score[s] = |sum(rec[s:s+L] * tmpl)| / (||rec[s:s+L]|| * ||tmpl||)`` — invariant to
+    recording gain, so scrcpy/mic AGC cannot fake or hide a match.
+    """
+    rec = recording.astype(np.float64)
+    tmpl = template.astype(np.float64)
+    n = len(rec)
+    length = len(tmpl)
+    if length == 0 or n < length:
+        return np.zeros(0)
+    size = 1
+    while size < n + length:
+        size *= 2
+    corr = np.fft.irfft(
+        np.fft.rfft(rec, size) * np.conj(np.fft.rfft(tmpl, size)), size
+    )[: n - length + 1]
+    energy = np.concatenate(([0.0], np.cumsum(rec * rec)))
+    window_energy = energy[length:] - energy[: n - length + 1]
+    tmpl_norm = float(np.sqrt(np.sum(tmpl * tmpl)))
+    denom = np.sqrt(np.maximum(window_energy, 1e-12)) * max(tmpl_norm, 1e-12)
+    return np.abs(corr) / denom
+
+
+def find_onset(
+    recording: Any,
+    template: Any,
+    np: Any,
+    *,
+    start: int = 0,
+    end: int | None = None,
+) -> tuple[int | None, float, float]:
+    """Best template onset inside ``recording[start:end]``.
+
+    Returns ``(onset_sample, score, prominence)`` — onset ``None`` when the peak fails the
+    score/prominence gates (never guess an onset the data does not support).
+    """
+    end = len(recording) if end is None else min(end, len(recording))
+    segment = recording[start:end]
+    scores = normalized_match(segment, template, np)
+    if len(scores) == 0:
+        return None, 0.0, 0.0
+    peak_idx = int(np.argmax(scores))
+    peak = float(scores[peak_idx])
+    median = float(np.median(scores))
+    prominence = peak / max(median, 1e-9)
+    if peak < MATCH_MIN_SCORE or prominence < MATCH_MIN_PROMINENCE:
+        return None, peak, prominence
+    return start + peak_idx, peak, prominence
+
+
+@dataclass
+class ClockMap:
+    """Linear map recording-sample → PC wall ms, anchored on one or two chirps."""
+
+    anchor_sample: int
+    anchor_wall_ms: float
+    ms_per_sample: float
+
+    def wall_ms(self, sample: int) -> float:
+        return self.anchor_wall_ms + (sample - self.anchor_sample) * self.ms_per_sample
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def build_clock_map(
+    recording: Any,
+    samplerate: int,
+    chirps: list[ChirpMark],
+    np: Any,
+) -> tuple[ClockMap, list[dict[str, Any]]]:
+    """Locate each chirp in the recording and fit the sample↔wall-clock map.
+
+    With two located chirps the slope corrects capture-clock drift; with one, the nominal
+    samplerate is trusted. Raises ``ValueError`` when no chirp is found — without an anchor
+    every downstream number would be fiction.
+    """
+    template = make_chirp(samplerate, np)
+    third = len(recording) // 3
+    found: list[tuple[ChirpMark, int]] = []
+    detail: list[dict[str, Any]] = []
+    for mark in chirps:
+        if mark.label == "start":
+            onset, score, prom = find_onset(recording, template, np, start=0, end=2 * third)
+        else:
+            onset, score, prom = find_onset(recording, template, np, start=third)
+        detail.append(
+            {
+                "label": mark.label,
+                "onset_sample": onset,
+                "score": round(score, 4),
+                "prominence": round(prom, 2),
+                "anchor_wall_ms": mark.anchor_wall_ms(),
+            }
+        )
+        if onset is not None:
+            found.append((mark, onset))
+    if not found:
+        raise ValueError("no sync chirp located in the recording — cannot anchor the clock map")
+    nominal = 1000.0 / samplerate
+    if len(found) >= 2:
+        (m0, s0), (m1, s1) = found[0], found[-1]
+        if s1 > s0 + samplerate:  # anchors must be well separated to fit a slope
+            slope = (m1.anchor_wall_ms() - m0.anchor_wall_ms()) / (s1 - s0)
+            # A capture clock more than 5% off nominal means a mis-located chirp, not drift.
+            if abs(slope - nominal) / nominal < 0.05:
+                return ClockMap(s0, m0.anchor_wall_ms(), slope), detail
+            _log.warning(
+                "chirp-pair slope %.6f ms/sample deviates >5%% from nominal %.6f — "
+                "falling back to single-anchor map",
+                slope,
+                nominal,
+            )
+    mark, sample = found[0]
+    return ClockMap(sample, mark.anchor_wall_ms(), nominal), detail
+
+
+def _load_wav_mono(path: Path, np: Any) -> tuple[Any, int]:
+    with wave.open(str(path), "rb") as wf:
+        samplerate = wf.getframerate()
+        channels = wf.getnchannels()
+        width = wf.getsampwidth()
+        raw = wf.readframes(wf.getnframes())
+    if width == 2:
+        data = np.frombuffer(raw, dtype="<i2").astype(np.float64) / 32768.0
+    elif width == 4:
+        data = np.frombuffer(raw, dtype="<i4").astype(np.float64) / 2147483648.0
+    else:
+        raise ValueError(f"unsupported sample width {width} in {path}")
+    if channels > 1:
+        data = data.reshape(-1, channels).mean(axis=1)
+    return data, samplerate
+
+
+def _resample_linear(signal: Any, sr_from: int, sr_to: int, np: Any) -> Any:
+    if sr_from == sr_to:
+        return signal
+    n_to = int(round(len(signal) * sr_to / sr_from))
+    x_to = np.linspace(0.0, len(signal) - 1.0, n_to)
+    return np.interp(x_to, np.arange(len(signal)), signal)
+
+
+# --------------------------------------------------------------------------------------------
+# Analysis
+# --------------------------------------------------------------------------------------------
+
+
+def analyze(
+    *,
+    recording_path: Path,
+    bank_dir: Path,
+    dispatches: list[dict[str, Any]],
+    chirps: list[ChirpMark],
+    echoes: list[dict[str, Any]] | None = None,
+    act_budget_ms: float = DEFAULT_ACT_BUDGET_MS,
+) -> AudibleLatencyReport:
+    """Locate every dispatched clip in the room recording and build the timeliness report."""
+    import numpy as np
+
+    from tools.ai_sidecar.voice.manifest import MANIFEST_FILENAME, Manifest
+    from tools.ai_sidecar.voice.playback import Bank
+
+    recording, rec_sr = _load_wav_mono(recording_path, np)
+    manifest = Manifest.load(bank_dir / MANIFEST_FILENAME)
+    bank = Bank.from_manifest(manifest, bank_dir)
+
+    clock_map, chirp_detail = build_clock_map(recording, rec_sr, chirps, np)
+    echo_by_seq = {e.get("seq"): e for e in (echoes or [])}
+
+    cues: list[CueResult] = []
+    for d in dispatches:
+        seq = int(d.get("seq", -1))
+        clip_id = str(d.get("clip_id", ""))
+        t_dispatch = float(d.get("t_wall_ms", 0.0))
+        cue = CueResult(
+            seq=seq,
+            clip_id=clip_id,
+            kind=str(d.get("kind", "")),
+            urgency=str(d.get("urgency", "")),
+            register=str(d.get("register", "")),
+            t_dispatch_wall_ms=t_dispatch,
+            matched=False,
+        )
+        echo = echo_by_seq.get(seq)
+        if echo is not None:
+            t_server = echo.get("t_server_ms")
+            t_receive = echo.get("t_receive_ms")
+            t_play = echo.get("t_play_ms")
+            if isinstance(t_server, int | float):
+                cue.rtt_ms = float(t_server) - t_dispatch
+            if isinstance(t_receive, int | float) and isinstance(t_play, int | float):
+                cue.js_play_ms = float(t_play) - float(t_receive)
+            state = echo.get("buffer_state")
+            cue.buffer_state = state if isinstance(state, str) else None
+
+        pcm = bank.get(clip_id)
+        if pcm is None or t_dispatch <= 0:
+            cues.append(cue)
+            continue
+        template = _resample_linear(np.asarray(pcm, dtype=np.float64), bank.samplerate, rec_sr, np)
+        # Search from the dispatch stamp forward; a small negative margin absorbs clock-map
+        # uncertainty without letting a pre-dispatch sound masquerade as the cue.
+        start_wall = t_dispatch - 100.0
+        start_sample = clock_map.anchor_sample + int(
+            (start_wall - clock_map.anchor_wall_ms) / clock_map.ms_per_sample
+        )
+        end_sample = start_sample + int((SEARCH_WINDOW_MS + 100.0) / clock_map.ms_per_sample)
+        onset, score, prom = find_onset(
+            recording, template, np, start=max(0, start_sample), end=max(0, end_sample)
+        )
+        cue.match_score = round(score, 4)
+        cue.match_prominence = round(prom, 2)
+        if onset is not None:
+            cue.matched = True
+            cue.onset_wall_ms = clock_map.wall_ms(onset)
+            cue.audible_latency_ms = cue.onset_wall_ms - t_dispatch
+        cues.append(cue)
+
+    matched = [c for c in cues if c.matched and c.audible_latency_ms is not None]
+    latencies = [c.audible_latency_ms for c in matched if c.audible_latency_ms is not None]
+    act_latencies = [
+        c.audible_latency_ms
+        for c in matched
+        if c.urgency == "act" and c.audible_latency_ms is not None
+    ]
+    stats: dict[str, Any] = {
+        "dispatched": len(cues),
+        "matched": len(matched),
+        "unmatched": len(cues) - len(matched),
+    }
+    if latencies:
+        stats["latency_ms"] = _percentiles(latencies)
+    if act_latencies:
+        stats["act_latency_ms"] = _percentiles(act_latencies)
+
+    # The chirp anchor carries the PC output path estimate; when the DAC stamp was available
+    # the residual is small, otherwise the full pre-play stamp uncertainty applies.
+    dac_ok = all(m.t_dac_wall_ms is not None for m in chirps)
+    systematic = 15.0 if dac_ok else 60.0
+
+    assertions = {
+        "clock_map_anchored": True,
+        "all_dispatched_cues_matched": len(matched) == len(cues) and len(cues) > 0,
+        "act_cues_within_budget": bool(act_latencies)
+        and max(act_latencies) + systematic <= act_budget_ms,
+    }
+    return AudibleLatencyReport(
+        recording=str(recording_path),
+        recording_samplerate=rec_sr,
+        chirps=chirp_detail,
+        clock_map=clock_map.to_dict(),
+        cues=cues,
+        stats=stats,
+        assertions=assertions,
+        systematic_uncertainty_ms=systematic,
+    )
+
+
+def _percentiles(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    return {
+        "n": len(ordered),
+        "p50": round(statistics.median(ordered), 1),
+        "p95": round(ordered[max(0, int(round(0.95 * (len(ordered) - 1))))], 1),
+        "max": round(ordered[-1], 1),
+        "min": round(ordered[0], 1),
+    }
+
+
+def render_markdown(report: AudibleLatencyReport) -> str:
+    lines = [
+        "# Audible-latency report (#381 / #511 Part D)",
+        "",
+        f"Recording: `{report.recording}` @ {report.recording_samplerate} Hz",
+        f"Systematic uncertainty: +/-{report.systematic_uncertainty_ms:.0f} ms "
+        "(PC output-path anchor)",
+        "",
+        "| seq | clip | urgency | register | dispatch->audible ms | rtt ms | js ms | score |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for c in report.cues:
+        lat = f"{c.audible_latency_ms:.1f}" if c.audible_latency_ms is not None else "UNMATCHED"
+        rtt = f"{c.rtt_ms:.1f}" if c.rtt_ms is not None else "-"
+        js = f"{c.js_play_ms:.1f}" if c.js_play_ms is not None else "-"
+        score = f"{c.match_score:.2f}" if c.match_score is not None else "-"
+        lines.append(
+            f"| {c.seq} | {c.clip_id} | {c.urgency} | {c.register} | {lat} | {rtt} | {js} "
+            f"| {score} |"
+        )
+    lines.append("")
+    lines.append(f"Stats: `{json.dumps(report.stats)}`")
+    lines.append(f"Assertions: `{json.dumps(report.assertions)}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------------------------
+# Run orchestration (scrcpy capture + WS cue injection + HTTP scraping)
+# --------------------------------------------------------------------------------------------
+
+
+def _http_get_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
+    if not url.startswith(("http://127.0.0.1", "http://localhost")):
+        raise ValueError(f"refusing non-loopback sidecar URL: {url}")
+    with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 - loopback-only
+        return json.loads(resp.read().decode("utf-8"))
+
+
+async def _ws_session(
+    url: str,
+    *,
+    burst: int,
+    burst_interval_s: float,
+    observe_seconds: float,
+    collected: list[dict[str, Any]],
+) -> None:
+    """Subscribe to ``coaching.voice``; optionally inject ``voice.demo`` burst cues."""
+    import websockets
+
+    async with websockets.connect(url) as ws:
+        await ws.send(
+            json.dumps(
+                {"v": 1, "type": "hello", "client": "audible-latency", "client_class": "voice"}
+            )
+        )
+        await ws.send(json.dumps({"v": 1, "type": "state.subscribe", "topics": ["coaching.voice"]}))
+
+        async def _collect(deadline: float) -> None:
+            while time.monotonic() < deadline:
+                budget = max(0.05, deadline - time.monotonic())
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=budget)
+                except TimeoutError:
+                    return
+                try:
+                    frame = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if frame.get("topic") == "coaching.voice":
+                    payload = frame.get("payload")
+                    if isinstance(payload, dict):
+                        payload["t_client_recv_ms"] = time.time() * 1000.0
+                        collected.append(payload)
+
+        if burst > 0:
+            for i in range(burst):
+                cue = dict(_BURST_CUES[i % len(_BURST_CUES)])
+                cue.update({"v": 1, "type": "voice.demo"})
+                # Vary the corner per round so the scheduler's dedup window never eats a
+                # repeat (dedup keys on kind:corner:register).
+                if "corner" in cue and cue["corner"] is not None:
+                    cue["corner"] = (int(cue["corner"]) + 2 * (i // len(_BURST_CUES))) % 20
+                await ws.send(json.dumps(cue))
+                await _collect(time.monotonic() + burst_interval_s)
+        else:
+            await _collect(time.monotonic() + observe_seconds)
+
+
+def run(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    recording_path = out_dir / "room_capture.wav"
+
+    cue_phase_s = (
+        args.burst * args.burst_interval if args.burst > 0 else float(args.observe_seconds)
+    )
+    total_s = int(args.lead_in + cue_phase_s + args.tail + 2 * CHIRP_DURATION_S) + 3
+
+    scrcpy_cmd = [
+        args.scrcpy,
+        "--no-video",
+        "--no-playback",
+        f"--audio-source={args.audio_source}",
+        "--audio-codec=raw",
+        f"--record={recording_path}",
+        "--record-format=wav",
+        f"--time-limit={total_s}",
+    ]
+    _log.info("starting capture: %s", " ".join(scrcpy_cmd))
+    scrcpy_log = (out_dir / "scrcpy.log").open("w", encoding="utf-8")
+    proc = subprocess.Popen(scrcpy_cmd, stdout=scrcpy_log, stderr=subprocess.STDOUT)
+    try:
+        time.sleep(args.lead_in)  # let the capture stream settle before the first anchor
+        if proc.poll() is not None:
+            _log.error("scrcpy exited early (rc=%s) — see %s", proc.returncode, scrcpy_log.name)
+            return 2
+
+        chirps = [play_chirp("start", device=args.chirp_device, host_api=args.chirp_host_api)]
+
+        collected: list[dict[str, Any]] = []
+        asyncio.run(
+            _ws_session(
+                args.sidecar_url,
+                burst=args.burst,
+                burst_interval_s=args.burst_interval,
+                observe_seconds=float(args.observe_seconds),
+                collected=collected,
+            )
+        )
+
+        chirps.append(play_chirp("end", device=args.chirp_device, host_api=args.chirp_host_api))
+        _log.info("cue phase complete (%d coaching.voice frames); waiting for capture to close",
+                  len(collected))
+        try:
+            proc.wait(timeout=total_s + 30)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait(timeout=10)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+        scrcpy_log.close()
+
+    http_base = args.http_url.rstrip("/")
+    dispatches = _http_get_json(f"{http_base}/voice/dispatches").get("dispatches", [])
+    echoes = _http_get_json(f"{http_base}/voice/echoes").get("echoes", [])
+    (out_dir / "dispatches.json").write_text(json.dumps(dispatches, indent=2), encoding="utf-8")
+    (out_dir / "echoes.json").write_text(json.dumps(echoes, indent=2), encoding="utf-8")
+    (out_dir / "chirps.json").write_text(
+        json.dumps([asdict(c) for c in chirps], indent=2), encoding="utf-8"
+    )
+    (out_dir / "ws_frames.json").write_text(json.dumps(collected, indent=2), encoding="utf-8")
+
+    report = analyze(
+        recording_path=recording_path,
+        bank_dir=Path(args.bank),
+        dispatches=dispatches,
+        chirps=chirps,
+        echoes=echoes,
+        act_budget_ms=args.act_budget_ms,
+    )
+    return _emit_report(report, out_dir)
+
+
+def analyze_cmd(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    dispatches = json.loads(Path(args.dispatches).read_text(encoding="utf-8"))
+    if isinstance(dispatches, dict):
+        dispatches = dispatches.get("dispatches", [])
+    chirps_raw = json.loads(Path(args.chirps).read_text(encoding="utf-8"))
+    chirps = [ChirpMark(**c) for c in chirps_raw]
+    echoes: list[dict[str, Any]] = []
+    if args.echoes:
+        echoes = json.loads(Path(args.echoes).read_text(encoding="utf-8"))
+        if isinstance(echoes, dict):
+            echoes = echoes.get("echoes", [])
+    report = analyze(
+        recording_path=Path(args.recording),
+        bank_dir=Path(args.bank),
+        dispatches=dispatches,
+        chirps=chirps,
+        echoes=echoes,
+        act_budget_ms=args.act_budget_ms,
+    )
+    return _emit_report(report, out_dir)
+
+
+def _emit_report(report: AudibleLatencyReport, out_dir: Path) -> int:
+    (out_dir / "audible_latency.json").write_text(
+        json.dumps(report.to_dict(), indent=2), encoding="utf-8"
+    )
+    md = render_markdown(report)
+    (out_dir / "audible_latency.md").write_text(md, encoding="utf-8")
+    print(md)
+    ok = all(report.assertions.values())
+    print(f"assertions: {'PASS' if ok else 'FAIL'} -> {json.dumps(report.assertions)}")
+    return 0 if ok else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--bank", required=True, help="baked voice bank dir (clip templates)")
+    common.add_argument("--out-dir", required=True, help="artifact output directory")
+    common.add_argument("--act-budget-ms", type=float, default=DEFAULT_ACT_BUDGET_MS)
+
+    p_run = sub.add_parser("run", parents=[common], help="capture + inject + analyze")
+    p_run.add_argument("--sidecar-url", default="ws://127.0.0.1:8765")
+    p_run.add_argument("--http-url", default="http://127.0.0.1:8765")
+    p_run.add_argument("--burst", type=int, default=0, help="inject N voice.demo cues")
+    p_run.add_argument("--burst-interval", type=float, default=4.0)
+    p_run.add_argument(
+        "--observe-seconds", type=float, default=60.0, help="passive window (drive mode)"
+    )
+    p_run.add_argument("--lead-in", type=float, default=3.0)
+    p_run.add_argument("--tail", type=float, default=4.0)
+    p_run.add_argument("--scrcpy", default="scrcpy", help="scrcpy executable path")
+    p_run.add_argument(
+        "--audio-source",
+        default="mic-unprocessed",
+        choices=["mic", "mic-unprocessed", "mic-camcorder", "mic-voice-recognition"],
+    )
+    p_run.add_argument("--chirp-device", default=None, help="PC output device name substring")
+    p_run.add_argument("--chirp-host-api", default=None)
+    p_run.set_defaults(func=run)
+
+    p_an = sub.add_parser("analyze", parents=[common], help="analyze an existing capture")
+    p_an.add_argument("--recording", required=True)
+    p_an.add_argument("--dispatches", required=True)
+    p_an.add_argument("--chirps", required=True)
+    p_an.add_argument("--echoes", default=None)
+    p_an.set_defaults(func=analyze_cmd)
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ai_sidecar/voice/dispatch.py
+++ b/tools/ai_sidecar/voice/dispatch.py
@@ -1,0 +1,121 @@
+"""Dispatch tap — observe what the scheduler ACTUALLY plays, without touching arbitration.
+
+Issue #511 Part D: a remote audio endpoint (the tablet page) must mirror exactly what the
+in-process coach speaks. Re-implementing the scheduler's cooldown/dedup/barge-in in a second
+place would drift, so instead the real :class:`~tools.ai_sidecar.voice.playback.Playback` is
+wrapped in :class:`DispatchTapPlayback`: every successful ``play`` builds a
+:class:`VoiceDispatch` record (seq + wall/monotonic timestamps + clip identity) and hands it
+to a listener. The sidecar's listener broadcasts it as a ``coaching.voice`` frame; the
+audible-latency harness (issue #381 verification) anchors its end-to-end measurement on the
+``t_wall_ms`` stamped here.
+
+The tap is strictly pass-through for scheduling semantics: ``current``/``cancel``/``close``
+forward untouched, a listener fault never breaks audio, and when no listener is installed the
+engine does not wrap at all — zero behavior change for existing deployments.
+
+Pure stdlib.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+
+from tools.ai_sidecar.voice.playback import Playback
+from tools.ai_sidecar.voice.utterance import Utterance
+
+_log = logging.getLogger("ai_sidecar.voice.dispatch")
+
+
+@dataclass(frozen=True)
+class VoiceDispatch:
+    """One clip the scheduler dispatched to playback, stamped at dispatch time.
+
+    ``t_wall_ms`` is Unix-epoch milliseconds (``time.time()``) — the cross-host anchor the
+    audible-latency harness compares acoustic onsets against. ``t_mono_ms`` is the server's
+    monotonic clock in milliseconds — immune to wall-clock steps, used for intra-server
+    interval math. ``duration_ms`` is the pre-decoded clip length when known (``None`` when
+    the playback was injected without a bank, e.g. in tests).
+    """
+
+    seq: int
+    clip_id: str
+    kind: str
+    urgency: str
+    register: str
+    corner: int | None
+    text: str
+    duration_ms: float | None
+    t_wall_ms: float
+    t_mono_ms: float
+
+    def to_payload(self) -> dict[str, object]:
+        """The ``coaching.voice`` wire payload (plain JSON-safe dict)."""
+        return asdict(self)
+
+
+class DispatchTapPlayback:
+    """A :class:`Playback` wrapper that notifies a listener on every successful ``play``.
+
+    The listener runs on the scheduler worker thread and MUST be cheap/non-blocking (the
+    sidecar's listener only appends to a deque and schedules an async broadcast). Any
+    listener exception is swallowed and logged — the audio path always wins.
+    """
+
+    def __init__(
+        self,
+        inner: Playback,
+        listener: Callable[[VoiceDispatch], None],
+        *,
+        duration_lookup: Callable[[str], float | None] | None = None,
+        wall_clock: Callable[[], float] = time.time,
+        mono_clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._inner = inner
+        self._listener = listener
+        self._duration_lookup = duration_lookup
+        self._wall_clock = wall_clock
+        self._mono_clock = mono_clock
+        self._seq = itertools.count(1)
+
+    @property
+    def current(self) -> Utterance | None:
+        return self._inner.current
+
+    def play(self, utterance: Utterance) -> None:
+        # Play FIRST: if the backend raises, no dispatch happened and no event is emitted.
+        self._inner.play(utterance)
+        dispatch = VoiceDispatch(
+            seq=next(self._seq),
+            clip_id=utterance.clip_id,
+            kind=utterance.kind,
+            urgency=utterance.urgency,
+            register=utterance.register,
+            corner=utterance.corner,
+            text=utterance.text,
+            duration_ms=self._duration(utterance.clip_id),
+            t_wall_ms=self._wall_clock() * 1000.0,
+            t_mono_ms=self._mono_clock() * 1000.0,
+        )
+        try:
+            self._listener(dispatch)
+        except Exception:  # noqa: BLE001 — the tap must never break the audio path
+            _log.exception("voice: dispatch listener failed for %s", utterance.clip_id)
+
+    def cancel(self) -> None:
+        self._inner.cancel()
+
+    def close(self) -> None:
+        self._inner.close()
+
+    def _duration(self, clip_id: str) -> float | None:
+        if self._duration_lookup is None:
+            return None
+        try:
+            return self._duration_lookup(clip_id)
+        except Exception:  # noqa: BLE001 — duration is advisory metadata only
+            _log.exception("voice: duration lookup failed for %s", clip_id)
+            return None

--- a/tools/ai_sidecar/voice/dispatch.py
+++ b/tools/ai_sidecar/voice/dispatch.py
@@ -86,7 +86,14 @@ class DispatchTapPlayback:
         return self._inner.current
 
     def play(self, utterance: Utterance) -> None:
-        # Play FIRST: if the backend raises, no dispatch happened and no event is emitted.
+        # Stamp the clocks BEFORE the backend call: on the sounddevice fallback, play()
+        # opens a fresh output stream (tens of ms on WASAPI), and a post-play stamp would
+        # silently exclude that interval from every downstream latency measurement — a
+        # one-sided bias toward false PASS on the 450 ms act budget (PR #519 adversarial
+        # review). The event itself is still emitted only after play() returns, so the
+        # no-event-on-failure invariant holds.
+        t_wall_ms = self._wall_clock() * 1000.0
+        t_mono_ms = self._mono_clock() * 1000.0
         self._inner.play(utterance)
         duration_ms = self._duration(utterance.clip_id)
         if self._duration_lookup is not None and duration_ms is None:
@@ -109,8 +116,8 @@ class DispatchTapPlayback:
             corner=utterance.corner,
             text=utterance.text,
             duration_ms=duration_ms,
-            t_wall_ms=self._wall_clock() * 1000.0,
-            t_mono_ms=self._mono_clock() * 1000.0,
+            t_wall_ms=t_wall_ms,
+            t_mono_ms=t_mono_ms,
         )
         try:
             self._listener(dispatch)

--- a/tools/ai_sidecar/voice/dispatch.py
+++ b/tools/ai_sidecar/voice/dispatch.py
@@ -88,6 +88,18 @@ class DispatchTapPlayback:
     def play(self, utterance: Utterance) -> None:
         # Play FIRST: if the backend raises, no dispatch happened and no event is emitted.
         self._inner.play(utterance)
+        duration_ms = self._duration(utterance.clip_id)
+        if self._duration_lookup is not None and duration_ms is None:
+            # The bank-backed backends degrade per-clip: a missing/sha-bad/undecodable clip
+            # is SKIPPED by play() (logged no-op), and the same bank drives this duration
+            # lookup — so no duration means no audio actually sounded. Never broadcast a
+            # dispatch for silence (PR #519 review): the tablet would speak a clip the
+            # in-ear coach never played.
+            _log.warning(
+                "voice: suppressing dispatch event for %s — clip absent from the loaded bank",
+                utterance.clip_id,
+            )
+            return
         dispatch = VoiceDispatch(
             seq=next(self._seq),
             clip_id=utterance.clip_id,
@@ -96,7 +108,7 @@ class DispatchTapPlayback:
             register=utterance.register,
             corner=utterance.corner,
             text=utterance.text,
-            duration_ms=self._duration(utterance.clip_id),
+            duration_ms=duration_ms,
             t_wall_ms=self._wall_clock() * 1000.0,
             t_mono_ms=self._mono_clock() * 1000.0,
         )

--- a/tools/ai_sidecar/voice/engine.py
+++ b/tools/ai_sidecar/voice/engine.py
@@ -42,6 +42,28 @@ from tools.ai_sidecar.voice.scheduler import Scheduler
 _log = logging.getLogger("ai_sidecar.voice.engine")
 
 
+def _bank_duration_lookup(playback: Playback) -> Callable[[str], float | None] | None:
+    """Best-effort clip-duration lookup from a real backend's pre-decoded bank.
+
+    The real backends (:class:`RtMixerPlayback` / :class:`SoundDevicePlayback`) hold their
+    ``Bank`` privately; the dispatch tap only needs read-only durations for the
+    ``coaching.voice`` payload, so duck-read it rather than widening the Playback protocol.
+    Returns ``None`` (durations omitted) for playbacks without a bank (injected test doubles).
+    """
+    bank = getattr(playback, "_bank", None)
+    samplerate = getattr(bank, "samplerate", 0)
+    if bank is None or not samplerate:
+        return None
+
+    def _duration_ms(clip_id: str) -> float | None:
+        pcm = bank.get(clip_id)
+        if pcm is None:
+            return None
+        return len(pcm) / samplerate * 1000.0
+
+    return _duration_ms
+
+
 class VoiceCoach:
     """Wires resolver + scheduler + playback. One coach per output channel."""
 
@@ -108,6 +130,7 @@ class VoiceCoach:
         playback: Playback | None = None,
         clock: Callable[[], float] = time.monotonic,
         backend: str = "rtmixer",
+        dispatch_listener: Callable[..., None] | None = None,
     ) -> VoiceCoach:
         """Build a coach from a baked bank directory.
 
@@ -117,6 +140,11 @@ class VoiceCoach:
         :meth:`disabled` rather than raising. ``playback`` may be injected (tests pass a
         :class:`~tools.ai_sidecar.voice.playback.RecordingPlayback`); otherwise the real backend is
         built lazily from the bank.
+
+        ``dispatch_listener`` (issue #511 Part D) is called with one
+        :class:`~tools.ai_sidecar.voice.dispatch.VoiceDispatch` per clip the scheduler actually
+        dispatches — the seam the sidecar uses to broadcast ``coaching.voice`` frames to remote
+        audio endpoints. ``None`` (the default) leaves the playback unwrapped.
         """
         config = config or VoiceConfig()
         base = Path(bank_dir)
@@ -144,6 +172,15 @@ class VoiceCoach:
             playback = cls._build_playback(manifest, base, config, backend)
             if playback is None:
                 return cls.disabled(f"could not initialize audio backend {backend!r}")
+
+        if dispatch_listener is not None:
+            from tools.ai_sidecar.voice.dispatch import DispatchTapPlayback
+
+            playback = DispatchTapPlayback(
+                playback,
+                dispatch_listener,
+                duration_lookup=_bank_duration_lookup(playback),
+            )
 
         resolver = Resolver(manifest)
         scheduler = Scheduler(resolver, playback, config, clock=clock)

--- a/tools/ai_sidecar/voice/web/tablet_voice.html
+++ b/tools/ai_sidecar/voice/web/tablet_voice.html
@@ -84,8 +84,8 @@
   var state = {
     ws: null, wsOpen: false, armed: false, ctx: null,
     buffers: {},           // clip_id -> AudioBuffer
-    fileToClip: {},        // wav file name -> clip_id
-    clipsLoaded: 0, clipsTotal: 0,
+    clipFiles: {},         // clip_id -> wav file name (for on-demand re-preload)
+    clipsLoaded: 0, clipsTotal: 0, bankLoading: false,
     currentSource: null, currentSeq: -1,
     cueCount: 0, logLines: [],
     reconnectDelay: 1000,
@@ -139,7 +139,10 @@
   }
 
   function loadBank() {
-    if (state.clipsTotal > 0) return; // already loaded
+    // Guard BOTH completed and in-flight loads: a double-tap on ARM before the manifest
+    // resolves must not fetch+decode the whole 76-clip bank twice (2 GB device).
+    if (state.clipsTotal > 0 || state.bankLoading) return;
+    state.bankLoading = true;
     fetch("/voice/manifest.json").then(function (r) {
       if (!r.ok) throw new Error("manifest " + r.status);
       return r.json();
@@ -151,27 +154,38 @@
       });
       state.clipsTotal = entries.length;
       setPill("s-clips", "0/" + state.clipsTotal);
-      entries.forEach(function (entry) { preloadClip(entry); });
+      entries.forEach(function (entry) {
+        if (entry && entry.file && entry.clip_id) {
+          state.clipFiles[entry.clip_id] = entry.file;
+          preloadClip(entry.clip_id);
+        }
+      });
     }).catch(function (err) {
+      state.bankLoading = false;
       logLine("manifest load failed: " + err.message);
       setTimeout(loadBank, 5000);
     });
   }
-  function preloadClip(entry) {
-    if (!entry || !entry.file || !entry.clip_id) return;
-    state.fileToClip[entry.file] = entry.clip_id;
-    fetch("/voice/clips/" + encodeURIComponent(entry.file)).then(function (r) {
+  function preloadClip(clipId) {
+    var file = state.clipFiles[clipId];
+    if (!file || state.buffers[clipId]) return Promise.resolve(null);
+    return fetch("/voice/clips/" + encodeURIComponent(file)).then(function (r) {
       if (!r.ok) throw new Error("clip " + r.status);
       return r.arrayBuffer();
     }).then(function (raw) {
       return state.ctx.decodeAudioData(raw);
     }).then(function (buf) {
-      state.buffers[entry.clip_id] = buf;
-      state.clipsLoaded += 1;
-      setPill("s-clips", state.clipsLoaded + "/" + state.clipsTotal,
-        state.clipsLoaded === state.clipsTotal ? "ok" : "");
+      if (!state.buffers[clipId]) {
+        state.buffers[clipId] = buf;
+        state.clipsLoaded += 1;
+        setPill("s-clips", state.clipsLoaded + "/" + state.clipsTotal,
+          state.clipsLoaded === state.clipsTotal ? "ok" : "");
+      }
+      return buf;
     }).catch(function (err) {
-      logLine("preload failed " + entry.clip_id + ": " + err.message);
+      // Not permanent: a missed clip is retried on demand when a dispatch names it.
+      logLine("preload failed " + clipId + ": " + err.message);
+      return null;
     });
   }
 
@@ -185,7 +199,17 @@
     }
     var tPlay = null;
     var buf = state.buffers[p.clip_id];
-    if (buf && state.armed) {
+    // Android Go can suspend the context behind our back (backgrounding, route change);
+    // a suspended context makes source.start() a silent no-op — never report a fake
+    // t_play_ms for audio that cannot be sounding.
+    var ctxRunning = state.ctx && state.ctx.state === "running";
+    if (state.armed && !ctxRunning) {
+      state.armed = false;
+      setPill("s-audio", "suspended", "bad");
+      document.getElementById("arm").style.display = "flex";
+      if (state.ctx) state.ctx.resume();
+    }
+    if (buf && state.armed && ctxRunning) {
       var src = state.ctx.createBufferSource();
       src.buffer = buf;
       src.connect(state.ctx.destination);
@@ -195,6 +219,7 @@
       src.onended = function () { if (state.currentSource === src) state.currentSource = null; };
     } else {
       bufferState = buf ? "decoded" : "missing";
+      if (!buf && state.ctx) preloadClip(p.clip_id); // retry on demand — not permanent
     }
     state.currentSeq = p.seq;
     state.cueCount += 1;

--- a/tools/ai_sidecar/voice/web/tablet_voice.html
+++ b/tools/ai_sidecar/voice/web/tablet_voice.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+  Tablet coaching-audio endpoint (issue #511 Part D).
+
+  Served by the sidecar at /tablet/voice on the same port as the WebSocket (default 8765).
+  Deployment (USB, no WiFi): on the rig PC run `adb reverse tcp:8765 tcp:8765`, then open
+  http://127.0.0.1:8765/tablet/voice in the tablet browser / Fully Kiosk.
+
+  Design constraints (PRITOM P7 — Android 13 Go, 2 GB RAM, 1024x600, WebView Chrome 149):
+  DOM/CSS only, no frameworks, no WebGL, throttled DOM writes, self-contained single file.
+
+  Behavior: registers as a `voice`-class WS client, subscribes to `coaching.voice` (the
+  post-scheduler dispatch stream — this page never re-arbitrates cues), preloads every bank
+  clip into WebAudio buffers, plays each dispatch with seq-based barge-in, keeps the Android
+  audio HAL warm with a silent loop, and reports per-cue timestamps back as `voice.echo`
+  frames for the #381 audible-latency harness.
+-->
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AC Copilot — Voice Endpoint</title>
+<style>
+  :root {
+    --bg: #101114; --panel: #1a1c21; --edge: #2a2d34; --text: #e8e6e0; --dim: #8a8d94;
+    --ok: #35c46f; --warn: #e0a93c; --bad: #e05b4c;
+    --calm: #7fb4d9; --alert: #e0c85a; --urgent: #e08a3c; --critical: #e04a3a;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; background: var(--bg); color: var(--text);
+    font-family: system-ui, sans-serif; overflow: hidden; }
+  #app { display: flex; flex-direction: column; height: 100%; padding: 12px; gap: 10px; }
+  #statusbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .pill { padding: 4px 12px; border-radius: 4px; background: var(--panel);
+    border: 1px solid var(--edge); font-size: 15px; white-space: nowrap; }
+  .pill b { font-weight: 600; }
+  .ok { color: var(--ok); } .warn { color: var(--warn); } .bad { color: var(--bad); }
+  #cue { flex: 1; display: flex; flex-direction: column; justify-content: center;
+    align-items: center; background: var(--panel); border: 1px solid var(--edge);
+    border-radius: 6px; text-align: center; padding: 10px; min-height: 120px; }
+  #cue-text { font-size: 44px; font-weight: 700; line-height: 1.15; }
+  #cue-meta { font-size: 17px; color: var(--dim); margin-top: 8px;
+    font-variant-numeric: tabular-nums; }
+  #log { background: var(--panel); border: 1px solid var(--edge); border-radius: 6px;
+    padding: 8px 10px; font-size: 14px; font-family: ui-monospace, monospace;
+    color: var(--dim); height: 152px; overflow: hidden; line-height: 1.35;
+    font-variant-numeric: tabular-nums; }
+  #arm { position: fixed; inset: 0; background: rgba(10,11,13,.94); display: flex;
+    flex-direction: column; align-items: center; justify-content: center; gap: 16px;
+    z-index: 10; }
+  #arm button { font-size: 30px; padding: 22px 56px; border-radius: 8px; border: 0;
+    background: var(--ok); color: #06130b; font-weight: 700; }
+  #arm p { color: var(--dim); font-size: 16px; max-width: 640px; text-align: center; }
+  .r-calm { color: var(--calm); } .r-alert { color: var(--alert); }
+  .r-urgent { color: var(--urgent); } .r-critical { color: var(--critical); }
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="statusbar">
+    <span class="pill">WS <b id="s-ws" class="bad">connecting…</b></span>
+    <span class="pill">Audio <b id="s-audio" class="bad">locked</b></span>
+    <span class="pill">Clips <b id="s-clips">0/0</b></span>
+    <span class="pill">Latency <b id="s-lat">out=?</b></span>
+    <span class="pill">Cues <b id="s-count">0</b></span>
+  </div>
+  <div id="cue">
+    <div id="cue-text" class="r-calm">— waiting for coaching —</div>
+    <div id="cue-meta"></div>
+  </div>
+  <div id="log"></div>
+</div>
+<div id="arm">
+  <button id="arm-btn">TAP TO ARM AUDIO</button>
+  <p>One tap unlocks WebAudio (browser autoplay policy) and starts the silent keep-warm
+     loop so the first coaching cue plays without the Android audio-HAL wake-up penalty.
+     Plug the earpiece in first.</p>
+</div>
+<script>
+"use strict";
+(function () {
+  var WS_URL = (location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/";
+  var $ = function (id) { return document.getElementById(id); };
+  var state = {
+    ws: null, wsOpen: false, armed: false, ctx: null,
+    buffers: {},           // clip_id -> AudioBuffer
+    fileToClip: {},        // wav file name -> clip_id
+    clipsLoaded: 0, clipsTotal: 0,
+    currentSource: null, currentSeq: -1,
+    cueCount: 0, logLines: [],
+    reconnectDelay: 1000,
+  };
+
+  function setPill(id, text, cls) {
+    var el = $(id);
+    el.textContent = text;
+    if (cls !== undefined) el.className = cls;
+  }
+  function logLine(text) {
+    state.logLines.push(text);
+    if (state.logLines.length > 8) state.logLines.shift();
+    $("log").textContent = state.logLines.join("\n");
+  }
+
+  // ---- audio ---------------------------------------------------------------------------
+  function armAudio() {
+    if (!state.ctx) {
+      var AC = window.AudioContext || window.webkitAudioContext;
+      state.ctx = new AC({ latencyHint: "interactive" });
+    }
+    state.ctx.resume().then(function () {
+      state.armed = true;
+      $("arm").style.display = "none";
+      setPill("s-audio", "armed", "ok");
+      startKeepWarm();
+      updateLatencyPill();
+      loadBank(); // (re)load once armed so decodeAudioData has a running context
+    });
+  }
+  function startKeepWarm() {
+    // A near-silent looping buffer keeps the Android audio HAL out of its low-power sleep;
+    // without it the first cue after ~30 s of silence pays a 100-200 ms wake-up penalty.
+    var ctx = state.ctx;
+    var buf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+    var src = ctx.createBufferSource();
+    var gain = ctx.createGain();
+    gain.gain.value = 0.0001; // inaudible, but keeps the output stream running
+    src.buffer = buf; src.loop = true;
+    src.connect(gain); gain.connect(ctx.destination);
+    src.start();
+  }
+  function updateLatencyPill() {
+    var ctx = state.ctx;
+    if (!ctx) return;
+    var base = ctx.baseLatency !== undefined ? Math.round(ctx.baseLatency * 1000) : "?";
+    var out = ctx.outputLatency !== undefined && ctx.outputLatency > 0
+      ? Math.round(ctx.outputLatency * 1000) : "?";
+    setPill("s-lat", "base=" + base + "ms out=" + out + "ms");
+  }
+
+  function loadBank() {
+    if (state.clipsTotal > 0) return; // already loaded
+    fetch("/voice/manifest.json").then(function (r) {
+      if (!r.ok) throw new Error("manifest " + r.status);
+      return r.json();
+    }).then(function (manifest) {
+      var clips = manifest.clips || [];
+      // Manifest `clips` may be a list of entries or an object keyed by clip_id.
+      var entries = Array.isArray(clips) ? clips : Object.keys(clips).map(function (k) {
+        return clips[k];
+      });
+      state.clipsTotal = entries.length;
+      setPill("s-clips", "0/" + state.clipsTotal);
+      entries.forEach(function (entry) { preloadClip(entry); });
+    }).catch(function (err) {
+      logLine("manifest load failed: " + err.message);
+      setTimeout(loadBank, 5000);
+    });
+  }
+  function preloadClip(entry) {
+    if (!entry || !entry.file || !entry.clip_id) return;
+    state.fileToClip[entry.file] = entry.clip_id;
+    fetch("/voice/clips/" + encodeURIComponent(entry.file)).then(function (r) {
+      if (!r.ok) throw new Error("clip " + r.status);
+      return r.arrayBuffer();
+    }).then(function (raw) {
+      return state.ctx.decodeAudioData(raw);
+    }).then(function (buf) {
+      state.buffers[entry.clip_id] = buf;
+      state.clipsLoaded += 1;
+      setPill("s-clips", state.clipsLoaded + "/" + state.clipsTotal,
+        state.clipsLoaded === state.clipsTotal ? "ok" : "");
+    }).catch(function (err) {
+      logLine("preload failed " + entry.clip_id + ": " + err.message);
+    });
+  }
+
+  function playDispatch(p, tReceive) {
+    // seq-based barge-in: every new dispatch stops whatever is sounding. The PC-side
+    // scheduler already arbitrated (cooldown/dedup/urgency); this page mirrors its output.
+    var bufferState = "preloaded";
+    if (state.currentSource) {
+      try { state.currentSource.stop(); } catch (e) { /* already ended */ }
+      state.currentSource = null;
+    }
+    var tPlay = null;
+    var buf = state.buffers[p.clip_id];
+    if (buf && state.armed) {
+      var src = state.ctx.createBufferSource();
+      src.buffer = buf;
+      src.connect(state.ctx.destination);
+      src.start(0);
+      tPlay = Date.now();
+      state.currentSource = src;
+      src.onended = function () { if (state.currentSource === src) state.currentSource = null; };
+    } else {
+      bufferState = buf ? "decoded" : "missing";
+    }
+    state.currentSeq = p.seq;
+    state.cueCount += 1;
+    setPill("s-count", String(state.cueCount));
+    var reg = p.register || "calm";
+    var cueText = $("cue-text");
+    cueText.textContent = p.text || p.clip_id;
+    cueText.className = "r-" + reg;
+    $("cue-meta").textContent = "#" + p.seq + "  " + p.clip_id + "  " +
+      (p.duration_ms ? Math.round(p.duration_ms) + "ms" : "");
+    logLine("#" + p.seq + " " + reg + " " + p.clip_id +
+      (tPlay !== null ? " js+" + (tPlay - tReceive) + "ms" : " [" + bufferState + "]"));
+    updateLatencyPill();
+    return { t_play_ms: tPlay, buffer_state: bufferState };
+  }
+
+  // ---- websocket -----------------------------------------------------------------------
+  function connect() {
+    var ws = new WebSocket(WS_URL);
+    state.ws = ws;
+    ws.onopen = function () {
+      state.wsOpen = true;
+      state.reconnectDelay = 1000;
+      setPill("s-ws", "connected", "ok");
+      ws.send(JSON.stringify({ v: 1, type: "hello", client: "tablet-voice",
+        client_class: "voice" }));
+      ws.send(JSON.stringify({ v: 1, type: "state.subscribe",
+        topics: ["coaching.voice"] }));
+    };
+    ws.onmessage = function (event) {
+      var tReceive = Date.now();
+      var frame;
+      try { frame = JSON.parse(event.data); } catch (e) { return; }
+      if (frame.type !== "state.snapshot" || frame.topic !== "coaching.voice") return;
+      var p = frame.payload || {};
+      if (typeof p.seq !== "number" || !p.clip_id) return;
+      var played = playDispatch(p, tReceive);
+      var echo = { v: 1, type: "voice.echo", seq: p.seq, clip_id: p.clip_id,
+        t_dispatch_ms: p.t_wall_ms || 0, t_receive_ms: tReceive,
+        buffer_state: played.buffer_state, audio_armed: state.armed };
+      if (played.t_play_ms !== null) echo.t_play_ms = played.t_play_ms;
+      if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(echo));
+    };
+    ws.onclose = function () {
+      state.wsOpen = false;
+      setPill("s-ws", "reconnecting…", "warn");
+      setTimeout(connect, state.reconnectDelay);
+      state.reconnectDelay = Math.min(state.reconnectDelay * 2, 10000);
+    };
+    ws.onerror = function () { ws.close(); };
+  }
+
+  $("arm-btn").addEventListener("click", armAudio);
+  connect();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

**#511 Part D** — the 7" Android tablet becomes the in-ear coaching-audio endpoint over USB, plus the **#381** end-to-end audible-timeliness harness (operator directive 2026-07-11: *"fully test realistic component of voice and HOW TIMELY it is"*, with the tablet as the PC's mic and the earpiece separating coaching from engine noise).

Design was council-reviewed before implementation (3/3 quorum — see the scoping comments on #511 and #381).

### Sidecar / protocol (additive only)
- **`coaching.voice` topic** — one frame per clip the `VoiceCoach` scheduler *actually dispatches* (post cooldown/dedup/barge-in), stamped `t_wall_ms`/`t_mono_ms` at dispatch via a new pass-through `DispatchTapPlayback` (`tools/ai_sidecar/voice/dispatch.py`). No listener installed → zero behavior change.
- **`voice.echo`** (client→server): per-cue tablet timestamps recorded to a bounded ring buffer; **cross-device clocks are never subtracted** (tablet-local and server-local intervals reported separately).
- **`voice.demo`** (loopback-only): one synthetic advisory through the REAL scheduler + broadcast path — the bench entrypoint for burst measurement runs.
- **HTTP on the same port** (read-only, ungated like `/health`): `/tablet/voice` (self-contained page), `/voice/manifest.json`, `/voice/clips/<file>` (**exact-match against the manifest allow-list — no traversal surface**), `/voice/dispatches`, `/voice/echoes`.

### Tablet page (`tools/ai_sidecar/voice/web/tablet_voice.html`)
Self-contained (PRITOM P7 budget: DOM/CSS only, no frameworks): WebAudio preload of all bank clips, tap-once autoplay arm, silent-loop HAL keep-warm, **seq-based barge-in**, WS auto-reconnect, `voice.echo` reporting. Reached over `adb reverse tcp:8765 tcp:8765` — no WiFi (sidesteps the mesh cross-AP block + tablet CGNAT, #511).

### Measurement harness (`tools/ai_sidecar/voice/audible_latency.py`)
scrcpy tablet-mic room capture → DAC-stamped 5–15 kHz chirp clock sync (start+end anchors, drift-corrected, systematic uncertainty **stated** in the report) → matched-filter onset detection using each dispatched clip's own baked waveform (robust under engine noise) → per-cue `dispatch→audible` latency + P50/P95/max vs the 450 ms act budget. Unmatched cue = FAILED assertion, never a dropped row.

## Invariants held
- Pre-baked bank only; no live TTS in the hot path.
- One arbiter: the tablet never re-arbitrates cues.
- Additive protocol only — ESP32/existing WS clients unaffected.
- Listener faults can never break the audio path (tap + server listener both guard).

## Verification
- `tests/test_voice_tablet_endpoint.py` (16) — protocol validation, dispatch tap through the real scheduler, HTTP allow-list (incl. traversal attempts), WS `voice.echo`/`voice.demo` flows on real sockets.
- `tests/test_audible_latency.py` (6) — synthetic-room end-to-end: clock map (1- and 2-anchor drift fit), onset recovery at 180 ms ± 15 ms, refusal on absent templates, CLI round-trip.
- Focused regression: 108 passed (voice engine/wiring/playback/timing + external protocol).
- Live rig verification (tablet audio + realistic drive + timeliness report) follows in this session and will be posted as evidence on #381.

Refs #511 (Part D). Verification harness for #381 (does not close either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
