### PR TITLE
fix(harness): serialize autonomous rig sessions (#555)

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1882,7 +1882,8 @@ def test_sim_process_identity_monitor_rejects_multiple_initial_acs_processes():
     monitor = SimProcessIdentityMonitor({303, 101})
     assert monitor.expected_pid is None
     assert monitor.observe({101, 303}) == (101, 303)
-    assert monitor.observe({101}) == (101, 303)
+    assert monitor.observe({101}) == (101,)
+    assert monitor.observe(set()) == (101, 303)
     assert monitor.expected_pid is None
 
 
@@ -1899,6 +1900,47 @@ def test_main_releases_registered_rig_cleanup_on_exception(monkeypatch):
     with pytest.raises(RuntimeError, match="evidence capture failed"):
         auto_drive_module._main([])
     assert released == [True]
+
+
+def test_rig_drive_synchronously_checks_pid_before_clean_stop(monkeypatch):
+    import tools.ac_harness.ai_line as ai_line_module
+    import tools.ac_harness.auto_drive as auto_drive_module
+    import tools.ac_harness.entry_launcher as entry_launcher_module
+
+    class NoopThread:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def join(self, **_kwargs) -> None:
+            pass
+
+    class Driver:
+        pass
+
+    observations = iter(({101}, {202}, {202}))
+    monkeypatch.setattr(ai_line_module, "load_ai_line", lambda _path: _LINE)
+    monkeypatch.setattr(
+        auto_drive_module, "resolve_fast_lane", lambda *_args: pathlib.Path("fast_lane.ai")
+    )
+    monkeypatch.setattr(auto_drive_module, "_build_driver", lambda *_args: Driver())
+    monkeypatch.setattr(auto_drive_module.threading, "Thread", NoopThread)
+    monkeypatch.setattr(
+        entry_launcher_module, "running_process_ids", lambda _name: frozenset(next(observations))
+    )
+    stop = threading.Event()
+    stop.set()
+
+    stats = auto_drive_module.rig_drive(
+        FakeController(), _cfg(driver="lap", drive_seconds=1.0, spawn_to_line=False), stop
+    )
+
+    assert stats.session_replaced is True
+    assert stats.sim_pid == 101
+    assert stats.unexpected_sim_pids == [202]
+    assert "expected_sim_pid=101" in stats.reason
 
 
 def test_progress_watchdog_rejects_nonpositive_params():

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1882,6 +1882,23 @@ def test_sim_process_identity_monitor_rejects_multiple_initial_acs_processes():
     monitor = SimProcessIdentityMonitor({303, 101})
     assert monitor.expected_pid is None
     assert monitor.observe({101, 303}) == (101, 303)
+    assert monitor.observe({101}) == (101, 303)
+    assert monitor.expected_pid is None
+
+
+def test_main_releases_registered_rig_cleanup_on_exception(monkeypatch):
+    import tools.ac_harness.auto_drive as auto_drive_module
+
+    released: list[bool] = []
+
+    def fail_after_lock(_argv, cleanup):
+        cleanup.callback(released.append, True)
+        raise RuntimeError("evidence capture failed")
+
+    monkeypatch.setattr(auto_drive_module, "_main_impl", fail_after_lock)
+    with pytest.raises(RuntimeError, match="evidence capture failed"):
+        auto_drive_module._main([])
+    assert released == [True]
 
 
 def test_progress_watchdog_rejects_nonpositive_params():

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -18,6 +18,7 @@ from tools.ac_harness.auto_drive import (
     AutoDriveReport,
     DriveStats,
     ProgressWatchdog,
+    SimProcessIdentityMonitor,
     _build_arg_parser,
     _build_driver,
     _config_from_args,
@@ -1107,6 +1108,8 @@ def test_cli_args_map_to_config():
             "40",
             "--tap-seconds",
             "15",
+            "--rig-lock-timeout",
+            "12",
         ]
     )
     cfg = _config_from_args(args)
@@ -1119,6 +1122,7 @@ def test_cli_args_map_to_config():
     assert cfg.target_speed_kmh == 70
     assert cfg.min_corner_speed_kmh == 40
     assert cfg.tap_seconds == 15
+    assert args.rig_lock_timeout == 12
     # --ac-root omitted -> default factory used.
     assert cfg.ac_root == default_ac_root()
 
@@ -1139,6 +1143,24 @@ def test_report_summary_renders_all_sections():
     assert "drove=True" in text
     assert "coaching.snapshot=300" in text
     assert "delta: not in window" in text
+
+
+def test_report_summary_distinguishes_session_takeover_from_sim_death():
+    report = AutoDriveReport(
+        ok=False,
+        stage="done",
+        drive=DriveStats(
+            drove=True,
+            sim_pid=101,
+            unexpected_sim_pids=[202],
+            session_replaced=True,
+            reason="unexpected acs.exe PID takeover",
+        ),
+    )
+    text = report.summary()
+    assert "session_replaced=True" in text
+    assert "sim_dead=False" in text
+    assert "unexpected_sim_pids=[202]" in text
 
 
 # ---------------------------------------------------------------------------
@@ -1838,10 +1860,28 @@ def test_drive_leg_succeeded_vetoes_every_528_failure_shape():
     assert drive_leg_succeeded(None) is False
     assert drive_leg_succeeded(DriveStats(drove=False, total_distance_m=0.0)) is False
     assert drive_leg_succeeded(DriveStats(drove=True, sim_dead=True)) is False
+    assert drive_leg_succeeded(DriveStats(drove=True, session_replaced=True)) is False
     assert (
         drive_leg_succeeded(DriveStats(drove=True, total_distance_m=560.0, recovery_capped=True))
         is False
     )
+
+
+def test_sim_process_identity_monitor_adopts_one_pid_and_detects_takeover():
+    monitor = SimProcessIdentityMonitor()
+    assert monitor.observe(set()) == ()
+    assert monitor.observe({101}) == ()
+    assert monitor.expected_pid == 101
+    assert monitor.observe({101}) == ()
+    assert monitor.observe(set()) == ()  # expected process can disappear before stall attribution
+    assert monitor.observe({202}) == (202,)
+    assert monitor.observe({101, 303}) == (303,)
+
+
+def test_sim_process_identity_monitor_rejects_multiple_initial_acs_processes():
+    monitor = SimProcessIdentityMonitor({303, 101})
+    assert monitor.expected_pid is None
+    assert monitor.observe({101, 303}) == (101, 303)
 
 
 def test_progress_watchdog_rejects_nonpositive_params():

--- a/tests/test_ac_harness_entry_launcher.py
+++ b/tests/test_ac_harness_entry_launcher.py
@@ -22,6 +22,7 @@ from tools.ac_harness.entry_launcher import (
     classify_entry_phase,
     make_actuator,
     normalize_race_ini_spawn_set,
+    running_process_ids,
 )
 from tools.ac_harness.shared_memory import (
     AcGameStatus,
@@ -323,6 +324,37 @@ def test_cold_restart_normalize_kills_even_without_race_ini(monkeypatch, tmp_pat
     assert event is not None
     assert event.detail == "killed acs.exe"
     assert calls == [["taskkill", "/IM", "acs.exe", "/F", "/T"]]
+
+
+def test_running_process_ids_parses_all_matching_acs_rows(monkeypatch):
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+    calls: list[list[str]] = []
+
+    def runner(cmd, **kwargs):  # noqa: ANN001
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout='"acs.exe","101","Console","1","1,024 K"\n'
+            '"ACS.EXE","202","Console","1","1,024 K"\n',
+            stderr="",
+        )
+
+    assert running_process_ids("acs.exe", runner) == frozenset({101, 202})
+    assert calls == [["tasklist", "/FI", "IMAGENAME eq acs.exe", "/FO", "CSV", "/NH"]]
+
+
+def test_running_process_ids_treats_no_match_and_tasklist_failure_as_empty(monkeypatch):
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+
+    def no_match(cmd, **kwargs):  # noqa: ANN001
+        return subprocess.CompletedProcess(cmd, 0, stdout="INFO: No tasks are running", stderr="")
+
+    def failed(cmd, **kwargs):  # noqa: ANN001
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="access denied")
+
+    assert running_process_ids("acs.exe", no_match) == frozenset()
+    assert running_process_ids("acs.exe", failed) == frozenset()
 
 
 def test_cold_restart_relaunch_reapplies_race_ini_normalization(monkeypatch, tmp_path: Path):

--- a/tests/test_ac_harness_entry_launcher.py
+++ b/tests/test_ac_harness_entry_launcher.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -355,6 +357,11 @@ def test_running_process_ids_treats_no_match_and_tasklist_failure_as_empty(monke
 
     assert running_process_ids("acs.exe", no_match) == frozenset()
     assert running_process_ids("acs.exe", failed) == frozenset()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Toolhelp32 is Windows-only")
+def test_running_process_ids_native_snapshot_finds_current_python():
+    assert os.getpid() in running_process_ids(Path(sys.executable).name)
 
 
 def test_cold_restart_relaunch_reapplies_race_ini_normalization(monkeypatch, tmp_path: Path):

--- a/tests/test_ac_harness_rig_lock.py
+++ b/tests/test_ac_harness_rig_lock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import subprocess
 import sys
@@ -90,3 +91,17 @@ def test_lock_validates_timing(tmp_path: Path) -> None:
         RigSessionLock(tmp_path / "lock", owner=_owner(1), timeout=-1)
     with pytest.raises(ValueError, match="poll interval"):
         RigSessionLock(tmp_path / "lock", owner=_owner(1), poll_interval=0)
+
+
+def test_unexpected_lock_os_error_is_not_reported_as_busy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock = RigSessionLock(tmp_path / "lock", owner=_owner(1))
+
+    def fail_lock(_lock_file) -> None:
+        raise OSError(errno.EIO, "device failure")
+
+    monkeypatch.setattr(lock, "_lock_byte", fail_lock)
+    with pytest.raises(OSError, match="device failure") as exc_info:
+        lock.acquire()
+    assert exc_info.value.errno == errno.EIO

--- a/tests/test_ac_harness_rig_lock.py
+++ b/tests/test_ac_harness_rig_lock.py
@@ -1,0 +1,92 @@
+"""Cross-process ownership tests for the single physical AC rig (#555)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.ac_harness.rig_lock import (
+    RigSessionBusy,
+    RigSessionLock,
+    RigSessionOwner,
+    default_rig_session_lock_path,
+)
+
+
+def _owner(pid: int) -> RigSessionOwner:
+    return RigSessionOwner(
+        pid=pid,
+        cwd=f"worktree-{pid}",
+        car="ks_audi_r8_lms",
+        track="magione",
+        started_at="2026-07-13T12:00:00Z",
+    )
+
+
+def test_default_lock_path_is_shared_app_data_not_worktree(tmp_path: Path) -> None:
+    path = default_rig_session_lock_path(local_app_data=tmp_path)
+    assert path == tmp_path / "AC Copilot Trainer" / "Harness" / "rig-session.lock"
+
+
+def test_second_process_fails_busy_with_owner_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "rig-session.lock"
+    ready = tmp_path / "ready"
+    release = tmp_path / "release"
+    script = """
+import sys
+import time
+from pathlib import Path
+from tools.ac_harness.rig_lock import RigSessionLock, RigSessionOwner
+
+path, ready, release = map(Path, sys.argv[1:])
+owner = RigSessionOwner(
+    pid=4242, cwd='peer-worktree', car='peer-car', track='peer-track'
+)
+with RigSessionLock(path, owner=owner):
+    ready.touch()
+    while not release.exists():
+        time.sleep(0.01)
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script, str(path), str(ready), str(release)], env=env
+    )
+    try:
+        for _ in range(500):
+            if ready.exists():
+                break
+            if proc.poll() is not None:
+                raise AssertionError(f"lock-holder exited early: {proc.returncode}")
+            time.sleep(0.01)
+        assert ready.exists()
+
+        with pytest.raises(RigSessionBusy) as exc_info:
+            RigSessionLock(path, owner=_owner(9999)).acquire()
+
+        assert exc_info.value.owner["pid"] == 4242
+        assert exc_info.value.owner["car"] == "peer-car"
+        assert "peer-worktree" in str(exc_info.value)
+    finally:
+        release.touch()
+        proc.wait(timeout=5)
+
+
+def test_lock_is_released_for_next_owner(tmp_path: Path) -> None:
+    path = tmp_path / "rig-session.lock"
+    with RigSessionLock(path, owner=_owner(1)):
+        pass
+    with RigSessionLock(path, owner=_owner(2)):
+        assert path.exists()
+
+
+def test_lock_validates_timing(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="timeout"):
+        RigSessionLock(tmp_path / "lock", owner=_owner(1), timeout=-1)
+    with pytest.raises(ValueError, match="poll interval"):
+        RigSessionLock(tmp_path / "lock", owner=_owner(1), poll_interval=0)

--- a/tests/test_false_green_kpi.py
+++ b/tests/test_false_green_kpi.py
@@ -139,15 +139,16 @@ def test_corpus_expected_labels_and_oracles_are_valid():
         assert callable(sc.run)
 
 
-def test_weakening_the_drive_oracle_leaks_the_528_stall_shapes(monkeypatch):
+def test_weakening_the_drive_oracle_leaks_drive_failure_shapes(monkeypatch):
     # Defang the drive-leg verdict (patch the symbol build_corpus resolves at call time): a
     # recovery-capped pit-start stall and a never-landed hijack now read as a successful drive, so
-    # both #528 broken scenarios leak. Proves the drive oracle has teeth without a test-only knob.
+    # both #528 scenarios and #555 session replacement leak. Proves the drive oracle has teeth.
     monkeypatch.setattr(false_green_kpi, "drive_leg_succeeded", lambda stats: True)
     weak = run_kpi()
-    assert weak.broken_false_green >= 2  # spawn_stall_recovery_capped + hijack_never_landed leak
+    assert weak.broken_false_green >= 3
     assert "broken_spawn_stall_recovery_capped" in weak.false_greens
     assert "broken_hijack_never_landed" in weak.false_greens
+    assert "broken_session_replaced" in weak.false_greens
     assert weak.ok is False
 
 

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -58,6 +58,7 @@ import configparser
 import json
 import logging
 import math
+import os
 import re
 import threading
 import time
@@ -202,6 +203,11 @@ class DriveStats:
     total_distance_m: float = 0.0
     samples: int = 0
     sim_dead: bool = False
+    # #555: process identity observed after hijack. A different acs.exe PID means another
+    # harness/CM launch replaced this session; that is distinct from a generic sim death.
+    sim_pid: int | None = None
+    unexpected_sim_pids: list[int] = field(default_factory=list)
+    session_replaced: bool = False
     recoveries: int = 0  # stuck/no-progress recoveries taken (capped by max_recoveries)
     recovery_capped: bool = False  # True when max_recoveries was exhausted (vetoes success)
     spawn_teleport: str = ""  # "" (not attempted) | "ok" | "failed" | "skipped (on line)"
@@ -221,6 +227,7 @@ def drive_leg_succeeded(stats: DriveStats | None) -> bool:
     * ``not stats.drove`` — the car never cleared the distance/speed floor (a pit-start stall that
       never moves reads ``drove=False`` at 0 m).
     * ``stats.sim_dead`` — ``acs.exe`` died mid-run; the totals are stale (#459/#460).
+    * ``stats.session_replaced`` — another harness/CM launch replaced the session (#555).
     * ``stats.recovery_capped`` — the car kept stalling until the recovery cap; it never sustained
       progress whatever the totals say (the pit-start recovery-cap stall, #528).
 
@@ -228,7 +235,13 @@ def drive_leg_succeeded(stats: DriveStats | None) -> bool:
     KPI corpus (`false_green_kpi.py`) exercises it directly, so dropping a veto here surfaces as a
     leaked broken scenario rather than a silent false green.
     """
-    return bool(stats) and stats.drove and not stats.sim_dead and not stats.recovery_capped
+    return (
+        bool(stats)
+        and stats.drove
+        and not stats.sim_dead
+        and not stats.session_replaced
+        and not stats.recovery_capped
+    )
 
 
 def should_try_line_teleport_on_recovery(
@@ -306,7 +319,10 @@ class AutoDriveReport:
             lines.append(
                 f"  drive: drove={d.drove} laps={d.laps} max_speed={d.max_speed_kmh:.1f}km/h "
                 f"top_gear={max(d.max_gear_used - 1, 0)} dist={d.total_distance_m:.0f}m "
-                f"recoveries={d.recoveries} sim_dead={d.sim_dead}"
+                f"recoveries={d.recoveries} sim_dead={d.sim_dead} "
+                f"session_replaced={d.session_replaced}"
+                + (f" sim_pid={d.sim_pid}" if d.sim_pid is not None else "")
+                + (f" unexpected_sim_pids={d.unexpected_sim_pids}" if d.unexpected_sim_pids else "")
                 + (f" spawn_teleport={d.spawn_teleport}" if d.spawn_teleport else "")
                 + (f" reason={d.reason}" if d.reason else "")
             )
@@ -1973,6 +1989,34 @@ def _teleport_onto_line(  # pragma: no cover - rig-only
     return landed <= 25.0
 
 
+class SimProcessIdentityMonitor:
+    """Track the one ``acs.exe`` process that owns a hijacked drive session (#555).
+
+    An empty first observation is tolerated (``tasklist`` can race process startup); the first
+    singleton observation becomes the expected process. Multiple processes are immediately unsafe,
+    and any later PID outside the expected singleton is a session takeover.
+    """
+
+    def __init__(self, initial_pids: frozenset[int] | set[int] = frozenset()) -> None:
+        self.expected_pid: int | None = None
+        self._initial_conflict: tuple[int, ...] = ()
+        self.observe(initial_pids)
+
+    def observe(self, current_pids: frozenset[int] | set[int]) -> tuple[int, ...]:
+        """Return unexpected PIDs, or ``()`` while the original session still owns the rig."""
+
+        current = {int(pid) for pid in current_pids if int(pid) > 0}
+        if self.expected_pid is None:
+            if len(current) == 1:
+                self.expected_pid = next(iter(current))
+                return ()
+            if len(current) > 1:
+                self._initial_conflict = tuple(sorted(current))
+                return self._initial_conflict
+            return self._initial_conflict
+        return tuple(sorted(current - {self.expected_pid}))
+
+
 class PhysicsStallDetector:
     """Sim-death detector: the main ``acpmf_physics`` packet_id stagnant for
     ``sim_dead_seconds`` means ``acs.exe`` died (#459/#460).
@@ -2110,6 +2154,7 @@ def rig_drive(  # pragma: no cover - rig-only
     # car is stationary — so watching Car0 falsely declared "acs.exe died" 4 s into a start-line
     # spawn, before the driver could even shift out of neutral. The main physics packet advances
     # every frame while the sim runs and freezes only when acs actually dies (#459 review).
+    from tools.ac_harness.entry_launcher import running_process_ids
     from tools.ac_harness.shared_memory import SharedMemoryReader, SharedMemoryUnavailable
 
     phys_reader: SharedMemoryReader | None = None
@@ -2152,6 +2197,12 @@ def rig_drive(  # pragma: no cover - rig-only
             return None
         return p.packet_id if p is not None else None
 
+    # Capture the process that owns the already-hijacked session. CM requests are machine-global;
+    # without this identity, a concurrent worktree that starts another Quick Drive session only
+    # surfaces later as frozen physics and the report misleadingly says generic ``sim_dead``.
+    process_monitor = SimProcessIdentityMonitor(running_process_ids("acs.exe"))
+    stats.sim_pid = process_monitor.expected_pid
+    next_process_probe = 0.0
     prev_plane: tuple[float, float] | None = None
     t0 = time.monotonic()
     # Anchor the sim-death timer at the loop start (not the first packet sample) so a sim that is
@@ -2163,6 +2214,19 @@ def rig_drive(  # pragma: no cover - rig-only
             if not cd:
                 time.sleep(0.02)
                 continue
+            wall_now = time.monotonic()
+            if wall_now >= next_process_probe:
+                unexpected = process_monitor.observe(running_process_ids("acs.exe"))
+                stats.sim_pid = process_monitor.expected_pid
+                next_process_probe = wall_now + 1.0
+                if unexpected:
+                    stats.session_replaced = True
+                    stats.unexpected_sim_pids = list(unexpected)
+                    stats.reason = (
+                        "unexpected acs.exe PID takeover during live drive "
+                        f"(harness_pid={stats.sim_pid}, observed={list(unexpected)})"
+                    )
+                    break
             # Sim-death: the main acpmf_physics packet_id stagnant for sim_dead_seconds means
             # acs.exe died. A None (physics mmap gone) does NOT reset the timer (#460 review) —
             # sustained None or a frozen packet both trip. Rule owned by PhysicsStallDetector.
@@ -2475,6 +2539,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="leave a harness-auto-started sidecar running after the run",
     )
     p.add_argument(
+        "--rig-lock-timeout",
+        type=_nonneg_float,
+        default=0.0,
+        help="seconds to wait for another auto-drive process to release the single-rig lock; "
+        "0 fails immediately and reports the owner (#555)",
+    )
+    p.add_argument(
         "--preflight-only",
         action="store_true",
         help="run the preflight asserts and exit (0 = ready to launch)",
@@ -2656,15 +2727,45 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             )
         print(f"auto-drive: setup resolved -> {config.setup_ini}")
 
-    sidecar_ok, sidecar_detail, sidecar_proc = ensure_sidecar(
-        config.sidecar_url, autostart=not args.no_sidecar_autostart
+    # #555: AC + Content Manager are one machine-global rig. A repo-local lock cannot serialize
+    # different worktrees, so own the shared LocalAppData lock from before sidecar/launch through
+    # drive teardown. A peer fails/waits here BEFORE either process can kill or relaunch its AC.
+    from tools.ac_harness.rig_lock import (
+        RigSessionBusy,
+        RigSessionLock,
+        RigSessionOwner,
+        default_rig_session_lock_path,
     )
-    print(f"auto-drive: {sidecar_detail}")
-    if not sidecar_ok:
-        return 2
 
-    run_started_epoch = time.time()
+    rig_lock = RigSessionLock(
+        default_rig_session_lock_path(),
+        owner=RigSessionOwner(
+            pid=os.getpid(),
+            cwd=str(Path.cwd()),
+            car=config.car_id,
+            track=config.track_id,
+            started_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        ),
+        timeout=args.rig_lock_timeout,
+    )
     try:
+        rig_lock.acquire()
+    except RigSessionBusy as exc:
+        print(f"auto-drive: RIG BUSY — {exc}")
+        return 3
+    print(f"auto-drive: rig lock acquired -> {rig_lock.path}")
+
+    sidecar_proc = None
+    try:
+        sidecar_ok, sidecar_detail, sidecar_proc = ensure_sidecar(
+            config.sidecar_url, autostart=not args.no_sidecar_autostart
+        )
+        print(f"auto-drive: {sidecar_detail}")
+        if not sidecar_ok:
+            rig_lock.release()
+            return 2
+
+        run_started_epoch = time.time()
         report = asyncio.run(
             run_auto_drive(
                 config,
@@ -2681,6 +2782,8 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         if sidecar_proc is not None and not args.keep_sidecar:
             sidecar_proc.terminate()
 
+    # Keep the rig owned through HUD/archive/report capture: otherwise a waiting worktree can
+    # relaunch AC in the narrow gap after drive teardown and corrupt this run's evidence bundle.
     hud = _capture_hud_evidence(evidence_dir, args.hud_region)
     # Gate the wait on the WS `lap` frame the tap actually saw (report.counts["lap"]) — the SAME
     # signal run_auto_drive's grace uses — not rig_drive's separate lap counter, so the two never
@@ -2769,7 +2872,9 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     if lap_archives:
         print(f"  lap archives ({len(lap_archives)}): {lap_archives[0]}")
     print(f"  evidence: {report_path}")
-    return 0 if report.ok else 1
+    exit_code = 0 if report.ok else 1
+    rig_lock.release()
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - rig-only CLI wiring

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2202,7 +2202,26 @@ def rig_drive(  # pragma: no cover - rig-only
     # surfaces later as frozen physics and the report misleadingly says generic ``sim_dead``.
     process_monitor = SimProcessIdentityMonitor(running_process_ids("acs.exe"))
     stats.sim_pid = process_monitor.expected_pid
-    next_process_probe = 0.0
+    process_probe_stop = threading.Event()
+    process_probe_lock = threading.Lock()
+    process_takeover: tuple[int, ...] = ()
+
+    def _watch_sim_process() -> None:
+        # Process enumeration takes ~20 ms on a busy rig. Keep it off the real-time control loop;
+        # one-second attribution latency is tiny beside the 4 s sim-death threshold.
+        nonlocal process_takeover
+        while not process_probe_stop.is_set():
+            unexpected = process_monitor.observe(running_process_ids("acs.exe"))
+            if unexpected:
+                with process_probe_lock:
+                    process_takeover = unexpected
+                return
+            process_probe_stop.wait(1.0)
+
+    process_probe_thread = threading.Thread(
+        target=_watch_sim_process, name="acs-process-identity", daemon=True
+    )
+    process_probe_thread.start()
     prev_plane: tuple[float, float] | None = None
     t0 = time.monotonic()
     # Anchor the sim-death timer at the loop start (not the first packet sample) so a sim that is
@@ -2214,19 +2233,17 @@ def rig_drive(  # pragma: no cover - rig-only
             if not cd:
                 time.sleep(0.02)
                 continue
-            wall_now = time.monotonic()
-            if wall_now >= next_process_probe:
-                unexpected = process_monitor.observe(running_process_ids("acs.exe"))
+            with process_probe_lock:
+                unexpected = process_takeover
+            if unexpected:
                 stats.sim_pid = process_monitor.expected_pid
-                next_process_probe = wall_now + 1.0
-                if unexpected:
-                    stats.session_replaced = True
-                    stats.unexpected_sim_pids = list(unexpected)
-                    stats.reason = (
-                        "unexpected acs.exe PID takeover during live drive "
-                        f"(harness_pid={stats.sim_pid}, observed={list(unexpected)})"
-                    )
-                    break
+                stats.session_replaced = True
+                stats.unexpected_sim_pids = list(unexpected)
+                stats.reason = (
+                    "unexpected acs.exe PID takeover during live drive "
+                    f"(harness_pid={stats.sim_pid}, observed={list(unexpected)})"
+                )
+                break
             # Sim-death: the main acpmf_physics packet_id stagnant for sim_dead_seconds means
             # acs.exe died. A None (physics mmap gone) does NOT reset the timer (#460 review) —
             # sustained None or a frozen packet both trip. Rule owned by PhysicsStallDetector.
@@ -2276,6 +2293,9 @@ def rig_drive(  # pragma: no cover - rig-only
                 stats.laps += 1
             time.sleep(0.012)
     finally:
+        process_probe_stop.set()
+        process_probe_thread.join(timeout=3.0)
+        stats.sim_pid = process_monitor.expected_pid
         # #532: if the handshake driver did not self-complete within the drive budget, finalize it
         # so the run still produces a result (which constants WERE measured), not "no result".
         finalize = getattr(driver, "finalize", None)

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -63,7 +63,7 @@ import re
 import threading
 import time
 from collections.abc import Awaitable, Callable, Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC
 from pathlib import Path
@@ -2007,6 +2007,8 @@ class SimProcessIdentityMonitor:
 
         current = {int(pid) for pid in current_pids if int(pid) > 0}
         if self.expected_pid is None:
+            if self._initial_conflict:
+                return self._initial_conflict
             if len(current) == 1:
                 self.expected_pid = next(iter(current))
                 return ()
@@ -2229,10 +2231,6 @@ def rig_drive(  # pragma: no cover - rig-only
     stall = PhysicsStallDetector(config.sim_dead_seconds, now=t0)
     try:
         while not stop.is_set() and time.monotonic() - t0 < config.drive_seconds:
-            cd = controller.read_car_data()
-            if not cd:
-                time.sleep(0.02)
-                continue
             with process_probe_lock:
                 unexpected = process_takeover
             if unexpected:
@@ -2241,9 +2239,13 @@ def rig_drive(  # pragma: no cover - rig-only
                 stats.unexpected_sim_pids = list(unexpected)
                 stats.reason = (
                     "unexpected acs.exe PID takeover during live drive "
-                    f"(harness_pid={stats.sim_pid}, observed={list(unexpected)})"
+                    f"(expected_sim_pid={stats.sim_pid}, observed={list(unexpected)})"
                 )
                 break
+            cd = controller.read_car_data()
+            if not cd:
+                time.sleep(0.02)
+                continue
             # Sim-death: the main acpmf_physics packet_id stagnant for sim_dead_seconds means
             # acs.exe died. A None (physics mmap gone) does NOT reset the timer (#460 review) —
             # sustained None or a frozen packet both trip. Rule owned by PhysicsStallDetector.
@@ -2607,7 +2609,9 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
     return AutoDriveConfig(**kwargs)
 
 
-def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only CLI wiring
+def _main_impl(
+    argv: list[str] | None, cleanup: ExitStack
+) -> int:  # pragma: no cover - rig-only CLI wiring
     args = _build_arg_parser().parse_args(argv)
     if args.cm_preset is None and not args.car:
         print("auto-drive: pass --car (preset is generated) or --cm-preset (hand-authored)")
@@ -2773,6 +2777,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     except RigSessionBusy as exc:
         print(f"auto-drive: RIG BUSY — {exc}")
         return 3
+    cleanup.callback(rig_lock.release)
     print(f"auto-drive: rig lock acquired -> {rig_lock.path}")
 
     sidecar_proc = None
@@ -2782,7 +2787,6 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         )
         print(f"auto-drive: {sidecar_detail}")
         if not sidecar_ok:
-            rig_lock.release()
             return 2
 
         run_started_epoch = time.time()
@@ -2893,8 +2897,14 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         print(f"  lap archives ({len(lap_archives)}): {lap_archives[0]}")
     print(f"  evidence: {report_path}")
     exit_code = 0 if report.ok else 1
-    rig_lock.release()
     return exit_code
+
+
+def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only CLI wiring
+    # ExitStack makes the machine-global rig lock exception-safe for both the CLI and programmatic
+    # callers, including failures during HUD/archive/report capture after the drive has stopped.
+    with ExitStack() as cleanup:
+        return _main_impl(argv, cleanup)
 
 
 if __name__ == "__main__":  # pragma: no cover - rig-only CLI wiring

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2008,7 +2008,9 @@ class SimProcessIdentityMonitor:
         current = {int(pid) for pid in current_pids if int(pid) > 0}
         if self.expected_pid is None:
             if self._initial_conflict:
-                return self._initial_conflict
+                # Ownership stays unsafe after an ambiguous start, but diagnostics should name the
+                # PIDs that are live now rather than replaying a stale historical set forever.
+                return tuple(sorted(current)) or self._initial_conflict
             if len(current) == 1:
                 self.expected_pid = next(iter(current))
                 return ()
@@ -2208,15 +2210,41 @@ def rig_drive(  # pragma: no cover - rig-only
     process_probe_lock = threading.Lock()
     process_takeover: tuple[int, ...] = ()
 
+    def _sample_sim_process() -> tuple[int, ...]:
+        """Synchronously sample ownership and latch any unsafe process identity."""
+
+        nonlocal process_takeover
+        current = running_process_ids("acs.exe")
+        with process_probe_lock:
+            unexpected = process_monitor.observe(current)
+            if unexpected:
+                process_takeover = unexpected
+            return process_takeover
+
+    def _record_process_takeover(*, synchronous: bool) -> bool:
+        """Copy a latched/fresh takeover into the structured drive verdict."""
+
+        if synchronous:
+            unexpected = _sample_sim_process()
+        else:
+            with process_probe_lock:
+                unexpected = process_takeover
+        if not unexpected:
+            return False
+        stats.sim_pid = process_monitor.expected_pid
+        stats.session_replaced = True
+        stats.unexpected_sim_pids = list(unexpected)
+        stats.reason = (
+            "unexpected acs.exe PID takeover during live drive "
+            f"(expected_sim_pid={stats.sim_pid}, observed={list(unexpected)})"
+        )
+        return True
+
     def _watch_sim_process() -> None:
         # Process enumeration takes ~20 ms on a busy rig. Keep it off the real-time control loop;
         # one-second attribution latency is tiny beside the 4 s sim-death threshold.
-        nonlocal process_takeover
         while not process_probe_stop.is_set():
-            unexpected = process_monitor.observe(running_process_ids("acs.exe"))
-            if unexpected:
-                with process_probe_lock:
-                    process_takeover = unexpected
+            if _sample_sim_process():
                 return
             process_probe_stop.wait(1.0)
 
@@ -2230,20 +2258,20 @@ def rig_drive(  # pragma: no cover - rig-only
     # already dead trips once stale car data appears, even on a short/ending run (codex on #513).
     stall = PhysicsStallDetector(config.sim_dead_seconds, now=t0)
     try:
-        while not stop.is_set() and time.monotonic() - t0 < config.drive_seconds:
-            with process_probe_lock:
-                unexpected = process_takeover
-            if unexpected:
-                stats.sim_pid = process_monitor.expected_pid
-                stats.session_replaced = True
-                stats.unexpected_sim_pids = list(unexpected)
-                stats.reason = (
-                    "unexpected acs.exe PID takeover during live drive "
-                    f"(expected_sim_pid={stats.sim_pid}, observed={list(unexpected)})"
-                )
+        while time.monotonic() - t0 < config.drive_seconds:
+            # The sidecar tap can stop the drive between one-second watcher polls. Refresh ownership
+            # synchronously before accepting that stop as clean (#555 review).
+            if stop.is_set():
+                _record_process_takeover(synchronous=True)
+                break
+            if _record_process_takeover(synchronous=False):
                 break
             cd = controller.read_car_data()
             if not cd:
+                # A replacement can tear down Car0 before the background watcher runs. Sample now,
+                # before missing telemetry continues past the only attribution opportunity.
+                if _record_process_takeover(synchronous=True):
+                    break
                 time.sleep(0.02)
                 continue
             # Sim-death: the main acpmf_physics packet_id stagnant for sim_dead_seconds means
@@ -2295,6 +2323,9 @@ def rig_drive(  # pragma: no cover - rig-only
                 stats.laps += 1
             time.sleep(0.012)
     finally:
+        # Close the final sub-second race at timeout/driver completion too; rig teardown has not
+        # begun yet, so a different PID here is always a session replacement rather than expected.
+        _record_process_takeover(synchronous=True)
         process_probe_stop.set()
         process_probe_thread.join(timeout=3.0)
         stats.sim_pid = process_monitor.expected_pid

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import csv
+import io
 import subprocess
 import sys
 import time
@@ -221,6 +223,39 @@ def _taskkill(
     detail = (result.stderr or result.stdout or "").strip()
     suffix = f": {detail}" if detail else " (process may not have been running)"
     return f"taskkill {process_name} exited {result.returncode}{suffix}"
+
+
+def running_process_ids(
+    process_name: str,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> frozenset[int]:
+    """Return PIDs for a Windows image name without adding a runtime dependency.
+
+    ``auto_drive`` samples this at a low cadence during the drive leg so a second CM launch from
+    another worktree is reported as a session takeover, not a generic frozen-physics ``sim_dead``.
+    ``tasklist /FO CSV`` is stable across whitespace/localized column headings; the no-match INFO
+    line is intentionally ignored because it is not a CSV row for ``process_name``.
+    """
+
+    if sys.platform != "win32":
+        return frozenset()
+    result = runner(
+        ["tasklist", "/FI", f"IMAGENAME eq {process_name}", "/FO", "CSV", "/NH"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return frozenset()
+    found: set[int] = set()
+    for row in csv.reader(io.StringIO(result.stdout or "")):
+        if len(row) < 2 or row[0].casefold() != process_name.casefold():
+            continue
+        try:
+            found.add(int(row[1]))
+        except ValueError:
+            continue
+    return frozenset(found)
 
 
 class ColdRestartActuator:

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -227,18 +227,19 @@ def _taskkill(
 
 def running_process_ids(
     process_name: str,
-    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+    runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> frozenset[int]:
     """Return PIDs for a Windows image name without adding a runtime dependency.
 
-    ``auto_drive`` samples this at a low cadence during the drive leg so a second CM launch from
-    another worktree is reported as a session takeover, not a generic frozen-physics ``sim_dead``.
-    ``tasklist /FO CSV`` is stable across whitespace/localized column headings; the no-match INFO
-    line is intentionally ignored because it is not a CSV row for ``process_name``.
+    Production uses Toolhelp32 directly so the real-time drive loop does not spawn ``tasklist`` and
+    incur a control-latency spike every second. Tests can inject ``runner`` to exercise the stable
+    CSV fallback/parser without relying on the host process table.
     """
 
     if sys.platform != "win32":
         return frozenset()
+    if runner is None:
+        return _toolhelp_process_ids(process_name)
     result = runner(
         ["tasklist", "/FI", f"IMAGENAME eq {process_name}", "/FO", "CSV", "/NH"],
         check=False,
@@ -255,6 +256,53 @@ def running_process_ids(
             found.add(int(row[1]))
         except ValueError:
             continue
+    return frozenset(found)
+
+
+def _toolhelp_process_ids(process_name: str) -> frozenset[int]:
+    """Enumerate Windows processes in-process via ``CreateToolhelp32Snapshot``."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    class ProcessEntry32W(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_size_t),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", wintypes.LONG),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", wintypes.WCHAR * 260),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.argtypes = (wintypes.DWORD, wintypes.DWORD)
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.Process32FirstW.argtypes = (wintypes.HANDLE, ctypes.POINTER(ProcessEntry32W))
+    kernel32.Process32FirstW.restype = wintypes.BOOL
+    kernel32.Process32NextW.argtypes = (wintypes.HANDLE, ctypes.POINTER(ProcessEntry32W))
+    kernel32.Process32NextW.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    snapshot = kernel32.CreateToolhelp32Snapshot(0x00000002, 0)  # TH32CS_SNAPPROCESS
+    if snapshot == wintypes.HANDLE(-1).value:
+        return frozenset()
+    found: set[int] = set()
+    try:
+        entry = ProcessEntry32W()
+        entry.dwSize = ctypes.sizeof(entry)
+        ok = kernel32.Process32FirstW(snapshot, ctypes.byref(entry))
+        while ok:
+            if entry.szExeFile.casefold() == process_name.casefold():
+                found.add(int(entry.th32ProcessID))
+            ok = kernel32.Process32NextW(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
     return frozenset(found)
 
 

--- a/tools/ac_harness/false_green_kpi.py
+++ b/tools/ac_harness/false_green_kpi.py
@@ -66,6 +66,7 @@ BROKEN_CLASSES: tuple[str, ...] = (
     "sim_death_physics_gone",  # #460 — physics mmap gone; None must not reset the timer
     "spawn_stall_recovery_capped",  # #528 — pit-start stall: car never escapes, recovery cap at 0 m
     "hijack_never_landed",  # #528 — carcsw hijack never landed; no drive leg ran at all
+    "session_replaced",  # #555 — another worktree launched a different acs.exe mid-drive
     "hud_blank",  # black HUD frame
     "hud_uniform",  # frozen/uniform HUD frame (almost no distinct values)
     "report_path_swallow",  # oracle FAIL must reach SelfTestReport.ok (no swallowing)
@@ -462,6 +463,27 @@ def build_corpus() -> list[Scenario]:
             "RED",
             "drive",
             lambda: drive(None),
+        ),
+        Scenario(
+            # #555 cross-worktree collision: the car had already driven far enough to satisfy the
+            # distance/speed floor when another CM request replaced its acs.exe. The explicit
+            # session_replaced veto is therefore load-bearing.
+            "broken_session_replaced",
+            "session_replaced",
+            "#555",
+            "RED",
+            "drive",
+            lambda: drive(
+                DriveStats(
+                    drove=True,
+                    total_distance_m=510.0,
+                    max_speed_kmh=132.0,
+                    sim_pid=101,
+                    unexpected_sim_pids=[202],
+                    session_replaced=True,
+                    reason="unexpected acs.exe PID takeover",
+                )
+            ),
         ),
         Scenario(
             "broken_render_black", "hud_blank", "-", "RED", "render", lambda: render(black_bgra)

--- a/tools/ac_harness/rig_lock.py
+++ b/tools/ac_harness/rig_lock.py
@@ -8,6 +8,7 @@ folder and uses an OS file lock that is released automatically when the owner pr
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import sys
@@ -106,7 +107,10 @@ class RigSessionLock:
             try:
                 self._lock_byte(lock_file)
                 break
-            except OSError:
+            except OSError as exc:
+                if not self._is_lock_contention(exc):
+                    lock_file.close()
+                    raise
                 if time.monotonic() >= deadline:
                     owner = self._read_owner(lock_file)
                     lock_file.close()
@@ -132,6 +136,23 @@ class RigSessionLock:
             self._unlock_byte(lock_file)
         finally:
             lock_file.close()
+
+    @staticmethod
+    def _is_lock_contention(exc: OSError) -> bool:
+        """Return whether an OS lock failure means another process owns the byte."""
+
+        if sys.platform == "win32":
+            # msvcrt.locking reports LK_NBLCK contention as EACCES on CPython; native callers may
+            # preserve ERROR_LOCK_VIOLATION (33). File-open permission failures happen earlier and
+            # unexpected lock API errors must retain their real diagnosis.
+            return exc.errno in {errno.EACCES, errno.EAGAIN} or getattr(exc, "winerror", None) in {
+                33
+            }
+        return isinstance(exc, BlockingIOError) or exc.errno in {
+            errno.EACCES,
+            errno.EAGAIN,
+            errno.EWOULDBLOCK,
+        }
 
     @staticmethod
     def _read_owner(lock_file: BinaryIO) -> dict[str, Any] | None:

--- a/tools/ac_harness/rig_lock.py
+++ b/tools/ac_harness/rig_lock.py
@@ -1,0 +1,168 @@
+"""Cross-process ownership guard for the single physical Assetto Corsa rig.
+
+Assetto Corsa and Content Manager are machine-global resources: two ``auto_drive`` processes from
+different git worktrees cannot safely share them.  A repository-local lock is insufficient because
+each worktree has its own ``.scratch`` directory, so the lock lives under the product's LocalAppData
+folder and uses an OS file lock that is released automatically when the owner process exits.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO
+
+
+def default_rig_session_lock_path(*, local_app_data: str | Path | None = None) -> Path:
+    """Return the cross-worktree lock path in the app's per-user data folder."""
+
+    base = local_app_data or os.environ.get("LOCALAPPDATA")
+    if base is None:
+        # Off-rig fallback for development hosts. Production is Windows and always supplies
+        # LOCALAPPDATA; tests pass an explicit temporary directory.
+        base = Path.home() / ".local" / "state"
+    return Path(base) / "AC Copilot Trainer" / "Harness" / "rig-session.lock"
+
+
+@dataclass(frozen=True)
+class RigSessionOwner:
+    """Human-readable metadata stored behind the lock byte for busy diagnostics."""
+
+    pid: int
+    cwd: str
+    car: str | None = None
+    track: str | None = None
+    started_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pid": self.pid,
+            "cwd": self.cwd,
+            "car": self.car,
+            "track": self.track,
+            "started_at": self.started_at,
+        }
+
+
+class RigSessionBusy(RuntimeError):
+    """Raised when another process owns the single-rig session lock."""
+
+    def __init__(self, path: Path, owner: dict[str, Any] | None = None) -> None:
+        self.path = path
+        self.owner = owner or {}
+        detail = ", ".join(
+            f"{key}={self.owner[key]}"
+            for key in ("pid", "car", "track", "cwd", "started_at")
+            if self.owner.get(key) not in (None, "")
+        )
+        super().__init__(
+            f"another harness owns the rig lock at {path}" + (f" ({detail})" if detail else "")
+        )
+
+
+class RigSessionLock:
+    """Non-reentrant cross-process file lock with stale-safe owner metadata."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        owner: RigSessionOwner,
+        timeout: float = 0.0,
+        poll_interval: float = 0.1,
+    ) -> None:
+        if timeout < 0:
+            raise ValueError("rig lock timeout must be >= 0")
+        if poll_interval <= 0:
+            raise ValueError("rig lock poll interval must be > 0")
+        self.path = Path(path)
+        self.owner = owner
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self._file: BinaryIO | None = None
+
+    def __enter__(self) -> RigSessionLock:
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        self.release()
+
+    def acquire(self) -> None:
+        if self._file is not None:
+            raise RuntimeError("rig session lock is already acquired")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_file = self.path.open("a+b")
+        if lock_file.seek(0, os.SEEK_END) == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+
+        deadline = time.monotonic() + self.timeout
+        while True:
+            try:
+                self._lock_byte(lock_file)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    owner = self._read_owner(lock_file)
+                    lock_file.close()
+                    raise RigSessionBusy(self.path, owner) from None
+                time.sleep(min(self.poll_interval, max(0.0, deadline - time.monotonic())))
+
+        self._file = lock_file
+        payload = json.dumps(self.owner.to_dict(), sort_keys=True).encode("utf-8")
+        lock_file.seek(1)
+        lock_file.truncate()
+        lock_file.write(payload)
+        lock_file.flush()
+
+    def release(self) -> None:
+        lock_file = self._file
+        if lock_file is None:
+            return
+        self._file = None
+        try:
+            lock_file.seek(1)
+            lock_file.truncate()
+            lock_file.flush()
+            self._unlock_byte(lock_file)
+        finally:
+            lock_file.close()
+
+    @staticmethod
+    def _read_owner(lock_file: BinaryIO) -> dict[str, Any] | None:
+        try:
+            lock_file.seek(1)
+            payload = lock_file.read().decode("utf-8").strip()
+            parsed = json.loads(payload) if payload else None
+            return parsed if isinstance(parsed, dict) else None
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+
+    @staticmethod
+    def _lock_byte(lock_file: BinaryIO) -> None:
+        lock_file.seek(0)
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    @staticmethod
+    def _unlock_byte(lock_file: BinaryIO) -> None:
+        lock_file.seek(0)
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)


### PR DESCRIPTION
Closes #555.

## Root cause correction
The CM log on AG_PC shows the apparent 02:25:04 and 02:32:46 respawns were explicit `acmanager://race/quick` requests from a concurrent #532 worktree, not an undocumented CM crash-restart setting. AC/CM are machine-global, while prior harness coordination was only in-process/repository-local.

## Implementation
- add a cross-process, cross-worktree rig session lock under `%LOCALAPPDATA%\AC Copilot Trainer\Harness`, with owner PID/combo/worktree metadata and optional bounded wait
- acquire the lock before sidecar/launch and hold it through drive teardown and evidence capture
- capture the expected `acs.exe` PID and monitor process identity off the control loop; report `session_replaced` with expected/unexpected PIDs instead of generic `sim_dead`
- add the takeover shape to the false-green KPI corpus

## Verification
- focused harness suite: 185 passed
- full `make ci-fast`: 2,695 passed, 113 skipped, 87.36% coverage; ruff, Bandit, policy, and CSP checks clean
- live lock contention on AG_PC: competing harness rejected with `RIG BUSY` and owner PID/combo/worktree metadata; active AC process remained responsive
- three consecutive hands-off `ks_audi_r8_lms` @ `magione` runs passed:
  - run 1: 1 lap, 2,637 m, 191.5 km/h, PID 15940, `sim_dead=false`, `session_replaced=false`
  - run 2: 1 lap, 2,642 m, 191.5 km/h, PID 23136, `sim_dead=false`, `session_replaced=false`
  - run 3: 1 lap, 2,664 m, 191.9 km/h, PID 11560, `sim_dead=false`, `session_replaced=false`
- HUD evidence was visually inspected and showed the R8 actively driving Magione with coaching rendered, not a menu/stall false green