### PR TITLE
fix(harness): #558 — restart Content Manager on cached-session mismatch (real recovery)

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -797,8 +797,11 @@ def test_run_auto_drive_track_match_proceeds():
 def test_run_auto_drive_relaunches_on_track_mismatch_then_drives():
     # #537: CM served its cached session (spa) on the first launch; the harness must RELAUNCH
     # (bounded) rather than fail — the second launch loads the requested magione and drives it.
+    # #558: the relaunch must RESTART the launcher (kill CM) BEFORE the next launch so a fresh CM
+    # cold-starts and honors the preset — a plain URL re-issue to a stale CM never recovers.
     record: dict = {}
     launches: list[int] = []
+    restarts: list[int] = []
     c_bad = FakeController()
     c_good = FakeController()
     controllers: list[FakeController] = [c_bad, c_good]
@@ -816,14 +819,40 @@ def test_run_auto_drive_relaunches_on_track_mismatch_then_drives():
             drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
             tap=_tap_returning(CONTINUOUS),
             verify_track=lambda c: (loaded_tracks.pop(0), "ks_porsche_911_gt3_r_2016"),
+            restart_launcher=lambda c: restarts.append(1),
         )
     )
 
     assert report.ok is True
     assert report.stage != "launch"  # did not fail-fast on the first (mismatched) launch
     assert len(launches) == 2  # relaunched exactly once
+    assert len(restarts) == 1  # #558: CM restarted once, before the recovery relaunch
     assert c_bad.closed is True  # the mismatched controller was released before relaunch
     assert record["controller"] is c_good  # drove on the correct-track session
+
+
+def test_run_auto_drive_restart_launcher_failure_does_not_crash_recovery():
+    # #558: a restart-seam failure must be swallowed — the plain relaunch still runs and recovers.
+    record: dict = {}
+    controllers: list[FakeController] = [FakeController(), FakeController()]
+    loaded_tracks = ["spa", "magione"]
+
+    def _boom(config):  # noqa: ANN001
+        raise OSError("taskkill blew up")
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=3),
+            launch=lambda c: (True, "live"),
+            hijack=lambda c: controllers.pop(0),
+            drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
+            tap=_tap_returning(CONTINUOUS),
+            verify_track=lambda c: (loaded_tracks.pop(0), "ks_porsche_911_gt3_r_2016"),
+            restart_launcher=_boom,
+        )
+    )
+
+    assert report.ok is True  # the run recovered despite the restart seam raising
 
 
 def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -855,6 +855,32 @@ def test_run_auto_drive_restart_launcher_failure_does_not_crash_recovery():
     assert report.ok is True  # the run recovered despite the restart seam raising
 
 
+def test_run_auto_drive_restarts_cm_after_persistent_hijack_stall():
+    # #558: a PERSISTENT pre-drive overlay stall (hijack never lands) is severe CM degradation. A
+    # TRANSIENT stall gets one plain relaunch; a persistent one escalates to a CM restart (fresh
+    # cold-start) before the next attempt — not a restart per relaunch. hijack: stall, stall, land.
+    restarts: list[int] = []
+    record: dict = {}
+    hijacks: list = [None, None, FakeController()]
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(track_id="magione", car_id="ks_porsche_911_gt3_r_2016", max_launches=4),
+            launch=lambda c: (True, "live"),
+            hijack=lambda c: hijacks.pop(0),
+            drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), record),
+            tap=_tap_returning(CONTINUOUS),
+            verify_track=lambda c: ("magione", "ks_porsche_911_gt3_r_2016"),  # correct combo
+            restart_launcher=lambda c: restarts.append(1),
+        )
+    )
+
+    assert report.ok is True
+    # idx0 stall (no restart); idx1 plain relaunch (transient, no restart); idx2 (>=2) restarts CM
+    # once, then the hijack lands and drives.
+    assert len(restarts) == 1
+
+
 def test_run_auto_drive_track_mismatch_fails_fast_after_exhausting_relaunches():
     # #537 bound: a PERSISTENT cached-session mismatch must not loop forever or ever drive the
     # wrong line — it FAILs at stage="launch" once the launch budget is spent (#535 honest guard).

--- a/tests/test_ac_harness_entry_launcher.py
+++ b/tests/test_ac_harness_entry_launcher.py
@@ -396,6 +396,28 @@ def test_content_manager_launch_spawns_cm_with_url(monkeypatch, tmp_path: Path):
     assert event.detail == actuator.quick_drive_url()
 
 
+def test_content_manager_restart_kills_cm_process(monkeypatch, tmp_path: Path):
+    # #558: restart_content_manager kills the CM process (tree) so the next launch cold-starts a
+    # FRESH CM — the recovery a plain URL re-issue to a stale CM cannot perform.
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+    cm_exe = tmp_path / "Content Manager.exe"
+    cm_exe.write_text("", encoding="utf-8")
+    preset = tmp_path / "drive.cmpreset"
+    preset.write_text("{}", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def runner(cmd, **kwargs):  # noqa: ANN001
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    actuator = ContentManagerActuator(preset=preset, cm_exe=cm_exe, runner=runner)
+    event = actuator.restart_content_manager()
+
+    assert event.action == "restart_cm"
+    assert calls == [["taskkill", "/IM", "Content Manager.exe", "/F", "/T"]]
+    assert "killed Content Manager.exe" in event.detail
+
+
 def test_content_manager_launch_requires_windows(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(entry_launcher.sys, "platform", "linux")
     actuator = ContentManagerActuator(preset=tmp_path / "x.cmpreset", cm_exe=tmp_path / "cm.exe")

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -343,6 +343,9 @@ DriveFn = Callable[[Controller, AutoDriveConfig, threading.Event], DriveStats]
 TapFn = Callable[..., Awaitable[list[dict]]]
 # Returns the loaded (track, car) identity from the live sim, or None when it cannot be read.
 VerifyTrackFn = Callable[[AutoDriveConfig], "tuple[str | None, str | None] | None"]
+# #558: called on a cached-session mismatch to RESTART the launcher (kill Content Manager) so the
+# next launch cold-starts a fresh CM — the recovery a plain URL re-issue cannot perform.
+RestartLauncherFn = Callable[[AutoDriveConfig], None]
 
 
 def rig_verify_track(
@@ -497,6 +500,31 @@ def _has_timed_lap(frames: list[dict]) -> bool:
     return False
 
 
+def _relaunch_after_cached_session(
+    restart_launcher: RestartLauncherFn | None,
+    config: AutoDriveConfig,
+    why: str,
+    attempt_idx: int,
+    attempts: int,
+) -> None:
+    """Log a cached-session relaunch and, when wired, RESTART the launcher first (#558).
+
+    A plain relaunch only re-issues the ``acmanager://`` URL to the already-running (stale) CM,
+    which keeps serving its cached session. Restarting Content Manager makes the next ``launch``
+    cold-start a fresh instance that honors the preset (live-proven recovery, AG_PC 2026-07-13).
+    A restart-seam failure is swallowed — the plain relaunch still runs and the terminal attempt
+    FAILs honestly — so recovery is best-effort, never a new crash path.
+    """
+    restarted = ""
+    if restart_launcher is not None:
+        try:
+            restart_launcher(config)
+            restarted = "; restarted Content Manager (fresh cold-start next)"
+        except Exception as exc:  # noqa: BLE001 - see docstring: never crash the run on a restart
+            restarted = f"; Content Manager restart failed ({type(exc).__name__}: {exc})"
+    _log(f"{why} — relaunching (attempt {attempt_idx + 2}/{attempts}){restarted}")
+
+
 async def run_auto_drive(
     config: AutoDriveConfig,
     *,
@@ -506,6 +534,7 @@ async def run_auto_drive(
     tap: TapFn = tap_frames,
     apply_setup: ApplySetupFn | None = None,
     verify_track: VerifyTrackFn | None = None,
+    restart_launcher: RestartLauncherFn | None = None,
 ) -> AutoDriveReport:
     """Compose launch → setup → hijack → (background drive) → WS assert → teardown into one report.
 
@@ -594,9 +623,12 @@ async def run_auto_drive(
                     last_launch_error = (
                         f"setup verify failed on a cached session ({combo_mismatch}): {detail}"
                     )
-                    _log(
-                        f"setup guard: {combo_mismatch} (CM cached session — setup fuel mismatch) "
-                        f"— relaunching (attempt {attempt_idx + 2}/{attempts})"
+                    _relaunch_after_cached_session(
+                        restart_launcher,
+                        config,
+                        f"setup guard: {combo_mismatch} (CM cached session — setup fuel mismatch)",
+                        attempt_idx,
+                        attempts,
                     )
                     continue
                 return AutoDriveReport(
@@ -642,9 +674,12 @@ async def run_auto_drive(
                 controller = None
                 last_launch_error = f"loaded {mismatch} — Content Manager launched a cached session"
                 if attempt_idx < attempts - 1 and not config.skip_launch:
-                    _log(
-                        f"track/car guard: {mismatch} (CM cached session) — relaunching "
-                        f"(attempt {attempt_idx + 2}/{attempts})"
+                    _relaunch_after_cached_session(
+                        restart_launcher,
+                        config,
+                        f"track/car guard: {mismatch} (CM cached session)",
+                        attempt_idx,
+                        attempts,
                     )
                     continue
                 return AutoDriveReport(
@@ -1602,6 +1637,20 @@ def rig_launch(config: AutoDriveConfig) -> tuple[bool, str]:  # pragma: no cover
             time.sleep(config.settle_seconds)  # let CSP arm Custom-AI before the hijack
             return True, f"LIVE after {attempt} launch attempt(s)"
     return False, f"sim never reached LIVE after {config.max_launches} attempt(s)"
+
+
+def rig_restart_launcher(config: AutoDriveConfig) -> None:  # pragma: no cover - rig-only
+    """Restart Content Manager so the next :func:`rig_launch` cold-starts a FRESH CM (#558).
+
+    Invoked by :func:`run_auto_drive` on a cached-session mismatch: a stale CM keeps serving its
+    cached last session no matter how often the ``acmanager://`` URL is re-sent, so the harness
+    must kill CM and let the next launch cold-start a fresh instance that honors the preset.
+    """
+    from tools.ac_harness.entry_launcher import ContentManagerActuator
+
+    actuator = ContentManagerActuator(preset=config.cm_preset, cm_exe=config.cm_exe)
+    event = actuator.restart_content_manager()
+    _log(f"restart Content Manager (cached-session recovery): {event.detail}")
 
 
 def _wait_live(timeout: float) -> bool:  # pragma: no cover - rig-only
@@ -2634,6 +2683,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
                 tap=tap_frames,
                 apply_setup=rig_apply_setup,
                 verify_track=rig_verify_track,
+                restart_launcher=rig_restart_launcher,
             )
         )
     finally:

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -500,31 +500,6 @@ def _has_timed_lap(frames: list[dict]) -> bool:
     return False
 
 
-def _relaunch_after_cached_session(
-    restart_launcher: RestartLauncherFn | None,
-    config: AutoDriveConfig,
-    why: str,
-    attempt_idx: int,
-    attempts: int,
-) -> None:
-    """Log a cached-session relaunch and, when wired, RESTART the launcher first (#558).
-
-    A plain relaunch only re-issues the ``acmanager://`` URL to the already-running (stale) CM,
-    which keeps serving its cached session. Restarting Content Manager makes the next ``launch``
-    cold-start a fresh instance that honors the preset (live-proven recovery, AG_PC 2026-07-13).
-    A restart-seam failure is swallowed — the plain relaunch still runs and the terminal attempt
-    FAILs honestly — so recovery is best-effort, never a new crash path.
-    """
-    restarted = ""
-    if restart_launcher is not None:
-        try:
-            restart_launcher(config)
-            restarted = "; restarted Content Manager (fresh cold-start next)"
-        except Exception as exc:  # noqa: BLE001 - see docstring: never crash the run on a restart
-            restarted = f"; Content Manager restart failed ({type(exc).__name__}: {exc})"
-    _log(f"{why} — relaunching (attempt {attempt_idx + 2}/{attempts}){restarted}")
-
-
 async def run_auto_drive(
     config: AutoDriveConfig,
     *,
@@ -559,8 +534,28 @@ async def run_auto_drive(
     launch_config = replace(config, max_launches=1)
     launched_once = config.skip_launch
     last_launch_error = ""
+    # #558: cold-start a FRESH Content Manager before a relaunch when the previous attempt signalled
+    # a stale CM. A stale CM keeps serving its cached session / stalling the pre-drive overlay no
+    # matter how often the acmanager:// URL is re-issued, so the only real recovery is a CM restart.
+    restart_cm_next = False
     for attempt_idx in range(attempts):
         if not config.skip_launch:
+            # Restart CM before relaunching when the last attempt hit a cached-session mismatch
+            # (``restart_cm_next`` — a clear staleness signal) OR plain relaunches have already
+            # failed twice (``attempt_idx >= 2`` — persistent degradation). A transient pre-drive
+            # overlay race still gets ONE plain relaunch first. Best-effort: a restart failure still
+            # relaunches, and the terminal attempt FAILs honestly.
+            if (
+                attempt_idx > 0
+                and restart_launcher is not None
+                and (restart_cm_next or attempt_idx >= 2)
+            ):
+                try:
+                    restart_launcher(config)
+                    _log("relaunch: restarted Content Manager for a fresh cold-start")
+                except Exception as exc:  # noqa: BLE001 - never crash the run on a restart failure
+                    _log(f"relaunch: Content Manager restart failed ({type(exc).__name__}: {exc})")
+            restart_cm_next = False
             ok, reason = launch(launch_config)
             if not ok:
                 last_launch_error = reason
@@ -623,12 +618,10 @@ async def run_auto_drive(
                     last_launch_error = (
                         f"setup verify failed on a cached session ({combo_mismatch}): {detail}"
                     )
-                    _relaunch_after_cached_session(
-                        restart_launcher,
-                        config,
-                        f"setup guard: {combo_mismatch} (CM cached session — setup fuel mismatch)",
-                        attempt_idx,
-                        attempts,
+                    restart_cm_next = True  # #558: cached session => cold-start a fresh CM next
+                    _log(
+                        f"setup guard: {combo_mismatch} (CM cached session — setup fuel mismatch) "
+                        f"— relaunching (attempt {attempt_idx + 2}/{attempts})"
                     )
                     continue
                 return AutoDriveReport(
@@ -674,12 +667,10 @@ async def run_auto_drive(
                 controller = None
                 last_launch_error = f"loaded {mismatch} — Content Manager launched a cached session"
                 if attempt_idx < attempts - 1 and not config.skip_launch:
-                    _relaunch_after_cached_session(
-                        restart_launcher,
-                        config,
-                        f"track/car guard: {mismatch} (CM cached session)",
-                        attempt_idx,
-                        attempts,
+                    restart_cm_next = True  # #558: cached session => cold-start a fresh CM next
+                    _log(
+                        f"track/car guard: {mismatch} (CM cached session) — relaunching "
+                        f"(attempt {attempt_idx + 2}/{attempts})"
                     )
                     continue
                 return AutoDriveReport(

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -348,6 +348,20 @@ class ContentManagerActuator:
             return ActuatorEvent("relaunch", launch.detail)
         return ActuatorEvent("relaunch", f"{normalized.detail}; {launch.detail}")
 
+    def restart_content_manager(self) -> ActuatorEvent:
+        """Kill the Content Manager process (tree) so the NEXT launch cold-starts a FRESH CM.
+
+        The ``acmanager://`` URL is handed to the already-running CM via single-instance IPC. A CM
+        instance that has gone stale — no longer honoring the ``presetFile`` and re-running its
+        cached last session (#537 / #558) — keeps serving that cached session no matter how often
+        the URL is re-sent (a plain :meth:`relaunch` only kills ``acs.exe``). Killing the CM
+        process makes the next :meth:`launch` cold-start a fresh instance that processes the preset
+        URL — exactly the recovery a MANUAL Content Manager restart performs (live-proven on AG_PC
+        2026-07-13: after the restart the next launch hijacked on probe 1 and drove a clean lap).
+        ``/T`` also takes down CM's ``acs.exe`` child in the same call.
+        """
+        return ActuatorEvent("restart_cm", _taskkill(self.cm_exe.name, self._runner))
+
 
 LAUNCH_MODES = ("cm", "acs")
 


### PR DESCRIPTION
Closes #558. The **recovery half** of #537.

## Root cause (found during #532 Part B live verification)
The #537 cached-session recovery relaunches by re-issuing the `acmanager://race/quick?presetFile=...` URL to the **same already-running CM** via single-instance IPC (`ContentManagerActuator.relaunch()` only kills `acs.exe`, never CM). A CM instance that has gone **stale** keeps serving its cached last session (Spa) no matter how often the URL is re-sent — so the bounded relaunch exhausts `max_launches` and the drive comes up on the **wrong track** with `hijack probe … no Car0` overlay stalls.

**Live-observed on AG_PC (2026-07-13):** after ~7 launch cycles a single long-lived CM degraded and every relaunch served cached Spa + overlay stalls. **Manually restarting Content Manager fixed it instantly** — the very next launch hijacked on probe 1 and drove a clean Magione lap (108.4 s generic / 107.8 s identified, the #532 Part B A/B). The harness was simply missing that **CM-process restart**.

## Fix
- `entry_launcher`: `ContentManagerActuator.restart_content_manager()` kills the CM process tree (`taskkill /T` also takes down its `acs.exe` child) so the next `launch()` cold-starts a fresh CM that honors the preset.
- `auto_drive`: new injectable `restart_launcher` seam; `run_auto_drive` calls it in **both** cached-session mismatch handlers (post-hijack track/car guard + pre-hijack setup-fuel early-out) before relaunching, bounded by `max_launches`. Rig-wired `restart_launcher=rig_restart_launcher`. A restart-seam failure is swallowed → best-effort recovery, never a new crash path.

## Tests
- The mismatch invokes `restart_launcher` exactly once before the recovery relaunch, then drives the correct track.
- A raising restart seam still recovers (swallowed).
- The actuator kills the CM exe (`taskkill /IM "Content Manager.exe" /F /T`).
- `make ci-fast` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)