### PR TITLE
fix(gate): coach-coverage denominator counts only coachable brake zones (#527)

### DIFF
--- a/tests/test_semantic_timeliness.py
+++ b/tests/test_semantic_timeliness.py
@@ -135,6 +135,80 @@ def _brake_mark_cue(t, mark, corner=None, urgency="prepare"):
     return cue, voice
 
 
+def _brake_onset(rows, t0, mark, span=(0.20, 0.80), seconds=24.0):
+    """Set a sustained brake onset on the tick whose spline first reaches ``mark``."""
+    onset_t = (mark - span[0]) / (span[1] - span[0]) * seconds
+    for r in rows:
+        rel = (r["t"] - t0) / 1000.0
+        if onset_t <= rel <= onset_t + 0.8:
+            r["brake"] = 0.8
+    return t0 + (onset_t - 3.0) * 1000.0  # a plausible ~3 s-ahead cue time for this mark
+
+
+def test_no_brake_marks_but_onsets_fails_gate(tmp_path):
+    """#527 codex P1: brake onsets with NO late_brake advisory marks must NOT pass vacuously —
+    that is a coaching pipeline emitting zero brake marks, not evidence of coverage."""
+    t0 = 6_000_000.0
+    rows = _ticks(t0, 24.0, 0.20, 0.80, 90.0)
+    _brake_onset(rows, t0, 0.35)
+    _brake_onset(rows, t0, 0.55)
+    # only a non-brake cue is present, so evidence_present is satisfied but there are no marks.
+    rows.append(
+        {
+            "t": t0 + 2000.0,
+            "k": "coaching.cue",
+            "payload": {"kind": "apex_deficit", "urgency": "info", "spline": 0.4},
+        }
+    )
+    rows.append(
+        {
+            "t": t0 + 2000.0,
+            "k": "coaching.voice",
+            "payload": {
+                "seq": 1,
+                "clip_id": "apex_deficit.info.calm.t01",
+                "kind": "apex_deficit",
+                "urgency": "info",
+                "register": "calm",
+                "duration_ms": 900,
+                "t_wall_ms": t0,
+            },
+        }
+    )
+    tap = tmp_path / "tap.jsonl"
+    _write_tap(tap, rows)
+    report = analyze(tap, track_length_m=2500.0)
+    assert report.brake_events >= 2 and report.zones_crossed == 0
+    assert report.assertions["brake_events_coached"] is False
+
+
+def test_cue_for_one_zone_does_not_cover_another(tmp_path):
+    """#527 codex P1: a cue must credit only its own mark/pass. Zone A cued+braked (coached);
+    zone B braked but its heads-up was dropped — A's cue must NOT make B look coached."""
+    t0 = 7_000_000.0
+    rows = _ticks(t0, 24.0, 0.20, 0.80, 90.0)
+    # Zone A: mark 0.35, braked, WITH an actionable cue (advisory + voice).
+    a_cue_t = _brake_onset(rows, t0, 0.35)
+    cue_a, voice_a = _brake_mark_cue(a_cue_t, 0.35, corner=1)
+    rows.extend([cue_a, voice_a])
+    # Zone B: mark 0.55, braked, advisory ONLY (dropped dispatch — no voice).
+    b_cue_t = _brake_onset(rows, t0, 0.55)
+    rows.append(
+        {
+            "t": b_cue_t,
+            "k": "coaching.cue",
+            "payload": {"kind": "late_brake", "urgency": "prepare", "spline": 0.55, "corner": 2},
+        }
+    )
+    tap = tmp_path / "tap.jsonl"
+    _write_tap(tap, rows)
+    report = analyze(tap, track_length_m=2500.0, audio_latency_s=0.1)
+    assert report.coachable_brake_zones == 2  # both zones braked in
+    assert report.coachable_brake_zones_coached == 1  # only A drew a cue; B not covered by A's cue
+    assert report.zones_crossed == 2 and report.zones_cued == 1
+    assert report.assertions["brake_events_coached"] is False
+
+
 def test_off_zone_onset_excluded_from_gate(tmp_path):
     """#527: a brake onset with no reference mark within 50 m is off-zone — it must NOT drag the
     coverage gate red. Two zones cued & braked in-window (coached) + one far-off correction dab."""

--- a/tests/test_semantic_timeliness.py
+++ b/tests/test_semantic_timeliness.py
@@ -110,7 +110,14 @@ def test_empty_tap_fails_evidence_assertion(tmp_path):
 
 
 def _brake_mark_cue(t, mark, corner=None, urgency="prepare"):
-    """A ``coaching.cue`` (advisory) + matching ``coaching.voice`` (dispatch) pair for a mark."""
+    """A ``coaching.cue`` (advisory) + matching ``coaching.voice`` (dispatch) pair for a mark.
+
+    Mirrors the real wire convention: the advisory ``coaching.cue`` carries the observer's 0-based
+    ``corner``; the dispatch ``coaching.voice`` carries the SPOKEN 1-based corner (``corner + 1``),
+    which is also the ``t0N`` clip label — so the analyzer's deterministic ``corner + 1`` binding is
+    exercised the way production emits it.
+    """
+    spoken = None if corner is None else corner + 1
     cue = {
         "t": t,
         "k": "coaching.cue",
@@ -121,7 +128,7 @@ def _brake_mark_cue(t, mark, corner=None, urgency="prepare"):
         "k": "coaching.voice",
         "payload": {
             "seq": int(t) % 100000,
-            "clip_id": f"late_brake.{urgency}.calm.t{corner or 0}",
+            "clip_id": f"late_brake.{urgency}.calm.t{spoken or 0:02d}",
             "kind": "late_brake",
             "urgency": urgency,
             "register": "calm",
@@ -131,7 +138,7 @@ def _brake_mark_cue(t, mark, corner=None, urgency="prepare"):
     }
     if corner is not None:
         cue["payload"]["corner"] = corner
-        voice["payload"]["corner"] = corner
+        voice["payload"]["corner"] = spoken
     return cue, voice
 
 
@@ -206,6 +213,33 @@ def test_cue_for_one_zone_does_not_cover_another(tmp_path):
     assert report.coachable_brake_zones == 2  # both zones braked in
     assert report.coachable_brake_zones_coached == 1  # only A drew a cue; B not covered by A's cue
     assert report.zones_crossed == 2 and report.zones_cued == 1
+    assert report.assertions["brake_events_coached"] is False
+
+
+def test_later_lap_dropped_cue_not_masked_by_earlier_lap(tmp_path):
+    """#527 codex P1: a later-lap pass whose advisory was dropped must NOT bind to the earlier
+    lap's coached occurrence just because the spline matches. The two passes are a lap-time apart,
+    so the stale earlier occurrence is rejected and the uncoached later pass is counted."""
+    t0 = 8_000_000.0
+    rows = []
+    # Two passes at the SAME brake mark (~0.45), ~30 s apart (i.e. different laps).
+    for base in (0.0, 30_000.0):
+        n = 80
+        for i in range(n + 1):
+            t = t0 + base + i / n * 4_000.0  # 4 s sweep, 20 Hz
+            spline = 0.40 + i / n * 0.10  # 0.40 -> 0.50 past the 0.45 mark
+            brake = 0.8 if 0.44 <= spline <= 0.47 else 0.0
+            rows.append({"t": t, "k": "tick", "spline": spline, "speed": 90.0, "brake": brake})
+    # Lap 1 (base 0): advisory + actionable voice ~3 s before the onset. Lap 2: NOTHING (dropped).
+    onset1_t = t0 + (0.44 - 0.40) / 0.10 * 4_000.0
+    cue, voice = _brake_mark_cue(onset1_t - 3_000.0, 0.45, corner=3)
+    rows.extend([cue, voice])
+    tap = tmp_path / "tap.jsonl"
+    _write_tap(tap, rows)
+    report = analyze(tap, track_length_m=2500.0, audio_latency_s=0.1)
+    assert report.brake_events == 2  # one onset per lap
+    assert report.coachable_brake_zones == 2  # two distinct passes, not collapsed
+    assert report.coachable_brake_zones_coached == 1  # only lap 1 drew a cue
     assert report.assertions["brake_events_coached"] is False
 
 

--- a/tests/test_semantic_timeliness.py
+++ b/tests/test_semantic_timeliness.py
@@ -109,6 +109,98 @@ def test_empty_tap_fails_evidence_assertion(tmp_path):
     assert report.assertions["evidence_present"] is False
 
 
+def _brake_mark_cue(t, mark, corner=None, urgency="prepare"):
+    """A ``coaching.cue`` (advisory) + matching ``coaching.voice`` (dispatch) pair for a mark."""
+    cue = {
+        "t": t,
+        "k": "coaching.cue",
+        "payload": {"kind": "late_brake", "urgency": urgency, "spline": mark},
+    }
+    voice = {
+        "t": t,
+        "k": "coaching.voice",
+        "payload": {
+            "seq": int(t) % 100000,
+            "clip_id": f"late_brake.{urgency}.calm.t{corner or 0}",
+            "kind": "late_brake",
+            "urgency": urgency,
+            "register": "calm",
+            "duration_ms": 1200,
+            "t_wall_ms": t,
+        },
+    }
+    if corner is not None:
+        cue["payload"]["corner"] = corner
+        voice["payload"]["corner"] = corner
+    return cue, voice
+
+
+def test_off_zone_onset_excluded_from_gate(tmp_path):
+    """#527: a brake onset with no reference mark within 50 m is off-zone — it must NOT drag the
+    coverage gate red. Two zones cued & braked in-window (coached) + one far-off correction dab."""
+    t0 = 4_000_000.0
+    # 0.20 -> 0.80 over 24 s at 90 km/h (25 m/s) on a 2500 m track = the whole lap.
+    rows = _ticks(t0, 24.0, 0.20, 0.80, 90.0)
+    # Two real brake zones the driver brakes in, each with a mark + cue ~3 s ahead.
+    for i, mark in enumerate((0.35, 0.55)):
+        # brake onset AT the mark: spline s=mark -> f=(mark-0.20)/0.60 -> t offset.
+        onset_t = (mark - 0.20) / 0.60 * 24.0
+        for r in rows:
+            if r["t"] >= t0 + onset_t * 1000.0:
+                r["brake"] = 0.8
+                break
+        # sustain the brake for the zone
+        for r in rows:
+            if t0 + onset_t * 1000.0 <= r["t"] <= t0 + onset_t * 1000.0 + 800.0:
+                r["brake"] = 0.8
+        cue, voice = _brake_mark_cue(t0 + (onset_t - 3.0) * 1000.0, mark, corner=i + 1)
+        rows.extend([cue, voice])
+    # An off-zone correction dab at spline ~0.70 — nearest mark 0.55 is 0.15*2500 = 375 m away.
+    for r in rows:
+        if r["t"] >= t0 + ((0.70 - 0.20) / 0.60 * 24.0) * 1000.0:
+            r["brake"] = 0.8
+            break
+    tap = tmp_path / "tap.jsonl"
+    _write_tap(tap, rows)
+    report = analyze(tap, track_length_m=2500.0, audio_latency_s=0.1)
+    # 3 raw onsets, 1 off-zone → 2 coachable zones, both coached → gate green.
+    assert report.brake_events == 3
+    assert report.off_zone_brake_onsets == 1
+    assert report.coachable_brake_zones == 2
+    assert report.coachable_brake_zones_coached == 2
+    assert report.assertions["brake_events_coached"] is True
+    assert report.zones_crossed == 2 and report.zones_cued == 2
+
+
+def test_repeat_onsets_in_one_zone_count_once(tmp_path):
+    """#527: several stab-and-release dabs inside ONE cued zone collapse to a single coachable
+    zone, so a scrappy driver does not inflate the denominator."""
+    t0 = 5_000_000.0
+    rows = _ticks(t0, 12.0, 0.30, 0.60, 90.0)
+    mark = 0.42
+    onset_t = (mark - 0.30) / 0.30 * 12.0  # seconds into the run where the car reaches the mark
+    # Four brake dabs clustered around the mark (all within 50 m at 25 m/s: ~2 m/tick).
+    dab_ts = [onset_t - 0.3, onset_t + 0.1, onset_t + 0.4, onset_t + 0.7]
+    for dab in dab_ts:
+        released = False
+        for r in rows:
+            rel_t = (r["t"] - t0) / 1000.0
+            if dab <= rel_t <= dab + 0.15:
+                r["brake"] = 0.8
+                released = True
+            elif released and rel_t > dab + 0.15:
+                break
+    cue, voice = _brake_mark_cue(t0 + (onset_t - 3.0) * 1000.0, mark, corner=4)
+    rows.extend([cue, voice])
+    tap = tmp_path / "tap.jsonl"
+    _write_tap(tap, rows)
+    report = analyze(tap, track_length_m=2500.0, audio_latency_s=0.1)
+    assert report.brake_events >= 2  # several raw onsets
+    assert report.coachable_brake_zones == 1  # collapsed to one zone
+    assert report.coachable_brake_zones_coached == 1
+    assert report.assertions["brake_events_coached"] is True
+
+
 def test_just_late_act_cue_is_too_late_not_redundant(tmp_path):
     """#523 review (Codex P2): timing verdicts precede REDUNDANT — a late act cue with the
     pedal already down must fail the gate as TOO_LATE, not hide as (non-gating) REDUNDANT."""

--- a/tools/ai_sidecar/realtime_observer.py
+++ b/tools/ai_sidecar/realtime_observer.py
@@ -105,8 +105,11 @@ _LEAD_LATCH_TTA_S = 1.5
 #: a driver onset within this many METERS of a mark is the SAME zone; farther away it is a
 #: different line/zone and does not calibrate. Metric, not normalized: a fixed spline fraction
 #: would accept ~400 m on a Nordschleife-length track (PR #525 review). Converted per observer
-#: via its track length (0.02 spline on the verified 2.5 km case).
-_CAL_MATCH_TOL_M = 50.0
+#: via its track length (0.02 spline on the verified 2.5 km case). Public: the semantic-timeliness
+#: analyzer imports this as its coachable-onset tolerance so the two share one source of truth.
+CAL_MATCH_TOL_M = 50.0
+#: back-compat alias for the pre-#527 private name (kept so any external importer does not break).
+_CAL_MATCH_TOL_M = CAL_MATCH_TOL_M
 #: weight of the newest lap in the per-zone EMA (recent laps dominate, old habits decay).
 _CAL_EMA_ALPHA = 0.4
 #: Schmitt-trigger thresholds for register quantization (rising / falling) — the falling edge
@@ -396,7 +399,7 @@ class RealtimeObserver:
         """Fold one of the driver's own completed laps into the per-zone brake-mark EMA.
 
         For each corner zone, the driver's sustained brake onset nearest the mark currently IN
-        FORCE (within ``_CAL_MATCH_TOL_M`` meters — the same zone, not a different line) updates
+        FORCE (within ``CAL_MATCH_TOL_M`` meters — the same zone, not a different line) updates
         that zone's EMA. Matching is one-to-one (greedy nearest-first): a single brake
         application between two closely spaced marks calibrates ONE zone, never both — else the
         per-zone distinction #522 adds would collapse (PR #525 review). Returns the number of
@@ -408,7 +411,7 @@ class RealtimeObserver:
             return 0
         if track_layout and self._track_layout and track_layout != self._track_layout:
             return 0
-        tol = _CAL_MATCH_TOL_M / self._track_length_m  # metric tolerance in spline units
+        tol = CAL_MATCH_TOL_M / self._track_length_m  # metric tolerance in spline units
         updated = 0
         for ref in self._refs:
             ref_marks = self._reference_marks(ref)

--- a/tools/ai_sidecar/voice/semantic_timeliness.py
+++ b/tools/ai_sidecar/voice/semantic_timeliness.py
@@ -41,17 +41,19 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+# An onset within this many metres of a reference/calibrated brake mark is *coachable* — a brake
+# point exists there to cue against. Farther out there is nothing to coach (a mid-straight
+# correction dab, or trail-braking where no corpus brake point sits), so counting it in the
+# coverage denominator penalises the coach for events it cannot address (issue #527). This IS the
+# observer's zone-match tolerance — imported, not re-declared, so analyzer and observer share one
+# source of truth and can never silently drift (Qodo rule 263211). The observer is stdlib-pure, so
+# the ``analyze`` path stays stdlib-only.
+from tools.ai_sidecar.realtime_observer import _CAL_MATCH_TOL_M as COACHABLE_TOL_M
+
 ACTIONABLE_MIN_S = 0.8
 ACTIONABLE_MAX_S = 6.0
 #: how far before a real brake onset a brake cue counts as having coached that event.
 COVERAGE_WINDOW_S = 6.0
-#: an onset within this many metres of a reference/calibrated brake mark is *coachable* — a brake
-#: point exists there to cue against. Farther out there is nothing to coach (a mid-straight
-#: correction dab, or trail-braking where no corpus brake point sits), so counting it in the
-#: coverage denominator penalises the coach for events it cannot address (issue #527). Mirrors the
-#: 50 m zone-match tolerance in ``realtime_observer._CAL_MATCH_TOL_M`` — kept in sync by value
-#: because the ``analyze`` path is deliberately stdlib-pure and does not import the observer.
-COACHABLE_TOL_M = 50.0
 DEFAULT_AUDIO_LATENCY_S = 0.10  # PC rtmixer path; tablet WebAudio measured ~0.45 (#511)
 
 
@@ -62,8 +64,11 @@ class CueVerdict:
     kind: str
     urgency: str
     register: str
-    #: 0-based corner index the cue belongs to (issue #511 Part D dispatch payload); ties the cue
-    #: to a brake zone for the #527 coverage metric. None on taps that predate the field.
+    #: the SPOKEN 1-based corner number the cue belongs to (``corner+1``), as ``coaching.voice``
+    #: carries it (issue #511 Part D dispatch payload → ``Utterance.corner``, voice/resolver.py) —
+    #: NOT the 0-based ``coaching.cue`` corner. Reported for readability only; the #527 coverage
+    #: metric binds cues to marks by timestamp, never by comparing this against a 0-based corner.
+    #: None on taps that predate the field.
     corner: int | None
     heard_at_spline: float | None
     speed_kmh: float | None

--- a/tools/ai_sidecar/voice/semantic_timeliness.py
+++ b/tools/ai_sidecar/voice/semantic_timeliness.py
@@ -45,15 +45,22 @@ from typing import Any
 # point exists there to cue against. Farther out there is nothing to coach (a mid-straight
 # correction dab, or trail-braking where no corpus brake point sits), so counting it in the
 # coverage denominator penalises the coach for events it cannot address (issue #527). This IS the
-# observer's zone-match tolerance — imported, not re-declared, so analyzer and observer share one
-# source of truth and can never silently drift (Qodo rule 263211). The observer is stdlib-pure, so
-# the ``analyze`` path stays stdlib-only.
-from tools.ai_sidecar.realtime_observer import _CAL_MATCH_TOL_M as COACHABLE_TOL_M
+# observer's public zone-match tolerance — imported, not re-declared, so analyzer and observer
+# share one source of truth and can never silently drift (Qodo rule 263211 / daemon #538 MEDIUM).
+# The observer is stdlib-pure, so the ``analyze`` path stays stdlib-only.
+from tools.ai_sidecar.realtime_observer import CAL_MATCH_TOL_M as COACHABLE_TOL_M
 
 ACTIONABLE_MIN_S = 0.8
 ACTIONABLE_MAX_S = 6.0
 #: how far before a real brake onset a brake cue counts as having coached that event.
 COVERAGE_WINDOW_S = 6.0
+#: how long (ms) BEFORE a brake onset the anticipatory advisory for that pass may have fired — the
+#: observer's lead budget (~3.2 s) plus approach travel and recorder skew. An advisory older than
+#: this is a DIFFERENT pass (a re-crossing on a later lap is a lap-time away), so an onset only
+#: binds to an advisory inside this window; a coachable onset with none is a dropped-advisory pass
+#: (uncoached), never a stale earlier-lap occurrence (codex #538 P1). Comfortably below any real
+#: lap time, comfortably above the max lead→onset gap.
+ONSET_CUE_LEAD_MAX_MS = 10_000.0
 DEFAULT_AUDIO_LATENCY_S = 0.10  # PC rtmixer path; tablet WebAudio measured ~0.45 (#511)
 
 
@@ -245,11 +252,9 @@ def analyze(
 
     # Reference brake-mark OCCURRENCES the observer flagged. Each anticipatory ``late_brake``
     # advisory (urgency prepare/act — the "ran deep" debrief is urgency=info at the apex, not a
-    # brake point) is one distinct pass at a brake mark: two advisories for the SAME corner at
-    # different times are different passes (a later lap) or different sub-zones of a merged corner
-    # (the observer splits them via ``detail.zone``), and must stay distinct so one coached
-    # occurrence never masks an uncued one (codex #538 P1). The occurrence identity is the advisory
-    # index; ``t`` (recorder clock) separates passes, ``corner``/``spline`` locate it.
+    # brake point) is one pass at a brake mark. The observer emits ONE such advisory per corner
+    # pass (deduped, reset on lap wrap), so an advisory maps 1:1 to a physical brake-zone pass; its
+    # occurrence identity is the advisory index, and ``t`` (recorder clock) places it in a lap.
     brake_mark_occ = [
         {"i": i, "spline": float(p["spline"]), "corner": p.get("corner"), "t": t}
         for i, (t, p) in enumerate(advisories)
@@ -258,66 +263,81 @@ def analyze(
         and p.get("urgency") != "info"
     ]
 
-    def _onset_occ(t_onset: float, spline: float) -> int | None:
-        """Index of the brake-mark occurrence this onset belongs to, or None when off-zone.
+    def _onset_occ(t_onset: float, spline: float) -> Any | None:
+        """Occurrence key of the brake pass an onset belongs to, or None when off-zone.
 
-        Nearest mark within COACHABLE_TOL_M (metric), tie-broken by time so repeat dabs at one mark
-        AND the correct pass of a re-crossed corner both resolve to a single occurrence. None means
-        no reference brake point sits within tolerance — nothing to coach against.
+        Off-zone = no reference mark within COACHABLE_TOL_M (nothing to coach). Otherwise bind to a
+        TIME-LOCAL advisory of THIS pass — one whose anticipatory cue could have led this onset
+        (fired within ``ONSET_CUE_LEAD_MAX_MS`` before it); a re-crossing on a later lap is a
+        lap-time away and is rejected as stale (codex #538 P1). A coachable onset with no local
+        advisory is a dropped-advisory pass → a distinct ``("gap", …)`` key that is never coached,
+        keyed so repeat dabs on this pass collapse yet other laps stay separate.
         """
-        best: tuple[tuple[float, float], int] | None = None
-        for occ in brake_mark_occ:
-            d = abs(_signed_gap_m(occ["spline"], spline, track_length_m))
-            if d <= COACHABLE_TOL_M:
-                score = (d, abs(occ["t"] - t_onset))  # nearest in space, then same pass in time
-                if best is None or score < best[0]:
-                    best = (score, occ["i"])
-        return best[1] if best else None
+        near = [
+            occ
+            for occ in brake_mark_occ
+            if abs(_signed_gap_m(occ["spline"], spline, track_length_m)) <= COACHABLE_TOL_M
+        ]
+        if not near:
+            return None
+        local = [occ for occ in near if -2000.0 <= (t_onset - occ["t"]) <= ONSET_CUE_LEAD_MAX_MS]
+        if local:
+            best = min(
+                local,
+                key=lambda o: (
+                    abs(_signed_gap_m(o["spline"], spline, track_length_m)),
+                    abs(o["t"] - t_onset),
+                ),
+            )
+            return ("occ", best["i"])
+        nearest = min(near, key=lambda o: abs(_signed_gap_m(o["spline"], spline, track_length_m)))
+        return ("gap", round(nearest["spline"], 3), int(t_onset // ONSET_CUE_LEAD_MAX_MS))
 
-    def _dispatch_occ(t_disp: float) -> int | None:
-        """Index of the brake-mark occurrence a dispatched cue belongs to: the advisory occurrence
-        NEAREST IN TIME within the ±2.5 s window. A cue and the advisory that spawned it share a
-        recorder timestamp to ~1 ms, while different occurrences (other corners, other sub-zones or
-        passes) are seconds apart, so nearest-time uniquely and correctly binds the pair — a cue
-        never credits a different mark or pass (codex #538 P1: T1's heads-up must not cover T2's
-        onset). Time, not ``corner``: the two topics use different corner bases by design —
-        ``coaching.cue`` is 0-based; ``coaching.voice`` carries the SPOKEN 1-based corner
-        (``corner+1``, voice/resolver.py) to match the ``t0N`` clip — so a corner-equality match
-        across them is unsafe.
+    def _dispatch_occ(t_disp: float, dispatch_corner: Any) -> Any | None:
+        """Occurrence key a dispatched cue belongs to, bound by the DETERMINISTIC corner relation
+        (advisory 0-based, dispatch spoken 1-based ⇒ ``occ.corner + 1 == dispatch.corner``),
+        tie-broken by nearest recorder time to pick the sub-zone/pass within that corner. Corner is
+        the deterministic key; time only disambiguates (daemon #538 HIGH — not a fuzzy time-only
+        match). Falls back to nearest-time when either corner is absent (older taps).
         """
         best: tuple[float, int] | None = None
         for occ in brake_mark_occ:
+            if (
+                dispatch_corner is not None
+                and occ["corner"] is not None
+                and occ["corner"] + 1 != dispatch_corner
+            ):
+                continue
             dt = abs(occ["t"] - t_disp)
             if dt <= 2500.0 and (best is None or dt < best[0]):
                 best = (dt, occ["i"])
-        return best[1] if best else None
+        return ("occ", best[1]) if best else None
 
     # Occurrences that drew an ACTIONABLE brake cue — the #522 guarantee ("a brake cue in its
     # actionable window") and the issue's "zones cued" signal. Grading on the per-cue ACTIONABLE
     # verdict (not sub-window onset timing) is what removes the noise #527 targets: a driver who
     # brakes a hair before hearing an otherwise-actionable cue must not flip the occurrence red;
     # TOO_LATE / AFTER_FACT brake cues stay caught globally by their own gates. ``cues`` is built
-    # one-per-dispatch in order, so it zips with ``dispatches`` for the dispatch clock.
-    coached_occ: set[int] = set()
-    # ``cues`` is built one-per-dispatch, in order, so it zips 1:1 with ``dispatches``.
+    # one-per-dispatch, in order, so it zips 1:1 with ``dispatches`` for the dispatch clock/corner.
+    coached_occ: set[Any] = set()
     for c, (t_disp, _p) in zip(cues, dispatches, strict=True):
         if c.kind == "late_brake" and c.verdict == "ACTIONABLE":
-            occ_i = _dispatch_occ(t_disp)
-            if occ_i is not None:
-                coached_occ.add(occ_i)
+            key = _dispatch_occ(t_disp, c.corner)
+            if key is not None:
+                coached_occ.add(key)
 
-    # Partition onsets: coachable occurrences (repeat dabs at one mark collapse to that occurrence)
-    # vs off-zone. Raw per-onset ratio kept for context; the gate divides on coachable occurrences.
-    coachable_occ: set[int] = set()
+    # Partition onsets: coachable passes (repeat dabs at one mark collapse to that occurrence) vs
+    # off-zone. Raw per-onset ratio kept for context; the gate divides on coachable passes.
+    coachable_occ: set[Any] = set()
     off_zone_brake_onsets = 0
     coached_raw = 0
     for t_ms, spline in onsets:
-        occ_i = _onset_occ(t_ms, spline)
-        if occ_i is None:
+        key = _onset_occ(t_ms, spline)
+        if key is None:
             off_zone_brake_onsets += 1
         else:
-            coachable_occ.add(occ_i)
-            if occ_i in coached_occ:
+            coachable_occ.add(key)
+            if key in coached_occ:
                 coached_raw += 1
 
     coachable_count = len(coachable_occ)

--- a/tools/ai_sidecar/voice/semantic_timeliness.py
+++ b/tools/ai_sidecar/voice/semantic_timeliness.py
@@ -62,6 +62,9 @@ class CueVerdict:
     kind: str
     urgency: str
     register: str
+    #: 0-based corner index the cue belongs to (issue #511 Part D dispatch payload); ties the cue
+    #: to a brake zone for the #527 coverage metric. None on taps that predate the field.
+    corner: int | None
     heard_at_spline: float | None
     speed_kmh: float | None
     brake: float | None
@@ -79,15 +82,17 @@ class TimelinessReport:
     #: for the reported raw ratio; no longer what the gate divides on (issue #527).
     brake_events: int
     brake_events_coached: int
-    #: coachable-zone counts (issue #527): onsets within COACHABLE_TOL_M of a reference brake mark,
-    #: collapsed to one per zone. ``coachable_brake_zones_coached`` is how many of those zones had
-    #: a covering cue. This ratio is what ``brake_events_coached`` asserts on.
+    #: coachable-zone counts (issue #527): distinct zones the driver braked in within
+    #: COACHABLE_TOL_M of a reference brake mark (repeats collapsed).
+    #: ``coachable_brake_zones_coached`` is how many of those zones drew an ACTIONABLE brake cue.
+    #: This ratio is what the ``brake_events_coached`` assertion gates on.
     coachable_brake_zones: int = 0
     coachable_brake_zones_coached: int = 0
     #: onsets with no reference mark within tolerance — nothing to coach against (excluded above).
     off_zone_brake_onsets: int = 0
-    #: per-zone coverage guarantee (#522): reference brake zones the car crossed vs zones a cue was
-    #: dispatched for. ``zones_cued == zones_crossed`` is the coverage guarantee stated directly.
+    #: per-pass coverage guarantee (#522): reference brake passes the observer flagged (crossed) vs
+    #: passes that drew an ACTIONABLE cue (cued). ``zones_cued == zones_crossed`` is the coverage
+    #: guarantee stated directly; a shortfall names the #522-V2 uncued passes (e.g. a dropped T2).
     zones_crossed: int = 0
     zones_cued: int = 0
     assertions: dict[str, bool] = field(default_factory=dict)
@@ -208,6 +213,7 @@ def analyze(
                 kind=kind,
                 urgency=urg,
                 register=str(p.get("register")),
+                corner=p.get("corner"),
                 heard_at_spline=round(sp, 4) if sp is not None else None,
                 speed_kmh=round(v, 1) if v is not None else None,
                 brake=round(b, 2) if b is not None else None,
@@ -232,81 +238,92 @@ def analyze(
             onsets.append((t, s))
         prev_b = b
 
-    # Reference brake marks the observer flagged this lap. Every ``late_brake`` advisory carries the
-    # corner it belongs to (``corner``) and the brake-point ``spline``; the anticipatory heads-up
-    # fires as the car approaches each zone, so the distinct corners here are the reference brake
-    # zones CROSSED during recording.
-    brake_marks: list[tuple[float, Any]] = [
-        (float(p["spline"]), p.get("corner"))
-        for (_t, p) in advisories
-        if p.get("kind") == "late_brake" and p.get("spline") is not None
-    ]
-
-    def _zone_of(spline: float) -> Any | None:
-        """Zone key of the reference brake mark nearest ``spline`` within tolerance, else None.
-
-        The key is the mark's ``corner`` index when present (stable across marks of the same
-        corner, so repeat onsets in one zone collapse); it falls back to the mark spline bucketed
-        to the tolerance when a tap predates the ``corner`` field. None means the onset is
-        *off-zone* — no reference brake point sits near it, so there is nothing to coach against.
-        """
-        best_key: Any | None = None
-        best_d: float | None = None
-        for ms, mc in brake_marks:
-            d = abs(_signed_gap_m(ms, spline, track_length_m))
-            if best_d is None or d < best_d:
-                best_d = d
-                best_key = mc if mc is not None else round(ms * track_length_m / COACHABLE_TOL_M)
-        if best_d is None or best_d > COACHABLE_TOL_M:
-            return None
-        return best_key
-
-    # Coverage anchors on HEARD-COMPLETE time (dispatch + audio latency + clip duration), matching
-    # the per-cue verdicts — a cue that finishes in-ear after the brake onset must not count as
-    # having coached it (PR #523 review).
-    brake_cue_heard = [
-        t + (audio_latency_s + float(p.get("duration_ms") or 500.0) / 1000.0) * 1000.0
-        for (t, p) in dispatches
+    # Reference brake-mark OCCURRENCES the observer flagged. Each anticipatory ``late_brake``
+    # advisory (urgency prepare/act — the "ran deep" debrief is urgency=info at the apex, not a
+    # brake point) is one distinct pass at a brake mark: two advisories for the SAME corner at
+    # different times are different passes (a later lap) or different sub-zones of a merged corner
+    # (the observer splits them via ``detail.zone``), and must stay distinct so one coached
+    # occurrence never masks an uncued one (codex #538 P1). The occurrence identity is the advisory
+    # index; ``t`` (recorder clock) separates passes, ``corner``/``spline`` locate it.
+    brake_mark_occ = [
+        {"i": i, "spline": float(p["spline"]), "corner": p.get("corner"), "t": t}
+        for i, (t, p) in enumerate(advisories)
         if p.get("kind") == "late_brake"
+        and p.get("spline") is not None
+        and p.get("urgency") != "info"
     ]
 
-    def _covered(t_ms: float) -> bool:
-        return any(
-            t_ms - COVERAGE_WINDOW_S * 1000.0 <= bt <= t_ms + 200.0 for bt in brake_cue_heard
-        )
+    def _onset_occ(t_onset: float, spline: float) -> int | None:
+        """Index of the brake-mark occurrence this onset belongs to, or None when off-zone.
 
-    # Partition onsets into coachable zones (collapsing repeats) vs off-zone. The gate divides on
-    # coachable zones only; the raw ratio (every onset) stays reported for context.
-    coachable_zones: dict[Any, bool] = {}  # zone key -> coached (any onset in the zone covered)
+        Nearest mark within COACHABLE_TOL_M (metric), tie-broken by time so repeat dabs at one mark
+        AND the correct pass of a re-crossed corner both resolve to a single occurrence. None means
+        no reference brake point sits within tolerance — nothing to coach against.
+        """
+        best: tuple[tuple[float, float], int] | None = None
+        for occ in brake_mark_occ:
+            d = abs(_signed_gap_m(occ["spline"], spline, track_length_m))
+            if d <= COACHABLE_TOL_M:
+                score = (d, abs(occ["t"] - t_onset))  # nearest in space, then same pass in time
+                if best is None or score < best[0]:
+                    best = (score, occ["i"])
+        return best[1] if best else None
+
+    def _dispatch_occ(t_disp: float) -> int | None:
+        """Index of the brake-mark occurrence a dispatched cue belongs to: the advisory occurrence
+        NEAREST IN TIME within the ±2.5 s window. A cue and the advisory that spawned it share a
+        recorder timestamp to ~1 ms, while different occurrences (other corners, other sub-zones or
+        passes) are seconds apart, so nearest-time uniquely and correctly binds the pair — a cue
+        never credits a different mark or pass (codex #538 P1: T1's heads-up must not cover T2's
+        onset). Time, not ``corner``: the two topics use different corner bases by design —
+        ``coaching.cue`` is 0-based; ``coaching.voice`` carries the SPOKEN 1-based corner
+        (``corner+1``, voice/resolver.py) to match the ``t0N`` clip — so a corner-equality match
+        across them is unsafe.
+        """
+        best: tuple[float, int] | None = None
+        for occ in brake_mark_occ:
+            dt = abs(occ["t"] - t_disp)
+            if dt <= 2500.0 and (best is None or dt < best[0]):
+                best = (dt, occ["i"])
+        return best[1] if best else None
+
+    # Occurrences that drew an ACTIONABLE brake cue — the #522 guarantee ("a brake cue in its
+    # actionable window") and the issue's "zones cued" signal. Grading on the per-cue ACTIONABLE
+    # verdict (not sub-window onset timing) is what removes the noise #527 targets: a driver who
+    # brakes a hair before hearing an otherwise-actionable cue must not flip the occurrence red;
+    # TOO_LATE / AFTER_FACT brake cues stay caught globally by their own gates. ``cues`` is built
+    # one-per-dispatch in order, so it zips with ``dispatches`` for the dispatch clock.
+    coached_occ: set[int] = set()
+    # ``cues`` is built one-per-dispatch, in order, so it zips 1:1 with ``dispatches``.
+    for c, (t_disp, _p) in zip(cues, dispatches, strict=True):
+        if c.kind == "late_brake" and c.verdict == "ACTIONABLE":
+            occ_i = _dispatch_occ(t_disp)
+            if occ_i is not None:
+                coached_occ.add(occ_i)
+
+    # Partition onsets: coachable occurrences (repeat dabs at one mark collapse to that occurrence)
+    # vs off-zone. Raw per-onset ratio kept for context; the gate divides on coachable occurrences.
+    coachable_occ: set[int] = set()
     off_zone_brake_onsets = 0
     coached_raw = 0
     for t_ms, spline in onsets:
-        cov = _covered(t_ms)
-        if cov:
-            coached_raw += 1
-        key = _zone_of(spline)
-        if key is None:
+        occ_i = _onset_occ(t_ms, spline)
+        if occ_i is None:
             off_zone_brake_onsets += 1
-            continue
-        coachable_zones[key] = coachable_zones.get(key, False) or cov
+        else:
+            coachable_occ.add(occ_i)
+            if occ_i in coached_occ:
+                coached_raw += 1
 
-    coachable_count = len(coachable_zones)
-    coachable_coached = sum(1 for v in coachable_zones.values() if v)
+    coachable_count = len(coachable_occ)
+    coachable_coached = len(coachable_occ & coached_occ)
 
-    # Per-zone coverage guarantee (#522): every reference brake zone the car crossed should have a
-    # cue dispatched for it. Distinct corners of the ``late_brake`` advisories (crossed) vs the
-    # ``late_brake`` dispatches (cued). Reported, not gated — a crossed-but-uncued zone (e.g. the
-    # T2 heads-up lost behind a playing exit debrief) is the #522 V2 phase-slot scheduler's scope.
-    zones_crossed = {
-        p.get("corner")
-        for (_t, p) in advisories
-        if p.get("kind") == "late_brake" and p.get("corner") is not None
-    }
-    zones_cued = {
-        p.get("corner")
-        for (_t, p) in dispatches
-        if p.get("kind") == "late_brake" and p.get("corner") is not None
-    }
+    # Per-pass coverage guarantee (#522), stated directly: reference brake passes the observer
+    # flagged (crossed) vs those that drew an ACTIONABLE cue (cued). A crossed-but-uncued pass
+    # (e.g. the T2 heads-up lost behind a still-playing exit debrief) is #522 V2 phase-slot
+    # scheduler scope — surfaced here, not regressed into this gate.
+    zones_crossed = len(brake_mark_occ)
+    zones_cued = len(coached_occ)
 
     brake_cues = [c for c in cues if c.kind == "late_brake"]
     assertions = {
@@ -315,11 +332,18 @@ def analyze(
         "evidence_present": len(ticks) >= 100 and len(cues) >= 1,
         "no_after_fact_brake_cues": all(c.verdict != "AFTER_FACT" for c in brake_cues),
         "no_too_late_brake_cues": all(c.verdict != "TOO_LATE" for c in brake_cues),
-        # Gate on COACHABLE zones only (issue #527): onsets with no reference mark within
-        # COACHABLE_TOL_M cannot be coached (no brake point to cue), and repeat onsets inside one
-        # zone count once — so a scrappy lap's correction dabs no longer drag the metric red.
+        # Gate on COACHABLE occurrences only (issue #527): onsets with no reference mark within
+        # COACHABLE_TOL_M cannot be coached, repeat dabs at one mark count once, and an occurrence
+        # is coached iff it drew an ACTIONABLE cue — so a scrappy lap's correction dabs (and a
+        # hair-early brake on an actionable cue) no longer drag it red. But brake onsets with NO
+        # brake marks at all must NOT pass vacuously (codex #538 P1): that is a coaching pipeline
+        # producing zero brake marks, not evidence of coverage.
         "brake_events_coached": (
-            not coachable_zones or coachable_coached / coachable_count >= coverage_min_fraction
+            False
+            if (onsets and not brake_mark_occ)
+            else (
+                not coachable_count or coachable_coached / coachable_count >= coverage_min_fraction
+            )
         ),
         "some_actionable_coaching": (
             not brake_cues or any(c.verdict == "ACTIONABLE" for c in brake_cues)
@@ -333,8 +357,8 @@ def analyze(
         coachable_brake_zones=coachable_count,
         coachable_brake_zones_coached=coachable_coached,
         off_zone_brake_onsets=off_zone_brake_onsets,
-        zones_crossed=len(zones_crossed),
-        zones_cued=len(zones_cued),
+        zones_crossed=zones_crossed,
+        zones_cued=zones_cued,
         assertions=assertions,
     )
 

--- a/tools/ai_sidecar/voice/semantic_timeliness.py
+++ b/tools/ai_sidecar/voice/semantic_timeliness.py
@@ -12,9 +12,13 @@ each spoken cue compute the car's true position/speed/brake at the moment the cl
     REDUNDANT    an act imperative while the driver is already braking >= 0.5
     DEBRIEF_OK   info-tier feedback delivered after the corner (its correct place)
 
-Also scores brake-zone coverage: every real braking event should have had a brake cue in
-its actionable window. The ``assert`` gate encodes #522's acceptance criteria: zero
-AFTER_FACT/TOO_LATE brake cues and >= the required fraction of brake events coached.
+Also scores brake-zone coverage: every real braking event NEAR A REFERENCE BRAKE MARK should have
+had a brake cue in its actionable window. Onsets with no reference mark within ``COACHABLE_TOL_M``
+(a mid-straight correction dab, trail-braking where no corpus brake point sits) are *off-zone* —
+they cannot be coached, so they are excluded from the coverage denominator, and repeat onsets in
+one zone count once (issue #527, split from #522). The ``assert`` gate encodes #522's acceptance
+criteria: zero AFTER_FACT/TOO_LATE brake cues and >= the required fraction of COACHABLE brake zones
+coached. The raw per-onset ratio and a reference zones-cued/zones-crossed line are reported too.
 
 Usage::
 
@@ -41,6 +45,13 @@ ACTIONABLE_MIN_S = 0.8
 ACTIONABLE_MAX_S = 6.0
 #: how far before a real brake onset a brake cue counts as having coached that event.
 COVERAGE_WINDOW_S = 6.0
+#: an onset within this many metres of a reference/calibrated brake mark is *coachable* — a brake
+#: point exists there to cue against. Farther out there is nothing to coach (a mid-straight
+#: correction dab, or trail-braking where no corpus brake point sits), so counting it in the
+#: coverage denominator penalises the coach for events it cannot address (issue #527). Mirrors the
+#: 50 m zone-match tolerance in ``realtime_observer._CAL_MATCH_TOL_M`` — kept in sync by value
+#: because the ``analyze`` path is deliberately stdlib-pure and does not import the observer.
+COACHABLE_TOL_M = 50.0
 DEFAULT_AUDIO_LATENCY_S = 0.10  # PC rtmixer path; tablet WebAudio measured ~0.45 (#511)
 
 
@@ -64,8 +75,21 @@ class CueVerdict:
 class TimelinessReport:
     cues: list[CueVerdict]
     summary: dict[str, int]
+    #: raw counts: EVERY gate-grade brake onset, and how many any brake cue covered in time. Kept
+    #: for the reported raw ratio; no longer what the gate divides on (issue #527).
     brake_events: int
     brake_events_coached: int
+    #: coachable-zone counts (issue #527): onsets within COACHABLE_TOL_M of a reference brake mark,
+    #: collapsed to one per zone. ``coachable_brake_zones_coached`` is how many of those zones had
+    #: a covering cue. This ratio is what ``brake_events_coached`` asserts on.
+    coachable_brake_zones: int = 0
+    coachable_brake_zones_coached: int = 0
+    #: onsets with no reference mark within tolerance — nothing to coach against (excluded above).
+    off_zone_brake_onsets: int = 0
+    #: per-zone coverage guarantee (#522): reference brake zones the car crossed vs zones a cue was
+    #: dispatched for. ``zones_cued == zones_crossed`` is the coverage guarantee stated directly.
+    zones_crossed: int = 0
+    zones_cued: int = 0
     assertions: dict[str, bool] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -198,26 +222,91 @@ def analyze(
     for c in cues:
         summary[c.verdict] = summary.get(c.verdict, 0) + 1
 
-    # brake-zone coverage: real brake onsets (brake crosses 0.4 upward at speed > 60)
-    onsets = []
+    # --- brake-zone coverage (issue #527) --------------------------------------------------------
+    # Real brake onsets: brake crosses 0.4 upward at speed > 60. Capture the spline at the onset so
+    # each onset can be matched to a reference brake zone.
+    onsets: list[tuple[float, float]] = []  # (t_ms, spline)
     prev_b = 0.0
-    for t, _s, v, b in ticks:
+    for t, s, v, b in ticks:
         if b >= 0.4 and prev_b < 0.4 and v > 60.0:
-            onsets.append(t)
+            onsets.append((t, s))
         prev_b = b
-    # Coverage anchors on HEARD-COMPLETE time (dispatch + audio latency + clip duration),
-    # matching the per-cue verdicts — a cue that finishes in-ear after the brake onset must
-    # not count as having coached it (PR #523 review).
+
+    # Reference brake marks the observer flagged this lap. Every ``late_brake`` advisory carries the
+    # corner it belongs to (``corner``) and the brake-point ``spline``; the anticipatory heads-up
+    # fires as the car approaches each zone, so the distinct corners here are the reference brake
+    # zones CROSSED during recording.
+    brake_marks: list[tuple[float, Any]] = [
+        (float(p["spline"]), p.get("corner"))
+        for (_t, p) in advisories
+        if p.get("kind") == "late_brake" and p.get("spline") is not None
+    ]
+
+    def _zone_of(spline: float) -> Any | None:
+        """Zone key of the reference brake mark nearest ``spline`` within tolerance, else None.
+
+        The key is the mark's ``corner`` index when present (stable across marks of the same
+        corner, so repeat onsets in one zone collapse); it falls back to the mark spline bucketed
+        to the tolerance when a tap predates the ``corner`` field. None means the onset is
+        *off-zone* — no reference brake point sits near it, so there is nothing to coach against.
+        """
+        best_key: Any | None = None
+        best_d: float | None = None
+        for ms, mc in brake_marks:
+            d = abs(_signed_gap_m(ms, spline, track_length_m))
+            if best_d is None or d < best_d:
+                best_d = d
+                best_key = mc if mc is not None else round(ms * track_length_m / COACHABLE_TOL_M)
+        if best_d is None or best_d > COACHABLE_TOL_M:
+            return None
+        return best_key
+
+    # Coverage anchors on HEARD-COMPLETE time (dispatch + audio latency + clip duration), matching
+    # the per-cue verdicts — a cue that finishes in-ear after the brake onset must not count as
+    # having coached it (PR #523 review).
     brake_cue_heard = [
         t + (audio_latency_s + float(p.get("duration_ms") or 500.0) / 1000.0) * 1000.0
         for (t, p) in dispatches
         if p.get("kind") == "late_brake"
     ]
-    coached = sum(
-        1
-        for t in onsets
-        if any(t - COVERAGE_WINDOW_S * 1000.0 <= bt <= t + 200.0 for bt in brake_cue_heard)
-    )
+
+    def _covered(t_ms: float) -> bool:
+        return any(
+            t_ms - COVERAGE_WINDOW_S * 1000.0 <= bt <= t_ms + 200.0 for bt in brake_cue_heard
+        )
+
+    # Partition onsets into coachable zones (collapsing repeats) vs off-zone. The gate divides on
+    # coachable zones only; the raw ratio (every onset) stays reported for context.
+    coachable_zones: dict[Any, bool] = {}  # zone key -> coached (any onset in the zone covered)
+    off_zone_brake_onsets = 0
+    coached_raw = 0
+    for t_ms, spline in onsets:
+        cov = _covered(t_ms)
+        if cov:
+            coached_raw += 1
+        key = _zone_of(spline)
+        if key is None:
+            off_zone_brake_onsets += 1
+            continue
+        coachable_zones[key] = coachable_zones.get(key, False) or cov
+
+    coachable_count = len(coachable_zones)
+    coachable_coached = sum(1 for v in coachable_zones.values() if v)
+
+    # Per-zone coverage guarantee (#522): every reference brake zone the car crossed should have a
+    # cue dispatched for it. Distinct corners of the ``late_brake`` advisories (crossed) vs the
+    # ``late_brake`` dispatches (cued). Reported, not gated — a crossed-but-uncued zone (e.g. the
+    # T2 heads-up lost behind a playing exit debrief) is the #522 V2 phase-slot scheduler's scope.
+    zones_crossed = {
+        p.get("corner")
+        for (_t, p) in advisories
+        if p.get("kind") == "late_brake" and p.get("corner") is not None
+    }
+    zones_cued = {
+        p.get("corner")
+        for (_t, p) in dispatches
+        if p.get("kind") == "late_brake" and p.get("corner") is not None
+    }
 
     brake_cues = [c for c in cues if c.kind == "late_brake"]
     assertions = {
@@ -226,7 +315,12 @@ def analyze(
         "evidence_present": len(ticks) >= 100 and len(cues) >= 1,
         "no_after_fact_brake_cues": all(c.verdict != "AFTER_FACT" for c in brake_cues),
         "no_too_late_brake_cues": all(c.verdict != "TOO_LATE" for c in brake_cues),
-        "brake_events_coached": (not onsets or coached / len(onsets) >= coverage_min_fraction),
+        # Gate on COACHABLE zones only (issue #527): onsets with no reference mark within
+        # COACHABLE_TOL_M cannot be coached (no brake point to cue), and repeat onsets inside one
+        # zone count once — so a scrappy lap's correction dabs no longer drag the metric red.
+        "brake_events_coached": (
+            not coachable_zones or coachable_coached / coachable_count >= coverage_min_fraction
+        ),
         "some_actionable_coaching": (
             not brake_cues or any(c.verdict == "ACTIONABLE" for c in brake_cues)
         ),
@@ -235,7 +329,12 @@ def analyze(
         cues=cues,
         summary=summary,
         brake_events=len(onsets),
-        brake_events_coached=coached,
+        brake_events_coached=coached_raw,
+        coachable_brake_zones=coachable_count,
+        coachable_brake_zones_coached=coachable_coached,
+        off_zone_brake_onsets=off_zone_brake_onsets,
+        zones_crossed=len(zones_crossed),
+        zones_cued=len(zones_cued),
         assertions=assertions,
     )
 
@@ -334,7 +433,15 @@ def main(argv: list[str] | None = None) -> int:
             f"brake={c.brake!s:>4} -> {c.verdict}"
         )
     print("summary:", json.dumps(report.summary))
-    print(f"brake events coached: {report.brake_events_coached}/{report.brake_events}")
+    print(
+        f"brake events coached (raw): {report.brake_events_coached}/{report.brake_events} "
+        f"({report.off_zone_brake_onsets} off-zone)"
+    )
+    print(
+        "coachable zones coached (gate): "
+        f"{report.coachable_brake_zones_coached}/{report.coachable_brake_zones}"
+    )
+    print(f"reference brake zones cued/crossed: {report.zones_cued}/{report.zones_crossed}")
     print("assertions:", json.dumps(report.assertions))
     if args.out:
         Path(args.out).write_text(json.dumps(report.to_dict(), indent=1), encoding="utf-8")


### PR DESCRIPTION
Closes #527. Split from #522 (parts 1-2 merged in #525, `56048ae`).

## Problem
`semantic_timeliness.analyze()` gated `brake_events_coached` on `coached / ALL gate-grade brake onsets`. The denominator included onsets that **cannot** be coached:
- a mid-straight **correction dab** with no reference mark near it (issue's measured case: spline 0.729, nearest mark ≈105 m away), and
- **repeat dabs inside one already-cued zone** (T4: 4 onsets at 0.634/0.640/0.647/0.672).

So a scrappy autonomous-driver lap read **red (7/9 = 77.8%)** while *every reference zone crossed drew an ACTIONABLE cue* (7/7 ACTIONABLE, junk 0). The metric was driver-scrappiness-sensitive around the 0.8 threshold — noisy about the very thing it measures.

## Fix
1. **Classify each onset** by metric distance to the nearest reference brake mark, reusing the **50 m** tolerance from `realtime_observer._CAL_MATCH_TOL_M` (`COACHABLE_TOL_M = 50.0`; value-synced, not imported — the `analyze` path is deliberately stdlib-pure). Marks come from the `late_brake` advisories in the tap, each carrying `corner` + brake-point `spline`.
2. **Gate on coachable zones only**, collapsing repeat onsets in one zone to one (keyed on the mark's `corner`; spline-bucket fallback for pre-`corner` taps). Off-zone onsets are excluded from the denominator.
3. **Report both ratios** — raw per-onset (`brake_events`/`brake_events_coached` + `off_zone_brake_onsets`) and the coachable-zone ratio (`coachable_brake_zones{,_coached}`) — plus a **zones-cued / zones-crossed** line (`zones_cued`/`zones_crossed`) that states the #522 coverage guarantee directly.

Off-zone and zones-crossed/cued are **reported, not gated**: a crossed-but-uncued zone (the T2 heads-up lost behind a still-playing T1 exit debrief) is the **#522 V2 phase-slot scheduler** scope, tracked there — not regressed into this gate.

## Tests
- `test_off_zone_onset_excluded_from_gate` — 3 raw onsets, 1 off-zone → 2/2 coachable zones green; **fails 2/3 = 67% red under the old logic**.
- `test_repeat_onsets_in_one_zone_count_once` — 4 dabs → 1 coachable zone.
- All existing `test_semantic_timeliness.py` tests still green; `make ci-fast` OK.

Live in-sim re-verification via `ac-harness` + `--assert-coaching` to follow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)