### PR TITLE
fix(coaching): coach every brake zone + per-driver brake-mark calibration (#522 parts 1-2)

### DIFF
--- a/tests/test_realtime_observer.py
+++ b/tests/test_realtime_observer.py
@@ -596,11 +596,12 @@ def test_wrapped_lead_first_corner_fires_once_per_approach():
 # ---- issue #522 part 2: per-driver brake-mark calibration ------------------------------------
 
 
-def _driver_trace(onset: float, *, end: float, window: tuple[float, float] = (0.0, 1.0)):
+def _driver_trace(
+    onset: float, *, end: float, window: tuple[float, float] = (0.0, 1.0), n: int = 400
+):
     """A flat 40 m/s LapTrace braking 0.8 over [onset, end] (sustained, gate-grade)."""
     from tools.ai_sidecar.lap_dynamics import LapTrace
 
-    n = 400
     spline = [i / (n - 1) for i in range(n)]
     brake = [0.8 if onset <= s <= end else 0.0 for s in spline]
     return LapTrace(
@@ -928,9 +929,10 @@ def test_calibration_tolerance_is_metric_not_normalized():
     ref = _i522_ref()  # mark 0.45
     long_track = RealtimeObserver([ref], track_length_m=20000.0)
     # 0.465 spline = 300 m from the mark on a 20 km track: a different feature, rejected
-    assert long_track.calibrate_from_driver_lap(_driver_trace(0.465, end=0.49)) == 0
-    # ~0.4511 spline = ~22 m: same zone, accepted
-    assert long_track.calibrate_from_driver_lap(_driver_trace(0.4505, end=0.49)) == 1
+    # (n=4000 so the fixture matches a real trace density on a track this long)
+    assert long_track.calibrate_from_driver_lap(_driver_trace(0.465, end=0.49, n=4000)) == 0
+    # ~0.4505 spline = ~10 m: same zone, accepted
+    assert long_track.calibrate_from_driver_lap(_driver_trace(0.4505, end=0.49, n=4000)) == 1
 
 
 def test_two_zones_inside_one_lead_emit_on_consecutive_frames_not_one_batch():
@@ -955,3 +957,51 @@ def test_two_zones_inside_one_lead_emit_on_consecutive_frames_not_one_batch():
     c2 = [a for a in second if a.kind == "late_brake"]
     assert len(c1) == 1 and c1[0].detail["zone"] == 0, "imminent zone speaks first, alone"
     assert len(c2) == 1 and c2[0].detail["zone"] == 1, "the second zone follows next frame"
+
+
+def test_calibration_rejects_wrong_layout_accepts_missing_layout():
+    """PR #525 review: multi-layout track ids share normalized splines that point at unrelated
+    features — a lap from another LAYOUT never calibrates; a lap without layout metadata falls
+    back to the id-only guard (older archives)."""
+    ref = _i522_ref()
+    obs = RealtimeObserver(
+        [ref], track_length_m=2500.0, track_id="ks_nordschleife", track_layout="endurance"
+    )
+    assert (
+        obs.calibrate_from_driver_lap(
+            _driver_trace(0.46, end=0.49), track_id="ks_nordschleife", track_layout="tourist"
+        )
+        == 0
+    )
+    assert (
+        obs.calibrate_from_driver_lap(
+            _driver_trace(0.46, end=0.49), track_id="ks_nordschleife", track_layout=None
+        )
+        == 1
+    )
+
+
+def test_calibration_keeps_following_a_mark_that_drifted_out_of_the_window():
+    """PR #525 review: onset scanning anchors on the marks IN FORCE — a learned mark that
+    drifted upstream of the reference window keeps adapting instead of snapping back."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.50,
+        spline_lo=0.44,  # tight window: reference scan would start at 0.42
+        spline_hi=0.60,
+        optimal_apex_kmh=100.0,
+        best_observed_apex_kmh=100.0,
+        best_brake_point_spline=0.445,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    # walk the EMA upstream over laps: 0.430 (d=0.015), then 0.418 near the learned 0.436
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.430, end=0.47)) == 1
+    marks = obs._effective_marks(ref)
+    assert marks[0][0] == pytest.approx(0.430, abs=0.003)
+    # 0.418 is 0.027 below the ORIGINAL window scan floor (0.42) — but only 0.012 from the
+    # learned mark: it must still fold.
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.418, end=0.47)) == 1
+    marks = obs._effective_marks(ref)
+    # EMA: 0.430 + 0.4*(0.418-0.430) ~= 0.425
+    assert marks[0][0] == pytest.approx(0.4255, abs=0.004)

--- a/tests/test_realtime_observer.py
+++ b/tests/test_realtime_observer.py
@@ -920,3 +920,38 @@ def test_tail_calibrated_first_corner_mark_survives_the_wrap():
     assert len(cues) == 1, "exactly one heads-up for the pass straddling start/finish"
     late_info = [a for a in [*fired, *exit_out] if a.detail.get("braked_late_uncoached")]
     assert late_info == [], "braking at the learned pre-line mark is NOT a late brake"
+
+
+def test_calibration_tolerance_is_metric_not_normalized():
+    """PR #525 review: the same-zone match window is 50 m, not a fixed spline fraction — on a
+    20 km track an onset ~300 m from the mark must NOT calibrate, while ~30 m still does."""
+    ref = _i522_ref()  # mark 0.45
+    long_track = RealtimeObserver([ref], track_length_m=20000.0)
+    # 0.465 spline = 300 m from the mark on a 20 km track: a different feature, rejected
+    assert long_track.calibrate_from_driver_lap(_driver_trace(0.465, end=0.49)) == 0
+    # ~0.4511 spline = ~22 m: same zone, accepted
+    assert long_track.calibrate_from_driver_lap(_driver_trace(0.4505, end=0.49)) == 1
+
+
+def test_two_zones_inside_one_lead_emit_on_consecutive_frames_not_one_batch():
+    """PR #525 review: marks closer than the lead open both arcs on the same tick; a same-batch
+    pair would make the voice scheduler drop one. The observer emits at most one heads-up per
+    corner per frame — the second zone follows on the next frame."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.52,
+        spline_lo=0.42,
+        spline_hi=0.62,
+        optimal_apex_kmh=90.0,
+        best_observed_apex_kmh=90.0,
+        best_brake_point_spline=0.45,
+        n_corpus=1,
+        brake_marks=[0.45, 0.475],  # both arcs open inside the default 3.2 s lead
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    first = obs.observe({"spline": 0.440, "speed": 110.0, "brake": 0.0})
+    second = obs.observe({"spline": 0.4405, "speed": 110.0, "brake": 0.0})
+    c1 = [a for a in first if a.kind == "late_brake"]
+    c2 = [a for a in second if a.kind == "late_brake"]
+    assert len(c1) == 1 and c1[0].detail["zone"] == 0, "imminent zone speaks first, alone"
+    assert len(c2) == 1 and c2[0].detail["zone"] == 1, "the second zone follows next frame"

--- a/tests/test_realtime_observer.py
+++ b/tests/test_realtime_observer.py
@@ -765,3 +765,95 @@ def test_trail_braking_previous_corner_does_not_latch_next_corner():
     obs2.observe({"spline": 0.440, "speed": 110.0, "brake": 0.6})  # tta ~0.8 s
     out2 = obs2.observe({"spline": 0.444, "speed": 110.0, "brake": 0.0})
     assert [a for a in out2 if a.kind == "late_brake"] == []
+
+
+def test_unconfirmed_wrap_carry_reverts_on_pit_return():
+    """PR #525 review (qodo bug + codex P2): a wrap-SHAPED jump with a known, un-advanced lap
+    counter may be a pit return — a pre-wrap-armed pass carried across it must be reverted
+    when the car drives on without the counter advancing, so the next lap-end approach still
+    gets its heads-up."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.06,
+        spline_lo=0.02,
+        spline_hi=0.10,
+        optimal_apex_kmh=80.0,
+        best_observed_apex_kmh=80.0,
+        best_brake_point_spline=0.03,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    obs.observe({"spline": 0.90, "speed": 180.0, "brake": 0.0, "lap": 1})
+    fired = obs.observe({"spline": 0.97, "speed": 180.0, "brake": 0.0, "lap": 1})
+    assert [a for a in fired if a.kind == "late_brake"]  # pre-wrap heads-up, pass armed
+    # wrap-shaped jump, counter KNOWN and not advanced -> ambiguous, carry deferred
+    obs.observe({"spline": 0.01, "speed": 60.0, "brake": 0.0, "lap": 1})
+    # car drives on past the wrap zone with the counter still at 1 -> it was a pit return
+    obs.observe({"spline": 0.40, "speed": 120.0, "brake": 0.0, "lap": 1})
+    # next lap-end approach: the reverted pass must arm + cue again
+    fired2 = obs.observe({"spline": 0.97, "speed": 180.0, "brake": 0.0, "lap": 1})
+    assert [a for a in fired2 if a.kind == "late_brake"], (
+        "carried pre-wrap state must be reverted when the jump turns out to be a pit return"
+    )
+
+
+def test_confirmed_wrap_keeps_carry_no_duplicate_cue():
+    """Counterpart: when the lagging counter DOES advance a frame after the wrap-shaped drop,
+    the carried pass is legitimate — the first-corner cue must not fire a second time."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.06,
+        spline_lo=0.02,
+        spline_hi=0.10,
+        optimal_apex_kmh=80.0,
+        best_observed_apex_kmh=80.0,
+        best_brake_point_spline=0.03,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    obs.observe({"spline": 0.90, "speed": 180.0, "brake": 0.0, "lap": 1})
+    fired = obs.observe({"spline": 0.97, "speed": 180.0, "brake": 0.0, "lap": 1})
+    assert [a for a in fired if a.kind == "late_brake"]
+    out = obs.observe({"spline": 0.005, "speed": 180.0, "brake": 0.0, "lap": 1})  # counter lags
+    out += obs.observe({"spline": 0.012, "speed": 180.0, "brake": 0.0, "lap": 2})  # advances
+    assert [a for a in out if a.kind == "late_brake" and a.urgency == "prepare"] == [], (
+        "a confirmed wrap keeps the carried pass — no duplicate first-corner cue"
+    )
+
+
+def test_calibration_follows_learned_mark_across_laps():
+    """PR #525 review: after a zone has drifted toward the driver's habit, later laps near the
+    LEARNED mark (but outside the original synthetic mark's tolerance) must keep adapting."""
+    ref = _i522_ref()  # synthetic mark 0.45
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.465, end=0.49)) == 1  # within 0.02
+    # 0.474 is 0.024 from the SYNTHETIC mark (outside tol) but 0.009 from the learned 0.465
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.474, end=0.50)) == 1
+    marks = obs._effective_marks(ref)
+    # EMA: 0.465 + 0.4*(0.474-0.465) = 0.4686
+    assert marks[0][0] == pytest.approx(0.4686, abs=0.003)
+
+
+def test_calibration_never_crosses_neighbouring_zone_marks():
+    """PR #525 review: an update that would move a zone past its neighbour's mark is skipped —
+    crossed marks would corrupt the per-zone segment arcs."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.52,
+        spline_lo=0.42,
+        spline_hi=0.62,
+        optimal_apex_kmh=90.0,
+        best_observed_apex_kmh=90.0,
+        best_brake_point_spline=0.45,
+        n_corpus=1,
+        brake_marks=[0.45, 0.47],
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    # two applications: one at 0.468 (zone1's neighbourhood), one at 0.485. Greedy matching
+    # pairs 0.468->zone1 (dist .002) and 0.485->zone... 0.485 is 0.035 from 0.45: no match.
+    # Then zone0's nearest remaining onset 0.468 would land AT/PAST zone1's mark region — but
+    # one-to-one matching already consumed it. Now try to drag zone0 past zone1 directly:
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.468, end=0.478)) == 1
+    marks = obs._effective_marks(ref)
+    assert marks[1][0] == pytest.approx(0.469, abs=0.002)  # zone1 calibrated
+    assert marks[0] == (0.45, "corpus_best")  # zone0 NOT dragged onto zone1's mark

--- a/tests/test_realtime_observer.py
+++ b/tests/test_realtime_observer.py
@@ -663,6 +663,75 @@ def test_calibration_survives_lap_wrap_reset():
     assert marks[0][1] == "driver_calibrated"
 
 
+def test_calibration_matches_wrapped_first_corner_onset():
+    """PR #525 review: for a mark near spline 0, the driver's onset sits at the END of the
+    completed lap trace (the archive finalizes before the S/F frame) — the scan must cross
+    the wrap, not clamp at 0."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.05,
+        spline_lo=0.005,
+        spline_hi=0.09,
+        optimal_apex_kmh=80.0,
+        best_observed_apex_kmh=80.0,
+        best_brake_point_spline=0.01,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    # driver onset at ~0.992 — ~0.018 spline before the 0.01 mark, across start/finish
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.992, end=1.0)) == 1
+    marks = obs._effective_marks(ref)
+    assert marks[0][1] == "driver_calibrated"
+    assert marks[0][0] == pytest.approx(0.992, abs=0.005)
+
+
+def test_one_driver_onset_calibrates_at_most_one_zone():
+    """PR #525 review: marks closer than twice the tolerance must not both snap to a single
+    brake application — matching is one-to-one, nearest first."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.52,
+        spline_lo=0.42,
+        spline_hi=0.62,
+        optimal_apex_kmh=90.0,
+        best_observed_apex_kmh=90.0,
+        best_brake_point_spline=0.45,
+        n_corpus=1,
+        brake_marks=[0.45, 0.475],  # 0.025 apart < 2 x 0.02 tolerance
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    # ONE sustained application between the marks: nearest zone wins, the other stays reference
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.462, end=0.50)) == 1
+    sources = [src for _m, src in obs._effective_marks(ref)]
+    assert sources.count("driver_calibrated") == 1
+
+
+def test_external_reset_clears_prewrap_armed_state():
+    """PR #525 review: reset() without the wrap carry (producer disconnect / teleport) must
+    clear a pre-wrap-armed pass — stale zone_cued state would suppress the fresh first-corner
+    heads-up of the NEW stream."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.06,
+        spline_lo=0.02,
+        spline_hi=0.10,
+        optimal_apex_kmh=80.0,
+        best_observed_apex_kmh=80.0,
+        best_brake_point_spline=0.03,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    # pre-wrap approach: heads-up fires, pass is armed
+    fired = obs.observe({"spline": 0.97, "speed": 180.0, "brake": 0.0})
+    assert [a for a in fired if a.kind == "late_brake"]
+    obs.reset()  # EXTERNAL reset (no carry): a new producer/stream takes over
+    # new stream starts just after S/F, still ahead of the mark: heads-up must fire again
+    fired2 = obs.observe({"spline": 0.005, "speed": 180.0, "brake": 0.0})
+    assert [a for a in fired2 if a.kind == "late_brake"], (
+        "stale pre-wrap state must not survive an external reset"
+    )
+
+
 def test_trail_braking_previous_corner_does_not_latch_next_corner():
     """#523 review (Codex P2): with the 3.2 s lead, closely spaced corners overlap — braking
     far out in the lead window (trail-braking the previous turn) must not consume the next

--- a/tests/test_realtime_observer.py
+++ b/tests/test_realtime_observer.py
@@ -500,6 +500,169 @@ def test_late_brake_feedback_survives_without_apex_deficit():
     assert "brake earlier next lap" in late_info[0].message
 
 
+# ---- issue #522 part 1: every brake zone of a merged corner gets its own heads-up ------------
+
+
+def _esses_ref() -> CornerReference:
+    """A merged esses corner: ONE driver-perceived corner window holding TWO brake zones."""
+    return CornerReference(
+        index=2,
+        apex_spline=0.52,
+        spline_lo=0.42,
+        spline_hi=0.62,
+        optimal_apex_kmh=90.0,
+        best_observed_apex_kmh=90.0,
+        best_brake_point_spline=0.45,
+        n_corpus=1,
+        brake_marks=[0.45, 0.50],
+    )
+
+
+def test_each_zone_of_a_merged_corner_gets_its_own_heads_up():
+    """#522 coverage: braking for (and being cued about) the first zone must not consume the
+    second zone's heads-up — each real brake zone gets exactly one calm anticipatory cue."""
+    obs = RealtimeObserver([_esses_ref()], track_length_m=2500.0, brake_prepare_lead_s=1.0)
+    fired = []
+    # 110 km/h -> 1 s lead = ~0.0122 spline: zone 1 window opens ~0.4378, zone 2 ~0.4878
+    fired += obs.observe({"spline": 0.440, "speed": 110.0, "brake": 0.0})  # zone 1 heads-up
+    fired += obs.observe({"spline": 0.449, "speed": 110.0, "brake": 0.7})  # brakes at mark 1
+    fired += obs.observe({"spline": 0.470, "speed": 95.0, "brake": 0.0})  # released between zones
+    fired += obs.observe({"spline": 0.490, "speed": 95.0, "brake": 0.0})  # zone 2 heads-up
+    fired += obs.observe({"spline": 0.499, "speed": 90.0, "brake": 0.7})  # brakes at mark 2
+    cues = [a for a in fired if a.kind == "late_brake"]
+    assert len(cues) == 2, f"one heads-up per ZONE, got {[(c.spline, c.detail) for c in cues]}"
+    assert [c.detail["zone"] for c in cues] == [0, 1]
+    assert [c.spline for c in cues] == [0.45, 0.50]
+    assert all(c.urgency == "prepare" and c.register == "calm" for c in cues)
+
+
+def test_missed_second_zone_flags_late_uncoached_at_exit():
+    """Braking correctly for zone 1 but sailing past zone 2's mark is still a late-brake miss —
+    silence live, owned by exit grading (#522)."""
+    obs = RealtimeObserver([_esses_ref()], track_length_m=2500.0, brake_prepare_lead_s=1.0)
+    obs.observe({"spline": 0.449, "speed": 110.0, "brake": 0.7})  # brakes for zone 1
+    obs.observe({"spline": 0.470, "speed": 95.0, "brake": 0.0})
+    out = obs.observe({"spline": 0.505, "speed": 95.0, "brake": 0.0})  # past mark 2, no brake
+    assert [a for a in out if a.kind == "late_brake"] == []  # silent past the mark
+    obs.observe({"spline": 0.52, "speed": 60.0, "brake": 0.0})  # slow apex
+    exit_out = obs.observe({"spline": 0.63, "speed": 90.0, "brake": 0.0})
+    deficits = [a for a in exit_out if a.kind == "apex_deficit"]
+    assert deficits and deficits[0].detail["braked_late_uncoached"] is True
+
+
+def test_multi_zone_marks_flow_from_reference_archive():
+    """build_observer_from_reference -> build_references -> add_corpus_lap must give the
+    observer every zone's mark (the #522 Magione back-half coverage path)."""
+    ref_lap = lap_trace_from_archive(_corner_archive())
+    refs = build_references(ref_lap)
+    add_corpus_lap(refs, ref_lap)
+    assert all(r.brake_marks for r in refs)
+    assert all(r.best_brake_point_spline == r.brake_marks[0] for r in refs)
+
+
+def test_wrapped_lead_first_corner_fires_once_per_approach():
+    """Regression (#522 follow-through): a first-corner mark near spline 0 wraps its lead window
+    over start/finish. The pre-wrap re-arm must be ONE-SHOT — without it the re-arm check reads
+    the approach's own heads-up as stale state and re-fires the cue every frame to the line —
+    and the armed pass must CARRY across the wrap so the cue does not fire a second time after
+    start/finish."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.06,
+        spline_lo=0.02,
+        spline_hi=0.10,
+        optimal_apex_kmh=80.0,
+        best_observed_apex_kmh=80.0,
+        best_brake_point_spline=0.03,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)  # default 3.2 s lead
+    fired = []
+    # two full laps sampled densely through the wrap zone and the corner
+    lap_points = [0.90, 0.93, 0.95, 0.96, 0.97, 0.98, 0.99, 0.005, 0.015, 0.025]
+    for lap_n in (1, 2):
+        for s in lap_points:
+            fired.extend(obs.observe({"spline": s, "speed": 180.0, "brake": 0.0, "lap": lap_n}))
+        fired.extend(obs.observe({"spline": 0.04, "speed": 90.0, "brake": 0.8, "lap": lap_n}))
+        fired.extend(obs.observe({"spline": 0.12, "speed": 120.0, "brake": 0.0, "lap": lap_n}))
+        fired.extend(obs.observe({"spline": 0.50, "speed": 180.0, "brake": 0.0, "lap": lap_n}))
+    cues = [a for a in fired if a.kind == "late_brake" and a.urgency == "prepare"]
+    assert len(cues) == 2, (
+        f"exactly ONE heads-up per approach over two laps, got {len(cues)}: "
+        f"{[(c.spline, c.detail.get('lead_s')) for c in cues]}"
+    )
+
+
+# ---- issue #522 part 2: per-driver brake-mark calibration ------------------------------------
+
+
+def _driver_trace(onset: float, *, end: float, window: tuple[float, float] = (0.0, 1.0)):
+    """A flat 40 m/s LapTrace braking 0.8 over [onset, end] (sustained, gate-grade)."""
+    from tools.ai_sidecar.lap_dynamics import LapTrace
+
+    n = 400
+    spline = [i / (n - 1) for i in range(n)]
+    brake = [0.8 if onset <= s <= end else 0.0 for s in spline]
+    return LapTrace(
+        spline=spline,
+        t_s=[0.05 * i for i in range(n)],
+        v_ms=[40.0] * n,
+        brake=brake,
+        throttle=[0.0] * n,
+        steer=[0.0] * n,
+        gear=[4] * n,
+        x=[1.0 * i for i in range(n)],
+        z=[0.0] * n,
+    )
+
+
+def test_calibration_moves_the_mark_to_the_drivers_demonstrated_point():
+    """#522 part 2: after the driver's own lap shows a sustained brake onset near the synthetic
+    mark, the cue anchors on the DRIVER's point with honest provenance."""
+    ref = _i522_ref()  # synthetic mark at 0.45
+    obs = RealtimeObserver([ref], track_length_m=2500.0, brake_prepare_lead_s=1.0)
+    updated = obs.calibrate_from_driver_lap(_driver_trace(0.46, end=0.49))
+    assert updated == 1
+    out = obs.observe({"spline": 0.4505, "speed": 110.0, "brake": 0.0})
+    cues = [a for a in out if a.kind == "late_brake"]
+    assert cues, "heads-up must fire in the calibrated mark's lead window"
+    assert cues[0].detail["mark_source"] == "driver_calibrated"
+    assert cues[0].spline == pytest.approx(0.46, abs=0.005)
+
+
+def test_calibration_ema_converges_over_laps():
+    ref = _i522_ref()
+    obs = RealtimeObserver([ref], track_length_m=2500.0, brake_prepare_lead_s=1.0)
+    obs.calibrate_from_driver_lap(_driver_trace(0.455, end=0.49))
+    obs.calibrate_from_driver_lap(_driver_trace(0.465, end=0.49))
+    # EMA(0.4): 0.455 + 0.4*(0.465-0.455) = 0.459
+    marks = obs._effective_marks(ref)
+    assert marks[0][1] == "driver_calibrated"
+    assert marks[0][0] == pytest.approx(0.459, abs=0.003)
+
+
+def test_calibration_ignores_distant_onsets_and_wrong_track():
+    ref = _i522_ref()  # mark 0.45
+    obs = RealtimeObserver(
+        [ref], track_length_m=2500.0, brake_prepare_lead_s=1.0, track_id="magione"
+    )
+    # onset 0.55 is ~0.10 spline from the mark — a different zone/line, never calibrates
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.55, end=0.58)) == 0
+    # right onset, wrong track: refused outright
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.46, end=0.49), track_id="imola") == 0
+    marks = obs._effective_marks(ref)
+    assert marks[0] == (0.45, "corpus_best")
+
+
+def test_calibration_survives_lap_wrap_reset():
+    ref = _i522_ref()
+    obs = RealtimeObserver([ref], track_length_m=2500.0, brake_prepare_lead_s=1.0)
+    obs.calibrate_from_driver_lap(_driver_trace(0.46, end=0.49))
+    obs.reset()  # lap wrap clears PASS state, not driver knowledge
+    marks = obs._effective_marks(ref)
+    assert marks[0][1] == "driver_calibrated"
+
+
 def test_trail_braking_previous_corner_does_not_latch_next_corner():
     """#523 review (Codex P2): with the 3.2 s lead, closely spaced corners overlap — braking
     far out in the lead window (trail-braking the previous turn) must not consume the next

--- a/tests/test_realtime_observer.py
+++ b/tests/test_realtime_observer.py
@@ -857,3 +857,66 @@ def test_calibration_never_crosses_neighbouring_zone_marks():
     marks = obs._effective_marks(ref)
     assert marks[1][0] == pytest.approx(0.469, abs=0.002)  # zone1 calibrated
     assert marks[0] == (0.45, "corpus_best")  # zone0 NOT dragged onto zone1's mark
+
+
+def test_pit_return_resuming_before_the_mark_still_gets_the_heads_up():
+    """PR #525 review round 3: a wrap-shaped pit return whose resume point is BEFORE the
+    first-corner mark must not keep the carried zone_cued — the deferral is bounded by
+    frames (a true wrap's counter advances within ~1 frame), so the revert lands before
+    the car reaches the mark."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.06,
+        spline_lo=0.02,
+        spline_hi=0.10,
+        optimal_apex_kmh=80.0,
+        best_observed_apex_kmh=80.0,
+        best_brake_point_spline=0.03,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    obs.observe({"spline": 0.90, "speed": 180.0, "brake": 0.0, "lap": 1})
+    fired = obs.observe({"spline": 0.97, "speed": 180.0, "brake": 0.0, "lap": 1})
+    assert [a for a in fired if a.kind == "late_brake"]  # pre-wrap heads-up spoken
+    # wrap-shaped jump to just after S/F, counter KNOWN and never advancing (pit return);
+    # the car creeps toward the mark WITHOUT ever passing the 0.25 drive-on discard point.
+    out = []
+    out += obs.observe({"spline": 0.004, "speed": 60.0, "brake": 0.0, "lap": 1})
+    out += obs.observe({"spline": 0.006, "speed": 60.0, "brake": 0.0, "lap": 1})
+    out += obs.observe({"spline": 0.008, "speed": 60.0, "brake": 0.0, "lap": 1})
+    out += obs.observe({"spline": 0.010, "speed": 60.0, "brake": 0.0, "lap": 1})
+    out += obs.observe({"spline": 0.014, "speed": 60.0, "brake": 0.0, "lap": 1})
+    cues = [a for a in out if a.kind == "late_brake" and a.urgency == "prepare"]
+    assert cues, "after the frame-bounded revert the fresh approach must be cued"
+
+
+def test_tail_calibrated_first_corner_mark_survives_the_wrap():
+    """PR #525 review round 3: a driver-calibrated first-corner mark can sit just BEFORE
+    start/finish (~0.99 for a corner at ~0.03+). Braking at that mark pre-wrap must carry
+    across a genuine wrap — no duplicate cue, and no false 'brake earlier next lap'."""
+    ref = CornerReference(
+        index=0,
+        apex_spline=0.05,
+        spline_lo=0.005,
+        spline_hi=0.09,
+        optimal_apex_kmh=80.0,
+        best_observed_apex_kmh=80.0,
+        best_brake_point_spline=0.01,
+        n_corpus=1,
+    )
+    obs = RealtimeObserver([ref], track_length_m=2500.0)
+    assert obs.calibrate_from_driver_lap(_driver_trace(0.992, end=1.0)) == 1  # mark -> ~0.992
+    fired = []
+    fired += obs.observe({"spline": 0.90, "speed": 180.0, "brake": 0.0, "lap": 1})
+    fired += obs.observe({"spline": 0.95, "speed": 180.0, "brake": 0.0, "lap": 1})  # heads-up
+    fired += obs.observe(
+        {"spline": 0.993, "speed": 150.0, "brake": 0.8, "lap": 1}
+    )  # brakes AT mark
+    fired += obs.observe({"spline": 0.005, "speed": 90.0, "brake": 0.0, "lap": 1})  # wrap, lag
+    fired += obs.observe({"spline": 0.02, "speed": 85.0, "brake": 0.0, "lap": 2})  # confirm
+    fired += obs.observe({"spline": 0.05, "speed": 80.0, "brake": 0.0, "lap": 2})  # apex at target
+    exit_out = obs.observe({"spline": 0.10, "speed": 90.0, "brake": 0.0, "lap": 2})
+    cues = [a for a in fired if a.kind == "late_brake" and a.urgency == "prepare"]
+    assert len(cues) == 1, "exactly one heads-up for the pass straddling start/finish"
+    late_info = [a for a in [*fired, *exit_out] if a.detail.get("braked_late_uncoached")]
+    assert late_info == [], "braking at the learned pre-line mark is NOT a late brake"

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -437,7 +437,9 @@ def _real_observer():
 def test_calibrate_brake_marks_from_lap_updates_observer(tmp_path, monkeypatch):
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
-    monkeypatch.setattr(server, "_last_brake_cal_key", None)
+    monkeypatch.setattr(
+        server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
+    )
     # calibration is core telemetry learning, deliberately INDEPENDENT of the optional LLM
     # debrief pipeline: it must fold with the debrief feature disabled (PR #525 review).
     monkeypatch.delenv("AC_COPILOT_OLLAMA_ENABLE", raising=False)
@@ -453,7 +455,9 @@ def test_calibrate_brake_marks_from_lap_updates_observer(tmp_path, monkeypatch):
 def test_calibration_skips_explicitly_invalid_lap(tmp_path, monkeypatch):
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
-    monkeypatch.setattr(server, "_last_brake_cal_key", None)
+    monkeypatch.setattr(
+        server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
+    )
     archive = _corner_archive()
     archive["lap"]["is_valid"] = False  # a cut lap's brake points are not calibration data
     path = _write_lap_archive(tmp_path, archive)
@@ -473,10 +477,12 @@ def test_unresolvable_frame_does_not_reserve_the_calibration_key(tmp_path, monke
     reserve the dedup key — the archive-backed re-send of the SAME lap must still calibrate."""
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
-    monkeypatch.setattr(server, "_last_brake_cal_key", None)
+    monkeypatch.setattr(
+        server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
+    )
     # plain frame: same lap identity, nothing loadable -> returns without reserving
     asyncio.run(server._calibrate_brake_marks_from_lap({"lap": 3, "lapTimeMs": 133498}))
-    assert server._last_brake_cal_key is None
+    assert len(server._recent_brake_cal_keys) == 0
     assert obs._driver_marks == {}
     # archive-backed re-send of the same physical lap -> calibrates
     path = _write_lap_archive(tmp_path, _corner_archive())
@@ -484,3 +490,47 @@ def test_unresolvable_frame_does_not_reserve_the_calibration_key(tmp_path, monke
         server._calibrate_brake_marks_from_lap({"lap": 3, "lapTimeMs": 133498, "archivePath": path})
     )
     assert obs._driver_marks, "the archive-backed re-send must not be starved by the empty frame"
+
+
+def test_late_resend_after_a_newer_lap_is_still_deduped(tmp_path, monkeypatch):
+    """PR #525 review: the dedup memory is a bounded set of recent lap identities, not a single
+    slot — a brainOnly re-send of lap N arriving AFTER lap N+1 folded must not refold lap N."""
+    obs = _real_observer()
+    monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(
+        server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
+    )
+    path_n = _write_lap_archive(tmp_path, _corner_archive(), name="lap_0003.json")
+    path_n1 = _write_lap_archive(tmp_path, _corner_archive(), name="lap_0004.json")
+    asyncio.run(
+        server._calibrate_brake_marks_from_lap(
+            {"lap": 3, "lapTimeMs": 133498, "archivePath": path_n}
+        )
+    )
+    laps_folded = next(iter(obs._driver_marks.values()))[1]
+    asyncio.run(
+        server._calibrate_brake_marks_from_lap(
+            {"lap": 4, "lapTimeMs": 132513, "archivePath": path_n1}
+        )
+    )
+    after_lap4 = next(iter(obs._driver_marks.values()))[1]
+    # the LATE re-send of lap 3 (same identity) must be a no-op
+    asyncio.run(
+        server._calibrate_brake_marks_from_lap(
+            {"lap": 3, "lapTimeMs": 133498, "archivePath": path_n}
+        )
+    )
+    assert next(iter(obs._driver_marks.values()))[1] == after_lap4
+    assert after_lap4 == laps_folded + 1
+
+
+def test_calibration_inactive_when_coach_v2_owns_the_cue_path(monkeypatch):
+    """PR #525 review: with coach v2 routing live telemetry, folding laps into the LEGACY
+    observer would log 'calibrated' with zero effect on the spoken cues — the task must not
+    be scheduled at all."""
+    monkeypatch.setattr(server, "_observer", _real_observer())
+    monkeypatch.setattr(server, "_coach_runtime", object())
+    monkeypatch.delenv("AC_COPILOT_BRAKE_CAL", raising=False)
+    assert server._brake_calibration_active() is False
+    monkeypatch.setattr(server, "_coach_runtime", None)
+    assert server._brake_calibration_active() is True

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -466,3 +466,23 @@ def test_calibration_env_kill_switch(monkeypatch):
     assert server._brake_calibration_enabled() is False
     monkeypatch.delenv("AC_COPILOT_BRAKE_CAL")
     assert server._brake_calibration_enabled() is True
+
+
+def test_unresolvable_frame_does_not_reserve_the_calibration_key(tmp_path, monkeypatch):
+    """PR #525 review: a lap_complete with neither an inline trace nor an archivePath must not
+    reserve the dedup key — the archive-backed re-send of the SAME lap must still calibrate."""
+    obs = _real_observer()
+    monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(server, "_last_brake_cal_key", None)
+    # plain frame: same lap identity, nothing loadable -> returns without reserving
+    asyncio.run(server._calibrate_brake_marks_from_lap({"lap": 3, "lapTimeMs": 133498}))
+    assert server._last_brake_cal_key is None
+    assert obs._driver_marks == {}
+    # archive-backed re-send of the same physical lap -> calibrates
+    path = _write_lap_archive(tmp_path, _corner_archive())
+    asyncio.run(
+        server._calibrate_brake_marks_from_lap(
+            {"lap": 3, "lapTimeMs": 133498, "archivePath": path}
+        )
+    )
+    assert obs._driver_marks, "the archive-backed re-send must not be starved by the empty frame"

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -481,8 +481,6 @@ def test_unresolvable_frame_does_not_reserve_the_calibration_key(tmp_path, monke
     # archive-backed re-send of the same physical lap -> calibrates
     path = _write_lap_archive(tmp_path, _corner_archive())
     asyncio.run(
-        server._calibrate_brake_marks_from_lap(
-            {"lap": 3, "lapTimeMs": 133498, "archivePath": path}
-        )
+        server._calibrate_brake_marks_from_lap({"lap": 3, "lapTimeMs": 133498, "archivePath": path})
     )
     assert obs._driver_marks, "the archive-backed re-send must not be starved by the empty frame"

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -413,3 +413,53 @@ def test_handler_routes_telemetry_tick_into_observer(monkeypatch):
     assert len(sent) == 1
     assert sent[0][0]["topic"] == TOPIC_COACHING_CUE
     assert sent[0][1] is ws  # producer excluded from its own cue fan-out
+
+
+# ---- issue #522 part 2: lap_complete -> per-driver brake-mark calibration --------------------
+
+
+def _write_lap_archive(tmp_path, archive: dict, name: str = "lap_0001.json") -> str:
+    laps = tmp_path / "journal" / "laps"
+    laps.mkdir(parents=True, exist_ok=True)
+    p = laps / name
+    p.write_text(json.dumps(archive), encoding="utf-8")
+    return str(p)
+
+
+def _real_observer():
+    from tools.ai_sidecar.realtime_observer import build_observer_from_reference
+
+    obs = build_observer_from_reference(_corner_archive())
+    assert obs is not None
+    return obs
+
+
+def test_calibrate_brake_marks_from_lap_updates_observer(tmp_path, monkeypatch):
+    obs = _real_observer()
+    monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(server, "_last_brake_cal_key", None)
+    path = _write_lap_archive(tmp_path, _corner_archive())
+    asyncio.run(server._calibrate_brake_marks_from_lap({"archivePath": path, "lap": 3}))
+    assert obs._driver_marks, "the driver's own lap must calibrate at least one zone"
+    laps_folded = next(iter(obs._driver_marks.values()))[1]
+    # the brainOnly re-send of the SAME lap must not double-weight the EMA
+    asyncio.run(server._calibrate_brake_marks_from_lap({"archivePath": path, "lap": 3}))
+    assert next(iter(obs._driver_marks.values()))[1] == laps_folded
+
+
+def test_calibration_skips_explicitly_invalid_lap(tmp_path, monkeypatch):
+    obs = _real_observer()
+    monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(server, "_last_brake_cal_key", None)
+    archive = _corner_archive()
+    archive["lap"]["is_valid"] = False  # a cut lap's brake points are not calibration data
+    path = _write_lap_archive(tmp_path, archive)
+    asyncio.run(server._calibrate_brake_marks_from_lap({"archivePath": path, "lap": 4}))
+    assert obs._driver_marks == {}
+
+
+def test_calibration_env_kill_switch(monkeypatch):
+    monkeypatch.setenv("AC_COPILOT_BRAKE_CAL", "0")
+    assert server._brake_calibration_enabled() is False
+    monkeypatch.delenv("AC_COPILOT_BRAKE_CAL")
+    assert server._brake_calibration_enabled() is True

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -438,6 +438,9 @@ def test_calibrate_brake_marks_from_lap_updates_observer(tmp_path, monkeypatch):
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
     monkeypatch.setattr(server, "_last_brake_cal_key", None)
+    # calibration is core telemetry learning, deliberately INDEPENDENT of the optional LLM
+    # debrief pipeline: it must fold with the debrief feature disabled (PR #525 review).
+    monkeypatch.delenv("AC_COPILOT_OLLAMA_ENABLE", raising=False)
     path = _write_lap_archive(tmp_path, _corner_archive())
     asyncio.run(server._calibrate_brake_marks_from_lap({"archivePath": path, "lap": 3}))
     assert obs._driver_marks, "the driver's own lap must calibrate at least one zone"

--- a/tests/test_track_reference.py
+++ b/tests/test_track_reference.py
@@ -6,9 +6,11 @@ import math
 
 from tools.ai_sidecar.lap_dynamics import LapTrace
 from tools.ai_sidecar.track_reference import (
+    CornerReference,
     add_corpus_lap,
     build_references,
     score_lap,
+    sustained_brake_onsets,
 )
 
 
@@ -125,3 +127,89 @@ def test_score_lap_on_target_no_finding():
 
 def _approx_kmh(v_ms: float) -> float:
     return round(v_ms * 3.6, 1)
+
+
+# ---- issue #522: multi-zone brake marks -----------------------------------------------------
+
+
+def _flat_trace(brake_by_spline: list[tuple[float, float]], *, n: int = 200) -> LapTrace:
+    """A constant-speed straight-line LapTrace whose brake pedal follows ``brake_by_spline``
+    ranges ``(lo, hi) -> 0.8`` (else 0), for exercising the brake-zone extraction directly."""
+    spline = [i / (n - 1) for i in range(n)]
+
+    def pedal(s: float) -> float:
+        return 0.8 if any(lo <= s <= hi for lo, hi in brake_by_spline) else 0.0
+
+    return LapTrace(
+        spline=spline,
+        t_s=[0.1 * i for i in range(n)],
+        v_ms=[40.0] * n,
+        brake=[pedal(s) for s in spline],
+        throttle=[0.0] * n,
+        steer=[0.0] * n,
+        gear=[4] * n,
+        x=[2.0 * i for i in range(n)],
+        z=[0.0] * n,
+    )
+
+
+def test_sustained_brake_onsets_splits_distinct_zones():
+    lap = _flat_trace([(0.30, 0.33), (0.40, 0.42)])
+    onsets = sustained_brake_onsets(lap, 0.25, 0.50)
+    assert len(onsets) == 2
+    assert onsets[0] == _approx_spline(0.30)
+    assert onsets[1] == _approx_spline(0.40)
+
+
+def test_sustained_brake_onsets_filters_light_lifts_and_blips():
+    lap = _flat_trace([(0.30, 0.33)])
+    # a light lift (peak 0.2 < min_peak) between real zones is NOT a coachable mark
+    lift = [0.2 if 0.40 <= s <= 0.42 else b for s, b in zip(lap.spline, lap.brake, strict=True)]
+    lap2 = LapTrace(
+        spline=lap.spline,
+        t_s=lap.t_s,
+        v_ms=lap.v_ms,
+        brake=lift,
+        throttle=lap.throttle,
+        steer=lap.steer,
+        gear=lap.gear,
+        x=lap.x,
+        z=lap.z,
+    )
+    onsets = sustained_brake_onsets(lap2, 0.25, 0.50)
+    assert len(onsets) == 1 and onsets[0] == _approx_spline(0.30)
+    # a single-sample blip is not a zone either (min_run)
+    blip = list(lap.brake)
+    blip[150] = 0.9  # isolated sample at spline ~0.754
+    lap3 = LapTrace(
+        spline=lap.spline,
+        t_s=lap.t_s,
+        v_ms=lap.v_ms,
+        brake=blip,
+        throttle=lap.throttle,
+        steer=lap.steer,
+        gear=lap.gear,
+        x=lap.x,
+        z=lap.z,
+    )
+    assert sustained_brake_onsets(lap3, 0.70, 0.80) == []
+
+
+def test_add_corpus_lap_captures_every_zone_of_a_merged_window():
+    """#522 coverage: a merged esses window holds several real brake zones — the best lap's
+    EVERY sustained zone becomes a mark, with best_brake_point_spline staying the first."""
+    ref = CornerReference(
+        index=0, apex_spline=0.45, spline_lo=0.25, spline_hi=0.55, optimal_apex_kmh=90.0
+    )
+    lap = _flat_trace([(0.30, 0.33), (0.40, 0.42)])
+    add_corpus_lap([ref], lap)
+    assert len(ref.brake_marks) == 2
+    assert ref.best_brake_point_spline == _approx_spline(ref.brake_marks[0])
+    assert ref.brake_marks[0] == _approx_spline(0.30)
+    assert ref.brake_marks[1] == _approx_spline(0.40)
+
+
+def _approx_spline(x: float):
+    import pytest
+
+    return pytest.approx(x, abs=0.011)

--- a/tests/test_voice_cue.py
+++ b/tests/test_voice_cue.py
@@ -148,3 +148,21 @@ def test_second_zone_of_merged_corner_not_suppressed_by_corner_cooldown():
     # DIFFERENT zone, same corner, still inside the 6 s corner window: must speak
     cue = arb.select([z1], now_s=103.0)
     assert cue is not None and cue.corner == 2
+
+
+def test_distinct_zone_heads_up_chains_through_global_cooldown():
+    """PR #525 review: two DIFFERENT brake zones < 2.5 s apart must both speak on the
+    WS/pyttsx3 path — the #522 observer emits only calm prepare cues, so without the zone
+    chain the second mark's coaching is silently dropped."""
+    arb = CueArbiter()
+    z0 = _adv("late_brake", 2, "prepare", register="calm", zone=0)
+    z1 = _adv("late_brake", 2, "prepare", register="calm", zone=1)
+    assert arb.select([z0], now_s=100.0) is not None
+    # different zone 1.8 s later (inside the 2.5 s global window, past the 1.2 s chain floor)
+    assert arb.select([z1], now_s=101.8) is not None
+    # but a repeat of the SAME zone inside the window stays suppressed (anti-chatter)
+    assert arb.select([z1], now_s=103.2) is None
+    # and a different zone under the chain floor stays suppressed (no talk-over)
+    arb2 = CueArbiter()
+    assert arb2.select([z0], now_s=200.0) is not None
+    assert arb2.select([z1], now_s=200.8) is None

--- a/tests/test_voice_cue.py
+++ b/tests/test_voice_cue.py
@@ -133,3 +133,18 @@ def test_arbiter_holds_info_cue_until_spline_lookahead_window():
     near = dict(far)
     near["car_spline"] = 0.495
     assert arb.select([near], now_s=0.0) is not None
+
+
+def test_second_zone_of_merged_corner_not_suppressed_by_corner_cooldown():
+    """PR #525 review: the per-corner cooldown key carries the brake-zone ordinal — a merged
+    esses corner's SECOND zone heads-up inside the 6 s window must speak, while a repeat of
+    the SAME zone stays suppressed."""
+    arb = CueArbiter()
+    z0 = _adv("late_brake", 2, "prepare", register="calm", zone=0)
+    z1 = _adv("late_brake", 2, "prepare", register="calm", zone=1)
+    assert arb.select([z0], now_s=100.0) is not None
+    # same zone again within the cooldown: suppressed (anti-nag unchanged)
+    assert arb.select([z0], now_s=103.0) is None
+    # DIFFERENT zone, same corner, still inside the 6 s corner window: must speak
+    cue = arb.select([z1], now_s=103.0)
+    assert cue is not None and cue.corner == 2

--- a/tests/test_voice_resolver.py
+++ b/tests/test_voice_resolver.py
@@ -20,6 +20,26 @@ def test_resolve_anticipatory_brake_maps_corner_0based_to_1based() -> None:
     assert "turn three" in utt.text
 
 
+def test_second_zone_of_a_merged_corner_gets_its_own_dedup_key() -> None:
+    """#522 coverage: a merged esses corner emits one heads-up PER BRAKE ZONE inside the 8 s
+    dedup window — a later zone's cue must not be swallowed as a repeat of the first."""
+    r = Resolver(build_manifest())
+    z0 = r.resolve(
+        make_advisory(
+            kind="late_brake", urgency="prepare", register="calm", corner=2, detail={"zone": 0}
+        )
+    )
+    z1 = r.resolve(
+        make_advisory(
+            kind="late_brake", urgency="prepare", register="calm", corner=2, detail={"zone": 1}
+        )
+    )
+    assert z0 is not None and z1 is not None
+    assert z0.dedup_key == "late_brake:2:calm"  # zone 0 keeps the pre-#522 key shape
+    assert z1.dedup_key == "late_brake:2z1:calm"
+    assert z0.dedup_key != z1.dedup_key
+
+
 def test_act_cue_is_terse_corner_dropped() -> None:
     r = Resolver(build_manifest())
     # An act/urgent cue for a numbered corner resolves to the TERSE generic clip (no corner number).

--- a/tests/test_voice_scheduler.py
+++ b/tests/test_voice_scheduler.py
@@ -246,3 +246,26 @@ def test_empty_queue_is_a_noop() -> None:
     sched, pb, clock = _scheduler()
     assert sched.process_pending(clock()) is None
     assert pb.played == []
+
+
+def test_distinct_zone_brake_cue_is_exempt_from_same_kind_cooldown() -> None:
+    """PR #525 review: two brake ZONES of a merged esses corner (#522) can sit closer than the
+    late_brake kind cooldown — the second zone's prepare heads-up is distinct coaching, not a
+    nag, and must speak; a same-zone repeat stays suppressed."""
+    sched, pb, clock = _scheduler(VoiceConfig(cooldown_s={"late_brake": 1.0}))
+    z0 = make_advisory(
+        kind="late_brake", urgency="prepare", register="calm", corner=2, detail={"zone": 0}
+    )
+    z1 = make_advisory(
+        kind="late_brake", urgency="prepare", register="calm", corner=2, detail={"zone": 1}
+    )
+    sched.submit(z0)
+    assert sched.process_pending(clock()) is not None
+    pb.finish()
+    clock.advance(0.5)  # inside the 1.0 s kind cooldown
+    sched.submit(z1)
+    assert sched.process_pending(clock()) is not None, "distinct zone must not be kind-suppressed"
+    pb.finish()
+    clock.advance(0.5)
+    sched.submit(z1)  # SAME zone again: dedup/cooldown own it
+    assert sched.process_pending(clock()) is None

--- a/tools/ai_sidecar/protocol.py
+++ b/tools/ai_sidecar/protocol.py
@@ -79,10 +79,12 @@ def _load_safe_archive_paths(raw_paths: Any) -> list[dict[str, Any]]:
     return out
 
 
-def _resolve_lap_archive(inbound: dict[str, Any]) -> dict[str, Any] | None:
-    """Resolve a full lap-archive dict (with a trace) for the brain, or None.
+def resolve_lap_archive(inbound: dict[str, Any]) -> dict[str, Any] | None:
+    """Resolve a full lap-archive dict (with a trace) from a lap_complete-style message, or None.
 
-    Prefers an inline ``trace`` on the message; else loads a safe ``archivePath``. Never raises.
+    Prefers an inline ``trace`` on the message; else loads a safe ``archivePath`` (traversal- and
+    size-guarded). Never raises. Shared by the attribution brain and the #522 per-driver
+    brake-mark calibration.
     """
     trace = inbound.get("trace")
     if isinstance(trace, dict) and isinstance(trace.get("samples"), list) and trace["samples"]:
@@ -101,7 +103,7 @@ def build_brain_followup(inbound: dict[str, Any]) -> dict[str, Any] | None:
     """
     if not debrief_feature_enabled():
         return None
-    archive = _resolve_lap_archive(inbound)
+    archive = resolve_lap_archive(inbound)
     if archive is None:
         return None
     # Normalize the lap counter: a lap_complete frame carries it as a top-level int (`lap: 9`), but

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -102,9 +102,11 @@ _LEAD_LATCH_TTA_S = 1.5
 # on the driver's demonstrated point instead of the synthetic one. Provenance rides on the
 # advisory (``mark_source: driver_calibrated``) — a calibrated mark is never passed off as the
 # reference's.
-#: a driver onset within this normalized-spline distance of a reference mark is the SAME zone
-#: (~50 m on a 2.5 km track); farther away it is a different line/zone and does not calibrate.
-_CAL_MATCH_TOL_SPLINE = 0.02
+#: a driver onset within this many METERS of a mark is the SAME zone; farther away it is a
+#: different line/zone and does not calibrate. Metric, not normalized: a fixed spline fraction
+#: would accept ~400 m on a Nordschleife-length track (PR #525 review). Converted per observer
+#: via its track length (0.02 spline on the verified 2.5 km case).
+_CAL_MATCH_TOL_M = 50.0
 #: weight of the newest lap in the per-zone EMA (recent laps dominate, old habits decay).
 _CAL_EMA_ALPHA = 0.4
 #: Schmitt-trigger thresholds for register quantization (rising / falling) — the falling edge
@@ -384,7 +386,7 @@ class RealtimeObserver:
         """Fold one of the driver's own completed laps into the per-zone brake-mark EMA.
 
         For each corner zone, the driver's sustained brake onset nearest the current reference
-        mark (within ``_CAL_MATCH_TOL_SPLINE`` — the same zone, not a different line) updates
+        mark (within ``_CAL_MATCH_TOL_M`` meters — the same zone, not a different line) updates
         that zone's EMA. Matching is one-to-one (greedy nearest-first): a single brake
         application between two closely spaced marks calibrates ONE zone, never both — else the
         per-zone distinction #522 adds would collapse (PR #525 review). Returns the number of
@@ -393,6 +395,7 @@ class RealtimeObserver:
         """
         if track_id and self._track_id and track_id != self._track_id:
             return 0
+        tol = _CAL_MATCH_TOL_M / self._track_length_m  # metric tolerance in spline units
         updated = 0
         for ref in self._refs:
             ref_marks = self._reference_marks(ref)
@@ -403,7 +406,7 @@ class RealtimeObserver:
             # window whose upstream margin crosses start/finish also scans the trace TAIL: the
             # archive finalizes the lap before the S/F frame, so the driver's onset for a mark
             # near spline 0 can sit at ~0.99 (PR #525 review).
-            lo = ref.spline_lo - _CAL_MATCH_TOL_SPLINE
+            lo = ref.spline_lo - tol
             onsets = sustained_brake_onsets(lap, max(0.0, lo), ref.spline_hi)
             if lo < 0.0:
                 onsets += sustained_brake_onsets(lap, lo % 1.0, 1.0)
@@ -421,11 +424,11 @@ class RealtimeObserver:
             )
             # forward positions from just upstream of the window, so "in lap order" is
             # well-defined even when the window (or a learned mark) crosses start/finish.
-            origin = (ref.spline_lo - _CAL_MATCH_TOL_SPLINE) % 1.0
+            origin = (ref.spline_lo - tol) % 1.0
             matched_zones: set[int] = set()
             consumed_onsets: set[float] = set()
             for dist, zi, onset in pairs:
-                if dist > _CAL_MATCH_TOL_SPLINE:
+                if dist > tol:
                     break  # sorted ascending: everything after is farther
                 if zi in matched_zones or onset in consumed_onsets:
                     continue
@@ -563,6 +566,7 @@ class RealtimeObserver:
             # lateral-g corner window, so a driver coasting past the real brake point is cued
             # there, not only once the window starts (codex #294 @176).
             marks = self._effective_marks(ref)
+            corner_cued_this_frame = False
             for zi, (bp, mark_source) in enumerate(marks):
                 lead = _lead_spline_fraction(
                     speed, self._track_length_m, self._brake_prepare_lead_s
@@ -606,10 +610,24 @@ class RealtimeObserver:
                     st.zone_braked[zi] = True
                 # The actionable window runs from the anticipatory lead (which can wrap over
                 # start/finish for a first corner with bp≈0) through the zone's segment end
-                # (codex review #371).
+                # (codex review #371). At most ONE heads-up per corner per FRAME: marks closer
+                # than the lead open both arcs on the same tick, and a same-batch pair would
+                # make the voice scheduler pick one and drop the imminent other — a deferred
+                # zone re-fires on the next frame instead (~50 ms at 20 Hz; PR #525 review).
                 if _in_arc(spline, lead_start, seg_end):
-                    a = self._brake_cue(ref, st, zi, bp, mark_source, spline, speed, brake)
+                    a = self._brake_cue(
+                        ref,
+                        st,
+                        zi,
+                        bp,
+                        mark_source,
+                        spline,
+                        speed,
+                        brake,
+                        allow_cue=not corner_cued_this_frame,
+                    )
                     if a is not None:
+                        corner_cued_this_frame = True
                         out.append(a)
             # Over-braking past the apex while still off-throttle → "release / ease" (#368). Needs
             # only the apex/window + brake/throttle, NOT a brake point — so it fires for GGV-only
@@ -646,6 +664,8 @@ class RealtimeObserver:
         spline: float,
         speed: float,
         brake: float,
+        *,
+        allow_cue: bool = True,
     ) -> Advisory | None:
         """Fire ONE calm anticipatory heads-up per brake zone per pass — the only live brake cue.
 
@@ -694,6 +714,11 @@ class RealtimeObserver:
             return None
         if st.zone_cued[zi]:
             return None  # already gave this zone its heads-up
+        if not allow_cue:
+            # another zone of this corner already cued on THIS frame: leave this zone's state
+            # untouched so it emits on the next frame (PR #525 review — a same-batch pair would
+            # make the voice scheduler drop one of the two).
+            return None
         # One calm anticipatory heads-up per zone per pass — the ONLY live brake cue (#522). A
         # live fault imperative is unfixable in principle: a driver braking exactly at the mark
         # is indistinguishable from one about to miss it until the mark itself, so a spoken

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -31,6 +31,7 @@ from tools.ai_sidecar.track_reference import (
     CornerReference,
     add_corpus_lap,
     build_references,
+    sustained_brake_onsets,
 )
 
 #: Spline drop between consecutive frames that signals a backward jump (wrap OR same-lap rewind).
@@ -86,6 +87,20 @@ _MAX_LEAD_SPLINE = 0.09
 #: corner (suppresses its heads-up); farther out it is likely trail-braking the previous
 #: corner inside an overlapping #522 lead window and must not latch (PR #523 review).
 _LEAD_LATCH_TTA_S = 1.5
+
+# --- Per-driver brake-mark calibration (issue #522 part 2) ---------------------------------------
+# The shipped reference is a synthetic ideal lap whose brake points sit ~25 m from where a real
+# driver on a real line brakes, so a fixed mark misclassifies an on-pace driver every pass. Each
+# completed VALID lap of the driver's own folds into a per-zone EMA of their demonstrated brake
+# onsets; once a zone has been observed, the cue mark (and the late/"ran deep" judgement) anchors
+# on the driver's demonstrated point instead of the synthetic one. Provenance rides on the
+# advisory (``mark_source: driver_calibrated``) — a calibrated mark is never passed off as the
+# reference's.
+#: a driver onset within this normalized-spline distance of a reference mark is the SAME zone
+#: (~50 m on a 2.5 km track); farther away it is a different line/zone and does not calibrate.
+_CAL_MATCH_TOL_SPLINE = 0.02
+#: weight of the newest lap in the per-zone EMA (recent laps dominate, old habits decay).
+_CAL_EMA_ALPHA = 0.4
 #: Schmitt-trigger thresholds for register quantization (rising / falling) — the falling edge
 #: sits below the rising edge so a severity hovering near a boundary does not flicker tone
 #: frame-to-frame.
@@ -168,24 +183,38 @@ class Advisory:
 
 @dataclass
 class _CornerPass:
-    """Mutable per-corner state for the current lap pass (reset on wrap)."""
+    """Mutable per-corner state for the current lap pass (reset on wrap).
+
+    Brake-cue state is PER ZONE (issue #522 coverage): a merged esses corner holds several real
+    brake zones, and braking for / being cued about one zone must not consume the next zone's
+    heads-up. The three parallel lists are indexed by the corner's zone ordinal.
+    """
 
     inside: bool = False
     min_speed_kmh: float | None = None
-    has_braked: bool = False  # any braking seen this pass — suppresses a false late-brake cue
-    #: rank of the HIGHEST brake-cue register emitted this pass (-1 = none). A cue re-fires only
-    #: when severity escalates to a strictly higher tier (calm→alert→urgent→critical), so a calm
-    #: lead-in never locks out the later critical alarm (issue #368 escalation; codex review #371).
-    brake_cue_rank: int = -1
+    #: per zone: braking observed FOR that zone this pass — suppresses its heads-up.
+    zone_braked: list[bool] = field(default_factory=list)
+    #: per zone: the one calm anticipatory heads-up was emitted (or locked out past the mark).
+    zone_cued: list[bool] = field(default_factory=list)
     #: rank of the highest brake-release register emitted this pass. A barely-over-threshold
     #: release warning can still escalate to urgent if the driver stays hard on the brake.
     release_cue_rank: int = -1
-    #: the driver ran too deep past the brake point for a spoken imperative to be actionable
+    #: the driver ran too deep past a brake mark for a spoken imperative to be actionable
     #: (issue #522) — the pass stayed silent and the miss is surfaced in exit grading instead.
     late_uncoached: bool = False
     exit_emitted: bool = False
     #: last tone register spoken for this corner pass — feeds register hysteresis (issue #368).
     last_register: str = "calm"
+    #: this pass was already re-armed for the NEXT lap by a wrapped lead window (a first-corner
+    #: mark near spline 0.0 whose lead opens BEFORE start/finish). One-shot: without it the
+    #: re-arm check sees the state the fresh approach itself creates (its own heads-up) and
+    #: resets again every frame — re-firing the first corner's cue for the rest of the lap.
+    armed_prewrap: bool = False
+
+    @property
+    def any_brake_state(self) -> bool:
+        """Any brake-cue/braking state accumulated this pass (drives the wrapped-lead reset)."""
+        return any(self.zone_braked) or any(self.zone_cued)
 
 
 def _num(value: Any) -> float | None:
@@ -237,6 +266,11 @@ def _forward_spline_delta(current: float, target: float) -> float:
     return (target - current) % 1.0
 
 
+def _signed_spline_delta(a: float, b: float) -> float:
+    """Shortest signed normalized distance from ``b`` to ``a``, wrap-aware, in [-0.5, 0.5)."""
+    return ((a - b + 0.5) % 1.0) - 0.5
+
+
 def _in_arc(x: float, lo: float, hi: float) -> bool:
     """True if normalized spline ``x`` is in the arc ``[lo, hi]``, wrap-aware (``lo`` may exceed
     ``hi`` when the arc crosses the start/finish line)."""
@@ -286,6 +320,7 @@ class RealtimeObserver:
         track_length_m: float | None = _DEFAULT_TRACK_LENGTH_M,
         brake_prepare_lead_s: float = _BRAKE_PREPARE_LEAD_S,
         lap_length_m: float | None = None,
+        track_id: str | None = None,
     ) -> None:
         # sorted by entry so the in/out-of-window scan is stable
         self._refs = sorted(references, key=lambda r: r.spline_lo)
@@ -298,7 +333,12 @@ class RealtimeObserver:
             lap_length_m if lap_length_m is not None else track_length_m
         )
         self._brake_prepare_lead_s = max(0.0, brake_prepare_lead_s)
-        self._passes: dict[int, _CornerPass] = {r.index: _CornerPass() for r in self._refs}
+        # per-driver brake-mark calibration state (issue #522 part 2): zone (corner idx, zone
+        # ordinal) -> (EMA of the driver's demonstrated onset spline, laps folded in). Survives
+        # lap wraps and reset() — it is knowledge about the driver, not pass state.
+        self._driver_marks: dict[tuple[int, int], tuple[float, int]] = {}
+        self._track_id = track_id  # when known, guards calibration against a wrong-track lap
+        self._passes: dict[int, _CornerPass] = {r.index: self._new_pass(r) for r in self._refs}
         self._last_spline: float | None = None
         self._last_lap: float | None = None  # monotonic lap counter (when the stream supplies it)
         # end-of-lap grading held across the wrap when a known lapCount may lag the spline drop by
@@ -306,9 +346,84 @@ class RealtimeObserver:
         self._pending_wrap: list[Advisory] = []
         self._pending_pre_lap: float | None = None
 
+    @staticmethod
+    def _reference_marks(ref: CornerReference) -> list[float]:
+        """All of a corner's reference brake marks (multi-zone when the corpus lap had them)."""
+        if ref.brake_marks:
+            return list(ref.brake_marks)
+        return [] if ref.best_brake_point_spline is None else [ref.best_brake_point_spline]
+
+    def _new_pass(self, ref: CornerReference) -> _CornerPass:
+        n = len(self._reference_marks(ref))
+        return _CornerPass(zone_braked=[False] * n, zone_cued=[False] * n)
+
+    def _effective_marks(self, ref: CornerReference) -> list[tuple[float, str]]:
+        """The cue marks actually in force for a corner: driver-calibrated where a zone has been
+        observed on the driver's own laps, else the reference's — with honest provenance."""
+        out: list[tuple[float, str]] = []
+        for zi, mark in enumerate(self._reference_marks(ref)):
+            cal = self._driver_marks.get((ref.index, zi))
+            if cal is not None:
+                out.append((cal[0] % 1.0, "driver_calibrated"))
+            else:
+                out.append((mark, _target_source(ref)))
+        return out
+
+    def calibrate_from_driver_lap(self, lap: LapTrace, *, track_id: str | None = None) -> int:
+        """Fold one of the driver's own completed laps into the per-zone brake-mark EMA.
+
+        For each corner zone, the driver's sustained brake onset nearest the current reference
+        mark (within ``_CAL_MATCH_TOL_SPLINE`` — the same zone, not a different line) updates
+        that zone's EMA. Returns the number of zones updated. A lap from a different track (when
+        both track ids are known) never calibrates.
+        """
+        if track_id and self._track_id and track_id != self._track_id:
+            return 0
+        updated = 0
+        for ref in self._refs:
+            ref_marks = self._reference_marks(ref)
+            if not ref_marks:
+                continue
+            # scan slightly upstream of the window too — a slower driver brakes EARLIER than the
+            # reference lap's deceleration onset that defined the window entry.
+            onsets = sustained_brake_onsets(
+                lap, max(0.0, ref.spline_lo - _CAL_MATCH_TOL_SPLINE), ref.spline_hi
+            )
+            if not onsets:
+                continue
+            for zi, mark in enumerate(ref_marks):
+                deltas = [(abs(_signed_spline_delta(o, mark)), o) for o in onsets]
+                dist, onset = min(deltas)
+                if dist > _CAL_MATCH_TOL_SPLINE:
+                    continue
+                cur = self._driver_marks.get((ref.index, zi))
+                if cur is None:
+                    self._driver_marks[(ref.index, zi)] = (onset % 1.0, 1)
+                else:
+                    ema, n = cur
+                    step = _CAL_EMA_ALPHA * _signed_spline_delta(onset, ema)
+                    self._driver_marks[(ref.index, zi)] = ((ema + step) % 1.0, n + 1)
+                updated += 1
+        return updated
+
     def reset(self) -> None:
-        """Clear per-corner pass state (start of a fresh lap). The lap counter persists."""
-        self._passes = {r.index: _CornerPass() for r in self._refs}
+        """Clear per-corner pass state (start of a fresh lap). The lap counter — and the
+        per-driver brake-mark calibration, which is knowledge about the driver — persist.
+
+        A pass re-armed pre-wrap (a first-corner lead window that opened before start/finish)
+        already belongs to the lap that begins at this wrap: it carries across — heads-up and
+        near-mark braking observed before the line stay valid — with its one-shot flag cleared
+        so the NEXT lap's pre-wrap approach can re-arm it again.
+        """
+        carried: dict[int, _CornerPass] = {}
+        for r in self._refs:
+            p = self._passes.get(r.index)
+            if p is not None and p.armed_prewrap:
+                p.armed_prewrap = False
+                carried[r.index] = p
+            else:
+                carried[r.index] = self._new_pass(r)
+        self._passes = carried
         self._last_spline = None
         self._pending_wrap = []
         self._pending_pre_lap = None
@@ -365,36 +480,48 @@ class RealtimeObserver:
 
         for ref in self._refs:
             st = self._passes[ref.index]
-            # Braking-evaluation region: from the (corpus/GGV) brake point to the apex — which may
-            # begin UPSTREAM of the lateral-g corner window, so a driver coasting past the real
-            # brake point is cued there, not only once the window starts (codex #294 @176). The
-            # window now opens a tone-register-independent anticipatory LEAD before the brake point
-            # so the cue's audio onset lands before/at the mark (issue #368 AC a).
-            bp = ref.best_brake_point_spline
-            if bp is not None:
+            # Braking-evaluation region PER BRAKE ZONE (issue #522 coverage: a merged esses
+            # corner holds several real zones and each needs its own heads-up): from a zone's
+            # mark back through its anticipatory lead — which may begin UPSTREAM of the
+            # lateral-g corner window, so a driver coasting past the real brake point is cued
+            # there, not only once the window starts (codex #294 @176).
+            marks = self._effective_marks(ref)
+            for zi, (bp, mark_source) in enumerate(marks):
                 lead = _lead_spline_fraction(
                     speed, self._track_length_m, self._brake_prepare_lead_s
                 )
                 lead_start = (bp - lead) % 1.0
-                wrapped_lead = bp - lead < 0.0 and spline >= lead_start
-                if wrapped_lead and (
-                    st.inside
-                    or st.has_braked
-                    or st.brake_cue_rank >= 0
-                    or st.release_cue_rank >= 0
-                    or st.exit_emitted
-                ):
+                wrapped_lead = zi == 0 and bp - lead < 0.0 and spline >= lead_start
+                if wrapped_lead:
                     # For a first-corner brake point near 0.0, the next lap's lead window starts
                     # before the spline wrap is observed (for example at s=0.995). Reset this
                     # corner's previous-lap cue state now so the anticipatory cue can still lead
-                    # the mark instead of being suppressed until after start/finish.
-                    self._passes[ref.index] = st = _CornerPass()
-                if bp <= spline <= ref.apex_spline and brake >= self._brake_on:
-                    st.has_braked = True  # so a later release before apex isn't "late to brake"
+                    # the mark instead of being suppressed until after start/finish. ONE-SHOT
+                    # per approach (``armed_prewrap``): the fresh approach's own heads-up must
+                    # not read as stale state and reset/re-fire every following frame.
+                    if not st.armed_prewrap and (
+                        st.inside
+                        or st.any_brake_state
+                        or st.release_cue_rank >= 0
+                        or st.exit_emitted
+                    ):
+                        self._passes[ref.index] = st = self._new_pass(ref)
+                    st.armed_prewrap = True
+                # A zone's braking segment runs from its mark to the next zone's mark (last
+                # zone: to the apex, or the window end for a mark past the apex) — braking
+                # there is braking FOR this zone, so a later release isn't "late to brake".
+                seg_end = (
+                    marks[zi + 1][0]
+                    if zi + 1 < len(marks)
+                    else (ref.apex_spline if bp <= ref.apex_spline else ref.spline_hi)
+                )
+                if bp <= spline <= seg_end and brake >= self._brake_on:
+                    st.zone_braked[zi] = True
                 # The actionable window runs from the anticipatory lead (which can wrap over
-                # start/finish for a first corner with bp≈0) through the apex (codex review #371).
-                if _in_arc(spline, lead_start, ref.apex_spline):
-                    a = self._brake_cue(ref, st, spline, speed, brake)
+                # start/finish for a first corner with bp≈0) through the zone's segment end
+                # (codex review #371).
+                if _in_arc(spline, lead_start, seg_end):
+                    a = self._brake_cue(ref, st, zi, bp, mark_source, spline, speed, brake)
                     if a is not None:
                         out.append(a)
             # Over-braking past the apex while still off-throttle → "release / ease" (#368). Needs
@@ -409,8 +536,11 @@ class RealtimeObserver:
                 st.min_speed_kmh = (
                     speed if st.min_speed_kmh is None else min(st.min_speed_kmh, speed)
                 )
-                if brake >= self._brake_on:
-                    st.has_braked = True
+                if brake >= self._brake_on and marks and spline < marks[0][0]:
+                    # braking inside the window before the FIRST mark is early braking for this
+                    # corner's first zone (normal trail-brake / rotation — codex #294); braking
+                    # at/past a mark is credited per zone segment above.
+                    st.zone_braked[0] = True
             elif st.inside and spline > ref.spline_hi and not st.exit_emitted:
                 # just left the corner (downstream of exit) → grade the apex
                 a = self._apex_deficit(ref, st)
@@ -420,39 +550,47 @@ class RealtimeObserver:
         return out
 
     def _brake_cue(
-        self, ref: CornerReference, st: _CornerPass, spline: float, speed: float, brake: float
+        self,
+        ref: CornerReference,
+        st: _CornerPass,
+        zi: int,
+        bp: float,
+        mark_source: str,
+        spline: float,
+        speed: float,
+        brake: float,
     ) -> Advisory | None:
-        """Fire ONE calm anticipatory heads-up per corner pass — the only live brake cue.
+        """Fire ONE calm anticipatory heads-up per brake zone per pass — the only live brake cue.
 
         Issue #522 (supersedes the #368/#371 escalation ladder): the cue fires when the lead
-        window opens (default ~3.2 s of audibility budget before the brake point) so the
+        window opens (default ~3.2 s of audibility budget before the zone's mark) so the
         clip FINISHES with human reaction time to spare. It is always ``prepare``/``calm``
         and never re-fires within a pass — there is deliberately no second-stage live
         imperative and no register escalation: a driver braking exactly at the mark is
         indistinguishable from one about to miss it until the mark itself, so a spoken
         correction is either a false alarm or after-the-fact noise (measured on the #522
         instrumented lap: every past-point "Brake!" completed with the mark already behind
-        the car). AT/PAST the mark the pass is flagged (``late_uncoached``) and corner-exit
-        grading owns the feedback.
+        the car). AT/PAST the mark the zone is locked out (``late_uncoached``) and
+        corner-exit grading owns the feedback.
 
-        Suppressed once the driver has braked anywhere in this pass (``has_braked``):
-        braking early and trailing off before the apex — normal trail-braking — is not a
-        fault and must not draw a cue (codex #294).
+        Suppressed once the driver has braked FOR this zone (``zone_braked[zi]``): braking
+        early and trailing off before the apex — normal trail-braking — is not a fault and
+        must not draw a cue (codex #294). Braking for one zone of a merged esses corner
+        must not consume the next zone's heads-up (issue #522 coverage).
         """
-        bp = ref.best_brake_point_spline
-        if bp is None or st.has_braked:
+        if st.zone_braked[zi]:
             return None
         if brake >= self._brake_on:
-            # Braking near the mark IS braking this pass (codex review #371) — but with the
-            # #522 lead the window can overlap the PREVIOUS corner on closely spaced turns,
-            # and trail-braking that corner must not latch has_braked for this one (PR #523
-            # review). Discriminator: only braking within the last _LEAD_LATCH_TTA_S of the
-            # approach counts as braking FOR this corner; farther out we just stay quiet on
-            # this frame and let the heads-up fire once the driver is off the brakes.
+            # Braking near the mark IS braking for this zone (codex review #371) — but with
+            # the #522 lead the window can overlap the PREVIOUS corner/zone on closely spaced
+            # turns, and trail-braking that one must not latch this zone (PR #523 review).
+            # Discriminator: only braking within the last _LEAD_LATCH_TTA_S of the approach
+            # counts as braking FOR this zone; farther out we just stay quiet on this frame
+            # and let the heads-up fire once the driver is off the brakes.
             delta = _forward_spline_delta(spline, bp)
             tta_now = delta * self._track_length_m / max(speed / 3.6, 0.1)
             if not (0.0 < delta <= _LAP_WRAP_DROP) or tta_now <= _LEAD_LATCH_TTA_S:
-                st.has_braked = True
+                st.zone_braked[zi] = True
             return None
         # "anticipatory" = the car has not yet reached the brake point — robust to a lead window
         # wraps over start/finish (a first corner with bp≈0): the forward distance to bp is a small
@@ -462,21 +600,21 @@ class RealtimeObserver:
             # Issue #522: an imperative spoken AT/PAST the mark cannot complete before it —
             # measured on the instrumented lap, every past-point "Brake!" was heard with the
             # mark already behind the car. The moment has passed: stay silent, lock out
-            # further imperatives this pass, and flag it so corner-exit grading owns the
+            # further imperatives for this zone, and flag it so corner-exit grading owns the
             # feedback ("brake earlier next lap") where it is actionable.
-            st.brake_cue_rank = REGISTER_RANK["critical"]
+            st.zone_cued[zi] = True
             st.late_uncoached = True
             return None
-        # One calm anticipatory heads-up per pass — the ONLY live brake cue (#522). A live
-        # fault imperative is unfixable in principle: a driver braking exactly at the mark is
-        # indistinguishable from one about to miss it until the mark itself, so a spoken
+        if st.zone_cued[zi]:
+            return None  # already gave this zone its heads-up
+        # One calm anticipatory heads-up per zone per pass — the ONLY live brake cue (#522). A
+        # live fault imperative is unfixable in principle: a driver braking exactly at the mark
+        # is indistinguishable from one about to miss it until the mark itself, so a spoken
         # correction is either a false alarm (on-pace driver) or after-the-fact (late one).
         # Real coaching splits the roles: anticipatory mark before, debrief after.
         tta_s = _forward_spline_delta(spline, bp) * self._track_length_m / max(speed / 3.6, 0.1)
         closing = _clamp01((speed - ref.target_apex_kmh) / _CLOSING_REF_KMH)
-        if st.brake_cue_rank >= 0:
-            return None  # already gave this pass its heads-up
-        st.brake_cue_rank = REGISTER_RANK["calm"]
+        st.zone_cued[zi] = True
         st.last_register = "calm"
         return Advisory(
             kind="late_brake",
@@ -492,7 +630,12 @@ class RealtimeObserver:
                 "lead_s": round(tta_s, 2),
                 "current_kmh": round(speed, 1),
                 "anticipatory": True,
+                # apex-target provenance (corpus vs GGV) — unchanged contract
                 "source": _target_source(ref),
+                # issue #522: which zone of the corner this mark belongs to, and whether the
+                # mark is the reference's or learned from the driver's own laps.
+                "zone": zi,
+                "mark_source": mark_source,
             },
         )
 
@@ -638,10 +781,12 @@ def build_observer_from_reference(
     add_corpus_lap(refs, ref_lap)  # the reference lap IS the corpus best
     track_obj = reference_archive.get("track")
     track = track_obj if isinstance(track_obj, dict) else {}
+    track_id = track.get("id")
     return RealtimeObserver(
         refs,
         track_length_m=_positive_track_length_m(track.get("lengthM")),
         brake_prepare_lead_s=(
             brake_prepare_lead_s if brake_prepare_lead_s is not None else _BRAKE_PREPARE_LEAD_S
         ),
+        track_id=track_id if isinstance(track_id, str) and track_id else None,
     )

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -374,8 +374,11 @@ class RealtimeObserver:
 
         For each corner zone, the driver's sustained brake onset nearest the current reference
         mark (within ``_CAL_MATCH_TOL_SPLINE`` — the same zone, not a different line) updates
-        that zone's EMA. Returns the number of zones updated. A lap from a different track (when
-        both track ids are known) never calibrates.
+        that zone's EMA. Matching is one-to-one (greedy nearest-first): a single brake
+        application between two closely spaced marks calibrates ONE zone, never both — else the
+        per-zone distinction #522 adds would collapse (PR #525 review). Returns the number of
+        zones updated. A lap from a different track (when both track ids are known) never
+        calibrates.
         """
         if track_id and self._track_id and track_id != self._track_id:
             return 0
@@ -385,17 +388,30 @@ class RealtimeObserver:
             if not ref_marks:
                 continue
             # scan slightly upstream of the window too — a slower driver brakes EARLIER than the
-            # reference lap's deceleration onset that defined the window entry.
-            onsets = sustained_brake_onsets(
-                lap, max(0.0, ref.spline_lo - _CAL_MATCH_TOL_SPLINE), ref.spline_hi
-            )
+            # reference lap's deceleration onset that defined the window entry. A first-corner
+            # window whose upstream margin crosses start/finish also scans the trace TAIL: the
+            # archive finalizes the lap before the S/F frame, so the driver's onset for a mark
+            # near spline 0 can sit at ~0.99 (PR #525 review).
+            lo = ref.spline_lo - _CAL_MATCH_TOL_SPLINE
+            onsets = sustained_brake_onsets(lap, max(0.0, lo), ref.spline_hi)
+            if lo < 0.0:
+                onsets += sustained_brake_onsets(lap, lo % 1.0, 1.0)
             if not onsets:
                 continue
-            for zi, mark in enumerate(ref_marks):
-                deltas = [(abs(_signed_spline_delta(o, mark)), o) for o in onsets]
-                dist, onset = min(deltas)
+            pairs = sorted(
+                (abs(_signed_spline_delta(onset, mark)), zi, onset)
+                for zi, mark in enumerate(ref_marks)
+                for onset in onsets
+            )
+            matched_zones: set[int] = set()
+            consumed_onsets: set[float] = set()
+            for dist, zi, onset in pairs:
                 if dist > _CAL_MATCH_TOL_SPLINE:
+                    break  # sorted ascending: everything after is farther
+                if zi in matched_zones or onset in consumed_onsets:
                     continue
+                matched_zones.add(zi)
+                consumed_onsets.add(onset)
                 cur = self._driver_marks.get((ref.index, zi))
                 if cur is None:
                     self._driver_marks[(ref.index, zi)] = (onset % 1.0, 1)
@@ -406,19 +422,22 @@ class RealtimeObserver:
                 updated += 1
         return updated
 
-    def reset(self) -> None:
+    def reset(self, *, carry_prewrap: bool = False) -> None:
         """Clear per-corner pass state (start of a fresh lap). The lap counter — and the
         per-driver brake-mark calibration, which is knowledge about the driver — persist.
 
-        A pass re-armed pre-wrap (a first-corner lead window that opened before start/finish)
-        already belongs to the lap that begins at this wrap: it carries across — heads-up and
-        near-mark braking observed before the line stay valid — with its one-shot flag cleared
-        so the NEXT lap's pre-wrap approach can re-arm it again.
+        With ``carry_prewrap`` (the true start/finish-wrap path only), a pass re-armed
+        pre-wrap (a first-corner lead window that opened before start/finish) already belongs
+        to the lap that begins at this wrap: it carries across — heads-up and near-mark braking
+        observed before the line stay valid — with its one-shot flag cleared so the NEXT lap's
+        pre-wrap approach can re-arm it again. External resets (producer disconnect) and
+        same-lap rewinds (pit/teleport) must NOT carry: the stream is discontinuous, and stale
+        ``zone_cued`` state would suppress a fresh first-corner heads-up (PR #525 review).
         """
         carried: dict[int, _CornerPass] = {}
         for r in self._refs:
             p = self._passes.get(r.index)
-            if p is not None and p.armed_prewrap:
+            if carry_prewrap and p is not None and p.armed_prewrap:
                 p.armed_prewrap = False
                 carried[r.index] = p
             else:
@@ -468,7 +487,9 @@ class RealtimeObserver:
                     if a is not None:
                         graded.append(a)
             pre_lap = self._last_lap
-            self.reset()
+            # A pre-wrap-armed first-corner pass carries only through a genuine start/finish
+            # crossing; a same-lap rewind (pit/teleport) clears everything (PR #525 review).
+            self.reset(carry_prewrap=lap_advanced or wrap_shaped)
             if lap_advanced or (wrap_shaped and not lap_known):
                 out.extend(graded)  # definite lap completion → grade now
             elif wrap_shaped and lap_known:

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -329,6 +329,7 @@ class RealtimeObserver:
         brake_prepare_lead_s: float = _BRAKE_PREPARE_LEAD_S,
         lap_length_m: float | None = None,
         track_id: str | None = None,
+        track_layout: str | None = None,
     ) -> None:
         # sorted by entry so the in/out-of-window scan is stable
         self._refs = sorted(references, key=lambda r: r.spline_lo)
@@ -345,7 +346,10 @@ class RealtimeObserver:
         # ordinal) -> (EMA of the driver's demonstrated onset spline, laps folded in). Survives
         # lap wraps and reset() — it is knowledge about the driver, not pass state.
         self._driver_marks: dict[tuple[int, int], tuple[float, int]] = {}
-        self._track_id = track_id  # when known, guards calibration against a wrong-track lap
+        # when known, guard calibration against a wrong-track (or wrong-LAYOUT — normalized
+        # splines of different layouts point at unrelated features) lap.
+        self._track_id = track_id
+        self._track_layout = track_layout
         self._passes: dict[int, _CornerPass] = {r.index: self._new_pass(r) for r in self._refs}
         self._last_spline: float | None = None
         self._last_lap: float | None = None  # monotonic lap counter (when the stream supplies it)
@@ -382,18 +386,27 @@ class RealtimeObserver:
                 out.append((mark, _target_source(ref)))
         return out
 
-    def calibrate_from_driver_lap(self, lap: LapTrace, *, track_id: str | None = None) -> int:
+    def calibrate_from_driver_lap(
+        self,
+        lap: LapTrace,
+        *,
+        track_id: str | None = None,
+        track_layout: str | None = None,
+    ) -> int:
         """Fold one of the driver's own completed laps into the per-zone brake-mark EMA.
 
-        For each corner zone, the driver's sustained brake onset nearest the current reference
-        mark (within ``_CAL_MATCH_TOL_M`` meters — the same zone, not a different line) updates
+        For each corner zone, the driver's sustained brake onset nearest the mark currently IN
+        FORCE (within ``_CAL_MATCH_TOL_M`` meters — the same zone, not a different line) updates
         that zone's EMA. Matching is one-to-one (greedy nearest-first): a single brake
         application between two closely spaced marks calibrates ONE zone, never both — else the
         per-zone distinction #522 adds would collapse (PR #525 review). Returns the number of
-        zones updated. A lap from a different track (when both track ids are known) never
-        calibrates.
+        zones updated. A lap from a different track — or a different LAYOUT of the same track,
+        when both sides carry one (multi-layout ids share normalized splines that point at
+        unrelated features) — never calibrates.
         """
         if track_id and self._track_id and track_id != self._track_id:
+            return 0
+        if track_layout and self._track_layout and track_layout != self._track_layout:
             return 0
         tol = _CAL_MATCH_TOL_M / self._track_length_m  # metric tolerance in spline units
         updated = 0
@@ -401,30 +414,44 @@ class RealtimeObserver:
             ref_marks = self._reference_marks(ref)
             if not ref_marks:
                 continue
-            # scan slightly upstream of the window too — a slower driver brakes EARLIER than the
-            # reference lap's deceleration onset that defined the window entry. A first-corner
-            # window whose upstream margin crosses start/finish also scans the trace TAIL: the
-            # archive finalizes the lap before the S/F frame, so the driver's onset for a mark
-            # near spline 0 can sit at ~0.99 (PR #525 review).
-            lo = ref.spline_lo - tol
-            onsets = sustained_brake_onsets(lap, max(0.0, lo), ref.spline_hi)
-            if lo < 0.0:
-                onsets += sustained_brake_onsets(lap, lo % 1.0, 1.0)
-            if not onsets:
-                continue
             # Anchor matching on the marks currently IN FORCE (learned EMA when a zone has one,
             # else the reference): once a zone has drifted toward the driver's habit, later laps
             # near the LEARNED mark must keep adapting even when they sit outside the synthetic
             # mark's tolerance (PR #525 review — "recent laps dominate" must not stall).
             anchors = [m for m, _src in self._effective_marks(ref)]
+            # Onsets are collected from each ANCHOR's ±tol neighbourhood (wrap-aware) — exactly
+            # the region matching can accept — so a learned mark that drifted upstream of the
+            # reference window, or one sitting just before start/finish (the archive finalizes
+            # the lap before the S/F frame), keeps adapting (PR #525 review).
+            onsets: list[float] = []
+            seen_onsets: set[float] = set()
+            for anchor in anchors:
+                # +tol of body allowance past the acceptance bound: an onset just inside the
+                # match window needs room for its ``min_run`` samples, or the window edge would
+                # truncate the zone below detection. Acceptance stays bounded by ``tol``.
+                lo_a, hi_a = anchor - tol, anchor + 2.0 * tol
+                if lo_a < 0.0:
+                    windows = [(lo_a % 1.0, 1.0), (0.0, hi_a)]
+                elif hi_a > 1.0:
+                    windows = [(lo_a, 1.0), (0.0, hi_a % 1.0)]
+                else:
+                    windows = [(lo_a, hi_a)]
+                for w_lo, w_hi in windows:
+                    for onset in sustained_brake_onsets(lap, w_lo, w_hi):
+                        if onset not in seen_onsets:
+                            seen_onsets.add(onset)
+                            onsets.append(onset)
+            if not onsets:
+                continue
             pairs = sorted(
                 (abs(_signed_spline_delta(onset, anchor)), zi, onset)
                 for zi, anchor in enumerate(anchors)
                 for onset in onsets
             )
-            # forward positions from just upstream of the window, so "in lap order" is
-            # well-defined even when the window (or a learned mark) crosses start/finish.
-            origin = (ref.spline_lo - tol) % 1.0
+            # forward positions from just upstream of the first mark, so "in lap order" is
+            # well-defined even when a mark crosses start/finish or drifts upstream of the
+            # reference window.
+            origin = (anchors[0] - 2.0 * tol) % 1.0
             matched_zones: set[int] = set()
             consumed_onsets: set[float] = set()
             for dist, zi, onset in pairs:
@@ -894,6 +921,7 @@ def build_observer_from_reference(
     track_obj = reference_archive.get("track")
     track = track_obj if isinstance(track_obj, dict) else {}
     track_id = track.get("id")
+    track_layout = track.get("layout")
     return RealtimeObserver(
         refs,
         track_length_m=_positive_track_length_m(track.get("lengthM")),
@@ -901,4 +929,5 @@ def build_observer_from_reference(
             brake_prepare_lead_s if brake_prepare_lead_s is not None else _BRAKE_PREPARE_LEAD_S
         ),
         track_id=track_id if isinstance(track_id, str) and track_id else None,
+        track_layout=track_layout if isinstance(track_layout, str) and track_layout else None,
     )

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -41,6 +41,12 @@ _LAP_WRAP_DROP = 0.5
 #: clear state WITHOUT grading the abandoned corner (mirrors delta.lua's wrap-vs-rolling-reset).
 _WRAP_PREV_MIN = 0.8
 _WRAP_CUR_MAX = 0.25
+#: frames a deferred (ambiguous) wrap may stay unresolved before it is treated as a pit return.
+#: A true wrap's lap counter advances within ~1 frame (delta.lua defers by at most one); a pit
+#: return can idle near the line for many frames, and its carried first-corner state must be
+#: reverted BEFORE the car reaches the mark, not only at the 0.25-spline drive-on discard
+#: (PR #525 review).
+_WRAP_CONFIRM_MAX_FRAMES = 3
 #: km/h a corner exit must be under the target before it's worth an advisory.
 _DEFICIT_MARGIN_KMH = 2.0
 #: brake pedal fraction above which we consider the driver "on the brakes".
@@ -349,6 +355,7 @@ class RealtimeObserver:
         # counter, not yet advanced): legitimized when the counter advances, reverted to fresh
         # state when the jump turns out to be a pit/teleport (PR #525 review).
         self._pending_carried: list[int] = []
+        self._pending_frames = 0  # frames the deferral has been unresolved (bounded)
 
     @staticmethod
     def _reference_marks(ref: CornerReference) -> list[float]:
@@ -475,6 +482,7 @@ class RealtimeObserver:
         self._pending_wrap = []
         self._pending_pre_lap = None
         self._pending_carried = []
+        self._pending_frames = 0
         return carried_ids
 
     def observe(self, frame: dict[str, Any]) -> list[Advisory]:
@@ -486,8 +494,12 @@ class RealtimeObserver:
         out: list[Advisory] = []
         # Resolve a wrap whose grading we deferred (a true wrap's lapCount can lag the drop by a
         # frame). Confirm the moment the counter advances; discard once the car has driven on past
-        # the wrap zone without an advance (that was a pit/teleport, not a lap).
-        if self._pending_wrap:
+        # the wrap zone without an advance (that was a pit/teleport, not a lap). Gate on EITHER
+        # deferred artifact: a pit return after a pre-wrap first-corner cue typically has NOTHING
+        # graded (no final corner in flight), so the carried-pass revert must not hide behind a
+        # non-empty grading list (PR #525 review).
+        if self._pending_wrap or self._pending_carried:
+            self._pending_frames += 1
             if (
                 lap is not None
                 and self._pending_pre_lap is not None
@@ -497,12 +509,14 @@ class RealtimeObserver:
                 self._pending_wrap = []
                 self._pending_pre_lap = None
                 self._pending_carried = []  # wrap confirmed → the carried passes are legit
-            elif spline > _WRAP_CUR_MAX:
+            elif spline > _WRAP_CUR_MAX or self._pending_frames > _WRAP_CONFIRM_MAX_FRAMES:
                 self._pending_wrap = []
                 self._pending_pre_lap = None
-                # That backward jump was a pit/teleport, not a wrap: revert any pre-wrap-armed
-                # pass carried across it — its stale zone_cued must not suppress the next
-                # legitimate first-corner heads-up of the resumed stream (PR #525 review).
+                # That backward jump was a pit/teleport, not a wrap (drove on, or the counter
+                # stayed put past its at-most-one-frame lag): revert any pre-wrap-armed pass
+                # carried across it — its stale zone_cued must not suppress the next legitimate
+                # first-corner heads-up of the resumed stream, which for a pit return near the
+                # line arrives BEFORE the 0.25-spline drive-on point (PR #525 review).
                 for ci in self._pending_carried:
                     ref_c = next((r for r in self._refs if r.index == ci), None)
                     if ref_c is not None:
@@ -554,22 +568,6 @@ class RealtimeObserver:
                     speed, self._track_length_m, self._brake_prepare_lead_s
                 )
                 lead_start = (bp - lead) % 1.0
-                wrapped_lead = zi == 0 and bp - lead < 0.0 and spline >= lead_start
-                if wrapped_lead:
-                    # For a first-corner brake point near 0.0, the next lap's lead window starts
-                    # before the spline wrap is observed (for example at s=0.995). Reset this
-                    # corner's previous-lap cue state now so the anticipatory cue can still lead
-                    # the mark instead of being suppressed until after start/finish. ONE-SHOT
-                    # per approach (``armed_prewrap``): the fresh approach's own heads-up must
-                    # not read as stale state and reset/re-fire every following frame.
-                    if not st.armed_prewrap and (
-                        st.inside
-                        or st.any_brake_state
-                        or st.release_cue_rank >= 0
-                        or st.exit_emitted
-                    ):
-                        self._passes[ref.index] = st = self._new_pass(ref)
-                    st.armed_prewrap = True
                 # A zone's braking segment runs from its mark to the next zone's mark (last
                 # zone: to the apex, or the window end for a mark past the apex) — braking
                 # there is braking FOR this zone, so a later release isn't "late to brake".
@@ -582,6 +580,28 @@ class RealtimeObserver:
                     seg_end = ref.apex_spline
                 else:
                     seg_end = ref.spline_hi
+                # The first zone's ACTIVE arc [lead_start .. mark .. seg_end] straddles
+                # start/finish whenever seg_end sits behind lead_start on the lap — either the
+                # lead window opened before the line (mark near 0.0) or a driver-calibrated
+                # mark itself sits just before the line (~0.99) with the corner beyond it
+                # (PR #525 review). In the pre-line part of that arc, re-arm for the lap that
+                # begins at the upcoming wrap.
+                wrapped_lead = zi == 0 and seg_end < lead_start and spline >= lead_start
+                if wrapped_lead:
+                    # For a first-corner arc that straddles the line, the next lap's approach
+                    # starts before the spline wrap is observed (for example at s=0.995). Reset
+                    # this corner's previous-lap cue state now so the anticipatory cue can still
+                    # lead the mark instead of being suppressed until after start/finish.
+                    # ONE-SHOT per approach (``armed_prewrap``): the fresh approach's own
+                    # heads-up must not read as stale state and reset/re-fire every frame.
+                    if not st.armed_prewrap and (
+                        st.inside
+                        or st.any_brake_state
+                        or st.release_cue_rank >= 0
+                        or st.exit_emitted
+                    ):
+                        self._passes[ref.index] = st = self._new_pass(ref)
+                    st.armed_prewrap = True
                 if _in_arc(spline, bp, seg_end) and brake >= self._brake_on:
                     st.zone_braked[zi] = True
                 # The actionable window runs from the anticipatory lead (which can wrap over

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -345,6 +345,10 @@ class RealtimeObserver:
         # a frame (delta.lua defers); confirmed on a later counter advance, discarded on drive-on.
         self._pending_wrap: list[Advisory] = []
         self._pending_pre_lap: float | None = None
+        # corners whose pre-wrap-armed pass was carried across an UNCONFIRMED wrap (known lap
+        # counter, not yet advanced): legitimized when the counter advances, reverted to fresh
+        # state when the jump turns out to be a pit/teleport (PR #525 review).
+        self._pending_carried: list[int] = []
 
     @staticmethod
     def _reference_marks(ref: CornerReference) -> list[float]:
@@ -398,11 +402,19 @@ class RealtimeObserver:
                 onsets += sustained_brake_onsets(lap, lo % 1.0, 1.0)
             if not onsets:
                 continue
+            # Anchor matching on the marks currently IN FORCE (learned EMA when a zone has one,
+            # else the reference): once a zone has drifted toward the driver's habit, later laps
+            # near the LEARNED mark must keep adapting even when they sit outside the synthetic
+            # mark's tolerance (PR #525 review — "recent laps dominate" must not stall).
+            anchors = [m for m, _src in self._effective_marks(ref)]
             pairs = sorted(
-                (abs(_signed_spline_delta(onset, mark)), zi, onset)
-                for zi, mark in enumerate(ref_marks)
+                (abs(_signed_spline_delta(onset, anchor)), zi, onset)
+                for zi, anchor in enumerate(anchors)
                 for onset in onsets
             )
+            # forward positions from just upstream of the window, so "in lap order" is
+            # well-defined even when the window (or a learned mark) crosses start/finish.
+            origin = (ref.spline_lo - _CAL_MATCH_TOL_SPLINE) % 1.0
             matched_zones: set[int] = set()
             consumed_onsets: set[float] = set()
             for dist, zi, onset in pairs:
@@ -410,42 +422,60 @@ class RealtimeObserver:
                     break  # sorted ascending: everything after is farther
                 if zi in matched_zones or onset in consumed_onsets:
                     continue
-                matched_zones.add(zi)
-                consumed_onsets.add(onset)
+                # Order preservation: an update that would move a zone AT or PAST a neighbour's
+                # mark is ambiguous (which zone did the driver brake for?) and is skipped —
+                # crossed marks would corrupt the per-zone segment arcs downstream (PR #525
+                # review).
                 cur = self._driver_marks.get((ref.index, zi))
                 if cur is None:
-                    self._driver_marks[(ref.index, zi)] = (onset % 1.0, 1)
+                    candidate = onset % 1.0
                 else:
                     ema, n = cur
-                    step = _CAL_EMA_ALPHA * _signed_spline_delta(onset, ema)
-                    self._driver_marks[(ref.index, zi)] = ((ema + step) % 1.0, n + 1)
+                    candidate = (ema + _CAL_EMA_ALPHA * _signed_spline_delta(onset, ema)) % 1.0
+                pos = _forward_spline_delta(origin, candidate)
+                if zi > 0 and pos <= _forward_spline_delta(origin, anchors[zi - 1]):
+                    continue
+                if zi + 1 < len(anchors) and pos >= _forward_spline_delta(origin, anchors[zi + 1]):
+                    continue
+                matched_zones.add(zi)
+                consumed_onsets.add(onset)
+                self._driver_marks[(ref.index, zi)] = (
+                    candidate,
+                    1 if cur is None else cur[1] + 1,
+                )
                 updated += 1
         return updated
 
-    def reset(self, *, carry_prewrap: bool = False) -> None:
+    def reset(self, *, carry_prewrap: bool = False) -> list[int]:
         """Clear per-corner pass state (start of a fresh lap). The lap counter — and the
         per-driver brake-mark calibration, which is knowledge about the driver — persist.
 
-        With ``carry_prewrap`` (the true start/finish-wrap path only), a pass re-armed
-        pre-wrap (a first-corner lead window that opened before start/finish) already belongs
-        to the lap that begins at this wrap: it carries across — heads-up and near-mark braking
-        observed before the line stay valid — with its one-shot flag cleared so the NEXT lap's
-        pre-wrap approach can re-arm it again. External resets (producer disconnect) and
-        same-lap rewinds (pit/teleport) must NOT carry: the stream is discontinuous, and stale
+        With ``carry_prewrap`` (the start/finish-wrap path only), a pass re-armed pre-wrap (a
+        first-corner lead window that opened before start/finish) already belongs to the lap
+        that begins at this wrap: it carries across — heads-up and near-mark braking observed
+        before the line stay valid — with its one-shot flag cleared so the NEXT lap's pre-wrap
+        approach can re-arm it again. External resets (producer disconnect) and same-lap
+        rewinds (pit/teleport) must NOT carry: the stream is discontinuous, and stale
         ``zone_cued`` state would suppress a fresh first-corner heads-up (PR #525 review).
+        Returns the carried corner indices so an UNCONFIRMED wrap (known lap counter that has
+        not advanced yet) can revert them if the jump turns out to be a pit return.
         """
-        carried: dict[int, _CornerPass] = {}
+        carried_ids: list[int] = []
+        passes: dict[int, _CornerPass] = {}
         for r in self._refs:
             p = self._passes.get(r.index)
             if carry_prewrap and p is not None and p.armed_prewrap:
                 p.armed_prewrap = False
-                carried[r.index] = p
+                passes[r.index] = p
+                carried_ids.append(r.index)
             else:
-                carried[r.index] = self._new_pass(r)
-        self._passes = carried
+                passes[r.index] = self._new_pass(r)
+        self._passes = passes
         self._last_spline = None
         self._pending_wrap = []
         self._pending_pre_lap = None
+        self._pending_carried = []
+        return carried_ids
 
     def observe(self, frame: dict[str, Any]) -> list[Advisory]:
         """Process one live frame; return the advisories it triggers (possibly empty)."""
@@ -466,9 +496,18 @@ class RealtimeObserver:
                 out.extend(self._pending_wrap)
                 self._pending_wrap = []
                 self._pending_pre_lap = None
+                self._pending_carried = []  # wrap confirmed → the carried passes are legit
             elif spline > _WRAP_CUR_MAX:
                 self._pending_wrap = []
                 self._pending_pre_lap = None
+                # That backward jump was a pit/teleport, not a wrap: revert any pre-wrap-armed
+                # pass carried across it — its stale zone_cued must not suppress the next
+                # legitimate first-corner heads-up of the resumed stream (PR #525 review).
+                for ci in self._pending_carried:
+                    ref_c = next((r for r in self._refs if r.index == ci), None)
+                    if ref_c is not None:
+                        self._passes[ci] = self._new_pass(ref_c)
+                self._pending_carried = []
         # A backward spline jump is either a true start/finish wrap or a same-lap rewind
         # (pit/teleport/replay). Shape alone is ambiguous — a return-to-pits also lands near the
         # line — so grade end-of-lap ONLY on real lap-completion evidence: an authoritative
@@ -489,12 +528,15 @@ class RealtimeObserver:
             pre_lap = self._last_lap
             # A pre-wrap-armed first-corner pass carries only through a genuine start/finish
             # crossing; a same-lap rewind (pit/teleport) clears everything (PR #525 review).
-            self.reset(carry_prewrap=lap_advanced or wrap_shaped)
+            carried = self.reset(carry_prewrap=lap_advanced or wrap_shaped)
             if lap_advanced or (wrap_shaped and not lap_known):
                 out.extend(graded)  # definite lap completion → grade now
             elif wrap_shaped and lap_known:
                 self._pending_wrap = graded  # ambiguous → defer until the counter advances
                 self._pending_pre_lap = pre_lap
+                # ...and the carry is equally unconfirmed: reverted if this turns out to be a
+                # pit return (resolved in the pending block above, same as the grading).
+                self._pending_carried = carried
         self._last_spline = spline
         if lap is not None:
             self._last_lap = lap
@@ -531,12 +573,16 @@ class RealtimeObserver:
                 # A zone's braking segment runs from its mark to the next zone's mark (last
                 # zone: to the apex, or the window end for a mark past the apex) — braking
                 # there is braking FOR this zone, so a later release isn't "late to brake".
-                seg_end = (
-                    marks[zi + 1][0]
-                    if zi + 1 < len(marks)
-                    else (ref.apex_spline if bp <= ref.apex_spline else ref.spline_hi)
-                )
-                if bp <= spline <= seg_end and brake >= self._brake_on:
+                # Arc-based (wrap-aware): a driver-calibrated first-corner mark can sit just
+                # BEFORE start/finish (e.g. 0.99 for a corner at 0.03), where linear compares
+                # would never latch (PR #525 review).
+                if zi + 1 < len(marks):
+                    seg_end = marks[zi + 1][0]
+                elif _in_arc(ref.apex_spline, bp, ref.spline_hi) or bp <= ref.apex_spline:
+                    seg_end = ref.apex_spline
+                else:
+                    seg_end = ref.spline_hi
+                if _in_arc(spline, bp, seg_end) and brake >= self._brake_on:
                     st.zone_braked[zi] = True
                 # The actionable window runs from the anticipatory lead (which can wrap over
                 # start/finish for a first corner with bp≈0) through the zone's segment end

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -765,7 +765,15 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
     observer = _observer
     if observer is None:
         return
-    key = str(inbound.get("archivePath") or "") or f"lap:{inbound.get('lap')}"
+    # One key per PHYSICAL lap across its resend forms: the plain lap_complete (which may carry
+    # an inline trace) and the archive-backed brainOnly re-send both carry the same
+    # lap + lapTimeMs identity, while their archivePath presence differs — keying on the path
+    # alone would fold the same lap twice (PR #525 review).
+    lap_n, lap_ms = inbound.get("lap"), inbound.get("lapTimeMs")
+    if lap_n is not None and lap_ms is not None:
+        key = f"lap:{lap_n}:{lap_ms}"
+    else:
+        key = str(inbound.get("archivePath") or "") or f"lap:{lap_n}"
     if key == _last_brake_cal_key:
         return
     # Reserve the key BEFORE the awaited loads (we are on the event loop here, so the

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -105,6 +105,7 @@ from tools.ai_sidecar.protocol import (
     build_brain_followup,
     build_ollama_followup,
     prepare_outbound_message,
+    resolve_lap_archive,
 )
 from tools.ai_sidecar.race_management import RaceManagementObserver
 from tools.ai_sidecar.realtime_observer import (
@@ -738,6 +739,58 @@ async def _send_brain_followup(websocket: Any, inbound: dict[str, Any]) -> None:
     if followup is None:
         return
     await _safe_send(websocket, followup)
+
+
+def _brake_calibration_enabled() -> bool:
+    """Per-driver brake-mark calibration (issue #522): on by default, ``AC_COPILOT_BRAKE_CAL=0``
+    disables."""
+    return os.environ.get("AC_COPILOT_BRAKE_CAL", "1").strip().lower() not in ("0", "false", "off")
+
+
+#: last lap_complete identity already folded into calibration — the plain lap_complete frame and
+#: its archive-backed ``brainOnly`` re-send both carry the same lap; the same lap must not be
+#: EMA-weighted twice.
+_last_brake_cal_key: str | None = None
+
+
+async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
+    """Fold the driver's completed lap into the observer's per-zone brake-mark EMA (#522).
+
+    Runs as a background task on lap_complete: loads the lap archive off the loop (safe-path
+    validated by :func:`resolve_lap_archive`), skips explicitly-invalid laps (a cut lap's brake
+    points are not calibration data), and applies the EMA update on the event loop — the same
+    loop that calls ``observer.observe``, so there is no cross-thread mutation.
+    """
+    global _last_brake_cal_key
+    observer = _observer
+    if observer is None:
+        return
+    key = str(inbound.get("archivePath") or "") or f"lap:{inbound.get('lap')}"
+    if key == _last_brake_cal_key:
+        return
+    try:
+        archive = await asyncio.to_thread(resolve_lap_archive, inbound)
+        if not isinstance(archive, dict):
+            return
+        lap_meta = archive.get("lap")
+        if isinstance(lap_meta, dict) and lap_meta.get("is_valid") is False:
+            return
+        from tools.ai_sidecar.lap_dynamics import lap_trace_from_archive
+
+        trace = await asyncio.to_thread(lap_trace_from_archive, archive)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.info("brake calibration skipped: %s", e)
+        return
+    _last_brake_cal_key = key
+    track_obj = archive.get("track")
+    track_id = track_obj.get("id") if isinstance(track_obj, dict) else None
+    updated = observer.calibrate_from_driver_lap(
+        trace, track_id=track_id if isinstance(track_id, str) else None
+    )
+    if updated:
+        logger.info("brake marks calibrated from the driver's lap: %d zone(s) updated", updated)
 
 
 async def _safe_send(websocket: Any, payload: dict[str, Any]) -> None:
@@ -2098,6 +2151,15 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
                     data.get("lapTimeMs"),
                     hints,
                 )
+                # Issue #522 part 2: each completed lap of the driver's own folds into the
+                # observer's per-zone brake-mark EMA so the cue marks anchor on where THIS
+                # driver demonstrably brakes, not the synthetic reference's points. Background
+                # task — never blocks the <100ms ack path; dedup inside guards the brainOnly
+                # re-send of the same lap.
+                if _observer is not None and _brake_calibration_enabled():
+                    cal_task = asyncio.create_task(_calibrate_brake_marks_from_lap(data))
+                    _background_tasks.add(cal_task)
+                    cal_task.add_done_callback(_background_tasks.discard)
 
             # Archive-backed activation frames are emitted after Lua knows the final archive path.
             # They should only run the brain, not the generic rules ack or Ollama narration.

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -765,6 +765,15 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
     observer = _observer
     if observer is None:
         return
+    # A frame with neither an inline trace nor an archivePath can never resolve: return WITHOUT
+    # reserving the dedup key, or the archive-backed brainOnly re-send racing this task would see
+    # the reservation, skip, and leave the lap uncalibrated after the rollback (PR #525 review).
+    trace = inbound.get("trace")
+    has_inline_trace = (
+        isinstance(trace, dict) and isinstance(trace.get("samples"), list) and trace["samples"]
+    )
+    if not has_inline_trace and not str(inbound.get("archivePath") or "").strip():
+        return
     # One key per PHYSICAL lap across its resend forms: the plain lap_complete (which may carry
     # an inline trace) and the archive-backed brainOnly re-send both carry the same
     # lap + lapTimeMs identity, while their archivePath presence differs — keying on the path

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -747,10 +747,23 @@ def _brake_calibration_enabled() -> bool:
     return os.environ.get("AC_COPILOT_BRAKE_CAL", "1").strip().lower() not in ("0", "false", "off")
 
 
-#: last lap_complete identity already folded into calibration — the plain lap_complete frame and
-#: its archive-backed ``brainOnly`` re-send both carry the same lap; the same lap must not be
-#: EMA-weighted twice.
-_last_brake_cal_key: str | None = None
+def _brake_calibration_active() -> bool:
+    """Calibration folds into the LEGACY observer's marks — the default live cue producer.
+
+    With coach v2 active (``AC_COPILOT_COACH_V2=1``), ``_publish_coaching_cues`` routes
+    telemetry through ``_coach_runtime`` instead, so folding laps into ``_observer`` would log
+    "calibrated" while having zero effect on the spoken cues — misleading. Skip; v2-side
+    calibration is tracked as #522 V2 scope (PR #525 review).
+    """
+    return _observer is not None and _coach_runtime is None and _brake_calibration_enabled()
+
+
+#: recent lap_complete identities already folded into calibration — the plain lap_complete frame
+#: and its archive-backed ``brainOnly`` re-send both carry the same lap; the same lap must not be
+#: EMA-weighted twice, even when the re-send arrives late (after a NEWER lap has folded), so a
+#: bounded set of recent keys is kept, not just the last one (PR #525 review). The most recent
+#: reservation is tracked separately so a failed load can roll itself back.
+_recent_brake_cal_keys: deque[str] = deque(maxlen=8)
 
 
 async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
@@ -761,7 +774,6 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
     points are not calibration data), and applies the EMA update on the event loop — the same
     loop that calls ``observer.observe``, so there is no cross-thread mutation.
     """
-    global _last_brake_cal_key
     observer = _observer
     if observer is None:
         return
@@ -783,7 +795,7 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
         key = f"lap:{lap_n}:{lap_ms}"
     else:
         key = str(inbound.get("archivePath") or "") or f"lap:{lap_n}"
-    if key == _last_brake_cal_key:
+    if key in _recent_brake_cal_keys:
         return
     # Reserve the key BEFORE the awaited loads (we are on the event loop here, so the
     # check-and-set is atomic): two archive-backed frames for the same lap arriving
@@ -791,12 +803,12 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
     # file — that would double-weight the EMA (PR #525 review). A failed LOAD rolls the
     # reservation back so a later frame with the same archive (e.g. after the async archive
     # write completes) still calibrates; a deliberate skip (invalid lap) keeps it.
-    _last_brake_cal_key = key
+    _recent_brake_cal_keys.append(key)
     try:
         archive = await asyncio.to_thread(resolve_lap_archive, inbound)
         if not isinstance(archive, dict):
-            if _last_brake_cal_key == key:
-                _last_brake_cal_key = None
+            with contextlib.suppress(ValueError):
+                _recent_brake_cal_keys.remove(key)
             return
         lap_meta = archive.get("lap")
         if isinstance(lap_meta, dict) and lap_meta.get("is_valid") is False:
@@ -808,8 +820,8 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
         raise
     except Exception as e:
         logger.info("brake calibration skipped: %s", e)
-        if _last_brake_cal_key == key:
-            _last_brake_cal_key = None
+        with contextlib.suppress(ValueError):
+            _recent_brake_cal_keys.remove(key)
         return
     track_obj = archive.get("track")
     track_id = track_obj.get("id") if isinstance(track_obj, dict) else None
@@ -2183,7 +2195,7 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
                 # driver demonstrably brakes, not the synthetic reference's points. Background
                 # task — never blocks the <100ms ack path; dedup inside guards the brainOnly
                 # re-send of the same lap.
-                if _observer is not None and _brake_calibration_enabled():
+                if _brake_calibration_active():
                     cal_task = asyncio.create_task(_calibrate_brake_marks_from_lap(data))
                     _background_tasks.add(cal_task)
                     cal_task.add_done_callback(_background_tasks.discard)

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -825,8 +825,11 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
         return
     track_obj = archive.get("track")
     track_id = track_obj.get("id") if isinstance(track_obj, dict) else None
+    track_layout = track_obj.get("layout") if isinstance(track_obj, dict) else None
     updated = observer.calibrate_from_driver_lap(
-        trace, track_id=track_id if isinstance(track_id, str) else None
+        trace,
+        track_id=track_id if isinstance(track_id, str) else None,
+        track_layout=track_layout if isinstance(track_layout, str) else None,
     )
     if updated:
         logger.info("brake marks calibrated from the driver's lap: %d zone(s) updated", updated)

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -768,9 +768,18 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
     key = str(inbound.get("archivePath") or "") or f"lap:{inbound.get('lap')}"
     if key == _last_brake_cal_key:
         return
+    # Reserve the key BEFORE the awaited loads (we are on the event loop here, so the
+    # check-and-set is atomic): two archive-backed frames for the same lap arriving
+    # back-to-back must not both pass the guard while the first is still off-loop reading the
+    # file — that would double-weight the EMA (PR #525 review). A failed LOAD rolls the
+    # reservation back so a later frame with the same archive (e.g. after the async archive
+    # write completes) still calibrates; a deliberate skip (invalid lap) keeps it.
+    _last_brake_cal_key = key
     try:
         archive = await asyncio.to_thread(resolve_lap_archive, inbound)
         if not isinstance(archive, dict):
+            if _last_brake_cal_key == key:
+                _last_brake_cal_key = None
             return
         lap_meta = archive.get("lap")
         if isinstance(lap_meta, dict) and lap_meta.get("is_valid") is False:
@@ -782,8 +791,9 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
         raise
     except Exception as e:
         logger.info("brake calibration skipped: %s", e)
+        if _last_brake_cal_key == key:
+            _last_brake_cal_key = None
         return
-    _last_brake_cal_key = key
     track_obj = archive.get("track")
     track_id = track_obj.get("id") if isinstance(track_obj, dict) else None
     updated = observer.calibrate_from_driver_lap(

--- a/tools/ai_sidecar/track_reference.py
+++ b/tools/ai_sidecar/track_reference.py
@@ -18,6 +18,13 @@ from dataclasses import dataclass, field
 
 from tools.ai_sidecar.lap_dynamics import LapTrace, segment_corners
 
+#: peak pedal fraction a sustained application must reach to count as a distinct BRAKE ZONE.
+#: ``segment_corners`` deliberately merges an esses complex into ONE driver-perceived corner, so a
+#: merged window can hold several real brake zones (issue #522: Magione's back half — 4 of 9 zones
+#: sat inside merged windows and got no mark). A lighter touch than this is a lift/drag on the way
+#: to an apex, not a coachable brake mark.
+_ZONE_MIN_PEAK_BRAKE = 0.35
+
 
 @dataclass
 class CornerReference:
@@ -31,6 +38,10 @@ class CornerReference:
     best_observed_apex_kmh: float | None = None  # fastest corpus lap through this window
     best_brake_point_spline: float | None = None  # earliest sustained brake of the best corpus lap
     n_corpus: int = 0
+    #: onset splines of EVERY distinct sustained brake zone of the best corpus lap in this window
+    #: (issue #522 coverage). ``best_brake_point_spline`` stays the first of these for consumers
+    #: that only understand one mark per corner.
+    brake_marks: list[float] = field(default_factory=list)
 
     @property
     def target_apex_kmh(self) -> float:
@@ -48,27 +59,38 @@ def _min_speed_kmh_in_window(lap: LapTrace, lo: float, hi: float) -> float | Non
     return min(vals) * 3.6 if vals else None
 
 
-def _first_brake_spline(
-    lap: LapTrace, lo: float, hi: float, thresh: float = 0.05, min_run: int = 3
-) -> float | None:
-    """Spline of the first SUSTAINED braking onset within [lo, hi] (the corpus lap's brake point).
+def sustained_brake_onsets(
+    lap: LapTrace,
+    lo: float,
+    hi: float,
+    *,
+    thresh: float = 0.05,
+    min_run: int = 3,
+    min_peak: float = _ZONE_MIN_PEAK_BRAKE,
+) -> list[float]:
+    """Onset splines of every DISTINCT sustained brake zone within [lo, hi], in lap order.
 
-    Requires ``min_run`` consecutive in-window samples above ``thresh`` so a single-frame blip is
-    not taken as the brake point — consistent with ``lap_dynamics`` treating a brake zone as
-    near-continuous rather than a lone sample.
+    A zone is ``min_run`` consecutive in-window samples above ``thresh`` (so a single-frame blip is
+    not a brake point — consistent with ``lap_dynamics`` treating a brake zone as near-continuous)
+    whose peak pedal reaches ``min_peak`` (so a light lift/drag between apexes is not promoted to a
+    coachable mark). Zones split where the pedal drops back to/below ``thresh``.
     """
     n = len(lap)
-    for i in range(n):
+    out: list[float] = []
+    i = 0
+    while i < n:
         if not (lo <= lap.spline[i] <= hi and lap.brake[i] > thresh):
+            i += 1
             continue
-        run = 1
+        peak = lap.brake[i]
         j = i + 1
         while j < n and lap.spline[j] <= hi and lap.brake[j] > thresh:
-            run += 1
+            peak = max(peak, lap.brake[j])
             j += 1
-        if run >= min_run:
-            return lap.spline[i]
-    return None
+        if j - i >= min_run and peak >= min_peak:
+            out.append(lap.spline[i])
+        i = j
+    return out
 
 
 def build_references(optimal_lap: LapTrace) -> list[CornerReference]:
@@ -106,7 +128,10 @@ def add_corpus_lap(references: list[CornerReference], lap: LapTrace) -> None:
         ref.n_corpus += 1
         if ref.best_observed_apex_kmh is None or v > ref.best_observed_apex_kmh:
             ref.best_observed_apex_kmh = round(v, 1)
-            ref.best_brake_point_spline = _first_brake_spline(lap, ref.spline_lo, ref.spline_hi)
+            # EVERY distinct sustained brake zone of the best lap becomes a mark (issue #522:
+            # a merged esses window holds several real zones and each needs a coachable cue).
+            ref.brake_marks = sustained_brake_onsets(lap, ref.spline_lo, ref.spline_hi)
+            ref.best_brake_point_spline = ref.brake_marks[0] if ref.brake_marks else None
 
 
 @dataclass

--- a/tools/ai_sidecar/voice/cue.py
+++ b/tools/ai_sidecar/voice/cue.py
@@ -143,7 +143,7 @@ class CueArbiter:
     global_cooldown_s: float = 2.5
     corner_cooldown_s: float = 6.0
     _last_spoken_s: float | None = None
-    _last_corner_kind_s: dict[tuple[int, str], float] = field(default_factory=dict)
+    _last_corner_kind_s: dict[tuple[int, int, str], float] = field(default_factory=dict)
 
     def select(self, advisories: list[dict[str, Any]], now_s: float) -> SpokenCue | None:
         """Choose the one cue to speak now, applying cooldowns + urgency preemption."""
@@ -162,7 +162,7 @@ class CueArbiter:
                 # arbitrate it (and never let it consume a cooldown slot).
                 continue
             is_act = _URGENCY_RANK.get(str(a.get("urgency", "")), 0) >= _URGENCY_RANK["act"]
-            key = (_corner_key(a), str(a.get("kind", "")))
+            key = (_corner_key(a), _zone_key(a), str(a.get("kind", "")))
             last = self._last_corner_kind_s.get(key)
             if not is_act and last is not None and now_s - last < self.corner_cooldown_s:
                 continue
@@ -181,7 +181,9 @@ class CueArbiter:
         ):
             return None
         self._last_spoken_s = now_s
-        self._last_corner_kind_s[(_corner_key(best), str(best.get("kind", "")))] = now_s
+        self._last_corner_kind_s[
+            (_corner_key(best), _zone_key(best), str(best.get("kind", "")))
+        ] = now_s
         return SpokenCue(
             text=advisory_to_phrase(best),
             urgency=str(best.get("urgency", "info")),
@@ -197,3 +199,15 @@ def _corner_key(advisory: dict[str, Any]) -> int:
         return int(advisory.get("corner"))
     except (TypeError, ValueError):
         return -1
+
+
+def _zone_key(advisory: dict[str, Any]) -> int:
+    """Brake-zone ordinal within a merged corner (issue #522), 0 when absent/unreadable.
+
+    Joins the per-corner cooldown key so the SECOND zone's heads-up in a merged esses corner
+    is not suppressed as a repeat of the first — mirroring the phrase-bank resolver's
+    zone-aware dedup key (PR #525 review).
+    """
+    detail = advisory.get("detail")
+    zone = detail.get("zone") if isinstance(detail, dict) else None
+    return zone if isinstance(zone, int) else 0

--- a/tools/ai_sidecar/voice/cue.py
+++ b/tools/ai_sidecar/voice/cue.py
@@ -142,7 +142,11 @@ class CueArbiter:
 
     global_cooldown_s: float = 2.5
     corner_cooldown_s: float = 6.0
+    #: floor between two DIFFERENT brake-zone heads-ups chaining through the global cooldown —
+    #: enough for the previous short clip to finish, well under the 2.5 s anti-chatter window.
+    zone_chain_min_gap_s: float = 1.2
     _last_spoken_s: float | None = None
+    _last_spoken_key: tuple[int, int, str] | None = None
     _last_corner_kind_s: dict[tuple[int, int, str], float] = field(default_factory=dict)
 
     def select(self, advisories: list[dict[str, Any]], now_s: float) -> SpokenCue | None:
@@ -173,17 +177,31 @@ class CueArbiter:
         # Highest urgency wins (ties: keep input order, i.e. the observer's per-frame order).
         best = max(fresh, key=lambda a: _URGENCY_RANK.get(str(a.get("urgency", "")), 0))
         is_act = _URGENCY_RANK.get(str(best.get("urgency", "")), 0) >= _URGENCY_RANK["act"]
-        # Global cooldown: stay silent unless this is an urgent 'act' cue (which may barge in).
+        best_key = (_corner_key(best), _zone_key(best), str(best.get("kind", "")))
+        # A DIFFERENT brake zone's heads-up may chain through the global cooldown after a short
+        # floor: two zones of a merged esses corner can sit < 2.5 s apart, the #522 observer
+        # emits only calm `prepare` brake cues (no act tier to barge in), and the second mark's
+        # coaching is lost if it waits out the full window (PR #525 review). Same-key repeats
+        # still respect the full cooldown (anti-chatter unchanged).
+        zone_chain = (
+            str(best.get("kind", "")) == "late_brake"
+            and self._last_spoken_key is not None
+            and best_key != self._last_spoken_key
+            and self._last_spoken_s is not None
+            and now_s - self._last_spoken_s >= self.zone_chain_min_gap_s
+        )
+        # Global cooldown: stay silent unless this is an urgent 'act' cue (which may barge in)
+        # or a distinct brake-zone heads-up past the chain floor.
         if (
             self._last_spoken_s is not None
             and now_s - self._last_spoken_s < self.global_cooldown_s
             and not is_act
+            and not zone_chain
         ):
             return None
         self._last_spoken_s = now_s
-        self._last_corner_kind_s[
-            (_corner_key(best), _zone_key(best), str(best.get("kind", "")))
-        ] = now_s
+        self._last_spoken_key = best_key
+        self._last_corner_kind_s[best_key] = now_s
         return SpokenCue(
             text=advisory_to_phrase(best),
             urgency=str(best.get("urgency", "info")),

--- a/tools/ai_sidecar/voice/resolver.py
+++ b/tools/ai_sidecar/voice/resolver.py
@@ -133,8 +133,15 @@ class Resolver:
         # Dedup is keyed on the *advisory's* identity (kind + 0-based corner + REQUESTED register),
         # so a genuine escalation (calm→alert→urgent→critical for one corner) is distinct, while a
         # repeat at the same register within a pass collapses to one utterance regardless of
-        # corner/register fallback.
-        dedup_key = f"{kind}:{getattr(advisory, 'corner', None)}:{register}"
+        # corner/register fallback. A merged esses corner holds several brake ZONES (issue #522
+        # coverage) whose heads-ups land within the dedup window — a later zone's cue must not be
+        # swallowed as a repeat of the first, so a non-zero zone ordinal joins the corner key.
+        corner_key = f"{getattr(advisory, 'corner', None)}"
+        detail = getattr(advisory, "detail", None)
+        zone = detail.get("zone") if isinstance(detail, dict) else None
+        if isinstance(zone, int) and zone > 0:
+            corner_key = f"{corner_key}z{zone}"
+        dedup_key = f"{kind}:{corner_key}:{register}"
         return Utterance(
             clip_id=clip_id,
             kind=kind,

--- a/tools/ai_sidecar/voice/scheduler.py
+++ b/tools/ai_sidecar/voice/scheduler.py
@@ -86,6 +86,9 @@ class Scheduler:
         self._last_spoke_key: dict[str, float] = {}
         # last time (clock) a given kind actually spoke — drives the per-kind cooldown.
         self._last_spoke_kind: dict[str, float] = {}
+        # last dedup_key spoken per kind — a DIFFERENT brake zone of a merged corner (#522)
+        # must not be swallowed by the same-kind cooldown as if it repeated the previous cue.
+        self._last_spoke_kind_key: dict[str, str] = {}
 
     # ---- submission (any thread) -------------------------------------------------------------
 
@@ -157,10 +160,17 @@ class Scheduler:
                 _log.debug("voice: dedup-suppress %s (key=%s)", utt.clip_id, utt.dedup_key)
                 return None
         # Cooldown: minimum gap between same-kind cues. ACT is exempt (never delayed/dropped).
+        # A late_brake cue for a DIFFERENT (corner, zone) than the kind's last spoken cue is
+        # also exempt: two brake zones of a merged esses corner (#522) can sit closer than the
+        # kind cooldown, and the second mark's heads-up is distinct coaching, not a nag —
+        # playback-busy arbitration still prevents talk-over (PR #525 review).
         if not is_act:
             last_kind = self._last_spoke_kind.get(utt.kind)
             cooldown = self._config.cooldown_for(utt.kind)
-            if last_kind is not None and (now - last_kind) < cooldown:
+            distinct_zone_brake = utt.kind == "late_brake" and self._last_spoke_kind_key.get(
+                utt.kind
+            ) not in (None, utt.dedup_key)
+            if last_kind is not None and (now - last_kind) < cooldown and not distinct_zone_brake:
                 _log.debug("voice: cooldown-suppress %s (kind=%s)", utt.clip_id, utt.kind)
                 return None
         return utt
@@ -224,6 +234,7 @@ class Scheduler:
                 )
         self._last_spoke_key[winner.dedup_key] = now
         self._last_spoke_kind[winner.kind] = now
+        self._last_spoke_kind_key[winner.kind] = winner.dedup_key
         return winner
 
     # ---- production worker thread ------------------------------------------------------------


### PR DESCRIPTION
Closes the two remaining measured gaps of #522 after V1 (PR #523): back-half brake zones uncoached (5-of-9) and synthetic-reference marks ~25 m off a real driver's points.

## Part 1 — every gate-grade brake zone gets a coachable mark

**Root cause (reproduced offline on the real Magione reference):** `segment_corners` deliberately merges an esses complex into ONE driver-perceived corner, so a merged window holds several real brake zones — and `add_corpus_lap` kept only the FIRST sustained onset per window. Zones @0.319 (T3 complex) and @0.823/@0.859 (T5 complex) had no mark; the `brake_events_coached` gate sat honestly red at 78%.

- `CornerReference.brake_marks`: every distinct sustained brake onset of the best corpus lap in the window (`sustained_brake_onsets`, peak ≥ 0.35 so a light lift is not promoted — the reference's 9th "zone" peaks at 0.16 brake and is deliberately filtered). `best_brake_point_spline` stays the first mark for single-mark consumers (timing_report, coach v2).
- `RealtimeObserver` tracks per-ZONE pass state (braked / cued / late): braking for zone 1 of a merged corner never consumes zone 2's heads-up; the trail-brake latch discriminator (PR #523) applies per zone; a missed zone still flags `late_uncoached` for exit grading.
- Voice dedup key gains a zone ordinal (`late_brake:2z1:calm`) so the second same-corner heads-up inside the 8 s dedup window is not swallowed. Zone-0 keys keep their pre-#522 shape (no churn for existing clients/tests).

**Offline proof on the real reference** (`.scratch/coach-demo/reference.json`): marks 5 → 8, all 8 gate-grade zones (brake ≥ 0.4 at speed > 60) covered exactly (d=0.0); replay of the full lap yields exactly one calm anticipatory heads-up per zone, 0 live imperatives.

## Part 2 — per-driver brake-mark calibration

Each completed **valid** lap of the driver's own folds into a per-zone EMA (α=0.4, match tolerance 0.02 spline ≈ 50 m — an onset farther out is a different line/zone and does not calibrate). Cue marks and the late/"ran deep" judgement then anchor on where THIS driver demonstrably brakes, with honest provenance (`detail.mark_source: driver_calibrated`; the apex-target `source` contract is unchanged).

- Server wiring: `lap_complete` → background task → safe-path archive load (`resolve_lap_archive`, traversal/size-guarded) → EMA applied on the event loop (same loop as `observe()`, no cross-thread mutation). Explicitly-invalid laps skipped; the `brainOnly` re-send of the same lap deduped; wrong-track laps refused (track id guard). `AC_COPILOT_BRAKE_CAL=0` disables.
- Calibration survives lap wraps and `reset()` — it is knowledge about the driver, not pass state.

## Also fixed: wrapped-lead cue spam (latent, surfaced by the replay)

A first-corner mark near spline 0 wraps its lead window over start/finish; the pass re-arm check read the approach's OWN heads-up as stale state and reset/re-fired the T1 cue every frame to the line (~55×/lap into the cue stream — masked in-ear by the 8 s voice dedup, but junk for HUD/WS consumers and the timeliness tap). The re-arm is now one-shot per approach and the armed pass carries across the wrap: exactly one cue per approach, none duplicated after start/finish. Regression test included.

## Tests

15 new tests (zone extraction/lift filtering, multi-zone corpus marks, per-zone heads-ups, missed-zone exit flag, wrapped-lead one-shot, EMA convergence/tolerance/wrong-track/wrap-survival, server calibration task incl. invalid-lap + dedup + env kill switch, zone dedup key). `make ci-fast` green (full suite).

## Remaining #522 scope (not this PR)

V2: phase-slot scheduler; LLM (in-repo Ollama `corner_advice`) selecting the ONE between-lap improvement point. Live re-verification of the coverage gate on the rig follows this PR's merge.

Refs #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)