### PR TITLE
docs(vault): close out issue #532

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -3,7 +3,7 @@
 ## type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-13T11:05:00Z
+last_updated: 2026-07-13T16:43:53Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-531-phase1-tablet-dash-2026-07-13.md
@@ -28,7 +28,18 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
-**Delivered (2026-07-13, latest):** PR
+**Delivered (2026-07-13, latest):**
+[#532](https://github.com/agorokh/ac-copilot-trainer/issues/532) **CLOSED** after live-state
+reconciliation. Part A shipped in PR [#535](https://github.com/agorokh/ac-copilot-trainer/pull/535)
+(`b023c92`); Part B shipped in PR [#551](https://github.com/agorokh/ac-copilot-trainer/pull/551)
+(`155aac6`). The final Magione closed-loop acceptance pass is complete: generic plant
+**108.447 s** versus identified plant **107.781 s**, both AC-valid. The stale Content Manager
+failure found during verification was fixed in PR
+[#559](https://github.com/agorokh/ac-copilot-trainer/pull/559) (`2cfd662`). Fresh focused
+verification on current `origin/main`: **217 passed** across the plant-ID, GGV-profile, and
+auto-drive suites. Detail: [[issue-532-partb-friction-id-2026-07-13]].
+
+**Delivered (2026-07-13, earlier):** PR
 [#547](https://github.com/agorokh/ac-copilot-trainer/pull/547) **MERGED**
 ([`9265521`](https://github.com/agorokh/ac-copilot-trainer/commit/92655217a0278214569abb3be5520258616d2398))
 — **#531 Phase 1**: the tablet GT dashboard is LIVE on the real PRITOM P7 in Fully Kiosk
@@ -46,8 +57,8 @@ closing [#552](https://github.com/agorokh/ac-copilot-trainer/issues/552). Plant 
 track layout end-to-end (artifact path/save/load, handshake result, driver construction, CLI lookup),
 with exact legacy naming for `layout=None` and hard A/B isolation. Merged-main filesystem proof
 observed separate legacy/GP/short artifacts and a `None` short lookup while only GP existed. PR #551
-also landed the #532 Part-B per-combo friction-ID core and review hardening. **#532 remains OPEN** for
-its distinct rig-only full-lap identified-vs-generic A/B criterion; code merge is not live-lap proof.
+also landed the #532 Part-B per-combo friction-ID core and review hardening. The distinct rig-only
+full-lap A/B criterion was subsequently verified and #532 is now closed (see the latest entry).
 
 **Delivered (2026-07-13, rig session):** Harness reliability —
 [#537](https://github.com/agorokh/ac-copilot-trainer/issues/537) **CLOSED**. AC #2 = PR

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-13T11:05:00Z
+last_updated: 2026-07-13T16:43:53Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-531-phase1-tablet-dash-2026-07-13.md
   - AcCopilotTrainer/03_Investigations/issue-537-ac1-rig-verify-2026-07-13.md
@@ -84,6 +84,18 @@ relates_to:
 
 # Next session handoff
 
+## Delivered (2026-07-13) - #532 CLOSED after live-state reconciliation
+
+[#532](https://github.com/agorokh/ac-copilot-trainer/issues/532) is **CLOSED**. Part A remains
+merged via PR [#535](https://github.com/agorokh/ac-copilot-trainer/pull/535) (`b023c92`), and
+Part B via PR [#551](https://github.com/agorokh/ac-copilot-trainer/pull/551) (`155aac6`). The final
+Magione A/B criterion is satisfied: generic `--use-plant off` **108.447 s** versus identified
+`--use-plant auto` **107.781 s**, both AC-valid. PR
+[#559](https://github.com/agorokh/ac-copilot-trainer/pull/559) (`2cfd662`) fixed the stale Content
+Manager recovery gap uncovered during that verification. Fresh closeout verification on current
+`origin/main`: **217 passed** across `test_plant_id.py`, `test_ggv_profile.py`, and
+`test_ac_harness_auto_drive.py`. Durable detail: [[issue-532-partb-friction-id-2026-07-13]].
+
 ## Delivered (2026-07-13) — #531 Phase 1: tablet GT dashboard LIVE on the P7 (PR #547 MERGED `9265521`)
 
 **PR [#547](https://github.com/agorokh/ac-copilot-trainer/pull/547) MERGED** (squash
@@ -135,11 +147,9 @@ loaded `{layout: short, rpm_up: 7200}`. Full parity at the reviewed head: **2,68
 86.61% coverage, `ci-fast: OK`**; GitHub build/docs/conformance green, 19/19 review threads resolved,
 Qodo 0 bugs, Gemini/Codex current-head clean.
 
-**Split truth / what remains:** [#532](https://github.com/agorokh/ac-copilot-trainer/issues/532)
-stays **OPEN**. Its Part-B code and #552 identity fix are merged, but the parent issue's final
-rig-only acceptance criterion is still pending: run an identified-plant full autonomous lap on
-Magione, confirm AC-valid, and record lap time versus the generic-plant baseline within tolerance.
-Do not treat #552 closure or off-sim filesystem proof as that separate live A/B result.
+**Historical split at PR #551 merge:** the Part-B code and #552 identity fix were merged before
+the parent issue's final rig-only A/B criterion ran. That criterion subsequently passed (results
+below), and #532 is now closed.
 
 **Live model-level verification done (2026-07-13, merged `155aac6`)** — durable node:
 [[issue-532-partb-friction-id-2026-07-13]]. The merged-code handshake fit a valid ggv block from


### PR DESCRIPTION
## What changed

- record #532 as closed in the canonical session handoff and current-focus nodes
- replace the stale A/B-pending state with the completed Magione result
- retain the merged implementation, recovery fix, and focused verification anchors

## Why

The final live A/B evidence had been posted and the implementation was merged, but #532 and one vault paragraph still reported the work as open.

## Verification

- gh issue view 532: CLOSED
- focused plant-ID/GGV/auto-drive suite: 217 passed
- git diff --check
- scripts/check_vault_follow_up.sh
- diff restricted to docs/01_Vault/**
