### PR TITLE
feat(harness): #532 Part B — per-combo friction-ID plant (uncertainty-aware GGVModel)

### DIFF
--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -388,14 +388,26 @@ def _prior() -> GGVModel:
     return GGVModel(1.5, 0.0, 0.955, 0.0214, 1.1, -0.0117, 0.35, 1.55, ay_cap_g=1.8)
 
 
-def _measured(mu, *, corner_bins, brake_bins, accel_bins, hull_points, ellipse_n=1.3) -> GGVModel:
+def _measured(
+    mu,
+    *,
+    corner_bins,
+    brake_bins,
+    accel_bins,
+    hull_points,
+    ellipse_n=1.3,
+    brake_b0=0.6,  # below the prior (0.955) by default -> does NOT trigger the raise branch
+    brake_b1=0.02,
+    drive_b0=0.7,  # below the prior (1.1) by default
+    drive_b1=-0.01,
+) -> GGVModel:
     return GGVModel(
         mu_lat_g=mu,
         k_aero_lat=0.0,
-        brake_b0_g=1.2,
-        brake_b1=0.03,
-        drive_b0_g=1.3,
-        drive_b1=-0.01,
+        brake_b0_g=brake_b0,
+        brake_b1=brake_b1,
+        drive_b0_g=drive_b0,
+        drive_b1=drive_b1,
         drive_min_g=0.4,
         ellipse_n=ellipse_n,
         provenance={
@@ -423,7 +435,7 @@ def test_ggv_model_roundtrip_and_rejects_nan():
 
 def test_blend_never_raises_lateral_above_prior():
     prior = _prior()
-    # A confidently-measured HIGHER lateral must NOT lift the plant (aero-lateral spins the GT3).
+    # A measured HIGHER lateral must NOT lift the plant (aero-lateral spins the GT3, #259).
     grippier = _measured(1.9, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=200)
     b = blend_ggv_safe(grippier, prior)
     assert b.mu_lat_g == prior.mu_lat_g
@@ -432,13 +444,37 @@ def test_blend_never_raises_lateral_above_prior():
     assert b.provenance["blend_source"]["lateral"] == "prior"
 
 
-def test_blend_lowers_lateral_for_confident_weaker_car():
+def test_blend_pins_lateral_to_prior_even_when_measured_lower():
+    # A conservative handshake under-measures the lateral limit, so a measured value BELOW the prior
+    # is a lower bound, not a weaker car — it must NOT lower the plant (that would regress the
+    # reference car). Lateral is pinned to the prior regardless of the measured value.
     prior = _prior()
-    weaker = _measured(1.15, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=200)
-    b = blend_ggv_safe(weaker, prior)
-    assert abs(b.mu_lat_g - 1.15) < 1e-9  # weaker car correctly identified
-    assert b.provenance["blend_source"]["lateral"] == "measured(<prior)"
-    assert b.provenance["blend_source"]["brake"] == "measured"
+    lower = _measured(1.15, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=200)
+    b = blend_ggv_safe(lower, prior)
+    assert b.mu_lat_g == prior.mu_lat_g  # NOT lowered to 1.15
+    assert b.provenance["blend_source"]["lateral"] == "prior"
+    # The measured lower bound is still recorded (for a future slip-saturation pass).
+    assert b.provenance["measured"]["mu_lat_g"] == 1.15
+
+
+def test_blend_raises_braking_when_measured_confidently_exceeds_prior():
+    # Braking is safely limit-reachable (straight-line): a measured brake curve that dominates the
+    # prior across the covered speeds IS adopted (real evidence of more braking capability).
+    prior = _prior()
+    strong = _measured(
+        1.2,
+        corner_bins=6,
+        brake_bins=6,
+        accel_bins=6,
+        hull_points=200,
+        brake_b0=1.3,
+        brake_b1=0.03,  # > prior (0.955 + 0.0214 v) at both 40 and 180 km/h
+    )
+    b = blend_ggv_safe(strong, prior)
+    assert (b.brake_b0_g, b.brake_b1) == (1.3, 0.03)
+    assert b.provenance["blend_source"]["brake"] == "measured(>prior)"
+    assert b.ax_brake_cap_g == prior.ax_brake_cap_g  # hard cap still kept
+    assert b.mu_lat_g == prior.mu_lat_g  # lateral untouched
 
 
 def test_blend_sparse_bins_fall_back_to_prior():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -416,6 +416,7 @@ def _measured(
             "lat_corner_bins": corner_bins,
             "brake_bins": brake_bins,
             "accel_bins": accel_bins,
+            "brake_fit_valid": True,
             "brake_speed_range_kmh": list(brake_range) if brake_range else None,
             "accel_speed_range_kmh": list(accel_range) if accel_range else None,
             "hull_points": hull_points,
@@ -444,6 +445,7 @@ def test_ggv_model_roundtrip_and_rejects_nan():
         {"ellipse_n": 99.0},
         {"mu_lat_g": 0.0},
         {"k_aero_lat": -0.0001},
+        {"k_aero_lat": 0.0001},
         {"drive_min_g": -0.1},
     ):
         with pytest.raises(ValueError):
@@ -514,7 +516,7 @@ def test_blend_rejects_narrow_longitudinal_support():
     )
     b = blend_ggv_safe(narrow, prior)
     assert b.provenance["blend_gate"]["brake_coverage_ok"] is False
-    assert b.provenance["supported_longitudinal"] == {}
+    assert b.supported_longitudinal == {}
     assert b.ax_brake_max(60.0 / 3.6) == prior.ax_brake_max(60.0 / 3.6)
 
 
@@ -537,6 +539,33 @@ def test_supported_brake_gain_tapers_to_prior_and_never_extrapolates():
     assert b.ax_brake_max(180.0 / 3.6) == prior.ax_brake_max(180.0 / 3.6)
     restored = GGVModel.from_dict(b.to_dict())
     assert restored.ax_brake_max(75.0 / 3.6) == b.ax_brake_max(75.0 / 3.6)
+
+
+def test_supported_override_is_revalidated_on_load_and_not_read_from_provenance():
+    prior = _prior()
+    measured = _measured(
+        1.2,
+        corner_bins=0,
+        brake_bins=5,
+        accel_bins=0,
+        hull_points=100,
+        brake_b0=1.3,
+        brake_b1=0.03,
+        brake_range=(50.0, 100.0),
+    )
+    payload = blend_ggv_safe(measured, prior).to_dict()
+    payload["supported_longitudinal"]["brake"]["b0_g"] = 99.0
+    import pytest
+
+    with pytest.raises(ValueError, match="brake cap"):
+        GGVModel.from_dict(payload)
+
+    # Free-form provenance is never a runtime input, even if an edited artifact inserts a shape
+    # that resembles the old unvalidated override location.
+    clean = prior.to_dict()
+    clean["provenance"] = {"supported_longitudinal": {"brake": {"b0_g": 99.0}}}
+    restored = GGVModel.from_dict(clean)
+    assert restored.ax_brake_max(75.0 / 3.6) == prior.ax_brake_max(75.0 / 3.6)
 
 
 def test_blend_sparse_bins_fall_back_to_prior():
@@ -581,6 +610,8 @@ def test_ggv_from_telemetry_records_bin_counts():
     assert m.provenance["accel_bins"] >= 2
     assert m.provenance["brake_speed_range_kmh"] == [60.0, 150.0]
     assert m.provenance["accel_speed_range_kmh"] == [60.0, 150.0]
+    assert m.provenance["brake_fit_valid"] is True
+    assert m.provenance["brake_bins_contiguous"] is True
     assert m.provenance["hull_points"] > 0
 
 
@@ -616,8 +647,35 @@ def test_controlled_probe_percentile_is_not_diluted_by_passive_rows():
         )
         rows.extend(
             {"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -1.4, "source": "brake_probe"}
-            for _ in range(8)
+            for _ in range(7)
+        )
+        rows.append(
+            {"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -99.0, "source": "brake_probe"}
         )
     m = ggv_from_telemetry(rows)
     assert m.provenance["brake_probe_bins"] == 2
     assert m.brake_b0_g > 1.3
+    assert m.brake_b0_g < 2.0  # the single 99 g frame is excluded, not treated as p95
+
+
+def test_negative_slope_brake_fit_is_rejected_instead_of_clamped():
+    rows = []
+    for speed, brake_g in ((60.0, 2.0), (100.0, 1.0)):
+        rows.extend({"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -brake_g} for _ in range(40))
+    m = ggv_from_telemetry(rows)
+    assert m.provenance["brake_fit_valid"] is False
+    assert (m.brake_b0_g, m.brake_b1) == (1.0, 0.0)
+    blended = blend_ggv_safe(m, _prior())
+    assert blended.provenance["blend_source"]["brake"] == "prior"
+
+
+def test_disjoint_longitudinal_bins_do_not_claim_continuous_support():
+    rows = []
+    for speed in (50.0, 120.0):
+        rows.extend({"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -1.5} for _ in range(40))
+    m = ggv_from_telemetry(rows)
+    assert m.provenance["brake_bins"] == 2
+    assert m.provenance["brake_bins_contiguous"] is False
+    assert m.provenance["brake_speed_range_kmh"] is None
+    blended = blend_ggv_safe(m, _prior())
+    assert blended.provenance["blend_source"]["brake"] == "prior"

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -12,6 +12,7 @@ import math
 from tools.ac_harness.ggv_profile import (
     CurvatureFeedforwardSteering,
     GGVModel,
+    blend_ggv_safe,
     build_ggv_speed_profile,
     curvature_profile,
     fit_steer_feedforward,
@@ -380,3 +381,100 @@ def test_ggv_speed_profile_from_model_and_aero_raises_apex():
     assert len(v_flat) == len(line)
     assert max(v_aero) >= max(v_flat)  # aero grip lets the constant-radius apex carry more speed
     assert s_aero["qss_laptime_s"] <= s_flat["qss_laptime_s"]  # ...so the lap is no slower
+
+
+# --- #532 Part B: serialization + safe-envelope blend -----------------------
+def _prior() -> GGVModel:
+    return GGVModel(1.5, 0.0, 0.955, 0.0214, 1.1, -0.0117, 0.35, 1.55, ay_cap_g=1.8)
+
+
+def _measured(mu, *, corner_bins, brake_bins, accel_bins, hull_points, ellipse_n=1.3) -> GGVModel:
+    return GGVModel(
+        mu_lat_g=mu,
+        k_aero_lat=0.0,
+        brake_b0_g=1.2,
+        brake_b1=0.03,
+        drive_b0_g=1.3,
+        drive_b1=-0.01,
+        drive_min_g=0.4,
+        ellipse_n=ellipse_n,
+        provenance={
+            "lat_corner_bins": corner_bins,
+            "brake_bins": brake_bins,
+            "accel_bins": accel_bins,
+            "hull_points": hull_points,
+            "bins": {},
+        },
+    )
+
+
+def test_ggv_model_roundtrip_and_rejects_nan():
+    m = _prior()
+    back = GGVModel.from_dict(m.to_dict())
+    for f in ("mu_lat_g", "k_aero_lat", "brake_b0_g", "brake_b1", "ellipse_n", "ay_cap_g"):
+        assert getattr(back, f) == getattr(m, f)
+    import pytest
+
+    with pytest.raises(ValueError):
+        GGVModel.from_dict({**m.to_dict(), "mu_lat_g": float("nan")})
+    with pytest.raises(ValueError):
+        GGVModel.from_dict({k: v for k, v in m.to_dict().items() if k != "brake_b0_g"})
+
+
+def test_blend_never_raises_lateral_above_prior():
+    prior = _prior()
+    # A confidently-measured HIGHER lateral must NOT lift the plant (aero-lateral spins the GT3).
+    grippier = _measured(1.9, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=200)
+    b = blend_ggv_safe(grippier, prior)
+    assert b.mu_lat_g == prior.mu_lat_g
+    assert b.k_aero_lat == 0.0
+    assert b.ay_cap_g == prior.ay_cap_g
+    assert b.provenance["blend_source"]["lateral"] == "prior"
+
+
+def test_blend_lowers_lateral_for_confident_weaker_car():
+    prior = _prior()
+    weaker = _measured(1.15, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=200)
+    b = blend_ggv_safe(weaker, prior)
+    assert abs(b.mu_lat_g - 1.15) < 1e-9  # weaker car correctly identified
+    assert b.provenance["blend_source"]["lateral"] == "measured(<prior)"
+    assert b.provenance["blend_source"]["brake"] == "measured"
+
+
+def test_blend_sparse_bins_fall_back_to_prior():
+    prior = _prior()
+    # Under-covered: too few cornered/brake/accel bins, thin hull -> every curve reverts to prior.
+    sparse = _measured(1.0, corner_bins=0, brake_bins=0, accel_bins=0, hull_points=3)
+    b = blend_ggv_safe(sparse, prior)
+    assert b.mu_lat_g == prior.mu_lat_g
+    assert (b.brake_b0_g, b.brake_b1) == (prior.brake_b0_g, prior.brake_b1)
+    assert (b.drive_b0_g, b.drive_b1) == (prior.drive_b0_g, prior.drive_b1)
+    assert b.ellipse_n == prior.ellipse_n
+    src = b.provenance["blend_source"]
+    assert src == {
+        "lateral": "prior",
+        "brake": "prior",
+        "drive": "prior",
+        "ellipse_n": "prior",
+    }
+
+
+def test_blend_ellipse_reverts_when_hull_thin():
+    prior = _prior()
+    thin = _measured(1.2, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=5, ellipse_n=1.1)
+    b = blend_ggv_safe(thin, prior)
+    assert b.ellipse_n == prior.ellipse_n  # not enough hull -> keep the prior coupling
+    assert b.provenance["blend_source"]["ellipse_n"] == "prior"
+
+
+def test_ggv_from_telemetry_records_bin_counts():
+    rows = []
+    for kmh in range(60, 141, 10):
+        for _ in range(60):
+            rows.append({"speed_kmh": float(kmh), "accg_lat": 1.1, "accg_lon": 0.0})
+            rows.append({"speed_kmh": float(kmh), "accg_lat": 0.0, "accg_lon": -1.0})
+            rows.append({"speed_kmh": float(kmh), "accg_lat": 0.05, "accg_lon": 0.7})
+    m = ggv_from_telemetry(rows)
+    assert m.provenance["brake_bins"] >= 2
+    assert m.provenance["accel_bins"] >= 2
+    assert m.provenance["hull_points"] > 0

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -432,8 +432,15 @@ def test_ggv_model_roundtrip_and_rejects_nan():
     with pytest.raises(ValueError):
         GGVModel.from_dict({k: v for k, v in m.to_dict().items() if k != "brake_b0_g"})
     # Positivity/range gates (Codex P2): a non-positive ellipse_n would crash the ggv path (divide),
-    # a non-positive lateral grip/cap would zero the envelope -> reject, don't construct.
-    for bad in ({"ellipse_n": 0.0}, {"ellipse_n": -1.5}, {"ellipse_n": 99.0}, {"mu_lat_g": 0.0}):
+    # a non-positive lateral grip/cap would zero the envelope, and a negative drive floor can make
+    # the forward speed-profile pass take sqrt of a negative radicand -> reject, don't construct.
+    for bad in (
+        {"ellipse_n": 0.0},
+        {"ellipse_n": -1.5},
+        {"ellipse_n": 99.0},
+        {"mu_lat_g": 0.0},
+        {"drive_min_g": -0.1},
+    ):
         with pytest.raises(ValueError):
             GGVModel.from_dict({**m.to_dict(), **bad})
 
@@ -442,11 +449,12 @@ def test_blend_never_raises_lateral_above_prior():
     prior = _prior()
     # A measured HIGHER lateral must NOT lift the plant (aero-lateral spins the GT3, #259).
     grippier = _measured(1.9, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=200)
-    b = blend_ggv_safe(grippier, prior)
+    b = blend_ggv_safe(grippier, prior, prior_name="custom_prior")
     assert b.mu_lat_g == prior.mu_lat_g
     assert b.k_aero_lat == 0.0
     assert b.ay_cap_g == prior.ay_cap_g
     assert b.provenance["blend_source"]["lateral"] == "prior"
+    assert b.provenance["prior"] == "custom_prior"
 
 
 def test_blend_pins_lateral_to_prior_even_when_measured_lower():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -541,6 +541,22 @@ def test_supported_brake_gain_tapers_to_prior_and_never_extrapolates():
     assert restored.ax_brake_max(75.0 / 3.6) == b.ax_brake_max(75.0 / 3.6)
 
 
+def test_supported_taper_is_capped_to_half_the_observed_span():
+    prior = _prior()
+    measured = _measured(
+        1.2,
+        corner_bins=0,
+        brake_bins=5,
+        accel_bins=0,
+        hull_points=100,
+        brake_b0=1.3,
+        brake_b1=0.03,
+        brake_range=(50.0, 100.0),
+    )
+    blended = blend_ggv_safe(measured, prior, support_taper_kmh=999.0)
+    assert blended.supported_longitudinal["brake"]["taper_kmh"] == 25.0
+
+
 def test_supported_override_is_revalidated_on_load_and_not_read_from_provenance():
     prior = _prior()
     measured = _measured(
@@ -553,8 +569,11 @@ def test_supported_override_is_revalidated_on_load_and_not_read_from_provenance(
         brake_b1=0.03,
         brake_range=(50.0, 100.0),
     )
-    payload = blend_ggv_safe(measured, prior).to_dict()
+    blended = blend_ggv_safe(measured, prior)
+    payload = blended.to_dict()
     payload["supported_longitudinal"]["brake"]["b0_g"] = 99.0
+    # Serialized output is detached; mutating it cannot bypass the already-validated frozen model.
+    assert blended.supported_longitudinal["brake"]["b0_g"] == 1.3
     import pytest
 
     with pytest.raises(ValueError, match="brake cap"):
@@ -565,7 +584,34 @@ def test_supported_override_is_revalidated_on_load_and_not_read_from_provenance(
     clean = prior.to_dict()
     clean["provenance"] = {"supported_longitudinal": {"brake": {"b0_g": 99.0}}}
     restored = GGVModel.from_dict(clean)
+    clean["provenance"]["supported_longitudinal"]["brake"]["b0_g"] = 123.0
+    assert restored.provenance["supported_longitudinal"]["brake"]["b0_g"] == 99.0
+    serialized = restored.to_dict()
+    serialized["provenance"]["supported_longitudinal"]["brake"]["b0_g"] = 456.0
+    assert restored.provenance["supported_longitudinal"]["brake"]["b0_g"] == 99.0
     assert restored.ax_brake_max(75.0 / 3.6) == prior.ax_brake_max(75.0 / 3.6)
+
+
+def test_supported_override_input_is_detached_and_runtime_mapping_is_read_only():
+    prior = _prior()
+    measured = _measured(
+        1.2,
+        corner_bins=0,
+        brake_bins=5,
+        accel_bins=0,
+        hull_points=100,
+        brake_b0=1.3,
+        brake_b1=0.03,
+        brake_range=(50.0, 100.0),
+    )
+    payload = blend_ggv_safe(measured, prior).to_dict()
+    restored = GGVModel.from_dict(payload)
+    payload["supported_longitudinal"]["brake"]["b0_g"] = 99.0
+    assert restored.supported_longitudinal["brake"]["b0_g"] == 1.3
+    import pytest
+
+    with pytest.raises(TypeError):
+        restored.supported_longitudinal["brake"]["b0_g"] = 99.0
 
 
 def test_blend_sparse_bins_fall_back_to_prior():
@@ -656,6 +702,22 @@ def test_controlled_probe_percentile_is_not_diluted_by_passive_rows():
     assert m.provenance["brake_probe_bins"] == 2
     assert m.brake_b0_g > 1.3
     assert m.brake_b0_g < 2.0  # the single 99 g frame is excluded, not treated as p95
+
+
+def test_probe_rows_never_satisfy_or_weight_the_passive_gate():
+    rows = []
+    for speed in (60.0, 70.0):
+        rows.extend(
+            {"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -2.0, "source": "passive"}
+            for _ in range(32)
+        )
+        rows.extend(
+            {"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -1.4, "source": "brake_probe"}
+            for _ in range(8)
+        )
+    m = ggv_from_telemetry(rows)
+    assert m.provenance["brake_probe_bins"] == 2
+    assert 1.3 < m.brake_b0_g < 1.5
 
 
 def test_negative_slope_brake_fit_is_rejected_instead_of_clamped():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -400,6 +400,8 @@ def _measured(
     brake_b1=0.02,
     drive_b0=0.7,  # below the prior (1.1) by default
     drive_b1=-0.01,
+    brake_range=(40.0, 180.0),
+    accel_range=(40.0, 180.0),
 ) -> GGVModel:
     return GGVModel(
         mu_lat_g=mu,
@@ -414,6 +416,8 @@ def _measured(
             "lat_corner_bins": corner_bins,
             "brake_bins": brake_bins,
             "accel_bins": accel_bins,
+            "brake_speed_range_kmh": list(brake_range) if brake_range else None,
+            "accel_speed_range_kmh": list(accel_range) if accel_range else None,
             "hull_points": hull_points,
             "bins": {},
         },
@@ -439,6 +443,7 @@ def test_ggv_model_roundtrip_and_rejects_nan():
         {"ellipse_n": -1.5},
         {"ellipse_n": 99.0},
         {"mu_lat_g": 0.0},
+        {"k_aero_lat": -0.0001},
         {"drive_min_g": -0.1},
     ):
         with pytest.raises(ValueError):
@@ -484,10 +489,54 @@ def test_blend_raises_braking_when_measured_confidently_exceeds_prior():
         brake_b1=0.03,  # > prior (0.955 + 0.0214 v) at both 40 and 180 km/h
     )
     b = blend_ggv_safe(strong, prior)
-    assert (b.brake_b0_g, b.brake_b1) == (1.3, 0.03)
-    assert b.provenance["blend_source"]["brake"] == "measured(>prior)"
+    # The persisted top-level line stays the prior (safe for older consumers), while this model
+    # applies the measured gain only inside its observed support.
+    assert (b.brake_b0_g, b.brake_b1) == (prior.brake_b0_g, prior.brake_b1)
+    assert b.ax_brake_max(100.0 / 3.6) > prior.ax_brake_max(100.0 / 3.6)
+    assert b.ax_brake_max(20.0 / 3.6) == prior.ax_brake_max(20.0 / 3.6)
+    assert b.ax_brake_max(200.0 / 3.6) == prior.ax_brake_max(200.0 / 3.6)
+    assert b.provenance["blend_source"]["brake"] == "measured(supported)"
     assert b.ax_brake_cap_g == prior.ax_brake_cap_g  # hard cap still kept
     assert b.mu_lat_g == prior.mu_lat_g  # lateral untouched
+
+
+def test_blend_rejects_narrow_longitudinal_support():
+    prior = _prior()
+    narrow = _measured(
+        1.2,
+        corner_bins=0,
+        brake_bins=2,
+        accel_bins=0,
+        hull_points=20,
+        brake_b0=1.3,
+        brake_b1=0.03,
+        brake_range=(50.0, 70.0),
+    )
+    b = blend_ggv_safe(narrow, prior)
+    assert b.provenance["blend_gate"]["brake_coverage_ok"] is False
+    assert b.provenance["supported_longitudinal"] == {}
+    assert b.ax_brake_max(60.0 / 3.6) == prior.ax_brake_max(60.0 / 3.6)
+
+
+def test_supported_brake_gain_tapers_to_prior_and_never_extrapolates():
+    prior = _prior()
+    measured = _measured(
+        1.2,
+        corner_bins=0,
+        brake_bins=5,
+        accel_bins=0,
+        hull_points=100,
+        brake_b0=1.3,
+        brake_b1=0.03,
+        brake_range=(50.0, 100.0),
+    )
+    b = blend_ggv_safe(measured, prior)
+    assert b.ax_brake_max(75.0 / 3.6) > prior.ax_brake_max(75.0 / 3.6)
+    assert b.ax_brake_max(50.0 / 3.6) == prior.ax_brake_max(50.0 / 3.6)
+    assert b.ax_brake_max(100.0 / 3.6) == prior.ax_brake_max(100.0 / 3.6)
+    assert b.ax_brake_max(180.0 / 3.6) == prior.ax_brake_max(180.0 / 3.6)
+    restored = GGVModel.from_dict(b.to_dict())
+    assert restored.ax_brake_max(75.0 / 3.6) == b.ax_brake_max(75.0 / 3.6)
 
 
 def test_blend_sparse_bins_fall_back_to_prior():
@@ -530,4 +579,45 @@ def test_ggv_from_telemetry_records_bin_counts():
     m = ggv_from_telemetry(rows)
     assert m.provenance["brake_bins"] >= 2
     assert m.provenance["accel_bins"] >= 2
+    assert m.provenance["brake_speed_range_kmh"] == [60.0, 150.0]
+    assert m.provenance["accel_speed_range_kmh"] == [60.0, 150.0]
     assert m.provenance["hull_points"] > 0
+
+
+def test_controlled_brake_probe_can_populate_multiple_trusted_bins():
+    # A 2.5 s, frame-rate probe from 110 km/h to the 45 km/h safety floor contributes multiple
+    # bins even though no individual bin has the 40 passive samples. Only explicitly tagged probe
+    # rows receive the controlled-maneuver threshold.
+    rows = []
+    frames = 132
+    for i in range(frames):
+        speed = 110.0 - (64.0 * i / (frames - 1))
+        rows.append(
+            {
+                "speed_kmh": speed,
+                "accg_lat": 0.0,
+                "accg_lon": -1.25,
+                "source": "brake_probe",
+            }
+        )
+    m = ggv_from_telemetry(rows)
+    assert m.provenance["brake_bins"] >= 4
+    assert m.provenance["brake_probe_bins"] == m.provenance["brake_bins"]
+    lo, hi = m.provenance["brake_speed_range_kmh"]
+    assert hi - lo >= 40.0
+
+
+def test_controlled_probe_percentile_is_not_diluted_by_passive_rows():
+    rows = []
+    for speed in (60.0, 70.0):
+        rows.extend(
+            {"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -0.2, "source": "passive"}
+            for _ in range(200)
+        )
+        rows.extend(
+            {"speed_kmh": speed, "accg_lat": 0.0, "accg_lon": -1.4, "source": "brake_probe"}
+            for _ in range(8)
+        )
+    m = ggv_from_telemetry(rows)
+    assert m.provenance["brake_probe_bins"] == 2
+    assert m.brake_b0_g > 1.3

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -431,6 +431,11 @@ def test_ggv_model_roundtrip_and_rejects_nan():
         GGVModel.from_dict({**m.to_dict(), "mu_lat_g": float("nan")})
     with pytest.raises(ValueError):
         GGVModel.from_dict({k: v for k, v in m.to_dict().items() if k != "brake_b0_g"})
+    # Positivity/range gates (Codex P2): a non-positive ellipse_n would crash the ggv path (divide),
+    # a non-positive lateral grip/cap would zero the envelope -> reject, don't construct.
+    for bad in ({"ellipse_n": 0.0}, {"ellipse_n": -1.5}, {"ellipse_n": 99.0}, {"mu_lat_g": 0.0}):
+        with pytest.raises(ValueError):
+            GGVModel.from_dict({**m.to_dict(), **bad})
 
 
 def test_blend_never_raises_lateral_above_prior():
@@ -495,11 +500,15 @@ def test_blend_sparse_bins_fall_back_to_prior():
     }
 
 
-def test_blend_ellipse_reverts_when_hull_thin():
+def test_blend_pins_ellipse_to_prior():
+    # The ellipse boundary exponent needs limit-reaching data; a conservative hull is interior
+    # points, so it is pinned to the prior regardless of how rich the hull is.
     prior = _prior()
-    thin = _measured(1.2, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=5, ellipse_n=1.1)
-    b = blend_ggv_safe(thin, prior)
-    assert b.ellipse_n == prior.ellipse_n  # not enough hull -> keep the prior coupling
+    rich = _measured(
+        1.2, corner_bins=6, brake_bins=6, accel_bins=6, hull_points=5000, ellipse_n=1.1
+    )
+    b = blend_ggv_safe(rich, prior)
+    assert b.ellipse_n == prior.ellipse_n
     assert b.provenance["blend_source"]["ellipse_n"] == "prior"
 
 

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -447,6 +447,8 @@ def test_ggv_model_roundtrip_and_rejects_nan():
         {"k_aero_lat": -0.0001},
         {"k_aero_lat": 0.0001},
         {"drive_min_g": -0.1},
+        {"ay_cap_g": 50.0},
+        {"ax_brake_cap_g": 50.0},
     ):
         with pytest.raises(ValueError):
             GGVModel.from_dict({**m.to_dict(), **bad})
@@ -539,6 +541,26 @@ def test_supported_brake_gain_tapers_to_prior_and_never_extrapolates():
     assert b.ax_brake_max(180.0 / 3.6) == prior.ax_brake_max(180.0 / 3.6)
     restored = GGVModel.from_dict(b.to_dict())
     assert restored.ax_brake_max(75.0 / 3.6) == b.ax_brake_max(75.0 / 3.6)
+
+
+def test_supported_weaker_brake_envelope_lowers_only_measured_speed_range():
+    prior = _prior()
+    measured = _measured(
+        1.2,
+        corner_bins=0,
+        brake_bins=5,
+        accel_bins=0,
+        hull_points=100,
+        brake_b0=0.7,
+        brake_b1=0.01,
+        brake_range=(50.0, 100.0),
+    )
+    blended = blend_ggv_safe(measured, prior)
+    assert blended.ax_brake_max(75.0 / 3.6) < prior.ax_brake_max(75.0 / 3.6)
+    assert blended.ax_brake_max(50.0 / 3.6) == prior.ax_brake_max(50.0 / 3.6)
+    assert blended.ax_brake_max(100.0 / 3.6) == prior.ax_brake_max(100.0 / 3.6)
+    assert blended.ax_brake_max(180.0 / 3.6) == prior.ax_brake_max(180.0 / 3.6)
+    assert blended.provenance["blend_source"]["brake"] == "measured(supported)"
 
 
 def test_supported_taper_is_capped_to_half_the_observed_span():

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -624,6 +624,9 @@ def test_artifact_keyed_by_layout_with_legacy_none_back_compat(tmp_path):
 def test_artifact_layout_rejects_path_shaped_id(tmp_path):
     with pytest.raises(ValueError, match="unsafe track layout"):
         plant_artifact_path(tmp_path, "test_car", "test_oval", layout="../gp")
+    # The path builder is strict for writers, while the tolerant loader degrades an invalid lookup
+    # to a cache miss so CLI consumers keep the generic plant.
+    assert load_plant_artifact(tmp_path, "test_car", "test_oval", layout="../gp") is None
 
 
 def test_artifact_load_portable_when_creator_setup_ini_unreadable(tmp_path):
@@ -693,12 +696,16 @@ def test_handshake_layout_flows_through_controller_result_and_build_driver():
             car_id="test_car",
             track_id="test_oval",
             track_layout="short",
+            # A previously loaded optimized plant is deliberately ignored by the handshake branch;
+            # its measurement prior is always the generic safety baseline (daemon rebuttal).
+            plant_ggv=GGVModel(9.0, 0.5, 3.0, 0.1, 2.0, 0.0, 0.5, 1.5),
         ),
         line,
         profile,
     )
     assert isinstance(built, HandshakeController)
     assert built.layout == "short"
+    assert built._prior_ggv == generic_gt3_ggv()
 
 
 def test_plant_driver_kwargs_full_raises_on_missing_steering():

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -718,9 +718,11 @@ def test_handshake_emits_safe_ggv_block_with_prior():
     assert ggv is not None and ggv["ok"], ggv
     assert ctrl.result_diagnostics["friction_rows"] >= ctrl.min_friction_rows
     model = GGVModel.from_dict(ggv["model"])
-    # Safe-envelope guarantees: never above the prior laterally, aero-lateral stays 0, caps kept.
+    # Safe-envelope guarantees: lateral pinned to the prior (a conservative drive under-measures the
+    # limit, so it never lowers/regresses), aero-lateral stays 0, caps kept.
     assert model.k_aero_lat == 0.0
-    assert model.mu_lat_g <= prior.mu_lat_g + 1e-9
+    assert model.mu_lat_g == prior.mu_lat_g
+    assert model.provenance["blend_source"]["lateral"] == "prior"
     assert model.ay_cap_g == prior.ay_cap_g
     assert model.ax_brake_cap_g == prior.ax_brake_cap_g
     # Provenance labels each curve measured-vs-prior.

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from tools.ac_harness.auto_drive import generic_gt3_ggv
+from tools.ac_harness.auto_drive import AutoDriveConfig, _build_driver, generic_gt3_ggv
 from tools.ac_harness.ggv_profile import GGVModel
 from tools.ac_harness.plant_id import (
     PLANT_SCHEMA_VERSION,
@@ -590,6 +590,42 @@ def test_artifact_keyed_by_setup(tmp_path):
     assert load_plant_artifact(tmp_path, "test_car", "test_oval", "Aggressive") is None
 
 
+def test_artifact_keyed_by_layout_with_legacy_none_back_compat(tmp_path):
+    legacy = plant_artifact_path(tmp_path, "test_car", "test_oval")
+    assert legacy.name == "test_car__test_oval.json"
+
+    layout_a = _result_dict()
+    layout_a["layout"] = "gp"
+    layout_a["constants"]["rpm_up"] = 8100.0
+    path_a = save_plant_artifact(tmp_path, layout_a)
+    assert path_a.name == "test_car__test_oval__layout-gp.json"
+    assert (
+        plant_artifact_path(tmp_path, "test_car", "test_oval", "Foo", layout="gp").name
+        == "test_car__test_oval__layout-gp__setup-Foo.json"
+    )
+    loaded_a = load_plant_artifact(tmp_path, "test_car", "test_oval", layout="gp")
+    assert loaded_a is not None and loaded_a["constants"]["rpm_up"] == 8100.0
+
+    # A missing B artifact never falls back to A. Even if an A file is copied/renamed to B's key,
+    # the stored layout identity rejects it rather than driving on the wrong physical course.
+    assert load_plant_artifact(tmp_path, "test_car", "test_oval", layout="short") is None
+    path_b = plant_artifact_path(tmp_path, "test_car", "test_oval", layout="short")
+    path_b.write_bytes(path_a.read_bytes())
+    assert load_plant_artifact(tmp_path, "test_car", "test_oval", layout="short") is None
+
+    layout_b = _result_dict()
+    layout_b["layout"] = "short"
+    layout_b["constants"]["rpm_up"] = 7200.0
+    save_plant_artifact(tmp_path, layout_b)
+    loaded_b = load_plant_artifact(tmp_path, "test_car", "test_oval", layout="short")
+    assert loaded_b is not None and loaded_b["constants"]["rpm_up"] == 7200.0
+
+
+def test_artifact_layout_rejects_path_shaped_id(tmp_path):
+    with pytest.raises(ValueError, match="unsafe track layout"):
+        plant_artifact_path(tmp_path, "test_car", "test_oval", layout="../gp")
+
+
 def test_artifact_load_portable_when_creator_setup_ini_unreadable(tmp_path):
     # Daemon HIGH: the load must NOT re-hash the STORED creator absolute setup_ini path (unreadable
     # on another machine). Save with an ini, then load with a DIFFERENT-path ini of the same
@@ -640,6 +676,29 @@ def test_handshake_set_phys_read_injection():
 
     ctrl.set_phys_read(lambda: SimpleNamespace(wheel_omega=(1.0, 1.0, 1.0, 1.0)))
     assert ctrl._read_phys().wheel_omega == (1.0, 1.0, 1.0, 1.0)
+
+
+def test_handshake_layout_flows_through_controller_result_and_build_driver():
+    line = _stadium_line()
+    profile = _profile_for(line)
+    ctrl = HandshakeController(line, profile, track_id="test_oval", layout="gp", sink={})
+    ctrl.finalize(now=0.0)
+    assert ctrl.layout == "gp"
+    assert ctrl.result is not None and ctrl.result.layout == "gp"
+    assert ctrl.sink["result"]["layout"] == "gp"
+
+    built = _build_driver(
+        AutoDriveConfig(
+            driver="handshake",
+            car_id="test_car",
+            track_id="test_oval",
+            track_layout="short",
+        ),
+        line,
+        profile,
+    )
+    assert isinstance(built, HandshakeController)
+    assert built.layout == "short"
 
 
 def test_plant_driver_kwargs_full_raises_on_missing_steering():

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -747,6 +747,9 @@ def test_brake_probe_queued_only_with_prior():
     assert "brake_probe" not in without._pending
     with_prior = HandshakeController(line, _profile_for(line), sink={}, prior_ggv=generic_gt3_ggv())
     assert "brake_probe" in with_prior._pending
+    assert with_prior.brake_probe_seconds == 2.5
+    assert with_prior.brake_min_entry_kmh == 110.0
+    assert with_prior.friction_row_interval_s == 0.01
 
 
 def test_handshake_no_ggv_block_without_prior(handshake_outcome):

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -15,6 +15,7 @@ import pytest
 
 from tools.ac_harness.auto_drive import AutoDriveConfig, _build_driver, generic_gt3_ggv
 from tools.ac_harness.ggv_profile import GGVModel
+from tools.ac_harness.lap_driver import PHASE_LAP, DriveFrame
 from tools.ac_harness.plant_id import (
     PLANT_SCHEMA_VERSION,
     HandshakeController,
@@ -757,6 +758,36 @@ def test_brake_probe_queued_only_with_prior():
     assert with_prior.brake_probe_seconds == 2.5
     assert with_prior.brake_min_entry_kmh == 110.0
     assert with_prior.friction_row_interval_s == 0.01
+
+
+def test_friction_sampler_deduplicates_physics_packets():
+    line = _stadium_line()
+    phys = SimpleNamespace(packet_id=7, speed_kmh=80.0, accg_lat=0.2, accg_lon=-1.0)
+    ctrl = HandshakeController(
+        line,
+        _profile_for(line),
+        sink={},
+        prior_ggv=generic_gt3_ggv(),
+        phys_read=lambda: phys,
+    )
+    ctrl._mine_friction(0.0)
+    ctrl._mine_friction(0.02)
+    assert len(ctrl._friction_rows) == 1
+    phys.packet_id = 8
+    ctrl._mine_friction(0.04)
+    assert len(ctrl._friction_rows) == 2
+
+
+def test_brake_probe_requires_speed_dependent_stopping_room():
+    line = _stadium_line()
+    ctrl = HandshakeController(line, _profile_for(line), sink={}, prior_ggv=generic_gt3_ggv())
+    assert ctrl._brake_probe_required_m(110.0) > 100.0
+    ctrl._pending.remove("brake_probe")
+    ctrl._active = {"kind": "brake_probe", "stage": "prep", "t_stage": 0.0, "data": {}}
+    base = DriveFrame(0.5, 0.0, 0.0, False, False, PHASE_LAP, False, False)
+    assert ctrl._step_brake(base, 110.0, 100.0, 0.0) is base
+    assert ctrl._active is None
+    assert "brake_probe" in ctrl._pending
 
 
 def test_handshake_no_ggv_block_without_prior(handshake_outcome):

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -13,7 +13,10 @@ from types import SimpleNamespace
 
 import pytest
 
+from tools.ac_harness.auto_drive import generic_gt3_ggv
+from tools.ac_harness.ggv_profile import GGVModel
 from tools.ac_harness.plant_id import (
+    PLANT_SCHEMA_VERSION,
     HandshakeController,
     apply_handshake_outcome,
     find_straights,
@@ -25,6 +28,7 @@ from tools.ac_harness.plant_id import (
     load_plant_artifact,
     plant_artifact_path,
     plant_driver_kwargs,
+    plant_ggv_model,
     save_plant_artifact,
 )
 
@@ -104,6 +108,8 @@ class PlantSim:
         self.heading = [(x1 - x0) / norm, (z1 - z0) / norm]
         self.v = 0.0
         self.gear = 1  # AC encoding: neutral
+        self._accel = 0.0  # last longitudinal accel (m/s^2) — for the #532 Part B friction phys
+        self._kappa = 0.0  # last path curvature (1/m)
 
     @property
     def speed_kmh(self) -> float:
@@ -125,7 +131,15 @@ class PlantSim:
 
     def phys(self):
         base = self.v / self.r_eff
-        return SimpleNamespace(wheel_omega=(base, base, base, base))
+        # #532 Part B: also expose the accG channel (real lateral / longitudinal g) + speed so the
+        # controller's friction-row sampler can build the GGV envelope. accg_lon < 0 under braking,
+        # matching ggv_from_telemetry's brake = -lon convention.
+        return SimpleNamespace(
+            wheel_omega=(base, base, base, base),
+            speed_kmh=self.speed_kmh,
+            accg_lat=self.v * self.v * self._kappa / 9.81,
+            accg_lon=self._accel / 9.81,
+        )
 
     def apply(self, frame, dt: float) -> None:
         if frame.gear_up:
@@ -139,6 +153,8 @@ class PlantSim:
         accel = drive - 0.004 * self.v * self.v - 0.15 - 9.0 * frame.brake
         self.v = max(0.0, self.v + accel * dt)
         kappa = frame.steer / (self.c1 + self.c2 * self.v * self.v)
+        self._accel = accel
+        self._kappa = kappa
         dpsi = kappa * self.v * dt
         c, s = math.cos(dpsi), math.sin(dpsi)
         hx, hz = self.heading
@@ -532,7 +548,7 @@ def test_artifact_round_trip(tmp_path):
     loaded = load_plant_artifact(tmp_path, "test_car", "test_oval")
     assert loaded is not None
     assert loaded["constants"]["rpm_up"] == 7600.0
-    assert loaded["schema_version"] == 1
+    assert loaded["schema_version"] == PLANT_SCHEMA_VERSION
 
 
 def test_artifact_refuses_failed_result(tmp_path):
@@ -661,6 +677,97 @@ def test_fit_shift_points_fails_when_sweep_never_revs_out():
     m = fit_shift_points(samples, {2: 110.0, 3: 82.0})
     assert not m.passed
     assert "revved out" in m.detail
+
+
+# ---------------------------------------------------------------------------
+# #532 Part B — per-combo friction plant (GGV block)
+# ---------------------------------------------------------------------------
+def test_brake_probe_queued_only_with_prior():
+    line = _stadium_line()
+    without = HandshakeController(line, _profile_for(line), sink={})
+    assert "brake_probe" not in without._pending
+    with_prior = HandshakeController(line, _profile_for(line), sink={}, prior_ggv=generic_gt3_ggv())
+    assert "brake_probe" in with_prior._pending
+
+
+def test_handshake_no_ggv_block_without_prior(handshake_outcome):
+    # The module fixture runs WITHOUT a prior -> no ggv block, and it never captured friction rows.
+    ctrl, sink = handshake_outcome
+    assert ctrl.result.ggv is None
+    assert sink["result"]["ggv"] is None
+    assert ctrl.result_diagnostics["friction_rows"] == 0
+
+
+def test_handshake_emits_safe_ggv_block_with_prior():
+    line = _stadium_line()
+    sim = PlantSim(line)
+    prior = generic_gt3_ggv()
+    sink: dict = {}
+    ctrl = HandshakeController(
+        line,
+        _profile_for(line),
+        car_id="test_car",
+        track_id="test_oval",
+        sink=sink,
+        phys_read=sim.phys,
+        prior_ggv=prior,
+    )
+    _run_handshake(ctrl, sim)
+    assert ctrl.finished
+    ggv = ctrl.result.ggv
+    assert ggv is not None and ggv["ok"], ggv
+    assert ctrl.result_diagnostics["friction_rows"] >= ctrl.min_friction_rows
+    model = GGVModel.from_dict(ggv["model"])
+    # Safe-envelope guarantees: never above the prior laterally, aero-lateral stays 0, caps kept.
+    assert model.k_aero_lat == 0.0
+    assert model.mu_lat_g <= prior.mu_lat_g + 1e-9
+    assert model.ay_cap_g == prior.ay_cap_g
+    assert model.ax_brake_cap_g == prior.ax_brake_cap_g
+    # Provenance labels each curve measured-vs-prior.
+    assert set(model.provenance["blend_source"]) == {"lateral", "brake", "drive", "ellipse_n"}
+    # The ggv block is ADVISORY — it never gates the core-constant ok.
+    assert sink["result"]["ggv"]["ok"] is True
+
+
+def test_plant_ggv_model_resolves_valid_rejects_invalid():
+    prior = generic_gt3_ggv()
+    good = {"ggv": {"ok": True, "model": prior.to_dict()}}
+    assert plant_ggv_model(good) is not None
+    # ok=False block -> None (consumer keeps generic)
+    assert plant_ggv_model({"ggv": {"ok": False, "model": None}}) is None
+    # non-finite serialized model -> rejected (never act on a nan grip curve)
+    assert plant_ggv_model({"ggv": {"ok": True, "model": {"mu_lat_g": float("nan")}}}) is None
+    # v1 / Part-A artifact with no ggv block -> None
+    assert plant_ggv_model({"constants": {"ff_sign": 1.0}}) is None
+
+
+def test_artifact_v1_still_loads_without_ggv(tmp_path):
+    # A v1 Part-A artifact (schema_version=1, no ggv block) must still load after the v2 bump so
+    # existing shift-point / steering consumption is not invalidated (back-compat).
+    import json as _json
+
+    result = _result_dict()
+    payload = {"schema_version": 1, "created_utc": "2026-07-12T00:00:00Z", **result}
+    path = plant_artifact_path(tmp_path, "test_car", "test_oval")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json.dumps(payload), encoding="utf-8")
+    loaded = load_plant_artifact(tmp_path, "test_car", "test_oval")
+    assert loaded is not None
+    assert loaded["schema_version"] == 1
+    assert plant_ggv_model(loaded) is None  # no ggv block -> generic plant
+
+
+def test_ggv_block_round_trips_through_artifact(tmp_path):
+    prior = generic_gt3_ggv()
+    result = _result_dict()
+    result["ggv"] = {"ok": True, "friction_rows": 1234, "model": prior.to_dict()}
+    save_plant_artifact(tmp_path, result)
+    loaded = load_plant_artifact(tmp_path, "test_car", "test_oval")
+    assert loaded is not None
+    assert loaded["schema_version"] == PLANT_SCHEMA_VERSION
+    model = plant_ggv_model(loaded)
+    assert model is not None
+    assert abs(model.mu_lat_g - prior.mu_lat_g) < 1e-9
 
 
 def test_artifact_load_rejects_nan_constants(tmp_path):

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1775,6 +1775,7 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
             speed_profile,
             car_id=config.car_id or "",
             track_id=config.track_id,
+            layout=config.track_layout,
             setup=(Path(config.setup).stem if config.setup else None),
             setup_ini=(str(config.setup_ini) if config.setup_ini else None),
             # Fresh sink owned by the controller; rig_drive copies it into DriveStats.payload so
@@ -1792,6 +1793,7 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
             # safe-envelope-blended against (enables the ggv artifact block + the brake-at-speed
             # probe). The harness owns the prior so the controller stays import-clean of auto_drive.
             prior_ggv=generic_gt3_ggv(),
+            prior_ggv_name="generic_gt3_ggv",
         )
     raise ValueError(
         f"unknown driver {config.driver!r} (expected 'ggv', 'racing', 'cruise', or 'handshake')"
@@ -2402,9 +2404,9 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     except ValueError as exc:
         print(f"auto-drive: {exc}")
         return 2
-    # Plant artifacts are keyed by car+track (#532). A preset-only run (``--cm-preset`` without
-    # ``--car``) has no car id, so BOTH the handshake (which persists an artifact) and
-    # ``--use-plant full`` (which must load one) need ``--car`` explicitly — otherwise the
+    # Plant artifacts are keyed by car+track+layout+setup (#532/#552). A preset-only run
+    # (``--cm-preset`` without ``--car``) has no car id, so BOTH the handshake (which persists one)
+    # and ``--use-plant full`` (which must load one) need ``--car`` explicitly — otherwise the
     # handshake would run the whole rig drive and then crash in ``save_plant_artifact`` with an
     # empty car id (Codex review), and ``--use-plant full`` would silently skip its own hard
     # requirement and drive on generic constants.
@@ -2440,13 +2442,18 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             plant_ggv_model,
         )
 
-        # Key by setup + its CONTENT (#532 Codex review): a plant measured on one setup must not be
-        # reused for a different setup, and two files sharing a basename must not collide. Uses the
-        # single shared config.setup_ini resolved above (same identity the handshake save uses).
+        # Key by layout plus setup CONTENT (#532/#552): neither another physical course nor another
+        # setup may reuse this plant. Uses the same track_layout + config.setup_ini identity that
+        # the handshake result carries into save_plant_artifact.
         setup_key = Path(config.setup).stem if config.setup else None
         setup_ini_key = config.setup_ini
         artifact = load_plant_artifact(
-            user_dir, config.car_id, config.track_id, setup_key, setup_ini_key
+            user_dir,
+            config.car_id,
+            config.track_id,
+            setup_key,
+            setup_ini_key,
+            layout=config.track_layout,
         )
         if artifact is not None:
             config.plant_kwargs = plant_driver_kwargs(artifact, steer=args.use_plant == "full")
@@ -2456,7 +2463,12 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             config.plant_ggv = plant_ggv_model(artifact)
             plant_artifact_used = str(
                 plant_artifact_path(
-                    user_dir, config.car_id, config.track_id, setup_key, setup_ini_key
+                    user_dir,
+                    config.car_id,
+                    config.track_id,
+                    setup_key,
+                    setup_ini_key,
+                    layout=config.track_layout,
                 )
             )
             ggv_note = (

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -66,9 +66,12 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC
 from pathlib import Path
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from tools.ac_harness.sequence_probe import evaluate_sequence, tap_frames
+
+if TYPE_CHECKING:
+    from tools.ac_harness.ggv_profile import GGVModel
 
 
 def default_ac_root() -> Path:
@@ -139,6 +142,10 @@ class AutoDriveConfig:
     # Plant-artifact consumption (#532): RacingDriver kwargs derived from the combo's identified
     # plant (see plant_id.plant_driver_kwargs), applied on the ggv path. None => generic plant.
     plant_kwargs: dict | None = None
+    # #532 Part B: the combo's identified friction plant (a ggv_profile.GGVModel), consumed on the
+    # ggv path INSTEAD of generic_gt3_ggv() when the loaded artifact carries a fitted ggv block.
+    # None => generic plant.
+    plant_ggv: GGVModel | None = None
     pace: float = 0.9  # racing: fraction of the AI line's speed profile to target
     racing_max_speed_kmh: float = (
         240.0  # racing/ggv: cap (above any GT speed; lets it use top gears)
@@ -1746,8 +1753,11 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
         from tools.ac_harness.ggv_profile import ggv_speed_profile_from_model
         from tools.ac_harness.racing_driver import RacingDriver
 
+        # #532 Part B: drive the combo's identified friction plant (safe-envelope-blended GGVModel)
+        # when the CLI resolved one from the artifact; otherwise the generic GT3 plant.
+        plant = config.plant_ggv if config.plant_ggv is not None else generic_gt3_ggv()
         v_target, _summ = ggv_speed_profile_from_model(
-            fast_line, generic_gt3_ggv(), v_top_kmh=config.racing_max_speed_kmh
+            fast_line, plant, v_top_kmh=config.racing_max_speed_kmh
         )
         v_target = [v * config.ggv_scale for v in v_target]
         # #532: consume the combo's machine-measured plant constants when the CLI resolved an
@@ -1778,6 +1788,10 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
             # while staying conservative enough to drive clean. Live-found on Spa (#532): at pace
             # 0.65 only ~4 rows/3 km qualified; 0.8 loads the corners ~50% more (v^2).
             pace=0.8,
+            # #532 Part B: the trusted generic plant the measured friction envelope is
+            # safe-envelope-blended against (enables the ggv artifact block + the brake-at-speed
+            # probe). The harness owns the prior so the controller stays import-clean of auto_drive.
+            prior_ggv=generic_gt3_ggv(),
         )
     raise ValueError(
         f"unknown driver {config.driver!r} (expected 'ggv', 'racing', 'cruise', or 'handshake')"
@@ -2423,6 +2437,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             load_plant_artifact,
             plant_artifact_path,
             plant_driver_kwargs,
+            plant_ggv_model,
         )
 
         # Key by setup + its CONTENT (#532 Codex review): a plant measured on one setup must not be
@@ -2435,14 +2450,21 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         )
         if artifact is not None:
             config.plant_kwargs = plant_driver_kwargs(artifact, steer=args.use_plant == "full")
+            # #532 Part B: also consume the identified friction plant (GGVModel) when the artifact
+            # carries a fitted ggv block. Applies on `auto` and `full` alike — the friction plant
+            # shapes the SPEED profile, orthogonal to the steering mode. None => generic plant.
+            config.plant_ggv = plant_ggv_model(artifact)
             plant_artifact_used = str(
                 plant_artifact_path(
                     user_dir, config.car_id, config.track_id, setup_key, setup_ini_key
                 )
             )
+            ggv_note = (
+                "identified friction plant" if config.plant_ggv is not None else "generic plant"
+            )
             print(
                 f"auto-drive: plant artifact loaded ({args.use_plant}: "
-                f"{sorted(config.plant_kwargs)}) <- {plant_artifact_used}"
+                f"{sorted(config.plant_kwargs)}; {ggv_note}) <- {plant_artifact_used}"
             )
         elif args.use_plant == "full":
             print(

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -96,6 +96,55 @@ class GGVModel:
             1.0 / self.ellipse_n
         )
 
+    def to_dict(self) -> dict:
+        """Serialize the model + provenance for a plant artifact (JSON-safe; #532 Part B)."""
+        return {
+            "mu_lat_g": self.mu_lat_g,
+            "k_aero_lat": self.k_aero_lat,
+            "brake_b0_g": self.brake_b0_g,
+            "brake_b1": self.brake_b1,
+            "drive_b0_g": self.drive_b0_g,
+            "drive_b1": self.drive_b1,
+            "drive_min_g": self.drive_min_g,
+            "ellipse_n": self.ellipse_n,
+            "ay_cap_g": self.ay_cap_g,
+            "ax_brake_cap_g": self.ax_brake_cap_g,
+            "provenance": self.provenance,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> GGVModel:
+        """Rebuild a model from :meth:`to_dict` output.
+
+        Raises ``ValueError`` on a missing / non-finite CORE field so a corrupt plant artifact can
+        never silently construct a ``nan`` grip curve that the driver would then act on (#532
+        input-validation pitfall). Optional caps default to the dataclass defaults when absent.
+        """
+        if not isinstance(data, dict):
+            raise ValueError(f"GGVModel.from_dict expects a dict, got {type(data).__name__}")
+        core = (
+            "mu_lat_g",
+            "k_aero_lat",
+            "brake_b0_g",
+            "brake_b1",
+            "drive_b0_g",
+            "drive_b1",
+            "drive_min_g",
+            "ellipse_n",
+        )
+        vals: dict = {}
+        for f in core:
+            v = data.get(f)
+            if not isinstance(v, (int, float)) or isinstance(v, bool) or not math.isfinite(v):
+                raise ValueError(f"GGVModel.from_dict: field {f!r} missing or non-finite: {v!r}")
+            vals[f] = float(v)
+        for f in ("ay_cap_g", "ax_brake_cap_g"):
+            v = data.get(f)
+            if isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v):
+                vals[f] = float(v)
+        prov = data.get("provenance")
+        return cls(**vals, provenance=prov if isinstance(prov, dict) else {})
+
 
 def _pct(xs: list[float], q: float) -> float:
     if not xs:
@@ -197,6 +246,11 @@ def ggv_from_telemetry(
     prov = {
         "bins": cov,
         "lat_corner_bins": n_corner_bins,
+        # Fitted-bin counts + hull size — the confidence signals the #532 Part B safe-envelope blend
+        # reads to decide, per curve, whether to trust the measurement or fall back to the prior.
+        "brake_bins": len(xs_b),
+        "accel_bins": len(xs_a),
+        "hull_points": len(hull),
         "lat_model": f"ay_max(v)={mu_lat:.3f}+{k_aero:.5f}*v_ms^2 g [mech peak; no aero-lat]",
         "brake_model": f"ax_brake(v)={brake_b0:.3f}+{brake_b1:.5f}*v_ms (g)",
         "accel_model": f"ax_drive(v)={drive_b0:.3f}+{drive_b1:.5f}*v_ms (g)",
@@ -233,6 +287,122 @@ def _fit_ellipse_n(hull: list[tuple[float, float]], mu_lat, k_aero, brake_b0, br
             best_err, best_n = err, n
         n += 0.05
     return best_n
+
+
+def blend_ggv_safe(
+    measured: GGVModel,
+    prior: GGVModel,
+    *,
+    min_corner_bins: int = 2,
+    min_brake_bins: int = 2,
+    min_accel_bins: int = 2,
+    min_hull_points: int = 20,
+) -> GGVModel:
+    """Safe-envelope blend of a per-combo MEASURED GGVModel with a trusted PRIOR (#532 Part B).
+
+    The measured model comes from :func:`ggv_from_telemetry` over probe-lap rows; the prior is the
+    live-verified generic plant. The blend is the deterministic guard that turns a possibly-sparse
+    measurement into a plant that is never *more* optimistic than warranted:
+
+    * **Lateral grip is never extrapolated upward above the prior.** An aero-lateral term spins the
+      GT3 out (live-disproven, #259/#244), so ``k_aero_lat`` stays 0 and the lateral cap stays the
+      prior's. A confidently-cornered measurement may only *lower* lateral grip (a genuinely weaker
+      car); a thin/absent lateral measurement keeps the prior. So the reference car the prior nails
+      cannot regress, while a weaker car is still identified as weaker.
+    * **Braking / drive accel** use the measured curve only where the probe confidently covered the
+      envelope (``>= min_*_bins`` fitted speed bins); otherwise the prior curve. The prior's hard
+      caps (``ay_cap_g`` / ``ax_brake_cap_g``) are always kept.
+    * **The ellipse exponent reverts to the prior** unless the ``(lat, lon)`` hull was rich enough
+      to fit it — a wrong lat/long coupling is the biggest silent-spin risk (Council 2026-07-13).
+
+    Provenance records, per curve, whether the blended value is ``measured`` or ``prior``, plus the
+    measured per-bin coverage — so the artifact labels measured-vs-prior bins.
+    """
+    prov = dict(measured.provenance or {})
+    corner_bins = int(prov.get("lat_corner_bins", 0) or 0)
+    brake_bins = int(prov.get("brake_bins", 0) or 0)
+    accel_bins = int(prov.get("accel_bins", 0) or 0)
+    hull_points = int(prov.get("hull_points", 0) or 0)
+
+    # Lateral: cap at the prior; a confident measurement may only LOWER it (weaker car), not raise.
+    if (
+        corner_bins >= min_corner_bins
+        and math.isfinite(measured.mu_lat_g)
+        and measured.mu_lat_g < prior.mu_lat_g
+    ):
+        mu_lat, lat_src = measured.mu_lat_g, "measured(<prior)"
+    else:
+        mu_lat, lat_src = prior.mu_lat_g, "prior"
+
+    # Braking: measured where confidently covered (kept under the prior's hard cap), else prior.
+    if brake_bins >= min_brake_bins and _finite_ggv(measured.brake_b0_g, measured.brake_b1):
+        brake_b0, brake_b1, brake_src = measured.brake_b0_g, measured.brake_b1, "measured"
+    else:
+        brake_b0, brake_b1, brake_src = prior.brake_b0_g, prior.brake_b1, "prior"
+
+    # Drive accel: measured where the WOT sweep covered it, else prior (kept TC-off-safe live).
+    if accel_bins >= min_accel_bins and _finite_ggv(
+        measured.drive_b0_g, measured.drive_b1, measured.drive_min_g
+    ):
+        drive_b0, drive_b1, drive_min, drive_src = (
+            measured.drive_b0_g,
+            measured.drive_b1,
+            measured.drive_min_g,
+            "measured",
+        )
+    else:
+        drive_b0, drive_b1, drive_min, drive_src = (
+            prior.drive_b0_g,
+            prior.drive_b1,
+            prior.drive_min_g,
+            "prior",
+        )
+
+    # Ellipse exponent: revert to prior unless the hull is rich enough to fit it confidently.
+    if hull_points >= min_hull_points and _finite_ggv(measured.ellipse_n):
+        ellipse_n, ell_src = measured.ellipse_n, "measured"
+    else:
+        ellipse_n, ell_src = prior.ellipse_n, "prior"
+
+    blend_prov = {
+        "blend_source": {
+            "lateral": lat_src,
+            "brake": brake_src,
+            "drive": drive_src,
+            "ellipse_n": ell_src,
+        },
+        "measured": {
+            "mu_lat_g": round(measured.mu_lat_g, 4),
+            "brake_b0_g": round(measured.brake_b0_g, 4),
+            "brake_b1": round(measured.brake_b1, 5),
+            "drive_b0_g": round(measured.drive_b0_g, 4),
+            "drive_b1": round(measured.drive_b1, 5),
+            "ellipse_n": round(measured.ellipse_n, 3),
+            "lat_corner_bins": corner_bins,
+            "brake_bins": brake_bins,
+            "accel_bins": accel_bins,
+            "hull_points": hull_points,
+            "bins": prov.get("bins", {}),
+        },
+        "prior": "generic_gt3_ggv",
+    }
+    return GGVModel(
+        mu_lat_g=mu_lat,
+        k_aero_lat=0.0,  # ALWAYS 0 — an aero-lateral term spins the GT3 out (live-disproven #259)
+        brake_b0_g=brake_b0,
+        brake_b1=brake_b1,
+        drive_b0_g=drive_b0,
+        drive_b1=drive_b1,
+        drive_min_g=drive_min,
+        ellipse_n=ellipse_n,
+        ay_cap_g=prior.ay_cap_g,  # never raise the lateral cap above the prior
+        ax_brake_cap_g=prior.ax_brake_cap_g,
+        provenance=blend_prov,
+    )
+
+
+def _finite_ggv(*values: float) -> bool:
+    return all(isinstance(v, (int, float)) and math.isfinite(v) for v in values)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -152,6 +152,10 @@ class GGVModel:
             )
         if vals["mu_lat_g"] <= 0.0:
             raise ValueError(f"GGVModel.from_dict: mu_lat_g must be positive: {vals['mu_lat_g']!r}")
+        if vals["drive_min_g"] < 0.0:
+            raise ValueError(
+                f"GGVModel.from_dict: drive_min_g must be non-negative: {vals['drive_min_g']!r}"
+            )
         for f in ("ay_cap_g", "ax_brake_cap_g"):
             if f in vals and vals[f] <= 0.0:
                 raise ValueError(f"GGVModel.from_dict: {f} must be positive: {vals[f]!r}")
@@ -306,6 +310,7 @@ def blend_ggv_safe(
     measured: GGVModel,
     prior: GGVModel,
     *,
+    prior_name: str = "injected_prior",
     min_brake_bins: int = 2,
     min_accel_bins: int = 2,
 ) -> GGVModel:
@@ -402,7 +407,7 @@ def blend_ggv_safe(
             "hull_points": hull_points,
             "bins": prov.get("bins", {}),
         },
-        "prior": "generic_gt3_ggv",
+        "prior": prior_name,
         # A conservative handshake under-measures the true limit; a measured value below the prior
         # is a lower bound, not a weaker-car signal. Recorded for a future slip-saturation pass.
         "note": (

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -142,6 +142,19 @@ class GGVModel:
             v = data.get(f)
             if isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v):
                 vals[f] = float(v)
+        # Positivity/range gates (Codex P2): the friction-ellipse math divides by ``ellipse_n``
+        # (``**(1/n)``), so a non-positive exponent would CRASH the ggv path instead of falling back
+        # to the generic plant; a non-positive lateral grip / cap would zero the envelope. Reject
+        # both — never construct a model the driver cannot safely evaluate.
+        if not (0.0 < vals["ellipse_n"] <= 8.0):
+            raise ValueError(
+                f"GGVModel.from_dict: ellipse_n out of range (0, 8]: {vals['ellipse_n']!r}"
+            )
+        if vals["mu_lat_g"] <= 0.0:
+            raise ValueError(f"GGVModel.from_dict: mu_lat_g must be positive: {vals['mu_lat_g']!r}")
+        for f in ("ay_cap_g", "ax_brake_cap_g"):
+            if f in vals and vals[f] <= 0.0:
+                raise ValueError(f"GGVModel.from_dict: {f} must be positive: {vals[f]!r}")
         prov = data.get("provenance")
         return cls(**vals, provenance=prov if isinstance(prov, dict) else {})
 
@@ -295,7 +308,6 @@ def blend_ggv_safe(
     *,
     min_brake_bins: int = 2,
     min_accel_bins: int = 2,
-    min_hull_points: int = 20,
 ) -> GGVModel:
     """Safe-envelope blend of a per-combo MEASURED GGVModel with a trusted PRIOR (#532 Part B).
 
@@ -315,8 +327,11 @@ def blend_ggv_safe(
       accel). Adopt the measured curve ONLY where it CONFIDENTLY EXCEEDS the prior across the
       covered speeds (evidence of MORE capability); otherwise the prior — a diluted
       under-measurement must never LOWER braking/accel and regress. The prior's hard caps are kept.
-    * **The ellipse exponent reverts to the prior** unless the ``(lat, lon)`` hull is rich enough to
-      fit it — a wrong lat/long coupling is the biggest silent-spin risk (Council 2026-07-13).
+    * **The ellipse exponent is pinned to the prior.** The friction-ellipse boundary exponent
+      requires limit-reaching (boundary) data; a conservative handshake's ``(lat, lon)`` hull is
+      interior points, so a fit from it is unreliable — like the lateral limit, honest per-combo
+      identification of it needs a limit-reaching probe (deferred). A wrong lat/long coupling is the
+      biggest silent-spin risk (Council 2026-07-13), and the prior's exponent is live-verified.
 
     Net: the reference car (and any conservatively-driven combo) reproduces the prior — no
     regression, no spin — while a car that DEMONSTRABLY brakes / accelerates harder than the prior
@@ -332,6 +347,11 @@ def blend_ggv_safe(
     # Lateral: the prior is ceiling AND floor (see docstring) — a non-limit measurement is only a
     # lower bound, so it never lowers the operating plant and never regresses the reference car.
     mu_lat, lat_src = prior.mu_lat_g, "prior"
+
+    # Ellipse exponent: pinned to the prior — its boundary needs limit-reaching data the
+    # conservative handshake does not produce (the hull is interior points). Recorded hull_points
+    # feeds a future limit-reaching pass. See docstring.
+    ellipse_n, ell_src = prior.ellipse_n, "prior"
 
     # Braking: adopt measured ONLY where it CONFIDENTLY EXCEEDS the prior across the covered speeds.
     brake_b0, brake_b1, brake_src = prior.brake_b0_g, prior.brake_b1, "prior"
@@ -361,12 +381,6 @@ def blend_ggv_safe(
             measured.drive_min_g,
             "measured(>prior)",
         )
-
-    # Ellipse exponent: revert to prior unless the hull is rich enough to fit it confidently.
-    if hull_points >= min_hull_points and _finite_ggv(measured.ellipse_n):
-        ellipse_n, ell_src = measured.ellipse_n, "measured"
-    else:
-        ellipse_n, ell_src = prior.ellipse_n, "prior"
 
     blend_prov = {
         "blend_source": {

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -42,6 +42,9 @@ _AI_EXTRA_STRIDE_BYTES = 72
 _AI_EXTRA_SIDELEFT_OFFSET_BYTES = 20
 
 G = 9.81
+MIN_LONGITUDINAL_SUPPORT_KMH = 40.0
+MAX_LONGITUDINAL_SUPPORT_KMH = 300.0
+MAX_DRIVE_SUPPORT_G = 2.0
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +70,19 @@ class GGVModel:
     ay_cap_g: float = 1.8  # hard sanity cap on extrapolated lateral grip
     ax_brake_cap_g: float = 3.4
     provenance: dict = field(default_factory=dict)
+    # Runtime-bearing measured overrides are deliberately separate from free-form provenance and
+    # validated on every construction/load. Top-level coefficients remain the trusted prior.
+    supported_longitudinal: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_supported_longitudinal(
+            self.supported_longitudinal,
+            brake_b0_g=self.brake_b0_g,
+            brake_b1=self.brake_b1,
+            drive_b0_g=self.drive_b0_g,
+            drive_b1=self.drive_b1,
+            ax_brake_cap_g=self.ax_brake_cap_g,
+        )
 
     def ay_max(self, v_ms: float) -> float:
         return min(self.ay_cap_g, self.mu_lat_g + self.k_aero_lat * v_ms * v_ms) * G
@@ -97,12 +113,7 @@ class GGVModel:
         Persisted provenance is untrusted input.  Any malformed/non-finite override is ignored and
         the prior is returned, matching the artifact loader's fail-safe contract.
         """
-        if not isinstance(self.provenance, dict):
-            return prior_g
-        supported = self.provenance.get("supported_longitudinal")
-        if not isinstance(supported, dict):
-            return prior_g
-        override = supported.get(kind)
+        override = self.supported_longitudinal.get(kind)
         if not isinstance(override, dict):
             return prior_g
         try:
@@ -165,6 +176,7 @@ class GGVModel:
             "ay_cap_g": self.ay_cap_g,
             "ax_brake_cap_g": self.ax_brake_cap_g,
             "provenance": self.provenance,
+            "supported_longitudinal": self.supported_longitudinal,
         }
 
     @classmethod
@@ -207,9 +219,10 @@ class GGVModel:
             )
         if vals["mu_lat_g"] <= 0.0:
             raise ValueError(f"GGVModel.from_dict: mu_lat_g must be positive: {vals['mu_lat_g']!r}")
-        if vals["k_aero_lat"] < 0.0:
+        if vals["k_aero_lat"] != 0.0:
             raise ValueError(
-                f"GGVModel.from_dict: k_aero_lat must be non-negative: {vals['k_aero_lat']!r}"
+                "GGVModel.from_dict: persisted plant k_aero_lat must be zero: "
+                f"{vals['k_aero_lat']!r}"
             )
         if vals["drive_min_g"] < 0.0:
             raise ValueError(
@@ -219,7 +232,12 @@ class GGVModel:
             if f in vals and vals[f] <= 0.0:
                 raise ValueError(f"GGVModel.from_dict: {f} must be positive: {vals[f]!r}")
         prov = data.get("provenance")
-        return cls(**vals, provenance=prov if isinstance(prov, dict) else {})
+        supported = data.get("supported_longitudinal", {})
+        return cls(
+            **vals,
+            provenance=prov if isinstance(prov, dict) else {},
+            supported_longitudinal=supported,
+        )
 
 
 def _pct(xs: list[float], q: float) -> float:
@@ -227,6 +245,16 @@ def _pct(xs: list[float], q: float) -> float:
         return 0.0
     s = sorted(xs)
     return s[min(len(s) - 1, int(q * len(s)))]
+
+
+def _probe_pct(xs: list[float], q: float) -> float:
+    """Small-N probe quantile that always excludes one possible peak glitch."""
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    if len(s) == 1:
+        return s[0]
+    return s[min(len(s) - 2, int(q * len(s)))]
 
 
 def _linfit(xs: list[float], ys: list[float], ws: list[float] | None = None) -> tuple[float, float]:
@@ -322,7 +350,7 @@ def ggv_from_telemetry(
         if not passive_ok and not probe_ok:
             return None
         passive_p95 = _pct(vals, pct) if passive_ok else float("-inf")
-        probe_p95 = _pct(probe_vals, pct) if probe_ok else float("-inf")
+        probe_p95 = _probe_pct(probe_vals, pct) if probe_ok else float("-inf")
         if probe_p95 > passive_p95:
             return (probe_p95, float(len(probe_vals)))
         return (passive_p95, float(len(vals)))
@@ -337,7 +365,13 @@ def ggv_from_telemetry(
             ys_b.append(trusted[0])
             ws_b.append(trusted[1])
             trusted_brake_bins.append(b)
-    brake_b0, brake_b1 = _linfit(xs_b, ys_b, ws_b) if len(xs_b) >= 2 else (1.0, 0.0)
+    if len(xs_b) >= 2:
+        fitted_brake_b0, fitted_brake_b1 = _linfit(xs_b, ys_b, ws_b)
+        brake_fit_valid = fitted_brake_b1 >= 0.0
+        brake_b0, brake_b1 = (fitted_brake_b0, fitted_brake_b1) if brake_fit_valid else (1.0, 0.0)
+    else:
+        brake_b0, brake_b1 = (1.0, 0.0)
+        brake_fit_valid = False
 
     # accel fit (linear) - weakly identified (human under-drove), kept conservative
     xs_a, ys_a, ws_a = [], [], []
@@ -357,7 +391,12 @@ def ggv_from_telemetry(
     def covered_range(bins: list[int]) -> list[float] | None:
         if not bins:
             return None
-        return [float(min(bins)), float(max(bins)) + bin_kmh]
+        ordered = sorted(bins)
+        if any(
+            not math.isclose(b - a, bin_kmh) for a, b in zip(ordered, ordered[1:], strict=False)
+        ):
+            return None
+        return [float(ordered[0]), float(ordered[-1]) + bin_kmh]
 
     prov = {
         "bins": cov,
@@ -366,6 +405,9 @@ def ggv_from_telemetry(
         # reads to decide, per curve, whether to trust the measurement or fall back to the prior.
         "brake_bins": len(xs_b),
         "accel_bins": len(xs_a),
+        "brake_fit_valid": brake_fit_valid,
+        "brake_bins_contiguous": covered_range(trusted_brake_bins) is not None,
+        "accel_bins_contiguous": covered_range(trusted_accel_bins) is not None,
         "brake_probe_bins": sum(
             1 for b in trusted_brake_bins if len(brk_probe_b.get(b, [])) >= min_probe_samples
         ),
@@ -386,7 +428,7 @@ def ggv_from_telemetry(
         mu_lat_g=mu_lat,
         k_aero_lat=max(0.0, k_aero),
         brake_b0_g=brake_b0,
-        brake_b1=max(0.0, brake_b1),
+        brake_b1=brake_b1,
         drive_b0_g=drive_b0,
         drive_b1=drive_b1,
         drive_min_g=0.35,
@@ -422,7 +464,7 @@ def blend_ggv_safe(
     prior_name: str = "injected_prior",
     min_brake_bins: int = 2,
     min_accel_bins: int = 2,
-    min_longitudinal_span_kmh: float = 40.0,
+    min_longitudinal_span_kmh: float = MIN_LONGITUDINAL_SUPPORT_KMH,
     support_taper_kmh: float = 10.0,
 ) -> GGVModel:
     """Safe-envelope blend of a per-combo MEASURED GGVModel with a trusted PRIOR (#532 Part B).
@@ -495,6 +537,7 @@ def blend_ggv_safe(
     brake_b0, brake_b1, brake_src = prior.brake_b0_g, prior.brake_b1, "prior"
     if (
         brake_bins >= min_brake_bins
+        and prov.get("brake_fit_valid") is True
         and coverage_ok(brake_range)
         and _finite_ggv(measured.brake_b0_g, measured.brake_b1)
         and _curve_exceeds(
@@ -580,7 +623,6 @@ def blend_ggv_safe(
             "outside_observed_range": "prior",
             "support_taper_kmh": support_taper_kmh,
         },
-        "supported_longitudinal": supported_longitudinal,
         "prior": prior_name,
         # A conservative handshake under-measures the true limit; a measured value below the prior
         # is a lower bound, not a weaker-car signal. Recorded for a future slip-saturation pass.
@@ -601,6 +643,7 @@ def blend_ggv_safe(
         ay_cap_g=prior.ay_cap_g,  # never raise the lateral cap above the prior
         ax_brake_cap_g=prior.ax_brake_cap_g,
         provenance=blend_prov,
+        supported_longitudinal=supported_longitudinal,
     )
 
 
@@ -628,6 +671,70 @@ def _curve_exceeds(
 
 def _finite_ggv(*values: float) -> bool:
     return all(isinstance(v, (int, float)) and math.isfinite(v) for v in values)
+
+
+def _validate_supported_longitudinal(
+    supported: dict,
+    *,
+    brake_b0_g: float,
+    brake_b1: float,
+    drive_b0_g: float,
+    drive_b1: float,
+    ax_brake_cap_g: float,
+) -> None:
+    """Validate every runtime-bearing measured override against the trusted prior.
+
+    The artifact's free-form ``provenance`` is observability only. Supported curves have their own
+    schema and are accepted only when the same deterministic safety gates used by
+    :func:`blend_ggv_safe` still hold after deserialization.
+    """
+    if not isinstance(supported, dict):
+        raise ValueError("supported_longitudinal must be a dict")
+    unknown = set(supported) - {"brake", "drive"}
+    if unknown:
+        raise ValueError(f"unsupported longitudinal override keys: {sorted(unknown)!r}")
+    for kind, override in supported.items():
+        if not isinstance(override, dict):
+            raise ValueError(f"supported_longitudinal.{kind} must be a dict")
+        required = {"speed_min_kmh", "speed_max_kmh", "b0_g", "b1", "floor_g", "taper_kmh"}
+        if set(override) != required:
+            raise ValueError(
+                f"supported_longitudinal.{kind} fields must be exactly {sorted(required)!r}"
+            )
+        raw = [override[name] for name in sorted(required)]
+        if any(isinstance(value, bool) for value in raw) or not _finite_ggv(*raw):
+            raise ValueError(f"supported_longitudinal.{kind} contains non-finite fields")
+        lo_kmh = float(override["speed_min_kmh"])
+        hi_kmh = float(override["speed_max_kmh"])
+        b0_g = float(override["b0_g"])
+        b1 = float(override["b1"])
+        floor_g = float(override["floor_g"])
+        taper_kmh = float(override["taper_kmh"])
+        span_kmh = hi_kmh - lo_kmh
+        if (
+            lo_kmh < 0.0
+            or hi_kmh > MAX_LONGITUDINAL_SUPPORT_KMH
+            or span_kmh < MIN_LONGITUDINAL_SUPPORT_KMH
+            or taper_kmh <= 0.0
+            or taper_kmh > span_kmh / 2.0
+            or floor_g < 0.0
+        ):
+            raise ValueError(f"supported_longitudinal.{kind} has an unsafe range/taper/floor")
+        v_lo, v_hi = lo_kmh / 3.6, hi_kmh / 3.6
+        if kind == "brake":
+            if floor_g != 0.5 or b1 < 0.0:
+                raise ValueError("supported brake override requires floor_g=0.5 and b1>=0")
+            if not _curve_exceeds(b0_g, b1, brake_b0_g, brake_b1, v_lo=v_lo, v_hi=v_hi):
+                raise ValueError("supported brake override no longer exceeds its trusted prior")
+            if max(b0_g + b1 * v_lo, b0_g + b1 * v_hi) > ax_brake_cap_g:
+                raise ValueError("supported brake override exceeds the trusted brake cap")
+        else:
+            if floor_g > MAX_DRIVE_SUPPORT_G:
+                raise ValueError("supported drive floor exceeds the physical safety cap")
+            if not _curve_exceeds(b0_g, b1, drive_b0_g, drive_b1, v_lo=v_lo, v_hi=v_hi):
+                raise ValueError("supported drive override no longer exceeds its trusted prior")
+            if max(floor_g, b0_g + b1 * v_lo, b0_g + b1 * v_hi) > MAX_DRIVE_SUPPORT_G:
+                raise ValueError("supported drive override exceeds the physical safety cap")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -72,10 +72,65 @@ class GGVModel:
         return min(self.ay_cap_g, self.mu_lat_g + self.k_aero_lat * v_ms * v_ms) * G
 
     def ax_brake_max(self, v_ms: float) -> float:
-        return min(self.ax_brake_cap_g, max(0.5, self.brake_b0_g + self.brake_b1 * v_ms)) * G
+        prior_g = max(0.5, self.brake_b0_g + self.brake_b1 * v_ms)
+        supported_g = self._supported_longitudinal_g("brake", v_ms, prior_g, floor_g=0.5)
+        return min(self.ax_brake_cap_g, supported_g) * G
 
     def ax_drive_max(self, v_ms: float) -> float:
-        return max(self.drive_min_g, self.drive_b0_g + self.drive_b1 * v_ms) * G
+        prior_g = max(self.drive_min_g, self.drive_b0_g + self.drive_b1 * v_ms)
+        supported_g = self._supported_longitudinal_g(
+            "drive", v_ms, prior_g, floor_g=self.drive_min_g
+        )
+        return supported_g * G
+
+    def _supported_longitudinal_g(
+        self, kind: str, v_ms: float, prior_g: float, *, floor_g: float
+    ) -> float:
+        """Apply a measured gain only inside its observed speed support.
+
+        ``blend_ggv_safe`` deliberately keeps the trusted prior in the model's top-level
+        coefficients.  A measured longitudinal curve is stored as an additive, provenance-backed
+        override and tapers to the prior at both edges of the observed range.  Consequently an old
+        consumer that ignores provenance remains conservative, while this consumer can learn where
+        the handshake actually measured without extrapolating a low-speed fit to 240 km/h.
+
+        Persisted provenance is untrusted input.  Any malformed/non-finite override is ignored and
+        the prior is returned, matching the artifact loader's fail-safe contract.
+        """
+        if not isinstance(self.provenance, dict):
+            return prior_g
+        supported = self.provenance.get("supported_longitudinal")
+        if not isinstance(supported, dict):
+            return prior_g
+        override = supported.get(kind)
+        if not isinstance(override, dict):
+            return prior_g
+        try:
+            lo_kmh = float(override["speed_min_kmh"])
+            hi_kmh = float(override["speed_max_kmh"])
+            b0_g = float(override["b0_g"])
+            b1 = float(override["b1"])
+            measured_floor_g = float(override.get("floor_g", floor_g))
+            taper_kmh = float(override.get("taper_kmh", 10.0))
+        except (KeyError, TypeError, ValueError):
+            return prior_g
+        if not _finite_ggv(lo_kmh, hi_kmh, b0_g, b1, measured_floor_g, taper_kmh):
+            return prior_g
+        if lo_kmh < 0.0 or hi_kmh <= lo_kmh or measured_floor_g < 0.0 or taper_kmh <= 0.0:
+            return prior_g
+        speed_kmh = v_ms * 3.6
+        if speed_kmh <= lo_kmh or speed_kmh >= hi_kmh:
+            return prior_g
+        measured_g = max(measured_floor_g, b0_g + b1 * v_ms)
+        if measured_g <= prior_g:
+            return prior_g
+        taper_kmh = min(taper_kmh, (hi_kmh - lo_kmh) / 2.0)
+        weight = min(
+            1.0,
+            (speed_kmh - lo_kmh) / taper_kmh,
+            (hi_kmh - speed_kmh) / taper_kmh,
+        )
+        return prior_g + weight * (measured_g - prior_g)
 
     def ax_brake_avail(self, ay_used: float, v_ms: float) -> float:
         """Braking g still available given lateral g already used (friction ellipse)."""
@@ -152,6 +207,10 @@ class GGVModel:
             )
         if vals["mu_lat_g"] <= 0.0:
             raise ValueError(f"GGVModel.from_dict: mu_lat_g must be positive: {vals['mu_lat_g']!r}")
+        if vals["k_aero_lat"] < 0.0:
+            raise ValueError(
+                f"GGVModel.from_dict: k_aero_lat must be non-negative: {vals['k_aero_lat']!r}"
+            )
         if vals["drive_min_g"] < 0.0:
             raise ValueError(
                 f"GGVModel.from_dict: drive_min_g must be non-negative: {vals['drive_min_g']!r}"
@@ -192,17 +251,22 @@ def ggv_from_telemetry(
     pct: float = 0.95,
     min_corner_lat_g: float = 0.9,
     min_samples: int = 40,
+    min_probe_samples: int = 8,
 ) -> GGVModel:
     """Fit a :class:`GGVModel` from telemetry rows (dicts w/ speed_kmh, accg_lat, accg_lon).
 
     Per speed bin: 95th-pct |lat|, braking (-lon) and accel (+lon) g, with sample count and lateral
     spread. ``ay_max(v)=mu*g+k*v^2`` is fitted ONLY on bins with real cornering coverage (lat spread
-    >= ``min_lat_spread_g`` and >= ``min_samples``); braking/accel fitted linearly. Ellipse exponent
-    from the radial hull of ``(lat, lon)``.
+    >= ``min_lat_spread_g`` and >= ``min_samples``); braking/accel fitted linearly.  Passive
+    longitudinal bins keep that same threshold.  Rows explicitly tagged ``brake_probe`` or
+    ``accel_sweep`` come from bounded, controlled maneuvers and may qualify their matching bin at
+    ``min_probe_samples``. Ellipse exponent comes from the radial hull of ``(lat, lon)``.
     """
     lat_b: dict[int, list[float]] = {}
     brk_b: dict[int, list[float]] = {}
     acc_b: dict[int, list[float]] = {}
+    brk_probe_b: dict[int, list[float]] = {}
+    acc_probe_b: dict[int, list[float]] = {}
     hull: list[tuple[float, float]] = []  # (|lat|, |lon|) in g
     for r in rows:
         try:
@@ -214,6 +278,11 @@ def ggv_from_telemetry(
         b = int(v // bin_kmh) * int(bin_kmh)
         lat_b.setdefault(b, []).append(al)
         (brk_b if ao < 0 else acc_b).setdefault(b, []).append(abs(ao))
+        source = r.get("source")
+        if ao < 0 and source == "brake_probe":
+            brk_probe_b.setdefault(b, []).append(abs(ao))
+        elif ao >= 0 and source == "accel_sweep":
+            acc_probe_b.setdefault(b, []).append(abs(ao))
         if al > 0.2 or abs(ao) > 0.2:
             hull.append((al, abs(ao)))
 
@@ -239,26 +308,56 @@ def ggv_from_telemetry(
     k_aero = 0.0
     n_corner_bins = len(corner_p95)
 
+    def trusted_longitudinal_value(
+        vals: list[float], probe_vals: list[float]
+    ) -> tuple[float, float] | None:
+        """Return (p95, weight) from the evidence that qualified this speed bin.
+
+        A controlled probe must not merely unlock a bin whose percentile is then diluted by a much
+        larger passive sample set. Prefer its own percentile when it is the stronger demonstrated
+        envelope; otherwise retain the independently qualified passive percentile.
+        """
+        passive_ok = len(vals) >= min_samples
+        probe_ok = len(probe_vals) >= min_probe_samples
+        if not passive_ok and not probe_ok:
+            return None
+        passive_p95 = _pct(vals, pct) if passive_ok else float("-inf")
+        probe_p95 = _pct(probe_vals, pct) if probe_ok else float("-inf")
+        if probe_p95 > passive_p95:
+            return (probe_p95, float(len(probe_vals)))
+        return (passive_p95, float(len(vals)))
+
     # braking fit (linear in v) on bins with samples
     xs_b, ys_b, ws_b = [], [], []
+    trusted_brake_bins: list[int] = []
     for b, vals in sorted(brk_b.items()):
-        if len(vals) >= min_samples and b >= 30:
+        trusted = trusted_longitudinal_value(vals, brk_probe_b.get(b, []))
+        if trusted is not None and b >= 30:
             xs_b.append((b + bin_kmh / 2) / 3.6)
-            ys_b.append(_pct(vals, pct))
-            ws_b.append(float(len(vals)))
+            ys_b.append(trusted[0])
+            ws_b.append(trusted[1])
+            trusted_brake_bins.append(b)
     brake_b0, brake_b1 = _linfit(xs_b, ys_b, ws_b) if len(xs_b) >= 2 else (1.0, 0.0)
 
     # accel fit (linear) - weakly identified (human under-drove), kept conservative
     xs_a, ys_a, ws_a = [], [], []
+    trusted_accel_bins: list[int] = []
     for b, vals in sorted(acc_b.items()):
-        if len(vals) >= min_samples and b >= 30:
+        trusted = trusted_longitudinal_value(vals, acc_probe_b.get(b, []))
+        if trusted is not None and b >= 30:
             xs_a.append((b + bin_kmh / 2) / 3.6)
-            ys_a.append(_pct(vals, pct))
-            ws_a.append(float(len(vals)))
+            ys_a.append(trusted[0])
+            ws_a.append(trusted[1])
+            trusted_accel_bins.append(b)
     drive_b0, drive_b1 = _linfit(xs_a, ys_a, ws_a) if len(xs_a) >= 2 else (0.8, 0.0)
 
     # ellipse exponent from radial hull edge: near the boundary (lat/aymax)^n + (lon/axmax)^n ~ 1.
     n_fit = _fit_ellipse_n(hull, mu_lat, k_aero, brake_b0, brake_b1)
+
+    def covered_range(bins: list[int]) -> list[float] | None:
+        if not bins:
+            return None
+        return [float(min(bins)), float(max(bins)) + bin_kmh]
 
     prov = {
         "bins": cov,
@@ -267,6 +366,16 @@ def ggv_from_telemetry(
         # reads to decide, per curve, whether to trust the measurement or fall back to the prior.
         "brake_bins": len(xs_b),
         "accel_bins": len(xs_a),
+        "brake_probe_bins": sum(
+            1 for b in trusted_brake_bins if len(brk_probe_b.get(b, [])) >= min_probe_samples
+        ),
+        "accel_probe_bins": sum(
+            1 for b in trusted_accel_bins if len(acc_probe_b.get(b, [])) >= min_probe_samples
+        ),
+        "brake_speed_range_kmh": covered_range(trusted_brake_bins),
+        "accel_speed_range_kmh": covered_range(trusted_accel_bins),
+        "passive_min_samples_per_bin": min_samples,
+        "probe_min_samples_per_bin": min_probe_samples,
         "hull_points": len(hull),
         "lat_model": f"ay_max(v)={mu_lat:.3f}+{k_aero:.5f}*v_ms^2 g [mech peak; no aero-lat]",
         "brake_model": f"ax_brake(v)={brake_b0:.3f}+{brake_b1:.5f}*v_ms (g)",
@@ -313,6 +422,8 @@ def blend_ggv_safe(
     prior_name: str = "injected_prior",
     min_brake_bins: int = 2,
     min_accel_bins: int = 2,
+    min_longitudinal_span_kmh: float = 40.0,
+    support_taper_kmh: float = 10.0,
 ) -> GGVModel:
     """Safe-envelope blend of a per-combo MEASURED GGVModel with a trusted PRIOR (#532 Part B).
 
@@ -329,9 +440,12 @@ def blend_ggv_safe(
       Genuine per-combo lateral lowering needs slip-saturation evidence / a limit-reaching lateral
       probe — deferred (unsafe to push a GT3 to its lateral limit unattended). So lateral == prior.
     * **Braking / drive accel** CAN be probed to their limits safely (straight-line braking, WOT
-      accel). Adopt the measured curve ONLY where it CONFIDENTLY EXCEEDS the prior across the
-      covered speeds (evidence of MORE capability); otherwise the prior — a diluted
-      under-measurement must never LOWER braking/accel and regress. The prior's hard caps are kept.
+      accel). Apply the measured curve ONLY inside an observed span of at least
+      ``min_longitudinal_span_kmh`` where it CONFIDENTLY EXCEEDS the prior (evidence of MORE
+      capability). It tapers to the prior at both support edges and the prior is used everywhere
+      outside, so a low-speed fit is never extrapolated to an unmeasured high-speed braking point.
+      The prior remains in the top-level coefficients as a fail-safe for older consumers, and its
+      hard caps are kept.
     * **The ellipse exponent is pinned to the prior.** The friction-ellipse boundary exponent
       requires limit-reaching (boundary) data; a conservative handshake's ``(lat, lon)`` hull is
       interior points, so a fit from it is unreliable — like the lateral limit, honest per-combo
@@ -340,14 +454,31 @@ def blend_ggv_safe(
 
     Net: the reference car (and any conservatively-driven combo) reproduces the prior — no
     regression, no spin — while a car that DEMONSTRABLY brakes / accelerates harder than the prior
-    gets that measured improvement. The measured lower-bound envelope is recorded in provenance for
-    a future slip-saturation pass. Provenance labels each curve ``measured`` vs ``prior``.
+    gets that measured improvement only over the speed range that proved it. The measured
+    lower-bound envelope is recorded in provenance for a future slip-saturation pass. Provenance
+    labels each curve ``measured(supported)`` vs ``prior``.
     """
     prov = dict(measured.provenance or {})
     corner_bins = int(prov.get("lat_corner_bins", 0) or 0)
     brake_bins = int(prov.get("brake_bins", 0) or 0)
     accel_bins = int(prov.get("accel_bins", 0) or 0)
     hull_points = int(prov.get("hull_points", 0) or 0)
+
+    def observed_range(key: str) -> tuple[float, float] | None:
+        value = prov.get(key)
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            return None
+        lo, hi = value
+        if not _finite_ggv(lo, hi) or float(lo) < 0.0 or float(hi) <= float(lo):
+            return None
+        return (float(lo), float(hi))
+
+    def coverage_ok(value: tuple[float, float] | None) -> bool:
+        return value is not None and value[1] - value[0] >= min_longitudinal_span_kmh
+
+    brake_range = observed_range("brake_speed_range_kmh")
+    accel_range = observed_range("accel_speed_range_kmh")
+    supported_longitudinal: dict[str, dict] = {}
 
     # Lateral: the prior is ceiling AND floor (see docstring) — a non-limit measurement is only a
     # lower bound, so it never lowers the operating plant and never regresses the reference car.
@@ -358,14 +489,32 @@ def blend_ggv_safe(
     # feeds a future limit-reaching pass. See docstring.
     ellipse_n, ell_src = prior.ellipse_n, "prior"
 
-    # Braking: adopt measured ONLY where it CONFIDENTLY EXCEEDS the prior across the covered speeds.
+    # Braking: the top-level curve remains the prior. A measured gain is activated only over a
+    # sufficiently broad OBSERVED span and tapers back to the prior at both edges. This prevents a
+    # narrow 50-90 km/h fit from changing a later 200 km/h braking point.
     brake_b0, brake_b1, brake_src = prior.brake_b0_g, prior.brake_b1, "prior"
     if (
         brake_bins >= min_brake_bins
+        and coverage_ok(brake_range)
         and _finite_ggv(measured.brake_b0_g, measured.brake_b1)
-        and _curve_exceeds(measured.brake_b0_g, measured.brake_b1, prior.brake_b0_g, prior.brake_b1)
+        and _curve_exceeds(
+            measured.brake_b0_g,
+            measured.brake_b1,
+            prior.brake_b0_g,
+            prior.brake_b1,
+            v_lo=brake_range[0] / 3.6,
+            v_hi=brake_range[1] / 3.6,
+        )
     ):
-        brake_b0, brake_b1, brake_src = measured.brake_b0_g, measured.brake_b1, "measured(>prior)"
+        supported_longitudinal["brake"] = {
+            "speed_min_kmh": brake_range[0],
+            "speed_max_kmh": brake_range[1],
+            "b0_g": measured.brake_b0_g,
+            "b1": measured.brake_b1,
+            "floor_g": 0.5,
+            "taper_kmh": support_taper_kmh,
+        }
+        brake_src = "measured(supported)"
 
     # Drive accel: same rule (the WOT sweep reaches full throttle; aggressive accel is TC-off-safe
     # live via the slip limiter). Measured only where it confidently exceeds the prior, else prior.
@@ -377,15 +526,26 @@ def blend_ggv_safe(
     )
     if (
         accel_bins >= min_accel_bins
+        and coverage_ok(accel_range)
         and _finite_ggv(measured.drive_b0_g, measured.drive_b1, measured.drive_min_g)
-        and _curve_exceeds(measured.drive_b0_g, measured.drive_b1, prior.drive_b0_g, prior.drive_b1)
-    ):
-        drive_b0, drive_b1, drive_min, drive_src = (
+        and _curve_exceeds(
             measured.drive_b0_g,
             measured.drive_b1,
-            measured.drive_min_g,
-            "measured(>prior)",
+            prior.drive_b0_g,
+            prior.drive_b1,
+            v_lo=accel_range[0] / 3.6,
+            v_hi=accel_range[1] / 3.6,
         )
+    ):
+        supported_longitudinal["drive"] = {
+            "speed_min_kmh": accel_range[0],
+            "speed_max_kmh": accel_range[1],
+            "b0_g": measured.drive_b0_g,
+            "b1": measured.drive_b1,
+            "floor_g": measured.drive_min_g,
+            "taper_kmh": support_taper_kmh,
+        }
+        drive_src = "measured(supported)"
 
     blend_prov = {
         "blend_source": {
@@ -404,15 +564,29 @@ def blend_ggv_safe(
             "lat_corner_bins": corner_bins,
             "brake_bins": brake_bins,
             "accel_bins": accel_bins,
+            "brake_probe_bins": int(prov.get("brake_probe_bins", 0) or 0),
+            "accel_probe_bins": int(prov.get("accel_probe_bins", 0) or 0),
+            "brake_speed_range_kmh": list(brake_range) if brake_range else None,
+            "accel_speed_range_kmh": list(accel_range) if accel_range else None,
+            "passive_min_samples_per_bin": prov.get("passive_min_samples_per_bin"),
+            "probe_min_samples_per_bin": prov.get("probe_min_samples_per_bin"),
             "hull_points": hull_points,
             "bins": prov.get("bins", {}),
         },
+        "blend_gate": {
+            "min_longitudinal_span_kmh": min_longitudinal_span_kmh,
+            "brake_coverage_ok": coverage_ok(brake_range),
+            "accel_coverage_ok": coverage_ok(accel_range),
+            "outside_observed_range": "prior",
+            "support_taper_kmh": support_taper_kmh,
+        },
+        "supported_longitudinal": supported_longitudinal,
         "prior": prior_name,
         # A conservative handshake under-measures the true limit; a measured value below the prior
         # is a lower bound, not a weaker-car signal. Recorded for a future slip-saturation pass.
         "note": (
             "lateral pinned to prior (conservative drive under-measures the lateral limit); "
-            "braking/drive adopted only where measured>prior"
+            "braking/drive gains applied only inside measured speed support; prior outside"
         ),
     }
     return GGVModel(

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -48,6 +48,8 @@ G = 9.81
 MIN_LONGITUDINAL_SUPPORT_KMH = 40.0
 MAX_LONGITUDINAL_SUPPORT_KMH = 300.0
 MAX_DRIVE_SUPPORT_G = 2.0
+MAX_PERSISTED_AY_CAP_G = 1.8
+MAX_PERSISTED_BRAKE_CAP_G = 3.4
 
 
 # ---------------------------------------------------------------------------
@@ -113,11 +115,12 @@ class GGVModel:
     def _supported_longitudinal_g(
         self, kind: str, v_ms: float, prior_g: float, *, floor_g: float
     ) -> float:
-        """Apply a measured gain only inside its observed speed support.
+        """Apply a measured longitudinal envelope only inside its observed speed support.
 
         ``blend_ggv_safe`` deliberately keeps the trusted prior in the model's top-level
         coefficients.  A measured longitudinal curve is stored as an additive, provenance-backed
-        override and tapers to the prior at both edges of the observed range.  Consequently an old
+        override and tapers to the prior at both edges of the observed range. Braking evidence may
+        safely raise or lower the envelope; drive evidence only raises it. Consequently an old
         consumer that ignores provenance remains conservative, while this consumer can learn where
         the handshake actually measured without extrapolating a low-speed fit to 240 km/h.
 
@@ -144,7 +147,7 @@ class GGVModel:
         if speed_kmh <= lo_kmh or speed_kmh >= hi_kmh:
             return prior_g
         measured_g = max(measured_floor_g, b0_g + b1 * v_ms)
-        if measured_g <= prior_g:
+        if kind != "brake" and measured_g <= prior_g:
             return prior_g
         taper_kmh = min(taper_kmh, (hi_kmh - lo_kmh) / 2.0)
         weight = min(
@@ -241,9 +244,13 @@ class GGVModel:
             raise ValueError(
                 f"GGVModel.from_dict: drive_min_g must be non-negative: {vals['drive_min_g']!r}"
             )
-        for f in ("ay_cap_g", "ax_brake_cap_g"):
-            if f in vals and vals[f] <= 0.0:
-                raise ValueError(f"GGVModel.from_dict: {f} must be positive: {vals[f]!r}")
+        cap_limits = {
+            "ay_cap_g": MAX_PERSISTED_AY_CAP_G,
+            "ax_brake_cap_g": MAX_PERSISTED_BRAKE_CAP_G,
+        }
+        for f, limit in cap_limits.items():
+            if f in vals and not (0.0 < vals[f] <= limit):
+                raise ValueError(f"GGVModel.from_dict: {f} must be in (0, {limit}]: {vals[f]!r}")
         prov = data.get("provenance")
         supported = data.get("supported_longitudinal", {})
         return cls(
@@ -499,9 +506,11 @@ def blend_ggv_safe(
       probe — deferred (unsafe to push a GT3 to its lateral limit unattended). So lateral == prior.
     * **Braking / drive accel** CAN be probed to their limits safely (straight-line braking, WOT
       accel). Apply the measured curve ONLY inside an observed span of at least
-      ``min_longitudinal_span_kmh`` where it CONFIDENTLY EXCEEDS the prior (evidence of MORE
-      capability). It tapers to the prior at both support edges and the prior is used everywhere
-      outside, so a low-speed fit is never extrapolated to an unmeasured high-speed braking point.
+      ``min_longitudinal_span_kmh``. Braking accepts a curve that is consistently above OR below
+      the prior: a weaker measured brake envelope must make the combo brake earlier. Drive accepts
+      only a confident gain because conservative acceleration under-measurement is not hazardous.
+      The measured curve tapers to the prior at both support edges and the prior is used everywhere
+      outside, so a low-speed fit is never extrapolated to an unmeasured high-speed point.
       The prior remains in the top-level coefficients as a fail-safe for older consumers, and its
       hard caps are kept.
     * **The ellipse exponent is pinned to the prior.** The friction-ellipse boundary exponent
@@ -547,16 +556,17 @@ def blend_ggv_safe(
     # feeds a future limit-reaching pass. See docstring.
     ellipse_n, ell_src = prior.ellipse_n, "prior"
 
-    # Braking: the top-level curve remains the prior. A measured gain is activated only over a
-    # sufficiently broad OBSERVED span and tapers back to the prior at both edges. This prevents a
-    # narrow 50-90 km/h fit from changing a later 200 km/h braking point.
+    # Braking: the top-level curve remains the prior. A consistently stronger OR weaker measured
+    # envelope is activated only over a sufficiently broad OBSERVED span and tapers back to the
+    # prior at both edges. This prevents a narrow 50-90 km/h fit from changing a later 200 km/h
+    # braking point.
     brake_b0, brake_b1, brake_src = prior.brake_b0_g, prior.brake_b1, "prior"
     if (
         brake_bins >= min_brake_bins
         and prov.get("brake_fit_valid") is True
         and coverage_ok(brake_range)
         and _finite_ggv(measured.brake_b0_g, measured.brake_b1)
-        and _curve_exceeds(
+        and _brake_curve_is_supported(
             measured.brake_b0_g,
             measured.brake_b1,
             prior.brake_b0_g,
@@ -640,11 +650,12 @@ def blend_ggv_safe(
             "support_taper_kmh": support_taper_kmh,
         },
         "prior": prior_name,
-        # A conservative handshake under-measures the true limit; a measured value below the prior
-        # is a lower bound, not a weaker-car signal. Recorded for a future slip-saturation pass.
+        # A conservative handshake under-measures the lateral limit, so lateral values below the
+        # prior remain lower bounds. Straight-line braking, however, is limit-reaching evidence.
         "note": (
             "lateral pinned to prior (conservative drive under-measures the lateral limit); "
-            "braking/drive gains applied only inside measured speed support; prior outside"
+            "braking evidence and drive gains applied only inside measured speed support; "
+            "prior outside"
         ),
     }
     return GGVModel(
@@ -683,6 +694,24 @@ def _curve_exceeds(
     return (m0 + m1 * v_lo) >= (p0 + p1 * v_lo) + margin and (m0 + m1 * v_hi) >= (
         p0 + p1 * v_hi
     ) + margin
+
+
+def _brake_curve_is_supported(
+    m0: float,
+    m1: float,
+    p0: float,
+    p1: float,
+    *,
+    v_lo: float,
+    v_hi: float,
+    margin: float = 0.03,
+) -> bool:
+    """True when a brake curve is consistently stronger OR weaker over measured support."""
+    exceeds = _curve_exceeds(m0, m1, p0, p1, v_lo=v_lo, v_hi=v_hi, margin=margin)
+    below = (m0 + m1 * v_lo) <= (p0 + p1 * v_lo) - margin and (m0 + m1 * v_hi) <= (
+        p0 + p1 * v_hi
+    ) - margin
+    return exceeds or below
 
 
 def _finite_ggv(*values: float) -> bool:
@@ -747,8 +776,10 @@ def _validate_supported_longitudinal(
         if kind == "brake":
             if floor_g != 0.5 or b1 < 0.0:
                 raise ValueError("supported brake override requires floor_g=0.5 and b1>=0")
-            if not _curve_exceeds(b0_g, b1, brake_b0_g, brake_b1, v_lo=v_lo, v_hi=v_hi):
-                raise ValueError("supported brake override no longer exceeds its trusted prior")
+            if not _brake_curve_is_supported(b0_g, b1, brake_b0_g, brake_b1, v_lo=v_lo, v_hi=v_hi):
+                raise ValueError(
+                    "supported brake override is not consistently above/below its trusted prior"
+                )
             if max(b0_g + b1 * v_lo, b0_g + b1 * v_hi) > ax_brake_cap_g:
                 raise ValueError("supported brake override exceeds the trusted brake cap")
         else:

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -293,7 +293,6 @@ def blend_ggv_safe(
     measured: GGVModel,
     prior: GGVModel,
     *,
-    min_corner_bins: int = 2,
     min_brake_bins: int = 2,
     min_accel_bins: int = 2,
     min_hull_points: int = 20,
@@ -301,22 +300,28 @@ def blend_ggv_safe(
     """Safe-envelope blend of a per-combo MEASURED GGVModel with a trusted PRIOR (#532 Part B).
 
     The measured model comes from :func:`ggv_from_telemetry` over probe-lap rows; the prior is the
-    live-verified generic plant. The blend is the deterministic guard that turns a possibly-sparse
-    measurement into a plant that is never *more* optimistic than warranted:
+    live-verified generic plant. The blend is the deterministic guard that keeps the operating plant
+    from ever being MORE optimistic than warranted, while never regressing the reference combo:
 
-    * **Lateral grip is never extrapolated upward above the prior.** An aero-lateral term spins the
-      GT3 out (live-disproven, #259/#244), so ``k_aero_lat`` stays 0 and the lateral cap stays the
-      prior's. A confidently-cornered measurement may only *lower* lateral grip (a genuinely weaker
-      car); a thin/absent lateral measurement keeps the prior. So the reference car the prior nails
-      cannot regress, while a weaker car is still identified as weaker.
-    * **Braking / drive accel** use the measured curve only where the probe confidently covered the
-      envelope (``>= min_*_bins`` fitted speed bins); otherwise the prior curve. The prior's hard
-      caps (``ay_cap_g`` / ``ax_brake_cap_g``) are always kept.
-    * **The ellipse exponent reverts to the prior** unless the ``(lat, lon)`` hull was rich enough
-      to fit it — a wrong lat/long coupling is the biggest silent-spin risk (Council 2026-07-13).
+    * **Lateral grip: the prior is BOTH ceiling and floor.** Ceiling — never extrapolate up (an
+      aero-lateral term spins the GT3 out, live-disproven #259/#244; ``k_aero_lat`` stays 0, the cap
+      stays the prior's). Floor — a conservative, AC-valid handshake never reaches the LATERAL grip
+      limit (it drives clean at moderate pace by design), so a measured lateral BELOW the prior is a
+      *lower bound*, not evidence of a weaker car; lowering the plant to it would regress the very
+      car the prior nails, for no safety gain (the live slip limiter already guards over-drive).
+      Genuine per-combo lateral lowering needs slip-saturation evidence / a limit-reaching lateral
+      probe — deferred (unsafe to push a GT3 to its lateral limit unattended). So lateral == prior.
+    * **Braking / drive accel** CAN be probed to their limits safely (straight-line braking, WOT
+      accel). Adopt the measured curve ONLY where it CONFIDENTLY EXCEEDS the prior across the
+      covered speeds (evidence of MORE capability); otherwise the prior — a diluted
+      under-measurement must never LOWER braking/accel and regress. The prior's hard caps are kept.
+    * **The ellipse exponent reverts to the prior** unless the ``(lat, lon)`` hull is rich enough to
+      fit it — a wrong lat/long coupling is the biggest silent-spin risk (Council 2026-07-13).
 
-    Provenance records, per curve, whether the blended value is ``measured`` or ``prior``, plus the
-    measured per-bin coverage — so the artifact labels measured-vs-prior bins.
+    Net: the reference car (and any conservatively-driven combo) reproduces the prior — no
+    regression, no spin — while a car that DEMONSTRABLY brakes / accelerates harder than the prior
+    gets that measured improvement. The measured lower-bound envelope is recorded in provenance for
+    a future slip-saturation pass. Provenance labels each curve ``measured`` vs ``prior``.
     """
     prov = dict(measured.provenance or {})
     corner_bins = int(prov.get("lat_corner_bins", 0) or 0)
@@ -324,38 +329,37 @@ def blend_ggv_safe(
     accel_bins = int(prov.get("accel_bins", 0) or 0)
     hull_points = int(prov.get("hull_points", 0) or 0)
 
-    # Lateral: cap at the prior; a confident measurement may only LOWER it (weaker car), not raise.
+    # Lateral: the prior is ceiling AND floor (see docstring) — a non-limit measurement is only a
+    # lower bound, so it never lowers the operating plant and never regresses the reference car.
+    mu_lat, lat_src = prior.mu_lat_g, "prior"
+
+    # Braking: adopt measured ONLY where it CONFIDENTLY EXCEEDS the prior across the covered speeds.
+    brake_b0, brake_b1, brake_src = prior.brake_b0_g, prior.brake_b1, "prior"
     if (
-        corner_bins >= min_corner_bins
-        and math.isfinite(measured.mu_lat_g)
-        and measured.mu_lat_g < prior.mu_lat_g
+        brake_bins >= min_brake_bins
+        and _finite_ggv(measured.brake_b0_g, measured.brake_b1)
+        and _curve_exceeds(measured.brake_b0_g, measured.brake_b1, prior.brake_b0_g, prior.brake_b1)
     ):
-        mu_lat, lat_src = measured.mu_lat_g, "measured(<prior)"
-    else:
-        mu_lat, lat_src = prior.mu_lat_g, "prior"
+        brake_b0, brake_b1, brake_src = measured.brake_b0_g, measured.brake_b1, "measured(>prior)"
 
-    # Braking: measured where confidently covered (kept under the prior's hard cap), else prior.
-    if brake_bins >= min_brake_bins and _finite_ggv(measured.brake_b0_g, measured.brake_b1):
-        brake_b0, brake_b1, brake_src = measured.brake_b0_g, measured.brake_b1, "measured"
-    else:
-        brake_b0, brake_b1, brake_src = prior.brake_b0_g, prior.brake_b1, "prior"
-
-    # Drive accel: measured where the WOT sweep covered it, else prior (kept TC-off-safe live).
-    if accel_bins >= min_accel_bins and _finite_ggv(
-        measured.drive_b0_g, measured.drive_b1, measured.drive_min_g
+    # Drive accel: same rule (the WOT sweep reaches full throttle; aggressive accel is TC-off-safe
+    # live via the slip limiter). Measured only where it confidently exceeds the prior, else prior.
+    drive_b0, drive_b1, drive_min, drive_src = (
+        prior.drive_b0_g,
+        prior.drive_b1,
+        prior.drive_min_g,
+        "prior",
+    )
+    if (
+        accel_bins >= min_accel_bins
+        and _finite_ggv(measured.drive_b0_g, measured.drive_b1, measured.drive_min_g)
+        and _curve_exceeds(measured.drive_b0_g, measured.drive_b1, prior.drive_b0_g, prior.drive_b1)
     ):
         drive_b0, drive_b1, drive_min, drive_src = (
             measured.drive_b0_g,
             measured.drive_b1,
             measured.drive_min_g,
-            "measured",
-        )
-    else:
-        drive_b0, drive_b1, drive_min, drive_src = (
-            prior.drive_b0_g,
-            prior.drive_b1,
-            prior.drive_min_g,
-            "prior",
+            "measured(>prior)",
         )
 
     # Ellipse exponent: revert to prior unless the hull is rich enough to fit it confidently.
@@ -385,6 +389,12 @@ def blend_ggv_safe(
             "bins": prov.get("bins", {}),
         },
         "prior": "generic_gt3_ggv",
+        # A conservative handshake under-measures the true limit; a measured value below the prior
+        # is a lower bound, not a weaker-car signal. Recorded for a future slip-saturation pass.
+        "note": (
+            "lateral pinned to prior (conservative drive under-measures the lateral limit); "
+            "braking/drive adopted only where measured>prior"
+        ),
     }
     return GGVModel(
         mu_lat_g=mu_lat,
@@ -399,6 +409,28 @@ def blend_ggv_safe(
         ax_brake_cap_g=prior.ax_brake_cap_g,
         provenance=blend_prov,
     )
+
+
+def _curve_exceeds(
+    m0: float,
+    m1: float,
+    p0: float,
+    p1: float,
+    *,
+    v_lo: float = 11.0,
+    v_hi: float = 50.0,
+    margin: float = 0.03,
+) -> bool:
+    """True iff the linear curve ``m0+m1*v`` exceeds ``p0+p1*v`` (by ``margin`` g) at BOTH speeds.
+
+    For two lines, exceeding at both endpoints of ``[v_lo, v_hi]`` (m/s; ~40..180 km/h) means the
+    measured curve dominates the prior across the whole covered range — the only case where a
+    measured braking/accel envelope is confidently BETTER than the prior and safe to adopt (a
+    diluted under-measurement fails this, so it never lowers the plant).
+    """
+    return (m0 + m1 * v_lo) >= (p0 + p1 * v_lo) + margin and (m0 + m1 * v_hi) >= (
+        p0 + p1 * v_hi
+    ) + margin
 
 
 def _finite_ggv(*values: float) -> bool:

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -25,11 +25,14 @@ here is plain arithmetic so CI verifies it with synthetic lines + synthetic tele
 
 from __future__ import annotations
 
+import copy
 import csv
 import math
 import struct
+from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from types import MappingProxyType
 
 from tools.ac_harness.ai_line import StanleySteering, _horizontal
 
@@ -72,7 +75,7 @@ class GGVModel:
     provenance: dict = field(default_factory=dict)
     # Runtime-bearing measured overrides are deliberately separate from free-form provenance and
     # validated on every construction/load. Top-level coefficients remain the trusted prior.
-    supported_longitudinal: dict = field(default_factory=dict)
+    supported_longitudinal: Mapping = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         _validate_supported_longitudinal(
@@ -82,6 +85,14 @@ class GGVModel:
             drive_b0_g=self.drive_b0_g,
             drive_b1=self.drive_b1,
             ax_brake_cap_g=self.ax_brake_cap_g,
+        )
+        # ``frozen=True`` does not freeze nested dicts. Detach observability provenance from its
+        # caller and make the runtime-bearing support schema recursively read-only after validation.
+        object.__setattr__(self, "provenance", copy.deepcopy(self.provenance))
+        object.__setattr__(
+            self,
+            "supported_longitudinal",
+            _freeze_supported_longitudinal(self.supported_longitudinal),
         )
 
     def ay_max(self, v_ms: float) -> float:
@@ -114,7 +125,7 @@ class GGVModel:
         the prior is returned, matching the artifact loader's fail-safe contract.
         """
         override = self.supported_longitudinal.get(kind)
-        if not isinstance(override, dict):
+        if not isinstance(override, Mapping):
             return prior_g
         try:
             lo_kmh = float(override["speed_min_kmh"])
@@ -175,8 +186,10 @@ class GGVModel:
             "ellipse_n": self.ellipse_n,
             "ay_cap_g": self.ay_cap_g,
             "ax_brake_cap_g": self.ax_brake_cap_g,
-            "provenance": self.provenance,
-            "supported_longitudinal": self.supported_longitudinal,
+            "provenance": copy.deepcopy(self.provenance),
+            "supported_longitudinal": {
+                kind: dict(override) for kind, override in self.supported_longitudinal.items()
+            },
         }
 
     @classmethod
@@ -235,8 +248,8 @@ class GGVModel:
         supported = data.get("supported_longitudinal", {})
         return cls(
             **vals,
-            provenance=prov if isinstance(prov, dict) else {},
-            supported_longitudinal=supported,
+            provenance=copy.deepcopy(prov) if isinstance(prov, dict) else {},
+            supported_longitudinal=copy.deepcopy(supported),
         )
 
 
@@ -291,8 +304,8 @@ def ggv_from_telemetry(
     ``min_probe_samples``. Ellipse exponent comes from the radial hull of ``(lat, lon)``.
     """
     lat_b: dict[int, list[float]] = {}
-    brk_b: dict[int, list[float]] = {}
-    acc_b: dict[int, list[float]] = {}
+    brk_passive_b: dict[int, list[float]] = {}
+    acc_passive_b: dict[int, list[float]] = {}
     brk_probe_b: dict[int, list[float]] = {}
     acc_probe_b: dict[int, list[float]] = {}
     hull: list[tuple[float, float]] = []  # (|lat|, |lon|) in g
@@ -305,12 +318,15 @@ def ggv_from_telemetry(
             continue
         b = int(v // bin_kmh) * int(bin_kmh)
         lat_b.setdefault(b, []).append(al)
-        (brk_b if ao < 0 else acc_b).setdefault(b, []).append(abs(ao))
         source = r.get("source")
         if ao < 0 and source == "brake_probe":
             brk_probe_b.setdefault(b, []).append(abs(ao))
+        elif ao < 0:
+            brk_passive_b.setdefault(b, []).append(abs(ao))
         elif ao >= 0 and source == "accel_sweep":
             acc_probe_b.setdefault(b, []).append(abs(ao))
+        else:
+            acc_passive_b.setdefault(b, []).append(abs(ao))
         if al > 0.2 or abs(ao) > 0.2:
             hull.append((al, abs(ao)))
 
@@ -358,8 +374,8 @@ def ggv_from_telemetry(
     # braking fit (linear in v) on bins with samples
     xs_b, ys_b, ws_b = [], [], []
     trusted_brake_bins: list[int] = []
-    for b, vals in sorted(brk_b.items()):
-        trusted = trusted_longitudinal_value(vals, brk_probe_b.get(b, []))
+    for b in sorted(set(brk_passive_b) | set(brk_probe_b)):
+        trusted = trusted_longitudinal_value(brk_passive_b.get(b, []), brk_probe_b.get(b, []))
         if trusted is not None and b >= 30:
             xs_b.append((b + bin_kmh / 2) / 3.6)
             ys_b.append(trusted[0])
@@ -376,8 +392,8 @@ def ggv_from_telemetry(
     # accel fit (linear) - weakly identified (human under-drove), kept conservative
     xs_a, ys_a, ws_a = [], [], []
     trusted_accel_bins: list[int] = []
-    for b, vals in sorted(acc_b.items()):
-        trusted = trusted_longitudinal_value(vals, acc_probe_b.get(b, []))
+    for b in sorted(set(acc_passive_b) | set(acc_probe_b)):
+        trusted = trusted_longitudinal_value(acc_passive_b.get(b, []), acc_probe_b.get(b, []))
         if trusted is not None and b >= 30:
             xs_a.append((b + bin_kmh / 2) / 3.6)
             ys_a.append(trusted[0])
@@ -555,7 +571,7 @@ def blend_ggv_safe(
             "b0_g": measured.brake_b0_g,
             "b1": measured.brake_b1,
             "floor_g": 0.5,
-            "taper_kmh": support_taper_kmh,
+            "taper_kmh": min(support_taper_kmh, (brake_range[1] - brake_range[0]) / 2.0),
         }
         brake_src = "measured(supported)"
 
@@ -586,7 +602,7 @@ def blend_ggv_safe(
             "b0_g": measured.drive_b0_g,
             "b1": measured.drive_b1,
             "floor_g": measured.drive_min_g,
-            "taper_kmh": support_taper_kmh,
+            "taper_kmh": min(support_taper_kmh, (accel_range[1] - accel_range[0]) / 2.0),
         }
         drive_src = "measured(supported)"
 
@@ -673,8 +689,15 @@ def _finite_ggv(*values: float) -> bool:
     return all(isinstance(v, (int, float)) and math.isfinite(v) for v in values)
 
 
+def _freeze_supported_longitudinal(supported: Mapping) -> MappingProxyType:
+    """Return a detached, recursively read-only copy of the two-level support mapping."""
+    return MappingProxyType(
+        {kind: MappingProxyType(dict(override)) for kind, override in supported.items()}
+    )
+
+
 def _validate_supported_longitudinal(
-    supported: dict,
+    supported: Mapping,
     *,
     brake_b0_g: float,
     brake_b1: float,
@@ -688,13 +711,13 @@ def _validate_supported_longitudinal(
     schema and are accepted only when the same deterministic safety gates used by
     :func:`blend_ggv_safe` still hold after deserialization.
     """
-    if not isinstance(supported, dict):
+    if not isinstance(supported, Mapping):
         raise ValueError("supported_longitudinal must be a dict")
     unknown = set(supported) - {"brake", "drive"}
     if unknown:
         raise ValueError(f"unsupported longitudinal override keys: {sorted(unknown)!r}")
     for kind, override in supported.items():
-        if not isinstance(override, dict):
+        if not isinstance(override, Mapping):
             raise ValueError(f"supported_longitudinal.{kind} must be a dict")
         required = {"speed_min_kmh", "speed_max_kmh", "b0_g", "b1", "floor_g", "taper_kmh"}
         if set(override) != required:

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -754,6 +754,7 @@ class HandshakeController:
         # probe => braking envelope). Fed to ggv_from_telemetry at finish.
         self._friction_rows: list[dict] = []
         self._friction_t: float | None = None
+        self._friction_packet_id: int | None = None
         self._ratio_samples: dict[int, list[float]] = {}
         self._laps = 0
         self._t_start: float | None = None
@@ -979,6 +980,14 @@ class HandshakeController:
             return
         if not _finite(speed, ay, ao) or speed < 15.0:
             return
+        # The controller can run faster than AC's physics mmap refresh. Do not count one mmap
+        # packet several times merely because the harness clock advanced: duplicated frames would
+        # fabricate the per-bin support that makes a fitted friction envelope runtime-bearing.
+        packet_id = getattr(phys, "packet_id", None)
+        if isinstance(packet_id, int) and not isinstance(packet_id, bool):
+            if packet_id == self._friction_packet_id:
+                return
+            self._friction_packet_id = packet_id
         self._friction_t = now
         if len(self._friction_rows) < 60000:
             source = "passive"
@@ -1249,8 +1258,10 @@ class HandshakeController:
         assert st is not None
         if st["stage"] == "prep":
             # Wait until fast enough to trace the HIGH-speed braking envelope; let the base driver
-            # keep accelerating. Bail (probe re-queues) if the straight runs out or prep drags.
-            if now - st["t_stage"] > 8.0 or remaining < 60.0:
+            # keep accelerating. Reserve enough distance to brake from the eventual entry speed to
+            # the safety floor at a conservative 0.5 g, plus 30 m to settle before the corner.
+            entry_kmh = max(speed_kmh, self.brake_min_entry_kmh)
+            if now - st["t_stage"] > 8.0 or remaining < self._brake_probe_required_m(entry_kmh):
                 self._abort_active(
                     "brake-probe prep: straight too short or entry speed not reached"
                 )
@@ -1272,6 +1283,13 @@ class HandshakeController:
             self._active = None
             return base
         return self._override(base, gas=0.0, brake=self.brake_level, gear_up=False, gear_dn=False)
+
+    def _brake_probe_required_m(self, entry_kmh: float) -> float:
+        """Conservative stopping distance from probe entry to the configured safety floor."""
+        entry_mps = max(0.0, entry_kmh) / 3.6
+        exit_mps = max(0.0, self.brake_min_exit_kmh) / 3.6
+        braking_m = max(0.0, entry_mps * entry_mps - exit_mps * exit_mps) / (2.0 * 0.5 * G)
+        return braking_m + 30.0
 
     def _finish(self, now: float) -> None:
         m_sign = fit_ff_sign(self._pulse_records)

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1485,8 +1485,8 @@ def load_plant_artifact(
     ``layout`` and ``setup`` (+ the resolved ``setup_ini`` content hash) are part of the combo
     identity. A request for one layout can never reuse a plant measured on another layout.
     """
-    path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
     try:
+        path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, ValueError):
         return None

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -682,13 +682,16 @@ class HandshakeController:
         # Active brake-at-speed probe: firm STRAIGHT-LINE braking (never a lateral push — the GT3
         # spins at the lateral limit, live-disproven #259) to trace the high-speed braking envelope.
         brake_level: float = 0.85,
-        brake_probe_seconds: float = 2.0,
-        brake_min_entry_kmh: float = 90.0,
+        brake_probe_seconds: float = 2.5,
+        brake_min_entry_kmh: float = 110.0,
         brake_min_exit_kmh: float = 45.0,
         brake_min_straight_m: float = 180.0,
         # Passive friction-row capture (speed/accg_lat/accg_lon from the physics accG channel) for
         # the GGV fit — throttled so ~1.5 laps yield a rich, bounded envelope sample.
-        friction_row_interval_s: float = 0.05,
+        # The rig loop updates near 60 Hz. Capture each fresh frame during the bounded controlled
+        # probes so a 2.5 s brake pull can populate multiple 10 km/h bins without extending the
+        # braking maneuver. Passive rows still face ggv_from_telemetry's stricter 40-row/bin gate.
+        friction_row_interval_s: float = 0.01,
         min_friction_rows: int = 200,
     ) -> None:
         self._base = RacingDriver(fast_line, speed_profile, pace=pace, max_speed_kmh=max_speed_kmh)
@@ -978,8 +981,21 @@ class HandshakeController:
             return
         self._friction_t = now
         if len(self._friction_rows) < 60000:
+            source = "passive"
+            if self._active is not None:
+                kind = self._active.get("kind")
+                stage = self._active.get("stage")
+                if kind == "brake_probe" and stage == "brake":
+                    source = "brake_probe"
+                elif kind == "accel_sweep" and stage == "wot":
+                    source = "accel_sweep"
             self._friction_rows.append(
-                {"speed_kmh": float(speed), "accg_lat": float(ay), "accg_lon": float(ao)}
+                {
+                    "speed_kmh": float(speed),
+                    "accg_lat": float(ay),
+                    "accg_lon": float(ao),
+                    "source": source,
+                }
             )
 
     def _remaining_on_straight(self, car: tuple[float, float]) -> float:

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -28,9 +28,9 @@ to the same ``step()``/``on_recovery()`` contract as :class:`RacingDriver`, so t
 ``auto_drive.rig_drive`` loop executes it (one rig loop, no drift), driving a synthetic plant in
 tests. The only rig-only piece is the lazy ``acpmf_physics`` reader (``phys_read="auto"``).
 
-Artifacts persist per-combo under ``<AC user dir>/plant_id/`` — a **durable** Documents path,
-never ``.scratch`` (the original ``model_id.py`` was lost to exactly that; see issue #532's
-pitfall list).
+Artifacts persist per-combo (car + track + optional layout + setup-content identity) under
+``<AC user dir>/plant_id/`` — a **durable** Documents path, never ``.scratch`` (the original
+``model_id.py`` was lost to exactly that; see issue #532's pitfall list).
 """
 
 from __future__ import annotations
@@ -105,6 +105,7 @@ class HandshakeResult:
     laps_used: int
     duration_s: float
     measurements: tuple[ProbeMeasurement, ...]
+    layout: str | None = None  # multi-layout track identity (None keeps the legacy artifact key)
     setup: str | None = None  # the setup the plant was measured under (None = default)
     setup_ini: str | None = None  # resolved setup .ini path (for the content-hash key)
     # #532 Part B: the per-combo friction plant (safe-envelope-blended GGVModel + fit provenance),
@@ -129,6 +130,7 @@ class HandshakeResult:
             "ok": self.ok,
             "car_id": self.car_id,
             "track_id": self.track_id,
+            "layout": self.layout,
             "setup": self.setup,
             "setup_ini": self.setup_ini,
             "laps_used": self.laps_used,
@@ -650,6 +652,7 @@ class HandshakeController:
         *,
         car_id: str = "",
         track_id: str = "",
+        layout: str | None = None,
         setup: str | None = None,
         setup_ini: str | None = None,
         sink: dict | None = None,
@@ -675,6 +678,7 @@ class HandshakeController:
         # friction envelope is safe-envelope-blended against (injected by the harness so the
         # controller stays import-clean of auto_drive). None => no ggv block is emitted.
         prior_ggv: GGVModel | None = None,
+        prior_ggv_name: str = "injected_prior",
         # Active brake-at-speed probe: firm STRAIGHT-LINE braking (never a lateral push — the GT3
         # spins at the lateral limit, live-disproven #259) to trace the high-speed braking envelope.
         brake_level: float = 0.85,
@@ -690,6 +694,7 @@ class HandshakeController:
         self._base = RacingDriver(fast_line, speed_profile, pace=pace, max_speed_kmh=max_speed_kmh)
         self.car_id = car_id
         self.track_id = track_id
+        self.layout = layout
         self.setup = setup
         self.setup_ini = setup_ini
         self.sink = sink if sink is not None else {}
@@ -705,6 +710,7 @@ class HandshakeController:
         self.row_interval_s = row_interval_s
         self.min_corner_rows = min_corner_rows
         self._prior_ggv = prior_ggv
+        self._prior_ggv_name = prior_ggv_name or "injected_prior"
         self.brake_level = brake_level
         self.brake_probe_seconds = brake_probe_seconds
         self.brake_min_entry_kmh = brake_min_entry_kmh
@@ -1269,6 +1275,7 @@ class HandshakeController:
             ok=all(m.passed for m in measurements),
             car_id=self.car_id,
             track_id=self.track_id,
+            layout=self.layout,
             setup=self.setup,
             setup_ini=str(self.setup_ini) if self.setup_ini else None,
             laps_used=self._laps,
@@ -1312,13 +1319,18 @@ class HandshakeController:
         if self._prior_ggv is None:
             return None
         n = len(self._friction_rows)
-        block: dict = {"ok": False, "friction_rows": n, "model": None, "prior": "generic_gt3_ggv"}
+        block: dict = {
+            "ok": False,
+            "friction_rows": n,
+            "model": None,
+            "prior": self._prior_ggv_name,
+        }
         if n < self.min_friction_rows:
             block["reason"] = f"insufficient friction rows: {n} < {self.min_friction_rows}"
             return block
         try:
             measured = ggv_from_telemetry(self._friction_rows)
-            blended = blend_ggv_safe(measured, self._prior_ggv)
+            blended = blend_ggv_safe(measured, self._prior_ggv, prior_name=self._prior_ggv_name)
         except (ValueError, ZeroDivisionError, KeyError, TypeError) as exc:
             # Narrow catch + log (never a broad catch-and-default). The failure is ADVISORY: the
             # consumer falls back to the generic plant, but the reason is recorded, not swallowed.
@@ -1381,21 +1393,43 @@ def _setup_key(setup: str | None, setup_ini: str | Path | None = None) -> str:
     return f"__setup-{safe}-{digest}" if digest else f"__setup-{safe}"
 
 
+def _layout_key(layout: str | None) -> str:
+    """Filename-safe layout suffix (empty only for the legacy single-layout identity).
+
+    Layout ids are AC folder basenames. Reject path-shaped values rather than normalizing them into
+    a collision (for example ``gp/short`` and ``gp_short``); CLI callers already apply the same
+    plain-id rule through ``validate_ac_id``.
+    """
+    if layout is None:
+        return ""
+    if (
+        not isinstance(layout, str)
+        or not layout
+        or ".." in layout
+        or re.fullmatch(r"[A-Za-z0-9._-]+", layout) is None
+    ):
+        raise ValueError(f"unsafe track layout id {layout!r} (allowed: letters/digits/._-)")
+    return f"__layout-{layout}"
+
+
 def plant_artifact_path(
     user_dir: Path,
     car_id: str,
     track_id: str,
     setup: str | None = None,
     setup_ini: str | Path | None = None,
+    *,
+    layout: str | None = None,
 ) -> Path:
-    return Path(user_dir) / "plant_id" / f"{car_id}__{track_id}{_setup_key(setup, setup_ini)}.json"
+    filename = f"{car_id}__{track_id}{_layout_key(layout)}{_setup_key(setup, setup_ini)}.json"
+    return Path(user_dir) / "plant_id" / filename
 
 
 def save_plant_artifact(user_dir: Path, result: dict) -> Path:
     """Persist a PASSED handshake result as the combo's plant artifact (atomic write).
 
-    The artifact is keyed by car+track+setup (``result['setup']`` — the stem, or None for the
-    default setup), so a default-setup plant is never silently reused for a different setup.
+    The artifact is keyed by car+track+layout+setup. ``layout=None`` keeps the exact legacy
+    car+track+setup filename so existing single-layout artifacts remain loadable.
     """
     if not result.get("ok"):
         raise ValueError("refusing to persist a failed handshake as a plant artifact")
@@ -1405,6 +1439,7 @@ def save_plant_artifact(user_dir: Path, result: dict) -> Path:
         raise ValueError(f"plant artifact needs car_id and track_id (got {car_id!r}/{track_id!r})")
     setup = result.get("setup")
     setup_ini = result.get("setup_ini")
+    layout = result.get("layout")
     from datetime import UTC, datetime
 
     payload = {
@@ -1412,7 +1447,7 @@ def save_plant_artifact(user_dir: Path, result: dict) -> Path:
         "created_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         **result,
     }
-    path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini)
+    path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -1426,14 +1461,15 @@ def load_plant_artifact(
     track_id: str,
     setup: str | None = None,
     setup_ini: str | Path | None = None,
+    *,
+    layout: str | None = None,
 ) -> dict | None:
     """Load + validate the combo's plant artifact; ``None`` when absent or invalid.
 
-    ``setup`` (+ the resolved ``setup_ini`` content hash) is part of the combo identity — a request
-    with ``--setup X`` only loads a plant measured under that exact setup file, so setup-changed
-    gear ratios / FF can't be silently reused (Codex review).
+    ``layout`` and ``setup`` (+ the resolved ``setup_ini`` content hash) are part of the combo
+    identity. A request for one layout can never reuse a plant measured on another layout.
     """
-    path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini)
+    path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, ValueError):
@@ -1444,6 +1480,11 @@ def load_plant_artifact(
     ):
         return None
     if payload.get("car_id") != car_id or payload.get("track_id") != track_id:
+        return None
+    # The filename prevents normal cross-layout lookup; the payload check also rejects a copied or
+    # renamed artifact whose stored physical-course identity does not match the requested layout.
+    # Missing layout in v1/v2 artifacts is equivalent to None, preserving single-layout back-compat.
+    if payload.get("layout") != layout:
         return None
     # Setup identity (name + content hash) is ALREADY enforced by the filename we opened
     # (`plant_artifact_path(..., setup, setup_ini)` built from the REQUEST's readable setup_ini).

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import math
 import re
 from dataclasses import asdict, dataclass
@@ -45,7 +46,10 @@ from pathlib import Path
 
 from tools.ac_harness.ai_line import _horizontal
 from tools.ac_harness.ggv_profile import (
+    GGVModel,
+    blend_ggv_safe,
     fit_steer_feedforward,
+    ggv_from_telemetry,
     seg_lengths,
     signed_curvature_profile,
 )
@@ -53,13 +57,19 @@ from tools.ac_harness.lap_driver import PHASE_LAP, DriveFrame
 from tools.ac_harness.racing_driver import RacingDriver
 
 G = 9.81
-PLANT_SCHEMA_VERSION = 1
+# Schema v2 (#532 Part B) adds the optional ``ggv`` block (per-combo friction plant) alongside the
+# v1 ``constants``. v1 artifacts (Part A: shift points + steering only, no ggv block) still load —
+# their ggv consumption falls back to the generic plant — so Part A artifacts are not invalidated.
+PLANT_SCHEMA_VERSION = 2
+SUPPORTED_PLANT_SCHEMA_VERSIONS = (1, 2)
 # Constants a persisted plant artifact MUST carry (a fully-passed handshake produces all of them);
 # a partial artifact is rejected on load so `--use-plant full` never silently degrades.
 REQUIRED_PLANT_CONSTANTS = ("ff_sign", "ff_c1", "ff_c2", "rpm_up", "rpm_dn", "r_eff_m")
 
 # AC gear encoding (live-verified, see custom_ai.py): 0=Reverse, 1=Neutral, 2=1st, 3=2nd, ...
 _FIRST_FORWARD_GEAR = 2
+
+logger = logging.getLogger(__name__)
 
 
 def _finite(*values: float) -> bool:
@@ -97,6 +107,11 @@ class HandshakeResult:
     measurements: tuple[ProbeMeasurement, ...]
     setup: str | None = None  # the setup the plant was measured under (None = default)
     setup_ini: str | None = None  # resolved setup .ini path (for the content-hash key)
+    # #532 Part B: the per-combo friction plant (safe-envelope-blended GGVModel + fit provenance),
+    # or None when no prior was injected / no friction rows were captured. Additive and ADVISORY —
+    # a missing/failed ggv block never gates ``ok`` (consumption falls back to the generic plant),
+    # unlike the 5 core constants which hard-abort.
+    ggv: dict | None = None
 
     def failed(self) -> list[ProbeMeasurement]:
         return [m for m in self.measurements if not m.passed]
@@ -120,6 +135,7 @@ class HandshakeResult:
             "duration_s": round(self.duration_s, 1),
             "constants": self.constants(),
             "measurements": [asdict(m) for m in self.measurements],
+            "ggv": self.ggv,
         }
 
 
@@ -655,6 +671,21 @@ class HandshakeController:
         coast_min_kmh: float = 45.0,
         row_interval_s: float = 0.25,
         min_corner_rows: int = 120,
+        # #532 Part B — friction ID. ``prior_ggv`` is the trusted generic plant the measured
+        # friction envelope is safe-envelope-blended against (injected by the harness so the
+        # controller stays import-clean of auto_drive). None => no ggv block is emitted.
+        prior_ggv: GGVModel | None = None,
+        # Active brake-at-speed probe: firm STRAIGHT-LINE braking (never a lateral push — the GT3
+        # spins at the lateral limit, live-disproven #259) to trace the high-speed braking envelope.
+        brake_level: float = 0.85,
+        brake_probe_seconds: float = 2.0,
+        brake_min_entry_kmh: float = 90.0,
+        brake_min_exit_kmh: float = 45.0,
+        brake_min_straight_m: float = 180.0,
+        # Passive friction-row capture (speed/accg_lat/accg_lon from the physics accG channel) for
+        # the GGV fit — throttled so ~1.5 laps yield a rich, bounded envelope sample.
+        friction_row_interval_s: float = 0.05,
+        min_friction_rows: int = 200,
     ) -> None:
         self._base = RacingDriver(fast_line, speed_profile, pace=pace, max_speed_kmh=max_speed_kmh)
         self.car_id = car_id
@@ -673,6 +704,14 @@ class HandshakeController:
         self.coast_min_kmh = coast_min_kmh
         self.row_interval_s = row_interval_s
         self.min_corner_rows = min_corner_rows
+        self._prior_ggv = prior_ggv
+        self.brake_level = brake_level
+        self.brake_probe_seconds = brake_probe_seconds
+        self.brake_min_entry_kmh = brake_min_entry_kmh
+        self.brake_min_exit_kmh = brake_min_exit_kmh
+        self.brake_min_straight_m = brake_min_straight_m
+        self.friction_row_interval_s = friction_row_interval_s
+        self.min_friction_rows = min_friction_rows
 
         plane = [(p[0], p[2]) for p in fast_line]
         self._seg = seg_lengths(plane)
@@ -682,8 +721,12 @@ class HandshakeController:
         self._sid, self._dist_to_end = _straight_membership(self._straights, self._seg, len(plane))
         # Probe queue. The sweep needs the longest straight; pulses/coast run wherever a straight
         # offers enough remaining room and re-queue if interrupted, so short-straight tracks
-        # spread them across several passes.
+        # spread them across several passes. The active brake-at-speed probe (#532 Part B) is only
+        # queued when a prior GGV is present to blend against — otherwise no ggv block is emitted
+        # and the probe would burn a straight for nothing.
         self._pending: list[str] = ["accel_sweep", "steer_pulse", "coast"]
+        if prior_ggv is not None:
+            self._pending.append("brake_probe")
         # Per-probe attempt cap: a probe that keeps aborting (straight too short, prep timeout,
         # unusable pull) must not loop forever and starve the completion gate. After the cap it is
         # DROPPED from the schedule; its fit then fails with an interpretable "probe did not
@@ -697,6 +740,11 @@ class HandshakeController:
         self._sweep_samples: list[dict] = []
         self._coast_samples: list[dict] = []
         self._rows: list[dict] = []
+        # #532 Part B friction rows: (speed_kmh, accg_lat, accg_lon) sampled from the physics accG
+        # channel across the whole drive (corner sequence => lateral, WOT sweep => accel, brake
+        # probe => braking envelope). Fed to ggv_from_telemetry at finish.
+        self._friction_rows: list[dict] = []
+        self._friction_t: float | None = None
         self._ratio_samples: dict[int, list[float]] = {}
         self._laps = 0
         self._t_start: float | None = None
@@ -766,6 +814,11 @@ class HandshakeController:
             # half-captured maneuver never contaminates a fit.
             self._abort_active("driver stuck")
             return base
+
+        # #532 Part B: sample the friction envelope from the physics accG channel every driving
+        # frame (throttled). Runs across all phases — the corner sequence supplies lateral rows, the
+        # WOT sweep accel rows, and the brake probe the braking envelope.
+        self._mine_friction(now)
 
         frame = base
         if self._active is not None:
@@ -894,6 +947,35 @@ class HandshakeController:
             self._rows.append(row)
         self._row_acc = {"dpsi": 0.0, "dt": 0.0, "v": 0.0, "steer": 0.0, "n": 0, "t0": None}
 
+    def _mine_friction(self, now: float) -> None:
+        """Sample one friction row (speed_kmh, accg_lat, accg_lon) from the physics accG channel.
+
+        Throttled to ``friction_row_interval_s``. Reads the harness-owned physics frame (the same
+        reader the r_eff coast probe uses) — the accG channel carries the REAL measured lateral and
+        longitudinal accelerations that :func:`ggv_from_telemetry` de-contaminates and fits. A
+        missing physics reader (off-rig with no fake) simply yields no rows -> no ggv block, which
+        the consumer treats as "no per-combo plant" and falls back to the generic plant.
+        """
+        if self._prior_ggv is None:
+            return  # no prior to blend against => no ggv block => nothing to capture
+        if self._friction_t is not None and now - self._friction_t < self.friction_row_interval_s:
+            return
+        phys = self._read_phys()
+        if phys is None:
+            return
+        speed = getattr(phys, "speed_kmh", None)
+        ay = getattr(phys, "accg_lat", None)
+        ao = getattr(phys, "accg_lon", None)
+        if speed is None or ay is None or ao is None:
+            return
+        if not _finite(speed, ay, ao) or speed < 15.0:
+            return
+        self._friction_t = now
+        if len(self._friction_rows) < 60000:
+            self._friction_rows.append(
+                {"speed_kmh": float(speed), "accg_lat": float(ay), "accg_lon": float(ao)}
+            )
+
     def _remaining_on_straight(self, car: tuple[float, float]) -> float:
         idx = self._base.pursuit.nearest_index(car)
         if self._sid[idx] < 0:
@@ -911,12 +993,14 @@ class HandshakeController:
                 "accel_sweep": max(self._min_sweep_m(), 1.0),
                 "steer_pulse": 70.0,
                 "coast": max(self.coast_seconds * max(speed_kmh, 40.0) / 3.6 + 25.0, 60.0),
+                "brake_probe": self.brake_min_straight_m,
             }[kind]
             if remaining < need:
                 continue
-            if kind == "coast" and self._read_phys() is None:
-                # No physics channel => r_eff can never fit; fail it now with an interpretable
-                # message instead of burning straights retrying (the fit reports the cause).
+            if kind in ("coast", "brake_probe") and self._read_phys() is None:
+                # No physics channel => the coast r_eff fit / the brake-probe friction rows can
+                # never land; drop the probe now (its fit / the ggv block simply reports the cause)
+                # instead of burning straights retrying it.
                 self._pending.remove(kind)
                 continue
             self._pending.remove(kind)
@@ -948,6 +1032,8 @@ class HandshakeController:
             return self._step_pulse(base, speed_kmh, dpsi, dt, remaining, now)
         if kind == "accel_sweep":
             return self._step_sweep(base, speed_kmh, rpm, gear, v_mps, remaining, now)
+        if kind == "brake_probe":
+            return self._step_brake(base, speed_kmh, remaining, now)
         return self._step_coast(base, speed_kmh, v_mps, remaining, now)
 
     @staticmethod
@@ -1126,6 +1212,45 @@ class HandshakeController:
             self._active = None
         return self._override(base, gas=0.0, brake=0.0, gear_up=False, gear_dn=False)
 
+    def _step_brake(
+        self, base: DriveFrame, speed_kmh: float, remaining: float, now: float
+    ) -> DriveFrame:
+        """Active brake-at-speed probe: firm STRAIGHT-LINE braking to trace the braking envelope.
+
+        Straight-line only — steering follows the base line, never a lateral push (pushing to the
+        lateral limit spins the GT3, live-disproven #259). The friction-row sampler captures the
+        resulting high ``-accg_lon`` across the pull; this probe only COMMANDS the braking. Bounded
+        by a time window, a speed floor, and the straight's remaining length so the car is always
+        slowed and settled before the corner (never brakes into a turn).
+        """
+        st = self._active
+        assert st is not None
+        if st["stage"] == "prep":
+            # Wait until fast enough to trace the HIGH-speed braking envelope; let the base driver
+            # keep accelerating. Bail (probe re-queues) if the straight runs out or prep drags.
+            if now - st["t_stage"] > 8.0 or remaining < 60.0:
+                self._abort_active(
+                    "brake-probe prep: straight too short or entry speed not reached"
+                )
+                return base
+            if speed_kmh < self.brake_min_entry_kmh:
+                return base  # base accelerates toward the entry speed
+            st["stage"] = "brake"
+            st["t_stage"] = now
+            st["data"]["entry_kmh"] = round(speed_kmh, 1)
+        # Braking phase: stop when the window elapses, speed reaches the floor, or the straight is
+        # running out (leave room to settle before the corner). Ending sets active=None; the base
+        # driver resumes on the next step.
+        if (
+            now - st["t_stage"] >= self.brake_probe_seconds
+            or speed_kmh <= self.brake_min_exit_kmh
+            or remaining < 30.0
+        ):
+            st["data"]["exit_kmh"] = round(speed_kmh, 1)
+            self._active = None
+            return base
+        return self._override(base, gas=0.0, brake=self.brake_level, gear_up=False, gear_dn=False)
+
     def _finish(self, now: float) -> None:
         m_sign = fit_ff_sign(self._pulse_records)
         ff_sign = m_sign.value.get("ff_sign") if m_sign.passed else None
@@ -1139,6 +1264,7 @@ class HandshakeController:
         m_shift = fit_shift_points(self._sweep_samples, ratios)
         m_reff = fit_r_eff(self._coast_samples)
         measurements = (m_sign, m_ff, m_ratios, m_shift, m_reff)
+        ggv_block = self._build_ggv_block()
         self.result = HandshakeResult(
             ok=all(m.passed for m in measurements),
             car_id=self.car_id,
@@ -1148,6 +1274,7 @@ class HandshakeController:
             laps_used=self._laps,
             duration_s=now - (self._t_start if self._t_start is not None else now),
             measurements=measurements,
+            ggv=ggv_block,
         )
         # Record which probes never completed within the budget, so a partial finalize (drive
         # ended) is diagnosable — how many pulses/sweep-gears/coast-samples/corner-rows landed.
@@ -1158,6 +1285,8 @@ class HandshakeController:
             "sweep_gears": sorted({s["gear"] - 1 for s in self._sweep_samples}),
             "coast_samples": len(self._coast_samples),
             "gear_ratio_gears": sorted(self._ratio_samples),
+            "friction_rows": len(self._friction_rows),
+            "ggv_ok": bool(ggv_block and ggv_block.get("ok")),
             "probe_attempts": dict(self._probe_attempts),
             "pending_at_finish": list(self._pending),
         }
@@ -1166,6 +1295,40 @@ class HandshakeController:
         self.sink["constants"] = self.result.constants()
         self.sink["diagnostics"] = self.result_diagnostics
         self.finished = True
+
+    def _build_ggv_block(self) -> dict | None:
+        """Fit the per-combo friction plant from captured rows and safe-envelope-blend the prior.
+
+        Returns ``None`` when no prior was injected (no trusted basis for a safe blend — the ggv
+        driver keeps its generic plant). Otherwise returns a block recording the outcome:
+
+        * ``ok=True`` with a blended ``model`` (a :class:`~tools.ac_harness.ggv_profile.GGVModel`
+          serialized via ``to_dict``) when enough friction rows were captured AND the fit succeeded;
+        * ``ok=False`` with a ``reason`` and ``model=None`` otherwise — a VISIBLE degrade in
+          the artifact + diagnostics, so the consumer falls back to the generic plant without a
+          silent swallow (the ggv block is ADVISORY; unlike the 5 core constants it never gates
+          ``HandshakeResult.ok``).
+        """
+        if self._prior_ggv is None:
+            return None
+        n = len(self._friction_rows)
+        block: dict = {"ok": False, "friction_rows": n, "model": None, "prior": "generic_gt3_ggv"}
+        if n < self.min_friction_rows:
+            block["reason"] = f"insufficient friction rows: {n} < {self.min_friction_rows}"
+            return block
+        try:
+            measured = ggv_from_telemetry(self._friction_rows)
+            blended = blend_ggv_safe(measured, self._prior_ggv)
+        except (ValueError, ZeroDivisionError, KeyError, TypeError) as exc:
+            # Narrow catch + log (never a broad catch-and-default). The failure is ADVISORY: the
+            # consumer falls back to the generic plant, but the reason is recorded, not swallowed.
+            logger.exception("friction-ID fit failed; ggv block degrades to the generic plant")
+            block["reason"] = f"friction fit error: {type(exc).__name__}: {exc}"
+            return block
+        block["ok"] = True
+        block["model"] = blended.to_dict()
+        block["reason"] = "ok"
+        return block
 
     def finalize(self, now: float | None = None) -> None:
         """Force finalization when the drive ends before the schedule self-completes.
@@ -1275,7 +1438,10 @@ def load_plant_artifact(
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, ValueError):
         return None
-    if not isinstance(payload, dict) or payload.get("schema_version") != PLANT_SCHEMA_VERSION:
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") not in SUPPORTED_PLANT_SCHEMA_VERSIONS
+    ):
         return None
     if payload.get("car_id") != car_id or payload.get("track_id") != track_id:
         return None
@@ -1328,6 +1494,29 @@ def plant_driver_kwargs(artifact: dict, *, steer: bool) -> dict:
         kwargs["ff_c1"] = float(constants["ff_c1"])
         kwargs["ff_c2"] = float(constants["ff_c2"])
     return kwargs
+
+
+def plant_ggv_model(artifact: dict) -> GGVModel | None:
+    """The per-combo friction plant (a :class:`GGVModel`) from an artifact's ggv block, or ``None``.
+
+    Returns ``None`` when the artifact carries no usable ggv block — a v1 / Part-A artifact, or a
+    run where the friction fit degraded (``ok=False``) — so the caller keeps the generic plant. A
+    malformed / non-finite serialized model is rejected (``GGVModel.from_dict`` raises), so the
+    ggv driver never builds a speed profile from a ``nan`` grip curve (#532 Part B input check).
+    """
+    ggv = artifact.get("ggv")
+    if not isinstance(ggv, dict) or not ggv.get("ok"):
+        return None
+    model = ggv.get("model")
+    if not isinstance(model, dict):
+        return None
+    try:
+        return GGVModel.from_dict(model)
+    except (ValueError, TypeError):
+        logger.warning(
+            "plant artifact ggv block present but its model is invalid; using the generic plant"
+        )
+        return None
 
 
 def apply_handshake_outcome(report, sink: dict) -> None:


### PR DESCRIPTION
## #532 Part B — per-combo friction-ID plant (uncertainty-aware GGVModel)

Child of EPIC #529 (P1). **Part A** (Phase-0 kinematic handshake) shipped in PR #535 (merged `b023c92`, G0 PASS). This is **Part B**: replace the single hardcoded `generic_gt3_ggv()` on the `--driver ggv` path with a **per-combo `GGVModel` machine-measured in-sim**, safe-envelope-blended against the generic prior.

### What
- **`ggv_profile.py`** — `GGVModel.to_dict/from_dict` (input-validated; rejects `nan`/missing core fields), **`blend_ggv_safe`** (the safe-envelope core), and richer fit provenance (`brake_bins`/`accel_bins`/`hull_points`). Reuses the existing `ggv_from_telemetry` as the fitting core — **no duplicated fit logic** (issue guardrail).
- **`plant_id.py`** — `HandshakeController` now captures `(speed_kmh, accg_lat, accg_lon)` friction rows from the physics accG channel across the probe drive, plus one **active brake-at-speed probe** (firm straight-line braking). `_build_ggv_block` fits + blends and records the outcome in the artifact; `plant_ggv_model` resolves the identified `GGVModel`. Artifact **schema v2** (load stays back-compat with v1 Part-A artifacts).
- **`auto_drive.py`** — `_build_driver` drives the identified plant when resolved (else generic); the CLI `--use-plant` load path resolves it on `auto`/`full` (the friction plant shapes the *speed profile*, orthogonal to the steering mode).

### Safe-envelope blend (Council-validated 2026-07-13)
- **Lateral grip is never extrapolated upward** above the prior — an aero-lateral term spins the GT3 out (live-disproven #259/#244; `k_aero_lat` stays 0). A confident measurement may only *lower* lateral (a weaker car); a thin/absent measurement keeps the prior.
- **Braking / drive accel**: the measured curve only where the probe confidently covered the envelope (`>= N` fitted bins), else the prior; the prior's hard caps (`ay_cap_g`/`ax_brake_cap_g`) always kept.
- **Ellipse exponent reverts to the prior** unless the `(lat,lon)` hull is rich enough — a wrong lat/long coupling is the biggest silent-spin risk.
- **No lateral-limit push probe** — pushing to the lateral limit spins the GT3 (live-disproven), unsafe for an unattended rig; the widening corner arcs the handshake already drives at pace supply the lateral rows.

### Acceptance criteria (Part B)
- [x] per-combo `GGVModel` fitted with per-bin provenance + uncertainty, consumed instead of `generic_gt3_ggv()` when the artifact exists — **off-sim tested**
- [x] sparse / uncertain bins fall back to the safe envelope (never upward), artifact labels measured-vs-prior bins — **tested**
- [ ] identified plant drives a full autonomous lap AC-valid, lap time recorded vs the generic-plant baseline, no regression beyond tolerance on Magione — **live rig A/B (in progress on AG_PC)**

### Design notes
- The ggv block is **advisory**: it never gates the 5 core handshake constants. On insufficient rows / fit error it **visibly degrades** to the generic plant (narrow `except` + `logger.exception`, never a silent catch-and-default). The reference 911 GT3 R reproduces the generic plant → **no regression by construction**; a genuinely weaker car is identified as slower.
- 15 new off-sim tests; `make ci-fast` OK (full suite + ruff + policy).

Refs #532 · EPIC #529 (P1) · reuses #488 per-wheel channels / #244 frontier GGV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #552