### PR TITLE
feat(harness): #533 per-car FFB gain auto-calibration (finalFF clipping -> user_ff.ini)

### DIFF
--- a/tests/test_ac_harness_ffb_calibrate.py
+++ b/tests/test_ac_harness_ffb_calibrate.py
@@ -1,0 +1,370 @@
+"""Pure unit tests for per-car FFB gain auto-calibration (issue #533).
+
+Exercise the platform-independent core of ``tools/ac_harness/ffb_calibrate.py`` — the sample
+statistics, the gain recommendation maths, the ``user_ff.ini`` surgical read/write (backup +
+install-tree guard + newline preservation), and the sampling loop (with a fake reader + injected
+clock). No Assetto Corsa, no Windows, no shared memory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.ac_harness.ffb_calibrate import (
+    DEFAULT_GAIN,
+    GAIN_CEIL,
+    GAIN_FLOOR,
+    TARGET_PEAK,
+    CalibrationResult,
+    calibrate_from_samples,
+    collect_final_ff,
+    format_result,
+    parse_user_ff_gain,
+    read_user_ff_text,
+    recommend_gain,
+    resolve_user_ff_ini,
+    set_user_ff_gain,
+    summarize_final_ff,
+    validate_user_ff_write_target,
+    write_user_ff,
+)
+
+
+# --------------------------------------------------------------------------- summarize
+def test_summarize_empty_is_all_zero():
+    obs = summarize_final_ff([])
+    assert obs.sample_count == 0
+    assert obs.peak == 0.0
+    assert obs.clip_fraction == 0.0
+    assert obs.mean_abs == 0.0
+
+
+def test_summarize_peak_and_mean_use_absolute_value():
+    obs = summarize_final_ff([0.2, -0.8, 0.4, -0.6])
+    assert obs.peak == pytest.approx(0.8)
+    assert obs.mean_abs == pytest.approx((0.2 + 0.8 + 0.4 + 0.6) / 4)
+    assert obs.sample_count == 4
+
+
+def test_summarize_clip_fraction_counts_saturated_frames():
+    # 2 of 5 samples at/above the 0.99 threshold.
+    obs = summarize_final_ff([0.5, 0.999, -1.0, 0.3, 0.1], clip_threshold=0.99)
+    assert obs.clip_fraction == pytest.approx(2 / 5)
+
+
+# --------------------------------------------------------------------------- recommend_gain
+def test_recommend_raises_gain_when_peak_below_target():
+    obs = summarize_final_ff([0.45, -0.45, 0.30])  # peak 0.45, no clip
+    rec = recommend_gain(1.0, obs)
+    # 1.0 * 0.90 / 0.45 == 2.0 -> hits the ceiling but is still a raise
+    assert rec.recommended == pytest.approx(min(2.0, TARGET_PEAK / 0.45))
+    assert rec.enough_signal is True
+    assert "raise gain" in rec.reason or "clamped" in rec.reason
+
+
+def test_recommend_reduces_gain_when_clipping():
+    obs = summarize_final_ff([1.0, 1.0, 1.0, 0.99])  # heavy clip, peak 1.0
+    rec = recommend_gain(1.0, obs)
+    assert rec.recommended == pytest.approx(0.9)  # 1.0 * 0.90 / 1.0
+    assert rec.recommended < 1.0
+    assert "reduce gain" in rec.reason
+
+
+def test_recommend_small_trim_when_near_target_no_clip():
+    obs = summarize_final_ff([0.92, -0.90, 0.88])  # peak 0.92, above target, not clipping
+    rec = recommend_gain(1.0, obs)
+    assert rec.recommended == pytest.approx(round(0.90 / 0.92, 3))
+    assert rec.recommended < 1.0
+    assert "trim" in rec.reason
+
+
+def test_recommend_clamps_to_floor_and_flags():
+    obs = summarize_final_ff([1.0] * 10)  # would push gain far down from a huge current
+    rec = recommend_gain(0.1, obs, gain_floor=GAIN_FLOOR, gain_ceil=GAIN_CEIL)
+    assert rec.recommended == GAIN_FLOOR
+    assert rec.clamped is True
+    assert "clamped" in rec.reason
+
+
+def test_recommend_clamps_to_ceiling():
+    obs = summarize_final_ff([0.1, -0.1])  # tiny peak -> huge raise
+    rec = recommend_gain(1.0, obs)
+    assert rec.recommended == GAIN_CEIL
+    assert rec.clamped is True
+
+
+def test_recommend_keeps_gain_when_no_signal():
+    obs = summarize_final_ff([])
+    rec = recommend_gain(1.05, obs)
+    assert rec.recommended == pytest.approx(1.05)
+    assert rec.enough_signal is False
+    assert "insufficient signal" in rec.reason
+
+
+def test_recommend_keeps_gain_when_all_zero_samples():
+    obs = summarize_final_ff([0.0, 0.0, 0.0])
+    rec = recommend_gain(1.0, obs)
+    assert rec.enough_signal is False
+
+
+def test_recommend_rounds_to_three_dp():
+    obs = summarize_final_ff([0.7])  # 0.90/0.70 = 1.2857... -> 1.286
+    rec = recommend_gain(1.0, obs)
+    assert rec.recommended == pytest.approx(1.286)
+
+
+# --------------------------------------------------------------------------- user_ff.ini parse
+_SAMPLE_INI = (
+    "[ks_porsche_911_rsr_2017]\nVALUE=1.053\n\n"
+    "[bmw_m3_gt2]\nVALUE=1.010\n\n"
+    "[ks_mazda_mx5_nd]\nVALUE=1.011\n"
+)
+
+
+def test_parse_gain_reads_named_car():
+    assert parse_user_ff_gain(_SAMPLE_INI, "bmw_m3_gt2") == pytest.approx(1.010)
+    assert parse_user_ff_gain(_SAMPLE_INI, "ks_porsche_911_rsr_2017") == pytest.approx(1.053)
+
+
+def test_parse_gain_missing_car_is_none():
+    assert parse_user_ff_gain(_SAMPLE_INI, "ks_porsche_911_gt3_r_2016") is None
+
+
+def test_parse_gain_section_without_value_is_none():
+    assert parse_user_ff_gain("[car_x]\n; no value here\n", "car_x") is None
+
+
+# ----------------------------------------------------------------- user_ff.ini surgical set
+def test_set_gain_updates_existing_and_preserves_other_cars():
+    updated = set_user_ff_gain(_SAMPLE_INI, "bmw_m3_gt2", 0.925)
+    assert parse_user_ff_gain(updated, "bmw_m3_gt2") == pytest.approx(0.925)
+    # the other two cars are untouched
+    assert parse_user_ff_gain(updated, "ks_porsche_911_rsr_2017") == pytest.approx(1.053)
+    assert parse_user_ff_gain(updated, "ks_mazda_mx5_nd") == pytest.approx(1.011)
+    assert "VALUE=0.925" in updated
+
+
+def test_set_gain_appends_new_section_when_absent():
+    updated = set_user_ff_gain(_SAMPLE_INI, "ks_porsche_911_gt3_r_2016", 0.880)
+    assert "[ks_porsche_911_gt3_r_2016]" in updated
+    assert parse_user_ff_gain(updated, "ks_porsche_911_gt3_r_2016") == pytest.approx(0.880)
+    # pre-existing content preserved
+    assert parse_user_ff_gain(updated, "bmw_m3_gt2") == pytest.approx(1.010)
+
+
+def test_set_gain_appends_to_empty_file():
+    updated = set_user_ff_gain("", "bmw_m3_gt2", 1.0)
+    assert updated == "[bmw_m3_gt2]\nVALUE=1.000\n"
+
+
+def test_set_gain_inserts_value_when_section_has_none():
+    updated = set_user_ff_gain("[car_x]\n", "car_x", 0.5)
+    assert parse_user_ff_gain(updated, "car_x") == pytest.approx(0.5)
+
+
+def test_set_gain_preserves_crlf_newlines():
+    crlf = "[bmw_m3_gt2]\r\nVALUE=1.010\r\n"
+    updated = set_user_ff_gain(crlf, "bmw_m3_gt2", 0.9)
+    assert updated == "[bmw_m3_gt2]\r\nVALUE=0.900\r\n"
+    assert "\n" not in updated.replace("\r\n", "")  # no lone LF introduced
+
+
+def test_set_gain_only_changes_target_line_bytewise():
+    before = _SAMPLE_INI
+    after = set_user_ff_gain(before, "bmw_m3_gt2", 0.925)
+    # exactly one line differs
+    diff = [(a, b) for a, b in zip(before.splitlines(), after.splitlines(), strict=False) if a != b]
+    assert diff == [("VALUE=1.010", "VALUE=0.925")]
+
+
+# --------------------------------------------------------------------------- write-target guard
+def _valid_target(tmp_path: Path) -> Path:
+    cfg = tmp_path / "Assetto Corsa" / "cfg"
+    cfg.mkdir(parents=True)
+    return cfg / "user_ff.ini"
+
+
+def test_validate_accepts_ac_cfg_user_ff(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    assert validate_user_ff_write_target(target).name == "user_ff.ini"
+
+
+def test_validate_rejects_install_tree(tmp_path: Path):
+    bad = tmp_path / "steamapps" / "common" / "assettocorsa" / "user_ff.ini"
+    bad.parent.mkdir(parents=True)
+    with pytest.raises(ValueError, match="must be <AC Documents>"):
+        validate_user_ff_write_target(bad)
+
+
+def test_validate_rejects_wrong_filename(tmp_path: Path):
+    cfg = tmp_path / "Assetto Corsa" / "cfg"
+    cfg.mkdir(parents=True)
+    with pytest.raises(ValueError, match="must be <AC Documents>"):
+        validate_user_ff_write_target(cfg / "race.ini")
+
+
+def test_resolve_user_ff_ini_joins_cfg():
+    assert resolve_user_ff_ini(Path("/x/Assetto Corsa")) == Path("/x/Assetto Corsa/cfg/user_ff.ini")
+
+
+# --------------------------------------------------------------------------- write + backup
+def test_write_creates_file_without_backup_when_absent(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    backup = write_user_ff(target, "[bmw_m3_gt2]\nVALUE=0.900\n")
+    assert backup is None
+    assert target.is_file()
+    assert parse_user_ff_gain(read_user_ff_text(target), "bmw_m3_gt2") == pytest.approx(0.9)
+
+
+def test_write_backs_up_existing(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    target.write_bytes(b"[bmw_m3_gt2]\nVALUE=1.010\n")
+    backup = write_user_ff(target, "[bmw_m3_gt2]\nVALUE=0.900\n")
+    assert backup is not None and backup.name == "user_ff.ini.backup"
+    assert backup.read_bytes() == b"[bmw_m3_gt2]\nVALUE=1.010\n"  # original preserved
+    assert parse_user_ff_gain(read_user_ff_text(target), "bmw_m3_gt2") == pytest.approx(0.9)
+
+
+def test_write_preserves_crlf_bytes(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    write_user_ff(target, "[bmw_m3_gt2]\r\nVALUE=0.900\r\n")
+    assert b"\r\n" in target.read_bytes()
+
+
+def test_write_refuses_bad_target(tmp_path: Path):
+    bad = tmp_path / "assettocorsa" / "user_ff.ini"
+    bad.parent.mkdir(parents=True)
+    with pytest.raises(ValueError):
+        write_user_ff(bad, "x")
+
+
+# --------------------------------------------------------------------------- collect_final_ff loop
+class _FakeClock:
+    """Monotonic clock advancing ``step`` per call; first call returns 0.0."""
+
+    def __init__(self, step: float) -> None:
+        self._t = -step
+        self._step = step
+
+    def __call__(self) -> float:
+        self._t += self._step
+        return self._t
+
+
+class _FakeReader:
+    """Returns scripted finalFF values; ``"torn"`` raises ValueError, exhaustion returns 0.0."""
+
+    def __init__(self, values: list) -> None:
+        self._it = iter(values)
+
+    def read_final_ff(self):
+        try:
+            v = next(self._it)
+        except StopIteration:
+            return 0.0
+        if v == "torn":
+            raise ValueError("torn read")
+        return v
+
+
+def test_collect_samples_for_duration():
+    reader = _FakeReader([0.1, 0.2, -0.3, 0.95, 0.4])
+    samples, meta = collect_final_ff(
+        reader, sample_hz=100, duration_s=0.055, clock=_FakeClock(0.01), sleep=lambda _: None
+    )
+    assert samples == [0.1, 0.2, -0.3, 0.95, 0.4]
+    assert meta.read_ok == 5
+    assert meta.torn_reads == 0
+    assert meta.offset_ok is True
+
+
+def test_collect_skips_torn_and_none_frames():
+    reader = _FakeReader([0.5, "torn", None, 0.9])
+    samples, meta = collect_final_ff(
+        reader, sample_hz=100, duration_s=0.045, clock=_FakeClock(0.01), sleep=lambda _: None
+    )
+    assert samples == [0.5, 0.9]
+    assert meta.torn_reads == 1
+    assert meta.no_physics == 1
+
+
+def test_collect_flags_out_of_range_offset():
+    reader = _FakeReader([0.5, 1.5])
+    samples, meta = collect_final_ff(
+        reader, sample_hz=100, duration_s=0.025, clock=_FakeClock(0.01), sleep=lambda _: None
+    )
+    assert meta.offset_ok is False
+    assert 1.5 in samples
+
+
+def test_collect_honors_stop_event():
+    class _Stop:
+        def is_set(self) -> bool:
+            return True
+
+    reader = _FakeReader([0.5, 0.6])
+    samples, meta = collect_final_ff(
+        reader,
+        sample_hz=100,
+        duration_s=10.0,
+        stop=_Stop(),
+        clock=_FakeClock(0.01),
+        sleep=lambda _: None,
+    )
+    assert samples == []
+    assert meta.read_ok == 0
+
+
+# --------------------------------------------------------------------------- calibrate_from_samples
+def test_calibrate_dry_run_does_not_write(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    result = calibrate_from_samples(
+        [1.0, 1.0, 0.99], car_id="bmw_m3_gt2", user_ff_path=target, write=False
+    )
+    assert isinstance(result, CalibrationResult)
+    assert result.written is False
+    assert not target.exists()
+
+
+def test_calibrate_writes_reduced_gain_on_clipping(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    target.write_bytes(b"[bmw_m3_gt2]\nVALUE=1.000\n")
+    result = calibrate_from_samples(
+        [1.0, 1.0, 1.0, 0.995], car_id="bmw_m3_gt2", user_ff_path=target, write=True
+    )
+    assert result.written is True
+    assert result.backup_path is not None
+    assert result.recommendation.recommended == pytest.approx(0.9)
+    assert parse_user_ff_gain(read_user_ff_text(target), "bmw_m3_gt2") == pytest.approx(0.9)
+
+
+def test_calibrate_uses_default_gain_when_car_absent(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    result = calibrate_from_samples(
+        [0.45, -0.45], car_id="new_car", user_ff_path=target, write=True
+    )
+    assert result.recommendation.current_gain == pytest.approx(DEFAULT_GAIN)
+    assert result.written is True
+
+
+def test_calibrate_does_not_write_without_signal(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    target.write_bytes(b"[bmw_m3_gt2]\nVALUE=1.010\n")
+    result = calibrate_from_samples([], car_id="bmw_m3_gt2", user_ff_path=target, write=True)
+    assert result.written is False
+    # untouched hand-tuned value
+    assert parse_user_ff_gain(read_user_ff_text(target), "bmw_m3_gt2") == pytest.approx(1.010)
+
+
+def test_format_result_contains_key_fields(tmp_path: Path):
+    target = _valid_target(tmp_path)
+    result = calibrate_from_samples(
+        [0.95, 0.99, 1.0], car_id="bmw_m3_gt2", user_ff_path=target, write=False
+    )
+    text = format_result(result)
+    assert "bmw_m3_gt2" in text
+    assert "observed peak" in text
+    assert "recommended VALUE" in text
+    assert "clipping" in text

--- a/tests/test_ac_harness_shared_memory.py
+++ b/tests/test_ac_harness_shared_memory.py
@@ -20,6 +20,9 @@ from tools.ac_harness.shared_memory import (
     GRAPHICS_MIN_BYTES,
     GRAPHICS_PACKET_ID_OFFSET,
     GRAPHICS_STATUS_OFFSET,
+    PHYSICS_FINAL_FF_MIN_BYTES,
+    PHYSICS_FINAL_FF_OFFSET,
+    PHYSICS_MAP_BYTES,
     PHYSICS_MIN_BYTES,
     PHYSICS_PACKET_ID_OFFSET,
     AcGameStatus,
@@ -28,6 +31,7 @@ from tools.ac_harness.shared_memory import (
     PhysicsSnapshot,
     SharedMemoryUnavailable,
     open_shared_memory,
+    parse_final_ff,
     parse_graphics,
     parse_physics,
 )
@@ -278,3 +282,40 @@ def test_detector_validates_constructor_args(kwargs: dict, match: str):
 def test_open_shared_memory_raises_off_windows():
     with pytest.raises(SharedMemoryUnavailable, match="Windows-only"):
         open_shared_memory("acpmf_graphics", 256)
+
+
+# --------------------------------------------------------------------------- finalFF decode (#533)
+def _physics_ff_bytes(final_ff: float, *, size: int = PHYSICS_FINAL_FF_MIN_BYTES) -> bytes:
+    """Build an acpmf_physics buffer carrying finalFF at its documented offset (308)."""
+    buf = bytearray(size)
+    struct.pack_into("<f", buf, PHYSICS_FINAL_FF_OFFSET, final_ff)
+    return bytes(buf)
+
+
+def test_final_ff_constants_are_consistent():
+    # finalFF is the last field the harness decodes; the mapped page must cover it.
+    assert PHYSICS_FINAL_FF_OFFSET == 308
+    assert PHYSICS_FINAL_FF_MIN_BYTES == PHYSICS_FINAL_FF_OFFSET + 4
+    assert PHYSICS_MAP_BYTES >= PHYSICS_FINAL_FF_MIN_BYTES
+
+
+@pytest.mark.parametrize("value", [0.0, 0.25, -0.5, 0.9, 1.0, -1.0])
+def test_parse_final_ff_decodes_at_offset_308(value: float):
+    decoded = parse_final_ff(_physics_ff_bytes(value))
+    assert decoded == pytest.approx(value, abs=1e-6)
+
+
+def test_parse_final_ff_rejects_short_buffer():
+    with pytest.raises(ValueError, match="too short for finalFF"):
+        parse_final_ff(bytes(PHYSICS_FINAL_FF_MIN_BYTES - 1))
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_parse_final_ff_rejects_non_finite(bad: float):
+    with pytest.raises(ValueError, match="non-finite"):
+        parse_final_ff(_physics_ff_bytes(bad))
+
+
+def test_parse_final_ff_does_not_clamp_out_of_range():
+    # A magnitude >1 must be surfaced (evidence the offset is wrong), not silently clamped.
+    assert parse_final_ff(_physics_ff_bytes(2.5)) == pytest.approx(2.5, abs=1e-6)

--- a/tools/ac_harness/ffb_calibrate.py
+++ b/tools/ac_harness/ffb_calibrate.py
@@ -1,0 +1,634 @@
+"""Per-car FFB gain auto-calibration (issue #533).
+
+Assetto Corsa stores a **per-car force-feedback gain** in
+``Documents/Assetto Corsa/cfg/user_ff.ini`` as ``[car_id]  VALUE=x.xxx`` — one multiplier per car.
+Today it is trimmed by hand in-seat by watching the in-game FFB app for **clipping** (the force
+pinned at ±1.0). ``acpmf_physics.finalFF`` (−1..1) is that exact force, so clipping is directly
+measurable and the trim can be made objective and automatic:
+
+    drive the car flat-out for ≥1 lap → sample ``finalFF`` at ~100 Hz → measure peak + clipping %
+    → recommend the ``VALUE`` that puts peak at ~0.90 with no sustained clip → write it back.
+
+Design split (so CI verifies the maths on any OS with zero Assetto Corsa / Windows):
+
+* **Pure core** — :func:`summarize_final_ff`, :func:`recommend_gain`, and the ``user_ff.ini``
+  read/write helpers (:func:`parse_user_ff_gain`, :func:`set_user_ff_gain`, :func:`write_user_ff`).
+  Unit-tested with synthetic sample lists and in-memory INI text.
+* **Rig-only** — :func:`collect_final_ff` (the ~100 Hz sampling loop; testable with a fake reader +
+  injected clock) and the CLI, which composes on ``tools.ac_harness.auto_drive`` to actually drive.
+
+Safety invariants (mirrors the ``race.ini`` write guard in ``auto_drive``):
+
+* The ONLY file ever written is ``<AC Documents>/Assetto Corsa/cfg/user_ff.ini`` (validated by
+  :func:`validate_user_ff_write_target`) plus its sibling ``.backup`` — **never** the AC/CSP install
+  tree. A pre-write backup is always taken.
+* Every other car's entry, comments, and the file's newline style are preserved byte-for-byte
+  (the preserve-manual-work invariant): only the target car's ``VALUE`` line changes.
+* Recommended gains are floor/ceiling-clamped, and a non-finite ``finalFF`` (torn read / wrong
+  offset) is rejected upstream in :func:`shared_memory.parse_final_ff` rather than averaged in.
+
+CLI::
+
+    # drive + calibrate (composes on auto_drive's ggv flat-out driver):
+    python -m tools.ac_harness.ffb_calibrate --car ks_porsche_911_gt3_r_2016 --track spa
+    # sample a session that is already live (operator- or peer-driven), don't launch:
+    python -m tools.ac_harness.ffb_calibrate --car bmw_m3_gt2 --attach --seconds 120
+    # preview only, never touch user_ff.ini:
+    python -m tools.ac_harness.ffb_calibrate --car bmw_m3_gt2 --attach --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.ac_harness.shared_memory import PHYSICS_FINAL_FF_OFFSET
+
+# ---------------------------------------------------------------------------
+# Calibration constants (all overridable on the CLI).
+# ---------------------------------------------------------------------------
+#: |finalFF| at or above this counts the frame as clipping. finalFF saturates at ±1.0; 0.99 keeps a
+#: hair of margin off the exact rail so a value quantised just below 1.0 still reads as clipped.
+CLIP_THRESHOLD = 0.99
+#: Target peak |finalFF| the recommended gain aims for — full wheel range with headroom, no clip.
+TARGET_PEAK = 0.90
+#: Fraction of samples allowed at/above CLIP_THRESHOLD before the recommendation is forced to reduce
+#: gain ("no sustained clip"). A brief kerb strike is fine; a lap spent on the rail is not.
+CLIP_TOLERANCE = 0.01
+#: Hard clamps on the written multiplier — AC per-car VALUEs sit near 1.0 (hand-tuned 1.01–1.05); a
+#: recommendation outside this band means something is wrong (bad signal), so clamp and flag it.
+GAIN_FLOOR = 0.30
+GAIN_CEIL = 2.0
+#: The AC default when a car has no user_ff.ini entry yet (100 % of the computed physics force).
+DEFAULT_GAIN = 1.0
+#: Sampling rate for the finalFF collector (~physics-adjacent; finer than needed but cheap).
+SAMPLE_HZ = 100
+#: Default sampling window for --attach mode (drive mode samples for the whole auto_drive drive).
+DEFAULT_ATTACH_SECONDS = 120.0
+
+_SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+_VALUE_KEY_RE = re.compile(r"^\s*VALUE\s*=", re.IGNORECASE)
+_VALUE_LINE_RE = re.compile(r"^\s*VALUE\s*=\s*(.+?)\s*$", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Pure core — statistics + gain recommendation.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class FfbObservation:
+    """Summary statistics of a ``finalFF`` sample window."""
+
+    sample_count: int
+    peak: float  # max |finalFF| observed
+    clip_fraction: float  # fraction of samples with |finalFF| >= clip_threshold
+    mean_abs: float  # mean |finalFF| (drive intensity sanity signal)
+    clip_threshold: float
+
+
+@dataclass(frozen=True)
+class GainRecommendation:
+    """A recommended ``user_ff.ini`` VALUE plus the reasoning and guard state."""
+
+    current_gain: float
+    recommended: float
+    reason: str
+    clamped: bool
+    enough_signal: bool
+
+
+def summarize_final_ff(
+    samples: Sequence[float], *, clip_threshold: float = CLIP_THRESHOLD
+) -> FfbObservation:
+    """Reduce a ``finalFF`` sample list to peak / clip-fraction / mean-abs (pure)."""
+    n = len(samples)
+    if n == 0:
+        return FfbObservation(0, 0.0, 0.0, 0.0, clip_threshold)
+    mags = [abs(s) for s in samples]
+    peak = max(mags)
+    clipped = sum(1 for m in mags if m >= clip_threshold)
+    return FfbObservation(
+        sample_count=n,
+        peak=peak,
+        clip_fraction=clipped / n,
+        mean_abs=sum(mags) / n,
+        clip_threshold=clip_threshold,
+    )
+
+
+def recommend_gain(
+    current_gain: float,
+    obs: FfbObservation,
+    *,
+    target_peak: float = TARGET_PEAK,
+    clip_tolerance: float = CLIP_TOLERANCE,
+    gain_floor: float = GAIN_FLOOR,
+    gain_ceil: float = GAIN_CEIL,
+) -> GainRecommendation:
+    """Recommend the ``user_ff.ini`` VALUE putting peak at ``target_peak`` with no sustained clip.
+
+    ``finalFF`` already includes the current gain, so peak scales ~linearly with it: to move the
+    observed ``peak`` onto ``target_peak`` the multiplier scales by ``target_peak / peak``. When the
+    signal is clipping, ``peak`` is capped near 1.0 and so *underestimates* the true force — the
+    resulting gain is an **upper bound**: a guaranteed reduction that may need a second
+    pass to fully converge (surfaced in ``reason`` and via ``clip_fraction``). The result is rounded
+    to 3 dp (AC's VALUE precision) and clamped to ``[gain_floor, gain_ceil]``.
+    """
+    if obs.sample_count == 0 or obs.peak <= 0.0:
+        return GainRecommendation(
+            current_gain=current_gain,
+            recommended=round(current_gain, 3),
+            reason="insufficient signal (no non-zero finalFF samples) — kept current gain",
+            clamped=False,
+            enough_signal=False,
+        )
+
+    raw = current_gain * (target_peak / obs.peak)
+    clamped = False
+    if raw < gain_floor:
+        raw, clamped = gain_floor, True
+    elif raw > gain_ceil:
+        raw, clamped = gain_ceil, True
+    recommended = round(raw, 3)
+
+    clip_pct = obs.clip_fraction * 100.0
+    tol_pct = clip_tolerance * 100.0
+    if obs.clip_fraction > clip_tolerance:
+        reason = (
+            f"clipping {clip_pct:.1f}% of samples (> {tol_pct:.1f}% tolerance) — reduce gain; "
+            f"peak underestimates true force while clipped, so re-run to confirm convergence"
+        )
+    elif obs.peak < target_peak:
+        reason = f"peak {obs.peak:.3f} below target {target_peak:.2f} — raise gain for full range"
+    else:
+        reason = f"peak {obs.peak:.3f} near target {target_peak:.2f} — small trim"
+    if clamped:
+        reason += f" [clamped to [{gain_floor}, {gain_ceil}]]"
+    return GainRecommendation(
+        current_gain=current_gain,
+        recommended=recommended,
+        reason=reason,
+        clamped=clamped,
+        enough_signal=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure core — user_ff.ini parse / surgical update / write-target guard.
+# ---------------------------------------------------------------------------
+def format_gain(value: float) -> str:
+    """Format a gain as AC writes it in user_ff.ini (3 decimal places)."""
+    return f"{value:.3f}"
+
+
+def parse_user_ff_gain(text: str, car_id: str) -> float | None:
+    """Return the current ``VALUE`` for ``car_id``, or ``None`` if absent/unparseable."""
+    current: str | None = None
+    for line in text.splitlines():
+        section = _SECTION_RE.match(line)
+        if section:
+            current = section.group(1).strip()
+            continue
+        if current == car_id:
+            m = _VALUE_LINE_RE.match(line)
+            if m:
+                try:
+                    return float(m.group(1))
+                except ValueError:
+                    return None
+    return None
+
+
+def _trailing_eol(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def set_user_ff_gain(text: str, car_id: str, value: float) -> str:
+    """Return ``text`` with car ``car_id``'s ``VALUE`` set to ``value``, preserving everything else.
+
+    Surgical (preserve-manual-work invariant): only the target car's ``VALUE`` line is replaced (or
+    inserted); every other car's entry, comment, blank line, and the file's newline style are kept
+    byte-for-byte. If ``car_id`` has no section, a new ``[car_id]`` section is appended.
+    """
+    value_str = format_gain(value)
+    eol = "\r\n" if "\r\n" in text else "\n"
+    lines = text.splitlines(keepends=True)
+
+    header_idx: int | None = None
+    for i, line in enumerate(lines):
+        m = _SECTION_RE.match(line)
+        if m and m.group(1).strip() == car_id:
+            header_idx = i
+            break
+
+    if header_idx is None:
+        body = "".join(lines)
+        if body and not body.endswith("\n"):
+            body += eol
+        separator = (
+            eol if body.strip() else ""
+        )  # blank line before a new section in a non-empty file
+        return f"{body}{separator}[{car_id}]{eol}VALUE={value_str}{eol}"
+
+    # Scan the target section (header+1 .. next header / EOF) for an existing VALUE line.
+    value_idx: int | None = None
+    for j in range(header_idx + 1, len(lines)):
+        if _SECTION_RE.match(lines[j]):
+            break
+        if value_idx is None and _VALUE_KEY_RE.match(lines[j]):
+            value_idx = j
+
+    if value_idx is not None:
+        line_eol = _trailing_eol(lines[value_idx]) or eol
+        lines[value_idx] = f"VALUE={value_str}{line_eol}"
+    else:
+        if not _trailing_eol(lines[header_idx]):
+            lines[header_idx] = lines[header_idx] + eol
+        lines.insert(header_idx + 1, f"VALUE={value_str}{eol}")
+    return "".join(lines)
+
+
+def validate_user_ff_write_target(path: Path) -> Path:
+    """Return ``path`` only when it is ``<AC Documents>/Assetto Corsa/cfg/user_ff.ini``.
+
+    Mirrors ``auto_drive.validate_race_ini_write_target``: the calibrator must NEVER write into the
+    AC/CSP install tree, only the user-data ``cfg/user_ff.ini``. Raises :class:`ValueError` else.
+    """
+    logical = path.absolute()
+    if (
+        logical.name.lower() != "user_ff.ini"
+        or logical.parent.name.lower() != "cfg"
+        or logical.parent.parent.name.lower() != "assetto corsa"
+    ):
+        raise ValueError(
+            "user_ff.ini write target must be <AC Documents>/Assetto Corsa/cfg/user_ff.ini: "
+            f"{logical}"
+        )
+    return logical
+
+
+def resolve_user_ff_ini(ac_user_dir: Path) -> Path:
+    """``<ac_user_dir>/cfg/user_ff.ini`` (pure path join; existence not required)."""
+    return ac_user_dir / "cfg" / "user_ff.ini"
+
+
+def read_user_ff_text(path: Path) -> str:
+    """Read user_ff.ini text (empty string if it does not exist yet), newline-preserving.
+
+    Reads via bytes (not ``read_text``) so the exact CRLF/LF bytes survive: ``read_text`` does
+    universal-newline translation that would collapse the file's CRLFs, and its ``newline`` kwarg
+    only exists on Python 3.13+.
+    """
+    if not path.is_file():
+        return ""
+    return path.read_bytes().decode("utf-8", "surrogateescape")
+
+
+def write_user_ff(path: Path, text: str, *, backup_suffix: str = ".backup") -> Path | None:
+    """Atomically write ``text`` to the validated user_ff.ini, backing up any existing file first.
+
+    Returns the backup path, or ``None`` when there was no pre-existing file to back up. Only ever
+    writes ``user_ff.ini`` and its sibling ``.backup`` (target validated).
+    """
+    target = validate_user_ff_write_target(path)
+    backup_path: Path | None = None
+    if target.is_file():
+        backup_path = target.with_name(target.name + backup_suffix)
+        backup_path.write_bytes(target.read_bytes())
+    tmp = target.with_name(f"{target.name}.tmp-{os.getpid()}")
+    # Write via bytes so the exact CRLF/LF bytes embedded in ``text`` survive (no translation, and
+    # no dependency on write_text's 3.13-only ``newline`` kwarg).
+    tmp.write_bytes(text.encode("utf-8", "surrogateescape"))
+    os.replace(tmp, target)
+    return backup_path
+
+
+# ---------------------------------------------------------------------------
+# Rig sampler — testable with a fake reader + injected clock (loop logic is pure).
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class SampleMeta:
+    """Bookkeeping from a :func:`collect_final_ff` run."""
+
+    read_ok: int
+    torn_reads: int  # frames where parse_final_ff raised (short/non-finite) — skipped
+    no_physics: int  # frames where read_final_ff returned None (physics unmapped)
+    elapsed_s: float
+    offset_ok: bool  # every sample had |finalFF| <= 1 + eps (validates PHYSICS_FINAL_FF_OFFSET)
+
+
+class _FinalFfReader:  # pragma: no cover - structural Protocol-ish; real impl is SharedMemoryReader
+    def read_final_ff(self) -> float | None: ...
+
+
+def collect_final_ff(
+    reader: _FinalFfReader,
+    *,
+    sample_hz: float = SAMPLE_HZ,
+    duration_s: float = DEFAULT_ATTACH_SECONDS,
+    stop: object | None = None,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+    offset_eps: float = 1e-3,
+) -> tuple[list[float], SampleMeta]:
+    """Sample ``reader.read_final_ff()`` at ~``sample_hz`` for ``duration_s`` (or until ``stop``).
+
+    Duration-based on purpose: AC only counts VALID laps in ``completedLaps`` (a kerb clip
+    invalidates a lap), so a lap counter is an unreliable stop condition here — a fixed flat-out
+    window that spans ≥1 lap is both simpler and more robust for capturing peak/clip. Torn reads
+    (:class:`ValueError` from the parser) and unmapped-physics frames (``None``) are counted and
+    skipped, never mixed into the samples. ``stop`` (if given) is anything with ``.is_set()``.
+    """
+    interval = 1.0 / sample_hz if sample_hz > 0 else 0.0
+    samples: list[float] = []
+    torn = 0
+    no_phys = 0
+    offset_ok = True
+    t0 = clock()
+    while True:
+        now = clock()
+        if now - t0 >= duration_s:
+            break
+        if stop is not None and getattr(stop, "is_set", lambda: False)():
+            break
+        try:
+            value = reader.read_final_ff()
+        except ValueError:
+            # Torn read / non-finite (short buffer or wrong offset) — skip, don't also count as
+            # "no physics" (that is reserved for a genuinely unmapped physics page).
+            torn += 1
+            if interval:
+                sleep(interval)
+            continue
+        if value is None:
+            no_phys += 1
+        else:
+            if abs(value) > 1.0 + offset_eps:
+                offset_ok = False
+            samples.append(value)
+        if interval:
+            sleep(interval)
+    return samples, SampleMeta(
+        read_ok=len(samples),
+        torn_reads=torn,
+        no_physics=no_phys,
+        elapsed_s=clock() - t0,
+        offset_ok=offset_ok,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI / orchestration (rig-only).
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class CalibrationResult:
+    """Everything the CLI reports for one car."""
+
+    car_id: str
+    observation: FfbObservation
+    recommendation: GainRecommendation
+    user_ff_path: Path
+    written: bool
+    backup_path: Path | None
+
+
+def format_result(result: CalibrationResult) -> str:
+    """Human-readable one-block summary (also the acceptance-criterion CLI output)."""
+    obs = result.observation
+    rec = result.recommendation
+    lines = [
+        f"FFB calibration — {result.car_id}",
+        f"  samples          : {obs.sample_count} (mean|FF| {obs.mean_abs:.3f})",
+        f"  observed peak    : {obs.peak:.3f}",
+        f"  clipping         : {obs.clip_fraction * 100:.1f}% of samples >= {obs.clip_threshold}",
+        f"  current VALUE    : {format_gain(rec.current_gain)}",
+        f"  recommended VALUE: {format_gain(rec.recommended)}  ({rec.reason})",
+    ]
+    if result.written:
+        lines.append(
+            f"  written VALUE    : {format_gain(rec.recommended)} -> {result.user_ff_path}"
+        )
+        if result.backup_path is not None:
+            lines.append(f"  backup           : {result.backup_path}")
+    else:
+        lines.append(f"  written VALUE    : (dry-run — {result.user_ff_path} unchanged)")
+    return "\n".join(lines)
+
+
+def calibrate_from_samples(
+    samples: Sequence[float],
+    *,
+    car_id: str,
+    user_ff_path: Path,
+    write: bool,
+    clip_threshold: float = CLIP_THRESHOLD,
+    target_peak: float = TARGET_PEAK,
+    clip_tolerance: float = CLIP_TOLERANCE,
+) -> CalibrationResult:
+    """Turn collected ``finalFF`` samples into an observation + recommendation, optionally writing.
+
+    Pure except for the optional file write (guarded/backed-up in :func:`write_user_ff`). The write
+    is skipped when there is not enough signal to recommend a change, so a bad/empty drive never
+    clobbers a hand-tuned VALUE.
+    """
+    obs = summarize_final_ff(samples, clip_threshold=clip_threshold)
+    current = parse_user_ff_gain(read_user_ff_text(user_ff_path), car_id)
+    current_gain = DEFAULT_GAIN if current is None else current
+    rec = recommend_gain(current_gain, obs, target_peak=target_peak, clip_tolerance=clip_tolerance)
+
+    written = False
+    backup_path: Path | None = None
+    if write and rec.enough_signal:
+        updated = set_user_ff_gain(read_user_ff_text(user_ff_path), car_id, rec.recommended)
+        backup_path = write_user_ff(user_ff_path, updated)
+        written = True
+    return CalibrationResult(
+        car_id=car_id,
+        observation=obs,
+        recommendation=rec,
+        user_ff_path=user_ff_path,
+        written=written,
+        backup_path=backup_path,
+    )
+
+
+def _drive_and_sample(  # pragma: no cover - rig-only
+    args: argparse.Namespace, reader_factory: Callable[[], _FinalFfReader]
+) -> tuple[list[float], SampleMeta]:
+    """Compose on ``auto_drive``: launch a ggv flat-out drive in a subprocess, sample concurrently.
+
+    Two independent shared-memory readers is fine — the section is read-only. auto_drive owns the
+    launch/hijack/drive/veto machinery (single-rig, one-driver); this process only reads finalFF.
+    """
+    import subprocess
+    import threading
+
+    stop = threading.Event()
+    cmd = [
+        sys.executable,
+        "-m",
+        "tools.ac_harness.auto_drive",
+        "--car",
+        args.car,
+        "--track",
+        args.track,
+        "--driver",
+        "ggv",
+        "--drive-seconds",
+        str(args.seconds),
+    ]
+    if args.no_setup:
+        cmd.append("--no-setup")
+    print(f"ffb-calibrate: composing on auto_drive: {' '.join(cmd)}", flush=True)
+    proc = subprocess.Popen(cmd)  # noqa: S603 - fixed argv, no shell
+    samples: list[float] = []
+    meta_box: dict[str, SampleMeta] = {}
+
+    def _sample() -> None:
+        reader = reader_factory()
+        try:
+            s, m = collect_final_ff(
+                reader, sample_hz=args.sample_hz, duration_s=args.seconds + 60.0, stop=stop
+            )
+        finally:
+            close = getattr(reader, "close", None)
+            if callable(close):
+                close()
+        samples.extend(s)
+        meta_box["meta"] = m
+
+    worker = threading.Thread(target=_sample, name="finalff-sampler")
+    worker.start()
+    proc.wait()
+    stop.set()
+    worker.join()
+    return samples, meta_box.get("meta", SampleMeta(0, 0, 0, 0.0, True))
+
+
+def _attach_and_sample(  # pragma: no cover - rig-only
+    args: argparse.Namespace, reader_factory: Callable[[], _FinalFfReader]
+) -> tuple[list[float], SampleMeta]:
+    """Sample a session that is already live (operator- or peer-driven) — no launch."""
+    print(
+        f"ffb-calibrate: attaching to live AC, sampling finalFF for {args.seconds:.0f}s "
+        f"(drive the car flat-out now)",
+        flush=True,
+    )
+    reader = reader_factory()
+    try:
+        return collect_final_ff(reader, sample_hz=args.sample_hz, duration_s=args.seconds)
+    finally:
+        close = getattr(reader, "close", None)
+        if callable(close):
+            close()
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Per-car FFB gain auto-calibration from acpmf_physics.finalFF clipping (#533)"
+    )
+    p.add_argument("--car", required=True, help="AC car id, e.g. ks_porsche_911_gt3_r_2016")
+    p.add_argument("--track", help="AC track id (required unless --attach)")
+    p.add_argument(
+        "--attach",
+        action="store_true",
+        help="sample a session already on track instead of launching a drive",
+    )
+    p.add_argument(
+        "--seconds",
+        type=float,
+        default=DEFAULT_ATTACH_SECONDS,
+        help="drive/sample window seconds (must span >=1 flat-out lap)",
+    )
+    p.add_argument("--sample-hz", type=float, default=SAMPLE_HZ, help="finalFF sampling rate")
+    p.add_argument("--target-peak", type=float, default=TARGET_PEAK, help="target peak |finalFF|")
+    p.add_argument(
+        "--clip-threshold", type=float, default=CLIP_THRESHOLD, help="|finalFF| counted as clipping"
+    )
+    p.add_argument(
+        "--clip-tolerance",
+        type=float,
+        default=CLIP_TOLERANCE,
+        help="fraction of clipped samples tolerated before forcing a gain reduction",
+    )
+    p.add_argument("--no-setup", action="store_true", help="pass --no-setup to auto_drive")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="compute + print the recommendation but do NOT write user_ff.ini",
+    )
+    p.add_argument(
+        "--ac-user-dir",
+        type=Path,
+        default=None,
+        help="AC user-data root (Documents/Assetto Corsa; auto-detects OneDrive redirect)",
+    )
+    return p
+
+
+def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only CLI wiring
+    args = _build_arg_parser().parse_args(argv)
+    if not args.attach and not args.track:
+        print("error: --track is required unless --attach is given", file=sys.stderr)
+        return 2
+
+    # Lazy import so the pure core (and its tests) never pull auto_drive's heavier deps.
+    from tools.ac_harness.auto_drive import resolve_ac_user_dir
+    from tools.ac_harness.shared_memory import SharedMemoryReader
+
+    ac_user_dir = resolve_ac_user_dir(args.ac_user_dir)
+    user_ff_path = resolve_user_ff_ini(ac_user_dir)
+    # Fail loud BEFORE driving if the write target is not the AC user-data cfg file.
+    validate_user_ff_write_target(user_ff_path)
+
+    def reader_factory() -> _FinalFfReader:
+        return SharedMemoryReader(with_physics=True)
+
+    sampler = _attach_and_sample if args.attach else _drive_and_sample
+    samples, meta = sampler(args, reader_factory)
+    print(
+        f"ffb-calibrate: collected {meta.read_ok} finalFF samples "
+        f"(torn={meta.torn_reads}, no_physics={meta.no_physics}, {meta.elapsed_s:.0f}s)",
+        flush=True,
+    )
+    if not meta.offset_ok:
+        print(
+            f"ffb-calibrate: WARNING |finalFF| exceeded 1.0 — PHYSICS_FINAL_FF_OFFSET "
+            f"({PHYSICS_FINAL_FF_OFFSET}) may be wrong on this CSP build; NOT writing",
+            file=sys.stderr,
+        )
+        return 1
+    if meta.read_ok == 0:
+        print("ffb-calibrate: no finalFF samples (is AC live and driving?)", file=sys.stderr)
+        return 1
+
+    result = calibrate_from_samples(
+        samples,
+        car_id=args.car,
+        user_ff_path=user_ff_path,
+        write=not args.dry_run,
+        clip_threshold=args.clip_threshold,
+        target_peak=args.target_peak,
+        clip_tolerance=args.clip_tolerance,
+    )
+    print(format_result(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - rig-only CLI wiring
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _repo_root = str(_Path(__file__).resolve().parents[2])
+    if _repo_root not in _sys.path:
+        _sys.path.insert(0, _repo_root)
+    raise SystemExit(_main())

--- a/tools/ac_harness/shared_memory.py
+++ b/tools/ac_harness/shared_memory.py
@@ -41,6 +41,7 @@ offset can be confirmed on this CSP build (see :data:`GRAPHICS_IS_IN_PIT_OFFSET`
 from __future__ import annotations
 
 import argparse
+import math
 import struct
 import sys
 import time
@@ -81,13 +82,27 @@ GRAPHICS_IS_IN_PIT_OFFSET = 160
 # Minimum bytes that must be readable to decode every field above (isInPit + its 4 bytes).
 GRAPHICS_MIN_BYTES = GRAPHICS_IS_IN_PIT_OFFSET + 4  # 164
 
-# acpmf_physics (SPageFilePhysics): the only field used here is the leading packetId,
-# whose stagnation distinguishes a genuinely-live frame from a paused/menu frame that AC
-# left flagged LIVE (AcSharedMemory.cs documents that AC "sometimes doesn't bother setting
-# Status to Pause" and derives pause from packetId stagnation instead).
-#   int packetId @ 0
+# acpmf_physics (SPageFilePhysics): the leading packetId gates liveness — its stagnation
+# distinguishes a genuinely-live frame from a paused/menu frame AC left flagged LIVE
+# (AcSharedMemory.cs documents that AC "sometimes doesn't bother setting Status to Pause" and
+# derives pause from packetId stagnation instead). ``finalFF`` @ 308 is the exact normalized
+# force AC sends to the wheel this frame (−1..1); |finalFF| → 1.0 is FFB clipping (issue #533).
+#
+# finalFF @ 308 follows the standard SPageFilePhysics layout (Kunos SharedFileOut.h, Pack=4):
+#   packetId@0, gas@4, brake@8, fuel@12, gear@16, rpms@20, steerAngle@24, speedKmh@28,
+#   velocity[3]@32, accG[3]@44, wheelSlip[4]@56, wheelLoad[4]@72, wheelsPressure[4]@88,
+#   wheelAngularSpeed[4]@104, tyreWear[4]@120, tyreDirtyLevel[4]@136, tyreCoreTemperature[4]@152,
+#   camberRAD[4]@168, suspensionTravel[4]@184, drs@200, tc@204, heading@208, pitch@212, roll@216,
+#   cgHeight@220, carDamage[5]@224, numberOfTyresOut@244, pitLimiterOn@248, abs@252, kersCharge@256,
+#   kersInput@260, autoShifterOn@264, rideHeight[2]@268, turboBoost@276, ballast@280,
+#   airDensity@284, airTemp@288, roadTemp@292, localAngularVel[3]@296, finalFF@308.
+# The prefix through wheelAngularSpeed[4]@104 is cross-confirmed by racing_telemetry.parse_physics
+# in this repo; the tail to finalFF@308 follows the same struct. The offset is asserted empirically
+# on the rig (|finalFF| ≤ 1 while driving) — see the #533 PR evidence and :func:`parse_final_ff`.
 PHYSICS_PACKET_ID_OFFSET = 0
 PHYSICS_MIN_BYTES = PHYSICS_PACKET_ID_OFFSET + 4  # 4
+PHYSICS_FINAL_FF_OFFSET = 308
+PHYSICS_FINAL_FF_MIN_BYTES = PHYSICS_FINAL_FF_OFFSET + 4  # 312
 
 # Windows named shared-memory objects created by acs.exe. AC creates them in the session
 # namespace as ``Local\<name>``; a bare name resolves to ``Local\`` for processes in the
@@ -100,11 +115,12 @@ SHM_STATIC = "acpmf_static"
 # safe prefix avoids over-mapping while covering every field we read.
 GRAPHICS_MAP_BYTES = 256
 # One consistent physics-page map size that covers EVERY field any reader unpacks from
-# ``acpmf_physics``. ``shared_memory.parse_physics`` here only needs ``packet_id@0`` (4 bytes), but
-# ``racing_telemetry.parse_physics`` unpacks through ``wheelAngularSpeed[4]@104`` (120 bytes); a
-# single page mapped 160 wide keeps the two same-named parsers from disagreeing on buffer size
-# (cross-file trap flagged in review) at negligible cost — it is one mmap view of the same page.
-PHYSICS_MAP_BYTES = 160
+# ``acpmf_physics``. ``parse_physics`` here needs only ``packet_id@0`` (4 bytes),
+# ``racing_telemetry.parse_physics`` unpacks through ``wheelAngularSpeed[4]@104`` (120 bytes), and
+# ``parse_final_ff`` reads ``finalFF@308`` (issue #533). Mapping 320 wide (≥
+# ``PHYSICS_FINAL_FF_MIN_BYTES`` = 312) covers all three off one mmap view of the same page at
+# negligible cost — the real section is multiple KB, so the wider map never over-reads.
+PHYSICS_MAP_BYTES = 320
 # acpmf_static: wide-char (UTF-16LE) strings; ``carModel`` is a 33-char field at byte offset 68 and
 # ``track`` a 33-char field at byte offset 134 (live-verified against a running session:
 # smVersion@0, carModel@68, track@134). Mapping 260 bytes covers both with headroom.
@@ -204,6 +220,33 @@ def parse_physics(buf: bytes) -> PhysicsSnapshot:
         raise ValueError(f"acpmf_physics buffer too short: {len(buf)} < {PHYSICS_MIN_BYTES} bytes")
     packet_id = struct.unpack_from("<i", buf, PHYSICS_PACKET_ID_OFFSET)[0]
     return PhysicsSnapshot(packet_id=packet_id)
+
+
+def parse_final_ff(buf: bytes) -> float:
+    """Decode ``finalFF`` (normalized FFB force, −1..1) from an ``acpmf_physics`` buffer (pure).
+
+    ``finalFF`` is the exact normalized force AC sends to the wheel this frame; a magnitude
+    approaching 1.0 is FFB clipping (the force the physics wants exceeds what the −1..1 channel can
+    carry). ``buf`` must be at least :data:`PHYSICS_FINAL_FF_MIN_BYTES`. Raises :class:`ValueError`
+    on a short buffer or a non-finite value — a NaN/Inf is a torn read or the wrong offset and must
+    surface rather than be silently averaged into a calibration.
+
+    The physical range is [−1, 1]; the decode does **not** clamp. A magnitude comfortably above 1 is
+    evidence the offset is wrong on this build, so callers (and the #533 rig live-probe) can assert
+    ``abs(value) <= 1`` to validate :data:`PHYSICS_FINAL_FF_OFFSET` empirically.
+    """
+    if len(buf) < PHYSICS_FINAL_FF_MIN_BYTES:
+        raise ValueError(
+            f"acpmf_physics buffer too short for finalFF: "
+            f"{len(buf)} < {PHYSICS_FINAL_FF_MIN_BYTES} bytes"
+        )
+    value = struct.unpack_from("<f", buf, PHYSICS_FINAL_FF_OFFSET)[0]
+    if not math.isfinite(value):
+        raise ValueError(
+            f"finalFF is non-finite ({value!r}); offset {PHYSICS_FINAL_FF_OFFSET} suspect "
+            f"(torn read or wrong CSP build)"
+        )
+    return value
 
 
 class DrivingEntryDetector:
@@ -444,6 +487,16 @@ class SharedMemoryReader:  # pragma: no cover - Windows/rig-only; validated via 
         if self._physics is None:
             return None
         return self._physics.read(nbytes)
+
+    def read_final_ff(self) -> float | None:
+        """Read ``finalFF`` (−1..1) off the mapped physics page, or ``None`` if physics is unmapped.
+
+        Reuses the SAME ``acpmf_physics`` view as :meth:`read_physics` (no second OS map): the page
+        is mapped :data:`PHYSICS_MAP_BYTES` wide, which covers :data:`PHYSICS_FINAL_FF_MIN_BYTES`.
+        """
+        if self._physics is None:
+            return None
+        return parse_final_ff(self._physics.read(PHYSICS_FINAL_FF_MIN_BYTES))
 
     def close(self) -> None:
         for section in (self._graphics, self._physics):


### PR DESCRIPTION
## What & why

Closes #533. Automates the last manual FFB step: **per-car gain calibration**.

AC already computes FFB *feel* per car (physics). The *gain* trim (`cfg/user_ff.ini` `[car_id] VALUE=x.xxx`) was tuned by hand in-seat by watching the in-game FFB app for **clipping** (force pinned at ±1.0). `acpmf_physics.finalFF` (−1..1) *is* that exact force, so clipping is directly measurable — the trim becomes objective and automatable.

Pipeline: drive flat-out ≥1 lap → sample `finalFF` at ~100 Hz → measure peak + clip% → recommend the `VALUE` that puts peak at ~0.90 with no sustained clip → write `user_ff.ini`.

## Changes

- **`tools/ac_harness/shared_memory.py`** — decode `finalFF@308` (`parse_final_ff` + `SharedMemoryReader.read_final_ff`); widen the physics map 160→320 B to cover it. Offset cross-checked against `racing_telemetry.parse_physics` (which decodes through `wheelAngularSpeed[4]@104`); NaN/Inf-guarded; decode does **not** clamp so a wrong offset surfaces (callers/rig assert `|value| ≤ 1`).
- **`tools/ac_harness/ffb_calibrate.py`** (new) —
  - *Pure core (CI-tested):* peak / clip% stats; gain recommendation toward `target_peak=0.90`, floor/ceiling-clamped, 3 dp; **surgical** `user_ff.ini` read/write that preserves every other car's entry + the file's newline style byte-for-byte; **backup-before-write**; and a write-target guard mirroring `validate_race_ini_write_target` so it can **only** touch `<AC Documents>/Assetto Corsa/cfg/user_ff.ini` — never the AC/CSP install tree.
  - *Rig-only:* `collect_final_ff` (~100 Hz sampler, torn-read/None-guarded, injectable clock) + CLI composing on `auto_drive` (ggv flat-out), with `--attach` (sample an already-live session) and `--dry-run`.
- **Tests** — `finalFF` decode at offset 308 + 40 pure-core/sampler tests.

## Acceptance (#533)

- [x] `python -m tools.ac_harness.ffb_calibrate --car <car> --track <track>` prints observed peak / clip% and recommended vs written `VALUE`.
- [x] Writes only `user_ff.ini` (with a `.backup`), never the AC/CSP install tree (guard + tests).
- [x] `make ci-fast` green (2666 passed, 73 env skips).
- [ ] **Live-verified on 911 GT3 R + M3 GT2** — running on the rig this session; evidence to follow as a PR comment.

## Non-goals

FFB *feel* (per-car physics, untouched); global gain / MOZA base config (operator-owned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)