### PR TITLE
docs(vault): post-merge handoff for PR #539 (#528 pit-start stall)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -38,6 +38,20 @@ pre-merge: `--assert-coaching` exit 0 twice, coverage 80%/89% (was red 78%), jun
 `corner_advice` between-lap point + coach-v2-runtime calibration. Detail:
 [[issue-522-parts12-coverage-calibration-2026-07-12]].
 
+**Delivered (2026-07-12):** PR [#539](https://github.com/agorokh/ac-copilot-trainer/pull/539)
+**MERGED** ([`e0b5eef`](https://github.com/agorokh/ac-copilot-trainer/commit/e0b5eef)) — **#528
+CLOSED** (the standing "autonomous driver stalls near pit start" flake). `auto_drive` FAILed ~1/3
+of pit-start launches via a recovery-to-pit-trap loop (`spawn_teleport=failed`, recovery cap at
+0 m): a car OFF the racing line was recovered only by `teleport_to_pits` — the same trap. Fix:
+`rig_drive` tracks a mutable `off_line` state (set at an off-line spawn AND after any
+`teleport_to_pits`; cleared on a successful line teleport) and RETRIES the racing-line teleport on
+recovery whenever off-line — closing the mid-lap-spin-into-pits re-entry too. Pure
+`should_try_line_teleport_on_recovery` (honors `--no-spawn-line`) + `drive_leg_succeeded`; both
+failure shapes now labeled false-green-KPI regression scenarios (15 broken / 9 healthy / 0 leaks).
+Hardened over 3 review rounds (self-hosted cursor HIGH+MEDIUM, codex P2). **Live rig verification
+PENDING** — rig saturated by 5+ concurrent sessions at merge; run repeated `auto_drive` launches
+when free. Detail: [[issue-528-pit-start-stall-recovery-2026-07-12]].
+
 **Prior focus (2026-07-12, later):** Coaching QUALITY —
 [#522](https://github.com/agorokh/ac-copilot-trainer/issues/522) remaining parts. PR
 [#523](https://github.com/agorokh/ac-copilot-trainer/pull/523) **MERGED**

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-528-pit-start-stall-recovery-2026-07-12.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-528-pit-start-stall-recovery-2026-07-12.md
@@ -1,0 +1,53 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-07-12
+updated: 2026-07-12
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/03_Investigations/issue-515-lap-archives-race-2026-07-11.md
+  - AcCopilotTrainer/03_Investigations/issue-512-false-green-kpi-2026-07-11.md
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/528
+---
+
+# #528 — auto_drive pit-start stall: recovery escapes the off-line trap (PR #539)
+
+PR [#539](https://github.com/agorokh/ac-copilot-trainer/pull/539) **MERGED** (`e0b5eef`,
+2026-07-12), **#528 CLOSED**. Filing of the standing "autonomous driver stalls near pit start"
+flake (Next Session Handoff / #459 lineage).
+
+**Problem (~1/3 of launches FAIL at pit start), two shapes:**
+
+1. **Recovery-to-pit-trap loop.** `spawn_teleport=failed`, `recovery cap (6) exceeded at 0 m`,
+   `drove=False max_speed=0.9km/h`. Coaching pipeline healthy, HUD rendering — the car just never
+   escaped the pit box.
+2. **Hijack-probe exhaustion.** `FAIL (stage=hijack)`, Car0 never appears (pre-drive overlay stall).
+
+**Root cause of shape 1.** In `rig_drive`, an off-line spawn (`off_line_m > 12`) calls
+`_teleport_onto_line`; a missed 25 m read-back latched `line_teleport_works=False`, so `_recover`
+only called `teleport_to_pits()` — returning the car to the **same pit-box trap it is stuck in**.
+Every recovery was spent at 0 m; the `recovery_capped` veto then FAILed honestly (not a false green).
+
+**Fix (PR #539, hardened over 3 review rounds).**
+- `rig_drive` tracks a mutable `off_line` state — set at an off-line spawn AND after any
+  `teleport_to_pits()` (itself an off-line position), cleared on a successful line teleport — and
+  RETRIES the racing-line teleport on recovery whenever the car is off-line. Fixes both the off-line
+  spawn AND the **mid-lap-spin-recovered-to-pits** re-entry (self-hosted reviewer HIGH).
+- Decision extracted to the pure `should_try_line_teleport_on_recovery`, which **honors
+  `--no-spawn-line`** (`spawn_to_line_enabled=False` → pit exit only; codex P2). `teleport_to_pits`
+  stays the fallback. Strictly better-or-equal.
+- Both shapes folded into the false-green KPI corpus (`spawn_stall_recovery_capped` +
+  `hijack_never_landed`) via the extracted pure `drive_leg_succeeded` — the same drive-leg verdict
+  `run_auto_drive` uses, so the success gate and the corpus cannot drift.
+
+**Verified.** `make ci-fast` green; KPI 15 broken / 9 healthy / 0 leaks; new unit tests for both
+pure predicates + drive-oracle anti-vacuity + the `--no-spawn-line` opt-out. Rig-only teleport/drive
+paths stay `pragma: no cover`.
+
+**Live rig verification — PENDING (rig busy).** At merge the rig was saturated by 5+ concurrent
+agent sessions (cycling `acs.exe`), so an ambiguous live session must not be hijacked. When the rig
+is free, run several `python -m tools.ac_harness.auto_drive --car ks_porsche_911_gt3_r_2016
+--track magione --driver racing --drive-seconds 300 --wait-lap` launches to (a) confirm clean drives
+still PASS (no regression) and (b) ideally observe an off-line-spawn stall now escape via the
+recovery line-teleport (was: cap at 0 m). Fold any observed live stall into the false-green corpus.


### PR DESCRIPTION
Vault-only post-merge handoff for [#539](https://github.com/agorokh/ac-copilot-trainer/pull/539) (**#528 CLOSED**, `e0b5eef`).

- New investigation node `issue-528-pit-start-stall-recovery-2026-07-12.md` — the recovery-to-pit-trap root cause, the mutable `off_line` fix (retry line teleport when off-line; honor `--no-spawn-line`), the false-green KPI corpus additions, and the **pending live rig verification**.
- Current Focus: delivered entry for #528.

Strictly under `docs/01_Vault/**`. Auto-merged by the `vault-only` bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)