### PR TITLE
fix(harness): auto_drive pit-start recovery retries line teleport, not pit-box loop (#528)

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -28,6 +28,7 @@ from tools.ac_harness.auto_drive import (
     collect_lap_archives,
     custom_ai_enabled,
     default_ac_root,
+    drive_leg_succeeded,
     fuel_matches,
     generic_gt3_ggv,
     known_journal_laps_dir,
@@ -40,6 +41,7 @@ from tools.ac_harness.auto_drive import (
     rig_hijack,
     rig_launch,
     run_auto_drive,
+    should_try_line_teleport_on_recovery,
     verify_setup_ack,
     write_evidence,
     write_setup_baked_race_ini,
@@ -1366,6 +1368,39 @@ def test_progress_watchdog_reset_reanchors_after_recovery():
     dog.reset(6.0, 100.1)
     assert dog.update(100.2, 10.0) is False  # window restarted at reset
     assert dog.update(100.2, 11.2) is True
+
+
+def test_should_try_line_teleport_on_recovery_off_line_spawn_always_retries():
+    # The #528 fix: a car that spawned off the racing line must RETRY the line teleport on recovery
+    # even when the first spawn attempt missed the read-back (line_teleport_known_good False) —
+    # teleport_to_pits returns it to the same off-line trap and burns every recovery at 0 m.
+    assert should_try_line_teleport_on_recovery(spawn_off_line=True, line_teleport_known_good=False)
+    assert should_try_line_teleport_on_recovery(spawn_off_line=True, line_teleport_known_good=True)
+
+
+def test_should_try_line_teleport_on_recovery_on_line_spawn_uses_pits():
+    # An on-line spawn (never teleported) that spins mid-lap: teleport_to_pits is the correct reset,
+    # so the line teleport is not attempted unless a prior line teleport is known good.
+    assert not should_try_line_teleport_on_recovery(
+        spawn_off_line=False, line_teleport_known_good=False
+    )
+    assert should_try_line_teleport_on_recovery(spawn_off_line=False, line_teleport_known_good=True)
+
+
+def test_drive_leg_succeeded_true_only_for_a_real_clean_drive():
+    assert drive_leg_succeeded(DriveStats(drove=True, total_distance_m=3200.0)) is True
+
+
+def test_drive_leg_succeeded_vetoes_every_528_failure_shape():
+    # None (hijack never landed), a never-moved stall, sim-death, and a recovery-capped stall must
+    # each read as NOT a successful drive (#528). recovery_capped vetoes even with drove=True.
+    assert drive_leg_succeeded(None) is False
+    assert drive_leg_succeeded(DriveStats(drove=False, total_distance_m=0.0)) is False
+    assert drive_leg_succeeded(DriveStats(drove=True, sim_dead=True)) is False
+    assert (
+        drive_leg_succeeded(DriveStats(drove=True, total_distance_m=560.0, recovery_capped=True))
+        is False
+    )
 
 
 def test_progress_watchdog_rejects_nonpositive_params():

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1370,21 +1370,24 @@ def test_progress_watchdog_reset_reanchors_after_recovery():
     assert dog.update(100.2, 11.2) is True
 
 
-def test_should_try_line_teleport_on_recovery_off_line_spawn_always_retries():
-    # The #528 fix: a car that spawned off the racing line must RETRY the line teleport on recovery
-    # even when the first spawn attempt missed the read-back (line_teleport_known_good False) —
-    # teleport_to_pits returns it to the same off-line trap and burns every recovery at 0 m.
-    assert should_try_line_teleport_on_recovery(spawn_off_line=True, line_teleport_known_good=False)
-    assert should_try_line_teleport_on_recovery(spawn_off_line=True, line_teleport_known_good=True)
+def test_should_try_line_teleport_on_recovery_off_line_always_retries():
+    # #528: a car OFF the racing line must RETRY the line teleport on recovery even when no prior
+    # line teleport is known good. car_off_line covers BOTH an off-line spawn AND a car a prior
+    # recovery teleported into the pits (a mid-lap spin recovered to pits — the self-hosted
+    # reviewer's case): teleport_to_pits leaves it off-line and would otherwise loop at 0 m.
+    assert should_try_line_teleport_on_recovery(car_off_line=True, line_teleport_known_good=False)
+    assert should_try_line_teleport_on_recovery(car_off_line=True, line_teleport_known_good=True)
 
 
-def test_should_try_line_teleport_on_recovery_on_line_spawn_uses_pits():
-    # An on-line spawn (never teleported) that spins mid-lap: teleport_to_pits is the correct reset,
-    # so the line teleport is not attempted unless a prior line teleport is known good.
+def test_should_try_line_teleport_on_recovery_on_line_uses_pits():
+    # A car ON the line (never teleported off) that spins: teleport_to_pits is the correct first
+    # reset, so the line teleport is not attempted unless a prior line teleport is known good. Once
+    # that pit teleport leaves the car off-line, _recover flips off_line True and the next recovery
+    # takes the branch above — closing the mid-lap-into-pits loop the reviewer flagged.
     assert not should_try_line_teleport_on_recovery(
-        spawn_off_line=False, line_teleport_known_good=False
+        car_off_line=False, line_teleport_known_good=False
     )
-    assert should_try_line_teleport_on_recovery(spawn_off_line=False, line_teleport_known_good=True)
+    assert should_try_line_teleport_on_recovery(car_off_line=False, line_teleport_known_good=True)
 
 
 def test_drive_leg_succeeded_true_only_for_a_real_clean_drive():

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1375,8 +1375,12 @@ def test_should_try_line_teleport_on_recovery_off_line_always_retries():
     # line teleport is known good. car_off_line covers BOTH an off-line spawn AND a car a prior
     # recovery teleported into the pits (a mid-lap spin recovered to pits — the self-hosted
     # reviewer's case): teleport_to_pits leaves it off-line and would otherwise loop at 0 m.
-    assert should_try_line_teleport_on_recovery(car_off_line=True, line_teleport_known_good=False)
-    assert should_try_line_teleport_on_recovery(car_off_line=True, line_teleport_known_good=True)
+    assert should_try_line_teleport_on_recovery(
+        spawn_to_line_enabled=True, car_off_line=True, line_teleport_known_good=False
+    )
+    assert should_try_line_teleport_on_recovery(
+        spawn_to_line_enabled=True, car_off_line=True, line_teleport_known_good=True
+    )
 
 
 def test_should_try_line_teleport_on_recovery_on_line_uses_pits():
@@ -1385,9 +1389,20 @@ def test_should_try_line_teleport_on_recovery_on_line_uses_pits():
     # that pit teleport leaves the car off-line, _recover flips off_line True and the next recovery
     # takes the branch above — closing the mid-lap-into-pits loop the reviewer flagged.
     assert not should_try_line_teleport_on_recovery(
-        car_off_line=False, line_teleport_known_good=False
+        spawn_to_line_enabled=True, car_off_line=False, line_teleport_known_good=False
     )
-    assert should_try_line_teleport_on_recovery(car_off_line=False, line_teleport_known_good=True)
+    assert should_try_line_teleport_on_recovery(
+        spawn_to_line_enabled=True, car_off_line=False, line_teleport_known_good=True
+    )
+
+
+def test_should_try_line_teleport_on_recovery_honors_no_spawn_line():
+    # --no-spawn-line (spawn_to_line_enabled=False) opts out of racing-line teleports entirely: even
+    # an off-line car with a known-good line teleport must fall back to the pit exit, not the line,
+    # on every recovery (codex on #539).
+    assert not should_try_line_teleport_on_recovery(
+        spawn_to_line_enabled=False, car_off_line=True, line_teleport_known_good=True
+    )
 
 
 def test_drive_leg_succeeded_true_only_for_a_real_clean_drive():

--- a/tests/test_false_green_kpi.py
+++ b/tests/test_false_green_kpi.py
@@ -135,8 +135,20 @@ def test_report_path_propagates_healthy_verdict():
 def test_corpus_expected_labels_and_oracles_are_valid():
     for sc in build_corpus():
         assert sc.expected in ("GREEN", "RED")
-        assert sc.oracle in ("sequence", "schema", "sim_death", "render", "report_path")
+        assert sc.oracle in ("sequence", "schema", "sim_death", "render", "report_path", "drive")
         assert callable(sc.run)
+
+
+def test_weakening_the_drive_oracle_leaks_the_528_stall_shapes(monkeypatch):
+    # Defang the drive-leg verdict (patch the symbol build_corpus resolves at call time): a
+    # recovery-capped pit-start stall and a never-landed hijack now read as a successful drive, so
+    # both #528 broken scenarios leak. Proves the drive oracle has teeth without a test-only knob.
+    monkeypatch.setattr(false_green_kpi, "drive_leg_succeeded", lambda stats: True)
+    weak = run_kpi()
+    assert weak.broken_false_green >= 2  # spawn_stall_recovery_capped + hijack_never_landed leak
+    assert "broken_spawn_stall_recovery_capped" in weak.false_greens
+    assert "broken_hijack_never_landed" in weak.false_greens
+    assert weak.ok is False
 
 
 # ------------------------------------------------------------------- extracted sim-death oracle

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -193,6 +193,44 @@ class DriveStats:
     reason: str = ""
 
 
+def drive_leg_succeeded(stats: DriveStats | None) -> bool:
+    """Pure verdict on the drive leg — the motion half of :func:`run_auto_drive`'s success gate.
+
+    True only when the car really drove and no veto fired. Each False case is a real #528-class
+    failure that MUST stay caught (never leaked into a green report):
+
+    * ``stats is None`` — the hijack never landed, so no drive leg ran at all.
+    * ``not stats.drove`` — the car never cleared the distance/speed floor (a pit-start stall that
+      never moves reads ``drove=False`` at 0 m).
+    * ``stats.sim_dead`` — ``acs.exe`` died mid-run; the totals are stale (#459/#460).
+    * ``stats.recovery_capped`` — the car kept stalling until the recovery cap; it never sustained
+      progress whatever the totals say (the pit-start recovery-cap stall, #528).
+
+    :func:`run_auto_drive` composes this with the pipeline verdict and error state; the false-green
+    KPI corpus (`false_green_kpi.py`) exercises it directly, so dropping a veto here surfaces as a
+    leaked broken scenario rather than a silent false green.
+    """
+    return bool(stats) and stats.drove and not stats.sim_dead and not stats.recovery_capped
+
+
+def should_try_line_teleport_on_recovery(
+    *, spawn_off_line: bool, line_teleport_known_good: bool
+) -> bool:
+    """Whether a no-progress recovery should attempt the racing-line teleport before falling back
+    to ``teleport_to_pits``.
+
+    A car that SPAWNED off the racing line (pit box / laterally-offset grid slot) is stuck
+    *because* it is off the line — ``teleport_to_pits`` returns it to that same trap, so every
+    recovery is spent at 0 m and the run caps out honestly but needlessly (the pit-start stall,
+    #528). So attempt the line teleport whenever the spawn was off-line — even if the FIRST attempt
+    at spawn missed the 25 m read-back, because :func:`_teleport_onto_line` re-reads the car
+    position and retargets each call, so a later attempt can land where the spawn attempt missed —
+    or whenever a prior line teleport is known to have landed. When neither holds (an on-line
+    mid-lap spin), ``teleport_to_pits`` is the correct reset.
+    """
+    return line_teleport_known_good or spawn_off_line
+
+
 @dataclass
 class AutoDriveReport:
     """Structured result of one composed autonomous self-test run."""
@@ -545,16 +583,10 @@ async def run_auto_drive(
         finally:
             controller.close()
 
-    # Success needs a clean pipeline AND a real drive that did not die mid-run: sim_dead can be set
-    # after the car already passed the distance/speed thresholds (drove=True), so veto on it too.
-    # A recovery-capped run also vetoes: the car never sustained progress, whatever the totals say.
-    ok = (
-        bool(seq_ok)
-        and stats.drove
-        and not stats.sim_dead
-        and not stats.recovery_capped
-        and error is None
-    )
+    # Success needs a clean pipeline AND a real drive that did not die mid-run or stall out. The
+    # drive-leg vetoes (drove / sim_dead / recovery_capped) live in drive_leg_succeeded so this gate
+    # and the false-green KPI corpus that exercises them cannot drift apart (#528).
+    ok = bool(seq_ok) and drive_leg_succeeded(stats) and error is None
     return AutoDriveReport(
         ok=ok,
         stage=stage,
@@ -1713,9 +1745,10 @@ def rig_drive(  # pragma: no cover - rig-only
     * **recovery cap** — a car that keeps stalling stops with an honest FAIL naming the stall
       distance instead of teleport-looping until the clock runs out.
     * **spawn-to-line** — an off-line spawn (pit box) starts behind geometry the controllers are
-      blind to; a verified custom teleport
-      onto the line skips the trap. Falls back to the classic OUT-phase pit exit when the teleport
-      does not land (offsets are VERIFY LIVE).
+      blind to; a verified custom teleport onto the line skips the trap. An off-line spawn also
+      makes recovery RETRY the line teleport (not just teleport-to-pits, which returns the car to
+      the same trap and burns every recovery at 0 m — the pit-start stall, #528); teleport-to-pits
+      is the fallback when the line teleport cannot land (offsets are VERIFY LIVE).
     """
     from tools.ac_harness.ai_line import _horizontal, load_ai_line
 
@@ -1730,6 +1763,7 @@ def rig_drive(  # pragma: no cover - rig-only
     stats = DriveStats()
     watchdog = ProgressWatchdog(stall_seconds=config.progress_stall_seconds)
     line_teleport_works: bool | None = None
+    spawn_off_line = False  # car spawned off the racing line (pit box / offset grid slot) — #528
 
     if config.spawn_to_line:
         from tools.ac_harness.ai_line import PurePursuit
@@ -1742,6 +1776,7 @@ def rig_drive(  # pragma: no cover - rig-only
             car0 = _horizontal(cd0["position"])
             off_line_m = ((p0[0] - car0[0]) ** 2 + (p0[1] - car0[1]) ** 2) ** 0.5
             if off_line_m > 12.0:  # pit box / off-line spawn
+                spawn_off_line = True
                 line_teleport_works = _teleport_onto_line(controller, line)
                 stats.spawn_teleport = "ok" if line_teleport_works else "failed"
             else:
@@ -1749,6 +1784,7 @@ def rig_drive(  # pragma: no cover - rig-only
 
     def _recover(now: float) -> bool:
         """Shared recovery for driver-flagged stuck AND watchdog stalls. False = cap exceeded."""
+        nonlocal line_teleport_works
         stats.recoveries += 1
         if stats.recoveries > config.max_recoveries:
             stats.recovery_capped = True
@@ -1757,8 +1793,17 @@ def rig_drive(  # pragma: no cover - rig-only
             )
             return False
         recovered_to_line = False
-        if line_teleport_works:
+        # Attempt the racing-line teleport on recovery whenever the car spawned off the line (or a
+        # prior line teleport is known good). teleport_to_pits returns an off-line-spawned car to
+        # the SAME pit-box trap it is stuck in, so latching the spawn teleport's first miss and only
+        # teleporting to pits burns every recovery at 0 m (#528). _teleport_onto_line re-reads the
+        # position + retargets each call, so a later attempt can land where spawn missed.
+        if should_try_line_teleport_on_recovery(
+            spawn_off_line=spawn_off_line, line_teleport_known_good=bool(line_teleport_works)
+        ):
             recovered_to_line = _teleport_onto_line(controller, line)
+            if recovered_to_line:
+                line_teleport_works = True
         if not recovered_to_line:
             for _ in range(5):
                 controller.teleport_to_pits()

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -214,21 +214,23 @@ def drive_leg_succeeded(stats: DriveStats | None) -> bool:
 
 
 def should_try_line_teleport_on_recovery(
-    *, spawn_off_line: bool, line_teleport_known_good: bool
+    *, car_off_line: bool, line_teleport_known_good: bool
 ) -> bool:
     """Whether a no-progress recovery should attempt the racing-line teleport before falling back
     to ``teleport_to_pits``.
 
-    A car that SPAWNED off the racing line (pit box / laterally-offset grid slot) is stuck
-    *because* it is off the line — ``teleport_to_pits`` returns it to that same trap, so every
-    recovery is spent at 0 m and the run caps out honestly but needlessly (the pit-start stall,
-    #528). So attempt the line teleport whenever the spawn was off-line — even if the FIRST attempt
-    at spawn missed the 25 m read-back, because :func:`_teleport_onto_line` re-reads the car
-    position and retargets each call, so a later attempt can land where the spawn attempt missed —
-    or whenever a prior line teleport is known to have landed. When neither holds (an on-line
-    mid-lap spin), ``teleport_to_pits`` is the correct reset.
+    A car that is OFF the racing line is stuck *because* it is off the line — ``teleport_to_pits``
+    returns it to (or leaves it in) the pit box, so every recovery is spent at 0 m and the run caps
+    out honestly but needlessly (the pit-start stall, #528). ``car_off_line`` is true at an off-line
+    spawn (pit box / laterally-offset grid slot) AND after any recovery that teleported the car back
+    to the pits — itself an off-line position, so a mid-lap spin recovered to the pits would
+    otherwise re-enter the same loop. Attempt the line teleport whenever the car is off-line — even
+    if an earlier attempt missed the 25 m read-back, because :func:`_teleport_onto_line` re-reads
+    the car position and retargets each call so a later attempt can land — or whenever a prior line
+    teleport is known to have landed. Only when the car is on the line and no line teleport is known
+    good is ``teleport_to_pits`` the correct reset.
     """
-    return line_teleport_known_good or spawn_off_line
+    return line_teleport_known_good or car_off_line
 
 
 @dataclass
@@ -1745,10 +1747,12 @@ def rig_drive(  # pragma: no cover - rig-only
     * **recovery cap** — a car that keeps stalling stops with an honest FAIL naming the stall
       distance instead of teleport-looping until the clock runs out.
     * **spawn-to-line** — an off-line spawn (pit box) starts behind geometry the controllers are
-      blind to; a verified custom teleport onto the line skips the trap. An off-line spawn also
-      makes recovery RETRY the line teleport (not just teleport-to-pits, which returns the car to
-      the same trap and burns every recovery at 0 m — the pit-start stall, #528); teleport-to-pits
-      is the fallback when the line teleport cannot land (offsets are VERIFY LIVE).
+      blind to; a verified custom teleport onto the line skips the trap. Recovery RETRIES the line
+      teleport whenever the car is off the line — at an off-line spawn OR after a prior recovery
+      teleported it into the pits — instead of looping teleport-to-pits (which leaves the car
+      off-line and burns every recovery at 0 m, incl. a mid-lap spin recovered to pits — the
+      pit-start stall, #528); teleport-to-pits is the fallback when the line teleport cannot land
+      (offsets are VERIFY LIVE).
     """
     from tools.ac_harness.ai_line import _horizontal, load_ai_line
 
@@ -1763,7 +1767,10 @@ def rig_drive(  # pragma: no cover - rig-only
     stats = DriveStats()
     watchdog = ProgressWatchdog(stall_seconds=config.progress_stall_seconds)
     line_teleport_works: bool | None = None
-    spawn_off_line = False  # car spawned off the racing line (pit box / offset grid slot) — #528
+    # Whether the car is currently OFF the racing line — set at an off-line spawn (pit box / offset
+    # grid slot) AND whenever a recovery teleports it back to the pits (itself off-line). Recovery
+    # reads this to retry the line teleport vs. loop in the pits (#528).
+    off_line = False
 
     if config.spawn_to_line:
         from tools.ac_harness.ai_line import PurePursuit
@@ -1776,7 +1783,7 @@ def rig_drive(  # pragma: no cover - rig-only
             car0 = _horizontal(cd0["position"])
             off_line_m = ((p0[0] - car0[0]) ** 2 + (p0[1] - car0[1]) ** 2) ** 0.5
             if off_line_m > 12.0:  # pit box / off-line spawn
-                spawn_off_line = True
+                off_line = True
                 line_teleport_works = _teleport_onto_line(controller, line)
                 stats.spawn_teleport = "ok" if line_teleport_works else "failed"
             else:
@@ -1784,7 +1791,7 @@ def rig_drive(  # pragma: no cover - rig-only
 
     def _recover(now: float) -> bool:
         """Shared recovery for driver-flagged stuck AND watchdog stalls. False = cap exceeded."""
-        nonlocal line_teleport_works
+        nonlocal line_teleport_works, off_line
         stats.recoveries += 1
         if stats.recoveries > config.max_recoveries:
             stats.recovery_capped = True
@@ -1793,22 +1800,24 @@ def rig_drive(  # pragma: no cover - rig-only
             )
             return False
         recovered_to_line = False
-        # Attempt the racing-line teleport on recovery whenever the car spawned off the line (or a
-        # prior line teleport is known good). teleport_to_pits returns an off-line-spawned car to
-        # the SAME pit-box trap it is stuck in, so latching the spawn teleport's first miss and only
-        # teleporting to pits burns every recovery at 0 m (#528). _teleport_onto_line re-reads the
-        # position + retargets each call, so a later attempt can land where spawn missed.
+        # Retry the racing-line teleport whenever the car is off the line — an off-line spawn OR a
+        # prior recovery that teleported it into the pits — or a prior line teleport is known good.
+        # teleport_to_pits itself PLACES the car off-line, so latching only the spawn state and
+        # looping to pits burns every recovery at 0 m (#528, incl. a mid-lap spin recovered to
+        # pits). _teleport_onto_line re-reads position + retargets each call, so a later one lands.
         if should_try_line_teleport_on_recovery(
-            spawn_off_line=spawn_off_line, line_teleport_known_good=bool(line_teleport_works)
+            car_off_line=off_line, line_teleport_known_good=bool(line_teleport_works)
         ):
             recovered_to_line = _teleport_onto_line(controller, line)
             if recovered_to_line:
                 line_teleport_works = True
+                off_line = False  # back on the racing line
         if not recovered_to_line:
             for _ in range(5):
                 controller.teleport_to_pits()
                 time.sleep(0.1)
             time.sleep(0.8)
+            off_line = True  # teleport_to_pits leaves the car off-line (in the pits)
         driver.on_recovery()
         watchdog.reset(time.monotonic() - t0, stats.total_distance_m)
         return True

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -214,22 +214,28 @@ def drive_leg_succeeded(stats: DriveStats | None) -> bool:
 
 
 def should_try_line_teleport_on_recovery(
-    *, car_off_line: bool, line_teleport_known_good: bool
+    *, spawn_to_line_enabled: bool, car_off_line: bool, line_teleport_known_good: bool
 ) -> bool:
     """Whether a no-progress recovery should attempt the racing-line teleport before falling back
     to ``teleport_to_pits``.
 
-    A car that is OFF the racing line is stuck *because* it is off the line — ``teleport_to_pits``
-    returns it to (or leaves it in) the pit box, so every recovery is spent at 0 m and the run caps
-    out honestly but needlessly (the pit-start stall, #528). ``car_off_line`` is true at an off-line
-    spawn (pit box / laterally-offset grid slot) AND after any recovery that teleported the car back
-    to the pits — itself an off-line position, so a mid-lap spin recovered to the pits would
-    otherwise re-enter the same loop. Attempt the line teleport whenever the car is off-line — even
-    if an earlier attempt missed the 25 m read-back, because :func:`_teleport_onto_line` re-reads
-    the car position and retargets each call so a later attempt can land — or whenever a prior line
-    teleport is known to have landed. Only when the car is on the line and no line teleport is known
-    good is ``teleport_to_pits`` the correct reset.
+    ``spawn_to_line_enabled`` is ``config.spawn_to_line``: ``--no-spawn-line`` opts out of
+    racing-line teleports entirely (use the OUT-phase pit exit), so recovery must NEVER teleport
+    onto the line when it is false — regardless of off-line state (codex on #539).
+
+    Otherwise: a car that is OFF the racing line is stuck *because* it is off the line —
+    ``teleport_to_pits`` returns it to (or leaves it in) the pit box, so every recovery is spent
+    at 0 m and the run caps out honestly but needlessly (the pit-start stall, #528).
+    ``car_off_line`` is true at an off-line spawn (pit box / offset grid slot) AND after any
+    recovery that teleported the car back to the pits — itself off-line, so a mid-lap spin
+    recovered to the pits would otherwise re-enter the same loop. Attempt the line teleport
+    whenever the car is off-line — even if an earlier attempt missed the 25 m read-back, because
+    :func:`_teleport_onto_line` re-reads position and retargets each call so a later one can
+    land — or whenever a prior line teleport is known to have landed. Only when the car is on the
+    line and no line teleport is known good is ``teleport_to_pits`` the correct reset.
     """
+    if not spawn_to_line_enabled:
+        return False
     return line_teleport_known_good or car_off_line
 
 
@@ -1785,6 +1791,8 @@ def rig_drive(  # pragma: no cover - rig-only
             if off_line_m > 12.0:  # pit box / off-line spawn
                 off_line = True
                 line_teleport_works = _teleport_onto_line(controller, line)
+                if line_teleport_works:
+                    off_line = False  # spawn teleport landed → back on the racing line
                 stats.spawn_teleport = "ok" if line_teleport_works else "failed"
             else:
                 stats.spawn_teleport = "skipped (on line)"
@@ -1806,7 +1814,9 @@ def rig_drive(  # pragma: no cover - rig-only
         # looping to pits burns every recovery at 0 m (#528, incl. a mid-lap spin recovered to
         # pits). _teleport_onto_line re-reads position + retargets each call, so a later one lands.
         if should_try_line_teleport_on_recovery(
-            car_off_line=off_line, line_teleport_known_good=bool(line_teleport_works)
+            spawn_to_line_enabled=config.spawn_to_line,
+            car_off_line=off_line,
+            line_teleport_known_good=bool(line_teleport_works),
         ):
             recovered_to_line = _teleport_onto_line(controller, line)
             if recovered_to_line:

--- a/tools/ac_harness/false_green_kpi.py
+++ b/tools/ac_harness/false_green_kpi.py
@@ -18,6 +18,9 @@ reimplemented):
 * stream presence + ``session→lap`` ordering — `sequence_probe.evaluate_sequence`
 * out-of-schema field read (mock-fallacy / L0 schema gate) — `trace_replay.load_schema`
 * sim-death / frozen telemetry — `auto_drive.PhysicsStallDetector`
+* drive-leg outcome — a pit-start stall the car never escapes (recovery cap at 0 m) or a hijack
+  that never landed must NOT be reported as a successful drive — `auto_drive.drive_leg_succeeded`
+  (#528)
 * HUD render-liveness (black/uniform frame) — `hud_capture.liveness_score`
 * **report-path integrity** — `self_test.run_self_test` driven end-to-end with injected
   transports, so an oracle FAIL is proven to propagate to ``SelfTestReport.ok`` (catches the
@@ -40,7 +43,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from tools.ac_harness.auto_drive import PhysicsStallDetector
+from tools.ac_harness.auto_drive import DriveStats, PhysicsStallDetector, drive_leg_succeeded
 from tools.ac_harness.hud_capture import liveness_score
 from tools.ac_harness.self_test import SelfTestConfig, run_self_test
 from tools.ac_harness.sequence_probe import evaluate_sequence
@@ -61,6 +64,8 @@ BROKEN_CLASSES: tuple[str, ...] = (
     "out_of_schema_field",  # mock-fallacy — reading a field not in ac_schema.json
     "sim_death_frozen",  # acpmf_physics packet_id frozen (acs.exe died)
     "sim_death_physics_gone",  # #460 — physics mmap gone; None must not reset the timer
+    "spawn_stall_recovery_capped",  # #528 — pit-start stall: car never escapes, recovery cap at 0 m
+    "hijack_never_landed",  # #528 — carcsw hijack never landed; no drive leg ran at all
     "hud_blank",  # black HUD frame
     "hud_uniform",  # frozen/uniform HUD frame (almost no distinct values)
     "report_path_swallow",  # oracle FAIL must reach SelfTestReport.ok (no swallowing)
@@ -245,6 +250,9 @@ def build_corpus() -> list[Scenario]:
     def report_path(frames: list[dict]) -> bool:
         return _report_path_ok(frames)
 
+    def drive(stats: DriveStats | None) -> bool:
+        return drive_leg_succeeded(stats)
+
     # advancing packet ids (alive) vs frozen / gone (dead)
     advancing = [(i * 0.1, i + 1) for i in range(25)]
     frozen = [(0.0, 5), (0.5, 5), (1.6, 5)]
@@ -316,6 +324,16 @@ def build_corpus() -> list[Scenario]:
             "GREEN",
             "report_path",
             lambda: report_path(_healthy_stream()),
+        ),
+        Scenario(
+            "healthy_clean_drive",
+            "healthy",
+            "#528",
+            "GREEN",
+            "drive",
+            lambda: drive(
+                DriveStats(drove=True, laps=1, total_distance_m=3200.0, max_speed_kmh=210.0)
+            ),
         ),
         # ---- BROKEN (must be CAUGHT; a pass here is a FALSE GREEN) ----
         Scenario(
@@ -412,6 +430,38 @@ def build_corpus() -> list[Scenario]:
             "RED",
             "sim_death",
             lambda: sim(physics_gone),
+        ),
+        Scenario(
+            # #528 pit-start stall: the car kept stalling until the recovery cap. drove=True here
+            # (it limped 560 m across recoveries) makes the recovery_capped veto load-bearing — the
+            # drove/speed floor alone would pass this, so only the veto catches it. The live repro
+            # was worse (0 m, drove=False); a defanged recovery_capped veto must not leak this.
+            "broken_spawn_stall_recovery_capped",
+            "spawn_stall_recovery_capped",
+            "#528",
+            "RED",
+            "drive",
+            lambda: drive(
+                DriveStats(
+                    drove=True,
+                    total_distance_m=560.0,
+                    max_speed_kmh=48.0,
+                    recoveries=7,
+                    recovery_capped=True,
+                    spawn_teleport="failed",
+                    reason="recovery cap (6) exceeded at 560m",
+                )
+            ),
+        ),
+        Scenario(
+            # #528 hijack-probe exhaustion: the carcsw hijack never landed, so no drive leg ran at
+            # all (run_auto_drive returns stage=hijack, no DriveStats). A None drive is never green.
+            "broken_hijack_never_landed",
+            "hijack_never_landed",
+            "#528",
+            "RED",
+            "drive",
+            lambda: drive(None),
         ),
         Scenario(
             "broken_render_black", "hud_blank", "-", "RED", "render", lambda: render(black_bgra)


### PR DESCRIPTION
Closes #528.

## The bug (~1/3 of `auto_drive` launches FAIL at the pit start)

Two failure shapes, reproduced twice in one session with evidence bundles (Magione + 911 GT3 R):

1. **Recovery-to-pit-trap loop** — `spawn_teleport=failed`, `recovery cap (6) exceeded at 0 m`, car never moves (`drove=False max_speed=0.9km/h`). The coaching pipeline was healthy and the HUD was rendering; the car simply never escaped the pit box.
2. **hijack-probe exhaustion** — `FAIL (stage=hijack)`, Car0 never appears (pre-drive overlay stall).

## Root cause of shape 1

In `rig_drive`, an off-line spawn (`off_line_m > 12`) triggers `_teleport_onto_line`. When that misses the 25 m read-back, `line_teleport_works` was latched **False**, so `_recover` only called `teleport_to_pits()` — which returns the off-line-spawned car to the **same pit-box trap it is stuck in**. Every one of the 6 recoveries was spent at 0 m, then the run FAILed honestly.

## Fix

- **Recovery now retries the racing-line teleport whenever the car spawned off-line** — not only when the first spawn attempt landed. `_teleport_onto_line` re-reads the car position and retargets each call, so a later attempt can land where the spawn attempt missed. `teleport_to_pits` remains the fallback. The decision is extracted into the pure, unit-tested `should_try_line_teleport_on_recovery(...)`. **Strictly better-or-equal**: when the line teleport genuinely can't land, it reverts to today's behavior.
- **Both failure shapes folded into the false-green KPI corpus** (`false_green_kpi.py`) as labeled regression scenarios `spawn_stall_recovery_capped` + `hijack_never_landed` (#528), gated by the newly-extracted pure `drive_leg_succeeded` — the **same** drive-leg verdict `run_auto_drive` uses, so the success gate and the corpus cannot drift apart. Anti-vacuity test proves a defanged verdict leaks both.

Shape 2 (hijack exhaustion) is already an honest FAIL (`stage=hijack`) and self-recovers across the launch loop; it is now regression-protected in the corpus.

## Verification

- `make ci-fast` green.
- False-green KPI: **15 broken / 9 healthy / 0 leaks** (was 13/8); both new #528 classes covered.
- New unit tests: `should_try_line_teleport_on_recovery` (off-line always retries; on-line uses pits), `drive_leg_succeeded` (vetoes all #528 shapes incl. recovery-capped with `drove=True`), plus the drive-oracle anti-vacuity test.
- Rig-only teleport/drive paths stay `pragma: no cover`; the extracted decisions are pure and CI-tested.
- **Pending live rig verification**: repeated `auto_drive` launches on the rig to observe the escape reduces the pit-start stall rate (this PR opened draft until that lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)