### PR TITLE
fix(harness): #537 — bounded relaunch when Content Manager serves a cached wrong-track session

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -713,14 +713,13 @@ def test_track_ids_match_rules():
 
 def test_run_auto_drive_fails_fast_on_track_mismatch():
     # #532: CM launched a cached session (spa) instead of the requested track (magione). The
-    # harness must FAIL at stage="launch", not drive the requested line on the wrong track.
-    ctrl = FakeController()
-
+    # harness must FAIL at stage="launch" WITHOUT hijacking — the identity gateway rejects the
+    # wrong session before the hijack (#537), so the wrong line is never driven.
     report = asyncio.run(
         run_auto_drive(
             _cfg(track_id="magione", skip_launch=True),
             launch=_ok_launch,
-            hijack=lambda c: ctrl,
+            hijack=lambda c: pytest.fail("must not hijack a wrong session"),
             drive=lambda controller, config, stop: pytest.fail("must not drive the wrong track"),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),
@@ -729,7 +728,6 @@ def test_run_auto_drive_fails_fast_on_track_mismatch():
     assert report.ok is False
     assert report.stage == "launch"
     assert "spa" in report.error and "magione" in report.error
-    assert ctrl.closed is True  # controller released before bailing
 
 
 def test_handshake_outcome_gate_preserves_any_prior_failure():
@@ -761,13 +759,13 @@ def test_handshake_outcome_gate_preserves_any_prior_failure():
 
 def test_run_auto_drive_fails_fast_on_car_mismatch():
     # Same track, different CAR served by a cached CM session -> must not persist a mislabeled
-    # plant artifact under the requested car (#532 Codex review).
-    ctrl = FakeController()
+    # plant artifact under the requested car (#532 Codex review). The identity gateway rejects it
+    # before the hijack (#537).
     report = asyncio.run(
         run_auto_drive(
             _cfg(track_id="spa", car_id="ks_porsche_911_gt3_r_2016", skip_launch=True),
             launch=_ok_launch,
-            hijack=lambda c: ctrl,
+            hijack=lambda c: pytest.fail("must not hijack a wrong session"),
             drive=lambda controller, config, stop: pytest.fail("must not drive the wrong car"),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: ("spa", "ks_audi_r8_lms"),
@@ -796,23 +794,26 @@ def test_run_auto_drive_track_match_proceeds():
 
 def test_run_auto_drive_relaunches_on_track_mismatch_then_drives():
     # #537: CM served its cached session (spa) on the first launch; the harness must RELAUNCH
-    # (bounded) rather than fail — the second launch loads the requested magione and drives it.
+    # (bounded) rather than fail — the second launch loads the requested magione and drives it. The
+    # identity gateway rejects the cached session BEFORE the hijack, so no controller is taken.
     record: dict = {}
     launches: list[int] = []
-    c_bad = FakeController()
-    c_good = FakeController()
-    controllers: list[FakeController] = [c_bad, c_good]
+    hijacks: list[int] = []
     loaded_tracks = ["spa", "magione"]  # cached (wrong) first, requested second
 
     def _launch(config):  # noqa: ANN001
         launches.append(1)
         return True, "live"
 
+    def _hijack(config):  # noqa: ANN001
+        hijacks.append(1)
+        return FakeController()
+
     report = asyncio.run(
         run_auto_drive(
             _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=3),
             launch=_launch,
-            hijack=lambda c: controllers.pop(0),
+            hijack=_hijack,
             drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: (loaded_tracks.pop(0), "ks_porsche_911_gt3_r_2016"),
@@ -822,24 +823,23 @@ def test_run_auto_drive_relaunches_on_track_mismatch_then_drives():
     assert report.ok is True
     assert report.stage != "launch"  # did not fail-fast on the first (mismatched) launch
     assert len(launches) == 2  # relaunched exactly once
-    assert c_bad.closed is True  # the mismatched controller was released before relaunch
-    assert record["controller"] is c_good  # drove on the correct-track session
+    assert len(hijacks) == 1  # hijacked only the correct session, never the cached one
+    assert record["controller"] is not None  # drove on the correct-track session
 
 
 def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():
-    # #537 bound: a PERSISTENT cached-session mismatch must not loop forever or ever drive the
-    # wrong line — it FAILs at stage="launch" once the launch budget is spent (#535 honest guard).
+    # #537 bound: a PERSISTENT cached-session mismatch must not loop forever or ever hijack/drive
+    # the wrong line — it FAILs at stage="launch" once the launch budget is spent (#535 guard).
     launches: list[int] = []
-    controllers: list[FakeController] = []
+    hijacks: list[int] = []
 
     def _launch(config):  # noqa: ANN001
         launches.append(1)
         return True, "live"
 
     def _hijack(config):  # noqa: ANN001
-        ctrl = FakeController()
-        controllers.append(ctrl)
-        return ctrl
+        hijacks.append(1)
+        return FakeController()
 
     report = asyncio.run(
         run_auto_drive(
@@ -856,7 +856,7 @@ def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():
     assert report.stage == "launch"
     assert "spa" in report.error and "magione" in report.error
     assert len(launches) == 2  # bounded by max_launches — no infinite relaunch
-    assert all(c.closed for c in controllers)  # every mismatched controller released
+    assert hijacks == []  # never hijacked a wrong session (identity gateway is pre-hijack)
 
 
 def test_loaded_combo_mismatch_rules():
@@ -873,16 +873,12 @@ def test_loaded_combo_mismatch_rules():
 
 
 def test_setup_run_relaunches_on_cached_session_then_verifies():
-    # #537 (Codex P2): a --setup run whose first CM launch serves a cached wrong session fails setup
-    # fuel verification. The harness must RELAUNCH (bounded) rather than abort at stage="setup" on
-    # the first cached session, so setup A/B runs get the same #537 retry; attempt 2 loads the
-    # requested magione and the setup verifies.
-    acks = [
-        {"ok": False, "error": "fuel 60.0 != 45.0"},  # cached spa session — wrong fuel
-        {"ok": True, "name": "Realistic_BB_v3", "path": "x/Realistic_BB_v3.ini"},  # correct magione
-    ]
-    loaded_tracks = ["spa", "magione"]
+    # #537 (Codex P2): on a --setup run, a cached wrong session is rejected by the identity gateway
+    # BEFORE the setup verify runs, so the harness relaunches (bounded); the setup is applied
+    # ONLY on the correct magione session the relaunch loads — never wasted on the cached one.
+    loaded_tracks = ["spa", "magione"]  # cached (wrong) first, requested second
     launches: list[int] = []
+    applies: list[int] = []
     record: dict = {}
 
     def _launch(config):  # noqa: ANN001
@@ -890,7 +886,8 @@ def test_setup_run_relaunches_on_cached_session_then_verifies():
         return True, "live"
 
     async def _apply(config):  # noqa: ANN001
-        return acks.pop(0)
+        applies.append(1)
+        return {"ok": True, "name": "Realistic_BB_v3", "path": "x/Realistic_BB_v3.ini"}
 
     report = asyncio.run(
         run_auto_drive(
@@ -909,22 +906,26 @@ def test_setup_run_relaunches_on_cached_session_then_verifies():
         )
     )
     assert report.ok is True
-    assert report.stage != "setup"  # did not abort on the first cached session
+    assert report.stage != "setup"  # never aborted at setup on the cached session
     assert len(launches) == 2  # relaunched once for the cached session
+    assert len(applies) == 1  # setup applied ONLY on the correct session, not the cached one
     assert report.setup_applied is True
     assert record["controller"] is not None  # drove on the correct-combo session
 
 
-def test_setup_run_cached_session_fails_setup_stage_after_budget():
-    # Bound: a PERSISTENT cached wrong session on a --setup run still FAILs (bounded), and the error
-    # names the cached-session cause so the evidence bundle isn't misread as a plain setup bug.
+def test_setup_run_cached_session_fails_launch_stage_after_budget():
+    # #537: a PERSISTENT cached wrong session on a --setup run FAILs (bounded) at stage="launch"
+    # (the identity-gateway root cause), NOT stage="setup", and never runs the setup verify on the
+    # wrong session — so the evidence bundle points at CM, not at a phantom setup bug.
     launches: list[int] = []
+    applies: list[int] = []
 
     def _launch(config):  # noqa: ANN001
         launches.append(1)
         return True, "live"
 
     async def _apply(config):  # noqa: ANN001
+        applies.append(1)
         return {"ok": False, "error": "fuel 60.0 != 45.0"}
 
     report = asyncio.run(
@@ -944,15 +945,16 @@ def test_setup_run_cached_session_fails_setup_stage_after_budget():
         )
     )
     assert report.ok is False
-    assert report.stage == "setup"
+    assert report.stage == "launch"  # identity-gateway root cause, not a phantom setup failure
     assert len(launches) == 2  # bounded — no infinite relaunch
-    assert "cached session" in (report.error or "")  # names the real cause, not a plain setup bug
+    assert applies == []  # setup verify never ran on the wrong session
+    assert "spa" in report.error and "magione" in report.error
 
 
 def test_run_auto_drive_mismatch_then_launch_failure_reports_stage_launch():
-    # #537 (Codex P2): attempt 1 hits a cached-session mismatch (relaunch); attempt 2's launch never
-    # reaches LIVE. The report must read stage="launch" (the real terminal cause), not a misleading
-    # stage="hijack" that points the evidence bundle at the wrong subsystem.
+    # #537 (Codex P2): attempt 1 hits a cached-session mismatch (relaunch, pre-hijack); attempt 2's
+    # launch never reaches LIVE. The report must read stage="launch" (the real terminal cause), not
+    # a misleading stage="hijack" that points the evidence bundle at the wrong subsystem.
     launch_outcomes = [(True, "live"), (False, "sim never reached LIVE")]
 
     def _launch(config):  # noqa: ANN001
@@ -962,7 +964,9 @@ def test_run_auto_drive_mismatch_then_launch_failure_reports_stage_launch():
         run_auto_drive(
             _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=2),
             launch=_launch,
-            hijack=lambda c: FakeController(),  # only attempt 1 reaches hijack
+            hijack=lambda c: pytest.fail(
+                "must not hijack — attempt 1 mismatched, attempt 2 no LIVE"
+            ),
             drive=lambda controller, config, stop: pytest.fail("must not drive the wrong track"),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),  # attempt-1 mismatch

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -713,13 +713,14 @@ def test_track_ids_match_rules():
 
 def test_run_auto_drive_fails_fast_on_track_mismatch():
     # #532: CM launched a cached session (spa) instead of the requested track (magione). The
-    # harness must FAIL at stage="launch" WITHOUT hijacking — the identity gateway rejects the
-    # wrong session before the hijack (#537), so the wrong line is never driven.
+    # harness must FAIL at stage="launch", not drive the requested line on the wrong track.
+    ctrl = FakeController()
+
     report = asyncio.run(
         run_auto_drive(
             _cfg(track_id="magione", skip_launch=True),
             launch=_ok_launch,
-            hijack=lambda c: pytest.fail("must not hijack a wrong session"),
+            hijack=lambda c: ctrl,
             drive=lambda controller, config, stop: pytest.fail("must not drive the wrong track"),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),
@@ -728,6 +729,7 @@ def test_run_auto_drive_fails_fast_on_track_mismatch():
     assert report.ok is False
     assert report.stage == "launch"
     assert "spa" in report.error and "magione" in report.error
+    assert ctrl.closed is True  # controller released before bailing
 
 
 def test_handshake_outcome_gate_preserves_any_prior_failure():
@@ -759,13 +761,13 @@ def test_handshake_outcome_gate_preserves_any_prior_failure():
 
 def test_run_auto_drive_fails_fast_on_car_mismatch():
     # Same track, different CAR served by a cached CM session -> must not persist a mislabeled
-    # plant artifact under the requested car (#532 Codex review). The identity gateway rejects it
-    # before the hijack (#537).
+    # plant artifact under the requested car (#532 Codex review).
+    ctrl = FakeController()
     report = asyncio.run(
         run_auto_drive(
             _cfg(track_id="spa", car_id="ks_porsche_911_gt3_r_2016", skip_launch=True),
             launch=_ok_launch,
-            hijack=lambda c: pytest.fail("must not hijack a wrong session"),
+            hijack=lambda c: ctrl,
             drive=lambda controller, config, stop: pytest.fail("must not drive the wrong car"),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: ("spa", "ks_audi_r8_lms"),
@@ -794,26 +796,23 @@ def test_run_auto_drive_track_match_proceeds():
 
 def test_run_auto_drive_relaunches_on_track_mismatch_then_drives():
     # #537: CM served its cached session (spa) on the first launch; the harness must RELAUNCH
-    # (bounded) rather than fail — the second launch loads the requested magione and drives it. The
-    # identity gateway rejects the cached session BEFORE the hijack, so no controller is taken.
+    # (bounded) rather than fail — the second launch loads the requested magione and drives it.
     record: dict = {}
     launches: list[int] = []
-    hijacks: list[int] = []
+    c_bad = FakeController()
+    c_good = FakeController()
+    controllers: list[FakeController] = [c_bad, c_good]
     loaded_tracks = ["spa", "magione"]  # cached (wrong) first, requested second
 
     def _launch(config):  # noqa: ANN001
         launches.append(1)
         return True, "live"
 
-    def _hijack(config):  # noqa: ANN001
-        hijacks.append(1)
-        return FakeController()
-
     report = asyncio.run(
         run_auto_drive(
             _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=3),
             launch=_launch,
-            hijack=_hijack,
+            hijack=lambda c: controllers.pop(0),
             drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: (loaded_tracks.pop(0), "ks_porsche_911_gt3_r_2016"),
@@ -823,23 +822,24 @@ def test_run_auto_drive_relaunches_on_track_mismatch_then_drives():
     assert report.ok is True
     assert report.stage != "launch"  # did not fail-fast on the first (mismatched) launch
     assert len(launches) == 2  # relaunched exactly once
-    assert len(hijacks) == 1  # hijacked only the correct session, never the cached one
-    assert record["controller"] is not None  # drove on the correct-track session
+    assert c_bad.closed is True  # the mismatched controller was released before relaunch
+    assert record["controller"] is c_good  # drove on the correct-track session
 
 
 def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():
-    # #537 bound: a PERSISTENT cached-session mismatch must not loop forever or ever hijack/drive
-    # the wrong line — it FAILs at stage="launch" once the launch budget is spent (#535 guard).
+    # #537 bound: a PERSISTENT cached-session mismatch must not loop forever or ever drive the
+    # wrong line — it FAILs at stage="launch" once the launch budget is spent (#535 honest guard).
     launches: list[int] = []
-    hijacks: list[int] = []
+    controllers: list[FakeController] = []
 
     def _launch(config):  # noqa: ANN001
         launches.append(1)
         return True, "live"
 
     def _hijack(config):  # noqa: ANN001
-        hijacks.append(1)
-        return FakeController()
+        ctrl = FakeController()
+        controllers.append(ctrl)
+        return ctrl
 
     report = asyncio.run(
         run_auto_drive(
@@ -856,7 +856,7 @@ def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():
     assert report.stage == "launch"
     assert "spa" in report.error and "magione" in report.error
     assert len(launches) == 2  # bounded by max_launches — no infinite relaunch
-    assert hijacks == []  # never hijacked a wrong session (identity gateway is pre-hijack)
+    assert all(c.closed for c in controllers)  # every mismatched controller released
 
 
 def test_loaded_combo_mismatch_rules():
@@ -873,12 +873,16 @@ def test_loaded_combo_mismatch_rules():
 
 
 def test_setup_run_relaunches_on_cached_session_then_verifies():
-    # #537 (Codex P2): on a --setup run, a cached wrong session is rejected by the identity gateway
-    # BEFORE the setup verify runs, so the harness relaunches (bounded); the setup is applied
-    # ONLY on the correct magione session the relaunch loads — never wasted on the cached one.
-    loaded_tracks = ["spa", "magione"]  # cached (wrong) first, requested second
+    # #537 (Codex P2): a --setup run whose first CM launch serves a cached wrong session fails setup
+    # fuel verification. The harness must RELAUNCH (bounded) rather than abort at stage="setup" on
+    # the first cached session, so setup A/B runs get the same #537 retry; attempt 2 loads the
+    # requested magione and the setup verifies.
+    acks = [
+        {"ok": False, "error": "fuel 60.0 != 45.0"},  # cached spa session — wrong fuel
+        {"ok": True, "name": "Realistic_BB_v3", "path": "x/Realistic_BB_v3.ini"},  # correct magione
+    ]
+    loaded_tracks = ["spa", "magione"]
     launches: list[int] = []
-    applies: list[int] = []
     record: dict = {}
 
     def _launch(config):  # noqa: ANN001
@@ -886,8 +890,7 @@ def test_setup_run_relaunches_on_cached_session_then_verifies():
         return True, "live"
 
     async def _apply(config):  # noqa: ANN001
-        applies.append(1)
-        return {"ok": True, "name": "Realistic_BB_v3", "path": "x/Realistic_BB_v3.ini"}
+        return acks.pop(0)
 
     report = asyncio.run(
         run_auto_drive(
@@ -906,26 +909,22 @@ def test_setup_run_relaunches_on_cached_session_then_verifies():
         )
     )
     assert report.ok is True
-    assert report.stage != "setup"  # never aborted at setup on the cached session
+    assert report.stage != "setup"  # did not abort on the first cached session
     assert len(launches) == 2  # relaunched once for the cached session
-    assert len(applies) == 1  # setup applied ONLY on the correct session, not the cached one
     assert report.setup_applied is True
     assert record["controller"] is not None  # drove on the correct-combo session
 
 
-def test_setup_run_cached_session_fails_launch_stage_after_budget():
-    # #537: a PERSISTENT cached wrong session on a --setup run FAILs (bounded) at stage="launch"
-    # (the identity-gateway root cause), NOT stage="setup", and never runs the setup verify on the
-    # wrong session — so the evidence bundle points at CM, not at a phantom setup bug.
+def test_setup_run_cached_session_fails_setup_stage_after_budget():
+    # Bound: a PERSISTENT cached wrong session on a --setup run still FAILs (bounded), and the error
+    # names the cached-session cause so the evidence bundle isn't misread as a plain setup bug.
     launches: list[int] = []
-    applies: list[int] = []
 
     def _launch(config):  # noqa: ANN001
         launches.append(1)
         return True, "live"
 
     async def _apply(config):  # noqa: ANN001
-        applies.append(1)
         return {"ok": False, "error": "fuel 60.0 != 45.0"}
 
     report = asyncio.run(
@@ -945,16 +944,15 @@ def test_setup_run_cached_session_fails_launch_stage_after_budget():
         )
     )
     assert report.ok is False
-    assert report.stage == "launch"  # identity-gateway root cause, not a phantom setup failure
+    assert report.stage == "setup"
     assert len(launches) == 2  # bounded — no infinite relaunch
-    assert applies == []  # setup verify never ran on the wrong session
-    assert "spa" in report.error and "magione" in report.error
+    assert "cached session" in (report.error or "")  # names the real cause, not a plain setup bug
 
 
 def test_run_auto_drive_mismatch_then_launch_failure_reports_stage_launch():
-    # #537 (Codex P2): attempt 1 hits a cached-session mismatch (relaunch, pre-hijack); attempt 2's
-    # launch never reaches LIVE. The report must read stage="launch" (the real terminal cause), not
-    # a misleading stage="hijack" that points the evidence bundle at the wrong subsystem.
+    # #537 (Codex P2): attempt 1 hits a cached-session mismatch (relaunch); attempt 2's launch never
+    # reaches LIVE. The report must read stage="launch" (the real terminal cause), not a misleading
+    # stage="hijack" that points the evidence bundle at the wrong subsystem.
     launch_outcomes = [(True, "live"), (False, "sim never reached LIVE")]
 
     def _launch(config):  # noqa: ANN001
@@ -964,9 +962,7 @@ def test_run_auto_drive_mismatch_then_launch_failure_reports_stage_launch():
         run_auto_drive(
             _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=2),
             launch=_launch,
-            hijack=lambda c: pytest.fail(
-                "must not hijack — attempt 1 mismatched, attempt 2 no LIVE"
-            ),
+            hijack=lambda c: FakeController(),  # only attempt 1 reaches hijack
             drive=lambda controller, config, stop: pytest.fail("must not drive the wrong track"),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),  # attempt-1 mismatch

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -859,6 +859,120 @@ def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():
     assert all(c.closed for c in controllers)  # every mismatched controller released
 
 
+def test_loaded_combo_mismatch_rules():
+    from tools.ac_harness.auto_drive import loaded_combo_mismatch
+
+    c = _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016")
+    assert loaded_combo_mismatch(c, None) is None  # unreadable → cannot confirm → no block
+    assert loaded_combo_mismatch(c, ("magione", "ks_porsche_911_gt3_r_2016")) is None  # match
+    assert "track" in (loaded_combo_mismatch(c, ("spa", "ks_porsche_911_gt3_r_2016")) or "")
+    assert "car" in (loaded_combo_mismatch(c, ("magione", "ks_audi_r8_lms")) or "")
+    assert loaded_combo_mismatch(c, ("", "")) is None  # empty loaded id → cannot confirm
+    c2 = _cfg(track_id="magione")  # no car requested → car not checked
+    assert loaded_combo_mismatch(c2, ("magione", "anything")) is None
+
+
+def test_setup_run_relaunches_on_cached_session_then_verifies():
+    # #537 (Codex P2): a --setup run whose first CM launch serves a cached wrong session fails setup
+    # fuel verification. The harness must RELAUNCH (bounded) rather than abort at stage="setup" on
+    # the first cached session, so setup A/B runs get the same #537 retry; attempt 2 loads the
+    # requested magione and the setup verifies.
+    acks = [
+        {"ok": False, "error": "fuel 60.0 != 45.0"},  # cached spa session — wrong fuel
+        {"ok": True, "name": "Realistic_BB_v3", "path": "x/Realistic_BB_v3.ini"},  # correct magione
+    ]
+    loaded_tracks = ["spa", "magione"]
+    launches: list[int] = []
+    record: dict = {}
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    async def _apply(config):  # noqa: ANN001
+        return acks.pop(0)
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(
+                setup="Realistic_BB_v3",
+                track_id="magione",
+                car_id="ks_porsche_911_gt3_r_2016",
+                max_launches=3,
+            ),
+            launch=_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
+            tap=_tap_returning(CONTINUOUS),
+            apply_setup=_apply,
+            verify_track=lambda c: (loaded_tracks.pop(0), "ks_porsche_911_gt3_r_2016"),
+        )
+    )
+    assert report.ok is True
+    assert report.stage != "setup"  # did not abort on the first cached session
+    assert len(launches) == 2  # relaunched once for the cached session
+    assert report.setup_applied is True
+    assert record["controller"] is not None  # drove on the correct-combo session
+
+
+def test_setup_run_cached_session_fails_setup_stage_after_budget():
+    # Bound: a PERSISTENT cached wrong session on a --setup run still FAILs (bounded), and the error
+    # names the cached-session cause so the evidence bundle isn't misread as a plain setup bug.
+    launches: list[int] = []
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    async def _apply(config):  # noqa: ANN001
+        return {"ok": False, "error": "fuel 60.0 != 45.0"}
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(
+                setup="Realistic_BB_v3",
+                track_id="magione",
+                car_id="ks_porsche_911_gt3_r_2016",
+                max_launches=2,
+            ),
+            launch=_launch,
+            hijack=lambda c: pytest.fail("must not hijack the wrong session"),
+            drive=lambda *a: pytest.fail("must not drive"),
+            tap=_tap_returning(CONTINUOUS),
+            apply_setup=_apply,
+            verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),  # always cached spa
+        )
+    )
+    assert report.ok is False
+    assert report.stage == "setup"
+    assert len(launches) == 2  # bounded — no infinite relaunch
+    assert "cached session" in (report.error or "")  # names the real cause, not a plain setup bug
+
+
+def test_run_auto_drive_mismatch_then_launch_failure_reports_stage_launch():
+    # #537 (Codex P2): attempt 1 hits a cached-session mismatch (relaunch); attempt 2's launch never
+    # reaches LIVE. The report must read stage="launch" (the real terminal cause), not a misleading
+    # stage="hijack" that points the evidence bundle at the wrong subsystem.
+    launch_outcomes = [(True, "live"), (False, "sim never reached LIVE")]
+
+    def _launch(config):  # noqa: ANN001
+        return launch_outcomes.pop(0)
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=2),
+            launch=_launch,
+            hijack=lambda c: FakeController(),  # only attempt 1 reaches hijack
+            drive=lambda controller, config, stop: pytest.fail("must not drive the wrong track"),
+            tap=_tap_returning(CONTINUOUS),
+            verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),  # attempt-1 mismatch
+        )
+    )
+    assert report.ok is False
+    assert report.stage == "launch"  # not "hijack" — the terminal cause was the failed relaunch
+    assert "sim never reached LIVE" in (report.error or "")
+
+
 def test_run_auto_drive_handshake_drive_outlives_the_tap():
     # #532: the handshake self-terminates (driver.finished); the orchestrator must NOT stop it at
     # the tap boundary or the probe schedule dies mid-maneuver.

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -794,6 +794,71 @@ def test_run_auto_drive_track_match_proceeds():
     assert record["controller"] is not None  # the drive leg ran
 
 
+def test_run_auto_drive_relaunches_on_track_mismatch_then_drives():
+    # #537: CM served its cached session (spa) on the first launch; the harness must RELAUNCH
+    # (bounded) rather than fail — the second launch loads the requested magione and drives it.
+    record: dict = {}
+    launches: list[int] = []
+    c_bad = FakeController()
+    c_good = FakeController()
+    controllers: list[FakeController] = [c_bad, c_good]
+    loaded_tracks = ["spa", "magione"]  # cached (wrong) first, requested second
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=3),
+            launch=_launch,
+            hijack=lambda c: controllers.pop(0),
+            drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
+            tap=_tap_returning(CONTINUOUS),
+            verify_track=lambda c: (loaded_tracks.pop(0), "ks_porsche_911_gt3_r_2016"),
+        )
+    )
+
+    assert report.ok is True
+    assert report.stage != "launch"  # did not fail-fast on the first (mismatched) launch
+    assert len(launches) == 2  # relaunched exactly once
+    assert c_bad.closed is True  # the mismatched controller was released before relaunch
+    assert record["controller"] is c_good  # drove on the correct-track session
+
+
+def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():
+    # #537 bound: a PERSISTENT cached-session mismatch must not loop forever or ever drive the
+    # wrong line — it FAILs at stage="launch" once the launch budget is spent (#535 honest guard).
+    launches: list[int] = []
+    controllers: list[FakeController] = []
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    def _hijack(config):  # noqa: ANN001
+        ctrl = FakeController()
+        controllers.append(ctrl)
+        return ctrl
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=2),
+            launch=_launch,
+            hijack=_hijack,
+            drive=lambda controller, config, stop: pytest.fail("must never drive the wrong track"),
+            tap=_tap_returning(CONTINUOUS),
+            verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),  # always wrong
+        )
+    )
+
+    assert report.ok is False
+    assert report.stage == "launch"
+    assert "spa" in report.error and "magione" in report.error
+    assert len(launches) == 2  # bounded by max_launches — no infinite relaunch
+    assert all(c.closed for c in controllers)  # every mismatched controller released
+
+
 def test_run_auto_drive_handshake_drive_outlives_the_tap():
     # #532: the handshake self-terminates (driver.finished); the orchestrator must NOT stop it at
     # the tap boundary or the probe schedule dies mid-maneuver.

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -503,7 +503,7 @@ async def run_auto_drive(
     launch_config = replace(config, max_launches=1)
     launched_once = config.skip_launch
     last_launch_error = ""
-    for _ in range(attempts):
+    for attempt_idx in range(attempts):
         if not config.skip_launch:
             ok, reason = launch(launch_config)
             if not ok:
@@ -555,7 +555,7 @@ async def run_auto_drive(
             # Guard: CM sometimes launches its cached last session instead of the requested
             # preset (#532 rig-found). Driving the requested line on a different track — or
             # persisting a plant artifact under the requested car when a DIFFERENT car is loaded —
-            # is a guaranteed corruption, so verify the loaded (track, car) and FAIL fast at launch.
+            # is a guaranteed corruption, so verify the loaded (track, car) before driving.
             loaded = verify_track(config) if verify_track is not None else None
             if loaded is not None:
                 loaded_track, loaded_car = loaded
@@ -565,7 +565,24 @@ async def run_auto_drive(
                 elif config.car_id and not track_ids_match(config.car_id, loaded_car):
                     mismatch = f"car {loaded_car!r} != requested {config.car_id!r}"
                 if mismatch is not None:
+                    # #537: CM served its cached last session. RELAUNCH (bounded) rather than drive
+                    # the wrong line — the next launch kills acs.exe and re-issues the acmanager://
+                    # Quick-Drive URL to the now-running CM, which processes it via single-instance
+                    # IPC without the cold-start auto-resume race that served the stale combo. Only
+                    # the terminal attempt — or skip_launch, which has no launch leg to relaunch —
+                    # FAILs fast at stage="launch", preserving the #535/#532 honest-failure guard so
+                    # the harness never drives a mismatched combo or persists a mislabeled plant.
                     controller.close()
+                    controller = None
+                    last_launch_error = (
+                        f"loaded {mismatch} — Content Manager launched a cached session"
+                    )
+                    if attempt_idx < attempts - 1 and not config.skip_launch:
+                        _log(
+                            f"track/car guard: {mismatch} (CM cached session) — relaunching "
+                            f"(attempt {attempt_idx + 2}/{attempts})"
+                        )
+                        continue
                     return AutoDriveReport(
                         ok=False,
                         stage="launch",
@@ -576,8 +593,9 @@ async def run_auto_drive(
                         setup_ack=setup_ack,
                         error=(
                             f"loaded {mismatch} — Content Manager launched a cached session; "
-                            "relaunch with the correct preset (the harness will not drive the "
-                            "requested line on a different combo or persist a mislabeled plant)"
+                            f"still mismatched after {attempts} launch attempt(s) (the harness "
+                            "will not drive the requested line on a different combo or persist a "
+                            "mislabeled plant)"
                         ),
                         **identity,
                     )

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -535,49 +535,10 @@ async def run_auto_drive(
             # relaunch that reaches LIVE but fails to hijack must read as stage="hijack", while one
             # that never reaches LIVE (or re-serves a cached session) reads as stage="launch".
             last_launch_error = ""
-        # Session-identity gateway (#532/#537). CM sometimes serves its cached last session instead
-        # of the requested preset. verify_track reads the loaded (track, car) from acpmf_static — a
-        # STATIC page AC populates at session load — so it needs neither the setup verify nor the
-        # hijack. Check it ONCE here, before both, so the "when" is deterministic (a single source
-        # of truth for session validity, not contingent on whether a cached session's fuel
-        # coincidentally matches the requested setup) and neither the setup verify nor the hijack
-        # ever runs against a wrong session. On a positive mismatch, RELAUNCH (bounded): the next
-        # launch kills acs.exe and re-issues the acmanager:// Quick-Drive URL to the now-running CM,
-        # which processes it via single-instance IPC without the cold-start auto-resume race that
-        # served the stale combo. Only the terminal attempt — or skip_launch, which has no launch
-        # leg to relaunch — FAILs fast at stage="launch", preserving the #535/#532 honest guard so
-        # the harness never drives a mismatched combo or persists a mislabeled plant. A missing/
-        # unreadable identity is "cannot confirm" (loaded_combo_mismatch returns None) → proceed.
-        mismatch = loaded_combo_mismatch(
-            config, verify_track(config) if verify_track is not None else None
-        )
-        if mismatch is not None:
-            last_launch_error = f"loaded {mismatch} — Content Manager launched a cached session"
-            if attempt_idx < attempts - 1 and not config.skip_launch:
-                _log(
-                    f"track/car guard: {mismatch} (CM cached session) — relaunching "
-                    f"(attempt {attempt_idx + 2}/{attempts})"
-                )
-                continue
-            return AutoDriveReport(
-                ok=False,
-                stage="launch",
-                launched=not config.skip_launch,
-                setup_requested=setup_requested,
-                setup_applied=setup_applied,
-                error=(
-                    f"loaded {mismatch} — Content Manager launched a cached session; "
-                    f"still mismatched after {attempts} launch attempt(s) (the harness "
-                    "will not drive the requested line on a different combo or persist a "
-                    "mislabeled plant)"
-                ),
-                **identity,
-            )
         # The setup is BAKED at launch (AC only applies setups at spawn; the WS load is gated shut
         # for an autonomous car). Verify it BEFORE the hijack — the fuel read needs no hijack, and
         # a wrong setup must fail the run before it drives (#459 Part A). On a relaunch the launch
-        # leg re-bakes, so this re-verifies each attempt. The identity gateway above has already
-        # confirmed the correct session, so a setup failure here is a genuine setup problem.
+        # leg re-bakes, so this re-verifies each attempt.
         if config.setup:
             if apply_setup is None:
                 return AutoDriveReport(
@@ -604,6 +565,33 @@ async def run_auto_drive(
             ok_setup, detail = verify_setup_ack(setup_ack, setup_requested)
             setup_applied = ok_setup
             if not ok_setup:
+                # #537: a cached wrong session (CM served its last session) ALSO fails setup
+                # verification — its fuel won't match the requested setup. Setup is verified before
+                # the post-hijack track guard, so without this a --setup run would abort at
+                # stage="setup" on the very first cached session and never consume the retry budget.
+                # This is a BEST-EFFORT, FAIL-SAFE early-out — NOT the authoritative guard. It reads
+                # acpmf_static before the hijack, where the static page may not yet be populated; on
+                # "cannot confirm" it does NOT drive — it falls through to the setup-stage return
+                # below (safe), and the authoritative post-hijack guard remains the single
+                # source of truth for a session that DOES reach the drive leg. Only a POSITIVE early
+                # mismatch relaunches (bounded); a genuine setup failure on the CORRECT combo still
+                # fails fast at stage="setup" (combo_mismatch is None → skip).
+                combo_mismatch = loaded_combo_mismatch(
+                    config, verify_track(config) if verify_track is not None else None
+                )
+                if (
+                    combo_mismatch is not None
+                    and attempt_idx < attempts - 1
+                    and not config.skip_launch
+                ):
+                    last_launch_error = (
+                        f"setup verify failed on a cached session ({combo_mismatch}): {detail}"
+                    )
+                    _log(
+                        f"setup guard: {combo_mismatch} (CM cached session — setup fuel mismatch) "
+                        f"— relaunching (attempt {attempt_idx + 2}/{attempts})"
+                    )
+                    continue
                 return AutoDriveReport(
                     ok=False,
                     stage="setup",
@@ -611,11 +599,63 @@ async def run_auto_drive(
                     setup_requested=setup_requested,
                     setup_applied=False,
                     setup_ack=setup_ack,
-                    error=f"setup not applied: {detail}",
+                    error=(
+                        f"setup not applied: {detail}"
+                        + (
+                            f" (Content Manager served a cached session: {combo_mismatch}; still "
+                            f"mismatched after {attempts} launch attempt(s))"
+                            if combo_mismatch is not None
+                            else ""
+                        )
+                    ),
                     **identity,
                 )
         controller = hijack(config)
         if controller is not None:
+            # AUTHORITATIVE identity guard (#532/#535). CM sometimes launches its cached last
+            # session instead of the requested preset; driving the requested line on a different
+            # track — or persisting a plant artifact under the requested car when a DIFFERENT car
+            # is loaded — is a guaranteed corruption. This runs POST-hijack on purpose: a landed
+            # hijack means CSP created Car0, a STRONGER "session fully initialised" signal than
+            # _wait_live's LIVE + advancing-physics, so acpmf_static is reliably populated here
+            # (#535 rig-proven). This is the single source of truth — every drivable session passes
+            # through it — a not-yet-populated static page can never slip a mismatch to the drive.
+            mismatch = loaded_combo_mismatch(
+                config, verify_track(config) if verify_track is not None else None
+            )
+            if mismatch is not None:
+                # #537: CM served its cached last session. RELAUNCH (bounded) rather than drive
+                # the wrong line — the next launch kills acs.exe and re-issues the acmanager://
+                # Quick-Drive URL to the now-running CM, which processes it via single-instance
+                # IPC without the cold-start auto-resume race that served the stale combo. Only
+                # the terminal attempt — or skip_launch, which has no launch leg to relaunch —
+                # FAILs fast at stage="launch", preserving the #535/#532 honest-failure guard so
+                # the harness never drives a mismatched combo or persists a mislabeled plant.
+                controller.close()
+                controller = None
+                last_launch_error = f"loaded {mismatch} — Content Manager launched a cached session"
+                if attempt_idx < attempts - 1 and not config.skip_launch:
+                    _log(
+                        f"track/car guard: {mismatch} (CM cached session) — relaunching "
+                        f"(attempt {attempt_idx + 2}/{attempts})"
+                    )
+                    continue
+                return AutoDriveReport(
+                    ok=False,
+                    stage="launch",
+                    launched=not config.skip_launch,
+                    hijacked=True,
+                    setup_requested=setup_requested,
+                    setup_applied=setup_applied,
+                    setup_ack=setup_ack,
+                    error=(
+                        f"loaded {mismatch} — Content Manager launched a cached session; "
+                        f"still mismatched after {attempts} launch attempt(s) (the harness "
+                        "will not drive the requested line on a different combo or persist a "
+                        "mislabeled plant)"
+                    ),
+                    **identity,
+                )
             break
         if config.skip_launch:
             break

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -385,6 +385,26 @@ def track_ids_match(requested: str, loaded: str) -> bool:
     return want == got
 
 
+def loaded_combo_mismatch(
+    config: AutoDriveConfig, loaded: tuple[str | None, str | None] | None
+) -> str | None:
+    """Human-readable reason when the loaded ``(track, car)`` differs from the requested combo.
+
+    Returns ``None`` when it matches OR cannot be confirmed (``loaded is None``, or an empty id per
+    :func:`track_ids_match`) — a missing read never blocks; only a POSITIVE, different base id does.
+    Pure, so the same "CM served a cached session" verdict (#532/#537) is shared by the post-hijack
+    guard AND the setup-verify path (a cached wrong session also fails setup fuel verification).
+    """
+    if loaded is None:
+        return None
+    loaded_track, loaded_car = loaded
+    if not track_ids_match(config.track_id, loaded_track):
+        return f"track {loaded_track!r} != requested {config.track_id!r}"
+    if config.car_id and not track_ids_match(config.car_id, loaded_car):
+        return f"car {loaded_car!r} != requested {config.car_id!r}"
+    return None
+
+
 def verify_setup_ack(ack: dict | None, requested: str) -> tuple[bool, str]:
     """Pure check that a setup ack confirms the requested setup was applied AND verified.
 
@@ -510,6 +530,11 @@ async def run_auto_drive(
                 last_launch_error = reason
                 continue
             launched_once = True
+            # Reset so the post-loop stage report reflects THIS attempt's terminal cause, not a
+            # stale launch/mismatch error from an earlier attempt (#537 Codex P2 observability): a
+            # relaunch that reaches LIVE but fails to hijack must read as stage="hijack", while one
+            # that never reaches LIVE (or re-serves a cached session) reads as stage="launch".
+            last_launch_error = ""
         # The setup is BAKED at launch (AC only applies setups at spawn; the WS load is gated shut
         # for an autonomous car). Verify it BEFORE the hijack — the fuel read needs no hijack, and
         # a wrong setup must fail the run before it drives (#459 Part A). On a relaunch the launch
@@ -540,6 +565,29 @@ async def run_auto_drive(
             ok_setup, detail = verify_setup_ack(setup_ack, setup_requested)
             setup_applied = ok_setup
             if not ok_setup:
+                # #537: a cached wrong session (CM served its last session) ALSO fails setup
+                # verification — its fuel won't match the requested setup. Setup is verified before
+                # the post-hijack track guard, so without this a --setup run would abort at
+                # stage="setup" on the very first cached session and never consume the retry budget.
+                # If the loaded combo is the wrong one, relaunch (bounded) like the post-hijack
+                # guard so setup A/B runs get the same #537 retry; a genuine setup failure on the
+                # CORRECT combo still fails fast at stage="setup" (combo_mismatch is None → skip).
+                combo_mismatch = loaded_combo_mismatch(
+                    config, verify_track(config) if verify_track is not None else None
+                )
+                if (
+                    combo_mismatch is not None
+                    and attempt_idx < attempts - 1
+                    and not config.skip_launch
+                ):
+                    last_launch_error = (
+                        f"setup verify failed on a cached session ({combo_mismatch}): {detail}"
+                    )
+                    _log(
+                        f"setup guard: {combo_mismatch} (CM cached session — setup fuel mismatch) "
+                        f"— relaunching (attempt {attempt_idx + 2}/{attempts})"
+                    )
+                    continue
                 return AutoDriveReport(
                     ok=False,
                     stage="setup",
@@ -547,7 +595,15 @@ async def run_auto_drive(
                     setup_requested=setup_requested,
                     setup_applied=False,
                     setup_ack=setup_ack,
-                    error=f"setup not applied: {detail}",
+                    error=(
+                        f"setup not applied: {detail}"
+                        + (
+                            f" (Content Manager served a cached session: {combo_mismatch}; still "
+                            f"mismatched after {attempts} launch attempt(s))"
+                            if combo_mismatch is not None
+                            else ""
+                        )
+                    ),
                     **identity,
                 )
         controller = hijack(config)
@@ -556,49 +612,42 @@ async def run_auto_drive(
             # preset (#532 rig-found). Driving the requested line on a different track — or
             # persisting a plant artifact under the requested car when a DIFFERENT car is loaded —
             # is a guaranteed corruption, so verify the loaded (track, car) before driving.
-            loaded = verify_track(config) if verify_track is not None else None
-            if loaded is not None:
-                loaded_track, loaded_car = loaded
-                mismatch = None
-                if not track_ids_match(config.track_id, loaded_track):
-                    mismatch = f"track {loaded_track!r} != requested {config.track_id!r}"
-                elif config.car_id and not track_ids_match(config.car_id, loaded_car):
-                    mismatch = f"car {loaded_car!r} != requested {config.car_id!r}"
-                if mismatch is not None:
-                    # #537: CM served its cached last session. RELAUNCH (bounded) rather than drive
-                    # the wrong line — the next launch kills acs.exe and re-issues the acmanager://
-                    # Quick-Drive URL to the now-running CM, which processes it via single-instance
-                    # IPC without the cold-start auto-resume race that served the stale combo. Only
-                    # the terminal attempt — or skip_launch, which has no launch leg to relaunch —
-                    # FAILs fast at stage="launch", preserving the #535/#532 honest-failure guard so
-                    # the harness never drives a mismatched combo or persists a mislabeled plant.
-                    controller.close()
-                    controller = None
-                    last_launch_error = (
-                        f"loaded {mismatch} — Content Manager launched a cached session"
+            mismatch = loaded_combo_mismatch(
+                config, verify_track(config) if verify_track is not None else None
+            )
+            if mismatch is not None:
+                # #537: CM served its cached last session. RELAUNCH (bounded) rather than drive
+                # the wrong line — the next launch kills acs.exe and re-issues the acmanager://
+                # Quick-Drive URL to the now-running CM, which processes it via single-instance
+                # IPC without the cold-start auto-resume race that served the stale combo. Only
+                # the terminal attempt — or skip_launch, which has no launch leg to relaunch —
+                # FAILs fast at stage="launch", preserving the #535/#532 honest-failure guard so
+                # the harness never drives a mismatched combo or persists a mislabeled plant.
+                controller.close()
+                controller = None
+                last_launch_error = f"loaded {mismatch} — Content Manager launched a cached session"
+                if attempt_idx < attempts - 1 and not config.skip_launch:
+                    _log(
+                        f"track/car guard: {mismatch} (CM cached session) — relaunching "
+                        f"(attempt {attempt_idx + 2}/{attempts})"
                     )
-                    if attempt_idx < attempts - 1 and not config.skip_launch:
-                        _log(
-                            f"track/car guard: {mismatch} (CM cached session) — relaunching "
-                            f"(attempt {attempt_idx + 2}/{attempts})"
-                        )
-                        continue
-                    return AutoDriveReport(
-                        ok=False,
-                        stage="launch",
-                        launched=not config.skip_launch,
-                        hijacked=True,
-                        setup_requested=setup_requested,
-                        setup_applied=setup_applied,
-                        setup_ack=setup_ack,
-                        error=(
-                            f"loaded {mismatch} — Content Manager launched a cached session; "
-                            f"still mismatched after {attempts} launch attempt(s) (the harness "
-                            "will not drive the requested line on a different combo or persist a "
-                            "mislabeled plant)"
-                        ),
-                        **identity,
-                    )
+                    continue
+                return AutoDriveReport(
+                    ok=False,
+                    stage="launch",
+                    launched=not config.skip_launch,
+                    hijacked=True,
+                    setup_requested=setup_requested,
+                    setup_applied=setup_applied,
+                    setup_ack=setup_ack,
+                    error=(
+                        f"loaded {mismatch} — Content Manager launched a cached session; "
+                        f"still mismatched after {attempts} launch attempt(s) (the harness "
+                        "will not drive the requested line on a different combo or persist a "
+                        "mislabeled plant)"
+                    ),
+                    **identity,
+                )
             break
         if config.skip_launch:
             break
@@ -610,6 +659,21 @@ async def run_auto_drive(
                 stage="launch",
                 launched=False,
                 error=last_launch_error or "sim never reached LIVE",
+                **identity,
+            )
+        if last_launch_error:
+            # The most recent attempt failed at launch (never reached LIVE) or re-served a cached
+            # session — report that, not a generic hijack failure, so the evidence bundle points at
+            # the real subsystem (#537 Codex P2). Cleared on every successful launch above, so a
+            # true hijack failure (launch OK, no controller) still reads as stage="hijack" below.
+            return AutoDriveReport(
+                ok=False,
+                stage="launch",
+                launched=not config.skip_launch,
+                setup_requested=setup_requested,
+                setup_applied=setup_applied,
+                setup_ack=setup_ack,
+                error=last_launch_error,
                 **identity,
             )
         return AutoDriveReport(

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -535,10 +535,49 @@ async def run_auto_drive(
             # relaunch that reaches LIVE but fails to hijack must read as stage="hijack", while one
             # that never reaches LIVE (or re-serves a cached session) reads as stage="launch".
             last_launch_error = ""
+        # Session-identity gateway (#532/#537). CM sometimes serves its cached last session instead
+        # of the requested preset. verify_track reads the loaded (track, car) from acpmf_static — a
+        # STATIC page AC populates at session load — so it needs neither the setup verify nor the
+        # hijack. Check it ONCE here, before both, so the "when" is deterministic (a single source
+        # of truth for session validity, not contingent on whether a cached session's fuel
+        # coincidentally matches the requested setup) and neither the setup verify nor the hijack
+        # ever runs against a wrong session. On a positive mismatch, RELAUNCH (bounded): the next
+        # launch kills acs.exe and re-issues the acmanager:// Quick-Drive URL to the now-running CM,
+        # which processes it via single-instance IPC without the cold-start auto-resume race that
+        # served the stale combo. Only the terminal attempt — or skip_launch, which has no launch
+        # leg to relaunch — FAILs fast at stage="launch", preserving the #535/#532 honest guard so
+        # the harness never drives a mismatched combo or persists a mislabeled plant. A missing/
+        # unreadable identity is "cannot confirm" (loaded_combo_mismatch returns None) → proceed.
+        mismatch = loaded_combo_mismatch(
+            config, verify_track(config) if verify_track is not None else None
+        )
+        if mismatch is not None:
+            last_launch_error = f"loaded {mismatch} — Content Manager launched a cached session"
+            if attempt_idx < attempts - 1 and not config.skip_launch:
+                _log(
+                    f"track/car guard: {mismatch} (CM cached session) — relaunching "
+                    f"(attempt {attempt_idx + 2}/{attempts})"
+                )
+                continue
+            return AutoDriveReport(
+                ok=False,
+                stage="launch",
+                launched=not config.skip_launch,
+                setup_requested=setup_requested,
+                setup_applied=setup_applied,
+                error=(
+                    f"loaded {mismatch} — Content Manager launched a cached session; "
+                    f"still mismatched after {attempts} launch attempt(s) (the harness "
+                    "will not drive the requested line on a different combo or persist a "
+                    "mislabeled plant)"
+                ),
+                **identity,
+            )
         # The setup is BAKED at launch (AC only applies setups at spawn; the WS load is gated shut
         # for an autonomous car). Verify it BEFORE the hijack — the fuel read needs no hijack, and
         # a wrong setup must fail the run before it drives (#459 Part A). On a relaunch the launch
-        # leg re-bakes, so this re-verifies each attempt.
+        # leg re-bakes, so this re-verifies each attempt. The identity gateway above has already
+        # confirmed the correct session, so a setup failure here is a genuine setup problem.
         if config.setup:
             if apply_setup is None:
                 return AutoDriveReport(
@@ -565,29 +604,6 @@ async def run_auto_drive(
             ok_setup, detail = verify_setup_ack(setup_ack, setup_requested)
             setup_applied = ok_setup
             if not ok_setup:
-                # #537: a cached wrong session (CM served its last session) ALSO fails setup
-                # verification — its fuel won't match the requested setup. Setup is verified before
-                # the post-hijack track guard, so without this a --setup run would abort at
-                # stage="setup" on the very first cached session and never consume the retry budget.
-                # If the loaded combo is the wrong one, relaunch (bounded) like the post-hijack
-                # guard so setup A/B runs get the same #537 retry; a genuine setup failure on the
-                # CORRECT combo still fails fast at stage="setup" (combo_mismatch is None → skip).
-                combo_mismatch = loaded_combo_mismatch(
-                    config, verify_track(config) if verify_track is not None else None
-                )
-                if (
-                    combo_mismatch is not None
-                    and attempt_idx < attempts - 1
-                    and not config.skip_launch
-                ):
-                    last_launch_error = (
-                        f"setup verify failed on a cached session ({combo_mismatch}): {detail}"
-                    )
-                    _log(
-                        f"setup guard: {combo_mismatch} (CM cached session — setup fuel mismatch) "
-                        f"— relaunching (attempt {attempt_idx + 2}/{attempts})"
-                    )
-                    continue
                 return AutoDriveReport(
                     ok=False,
                     stage="setup",
@@ -595,59 +611,11 @@ async def run_auto_drive(
                     setup_requested=setup_requested,
                     setup_applied=False,
                     setup_ack=setup_ack,
-                    error=(
-                        f"setup not applied: {detail}"
-                        + (
-                            f" (Content Manager served a cached session: {combo_mismatch}; still "
-                            f"mismatched after {attempts} launch attempt(s))"
-                            if combo_mismatch is not None
-                            else ""
-                        )
-                    ),
+                    error=f"setup not applied: {detail}",
                     **identity,
                 )
         controller = hijack(config)
         if controller is not None:
-            # Guard: CM sometimes launches its cached last session instead of the requested
-            # preset (#532 rig-found). Driving the requested line on a different track — or
-            # persisting a plant artifact under the requested car when a DIFFERENT car is loaded —
-            # is a guaranteed corruption, so verify the loaded (track, car) before driving.
-            mismatch = loaded_combo_mismatch(
-                config, verify_track(config) if verify_track is not None else None
-            )
-            if mismatch is not None:
-                # #537: CM served its cached last session. RELAUNCH (bounded) rather than drive
-                # the wrong line — the next launch kills acs.exe and re-issues the acmanager://
-                # Quick-Drive URL to the now-running CM, which processes it via single-instance
-                # IPC without the cold-start auto-resume race that served the stale combo. Only
-                # the terminal attempt — or skip_launch, which has no launch leg to relaunch —
-                # FAILs fast at stage="launch", preserving the #535/#532 honest-failure guard so
-                # the harness never drives a mismatched combo or persists a mislabeled plant.
-                controller.close()
-                controller = None
-                last_launch_error = f"loaded {mismatch} — Content Manager launched a cached session"
-                if attempt_idx < attempts - 1 and not config.skip_launch:
-                    _log(
-                        f"track/car guard: {mismatch} (CM cached session) — relaunching "
-                        f"(attempt {attempt_idx + 2}/{attempts})"
-                    )
-                    continue
-                return AutoDriveReport(
-                    ok=False,
-                    stage="launch",
-                    launched=not config.skip_launch,
-                    hijacked=True,
-                    setup_requested=setup_requested,
-                    setup_applied=setup_applied,
-                    setup_ack=setup_ack,
-                    error=(
-                        f"loaded {mismatch} — Content Manager launched a cached session; "
-                        f"still mismatched after {attempts} launch attempt(s) (the harness "
-                        "will not drive the requested line on a different combo or persist a "
-                        "mislabeled plant)"
-                    ),
-                    **identity,
-                )
             break
         if config.skip_launch:
             break


### PR DESCRIPTION
## What

Addresses **#537** (AC #2 delivered + CI-tested; **AC #1 is rig-gated and pending live verification** — see below, so this PR does **not** auto-close the issue). When Content Manager (CM) launches its **cached last session** instead of the requested preset (the repro: `auto_drive --track magione`, CM resumed Spa), the harness now **relaunches (bounded)** until the requested track loads, rather than aborting the whole run on the first mismatch.

## Root cause

`run_auto_drive`'s track/car guard (shipped in PR #535 for #532) read `acpmf_static.track` after the hijack landed and **FAILed fast at `stage="launch"`** the instant `loaded != requested`. But a `max_launches` retry budget (default 5) and the per-attempt relaunch loop (`for _ in range(attempts)`) already existed *above* that guard — the mismatch branch just `return`ed instead of re-entering it. So a single transient CM cached-session hit killed the run with no retry.

## Fix (`tools/ac_harness/auto_drive.py`)

On a track/car mismatch: close the controller and **`continue` the retry loop** (relaunch) while budget remains and not `skip_launch`. Each relaunch kills `acs.exe` and re-issues the `acmanager://race/quick?presetFile=…` URL to the now-running CM, which processes it via single-instance IPC **without the cold-start auto-resume race** that served the stale combo (the #537 hypothesis: "CM auto-starting the previous Quick Drive before the URL is processed"). Only the **terminal attempt** — or `skip_launch`, which has no launch leg to relaunch — FAILs fast at `stage="launch"`, preserving the #535/#532 honest-failure guard so the harness **never drives a mismatched combo or persists a mislabeled plant**.

## Acceptance criteria

- [x] **AC #2** — GIVEN a transient CM cache of a different session, WHEN the harness launches, THEN it relaunches (bounded) until the correct track loads rather than driving the wrong line. *(implemented + CI-tested)*
- [ ] **AC #1** — `acpmf_static.track` reads the requested track for **two distinct tracks back-to-back** (magione then spa) with no manual CM interaction. *(rig-gated; live verification pending — see below)*

## Tests

- `test_run_auto_drive_relaunches_on_track_mismatch_then_drives` — transient mismatch (spa→magione) relaunches once and drives the correct session; mismatched controller released.
- `test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches` — a persistent mismatch is **bounded** by `max_launches` (no infinite relaunch), FAILs at `stage="launch"`, and never drives.
- Existing `#535` fail-fast guards (`skip_launch`) stay green.

`make ci-fast`: green locally except one macOS-homebrew env gap (`_tkinter` missing → `test_rig_launcher_theme`, unrelated to this diff; identical on the main venv). GitHub CI is the authoritative gate.

## Live verification (rig-gated — BLOCKED, tracked on #537)

AC #1 requires the real Assetto Corsa rig (`AG_PC`, Tailscale `pc` / `100.75.251.87`) to prove two tracks load back-to-back. This session runs on macOS (`epam-m5pro`), and rig SSH auth currently fails — `ssh arsen@100.75.251.87` → `Permission denied (publickey)` — even though the documented `mac-to-ag-pc` key was authorized as of the 2026-06-29 handoff (the rig's `authorized_keys` has evidently been reset since). Restoring it is an operator/access-control action, not something this session can (or should) do autonomously.

**Exact unblocker (run on the rig once SSH is restored, or by the operator directly):**
```
python -m tools.ac_harness.auto_drive --car ks_audi_r8_lms --track magione   # then confirm report.json track_id==magione and acpmf_static.track==magione
python -m tools.ac_harness.auto_drive --car ks_audi_r8_lms --track spa       # back-to-back, no manual CM interaction; confirm spa loads
```
Use a non-extended-physics car (`ks_audi_r8_lms`) on stock surfaces per the #277 carcsw gotcha.

Refs #537 #535 #532 #528 #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)