### PR TITLE
feat(harness): add uncertainty-aware plant identification (#543)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -72,7 +72,7 @@ Bundles live under `.scratch/` — **session ephemera**. A consuming task promot
 keep (reference archives, curated comparisons) to a durable location; never treat the bundle as
 long-term storage (scratch-dir disposability pitfall).
 
-## Plant-ID handshake (#529 P1 / #532 — measure the controller constants, then consume them)
+## Plant-ID handshake (#529 P1 / #532 / #543 — measure constants and uncertainty)
 
 The GGV driver's constants (`ff_sign`, `ff_c1/ff_c2`, shift points, `r_eff`) used to be
 hand-tuned per combo. The **handshake** measures them from designed in-sim probes in ≤2 laps
@@ -96,6 +96,26 @@ python -m tools.ac_harness.auto_drive --car ks_porsche_911_gt3_r_2016 --track ma
 - `--use-plant auto` (default) applies measured shift points when an artifact exists;
   `full` also enables the measured curvature-feedforward steering; `off` forces the generic
   GT3 plant. `full` without an artifact fails fast — run the handshake first.
+- Schema v3 promotes the GGV fit only after the run's immutable lap archive supplies all four
+  tyre-core temperatures, all four hot pressures, the car-true optimum, and at least 80% sample
+  coverage/residence within ±10 °C. Only valid laps in one compound/setup cohort and within
+  ±5 °C / ±2 psi of that cohort are fitted. The per-lap tag and selected UUIDs remain in
+  `report.json` under `extras.handshake.ggv.tyre_states`.
+- The promoted model carries 10 km/h bins from 0–300 km/h. Each lateral/brake/drive bin records a
+  Bayesian posterior mean, epistemic standard deviation, lower confidence bound, sample count, and
+  `measured`/`prior` provenance. The QSS always consumes `min(point estimate, lower bound)`.
+  Unmeasured bins use the lower bound of the generic prior; there is no neighbour or upward
+  extrapolation, and speeds above the map retain the last conservative bound.
+- Schema-v1/v2 constants remain backward-compatible. Their missing or point-estimate-only GGV data
+  is deliberately ignored at runtime until a fresh schema-v3 handshake establishes uncertainty.
+
+The uncertainty policy follows friction-adaptive stochastic control work that propagates Bayesian
+friction uncertainty into safe control, while the thermal gate follows measured tyre evidence that
+core/surface temperature changes lateral behaviour and pressure tracks temperature:
+[friction-adaptive SNMPC](https://arxiv.org/abs/2305.03798),
+[peak-friction estimation under sparse/noisy excitation](https://arxiv.org/abs/2603.09073),
+[SAE tyre core/surface temperature study](https://saemobilus.sae.org/articles/influence-tire-core-surface-temperature-lateral-tire-characteristics-2014-01-0074), and
+[SAE tyre temperature/pressure study](https://saemobilus.sae.org/papers/estimating-tire-pressure-based-different-tire-temperature-measurement-points-2024-01-5002).
 
 ## Composing downstream tasks (don't reinvent)
 

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -97,9 +97,15 @@ python -m tools.ac_harness.auto_drive --car ks_porsche_911_gt3_r_2016 --track ma
   `full` also enables the measured curvature-feedforward steering; `off` forces the generic
   GT3 plant. `full` without an artifact fails fast — run the handshake first.
 - Schema v3 promotes the GGV fit only after the run's immutable lap archive supplies all four
-  tyre-core temperatures, all four hot pressures, the car-true optimum, and at least 80% sample
-  coverage/residence within ±10 °C. Only valid laps in one compound/setup cohort and within
-  ±5 °C / ±2 psi of that cohort are fitted. The per-lap tag and selected UUIDs remain in
+  tyre-core temperatures, all four hot pressures, the car-true optimum, a setup identity, at least 80%
+  channel coverage, and at least 80% per-wheel stability within ±5 °C of each wheel's median. The
+  four wheel medians must remain within 15 °C of one another. Stable `cold`, `optimal`, and `hot`
+  laps are explicit, separate cohorts; residence within ±10 °C of the optimum is recorded but is not
+  an eligibility gate. This permits conservative identification on tyres that stabilize below the
+  declared optimum without mixing thermal regimes. When CSP writes the default setup as an empty
+  snapshot/hash, the harness derives its deterministic identity from that snapshot. Only valid laps
+  in one compound/setup/tag cohort
+  and within ±5 °C / ±2 psi of that cohort are fitted. The per-lap tag and selected UUIDs remain in
   `report.json` under `extras.handshake.ggv.tyre_states`.
 - The promoted model carries 10 km/h bins from 0–300 km/h. Each lateral/brake/drive bin records a
   Bayesian posterior mean, epistemic standard deviation, lower confidence bound, sample count, and

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1214,9 +1214,10 @@ state = {
   -- any mid-track clock seed (app load/reload mid-lap, post-reset re-arm) — Cursor + codex on #185.
   -- Defaults true: no delta until the first clean lap is started (an out-lap clock is mid-track).
   deltaRefStale = true,
-  -- One-frame confirmation for wrap-shaped same-lap spline jumps on CSP builds without
-  -- resetCounter: if lapCount does not catch up on the next frame, reset rolling state (#188).
+  -- Bounded confirmation for wrap-shaped same-lap spline jumps on CSP builds without
+  -- resetCounter: allow CSP's multi-frame lapCount lag, then reset rolling state (#188/#543).
   pendingWrapResetLapCount = nil,
+  pendingWrapResetFrames = 0,
   bestLapTrace = {},
   -- Local in-game PB/reference snapshot. When an imported reference is active,
   -- realtime code still reads `bestLapTrace`, but persistence saves these local fields.
@@ -1553,6 +1554,7 @@ local function resetRuntimeAfterLeavingTrack()
   state.lastResetCounter = nil  -- re-prime teleport detection on next track entry
   state.deltaRefStale = true  -- re-entry: no boundary-aligned clock yet, delta silent until first lap
   state.pendingWrapResetLapCount = nil
+  state.pendingWrapResetFrames = 0
   state.bestLapTrace = {}
   state.localBestLapTrace = {}
   state.localBestBrakePoints = {}
@@ -1669,6 +1671,7 @@ local function resetRollingDrivingState()
   telemetryPublisher.reset()  -- #180: reset delta/tire_temps rate-limiters
   state.deltaRefStale = true  -- #180/#185: clock reset; delta silent until the next clean lap boundary
   state.pendingWrapResetLapCount = nil
+  state.pendingWrapResetFrames = 0
   tel = newTelemetry()
   brakes = newBrakes()
   td:resetLapAggregates()
@@ -2519,6 +2522,12 @@ function script.update(dt)
         wsBridge = wsBridge,
       })
     end
+  end)
+
+  -- Keep the always-on tyre/tick streams independent from the optional reference-delta path
+  -- above. A malformed or stale reference trace must never abort this block before tyre state is
+  -- published: the harness, rig screen and thermal plant-ID gate all rely on these live samples.
+  pcall(function()
     local currentTireTemps = tires:currentTemps(car)
     telemetryPublisher.publishTireTempsIfDue({
       dt = dt,
@@ -2942,6 +2951,7 @@ function script.update(dt)
 
   local resetDecision = delta.rollingResetDecision({
     pendingWrapLapCount = state.pendingWrapResetLapCount,
+    pendingWrapFrames = state.pendingWrapResetFrames,
     lastLapCount = state.lastLapCount,
     lapCount = lc,
     prevSpline = state.lastSplinePos,
@@ -2949,6 +2959,7 @@ function script.update(dt)
     teleported = teleported,
   })
   state.pendingWrapResetLapCount = resetDecision.pendingWrapLapCount
+  state.pendingWrapResetFrames = resetDecision.pendingWrapFrames or 0
   if resetDecision.reset then
     -- Teleport/resetCounter, lap rollback, non-wrap same-lap spline rewind, or a deferred
     -- wrap-shaped same-lap jump whose lapCount did not catch up on the following frame (#188).

--- a/src/ac_copilot_trainer/modules/delta.lua
+++ b/src/ac_copilot_trainer/modules/delta.lua
@@ -149,39 +149,59 @@ function M.isBackwardSplineReset(prevSpline, spline)
   return not isLikelyLapWrap(prevSpline, spline)
 end
 
+-- CSP can expose the start/finish spline wrap several render frames before StateCar.lapCount
+-- advances. One-frame confirmation was too short on the live harness and reset the telemetry
+-- buffer immediately before the real lap boundary, producing an empty archive. Half a second at
+-- 60 Hz is still a short, bounded delay for the resetCounter-less return-to-pits fallback while
+-- comfortably covering the observed counter lag.
+local WRAP_CONFIRM_FRAMES = 30
+
 --- Decide whether the end-of-update rolling state should reset.
 ---
 --- Wrap-shaped same-lap jumps are ambiguous on CSP builds without `car.resetCounter`: they might
---- be a real lap wrap exposed one frame before `lapCount`, or a return-to-pits teleport landing
---- near the start line. Defer exactly one frame; if `lapCount` advances, it was a lap wrap; if it
---- does not, clear rolling state for the abandoned stint (#188).
+--- be a real lap wrap exposed before `lapCount`, or a return-to-pits teleport landing near the
+--- start line. Defer for a bounded confirmation window; if `lapCount` advances, it was a lap wrap;
+--- if it does not, clear rolling state for the abandoned stint (#188/#543).
 ---@param opts table
----@return table { reset: boolean, pendingWrapLapCount: number|nil }
+---@return table { reset: boolean, pendingWrapLapCount: number|nil, pendingWrapFrames: number }
 function M.rollingResetDecision(opts)
   opts = opts or {}
   local pendingWrapLapCount = opts.pendingWrapLapCount
+  local pendingWrapFrames = math.max(0, math.floor(tonumber(opts.pendingWrapFrames) or 0))
   local lastLapCount = opts.lastLapCount
   local lapCount = opts.lapCount
 
   if opts.teleported then
-    return { reset = true, pendingWrapLapCount = nil }
+    return { reset = true, pendingWrapLapCount = nil, pendingWrapFrames = 0 }
   end
 
   if type(lastLapCount) == "number"
       and type(lapCount) == "number"
       and lastLapCount >= 0
       and lapCount < lastLapCount then
-    return { reset = true, pendingWrapLapCount = nil }
+    return { reset = true, pendingWrapLapCount = nil, pendingWrapFrames = 0 }
   end
 
   if pendingWrapLapCount ~= nil then
     if type(lapCount) ~= "number" then
-      return { reset = false, pendingWrapLapCount = pendingWrapLapCount }
+      return {
+        reset = false,
+        pendingWrapLapCount = pendingWrapLapCount,
+        pendingWrapFrames = pendingWrapFrames,
+      }
     end
     if lapCount > pendingWrapLapCount then
-      return { reset = false, pendingWrapLapCount = nil }
+      return { reset = false, pendingWrapLapCount = nil, pendingWrapFrames = 0 }
     end
-    return { reset = true, pendingWrapLapCount = nil }
+    pendingWrapFrames = pendingWrapFrames + 1
+    if pendingWrapFrames >= WRAP_CONFIRM_FRAMES then
+      return { reset = true, pendingWrapLapCount = nil, pendingWrapFrames = 0 }
+    end
+    return {
+      reset = false,
+      pendingWrapLapCount = pendingWrapLapCount,
+      pendingWrapFrames = pendingWrapFrames,
+    }
   end
 
   if type(lastLapCount) == "number"
@@ -190,14 +210,14 @@ function M.rollingResetDecision(opts)
       and lapCount == lastLapCount
       and opts.prevSpline ~= nil then
     if M.isBackwardSplineReset(opts.prevSpline, opts.spline) then
-      return { reset = true, pendingWrapLapCount = nil }
+      return { reset = true, pendingWrapLapCount = nil, pendingWrapFrames = 0 }
     end
     if M.isWrapShapedBackwardSplineJump(opts.prevSpline, opts.spline) then
-      return { reset = false, pendingWrapLapCount = lapCount }
+      return { reset = false, pendingWrapLapCount = lapCount, pendingWrapFrames = 1 }
     end
   end
 
-  return { reset = false, pendingWrapLapCount = nil }
+  return { reset = false, pendingWrapLapCount = nil, pendingWrapFrames = 0 }
 end
 
 --- Sector durations (ms) for three spline thirds: [0,1/3), [1/3,2/3), [2/3,1).

--- a/src/ac_copilot_trainer/modules/persistence.lua
+++ b/src/ac_copilot_trainer/modules/persistence.lua
@@ -31,7 +31,8 @@ local function tryCarFromCar(car)
     local ok, v = pcall(function()
       return car[key]
     end)
-    if ok and type(v) == "function" then
+    local wasCallable = ok and type(v) == "function"
+    if wasCallable then
       local called, resolved = pcall(v)
       if not called then
         called, resolved = pcall(v, car)
@@ -44,6 +45,15 @@ local function tryCarFromCar(car)
     end
     if ok and type(v) == "string" and v ~= "" then
       return v
+    end
+    -- Direct CSP scalar/userdata fields historically stringify to useful content identifiers.
+    -- Keep that compatibility, but never stringify a callable result: accessors must resolve to a
+    -- real string so function/table address text cannot masquerade as stable archive identity.
+    if ok and not wasCallable and (type(v) == "number" or type(v) == "userdata") then
+      local rendered = tostring(v)
+      if rendered ~= "" then
+        return rendered
+      end
     end
   end
   return nil

--- a/src/ac_copilot_trainer/modules/persistence.lua
+++ b/src/ac_copilot_trainer/modules/persistence.lua
@@ -31,8 +31,19 @@ local function tryCarFromCar(car)
     local ok, v = pcall(function()
       return car[key]
     end)
-    if ok and v ~= nil and tostring(v) ~= "" then
-      return tostring(v)
+    if ok and type(v) == "function" then
+      local called, resolved = pcall(v)
+      if not called then
+        called, resolved = pcall(v, car)
+      end
+      if called then
+        v = resolved
+      else
+        v = nil
+      end
+    end
+    if ok and type(v) == "string" and v ~= "" then
+      return v
     end
   end
   return nil

--- a/src/ac_copilot_trainer/modules/persistence.lua
+++ b/src/ac_copilot_trainer/modules/persistence.lua
@@ -38,10 +38,18 @@ local function tryCarFromCar(car)
   return nil
 end
 
---- Lap archive / filenames: same field order as `sessionKey` fallbacks, then sanitize.
+--- Lap archive / filenames: prefer the stable content id from ``ac.getCarID(0)``. Some CSP
+--- ``StateCar`` builds expose ``car.id`` as a callable accessor; stringifying that value produces
+--- an address-shaped ``function_0x...`` id, which cannot match the harness combo and makes a real
+--- thermal lap unusable for plant identification. Only fall back to StateCar labels when the
+--- global content-id API is unavailable.
 ---@param car ac.StateCar|nil
 ---@return string|nil
 function M.archiveCarIdFromCar(car)
+  local globalId = ch.safeCarIdRaw()
+  if type(globalId) == "string" and globalId ~= "" then
+    return ch.sanitizeId(globalId, "unknown")
+  end
   local raw = tryCarFromCar(car)
   if not raw then
     return nil

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2191,6 +2191,45 @@ def test_collect_lap_archives_waits_for_async_archive(tmp_path):
     assert got == [str(lap)]
 
 
+def test_collect_lap_archives_waits_for_expected_handshake_count(tmp_path):
+    import os
+
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    first = laps / "lap_1.json"
+    second = laps / "lap_2.json"
+    first.write_text("{}")
+    os.utime(first, (2_000_000, 2_000_000))
+    clock = {"t": 0.0}
+
+    def _clock() -> float:
+        return clock["t"]
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        if clock["t"] >= 1.0 and not second.exists():
+            second.write_text("{}")
+            os.utime(second, (2_000_001, 2_000_001))
+
+    got = collect_lap_archives(
+        laps,
+        since_epoch=1_500_000,
+        wait_for_first=True,
+        min_count=2,
+        timeout_s=8.0,
+        poll_s=0.5,
+        _clock=_clock,
+        _sleep=_sleep,
+    )
+    assert got == [str(second), str(first)]
+    assert clock["t"] >= 1.0
+
+
+def test_collect_lap_archives_rejects_invalid_required_count(tmp_path):
+    with pytest.raises(ValueError, match="min_count"):
+        collect_lap_archives(tmp_path, since_epoch=0, min_count=0)
+
+
 def test_collect_lap_archives_wait_times_out_bounded(tmp_path):
     # If the archive never appears, the poll is bounded and returns [] rather than hanging.
     laps = tmp_path / "laps"

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2225,6 +2225,44 @@ def test_collect_lap_archives_waits_for_expected_handshake_count(tmp_path):
     assert clock["t"] >= 1.0
 
 
+def test_collect_lap_archives_waits_for_expected_valid_handshake_count(tmp_path):
+    import os
+
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    invalid = laps / "lap_invalid.json"
+    first = laps / "lap_valid_1.json"
+    invalid.write_text('{"lap":{"is_valid":false}}')
+    first.write_text('{"lap":{"is_valid":true}}')
+    os.utime(invalid, (2_000_000, 2_000_000))
+    os.utime(first, (2_000_001, 2_000_001))
+    second = laps / "lap_valid_2.json"
+    clock = {"t": 0.0}
+
+    def _clock() -> float:
+        return clock["t"]
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        if clock["t"] >= 1.0 and not second.exists():
+            second.write_text('{"lap":{"is_valid":true}}')
+            os.utime(second, (2_000_002, 2_000_002))
+
+    got = collect_lap_archives(
+        laps,
+        since_epoch=1_500_000,
+        wait_for_first=True,
+        min_count=2,
+        min_valid_count=2,
+        timeout_s=8.0,
+        poll_s=0.5,
+        _clock=_clock,
+        _sleep=_sleep,
+    )
+    assert got == [str(second), str(first), str(invalid)]
+    assert clock["t"] >= 1.0
+
+
 def test_collect_lap_archives_rejects_invalid_required_count(tmp_path):
     with pytest.raises(ValueError, match="min_count"):
         collect_lap_archives(tmp_path, since_epoch=0, min_count=0)

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2263,6 +2263,43 @@ def test_collect_lap_archives_waits_for_expected_valid_handshake_count(tmp_path)
     assert clock["t"] >= 1.0
 
 
+def test_collect_lap_archives_valid_count_applies_combo_predicate(tmp_path):
+    import os
+
+    laps = tmp_path / "laps"
+    laps.mkdir()
+    wrong = laps / "lap_wrong.json"
+    right = laps / "lap_right.json"
+    wrong.write_text('{"car":{"id":"other"},"track":{"id":"magione"},"lap":{"is_valid":true}}')
+    right.write_text('{"car":{"id":"car"},"track":{"id":"magione"},"lap":{"is_valid":true}}')
+    os.utime(wrong, (2_000_000, 2_000_000))
+    os.utime(right, (2_000_001, 2_000_001))
+    clock = {"t": 0.0}
+    final = laps / "lap_final.json"
+
+    def _sleep(dt: float) -> None:
+        clock["t"] += dt
+        if clock["t"] >= 1.0 and not final.exists():
+            final.write_text(
+                '{"car":{"id":"car"},"track":{"id":"magione"},"lap":{"is_valid":true}}'
+            )
+            os.utime(final, (2_000_002, 2_000_002))
+
+    got = collect_lap_archives(
+        laps,
+        since_epoch=1_500_000,
+        wait_for_first=True,
+        min_valid_count=2,
+        valid_archive_predicate=lambda payload: payload.get("car", {}).get("id") == "car",
+        timeout_s=8.0,
+        poll_s=0.5,
+        _clock=lambda: clock["t"],
+        _sleep=_sleep,
+    )
+    assert got[0] == str(final)
+    assert clock["t"] >= 1.0
+
+
 def test_collect_lap_archives_rejects_invalid_required_count(tmp_path):
     with pytest.raises(ValueError, match="min_count"):
         collect_lap_archives(tmp_path, since_epoch=0, min_count=0)

--- a/tests/test_ac_harness_shared_memory.py
+++ b/tests/test_ac_harness_shared_memory.py
@@ -16,6 +16,7 @@ import sys
 import pytest
 
 from tools.ac_harness.shared_memory import (
+    GRAPHICS_COMPLETED_LAPS_OFFSET,
     GRAPHICS_IS_IN_PIT_OFFSET,
     GRAPHICS_MIN_BYTES,
     GRAPHICS_PACKET_ID_OFFSET,
@@ -36,12 +37,15 @@ from tools.ac_harness.shared_memory import (
 
 
 # --------------------------------------------------------------------------- helpers
-def _graphics_bytes(*, packet_id: int, status: int, is_in_pit: bool) -> bytes:
+def _graphics_bytes(
+    *, packet_id: int, status: int, is_in_pit: bool, completed_laps: int = 0
+) -> bytes:
     """Build an acpmf_graphics buffer with the three decoded fields at their real offsets."""
     buf = bytearray(GRAPHICS_MIN_BYTES)
     struct.pack_into("<i", buf, GRAPHICS_PACKET_ID_OFFSET, packet_id)
     struct.pack_into("<i", buf, GRAPHICS_STATUS_OFFSET, status)
     struct.pack_into("<i", buf, GRAPHICS_IS_IN_PIT_OFFSET, 1 if is_in_pit else 0)
+    struct.pack_into("<i", buf, GRAPHICS_COMPLETED_LAPS_OFFSET, completed_laps)
     return bytes(buf)
 
 
@@ -65,11 +69,14 @@ def _g(status: AcGameStatus, *, in_pit: bool = False, packet_id: int = 0) -> Gra
 
 # --------------------------------------------------------------------------- parsers
 def test_parse_graphics_decodes_fields_at_documented_offsets():
-    snap = parse_graphics(_graphics_bytes(packet_id=4242, status=2, is_in_pit=False))
+    snap = parse_graphics(
+        _graphics_bytes(packet_id=4242, status=2, is_in_pit=False, completed_laps=37)
+    )
     assert snap.packet_id == 4242
     assert snap.status is AcGameStatus.LIVE
     assert snap.is_in_pit is False
     assert snap.is_live is True
+    assert snap.completed_laps == 37
 
 
 def test_parse_graphics_decodes_in_pit_true():

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -2,8 +2,9 @@
 
 `delta.isBackwardSplineJump(prevSpline, spline)` is the liberal skip guard for the live `delta`
 producer; `delta.isBackwardSplineReset(prevSpline, spline)` is the conservative immediate reset
-predicate for rolling state. The one-frame `rollingResetDecision` covers #188's ambiguous
-wrap-shaped same-lap jump on CSP builds where `car.resetCounter` is unavailable.
+predicate for rolling state. The bounded `rollingResetDecision` confirmation window covers #188's
+ambiguous wrap-shaped same-lap jump on CSP builds where `car.resetCounter` is unavailable while
+tolerating CSP's observed multi-frame lag before `lapCount` advances.
 
 A *lap wrap* (prev spline near 1.0, now near 0.0) is forward lap completion, NOT a reset, and must
 return False. The backward threshold is strict (`d < -0.2`).
@@ -47,6 +48,7 @@ def _is_wrap_jump(prev: str, cur: str):
 def _decision(
     *,
     pending: str = "nil",
+    pending_frames: str = "0",
     last_lap: str = "5",
     lap: str = "5",
     prev: str = "0.40",
@@ -56,12 +58,14 @@ def _decision(
     return _eval(
         "local r = D.rollingResetDecision({"
         f"pendingWrapLapCount = {pending}, "
+        f"pendingWrapFrames = {pending_frames}, "
         f"lastLapCount = {last_lap}, "
         f"lapCount = {lap}, "
         f"prevSpline = {prev}, "
         f"spline = {cur}, "
         f"teleported = {teleported}"
-        "}) return { reset = r.reset, pending = r.pendingWrapLapCount }"
+        "}) return { reset = r.reset, pending = r.pendingWrapLapCount, "
+        "frames = r.pendingWrapFrames }"
     )
 
 
@@ -131,24 +135,42 @@ def test_rolling_reset_decision_defer_wrap_shaped_same_lap_jump():
     out = _decision(prev="0.95", cur="0.05", last_lap="5", lap="5")
     assert out["reset"] is False
     assert out["pending"] == 5
+    assert out["frames"] == 1
 
 
 def test_rolling_reset_decision_clears_deferred_wrap_when_lap_count_catches_up():
     out = _decision(pending="5", prev="0.05", cur="0.08", last_lap="5", lap="6")
     assert out["reset"] is False
     assert out["pending"] is None
+    assert out["frames"] == 0
 
 
-def test_rolling_reset_decision_resets_deferred_wrap_when_lap_count_stays_same():
+def test_rolling_reset_decision_keeps_deferred_wrap_during_confirmation_window():
     out = _decision(pending="5", prev="0.05", cur="0.08", last_lap="5", lap="5")
+    assert out["reset"] is False
+    assert out["pending"] == 5
+    assert out["frames"] == 1
+
+
+def test_rolling_reset_decision_resets_when_confirmation_window_expires():
+    out = _decision(
+        pending="5",
+        pending_frames="29",
+        prev="0.20",
+        cur="0.21",
+        last_lap="5",
+        lap="5",
+    )
     assert out["reset"] is True
     assert out["pending"] is None
+    assert out["frames"] == 0
 
 
 def test_rolling_reset_decision_keeps_deferred_wrap_when_lap_count_unavailable():
     out = _decision(pending="5", prev="0.05", cur="0.08", last_lap="5", lap="nil")
     assert out["reset"] is False
     assert out["pending"] == 5
+    assert out["frames"] == 0
 
 
 def test_rolling_reset_decision_immediate_for_non_wrap_same_lap_rewind():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -468,7 +468,7 @@ def _uncertainty_rows() -> list[dict]:
                     "accg_lat": 1.2,
                     "accg_lon": -1.25,
                     "source": "brake_probe",
-                    "lap_index": 1,
+                    "lap_index": 0,
                 }
             )
             rows.append(
@@ -477,7 +477,7 @@ def _uncertainty_rows() -> list[dict]:
                     "accg_lat": 1.2,
                     "accg_lon": 0.75,
                     "source": "accel_sweep",
-                    "lap_index": 1,
+                    "lap_index": 0,
                 }
             )
     return rows
@@ -561,6 +561,7 @@ def _thermal_archive(
     lateral_g: float = 1.2,
     compound_index: int = 1,
     setup_hash: str = "setup-a",
+    lap_n: int = 1,
 ) -> dict:
     fields = list(TRACE_FIELDS)
     samples = []
@@ -591,7 +592,7 @@ def _thermal_archive(
         "schema_version": 1,
         "source": "in_game",
         "lap_uuid": lap_uuid,
-        "lap": {"lap_n": 2, "lap_ms": 90000, "is_valid": True},
+        "lap": {"lap_n": lap_n, "lap_ms": 90000, "is_valid": True},
         "setup": {"hash": setup_hash},
         "tyres": {"compoundIndex": compound_index, "name": "M", "optimalTempC": 90.0},
         "trace": {"fields": fields, "samples": samples, "samples_count": len(samples)},
@@ -641,7 +642,7 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     assert passive.ellipse_n == prior.ellipse_n
     assert passive.provenance["measured"]["hull_points"] == 0
 
-    wrong_lap_rows = [{**row, "lap_index": 0} for row in _uncertainty_rows()]
+    wrong_lap_rows = [{**row, "lap_index": 1} for row in _uncertainty_rows()]
     wrong_lap, wrong_lap_summary = ggv_from_lap_archives([warm], prior, probe_rows=wrong_lap_rows)
     assert wrong_lap_summary["probe_rows_seen"] > 0
     assert wrong_lap_summary["probe_rows"] == 0
@@ -652,6 +653,14 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     assert probed_summary["probe_rows_seen"] == probed_summary["probe_rows"]
     assert probed.uncertainty_bins[6]["brake"]["source"] == "measured"
     assert probed.uncertainty_bins[6]["drive"]["source"] == "measured"
+
+    resumed_session = _thermal_archive("resumed", core_c=90.0, lap_n=41)
+    resumed, resumed_summary = ggv_from_lap_archives(
+        [resumed_session], prior, probe_rows=_uncertainty_rows()
+    )
+    assert resumed_summary["lap_number_offset"] == 40
+    assert resumed_summary["probe_rows"] > 0
+    assert resumed.uncertainty_bins[6]["brake"]["source"] == "measured"
 
 
 def test_lap_archive_fit_never_mixes_compound_or_setup_cohorts():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -625,6 +625,26 @@ def test_tyre_state_observer_tags_core_surface_pressure_and_grip():
     assert cold["thermal_stability_fraction"] == 1.0
 
 
+def test_tyre_state_uses_independent_coverage_and_stability_thresholds():
+    coverage_lap = _thermal_archive("coverage", core_c=90.0)
+    fields = coverage_lap["trace"]["fields"]
+    index = {name: i for i, name in enumerate(fields)}
+    for sample in coverage_lap["trace"]["samples"][:150]:
+        for wheel in ("fl", "fr", "rl", "rr"):
+            sample[index[f"tyreCoreTemp_{wheel}"]] = 0.0
+    assert observe_lap_tyre_state(coverage_lap)["fit_eligible"] is False
+    assert observe_lap_tyre_state(coverage_lap, min_coverage_fraction=0.70)["fit_eligible"] is True
+
+    stability_lap = _thermal_archive("stability", core_c=90.0)
+    for sample in stability_lap["trace"]["samples"][:150]:
+        for wheel in ("fl", "fr", "rl", "rr"):
+            sample[index[f"tyreCoreTemp_{wheel}"]] = 70.0
+    assert observe_lap_tyre_state(stability_lap)["fit_eligible"] is False
+    assert (
+        observe_lap_tyre_state(stability_lap, min_stability_fraction=0.70)["fit_eligible"] is True
+    )
+
+
 def test_tyre_state_requires_coherent_per_wheel_state_and_known_compound():
     split = _thermal_archive("split", core_c=90.0)
     fields = split["trace"]["fields"]
@@ -646,6 +666,18 @@ def test_tyre_state_requires_coherent_per_wheel_state_and_known_compound():
     state = observe_lap_tyre_state(unknown)
     assert state["fit_eligible"] is False
     assert state["reason"] == "missing tyre compound identity"
+
+    unknown_setup = _thermal_archive("unknown-setup", core_c=90.0)
+    unknown_setup["setup"].pop("hash")
+    state = observe_lap_tyre_state(unknown_setup)
+    assert state["fit_eligible"] is False
+    assert state["reason"] == "missing setup identity"
+
+    default_setup = _thermal_archive("default-setup", core_c=90.0)
+    default_setup["setup"] = {"hash": "", "snapshot": []}
+    state = observe_lap_tyre_state(default_setup)
+    assert state["fit_eligible"] is True
+    assert state["setup_hash"].startswith("snapshot-sha256:")
 
 
 def test_lap_archive_fit_excludes_thermally_inconsistent_laps():
@@ -701,6 +733,24 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     )
     assert resumed_summary["probe_rows"] > 0
     assert resumed.uncertainty_bins[6]["brake"]["source"] == "measured"
+
+    # Live attribution uses a run nonce, not completedLaps: the graphics counter excludes invalid
+    # laps while the app's archive counter includes those boundaries.
+    nonce_rows = [
+        {**row, "lap_number": 999, "probe_run_id": "run-543"} for row in _uncertainty_rows()
+    ]
+    nonce_model, nonce_summary = ggv_from_lap_archives(
+        [resumed_session], prior, probe_rows=nonce_rows, probe_run_id="run-543"
+    )
+    assert nonce_summary["probe_attribution"] == "current-run nonce"
+    assert nonce_summary["probe_rows"] == len(nonce_rows)
+    assert nonce_model.uncertainty_bins[6]["brake"]["source"] == "measured"
+
+    wrong_nonce, wrong_nonce_summary = ggv_from_lap_archives(
+        [resumed_session], prior, probe_rows=nonce_rows, probe_run_id="other-run"
+    )
+    assert wrong_nonce_summary["probe_rows"] == 0
+    assert wrong_nonce.uncertainty_bins[6]["brake"]["source"] == "prior"
 
 
 def test_lap_archive_fit_never_mixes_compound_or_setup_cohorts():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -468,7 +468,7 @@ def _uncertainty_rows() -> list[dict]:
                     "accg_lat": 1.2,
                     "accg_lon": -1.25,
                     "source": "brake_probe",
-                    "lap_index": 0,
+                    "lap_number": 1,
                 }
             )
             rows.append(
@@ -477,7 +477,7 @@ def _uncertainty_rows() -> list[dict]:
                     "accg_lat": 1.2,
                     "accg_lon": 0.75,
                     "source": "accel_sweep",
-                    "lap_index": 0,
+                    "lap_number": 1,
                 }
             )
     return rows
@@ -506,8 +506,10 @@ def test_uncertainty_builder_rejects_partial_runtime_domain():
     import pytest
 
     prior = _prior()
-    with pytest.raises(ValueError, match="complete 0-300"):
+    with pytest.raises(ValueError, match="30x10"):
         with_binned_uncertainty(prior, _uncertainty_rows(), prior, max_speed_kmh=200.0)
+    with pytest.raises(ValueError, match="30x10"):
+        with_binned_uncertainty(prior, _uncertainty_rows(), prior, bin_kmh=20.0)
 
 
 def test_small_probe_posterior_drops_one_possible_peak_spike():
@@ -548,8 +550,13 @@ def test_uncertainty_map_roundtrip_is_validated_and_read_only():
         GGVModel.from_dict(corrupt)
     truncated = model.to_dict()
     truncated["uncertainty_bins"] = truncated["uncertainty_bins"][5:6]
-    with pytest.raises(ValueError, match="complete 0-300"):
+    with pytest.raises(ValueError, match="30x10"):
         GGVModel.from_dict(truncated)
+    giant = model.to_dict()
+    giant["uncertainty_bins"] = [giant["uncertainty_bins"][0]]
+    giant["uncertainty_bins"][0]["speed_max_kmh"] = 300.0
+    with pytest.raises(ValueError, match="30x10"):
+        GGVModel.from_dict(giant)
     with pytest.raises(ValueError, match="uncertainty_bins"):
         GGVModel.from_dict({**prior.to_dict(), "uncertainty_bins": None})
 
@@ -615,6 +622,28 @@ def test_tyre_state_observer_tags_core_surface_pressure_and_grip():
     assert cold["fit_eligible"] is False
 
 
+def test_tyre_state_requires_every_wheel_in_window_and_known_compound():
+    split = _thermal_archive("split", core_c=90.0)
+    fields = split["trace"]["fields"]
+    index = {name: i for i, name in enumerate(fields)}
+    for sample in split["trace"]["samples"]:
+        for wheel in ("fl", "fr"):
+            sample[index[f"tyreCoreTemp_{wheel}"]] = 70.0
+        for wheel in ("rl", "rr"):
+            sample[index[f"tyreCoreTemp_{wheel}"]] = 110.0
+    state = observe_lap_tyre_state(split)
+    assert state["core_temp_c"] == 90.0
+    assert state["thermal_residence_fraction"] == 0.0
+    assert state["fit_eligible"] is False
+
+    unknown = _thermal_archive("unknown", core_c=90.0)
+    unknown["tyres"].pop("compoundIndex")
+    unknown["tyres"].pop("name")
+    state = observe_lap_tyre_state(unknown)
+    assert state["fit_eligible"] is False
+    assert state["reason"] == "missing tyre compound identity"
+
+
 def test_lap_archive_fit_excludes_thermally_inconsistent_laps():
     prior = _prior()
     warm = _thermal_archive("warm", core_c=90.0, lateral_g=1.1)
@@ -642,7 +671,7 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     assert passive.ellipse_n == prior.ellipse_n
     assert passive.provenance["measured"]["hull_points"] == 0
 
-    wrong_lap_rows = [{**row, "lap_index": 1} for row in _uncertainty_rows()]
+    wrong_lap_rows = [{**row, "lap_number": 2} for row in _uncertainty_rows()]
     wrong_lap, wrong_lap_summary = ggv_from_lap_archives([warm], prior, probe_rows=wrong_lap_rows)
     assert wrong_lap_summary["probe_rows_seen"] > 0
     assert wrong_lap_summary["probe_rows"] == 0
@@ -655,10 +684,10 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     assert probed.uncertainty_bins[6]["drive"]["source"] == "measured"
 
     resumed_session = _thermal_archive("resumed", core_c=90.0, lap_n=41)
+    resumed_rows = [{**row, "lap_number": 41} for row in _uncertainty_rows()]
     resumed, resumed_summary = ggv_from_lap_archives(
-        [resumed_session], prior, probe_rows=_uncertainty_rows()
+        [resumed_session], prior, probe_rows=resumed_rows
     )
-    assert resumed_summary["lap_number_offset"] == 40
     assert resumed_summary["probe_rows"] > 0
     assert resumed.uncertainty_bins[6]["brake"]["source"] == "measured"
 

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -502,6 +502,32 @@ def test_uncertainty_map_derates_unmeasured_bins_and_drives_runtime_qss():
     assert model.ay_max(350.0 / 3.6) / 9.81 <= model.uncertainty_bins[-1]["lateral"]["safe_g"]
 
 
+def test_uncertainty_builder_rejects_partial_runtime_domain():
+    import pytest
+
+    prior = _prior()
+    with pytest.raises(ValueError, match="complete 0-300"):
+        with_binned_uncertainty(prior, _uncertainty_rows(), prior, max_speed_kmh=200.0)
+
+
+def test_small_probe_posterior_drops_one_possible_peak_spike():
+    prior = _prior()
+    rows = [
+        {
+            "speed_kmh": 65.0,
+            "accg_lat": 0.0,
+            "accg_lon": -(8.0 if index == 7 else 1.1),
+            "source": "brake_probe",
+        }
+        for index in range(8)
+    ]
+    model = with_binned_uncertainty(prior, rows, prior)
+    channel = model.uncertainty_bins[6]["brake"]
+    assert channel["source"] == "measured"
+    assert channel["n"] == 8
+    assert channel["mean_g"] < 2.0
+
+
 def test_uncertainty_map_roundtrip_is_validated_and_read_only():
     import pytest
 
@@ -610,6 +636,10 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     assert passive_summary["probe_rows_seen"] == 0
     assert passive.uncertainty_bins[6]["brake"]["source"] == "prior"
     assert passive.uncertainty_bins[6]["drive"]["source"] == "prior"
+    # The blended runtime exponent is prior-pinned, and the diagnostics hull also excludes passive
+    # longitudinal rows when this path disables passive cap identification.
+    assert passive.ellipse_n == prior.ellipse_n
+    assert passive.provenance["measured"]["hull_points"] == 0
 
     wrong_lap_rows = [{**row, "lap_index": 0} for row in _uncertainty_rows()]
     wrong_lap, wrong_lap_summary = ggv_from_lap_archives([warm], prior, probe_rows=wrong_lap_rows)

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -17,11 +17,15 @@ from tools.ac_harness.ggv_profile import (
     curvature_profile,
     fit_steer_feedforward,
     forward_backward_profile,
+    ggv_from_lap_archives,
     ggv_from_telemetry,
     menger_curvature,
+    observe_lap_tyre_state,
     seg_lengths,
     signed_curvature_profile,
+    with_binned_uncertainty,
 )
+from tools.ac_harness.reference_lap import TRACE_FIELDS
 
 G = 9.81
 
@@ -452,6 +456,158 @@ def test_ggv_model_roundtrip_and_rejects_nan():
     ):
         with pytest.raises(ValueError):
             GGVModel.from_dict({**m.to_dict(), **bad})
+
+
+def _uncertainty_rows() -> list[dict]:
+    rows = []
+    for speed in range(50, 151, 10):
+        for _ in range(50):
+            rows.append(
+                {
+                    "speed_kmh": float(speed),
+                    "accg_lat": 1.2,
+                    "accg_lon": -1.25,
+                    "source": "brake_probe",
+                }
+            )
+            rows.append(
+                {
+                    "speed_kmh": float(speed),
+                    "accg_lat": 1.2,
+                    "accg_lon": 0.75,
+                    "source": "accel_sweep",
+                }
+            )
+    return rows
+
+
+def test_uncertainty_map_derates_unmeasured_bins_and_drives_runtime_qss():
+    prior = _prior()
+    rows = _uncertainty_rows()
+    point = blend_ggv_safe(ggv_from_telemetry(rows), prior)
+    model = with_binned_uncertainty(point, rows, prior)
+    assert model.uncertainty_aware
+    measured = model.uncertainty_bins[6]  # 60-70 km/h
+    unmeasured = model.uncertainty_bins[20]  # 200-210 km/h
+    assert measured["lateral"]["source"] == "measured"
+    assert unmeasured["lateral"]["source"] == "prior"
+    assert unmeasured["lateral"]["epistemic_std_g"] > measured["lateral"]["epistemic_std_g"]
+    speed = 205.0 / 3.6
+    assert model.ay_max(speed) < point.ay_max(speed)
+    assert model.ax_brake_max(speed) < point.ax_brake_max(speed)
+    # Above the finite identification map, retain the final conservative bound instead of
+    # reverting to an optimistic point curve or extrapolating a neighbouring measured mean.
+    assert model.ay_max(350.0 / 3.6) / 9.81 <= model.uncertainty_bins[-1]["lateral"]["safe_g"]
+
+
+def test_uncertainty_map_roundtrip_is_validated_and_read_only():
+    import pytest
+
+    prior = _prior()
+    model = with_binned_uncertainty(prior, _uncertainty_rows(), prior)
+    payload = model.to_dict()
+    restored = GGVModel.from_dict(payload)
+    assert restored.uncertainty_aware
+    payload["uncertainty_bins"][0]["lateral"]["safe_g"] = 99.0
+    assert restored.uncertainty_bins[0]["lateral"]["safe_g"] != 99.0
+    with pytest.raises(TypeError):
+        restored.uncertainty_bins[0]["lateral"]["safe_g"] = 99.0
+    corrupt = model.to_dict()
+    corrupt["uncertainty_bins"][0]["lateral"]["safe_g"] = (
+        corrupt["uncertainty_bins"][0]["lateral"]["mean_g"] + 0.1
+    )
+    with pytest.raises(ValueError, match="uncertainty_bins"):
+        GGVModel.from_dict(corrupt)
+    with pytest.raises(ValueError, match="uncertainty_bins"):
+        GGVModel.from_dict({**prior.to_dict(), "uncertainty_bins": None})
+
+
+def _thermal_archive(
+    lap_uuid: str,
+    *,
+    core_c: float,
+    lateral_g: float = 1.2,
+    compound_index: int = 1,
+    setup_hash: str = "setup-a",
+) -> dict:
+    fields = list(TRACE_FIELDS)
+    samples = []
+    for i in range(600):
+        values = dict.fromkeys(fields, 0.0)
+        speed = 50.0 + float((i // 50) % 11) * 10.0
+        braking = i % 2 == 0
+        values.update(
+            {
+                "spline": i / 600.0,
+                "speed": speed,
+                "eMs": i * 10.0,
+                "brake": 0.8 if braking else 0.0,
+                "throttle": 0.0 if braking else 1.0,
+                "accG_lat": lateral_g,
+                "accG_long": -1.25 if braking else 0.75,
+            }
+        )
+        for wheel in ("fl", "fr", "rl", "rr"):
+            values[f"tyreCoreTemp_{wheel}"] = core_c
+            values[f"tyreTempInner_{wheel}"] = core_c + 2.0
+            values[f"tyreTempMid_{wheel}"] = core_c
+            values[f"tyreTempOuter_{wheel}"] = core_c - 2.0
+            values[f"wheelsPressure_{wheel}"] = 27.0
+            values[f"dy_{wheel}"] = 1.5
+        samples.append([values[field] for field in fields])
+    return {
+        "schema_version": 1,
+        "source": "in_game",
+        "lap_uuid": lap_uuid,
+        "lap": {"lap_n": 2, "lap_ms": 90000, "is_valid": True},
+        "setup": {"hash": setup_hash},
+        "tyres": {"compoundIndex": compound_index, "name": "M", "optimalTempC": 90.0},
+        "trace": {"fields": fields, "samples": samples, "samples_count": len(samples)},
+    }
+
+
+def test_tyre_state_observer_tags_core_surface_pressure_and_grip():
+    state = observe_lap_tyre_state(_thermal_archive("warm", core_c=90.0))
+    assert state["tag"] == "optimal"
+    assert state["fit_eligible"] is True
+    assert state["thermal_residence_fraction"] == 1.0
+    assert state["core_temp_c"] == 90.0
+    assert state["surface_temp_c"] == 90.0
+    assert state["pressure_psi"] == 27.0
+    assert state["grip_multiplier"] == 1.0
+    assert state["compound_index"] == 1
+    assert state["setup_hash"] == "setup-a"
+    cold = observe_lap_tyre_state(_thermal_archive("cold", core_c=55.0))
+    assert cold["tag"] == "cold"
+    assert cold["fit_eligible"] is False
+
+
+def test_lap_archive_fit_excludes_thermally_inconsistent_laps():
+    prior = _prior()
+    warm = _thermal_archive("warm", core_c=90.0, lateral_g=1.1)
+    cold = _thermal_archive("cold", core_c=55.0, lateral_g=1.7)
+    model, summary = ggv_from_lap_archives([warm, cold], prior)
+    assert model.uncertainty_aware
+    assert summary["selected_lap_uuids"] == ["warm"]
+    states = {state["lap_uuid"]: state for state in summary["tyre_states"]}
+    assert states["warm"]["fit_eligible"] is True
+    assert states["cold"]["fit_eligible"] is False
+    # The excluded 1.7 g cold lap cannot lift the posterior mean.
+    assert model.uncertainty_bins[6]["lateral"]["mean_g"] < 1.3
+
+
+def test_lap_archive_fit_never_mixes_compound_or_setup_cohorts():
+    prior = _prior()
+    baseline = _thermal_archive("baseline", core_c=90.0, lateral_g=1.1)
+    other_compound = _thermal_archive(
+        "other-compound", core_c=90.0, lateral_g=1.8, compound_index=2
+    )
+    other_setup = _thermal_archive("other-setup", core_c=90.0, lateral_g=1.8, setup_hash="setup-b")
+    model, summary = ggv_from_lap_archives([baseline, other_compound, other_setup], prior)
+    assert summary["selected_lap_uuids"] == ["baseline"]
+    assert summary["thermal_cohort"]["compound"] == 1
+    assert summary["thermal_cohort"]["setup_hash"] == "setup-a"
+    assert model.uncertainty_bins[6]["lateral"]["mean_g"] < 1.3
 
 
 def test_blend_never_raises_lateral_above_prior():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -778,6 +778,18 @@ def test_lap_archive_fit_never_mixes_compound_or_setup_cohorts():
     assert model.uncertainty_bins[6]["lateral"]["mean_g"] < 1.3
 
 
+def test_lap_archive_cohort_tie_prefers_optimal_then_newest():
+    prior = _prior()
+    cold = _thermal_archive("cold-tie", core_c=55.0)
+    optimal = _thermal_archive("optimal-tie", core_c=90.0)
+    _, summary = ggv_from_lap_archives([cold, optimal], prior)
+    assert summary["selected_lap_uuids"] == ["optimal-tie"]
+
+    hot = _thermal_archive("hot-newest", core_c=115.0)
+    _, summary = ggv_from_lap_archives([hot, cold], prior)
+    assert summary["selected_lap_uuids"] == ["hot-newest"]
+
+
 def test_blend_never_raises_lateral_above_prior():
     prior = _prior()
     # A measured HIGHER lateral must NOT lift the plant (aero-lateral spins the GT3, #259).

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -611,6 +611,7 @@ def test_tyre_state_observer_tags_core_surface_pressure_and_grip():
     assert state["tag"] == "optimal"
     assert state["fit_eligible"] is True
     assert state["thermal_residence_fraction"] == 1.0
+    assert state["thermal_stability_fraction"] == 1.0
     assert state["core_temp_c"] == 90.0
     assert state["surface_temp_c"] == 90.0
     assert state["pressure_psi"] == 27.0
@@ -619,10 +620,12 @@ def test_tyre_state_observer_tags_core_surface_pressure_and_grip():
     assert state["setup_hash"] == "setup-a"
     cold = observe_lap_tyre_state(_thermal_archive("cold", core_c=55.0))
     assert cold["tag"] == "cold"
-    assert cold["fit_eligible"] is False
+    assert cold["fit_eligible"] is True
+    assert cold["thermal_residence_fraction"] == 0.0
+    assert cold["thermal_stability_fraction"] == 1.0
 
 
-def test_tyre_state_requires_every_wheel_in_window_and_known_compound():
+def test_tyre_state_requires_coherent_per_wheel_state_and_known_compound():
     split = _thermal_archive("split", core_c=90.0)
     fields = split["trace"]["fields"]
     index = {name: i for i, name in enumerate(fields)}
@@ -634,6 +637,7 @@ def test_tyre_state_requires_every_wheel_in_window_and_known_compound():
     state = observe_lap_tyre_state(split)
     assert state["core_temp_c"] == 90.0
     assert state["thermal_residence_fraction"] == 0.0
+    assert state["wheel_spread_c"] == 40.0
     assert state["fit_eligible"] is False
 
     unknown = _thermal_archive("unknown", core_c=90.0)
@@ -648,12 +652,19 @@ def test_lap_archive_fit_excludes_thermally_inconsistent_laps():
     prior = _prior()
     warm = _thermal_archive("warm", core_c=90.0, lateral_g=1.1)
     cold = _thermal_archive("cold", core_c=55.0, lateral_g=1.7)
+    cold_fields = cold["trace"]["fields"]
+    cold_index = {name: i for i, name in enumerate(cold_fields)}
+    for row_i, sample in enumerate(cold["trace"]["samples"]):
+        offset = -20.0 if row_i < 300 else 20.0
+        for wheel in ("fl", "fr", "rl", "rr"):
+            sample[cold_index[f"tyreCoreTemp_{wheel}"]] += offset
     model, summary = ggv_from_lap_archives([warm, cold], prior)
     assert model.uncertainty_aware
     assert summary["selected_lap_uuids"] == ["warm"]
     states = {state["lap_uuid"]: state for state in summary["tyre_states"]}
     assert states["warm"]["fit_eligible"] is True
     assert states["cold"]["fit_eligible"] is False
+    assert states["cold"]["thermal_stability_fraction"] == 0.0
     # The excluded 1.7 g cold lap cannot lift the posterior mean.
     assert model.uncertainty_bins[6]["lateral"]["mean_g"] < 1.3
 

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -742,7 +742,7 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     nonce_model, nonce_summary = ggv_from_lap_archives(
         [resumed_session], prior, probe_rows=nonce_rows, probe_run_id="run-543"
     )
-    assert nonce_summary["probe_attribution"] == "current-run nonce"
+    assert nonce_summary["probe_attribution"] == "current-run nonce (complete thermal cohort)"
     assert nonce_summary["probe_rows"] == len(nonce_rows)
     assert nonce_model.uncertainty_bins[6]["brake"]["source"] == "measured"
 
@@ -751,6 +751,17 @@ def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
     )
     assert wrong_nonce_summary["probe_rows"] == 0
     assert wrong_nonce.uncertainty_bins[6]["brake"]["source"] == "prior"
+
+    invalid = _thermal_archive("invalid", core_c=55.0, lap_n=40)
+    invalid["lap"]["is_valid"] = False
+    gated, gated_summary = ggv_from_lap_archives(
+        [invalid, resumed_session], prior, probe_rows=nonce_rows, probe_run_id="run-543"
+    )
+    assert gated_summary["probe_attribution"] == (
+        "current-run nonce rejected (incomplete thermal cohort)"
+    )
+    assert gated_summary["probe_rows"] == 0
+    assert gated.uncertainty_bins[6]["brake"]["source"] == "prior"
 
 
 def test_lap_archive_fit_never_mixes_compound_or_setup_cohorts():

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -468,6 +468,7 @@ def _uncertainty_rows() -> list[dict]:
                     "accg_lat": 1.2,
                     "accg_lon": -1.25,
                     "source": "brake_probe",
+                    "lap_index": 1,
                 }
             )
             rows.append(
@@ -476,6 +477,7 @@ def _uncertainty_rows() -> list[dict]:
                     "accg_lat": 1.2,
                     "accg_lon": 0.75,
                     "source": "accel_sweep",
+                    "lap_index": 1,
                 }
             )
     return rows
@@ -518,6 +520,10 @@ def test_uncertainty_map_roundtrip_is_validated_and_read_only():
     )
     with pytest.raises(ValueError, match="uncertainty_bins"):
         GGVModel.from_dict(corrupt)
+    truncated = model.to_dict()
+    truncated["uncertainty_bins"] = truncated["uncertainty_bins"][5:6]
+    with pytest.raises(ValueError, match="complete 0-300"):
+        GGVModel.from_dict(truncated)
     with pytest.raises(ValueError, match="uncertainty_bins"):
         GGVModel.from_dict({**prior.to_dict(), "uncertainty_bins": None})
 
@@ -594,6 +600,28 @@ def test_lap_archive_fit_excludes_thermally_inconsistent_laps():
     assert states["cold"]["fit_eligible"] is False
     # The excluded 1.7 g cold lap cannot lift the posterior mean.
     assert model.uncertainty_bins[6]["lateral"]["mean_g"] < 1.3
+
+
+def test_lap_archive_passive_longitudinal_is_prior_until_probe_rows_exist():
+    prior = _prior()
+    warm = _thermal_archive("warm", core_c=90.0)
+    passive, passive_summary = ggv_from_lap_archives([warm], prior)
+    assert passive_summary["probe_rows"] == 0
+    assert passive_summary["probe_rows_seen"] == 0
+    assert passive.uncertainty_bins[6]["brake"]["source"] == "prior"
+    assert passive.uncertainty_bins[6]["drive"]["source"] == "prior"
+
+    wrong_lap_rows = [{**row, "lap_index": 0} for row in _uncertainty_rows()]
+    wrong_lap, wrong_lap_summary = ggv_from_lap_archives([warm], prior, probe_rows=wrong_lap_rows)
+    assert wrong_lap_summary["probe_rows_seen"] > 0
+    assert wrong_lap_summary["probe_rows"] == 0
+    assert wrong_lap.uncertainty_bins[6]["drive"]["source"] == "prior"
+
+    probed, probed_summary = ggv_from_lap_archives([warm], prior, probe_rows=_uncertainty_rows())
+    assert probed_summary["probe_rows"] > 0
+    assert probed_summary["probe_rows_seen"] == probed_summary["probe_rows"]
+    assert probed.uncertainty_bins[6]["brake"]["source"] == "measured"
+    assert probed.uncertainty_bins[6]["drive"]["source"] == "measured"
 
 
 def test_lap_archive_fit_never_mixes_compound_or_setup_cohorts():

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -81,6 +81,21 @@ def test_archive_car_identity_prefers_stable_global_over_callable_state_field(
     assert resolved == "ks_porsche_911_gt3_r_2016"
 
 
+def test_archive_car_identity_only_accepts_callable_string_result(tmp_path: pathlib.Path) -> None:
+    rt = _runtime(tmp_path)
+    resolved = rt.execute(
+        """
+        local persistence = require("persistence")
+        local good = persistence.archiveCarIdFromCar({ id = function() return "callable_car" end })
+        local bad = persistence.archiveCarIdFromCar({ id = function() return {} end })
+        return { good = good, bad = bad }
+        """
+    )
+    payload = _lua_to_py(resolved)
+    assert payload["good"] == "callable_car"
+    assert payload.get("bad") is None
+
+
 def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.Path) -> None:
     rt = _runtime(tmp_path)
     rt.execute(

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -81,19 +81,30 @@ def test_archive_car_identity_prefers_stable_global_over_callable_state_field(
     assert resolved == "ks_porsche_911_gt3_r_2016"
 
 
-def test_archive_car_identity_only_accepts_callable_string_result(tmp_path: pathlib.Path) -> None:
+def test_archive_car_identity_accepts_safe_direct_scalars_but_callable_strings_only(
+    tmp_path: pathlib.Path,
+) -> None:
     rt = _runtime(tmp_path)
     resolved = rt.execute(
         """
         local persistence = require("persistence")
         local good = persistence.archiveCarIdFromCar({ id = function() return "callable_car" end })
         local bad = persistence.archiveCarIdFromCar({ id = function() return {} end })
-        return { good = good, bad = bad }
+        local callableNumber = persistence.archiveCarIdFromCar({ id = function() return 42 end })
+        local directNumber = persistence.archiveCarIdFromCar({ id = 42 })
+        return {
+          good = good,
+          bad = bad,
+          callableNumber = callableNumber,
+          directNumber = directNumber,
+        }
         """
     )
     payload = _lua_to_py(resolved)
     assert payload["good"] == "callable_car"
     assert payload.get("bad") is None
+    assert payload.get("callableNumber") is None
+    assert payload["directNumber"] == "42"
 
 
 def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.Path) -> None:

--- a/tests/test_lap_archive_async.py
+++ b/tests/test_lap_archive_async.py
@@ -64,6 +64,23 @@ def _step(rt: lupa.LuaRuntime, rows: int) -> dict[str, Any]:
     return _lua_to_py(result)
 
 
+def test_archive_car_identity_prefers_stable_global_over_callable_state_field(
+    tmp_path: pathlib.Path,
+) -> None:
+    rt = _runtime(tmp_path)
+    resolved = rt.execute(
+        """
+        ac.getCarID = function(index)
+          assert(index == 0)
+          return "ks_porsche_911_gt3_r_2016"
+        end
+        local persistence = require("persistence")
+        return persistence.archiveCarIdFromCar({ id = function() return "wrong" end })
+        """
+    )
+    assert resolved == "ks_porsche_911_gt3_r_2016"
+
+
 def test_archive_write_job_streams_trace_over_multiple_steps(tmp_path: pathlib.Path) -> None:
     rt = _runtime(tmp_path)
     rt.execute(

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -846,7 +846,7 @@ def test_handshake_preserves_probe_rows_before_overall_friction_row_gate():
             "accg_lat": 0.0,
             "accg_lon": -1.1,
             "source": "brake_probe",
-            "lap_index": 0,
+            "lap_number": 1,
         }
         for _ in range(8)
     ]

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -829,6 +829,10 @@ def test_handshake_emits_provisional_ggv_until_thermal_archive_arrives():
     assert model.ax_brake_cap_g == prior.ax_brake_cap_g
     # Provenance labels each curve measured-vs-prior.
     assert set(model.provenance["blend_source"]) == {"lateral", "brake", "drive", "ellipse_n"}
+    assert ggv["provisional_probe_rows"]
+    assert all(
+        row["source"] in {"brake_probe", "accel_sweep"} for row in ggv["provisional_probe_rows"]
+    )
     # The ggv block is ADVISORY — it never gates the core-constant ok.
     assert sink["result"]["ggv"]["ok"] is False
 
@@ -883,6 +887,21 @@ def test_refine_ggv_rejects_stale_other_combo_archive():
     assert block["lap_archives_seen"] == 1
     assert block["lap_archives_loaded"] == 0
     assert any("identity mismatch" in error for error in block["load_errors"])
+
+
+def test_refine_ggv_accepts_current_run_archive_when_writer_omits_layout():
+    result = _result_dict()
+    result["layout"] = "gp"
+    archive = {
+        "car": {"id": "test_car"},
+        "track": {"id": "test_oval"},
+        "lap_uuid": "fresh-layout-run",
+    }
+    block = refine_ggv_from_lap_archives(result, [archive], generic_gt3_ggv())
+    assert block["ok"] is False  # no thermal trace, but identity was accepted
+    assert block["lap_archives_loaded"] == 1
+    assert block["load_errors"] == []
+    assert any("omitted layout" in note for note in block["identity_notes"])
 
 
 def test_artifact_v1_still_loads_without_ggv(tmp_path):

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -837,6 +837,25 @@ def test_handshake_emits_provisional_ggv_until_thermal_archive_arrives():
     assert sink["result"]["ggv"]["ok"] is False
 
 
+def test_handshake_preserves_probe_rows_before_overall_friction_row_gate():
+    line = _stadium_line()
+    ctrl = HandshakeController(line, _profile_for(line), prior_ggv=generic_gt3_ggv())
+    ctrl._friction_rows = [
+        {
+            "speed_kmh": 60.0,
+            "accg_lat": 0.0,
+            "accg_lon": -1.1,
+            "source": "brake_probe",
+            "lap_index": 0,
+        }
+        for _ in range(8)
+    ]
+    block = ctrl._build_ggv_block()
+    assert block is not None
+    assert "insufficient friction rows" in block["reason"]
+    assert len(block["provisional_probe_rows"]) == 8
+
+
 def _uncertain_prior() -> GGVModel:
     prior = generic_gt3_ggv()
     rows = []
@@ -868,6 +887,7 @@ def test_plant_ggv_model_resolves_valid_rejects_invalid():
 
 def test_refine_ggv_without_thermal_archive_stays_non_runtime():
     result = _result_dict()
+    result["ggv"] = {"ok": False, "reason": "awaiting thermally tagged lap archive"}
     block = refine_ggv_from_lap_archives(result, [], generic_gt3_ggv())
     assert block["ok"] is False
     assert block["model"] is None
@@ -875,8 +895,17 @@ def test_refine_ggv_without_thermal_archive_stays_non_runtime():
     assert plant_ggv_model({"ggv": block}) is None
 
 
+def test_refine_ggv_respects_explicit_friction_id_opt_out():
+    result = _result_dict()
+    block = refine_ggv_from_lap_archives(result, [], generic_gt3_ggv())
+    assert block["skipped"] is True
+    assert "not requested" in block["reason"]
+    assert "ggv" not in result
+
+
 def test_refine_ggv_rejects_stale_other_combo_archive():
     result = _result_dict()
+    result["ggv"] = {"ok": False, "reason": "awaiting thermally tagged lap archive"}
     stale = {
         "car": {"id": "other_car"},
         "track": {"id": "test_oval", "layout": None},
@@ -891,6 +920,7 @@ def test_refine_ggv_rejects_stale_other_combo_archive():
 
 def test_refine_ggv_accepts_current_run_archive_when_writer_omits_layout():
     result = _result_dict()
+    result["ggv"] = {"ok": False, "reason": "awaiting thermally tagged lap archive"}
     result["layout"] = "gp"
     archive = {
         "car": {"id": "test_car"},

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1009,11 +1009,20 @@ def test_refine_ggv_accepts_current_run_archive_when_writer_omits_layout():
         "track": {"id": "test_oval"},
         "lap_uuid": "fresh-layout-run",
     }
-    block = refine_ggv_from_lap_archives(result, [archive], generic_gt3_ggv())
+    block = refine_ggv_from_lap_archives(
+        result, [archive], generic_gt3_ggv(), archives_same_run=True
+    )
     assert block["ok"] is False  # no thermal trace, but identity was accepted
     assert block["lap_archives_loaded"] == 1
     assert block["load_errors"] == []
     assert any("omitted layout" in note for note in block["identity_notes"])
+
+    result = _result_dict()
+    result["ggv"] = {"ok": False, "reason": "awaiting thermally tagged lap archive"}
+    result["layout"] = "gp"
+    block = refine_ggv_from_lap_archives(result, [archive], generic_gt3_ggv())
+    assert block["lap_archives_loaded"] == 0
+    assert any("outside current-run scope" in error for error in block["load_errors"])
 
 
 def test_artifact_v1_still_loads_without_ggv(tmp_path):

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -837,6 +837,64 @@ def test_handshake_emits_provisional_ggv_until_thermal_archive_arrives():
     assert sink["result"]["ggv"]["ok"] is False
 
 
+def test_uncertainty_handshake_waits_for_clean_post_probe_thermal_lap():
+    line = _stadium_line()
+    ctrl = HandshakeController(
+        line,
+        _profile_for(line),
+        prior_ggv=generic_gt3_ggv(),
+        min_corner_rows=0,
+    )
+    ctrl._pending.clear()
+
+    def frame(*, lap_completed: bool) -> DriveFrame:
+        return DriveFrame(0.2, 0.0, 0.0, False, False, PHASE_LAP, lap_completed, False)
+
+    ctrl._base.step = lambda *args: frame(lap_completed=False)
+    ctrl.step((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 0.0)
+    assert ctrl.finished is False
+    assert ctrl._laps == 0
+
+    ctrl._base.step = lambda *args: frame(lap_completed=True)
+    ctrl.step((1.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 1.0)
+    assert ctrl.finished is False
+    assert ctrl._laps == 1
+
+    ctrl.step((2.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 2.0)
+    assert ctrl.finished is True
+    assert ctrl.result is not None and ctrl.result.laps_used == 2
+
+
+def test_uncertainty_handshake_uses_ac_completed_laps_over_false_line_wraps():
+    line = _stadium_line()
+    completed = {"value": 0}
+    ctrl = HandshakeController(
+        line,
+        _profile_for(line),
+        prior_ggv=generic_gt3_ggv(),
+        min_corner_rows=0,
+        phys_read=lambda: SimpleNamespace(completed_laps=completed["value"]),
+    )
+    ctrl._pending.clear()
+    ctrl._base.step = lambda *args: DriveFrame(0.2, 0.0, 0.0, False, False, PHASE_LAP, True, False)
+
+    for now in (0.0, 1.0, 2.0):
+        ctrl.step((now, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, now)
+    assert ctrl.finished is False
+    assert ctrl._uses_completed_laps is True
+    assert ctrl._laps == 0
+
+    completed["value"] = 1
+    ctrl.step((3.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 3.0)
+    assert ctrl.finished is False
+    assert ctrl._laps == 1
+
+    completed["value"] = 2
+    ctrl.step((4.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 4.0)
+    assert ctrl.finished is True
+    assert ctrl.result is not None and ctrl.result.laps_used == 2
+
+
 def test_handshake_preserves_probe_rows_before_overall_friction_row_gate():
     line = _stadium_line()
     ctrl = HandshakeController(line, _profile_for(line), prior_ggv=generic_gt3_ggv())

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -895,6 +895,30 @@ def test_uncertainty_handshake_uses_ac_completed_laps_over_false_line_wraps():
     assert ctrl.result is not None and ctrl.result.laps_used == 2
 
 
+def test_uncertainty_handshake_late_graphics_counter_preserves_fallback_laps():
+    line = _stadium_line()
+    physics = {"frame": SimpleNamespace(completed_laps=None)}
+    ctrl = HandshakeController(
+        line,
+        _profile_for(line),
+        prior_ggv=generic_gt3_ggv(),
+        min_corner_rows=0,
+        phys_read=lambda: physics["frame"],
+    )
+    ctrl._pending.clear()
+    ctrl._base.step = lambda *args: DriveFrame(0.2, 0.0, 0.0, False, False, PHASE_LAP, True, False)
+
+    ctrl.step((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 0.0)
+    assert ctrl._laps == 1
+    physics["frame"] = SimpleNamespace(completed_laps=7)
+    ctrl.step((1.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 1.0)
+    assert ctrl._uses_completed_laps is True
+    assert ctrl._laps == 1
+    physics["frame"] = SimpleNamespace(completed_laps=8)
+    ctrl.step((2.0, 0.0, 0.0), (1.0, 0.0, 0.0), 60.0, 5000.0, 3, 2.0)
+    assert ctrl._laps == 2
+
+
 def test_handshake_preserves_probe_rows_before_overall_friction_row_gate():
     line = _stadium_line()
     ctrl = HandshakeController(line, _profile_for(line), prior_ggv=generic_gt3_ggv())

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 import pytest
 
 from tools.ac_harness.auto_drive import AutoDriveConfig, _build_driver, generic_gt3_ggv
-from tools.ac_harness.ggv_profile import GGVModel
+from tools.ac_harness.ggv_profile import GGVModel, with_binned_uncertainty
 from tools.ac_harness.lap_driver import PHASE_LAP, DriveFrame
 from tools.ac_harness.plant_id import (
     PLANT_SCHEMA_VERSION,
@@ -30,6 +30,7 @@ from tools.ac_harness.plant_id import (
     plant_artifact_path,
     plant_driver_kwargs,
     plant_ggv_model,
+    refine_ggv_from_lap_archives,
     save_plant_artifact,
 )
 
@@ -798,7 +799,7 @@ def test_handshake_no_ggv_block_without_prior(handshake_outcome):
     assert ctrl.result_diagnostics["friction_rows"] == 0
 
 
-def test_handshake_emits_safe_ggv_block_with_prior():
+def test_handshake_emits_provisional_ggv_until_thermal_archive_arrives():
     line = _stadium_line()
     sim = PlantSim(line)
     prior = generic_gt3_ggv()
@@ -815,9 +816,10 @@ def test_handshake_emits_safe_ggv_block_with_prior():
     _run_handshake(ctrl, sim)
     assert ctrl.finished
     ggv = ctrl.result.ggv
-    assert ggv is not None and ggv["ok"], ggv
+    assert ggv is not None and ggv["ok"] is False, ggv
     assert ctrl.result_diagnostics["friction_rows"] >= ctrl.min_friction_rows
-    model = GGVModel.from_dict(ggv["model"])
+    assert ggv["reason"] == "awaiting thermally tagged lap archive"
+    model = GGVModel.from_dict(ggv["provisional_model"])
     # Safe-envelope guarantees: lateral pinned to the prior (a conservative drive under-measures the
     # limit, so it never lowers/regresses), aero-lateral stays 0, caps kept.
     assert model.k_aero_lat == 0.0
@@ -828,19 +830,59 @@ def test_handshake_emits_safe_ggv_block_with_prior():
     # Provenance labels each curve measured-vs-prior.
     assert set(model.provenance["blend_source"]) == {"lateral", "brake", "drive", "ellipse_n"}
     # The ggv block is ADVISORY — it never gates the core-constant ok.
-    assert sink["result"]["ggv"]["ok"] is True
+    assert sink["result"]["ggv"]["ok"] is False
+
+
+def _uncertain_prior() -> GGVModel:
+    prior = generic_gt3_ggv()
+    rows = []
+    for speed in range(50, 151, 10):
+        for _ in range(50):
+            rows.append(
+                {
+                    "speed_kmh": float(speed),
+                    "accg_lat": 1.2,
+                    "accg_lon": -1.2,
+                    "source": "brake_probe",
+                }
+            )
+    return with_binned_uncertainty(prior, rows, prior)
 
 
 def test_plant_ggv_model_resolves_valid_rejects_invalid():
     prior = generic_gt3_ggv()
-    good = {"ggv": {"ok": True, "model": prior.to_dict()}}
+    good = {"ggv": {"ok": True, "model": _uncertain_prior().to_dict()}}
     assert plant_ggv_model(good) is not None
+    assert plant_ggv_model({"ggv": {"ok": True, "model": prior.to_dict()}}) is None
     # ok=False block -> None (consumer keeps generic)
     assert plant_ggv_model({"ggv": {"ok": False, "model": None}}) is None
     # non-finite serialized model -> rejected (never act on a nan grip curve)
     assert plant_ggv_model({"ggv": {"ok": True, "model": {"mu_lat_g": float("nan")}}}) is None
     # v1 / Part-A artifact with no ggv block -> None
     assert plant_ggv_model({"constants": {"ff_sign": 1.0}}) is None
+
+
+def test_refine_ggv_without_thermal_archive_stays_non_runtime():
+    result = _result_dict()
+    block = refine_ggv_from_lap_archives(result, [], generic_gt3_ggv())
+    assert block["ok"] is False
+    assert block["model"] is None
+    assert "no thermally consistent" in block["reason"]
+    assert plant_ggv_model({"ggv": block}) is None
+
+
+def test_refine_ggv_rejects_stale_other_combo_archive():
+    result = _result_dict()
+    stale = {
+        "car": {"id": "other_car"},
+        "track": {"id": "test_oval", "layout": None},
+        "lap_uuid": "stale",
+    }
+    block = refine_ggv_from_lap_archives(result, [stale], generic_gt3_ggv())
+    assert block["ok"] is False
+    assert block["lap_archives_seen"] == 1
+    assert block["lap_archives_loaded"] == 0
+    assert any("identity mismatch" in error for error in block["load_errors"])
 
 
 def test_artifact_v1_still_loads_without_ggv(tmp_path):
@@ -859,10 +901,33 @@ def test_artifact_v1_still_loads_without_ggv(tmp_path):
     assert plant_ggv_model(loaded) is None  # no ggv block -> generic plant
 
 
+def test_artifact_v2_constants_load_but_point_ggv_falls_back_to_generic(tmp_path):
+    import json as _json
+
+    result = _result_dict()
+    result["ggv"] = {"ok": True, "model": generic_gt3_ggv().to_dict()}
+    payload = {"schema_version": 2, "created_utc": "2026-07-12T00:00:00Z", **result}
+    path = plant_artifact_path(tmp_path, "test_car", "test_oval")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json.dumps(payload), encoding="utf-8")
+    loaded = load_plant_artifact(tmp_path, "test_car", "test_oval")
+    assert loaded is not None
+    assert loaded["schema_version"] == 2
+    assert loaded["constants"]["rpm_up"] == 7600.0
+    assert plant_ggv_model(loaded) is None
+
+
+def test_schema_v3_artifact_refuses_point_estimate_ggv(tmp_path):
+    result = _result_dict()
+    result["ggv"] = {"ok": True, "model": generic_gt3_ggv().to_dict()}
+    with pytest.raises(ValueError, match="without uncertainty bins"):
+        save_plant_artifact(tmp_path, result)
+
+
 def test_ggv_block_round_trips_through_artifact(tmp_path):
     prior = generic_gt3_ggv()
     result = _result_dict()
-    result["ggv"] = {"ok": True, "friction_rows": 1234, "model": prior.to_dict()}
+    result["ggv"] = {"ok": True, "friction_rows": 1234, "model": _uncertain_prior().to_dict()}
     save_plant_artifact(tmp_path, result)
     loaded = load_plant_artifact(tmp_path, "test_car", "test_oval")
     assert loaded is not None
@@ -870,6 +935,7 @@ def test_ggv_block_round_trips_through_artifact(tmp_path):
     model = plant_ggv_model(loaded)
     assert model is not None
     assert abs(model.mu_lat_g - prior.mu_lat_g) < 1e-9
+    assert model.uncertainty_aware
 
 
 def test_artifact_load_rejects_nan_constants(tmp_path):

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1025,6 +1025,21 @@ def test_refine_ggv_accepts_current_run_archive_when_writer_omits_layout():
     assert any("outside current-run scope" in error for error in block["load_errors"])
 
 
+def test_refine_ggv_offline_rejects_wrong_or_unidentified_setup_archive():
+    result = _result_dict()
+    result["setup"] = "requested.ini"
+    result["ggv"] = {"ok": False, "reason": "awaiting thermally tagged lap archive"}
+    wrong = {
+        "car": {"id": "test_car"},
+        "track": {"id": "test_oval"},
+        "setup": {"path": "other.ini", "hash": "abc", "snapshot": {"path": "other.ini"}},
+        "lap_uuid": "wrong-setup",
+    }
+    block = refine_ggv_from_lap_archives(result, [wrong], generic_gt3_ggv())
+    assert block["lap_archives_loaded"] == 0
+    assert any("setup mismatch" in error for error in block["load_errors"])
+
+
 def test_artifact_v1_still_loads_without_ggv(tmp_path):
     # A v1 Part-A artifact (schema_version=1, no ggv block) must still load after the v2 bump so
     # existing shift-point / steering consumption is not invalidated (back-compat).

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -551,3 +551,20 @@ def test_mon_current_temps_nil_car_is_all_nil():
     assert out["has_fr"] is False
     assert out["has_rl"] is False
     assert out["has_rr"] is False
+
+
+def test_entry_isolates_tire_stream_from_optional_delta_failures():
+    """A reference/delta exception must not suppress the always-on tyre stream."""
+    entry = (REPO / "src" / "ac_copilot_trainer" / "ac_copilot_trainer.lua").read_text(
+        encoding="utf-8"
+    )
+    delta_start = entry.index("-- Issue #180 Part D step 2: telemetry topics")
+    tyre_start = entry.index("-- Keep the always-on tyre/tick streams", delta_start)
+    next_section = entry.index("-- Round 10: drain any corner_advice", tyre_start)
+
+    delta_block = entry[delta_start:tyre_start]
+    tyre_block = entry[tyre_start:next_section]
+    assert "publishDeltaIfDue" in delta_block
+    assert "publishTireTempsIfDue" not in delta_block
+    assert "pcall(function()" in tyre_block
+    assert "publishTireTempsIfDue" in tyre_block

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1487,6 +1487,7 @@ def collect_lap_archives(
     *,
     resolve: Callable[[], list[Path]] | None = None,
     wait_for_first: bool = False,
+    min_count: int = 1,
     timeout_s: float = 8.0,
     poll_s: float = 0.5,
     _clock: Callable[[], float] = time.monotonic,
@@ -1500,9 +1501,11 @@ def collect_lap_archives(
     exist yet (only a mid-stream temp file, which the ``lap_*.json`` glob correctly ignores) — a
     naive single scan then reports an empty list even though a lap was produced (#515).
 
-    With ``wait_for_first`` (set when the run produced a lap) this polls up to ``timeout_s`` for the
-    first archive to appear instead of racing the writer; it returns as soon as one exists, and
-    returns immediately with no wait when ``wait_for_first`` is false (a run that produced no lap).
+    With ``wait_for_first`` (set when the run produced a lap) this polls up to ``timeout_s`` for
+    ``min_count`` archives instead of racing the writer. A handshake passes its completed-lap count
+    so refinement cannot consume lap 1 while the thermally relevant lap 2 is still being finalized.
+    It returns immediately with no wait when ``wait_for_first`` is false (a run that produced no
+    lap).
 
     When ``journal_dir`` is ``None`` and ``resolve`` is given, the candidate dirs are **re-resolved
     each scan** via ``resolve()`` (which returns ALL candidate dirs) — so a fresh-profile dir the
@@ -1520,14 +1523,16 @@ def collect_lap_archives(
             return [journal_dir]
         return resolve() if resolve else []
 
+    if isinstance(min_count, bool) or not isinstance(min_count, int) or min_count < 1:
+        raise ValueError("min_count must be a positive integer")
     found = _scan_lap_archives(_current(), since_epoch)
-    if found or not wait_for_first:
+    if len(found) >= min_count or not wait_for_first:
         return found
     deadline = _clock() + max(0.0, timeout_s)
     while _clock() < deadline:
         _sleep(max(0.0, poll_s))
         found = _scan_lap_archives(_current(), since_epoch)
-        if found:
+        if len(found) >= min_count:
             return found
     return found
 
@@ -2699,11 +2704,21 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
     # CSP leaves stale default state dirs on rename, so preferring one dir lets a stale leftover
     # shadow the active renamed dir (#516 review). The fresh archive is found wherever the active
     # writer put it; stale files are excluded by the since_epoch gate.
+    handshake_laps_used = 0
+    if config.driver == "handshake" and report.drive and isinstance(report.drive.payload, dict):
+        pending_result = report.drive.payload.get("result")
+        if isinstance(pending_result, dict):
+            value = pending_result.get("laps_used")
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                handshake_laps_used = value
+    wait_for_archives = report.lap_grace_applied or handshake_laps_used > 0
     lap_archives = collect_lap_archives(
         None,
         run_started_epoch,
         resolve=lambda: candidate_journal_laps_dirs(user_dir),
-        wait_for_first=report.lap_grace_applied,
+        wait_for_first=wait_for_archives,
+        min_count=max(1, handshake_laps_used),
+        timeout_s=20.0 if handshake_laps_used > 0 else 8.0,
     )
     # Report the dir the archive was actually found in (correct even for a renamed install), so the
     # metadata matches the multi-dir scan, not the canonical-preferring discover (#516 review).
@@ -2740,7 +2755,23 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         # The handshake result flows out via DriveStats.payload (report.drive.payload), not a
         # config side-channel (daemon review).
         sink = dict(report.drive.payload) if report.drive and report.drive.payload else {}
-        if sink.get("ok") and isinstance(sink.get("result"), dict):
+        if (
+            sink.get("ok")
+            and isinstance(sink.get("result"), dict)
+            and handshake_laps_used > 0
+            and len(lap_archives) < handshake_laps_used
+        ):
+            # The bounded writer wait expired with a partial lap set. Do not promote a model from
+            # lap 1 while the thermal/probe-relevant lap 2 is absent; constants may still persist.
+            sink["result"]["ggv"] = {
+                "ok": False,
+                "model": None,
+                "reason": (
+                    "incomplete handshake lap archive set: "
+                    f"{len(lap_archives)} < {handshake_laps_used}"
+                ),
+            }
+        elif sink.get("ok") and isinstance(sink.get("result"), dict):
             # #543: live physics rows alone have no tyre state. Refine only from the immutable
             # #488 lap archives collected by the same run; no archive/thermal cohort means the ggv
             # block remains visibly unavailable and --use-plant safely keeps the generic plant.

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2139,10 +2139,16 @@ def rig_drive(  # pragma: no cover - rig-only
                 if buf is None:
                     return None
                 physics = _parse_phys(buf)
-                graphics = reader.read_graphics()
-                return replace(physics, completed_laps=graphics.completed_laps)
             except (ValueError, SharedMemoryUnavailable):
                 return None
+            try:
+                graphics = reader.read_graphics()
+                completed_laps = graphics.completed_laps
+            except (ValueError, SharedMemoryUnavailable):
+                # Graphics is optional provenance/completion state. Never discard a valid physics
+                # frame (including wheel speed and accG probes) because this secondary map failed.
+                completed_laps = None
+            return replace(physics, completed_laps=completed_laps)
 
         driver.set_phys_read(_read_hs_phys)
 
@@ -2780,7 +2786,11 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             # #488 lap archives collected by the same run; no archive/thermal cohort means the ggv
             # block remains visibly unavailable and --use-plant safely keeps the generic plant.
             refine_ggv_from_lap_archives(
-                sink["result"], lap_archives, generic_gt3_ggv(), prior_name="generic_gt3_ggv"
+                sink["result"],
+                lap_archives,
+                generic_gt3_ggv(),
+                prior_name="generic_gt3_ggv",
+                archives_same_run=True,
             )
         extras["handshake"] = sink
         # Fold the handshake outcome ONLY when the run otherwise fully SUCCEEDED (`report.ok`).

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1489,6 +1489,7 @@ def collect_lap_archives(
     wait_for_first: bool = False,
     min_count: int = 1,
     min_valid_count: int | None = None,
+    valid_archive_predicate: Callable[[dict], bool] | None = None,
     timeout_s: float = 8.0,
     poll_s: float = 0.5,
     _clock: Callable[[], float] = time.monotonic,
@@ -1536,7 +1537,8 @@ def collect_lap_archives(
 
     def _enough(paths: list[str]) -> bool:
         return len(paths) >= min_count and (
-            min_valid_count is None or _count_valid_lap_archives(paths) >= min_valid_count
+            min_valid_count is None
+            or _count_valid_lap_archives(paths, valid_archive_predicate) >= min_valid_count
         )
 
     found = _scan_lap_archives(_current(), since_epoch)
@@ -1551,7 +1553,9 @@ def collect_lap_archives(
     return found
 
 
-def _count_valid_lap_archives(paths: list[str]) -> int:
+def _count_valid_lap_archives(
+    paths: list[str], predicate: Callable[[dict], bool] | None = None
+) -> int:
     """Count finalized archive files whose canonical lap validity is explicitly true."""
     count = 0
     for item in paths:
@@ -1560,9 +1564,26 @@ def _count_valid_lap_archives(paths: list[str]) -> int:
         except (OSError, json.JSONDecodeError, TypeError, ValueError):
             continue
         lap = payload.get("lap") if isinstance(payload, dict) else None
-        if isinstance(lap, dict) and lap.get("is_valid") is True:
+        if (
+            isinstance(lap, dict)
+            and lap.get("is_valid") is True
+            and (predicate is None or predicate(payload))
+        ):
             count += 1
     return count
+
+
+def _archive_matches_combo(
+    payload: dict, *, car_id: str, track_id: str, layout: str | None
+) -> bool:
+    """Return whether a current-run archive can belong to the requested combo."""
+    car = payload.get("car") if isinstance(payload.get("car"), dict) else {}
+    track = payload.get("track") if isinstance(payload.get("track"), dict) else {}
+    if str(car.get("id") or "") != car_id or str(track.get("id") or "") != track_id:
+        return False
+    actual_layout = track.get("layout") or None
+    # The current Lua schema can omit layout; current-run scoping proves the requested launch.
+    return actual_layout is None or actual_layout == layout
 
 
 # ---------------------------------------------------------------------------
@@ -2750,6 +2771,15 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             if isinstance(value, int) and not isinstance(value, bool) and value > 0:
                 handshake_laps_used = value
     wait_for_archives = report.lap_grace_applied or handshake_laps_used > 0
+
+    def archive_matches_combo(payload: dict) -> bool:
+        return _archive_matches_combo(
+            payload,
+            car_id=config.car_id,
+            track_id=config.track_id,
+            layout=config.track_layout,
+        )
+
     lap_archives = collect_lap_archives(
         None,
         run_started_epoch,
@@ -2757,6 +2787,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         wait_for_first=wait_for_archives,
         min_count=max(1, handshake_laps_used),
         min_valid_count=handshake_laps_used if handshake_laps_used > 0 else None,
+        valid_archive_predicate=archive_matches_combo,
         timeout_s=20.0 if handshake_laps_used > 0 else 8.0,
     )
     # Report the dir the archive was actually found in (correct even for a renamed install), so the
@@ -2798,7 +2829,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             sink.get("ok")
             and isinstance(sink.get("result"), dict)
             and handshake_laps_used > 0
-            and _count_valid_lap_archives(lap_archives) < handshake_laps_used
+            and _count_valid_lap_archives(lap_archives, archive_matches_combo) < handshake_laps_used
         ):
             # The bounded writer wait expired with a partial lap set. Do not promote a model from
             # lap 1 while the thermal/probe-relevant lap 2 is absent; constants may still persist.
@@ -2807,7 +2838,8 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
                 "model": None,
                 "reason": (
                     "incomplete handshake lap archive set: "
-                    f"{_count_valid_lap_archives(lap_archives)} valid < {handshake_laps_used}"
+                    f"{_count_valid_lap_archives(lap_archives, archive_matches_combo)} "
+                    f"matching valid < {handshake_laps_used}"
                 ),
             }
         elif sink.get("ok") and isinstance(sink.get("result"), dict):

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2136,7 +2136,11 @@ def rig_drive(  # pragma: no cover - rig-only
                 return None
             try:
                 buf = reader.read_physics_bytes(PHYSICS_MAP_BYTES)
-                return _parse_phys(buf) if buf is not None else None
+                if buf is None:
+                    return None
+                physics = _parse_phys(buf)
+                graphics = reader.read_graphics()
+                return replace(physics, completed_laps=graphics.completed_laps)
             except (ValueError, SharedMemoryUnavailable):
                 return None
 

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1488,6 +1488,7 @@ def collect_lap_archives(
     resolve: Callable[[], list[Path]] | None = None,
     wait_for_first: bool = False,
     min_count: int = 1,
+    min_valid_count: int | None = None,
     timeout_s: float = 8.0,
     poll_s: float = 0.5,
     _clock: Callable[[], float] = time.monotonic,
@@ -1502,8 +1503,9 @@ def collect_lap_archives(
     naive single scan then reports an empty list even though a lap was produced (#515).
 
     With ``wait_for_first`` (set when the run produced a lap) this polls up to ``timeout_s`` for
-    ``min_count`` archives instead of racing the writer. A handshake passes its completed-lap count
-    so refinement cannot consume lap 1 while the thermally relevant lap 2 is still being finalized.
+    ``min_count`` archives and, when supplied, ``min_valid_count`` valid archives instead of racing
+    the writer. The latter is essential in hotlap mode: invalid boundaries still produce archive
+    files but do not advance AC's completed-lap counter.
     It returns immediately with no wait when ``wait_for_first`` is false (a run that produced no
     lap).
 
@@ -1525,16 +1527,42 @@ def collect_lap_archives(
 
     if isinstance(min_count, bool) or not isinstance(min_count, int) or min_count < 1:
         raise ValueError("min_count must be a positive integer")
+    if min_valid_count is not None and (
+        isinstance(min_valid_count, bool)
+        or not isinstance(min_valid_count, int)
+        or min_valid_count < 1
+    ):
+        raise ValueError("min_valid_count must be a positive integer or None")
+
+    def _enough(paths: list[str]) -> bool:
+        return len(paths) >= min_count and (
+            min_valid_count is None or _count_valid_lap_archives(paths) >= min_valid_count
+        )
+
     found = _scan_lap_archives(_current(), since_epoch)
-    if len(found) >= min_count or not wait_for_first:
+    if _enough(found) or not wait_for_first:
         return found
     deadline = _clock() + max(0.0, timeout_s)
     while _clock() < deadline:
         _sleep(max(0.0, poll_s))
         found = _scan_lap_archives(_current(), since_epoch)
-        if len(found) >= min_count:
+        if _enough(found):
             return found
     return found
+
+
+def _count_valid_lap_archives(paths: list[str]) -> int:
+    """Count finalized archive files whose canonical lap validity is explicitly true."""
+    count = 0
+    for item in paths:
+        try:
+            payload = json.loads(Path(item).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            continue
+        lap = payload.get("lap") if isinstance(payload, dict) else None
+        if isinstance(lap, dict) and lap.get("is_valid") is True:
+            count += 1
+    return count
 
 
 # ---------------------------------------------------------------------------
@@ -2728,6 +2756,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         resolve=lambda: candidate_journal_laps_dirs(user_dir),
         wait_for_first=wait_for_archives,
         min_count=max(1, handshake_laps_used),
+        min_valid_count=handshake_laps_used if handshake_laps_used > 0 else None,
         timeout_s=20.0 if handshake_laps_used > 0 else 8.0,
     )
     # Report the dir the archive was actually found in (correct even for a renamed install), so the
@@ -2769,7 +2798,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
             sink.get("ok")
             and isinstance(sink.get("result"), dict)
             and handshake_laps_used > 0
-            and len(lap_archives) < handshake_laps_used
+            and _count_valid_lap_archives(lap_archives) < handshake_laps_used
         ):
             # The bounded writer wait expired with a partial lap set. Do not promote a model from
             # lap 1 while the thermal/probe-relevant lap 2 is absent; constants may still persist.
@@ -2778,7 +2807,7 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
                 "model": None,
                 "reason": (
                     "incomplete handshake lap archive set: "
-                    f"{len(lap_archives)} < {handshake_laps_used}"
+                    f"{_count_valid_lap_archives(lap_archives)} valid < {handshake_laps_used}"
                 ),
             }
         elif sink.get("ok") and isinstance(sink.get("result"), dict):

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2731,11 +2731,22 @@ def _main(argv: list[str] | None = None) -> int:  # pragma: no cover - rig-only 
         # stage/error when the drive actually reached the handshake — a pre-drive failure
         # (stage=launch/hijack/setup, e.g. the track/car guard) is the authoritative root cause
         # and must NOT be clobbered with "handshake produced no result" (Codex + Qodo review).
-        from tools.ac_harness.plant_id import apply_handshake_outcome, save_plant_artifact
+        from tools.ac_harness.plant_id import (
+            apply_handshake_outcome,
+            refine_ggv_from_lap_archives,
+            save_plant_artifact,
+        )
 
         # The handshake result flows out via DriveStats.payload (report.drive.payload), not a
         # config side-channel (daemon review).
         sink = dict(report.drive.payload) if report.drive and report.drive.payload else {}
+        if sink.get("ok") and isinstance(sink.get("result"), dict):
+            # #543: live physics rows alone have no tyre state. Refine only from the immutable
+            # #488 lap archives collected by the same run; no archive/thermal cohort means the ggv
+            # block remains visibly unavailable and --use-plant safely keeps the generic plant.
+            refine_ggv_from_lap_archives(
+                sink["result"], lap_archives, generic_gt3_ggv(), prior_name="generic_gt3_ggv"
+            )
         extras["handshake"] = sink
         # Fold the handshake outcome ONLY when the run otherwise fully SUCCEEDED (`report.ok`).
         # report.ok already vetoes on a pipeline check failure (`seq_ok is False`) or a drive-leg

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -541,14 +541,14 @@ def with_binned_uncertainty(
     if not _finite_ggv(bin_kmh, max_speed_kmh, prior_relative_std, lcb_z):
         raise ValueError("uncertainty parameters must be finite")
     if (
-        bin_kmh <= 0.0
+        not math.isclose(bin_kmh, DEFAULT_UNCERTAINTY_BIN_KMH)
         or not math.isclose(max_speed_kmh, DEFAULT_UNCERTAINTY_MAX_KMH)
         or prior_relative_std <= 0.0
         or lcb_z <= 0.0
         or min_samples <= 0
         or min_probe_samples <= 0
     ):
-        raise ValueError("uncertainty parameters require the complete 0-300 km/h runtime range")
+        raise ValueError("uncertainty parameters require the complete 30x10 km/h runtime grid")
     if not math.isclose(bin_kmh, round(bin_kmh)):
         raise ValueError("bin_kmh must be a whole number of km/h")
     count = max_speed_kmh / bin_kmh
@@ -794,7 +794,7 @@ def observe_lap_tyre_state(
             core_mean = statistics.fmean(core)
             core_means.append(core_mean)
             pressure_means.append(statistics.fmean(pressure))
-            if abs(core_mean - optimal) <= thermal_window_half_width_c:
+            if all(abs(value - optimal) <= thermal_window_half_width_c for value in core):
                 in_window += 1
         surface = row_values(row, surface_names)
         if surface:
@@ -818,6 +818,7 @@ def observe_lap_tyre_state(
     is_valid = isinstance(lap, dict) and lap.get("is_valid") is True
     eligible = (
         is_valid
+        and (compound_index is not None or compound_name is not None)
         and coverage >= min_residence_fraction
         and residence >= min_residence_fraction
         and tag == "optimal"
@@ -835,7 +836,15 @@ def observe_lap_tyre_state(
         "lap_uuid": base["lap_uuid"],
         "tag": tag,
         "fit_eligible": eligible,
-        "reason": "thermally consistent" if eligible else "outside thermal/validity gate",
+        "reason": (
+            "thermally consistent"
+            if eligible
+            else (
+                "missing tyre compound identity"
+                if compound_index is None and compound_name is None
+                else "outside thermal/validity gate"
+            )
+        ),
         "optimal_temp_c": round(optimal, 3),
         "core_temp_c": round(mean_core, 3) if mean_core is not None else None,
         "surface_temp_c": (round(statistics.fmean(surface_means), 3) if surface_means else None),
@@ -934,16 +943,8 @@ def ggv_from_lap_archives(
         )
     # The immutable archive proves the thermal state and supplies passive cornering. Only the
     # handshake's explicitly tagged straight-line probes from a SELECTED thermal lap may identify
-    # longitudinal limits. Controller lap_index is zero-based; the archive's completed lap_n is
-    # one-based at the crossing.
-    fresh_lap_numbers = {
-        int(archive["lap"]["lap_n"])
-        for archive in archives
-        if isinstance(archive.get("lap"), dict)
-        and isinstance(archive["lap"].get("lap_n"), int)
-        and not isinstance(archive["lap"].get("lap_n"), bool)
-    }
-    lap_number_offset = min(fresh_lap_numbers) - 1 if fresh_lap_numbers else 0
+    # longitudinal limits. Both sides carry AC's absolute completed-lap number; never infer an
+    # offset from directory contents because a resumed LIVE session may include earlier manual laps.
     selected_lap_numbers = {
         int(archive["lap"]["lap_n"])
         for archive, _ in selected
@@ -955,9 +956,9 @@ def ggv_from_lap_archives(
         dict(row)
         for row in (probe_rows or [])
         if isinstance(row, dict)
-        and isinstance(row.get("lap_index"), int)
-        and not isinstance(row.get("lap_index"), bool)
-        and int(row["lap_index"]) + lap_number_offset + 1 in selected_lap_numbers
+        and isinstance(row.get("lap_number"), int)
+        and not isinstance(row.get("lap_number"), bool)
+        and int(row["lap_number"]) in selected_lap_numbers
     ]
     combined_rows = rows + thermal_probe_rows
     measured = ggv_from_telemetry(combined_rows, allow_passive_longitudinal=False)
@@ -967,7 +968,6 @@ def ggv_from_lap_archives(
         "friction_rows": len(rows),
         "probe_rows_seen": len(probe_rows or []),
         "probe_rows": len(thermal_probe_rows),
-        "lap_number_offset": lap_number_offset,
         "tyre_states": states,
         "selected_lap_uuids": [state.get("lap_uuid") for _, state in selected],
         "thermal_cohort": {
@@ -1318,8 +1318,16 @@ def _validate_uncertainty_bins(bins: tuple[Mapping, ...]) -> None:
     if bins and (
         not math.isclose(float(bins[0]["speed_min_kmh"]), 0.0)
         or not math.isclose(float(bins[-1]["speed_max_kmh"]), DEFAULT_UNCERTAINTY_MAX_KMH)
+        or len(bins) != int(DEFAULT_UNCERTAINTY_MAX_KMH / DEFAULT_UNCERTAINTY_BIN_KMH)
+        or any(
+            not math.isclose(
+                float(speed_bin["speed_max_kmh"]) - float(speed_bin["speed_min_kmh"]),
+                DEFAULT_UNCERTAINTY_BIN_KMH,
+            )
+            for speed_bin in bins
+        )
     ):
-        raise ValueError("uncertainty_bins must cover the complete 0-300 km/h runtime range")
+        raise ValueError("uncertainty_bins must cover the complete 30x10 km/h runtime grid")
 
 
 def _validate_supported_longitudinal(

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -353,6 +353,7 @@ def ggv_from_telemetry(
     min_corner_lat_g: float = 0.9,
     min_samples: int = 40,
     min_probe_samples: int = 8,
+    allow_passive_longitudinal: bool = True,
 ) -> GGVModel:
     """Fit a :class:`GGVModel` from telemetry rows (dicts w/ speed_kmh, accg_lat, accg_lon).
 
@@ -381,11 +382,11 @@ def ggv_from_telemetry(
         source = r.get("source")
         if ao < 0 and source == "brake_probe":
             brk_probe_b.setdefault(b, []).append(abs(ao))
-        elif ao < 0:
+        elif ao < 0 and allow_passive_longitudinal:
             brk_passive_b.setdefault(b, []).append(abs(ao))
         elif ao >= 0 and source == "accel_sweep":
             acc_probe_b.setdefault(b, []).append(abs(ao))
-        else:
+        elif allow_passive_longitudinal:
             acc_passive_b.setdefault(b, []).append(abs(ao))
         if al > 0.2 or abs(ao) > 0.2:
             hull.append((al, abs(ao)))
@@ -569,8 +570,6 @@ def with_binned_uncertainty(
             low,
             {
                 "lateral": [],
-                "brake": [],
-                "drive": [],
                 "brake_probe": [],
                 "drive_probe": [],
             },
@@ -578,11 +577,9 @@ def with_binned_uncertainty(
         bucket["lateral"].append(lateral)
         source = row.get("source")
         if longitudinal < 0.0:
-            bucket["brake"].append(abs(longitudinal))
             if source == "brake_probe":
                 bucket["brake_probe"].append(abs(longitudinal))
         else:
-            bucket["drive"].append(longitudinal)
             if source == "accel_sweep":
                 bucket["drive_probe"].append(longitudinal)
 
@@ -628,16 +625,18 @@ def with_binned_uncertainty(
         mid_ms = (lo + hi) * 0.5 / 3.6
         bucket = raw.get(int(lo), {})
         lateral = list(bucket.get("lateral", []))
-        brake_all = list(bucket.get("brake", []))
         brake_probe = list(bucket.get("brake_probe", []))
-        drive_all = list(bucket.get("drive", []))
         drive_probe = list(bucket.get("drive_probe", []))
 
         lateral_observed = len(lateral) >= min_samples and _pct(lateral, 0.95) >= 0.9
-        brake_values = brake_probe if len(brake_probe) >= min_probe_samples else brake_all
-        brake_observed = len(brake_probe) >= min_probe_samples or len(brake_all) >= min_samples
-        drive_values = drive_probe if len(drive_probe) >= min_probe_samples else drive_all
-        drive_observed = len(drive_probe) >= min_probe_samples or len(drive_all) >= min_samples
+        # Longitudinal caps require an explicit limit-reaching probe. Ordinary driving can provide
+        # thousands of near-zero coast/maintenance-throttle samples without saying anything about
+        # the available brake or drive envelope; treating their count as evidence can immobilize
+        # the runtime plant. Lateral remains passively observable in actual cornering.
+        brake_values = brake_probe
+        brake_observed = len(brake_probe) >= min_probe_samples
+        drive_values = drive_probe
+        drive_observed = len(drive_probe) >= min_probe_samples
         bins.append(
             {
                 "speed_min_kmh": float(lo),
@@ -852,6 +851,7 @@ def ggv_from_lap_archives(
     *,
     prior_name: str = "injected_prior",
     min_friction_rows: int = 200,
+    probe_rows: list[dict] | None = None,
 ) -> tuple[GGVModel, dict]:
     """Fit an uncertainty-aware GGV using only a thermally consistent lap cohort (#543)."""
     states = [observe_lap_tyre_state(archive) for archive in archives]
@@ -927,11 +927,33 @@ def ggv_from_lap_archives(
         raise ValueError(
             f"insufficient thermally consistent friction rows: {len(rows)} < {min_friction_rows}"
         )
-    measured = ggv_from_telemetry(rows)
+    # The immutable archive proves the thermal state and supplies passive cornering. Only the
+    # handshake's explicitly tagged straight-line probes from a SELECTED thermal lap may identify
+    # longitudinal limits. Controller lap_index is zero-based; the archive's completed lap_n is
+    # one-based at the crossing.
+    selected_lap_numbers = {
+        int(archive["lap"]["lap_n"])
+        for archive, _ in selected
+        if isinstance(archive.get("lap"), dict)
+        and isinstance(archive["lap"].get("lap_n"), int)
+        and not isinstance(archive["lap"].get("lap_n"), bool)
+    }
+    thermal_probe_rows = [
+        dict(row)
+        for row in (probe_rows or [])
+        if isinstance(row, dict)
+        and isinstance(row.get("lap_index"), int)
+        and not isinstance(row.get("lap_index"), bool)
+        and int(row["lap_index"]) + 1 in selected_lap_numbers
+    ]
+    combined_rows = rows + thermal_probe_rows
+    measured = ggv_from_telemetry(combined_rows, allow_passive_longitudinal=False)
     point_model = blend_ggv_safe(measured, prior, prior_name=prior_name)
-    model = with_binned_uncertainty(point_model, rows, prior)
+    model = with_binned_uncertainty(point_model, combined_rows, prior)
     summary = {
         "friction_rows": len(rows),
+        "probe_rows_seen": len(probe_rows or []),
+        "probe_rows": len(thermal_probe_rows),
         "tyre_states": states,
         "selected_lap_uuids": [state.get("lap_uuid") for _, state in selected],
         "thermal_cohort": {
@@ -1279,6 +1301,11 @@ def _validate_uncertainty_bins(bins: tuple[Mapping, ...]) -> None:
                 or source not in {"measured", "prior"}
             ):
                 raise ValueError(f"uncertainty_bins[{index}].{kind} is invalid")
+    if bins and (
+        not math.isclose(float(bins[0]["speed_min_kmh"]), 0.0)
+        or not math.isclose(float(bins[-1]["speed_max_kmh"]), DEFAULT_UNCERTAINTY_MAX_KMH)
+    ):
+        raise ValueError("uncertainty_bins must cover the complete 0-300 km/h runtime range")
 
 
 def _validate_supported_longitudinal(

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -388,7 +388,8 @@ def ggv_from_telemetry(
             acc_probe_b.setdefault(b, []).append(abs(ao))
         elif allow_passive_longitudinal:
             acc_passive_b.setdefault(b, []).append(abs(ao))
-        if al > 0.2 or abs(ao) > 0.2:
+        probe_source = source in {"brake_probe", "accel_sweep"}
+        if (allow_passive_longitudinal or probe_source) and (al > 0.2 or abs(ao) > 0.2):
             hull.append((al, abs(ao)))
 
     # Lateral grip: ONLY bins where the car DEMONSTRABLY cornered hard count (p95 lateral high).
@@ -541,14 +542,13 @@ def with_binned_uncertainty(
         raise ValueError("uncertainty parameters must be finite")
     if (
         bin_kmh <= 0.0
-        or max_speed_kmh <= 0.0
-        or max_speed_kmh > DEFAULT_UNCERTAINTY_MAX_KMH
+        or not math.isclose(max_speed_kmh, DEFAULT_UNCERTAINTY_MAX_KMH)
         or prior_relative_std <= 0.0
         or lcb_z <= 0.0
         or min_samples <= 0
         or min_probe_samples <= 0
     ):
-        raise ValueError("uncertainty parameters are outside safe ranges")
+        raise ValueError("uncertainty parameters require the complete 0-300 km/h runtime range")
     if not math.isclose(bin_kmh, round(bin_kmh)):
         raise ValueError("bin_kmh must be a whole number of km/h")
     count = max_speed_kmh / bin_kmh
@@ -589,6 +589,7 @@ def with_binned_uncertainty(
         *,
         floor_g: float,
         observed: bool,
+        probe_qualified: bool = False,
     ) -> dict:
         prior_std = max(0.03, abs(prior_mean) * prior_relative_std)
         if not observed:
@@ -598,7 +599,9 @@ def with_binned_uncertainty(
             n = 0
         else:
             n = len(values)
-            envelope = _pct(values, 0.95)
+            # At the eight-sample controlled-probe gate, ordinary p95 is the maximum. Reuse the
+            # telemetry fitter's small-N rule so one spike cannot lift a runtime-bearing posterior.
+            envelope = _probe_pct(values, 0.95) if probe_qualified else _pct(values, 0.95)
             median = _pct(values, 0.50)
             robust_scale = max(0.03, (envelope - median) / 1.645)
             effective_n = min(50.0, max(1.0, float(n)))
@@ -652,12 +655,14 @@ def with_binned_uncertainty(
                     prior.ax_brake_max(mid_ms) / G,
                     floor_g=0.5,
                     observed=brake_observed,
+                    probe_qualified=True,
                 ),
                 "drive": posterior(
                     drive_values,
                     prior.ax_drive_max(mid_ms) / G,
                     floor_g=0.10,
                     observed=drive_observed,
+                    probe_qualified=True,
                 ),
             }
         )

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -58,6 +58,8 @@ DEFAULT_UNCERTAINTY_LCB_Z = 1.96
 DEFAULT_PRIOR_RELATIVE_STD = 0.15
 DEFAULT_THERMAL_WINDOW_HALF_WIDTH_C = 10.0
 DEFAULT_THERMAL_RESIDENCE_FRACTION = 0.80
+DEFAULT_THERMAL_STABILITY_HALF_WIDTH_C = 5.0
+DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C = 15.0
 _WHEELS = ("fl", "fr", "rl", "rr")
 
 
@@ -689,13 +691,17 @@ def observe_lap_tyre_state(
     *,
     thermal_window_half_width_c: float = DEFAULT_THERMAL_WINDOW_HALF_WIDTH_C,
     min_residence_fraction: float = DEFAULT_THERMAL_RESIDENCE_FRACTION,
+    stability_half_width_c: float = DEFAULT_THERMAL_STABILITY_HALF_WIDTH_C,
+    max_wheel_spread_c: float = DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C,
 ) -> dict:
     """Tag one lap archive's tyre thermal/pressure/grip state (#543).
 
     The observer reads the canonical #488 archive channels. ``fit_eligible`` is deliberately strict:
-    a valid lap, all four core-temperature and hot-pressure channels, a car-true optimum, and at
-    least 80% thermal-window residence. Surface temperatures and CSP ``dy`` peak-mu are reported
-    when present; they do not fabricate eligibility when core/pressure evidence is missing.
+    a valid lap, all four core-temperature and hot-pressure channels, a car-true optimum, and a
+    stable within-lap per-wheel thermal state. ``tag`` still reports cold/optimal/hot relative to
+    the car's optimum; a stable cold lap is usable as a conservative, explicitly tagged cohort.
+    Surface temperatures and CSP ``dy`` peak-mu are reported when present; they do not fabricate
+    eligibility when core/pressure evidence is missing.
     """
     trace = archive.get("trace") if isinstance(archive, dict) else None
     fields = trace.get("fields") if isinstance(trace, dict) else None
@@ -718,7 +724,10 @@ def observe_lap_tyre_state(
         "compound_name": None,
         "setup_hash": None,
         "thermal_residence_fraction": 0.0,
+        "thermal_stability_fraction": 0.0,
         "sample_coverage_fraction": 0.0,
+        "wheel_core_temp_c": None,
+        "wheel_spread_c": None,
     }
     if not isinstance(fields, list) or not isinstance(samples, list) or not samples:
         return base
@@ -774,6 +783,7 @@ def observe_lap_tyre_state(
         return out
 
     core_means: list[float] = []
+    core_rows: list[list[float]] = []
     pressure_means: list[float] = []
     surface_means: list[float] = []
     grip_mu: list[float] = []
@@ -793,6 +803,7 @@ def observe_lap_tyre_state(
         if len(core) == len(_WHEELS) and len(pressure) == len(_WHEELS):
             core_mean = statistics.fmean(core)
             core_means.append(core_mean)
+            core_rows.append(core)
             pressure_means.append(statistics.fmean(pressure))
             if all(abs(value - optimal) <= thermal_window_half_width_c for value in core):
                 in_window += 1
@@ -805,6 +816,24 @@ def observe_lap_tyre_state(
 
     coverage = len(core_means) / len(samples)
     residence = in_window / len(core_means) if core_means else 0.0
+    wheel_centers = (
+        [statistics.median(row[i] for row in core_rows) for i in range(len(_WHEELS))]
+        if core_rows
+        else []
+    )
+    stable_rows = (
+        sum(
+            all(
+                abs(row[i] - wheel_centers[i]) <= stability_half_width_c
+                for i in range(len(_WHEELS))
+            )
+            for row in core_rows
+        )
+        if wheel_centers
+        else 0
+    )
+    stability = stable_rows / len(core_rows) if core_rows else 0.0
+    wheel_spread = max(wheel_centers) - min(wheel_centers) if wheel_centers else None
     mean_core = statistics.fmean(core_means) if core_means else None
     mean_pressure = statistics.fmean(pressure_means) if pressure_means else None
     tag = "unknown"
@@ -820,8 +849,10 @@ def observe_lap_tyre_state(
         is_valid
         and (compound_index is not None or compound_name is not None)
         and coverage >= min_residence_fraction
-        and residence >= min_residence_fraction
-        and tag == "optimal"
+        and stability >= min_residence_fraction
+        and wheel_spread is not None
+        and wheel_spread <= max_wheel_spread_c
+        and tag != "unknown"
     )
     grip_multiplier = None
     if grip_mu:
@@ -842,7 +873,7 @@ def observe_lap_tyre_state(
             else (
                 "missing tyre compound identity"
                 if compound_index is None and compound_name is None
-                else "outside thermal/validity gate"
+                else "outside thermal stability/validity gate"
             )
         ),
         "optimal_temp_c": round(optimal, 3),
@@ -855,7 +886,14 @@ def observe_lap_tyre_state(
         "compound_name": compound_name,
         "setup_hash": setup_hash,
         "thermal_residence_fraction": round(residence, 6),
+        "thermal_stability_fraction": round(stability, 6),
         "sample_coverage_fraction": round(coverage, 6),
+        "wheel_core_temp_c": (
+            {wheel: round(value, 3) for wheel, value in zip(_WHEELS, wheel_centers, strict=True)}
+            if wheel_centers
+            else None
+        ),
+        "wheel_spread_c": round(wheel_spread, 3) if wheel_spread is not None else None,
     }
 
 
@@ -879,12 +917,12 @@ def ggv_from_lap_archives(
 
     # A plant is per combo, which includes tyre compound and setup. A stale archive from the same
     # car/track session must not contaminate the posterior merely because its temperatures match.
-    cohort_groups: dict[tuple[object, object], list[tuple[dict, dict]]] = {}
+    cohort_groups: dict[tuple[object, object, object], list[tuple[dict, dict]]] = {}
     for archive, state in eligible:
         compound = state.get("compound_index")
         if compound is None:
             compound = state.get("compound_name")
-        key = (compound, state.get("setup_hash"))
+        key = (compound, state.get("setup_hash"), state.get("tag"))
         cohort_groups.setdefault(key, []).append((archive, state))
     cohort_key, eligible = sorted(
         cohort_groups.items(), key=lambda item: (-len(item[1]), repr(item[0]))
@@ -977,6 +1015,7 @@ def ggv_from_lap_archives(
             "pressure_tolerance_psi": 2.0,
             "compound": cohort_key[0],
             "setup_hash": cohort_key[1],
+            "thermal_tag": cohort_key[2],
         },
     }
     return model, summary

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import copy
 import csv
 import math
+import statistics
 import struct
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
@@ -50,6 +51,14 @@ MAX_LONGITUDINAL_SUPPORT_KMH = 300.0
 MAX_DRIVE_SUPPORT_G = 2.0
 MAX_PERSISTED_AY_CAP_G = 1.8
 MAX_PERSISTED_BRAKE_CAP_G = 3.4
+UNCERTAINTY_CHANNELS = ("lateral", "brake", "drive")
+DEFAULT_UNCERTAINTY_BIN_KMH = 10.0
+DEFAULT_UNCERTAINTY_MAX_KMH = 300.0
+DEFAULT_UNCERTAINTY_LCB_Z = 1.96
+DEFAULT_PRIOR_RELATIVE_STD = 0.15
+DEFAULT_THERMAL_WINDOW_HALF_WIDTH_C = 10.0
+DEFAULT_THERMAL_RESIDENCE_FRACTION = 0.80
+_WHEELS = ("fl", "fr", "rl", "rr")
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +87,10 @@ class GGVModel:
     # Runtime-bearing measured overrides are deliberately separate from free-form provenance and
     # validated on every construction/load. Top-level coefficients remain the trusted prior.
     supported_longitudinal: Mapping = field(default_factory=dict)
+    # Schema-v3 (#543): validated, runtime-bearing per-speed-bin posterior summaries. Each
+    # channel carries mean, epistemic standard deviation, lower-confidence safe value, sample
+    # count, and measured-vs-prior provenance. Empty means a legacy point-estimate model.
+    uncertainty_bins: tuple[Mapping, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         _validate_supported_longitudinal(
@@ -88,6 +101,7 @@ class GGVModel:
             drive_b1=self.drive_b1,
             ax_brake_cap_g=self.ax_brake_cap_g,
         )
+        _validate_uncertainty_bins(self.uncertainty_bins)
         # ``frozen=True`` does not freeze nested dicts. Detach observability provenance from its
         # caller and make the runtime-bearing support schema recursively read-only after validation.
         object.__setattr__(self, "provenance", copy.deepcopy(self.provenance))
@@ -96,21 +110,48 @@ class GGVModel:
             "supported_longitudinal",
             _freeze_supported_longitudinal(self.supported_longitudinal),
         )
+        object.__setattr__(
+            self, "uncertainty_bins", _freeze_uncertainty_bins(self.uncertainty_bins)
+        )
 
     def ay_max(self, v_ms: float) -> float:
-        return min(self.ay_cap_g, self.mu_lat_g + self.k_aero_lat * v_ms * v_ms) * G
+        point_g = min(self.ay_cap_g, self.mu_lat_g + self.k_aero_lat * v_ms * v_ms)
+        return self._uncertainty_safe_g("lateral", v_ms, point_g) * G
 
     def ax_brake_max(self, v_ms: float) -> float:
         prior_g = max(0.5, self.brake_b0_g + self.brake_b1 * v_ms)
         supported_g = self._supported_longitudinal_g("brake", v_ms, prior_g, floor_g=0.5)
-        return min(self.ax_brake_cap_g, supported_g) * G
+        point_g = min(self.ax_brake_cap_g, supported_g)
+        return self._uncertainty_safe_g("brake", v_ms, point_g) * G
 
     def ax_drive_max(self, v_ms: float) -> float:
         prior_g = max(self.drive_min_g, self.drive_b0_g + self.drive_b1 * v_ms)
         supported_g = self._supported_longitudinal_g(
             "drive", v_ms, prior_g, floor_g=self.drive_min_g
         )
-        return supported_g * G
+        return self._uncertainty_safe_g("drive", v_ms, supported_g) * G
+
+    @property
+    def uncertainty_aware(self) -> bool:
+        """Whether this model carries the schema-v3 runtime uncertainty map."""
+        return bool(self.uncertainty_bins)
+
+    def _uncertainty_safe_g(self, kind: str, v_ms: float, point_g: float) -> float:
+        """Return the lower-confidence grip for ``kind`` at speed, never above the point model.
+
+        The point model remains the upper operating envelope. The uncertainty layer can only derate
+        it. A missing or non-covering map is a legacy model and preserves the pre-v3 behavior.
+        """
+        speed_kmh = max(0.0, float(v_ms) * 3.6)
+        for speed_bin in self.uncertainty_bins:
+            if float(speed_bin["speed_min_kmh"]) <= speed_kmh < float(speed_bin["speed_max_kmh"]):
+                channel = speed_bin[kind]
+                return min(point_g, float(channel["safe_g"]))
+        if self.uncertainty_bins and speed_kmh >= float(self.uncertainty_bins[-1]["speed_max_kmh"]):
+            # Never fall back to the optimistic point model above the map. Carry the last safe
+            # bound flat; that is conservative extrapolation, not an upward grip claim.
+            return min(point_g, float(self.uncertainty_bins[-1][kind]["safe_g"]))
+        return point_g
 
     def _supported_longitudinal_g(
         self, kind: str, v_ms: float, prior_g: float, *, floor_g: float
@@ -193,6 +234,14 @@ class GGVModel:
             "supported_longitudinal": {
                 kind: dict(override) for kind, override in self.supported_longitudinal.items()
             },
+            "uncertainty_bins": [
+                {
+                    "speed_min_kmh": float(speed_bin["speed_min_kmh"]),
+                    "speed_max_kmh": float(speed_bin["speed_max_kmh"]),
+                    **{kind: dict(speed_bin[kind]) for kind in UNCERTAINTY_CHANNELS},
+                }
+                for speed_bin in self.uncertainty_bins
+            ],
         }
 
     @classmethod
@@ -253,10 +302,14 @@ class GGVModel:
                 raise ValueError(f"GGVModel.from_dict: {f} must be in (0, {limit}]: {vals[f]!r}")
         prov = data.get("provenance")
         supported = data.get("supported_longitudinal", {})
+        uncertainty_bins = data.get("uncertainty_bins", ())
+        if uncertainty_bins is None:
+            raise ValueError("GGVModel.from_dict: uncertainty_bins must be a list or tuple")
         return cls(
             **vals,
             provenance=copy.deepcopy(prov) if isinstance(prov, dict) else {},
             supported_longitudinal=copy.deepcopy(supported),
+            uncertainty_bins=tuple(copy.deepcopy(uncertainty_bins)),
         )
 
 
@@ -458,6 +511,439 @@ def ggv_from_telemetry(
         ellipse_n=n_fit,
         provenance=prov,
     )
+
+
+def with_binned_uncertainty(
+    point_model: GGVModel,
+    rows: list[dict],
+    prior: GGVModel,
+    *,
+    bin_kmh: float = DEFAULT_UNCERTAINTY_BIN_KMH,
+    max_speed_kmh: float = DEFAULT_UNCERTAINTY_MAX_KMH,
+    prior_relative_std: float = DEFAULT_PRIOR_RELATIVE_STD,
+    lcb_z: float = DEFAULT_UNCERTAINTY_LCB_Z,
+    min_samples: int = 40,
+    min_probe_samples: int = 8,
+) -> GGVModel:
+    """Attach a deterministic binned-Bayesian lower-confidence map (#543).
+
+    Each speed/channel bin starts from the generic plant as a normal prior. Directly observed
+    95th-percentile envelope evidence updates that prior with a normal likelihood. The persisted
+    posterior mean is useful for inspection, but the QSS consumes ``mean - z * epistemic_std``.
+    Unmeasured bins therefore stay explicitly high-uncertainty and run below the optimistic prior;
+    evidence never leaks into neighbouring speed bins.
+
+    Samples at 100+ Hz are correlated, so the likelihood uses a capped effective sample size. This
+    prevents a single two-second probe from claiming thousands of independent observations.
+    """
+    if not _finite_ggv(bin_kmh, max_speed_kmh, prior_relative_std, lcb_z):
+        raise ValueError("uncertainty parameters must be finite")
+    if (
+        bin_kmh <= 0.0
+        or max_speed_kmh <= 0.0
+        or max_speed_kmh > DEFAULT_UNCERTAINTY_MAX_KMH
+        or prior_relative_std <= 0.0
+        or lcb_z <= 0.0
+        or min_samples <= 0
+        or min_probe_samples <= 0
+    ):
+        raise ValueError("uncertainty parameters are outside safe ranges")
+    if not math.isclose(bin_kmh, round(bin_kmh)):
+        raise ValueError("bin_kmh must be a whole number of km/h")
+    count = max_speed_kmh / bin_kmh
+    if not math.isclose(count, round(count)):
+        raise ValueError("max_speed_kmh must be an exact multiple of bin_kmh")
+
+    raw: dict[int, dict[str, list[float]]] = {}
+    for row in rows:
+        try:
+            speed = float(row["speed_kmh"])
+            lateral = abs(float(row["accg_lat"]))
+            longitudinal = float(row["accg_lon"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if not _finite_ggv(speed, lateral, longitudinal) or not (0.0 <= speed < max_speed_kmh):
+            continue
+        low = int(speed // bin_kmh) * int(bin_kmh)
+        bucket = raw.setdefault(
+            low,
+            {
+                "lateral": [],
+                "brake": [],
+                "drive": [],
+                "brake_probe": [],
+                "drive_probe": [],
+            },
+        )
+        bucket["lateral"].append(lateral)
+        source = row.get("source")
+        if longitudinal < 0.0:
+            bucket["brake"].append(abs(longitudinal))
+            if source == "brake_probe":
+                bucket["brake_probe"].append(abs(longitudinal))
+        else:
+            bucket["drive"].append(longitudinal)
+            if source == "accel_sweep":
+                bucket["drive_probe"].append(longitudinal)
+
+    def posterior(
+        values: list[float],
+        prior_mean: float,
+        *,
+        floor_g: float,
+        observed: bool,
+    ) -> dict:
+        prior_std = max(0.03, abs(prior_mean) * prior_relative_std)
+        if not observed:
+            mean = prior_mean
+            std = prior_std
+            source = "prior"
+            n = 0
+        else:
+            n = len(values)
+            envelope = _pct(values, 0.95)
+            median = _pct(values, 0.50)
+            robust_scale = max(0.03, (envelope - median) / 1.645)
+            effective_n = min(50.0, max(1.0, float(n)))
+            likelihood_std = max(0.03, robust_scale / math.sqrt(effective_n))
+            prior_precision = 1.0 / (prior_std * prior_std)
+            likelihood_precision = 1.0 / (likelihood_std * likelihood_std)
+            variance = 1.0 / (prior_precision + likelihood_precision)
+            mean = variance * (prior_mean * prior_precision + envelope * likelihood_precision)
+            std = math.sqrt(variance)
+            source = "measured"
+        safe = max(floor_g, mean - lcb_z * std)
+        return {
+            "mean_g": round(mean, 6),
+            "epistemic_std_g": round(std, 6),
+            "safe_g": round(min(mean, safe), 6),
+            "n": int(n),
+            "source": source,
+        }
+
+    bins: list[dict] = []
+    for index in range(int(round(count))):
+        lo = index * bin_kmh
+        hi = lo + bin_kmh
+        mid_ms = (lo + hi) * 0.5 / 3.6
+        bucket = raw.get(int(lo), {})
+        lateral = list(bucket.get("lateral", []))
+        brake_all = list(bucket.get("brake", []))
+        brake_probe = list(bucket.get("brake_probe", []))
+        drive_all = list(bucket.get("drive", []))
+        drive_probe = list(bucket.get("drive_probe", []))
+
+        lateral_observed = len(lateral) >= min_samples and _pct(lateral, 0.95) >= 0.9
+        brake_values = brake_probe if len(brake_probe) >= min_probe_samples else brake_all
+        brake_observed = len(brake_probe) >= min_probe_samples or len(brake_all) >= min_samples
+        drive_values = drive_probe if len(drive_probe) >= min_probe_samples else drive_all
+        drive_observed = len(drive_probe) >= min_probe_samples or len(drive_all) >= min_samples
+        bins.append(
+            {
+                "speed_min_kmh": float(lo),
+                "speed_max_kmh": float(hi),
+                "lateral": posterior(
+                    lateral,
+                    prior.ay_max(mid_ms) / G,
+                    floor_g=0.5,
+                    observed=lateral_observed,
+                ),
+                "brake": posterior(
+                    brake_values,
+                    prior.ax_brake_max(mid_ms) / G,
+                    floor_g=0.5,
+                    observed=brake_observed,
+                ),
+                "drive": posterior(
+                    drive_values,
+                    prior.ax_drive_max(mid_ms) / G,
+                    floor_g=0.10,
+                    observed=drive_observed,
+                ),
+            }
+        )
+
+    provenance = copy.deepcopy(point_model.provenance)
+    provenance["uncertainty"] = {
+        "method": "binned_normal_posterior_lcb",
+        "bin_kmh": bin_kmh,
+        "max_speed_kmh": max_speed_kmh,
+        "prior_relative_std": prior_relative_std,
+        "lcb_z": lcb_z,
+        "runtime_uses": "min(point_estimate, lower_confidence_bound)",
+        "unmeasured": "lower-confidence generic prior; no neighbouring-bin extrapolation",
+        "measured_bins": {
+            kind: sum(1 for speed_bin in bins if speed_bin[kind]["source"] == "measured")
+            for kind in UNCERTAINTY_CHANNELS
+        },
+    }
+    return replace(point_model, provenance=provenance, uncertainty_bins=tuple(bins))
+
+
+def observe_lap_tyre_state(
+    archive: dict,
+    *,
+    thermal_window_half_width_c: float = DEFAULT_THERMAL_WINDOW_HALF_WIDTH_C,
+    min_residence_fraction: float = DEFAULT_THERMAL_RESIDENCE_FRACTION,
+) -> dict:
+    """Tag one lap archive's tyre thermal/pressure/grip state (#543).
+
+    The observer reads the canonical #488 archive channels. ``fit_eligible`` is deliberately strict:
+    a valid lap, all four core-temperature and hot-pressure channels, a car-true optimum, and at
+    least 80% thermal-window residence. Surface temperatures and CSP ``dy`` peak-mu are reported
+    when present; they do not fabricate eligibility when core/pressure evidence is missing.
+    """
+    trace = archive.get("trace") if isinstance(archive, dict) else None
+    fields = trace.get("fields") if isinstance(trace, dict) else None
+    samples = trace.get("samples") if isinstance(trace, dict) else None
+    lap = archive.get("lap") if isinstance(archive, dict) else None
+    tyres = archive.get("tyres") if isinstance(archive, dict) else None
+    setup = archive.get("setup") if isinstance(archive, dict) else None
+    lap_uuid = archive.get("lap_uuid") if isinstance(archive, dict) else None
+    base = {
+        "lap_uuid": lap_uuid if isinstance(lap_uuid, str) else None,
+        "tag": "unknown",
+        "fit_eligible": False,
+        "reason": "missing trace",
+        "optimal_temp_c": None,
+        "core_temp_c": None,
+        "surface_temp_c": None,
+        "pressure_psi": None,
+        "grip_multiplier": None,
+        "compound_index": None,
+        "compound_name": None,
+        "setup_hash": None,
+        "thermal_residence_fraction": 0.0,
+        "sample_coverage_fraction": 0.0,
+    }
+    if not isinstance(fields, list) or not isinstance(samples, list) or not samples:
+        return base
+    if not isinstance(tyres, dict):
+        tyres = {}
+    if not isinstance(setup, dict):
+        setup = {}
+    compound_index = tyres.get("compoundIndex")
+    if isinstance(compound_index, bool) or not isinstance(compound_index, (int, float)):
+        compound_index = None
+    elif not math.isfinite(float(compound_index)):
+        compound_index = None
+    else:
+        compound_index = int(compound_index)
+    compound_name = tyres.get("name")
+    if not isinstance(compound_name, str) or not compound_name.strip():
+        compound_name = None
+    setup_hash = setup.get("hash")
+    if not isinstance(setup_hash, str) or not setup_hash.strip():
+        setup_hash = None
+    base.update(
+        {
+            "compound_index": compound_index,
+            "compound_name": compound_name,
+            "setup_hash": setup_hash,
+        }
+    )
+    try:
+        optimal = float(tyres.get("optimalTempC"))
+    except (TypeError, ValueError):
+        optimal = float("nan")
+    if not math.isfinite(optimal):
+        base["reason"] = "missing car-true optimalTempC"
+        return base
+
+    index = {name: i for i, name in enumerate(fields)}
+    core_names = [f"tyreCoreTemp_{wheel}" for wheel in _WHEELS]
+    pressure_names = [f"wheelsPressure_{wheel}" for wheel in _WHEELS]
+    if any(name not in index for name in core_names + pressure_names):
+        base["optimal_temp_c"] = optimal
+        base["reason"] = "missing per-wheel core-temperature or pressure channels"
+        return base
+
+    def row_values(row, names: list[str]) -> list[float]:
+        out = []
+        for name in names:
+            try:
+                value = float(row[index[name]])
+            except (IndexError, TypeError, ValueError):
+                continue
+            if math.isfinite(value) and value != 0.0:
+                out.append(value)
+        return out
+
+    core_means: list[float] = []
+    pressure_means: list[float] = []
+    surface_means: list[float] = []
+    grip_mu: list[float] = []
+    in_window = 0
+    surface_names = [
+        f"tyreTemp{band}_{wheel}"
+        for band in ("Inner", "Mid", "Outer")
+        for wheel in _WHEELS
+        if f"tyreTemp{band}_{wheel}" in index
+    ]
+    dy_names = [f"dy_{wheel}" for wheel in _WHEELS if f"dy_{wheel}" in index]
+    for row in samples:
+        if not isinstance(row, (list, tuple)):
+            continue
+        core = row_values(row, core_names)
+        pressure = row_values(row, pressure_names)
+        if len(core) == len(_WHEELS) and len(pressure) == len(_WHEELS):
+            core_mean = statistics.fmean(core)
+            core_means.append(core_mean)
+            pressure_means.append(statistics.fmean(pressure))
+            if abs(core_mean - optimal) <= thermal_window_half_width_c:
+                in_window += 1
+        surface = row_values(row, surface_names)
+        if surface:
+            surface_means.append(statistics.fmean(surface))
+        dy = row_values(row, dy_names)
+        if dy:
+            grip_mu.append(statistics.fmean(dy))
+
+    coverage = len(core_means) / len(samples)
+    residence = in_window / len(core_means) if core_means else 0.0
+    mean_core = statistics.fmean(core_means) if core_means else None
+    mean_pressure = statistics.fmean(pressure_means) if pressure_means else None
+    tag = "unknown"
+    if mean_core is not None:
+        if mean_core < optimal - thermal_window_half_width_c:
+            tag = "cold"
+        elif mean_core > optimal + thermal_window_half_width_c:
+            tag = "hot"
+        else:
+            tag = "optimal"
+    is_valid = isinstance(lap, dict) and lap.get("is_valid") is True
+    eligible = (
+        is_valid
+        and coverage >= min_residence_fraction
+        and residence >= min_residence_fraction
+        and tag == "optimal"
+    )
+    grip_multiplier = None
+    if grip_mu:
+        peak = _pct(grip_mu, 0.95)
+        if peak > 0.0:
+            grip_multiplier = min(1.0, max(0.0, statistics.median(grip_mu) / peak))
+    elif eligible:
+        # No CSP dy channel: eligibility proves the thermal state, but not an absolute tyre-model
+        # multiplier. One is neutral and explicitly provenance-labelled by the missing dy input.
+        grip_multiplier = 1.0
+    return {
+        "lap_uuid": base["lap_uuid"],
+        "tag": tag,
+        "fit_eligible": eligible,
+        "reason": "thermally consistent" if eligible else "outside thermal/validity gate",
+        "optimal_temp_c": round(optimal, 3),
+        "core_temp_c": round(mean_core, 3) if mean_core is not None else None,
+        "surface_temp_c": (round(statistics.fmean(surface_means), 3) if surface_means else None),
+        "pressure_psi": round(mean_pressure, 3) if mean_pressure is not None else None,
+        "grip_multiplier": (round(grip_multiplier, 5) if grip_multiplier is not None else None),
+        "grip_multiplier_source": "dy_within_lap" if grip_mu else "thermal_neutral",
+        "compound_index": compound_index,
+        "compound_name": compound_name,
+        "setup_hash": setup_hash,
+        "thermal_residence_fraction": round(residence, 6),
+        "sample_coverage_fraction": round(coverage, 6),
+    }
+
+
+def ggv_from_lap_archives(
+    archives: list[dict],
+    prior: GGVModel,
+    *,
+    prior_name: str = "injected_prior",
+    min_friction_rows: int = 200,
+) -> tuple[GGVModel, dict]:
+    """Fit an uncertainty-aware GGV using only a thermally consistent lap cohort (#543)."""
+    states = [observe_lap_tyre_state(archive) for archive in archives]
+    eligible = [
+        (archive, state)
+        for archive, state in zip(archives, states, strict=True)
+        if state.get("fit_eligible")
+    ]
+    if not eligible:
+        raise ValueError("no thermally consistent valid lap archives")
+
+    # A plant is per combo, which includes tyre compound and setup. A stale archive from the same
+    # car/track session must not contaminate the posterior merely because its temperatures match.
+    cohort_groups: dict[tuple[object, object], list[tuple[dict, dict]]] = {}
+    for archive, state in eligible:
+        compound = state.get("compound_index")
+        if compound is None:
+            compound = state.get("compound_name")
+        key = (compound, state.get("setup_hash"))
+        cohort_groups.setdefault(key, []).append((archive, state))
+    cohort_key, eligible = sorted(
+        cohort_groups.items(), key=lambda item: (-len(item[1]), repr(item[0]))
+    )[0]
+    core_center = statistics.median(float(state["core_temp_c"]) for _, state in eligible)
+    pressure_center = statistics.median(float(state["pressure_psi"]) for _, state in eligible)
+    for state in states:
+        state["cohort_consistent"] = False
+    selected: list[tuple[dict, dict]] = []
+    for archive, state in eligible:
+        cohort_ok = (
+            abs(float(state["core_temp_c"]) - core_center) <= 5.0
+            and abs(float(state["pressure_psi"]) - pressure_center) <= 2.0
+        )
+        state["cohort_consistent"] = cohort_ok
+        if cohort_ok:
+            selected.append((archive, state))
+    if not selected:
+        raise ValueError("thermally eligible laps do not form a consistent temp/pressure cohort")
+
+    rows: list[dict] = []
+    for archive, state in selected:
+        trace = archive["trace"]
+        fields = trace["fields"]
+        index = {name: i for i, name in enumerate(fields)}
+        required = ("speed", "accG_lat", "accG_long", "brake", "throttle")
+        if any(name not in index for name in required):
+            continue
+        for sample in trace["samples"]:
+            try:
+                speed = float(sample[index["speed"]])
+                lateral = float(sample[index["accG_lat"]])
+                longitudinal = float(sample[index["accG_long"]])
+                brake = float(sample[index["brake"]])
+                throttle = float(sample[index["throttle"]])
+            except (IndexError, TypeError, ValueError):
+                continue
+            if not _finite_ggv(speed, lateral, longitudinal, brake, throttle):
+                continue
+            rows.append(
+                {
+                    "speed_kmh": speed,
+                    "accg_lat": lateral,
+                    "accg_lon": longitudinal,
+                    # The lap schema does not persist the controller's active-probe state. Do not
+                    # infer it from brake/throttle alone (normal driving can look identical) and
+                    # accidentally unlock the lower 8-sample probe gate; archive rows use the
+                    # stricter passive threshold.
+                    "source": "passive",
+                    "thermal_lap_uuid": state.get("lap_uuid"),
+                }
+            )
+    if len(rows) < min_friction_rows:
+        raise ValueError(
+            f"insufficient thermally consistent friction rows: {len(rows)} < {min_friction_rows}"
+        )
+    measured = ggv_from_telemetry(rows)
+    point_model = blend_ggv_safe(measured, prior, prior_name=prior_name)
+    model = with_binned_uncertainty(point_model, rows, prior)
+    summary = {
+        "friction_rows": len(rows),
+        "tyre_states": states,
+        "selected_lap_uuids": [state.get("lap_uuid") for _, state in selected],
+        "thermal_cohort": {
+            "core_temp_c": round(core_center, 3),
+            "pressure_psi": round(pressure_center, 3),
+            "core_tolerance_c": 5.0,
+            "pressure_tolerance_psi": 2.0,
+            "compound": cohort_key[0],
+            "setup_hash": cohort_key[1],
+        },
+    }
+    return model, summary
 
 
 def _fit_ellipse_n(hull: list[tuple[float, float]], mu_lat, k_aero, brake_b0, brake_b1) -> float:
@@ -723,6 +1209,76 @@ def _freeze_supported_longitudinal(supported: Mapping) -> MappingProxyType:
     return MappingProxyType(
         {kind: MappingProxyType(dict(override)) for kind, override in supported.items()}
     )
+
+
+def _freeze_uncertainty_bins(bins: tuple[Mapping, ...]) -> tuple[MappingProxyType, ...]:
+    """Return a detached, recursively read-only uncertainty map."""
+    return tuple(
+        MappingProxyType(
+            {
+                "speed_min_kmh": float(speed_bin["speed_min_kmh"]),
+                "speed_max_kmh": float(speed_bin["speed_max_kmh"]),
+                **{kind: MappingProxyType(dict(speed_bin[kind])) for kind in UNCERTAINTY_CHANNELS},
+            }
+        )
+        for speed_bin in bins
+    )
+
+
+def _validate_uncertainty_bins(bins: tuple[Mapping, ...]) -> None:
+    """Validate schema-v3 runtime uncertainty data before the QSS can consume it."""
+    if not isinstance(bins, (tuple, list)):
+        raise ValueError("uncertainty_bins must be a list or tuple")
+    previous_hi = None
+    for index, speed_bin in enumerate(bins):
+        if not isinstance(speed_bin, Mapping):
+            raise ValueError(f"uncertainty_bins[{index}] must be a dict")
+        expected = {"speed_min_kmh", "speed_max_kmh", *UNCERTAINTY_CHANNELS}
+        if set(speed_bin) != expected:
+            raise ValueError(
+                f"uncertainty_bins[{index}] fields must be exactly {sorted(expected)!r}"
+            )
+        lo = speed_bin["speed_min_kmh"]
+        hi = speed_bin["speed_max_kmh"]
+        if (
+            isinstance(lo, bool)
+            or isinstance(hi, bool)
+            or not _finite_ggv(lo, hi)
+            or float(lo) < 0.0
+            or float(hi) <= float(lo)
+            or float(hi) > DEFAULT_UNCERTAINTY_MAX_KMH
+        ):
+            raise ValueError(f"uncertainty_bins[{index}] has an unsafe speed range")
+        if previous_hi is not None and not math.isclose(float(lo), previous_hi):
+            raise ValueError("uncertainty_bins must be contiguous and sorted")
+        previous_hi = float(hi)
+        for kind in UNCERTAINTY_CHANNELS:
+            channel = speed_bin[kind]
+            if not isinstance(channel, Mapping):
+                raise ValueError(f"uncertainty_bins[{index}].{kind} must be a dict")
+            required = {"mean_g", "epistemic_std_g", "safe_g", "n", "source"}
+            if set(channel) != required:
+                raise ValueError(
+                    f"uncertainty_bins[{index}].{kind} fields must be exactly {sorted(required)!r}"
+                )
+            mean = channel["mean_g"]
+            std = channel["epistemic_std_g"]
+            safe = channel["safe_g"]
+            n = channel["n"]
+            source = channel["source"]
+            if (
+                any(isinstance(value, bool) for value in (mean, std, safe, n))
+                or not _finite_ggv(mean, std)
+                or not _finite_ggv(safe)
+                or float(mean) <= 0.0
+                or float(std) < 0.0
+                or float(safe) <= 0.0
+                or float(safe) > float(mean) + 1e-9
+                or not isinstance(n, int)
+                or n < 0
+                or source not in {"measured", "prior"}
+            ):
+                raise ValueError(f"uncertainty_bins[{index}].{kind} is invalid")
 
 
 def _validate_supported_longitudinal(

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import copy
 import csv
+import hashlib
+import json
 import math
 import statistics
 import struct
@@ -57,7 +59,8 @@ DEFAULT_UNCERTAINTY_MAX_KMH = 300.0
 DEFAULT_UNCERTAINTY_LCB_Z = 1.96
 DEFAULT_PRIOR_RELATIVE_STD = 0.15
 DEFAULT_THERMAL_WINDOW_HALF_WIDTH_C = 10.0
-DEFAULT_THERMAL_RESIDENCE_FRACTION = 0.80
+DEFAULT_THERMAL_COVERAGE_FRACTION = 0.80
+DEFAULT_THERMAL_STABILITY_FRACTION = 0.80
 DEFAULT_THERMAL_STABILITY_HALF_WIDTH_C = 5.0
 DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C = 15.0
 _WHEELS = ("fl", "fr", "rl", "rr")
@@ -390,7 +393,9 @@ def ggv_from_telemetry(
             acc_probe_b.setdefault(b, []).append(abs(ao))
         elif allow_passive_longitudinal:
             acc_passive_b.setdefault(b, []).append(abs(ao))
-        probe_source = source in {"brake_probe", "accel_sweep"}
+        # ``source`` comes from persisted/transported telemetry and can be malformed. Equality is
+        # intentionally non-hashing so one list/dict value cannot abort the whole defensive fit.
+        probe_source = source == "brake_probe" or source == "accel_sweep"
         if (allow_passive_longitudinal or probe_source) and (al > 0.2 or abs(ao) > 0.2):
             hull.append((al, abs(ao)))
 
@@ -690,7 +695,8 @@ def observe_lap_tyre_state(
     archive: dict,
     *,
     thermal_window_half_width_c: float = DEFAULT_THERMAL_WINDOW_HALF_WIDTH_C,
-    min_residence_fraction: float = DEFAULT_THERMAL_RESIDENCE_FRACTION,
+    min_coverage_fraction: float = DEFAULT_THERMAL_COVERAGE_FRACTION,
+    min_stability_fraction: float = DEFAULT_THERMAL_STABILITY_FRACTION,
     stability_half_width_c: float = DEFAULT_THERMAL_STABILITY_HALF_WIDTH_C,
     max_wheel_spread_c: float = DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C,
 ) -> dict:
@@ -747,7 +753,19 @@ def observe_lap_tyre_state(
         compound_name = None
     setup_hash = setup.get("hash")
     if not isinstance(setup_hash, str) or not setup_hash.strip():
-        setup_hash = None
+        setup_snapshot = setup.get("snapshot")
+        if isinstance(setup_snapshot, (dict, list)):
+            # CSP serializes the default/no-file setup as an empty snapshot and an empty hash. It is
+            # still a concrete setup cohort: derive a stable identity from the persisted snapshot so
+            # default laps group together without being conflated with genuinely missing metadata.
+            canonical_snapshot = json.dumps(
+                setup_snapshot, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+            )
+            setup_hash = (
+                "snapshot-sha256:" + hashlib.sha256(canonical_snapshot.encode("utf-8")).hexdigest()
+            )
+        else:
+            setup_hash = None
     base.update(
         {
             "compound_index": compound_index,
@@ -848,8 +866,9 @@ def observe_lap_tyre_state(
     eligible = (
         is_valid
         and (compound_index is not None or compound_name is not None)
-        and coverage >= min_residence_fraction
-        and stability >= min_residence_fraction
+        and setup_hash is not None
+        and coverage >= min_coverage_fraction
+        and stability >= min_stability_fraction
         and wheel_spread is not None
         and wheel_spread <= max_wheel_spread_c
         and tag != "unknown"
@@ -873,7 +892,11 @@ def observe_lap_tyre_state(
             else (
                 "missing tyre compound identity"
                 if compound_index is None and compound_name is None
-                else "outside thermal stability/validity gate"
+                else (
+                    "missing setup identity"
+                    if setup_hash is None
+                    else "outside thermal stability/validity gate"
+                )
             )
         ),
         "optimal_temp_c": round(optimal, 3),
@@ -904,6 +927,7 @@ def ggv_from_lap_archives(
     prior_name: str = "injected_prior",
     min_friction_rows: int = 200,
     probe_rows: list[dict] | None = None,
+    probe_run_id: str | None = None,
 ) -> tuple[GGVModel, dict]:
     """Fit an uncertainty-aware GGV using only a thermally consistent lap cohort (#543)."""
     states = [observe_lap_tyre_state(archive) for archive in archives]
@@ -979,10 +1003,12 @@ def ggv_from_lap_archives(
         raise ValueError(
             f"insufficient thermally consistent friction rows: {len(rows)} < {min_friction_rows}"
         )
-    # The immutable archive proves the thermal state and supplies passive cornering. Only the
-    # handshake's explicitly tagged straight-line probes from a SELECTED thermal lap may identify
-    # longitudinal limits. Both sides carry AC's absolute completed-lap number; never infer an
-    # offset from directory contents because a resumed LIVE session may include earlier manual laps.
+    # The immutable archive proves the thermal state and supplies passive cornering. In the live
+    # harness, archives are filtered to files written after this exact run began and the controller
+    # gives every probe a nonce. That run scope is authoritative even after an invalid AC lap,
+    # because graphics.completedLaps (valid laps) and the app archive counter (all boundaries) are
+    # deliberately different clocks. Direct/offline callers without a nonce retain exact lap-number
+    # matching and therefore cannot silently mix arbitrary probes into an archive cohort.
     selected_lap_numbers = {
         int(archive["lap"]["lap_n"])
         for archive, _ in selected
@@ -990,14 +1016,24 @@ def ggv_from_lap_archives(
         and isinstance(archive["lap"].get("lap_n"), int)
         and not isinstance(archive["lap"].get("lap_n"), bool)
     }
-    thermal_probe_rows = [
-        dict(row)
-        for row in (probe_rows or [])
-        if isinstance(row, dict)
-        and isinstance(row.get("lap_number"), int)
-        and not isinstance(row.get("lap_number"), bool)
-        and int(row["lap_number"]) in selected_lap_numbers
-    ]
+    valid_probe_run_id = isinstance(probe_run_id, str) and bool(probe_run_id.strip())
+    if valid_probe_run_id:
+        thermal_probe_rows = [
+            dict(row)
+            for row in (probe_rows or [])
+            if isinstance(row, dict) and row.get("probe_run_id") == probe_run_id
+        ]
+        probe_attribution = "current-run nonce"
+    else:
+        thermal_probe_rows = [
+            dict(row)
+            for row in (probe_rows or [])
+            if isinstance(row, dict)
+            and isinstance(row.get("lap_number"), int)
+            and not isinstance(row.get("lap_number"), bool)
+            and int(row["lap_number"]) in selected_lap_numbers
+        ]
+        probe_attribution = "archive lap number"
     combined_rows = rows + thermal_probe_rows
     measured = ggv_from_telemetry(combined_rows, allow_passive_longitudinal=False)
     point_model = blend_ggv_safe(measured, prior, prior_name=prior_name)
@@ -1006,6 +1042,7 @@ def ggv_from_lap_archives(
         "friction_rows": len(rows),
         "probe_rows_seen": len(probe_rows or []),
         "probe_rows": len(thermal_probe_rows),
+        "probe_attribution": probe_attribution,
         "tyre_states": states,
         "selected_lap_uuids": [state.get("lap_uuid") for _, state in selected],
         "thermal_cohort": {

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -936,6 +936,14 @@ def ggv_from_lap_archives(
     # handshake's explicitly tagged straight-line probes from a SELECTED thermal lap may identify
     # longitudinal limits. Controller lap_index is zero-based; the archive's completed lap_n is
     # one-based at the crossing.
+    fresh_lap_numbers = {
+        int(archive["lap"]["lap_n"])
+        for archive in archives
+        if isinstance(archive.get("lap"), dict)
+        and isinstance(archive["lap"].get("lap_n"), int)
+        and not isinstance(archive["lap"].get("lap_n"), bool)
+    }
+    lap_number_offset = min(fresh_lap_numbers) - 1 if fresh_lap_numbers else 0
     selected_lap_numbers = {
         int(archive["lap"]["lap_n"])
         for archive, _ in selected
@@ -949,7 +957,7 @@ def ggv_from_lap_archives(
         if isinstance(row, dict)
         and isinstance(row.get("lap_index"), int)
         and not isinstance(row.get("lap_index"), bool)
-        and int(row["lap_index"]) + 1 in selected_lap_numbers
+        and int(row["lap_index"]) + lap_number_offset + 1 in selected_lap_numbers
     ]
     combined_rows = rows + thermal_probe_rows
     measured = ggv_from_telemetry(combined_rows, allow_passive_longitudinal=False)
@@ -959,6 +967,7 @@ def ggv_from_lap_archives(
         "friction_rows": len(rows),
         "probe_rows_seen": len(probe_rows or []),
         "probe_rows": len(thermal_probe_rows),
+        "lap_number_offset": lap_number_offset,
         "tyre_states": states,
         "selected_lap_uuids": [state.get("lap_uuid") for _, state in selected],
         "thermal_cohort": {

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -942,14 +942,21 @@ def ggv_from_lap_archives(
     # A plant is per combo, which includes tyre compound and setup. A stale archive from the same
     # car/track session must not contaminate the posterior merely because its temperatures match.
     cohort_groups: dict[tuple[object, object, object], list[tuple[dict, dict]]] = {}
-    for archive, state in eligible:
+    cohort_first_index: dict[tuple[object, object, object], int] = {}
+    for archive_index, (archive, state) in enumerate(eligible):
         compound = state.get("compound_index")
         if compound is None:
             compound = state.get("compound_name")
         key = (compound, state.get("setup_hash"), state.get("tag"))
         cohort_groups.setdefault(key, []).append((archive, state))
+        cohort_first_index.setdefault(key, archive_index)
     cohort_key, eligible = sorted(
-        cohort_groups.items(), key=lambda item: (-len(item[1]), repr(item[0]))
+        cohort_groups.items(),
+        key=lambda item: (
+            -len(item[1]),
+            0 if item[0][2] == "optimal" else 1,
+            cohort_first_index[item[0]],
+        ),
     )[0]
     core_center = statistics.median(float(state["core_temp_c"]) for _, state in eligible)
     pressure_center = statistics.median(float(state["pressure_psi"]) for _, state in eligible)

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -1017,13 +1017,20 @@ def ggv_from_lap_archives(
         and not isinstance(archive["lap"].get("lap_n"), bool)
     }
     valid_probe_run_id = isinstance(probe_run_id, str) and bool(probe_run_id.strip())
-    if valid_probe_run_id:
+    complete_run_cohort = len(selected) == len(archives)
+    if valid_probe_run_id and complete_run_cohort:
         thermal_probe_rows = [
             dict(row)
             for row in (probe_rows or [])
             if isinstance(row, dict) and row.get("probe_run_id") == probe_run_id
         ]
-        probe_attribution = "current-run nonce"
+        probe_attribution = "current-run nonce (complete thermal cohort)"
+    elif valid_probe_run_id:
+        # The nonce proves invocation identity, not tyre state. If any current-run archive is
+        # invalid, thermally ineligible, or belongs to another cohort, conservatively keep every
+        # longitudinal bin on the prior rather than assigning a probe to the wrong tyre regime.
+        thermal_probe_rows = []
+        probe_attribution = "current-run nonce rejected (incomplete thermal cohort)"
     else:
         thermal_probe_rows = [
             dict(row)

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1358,6 +1358,12 @@ class HandshakeController:
             "friction_rows": n,
             "model": None,
             "prior": self._prior_ggv_name,
+            # Preserve explicit probe evidence before the overall point-fit gate. A fresh thermal
+            # archive can supply the passive row volume while these rows retain the only trustworthy
+            # brake/WOT limit tags.
+            "provisional_probe_rows": [
+                dict(row) for row in self._friction_rows if row.get("source") != "passive"
+            ],
         }
         if n < self.min_friction_rows:
             block["reason"] = f"insufficient friction rows: {n} < {self.min_friction_rows}"
@@ -1377,9 +1383,6 @@ class HandshakeController:
         # Ephemeral handoff only: refinement consumes these explicitly tagged live probe rows and
         # replaces the whole block before evidence/persistence. The lap archive proves the thermal
         # state; these tags prove which longitudinal samples were actually limit-reaching probes.
-        block["provisional_probe_rows"] = [
-            dict(row) for row in self._friction_rows if row.get("source") != "passive"
-        ]
         block["reason"] = "awaiting thermally tagged lap archive"
         return block
 
@@ -1411,6 +1414,14 @@ def refine_ggv_from_lap_archives(
     for hermetic tests. The result is mutated and returned so evidence and persistence consume the
     same final block.
     """
+    if "ggv" not in result or not isinstance(result.get("ggv"), dict):
+        # No prior was injected into HandshakeController, so friction ID was explicitly disabled.
+        # Thermal archives must not resurrect an unrequested GGV block.
+        return {
+            "ok": False,
+            "skipped": True,
+            "reason": "friction identification was not requested",
+        }
     loaded: list[dict] = []
     load_errors: list[str] = []
     for item in archives:
@@ -1469,6 +1480,7 @@ def refine_ggv_from_lap_archives(
         "lap_archives_loaded": len(matching),
         "load_errors": load_errors,
         "identity_notes": identity_notes,
+        "provisional_reason": previous_ggv.get("reason"),
     }
     try:
         model, summary = ggv_from_lap_archives(

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1492,6 +1492,12 @@ def refine_ggv_from_lap_archives(
             )
             continue
         if expected_layout is not None and actual_layout is None:
+            if not archives_same_run:
+                load_errors.append(
+                    f"archive {payload.get('lap_uuid') or '?'} omitted layout outside "
+                    "current-run scope"
+                )
+                continue
             # The current in-game archive schema does not serialize layout. These paths are
             # restricted to archives written after this run started, while car+track still match;
             # preserve the missing-layout fact rather than rejecting every multi-layout handshake.

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -40,6 +40,7 @@ import json
 import logging
 import math
 import re
+import uuid
 from dataclasses import asdict, dataclass
 from dataclasses import replace as dc_replace
 from pathlib import Path
@@ -760,6 +761,7 @@ class HandshakeController:
         self._laps = 0
         self._completed_laps_baseline: int | None = None
         self._uses_completed_laps = False
+        self._probe_run_id = uuid.uuid4().hex
         self._t_start: float | None = None
         self._prev_heading: tuple[float, float] | None = None
         self._prev_now: float | None = None
@@ -819,13 +821,6 @@ class HandshakeController:
             self._speed_hist.pop(0)
 
         self._mine_gear_ratio(now, rpm, gear, speed_kmh)
-        # Pure/off-sim fallback. On the rig, _mine_friction observes AC's authoritative
-        # acpmf_graphics.completedLaps and takes ownership of this counter below; the line-based
-        # driver's wrap heuristic can fire early when a probe rejoins near S/F and must not end a
-        # two-lap thermal handshake after only one real AC lap.
-        if base.lap_completed and not self._uses_completed_laps:
-            self._laps += 1
-
         if base.needs_recovery:
             # rig loop answers with a teleport + on_recovery(); abort the active probe here so a
             # half-captured maneuver never contaminates a fit.
@@ -836,6 +831,12 @@ class HandshakeController:
         # frame (throttled). Runs across all phases — the corner sequence supplies lateral rows, the
         # WOT sweep accel rows, and the brake probe the braking envelope.
         self._mine_friction(now)
+
+        # Pure/off-sim fallback. Observe the optional authoritative graphics counter first so an
+        # already-available counter suppresses a false geometric wrap. If graphics appears late,
+        # _mine_friction bridges its baseline without reducing laps already counted here.
+        if base.lap_completed and not self._uses_completed_laps:
+            self._laps += 1
 
         frame = base
         if self._active is not None:
@@ -996,7 +997,10 @@ class HandshakeController:
             and completed_laps >= 0
         ):
             if self._completed_laps_baseline is None:
-                self._completed_laps_baseline = completed_laps
+                # Preserve laps already observed through the geometry fallback if graphics became
+                # available late. A negative internal baseline is valid here: it is an affine
+                # bridge between two counters, not an AC lap number.
+                self._completed_laps_baseline = completed_laps - self._laps
             self._uses_completed_laps = True
             self._laps = max(0, completed_laps - self._completed_laps_baseline)
         speed = getattr(phys, "speed_kmh", None)
@@ -1024,22 +1028,16 @@ class HandshakeController:
                     source = "brake_probe"
                 elif kind == "accel_sweep" and stage == "wot":
                     source = "accel_sweep"
-            lap_number = None
-            if (
-                isinstance(completed_laps, int)
-                and not isinstance(completed_laps, bool)
-                and completed_laps >= 0
-            ):
-                # Rows gathered before the crossing belong to the lap that the archive will write
-                # as completedLaps + 1. This is absolute AC session state, not a guessed offset.
-                lap_number = completed_laps + 1
             self._friction_rows.append(
                 {
                     "speed_kmh": float(speed),
                     "accg_lat": float(ay),
                     "accg_lon": float(ao),
                     "source": source,
-                    "lap_number": lap_number,
+                    # ``completedLaps`` counts only AC-valid laps while the app archive counter also
+                    # advances across invalid boundaries. Attribute live probes with an invocation
+                    # nonce instead; auto_drive only trusts it beside archives filtered to this run.
+                    "probe_run_id": self._probe_run_id,
                 }
             )
 
@@ -1390,6 +1388,7 @@ class HandshakeController:
             "friction_rows": n,
             "model": None,
             "prior": self._prior_ggv_name,
+            "probe_run_id": self._probe_run_id,
             # Preserve explicit probe evidence before the overall point-fit gate. A fresh thermal
             # archive can supply the passive row volume while these rows retain the only trustworthy
             # brake/WOT limit tags.
@@ -1439,6 +1438,7 @@ def refine_ggv_from_lap_archives(
     prior: GGVModel,
     *,
     prior_name: str = "generic_gt3_ggv",
+    archives_same_run: bool = False,
 ) -> dict:
     """Replace a handshake's provisional GGV with a thermally gated schema-v3 model.
 
@@ -1504,6 +1504,7 @@ def refine_ggv_from_lap_archives(
     probe_rows = previous_ggv.get("provisional_probe_rows", [])
     if not isinstance(probe_rows, list):
         probe_rows = []
+    probe_run_id = previous_ggv.get("probe_run_id") if archives_same_run else None
     block: dict = {
         "ok": False,
         "model": None,
@@ -1516,7 +1517,11 @@ def refine_ggv_from_lap_archives(
     }
     try:
         model, summary = ggv_from_lap_archives(
-            matching, prior, prior_name=prior_name, probe_rows=probe_rows
+            matching,
+            prior,
+            prior_name=prior_name,
+            probe_rows=probe_rows,
+            probe_run_id=probe_run_id if isinstance(probe_run_id, str) else None,
         )
     except (ValueError, ZeroDivisionError, KeyError, TypeError) as exc:
         logger.exception("thermal uncertainty fit failed; ggv block degrades to the generic plant")

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -49,6 +49,7 @@ from tools.ac_harness.ggv_profile import (
     GGVModel,
     blend_ggv_safe,
     fit_steer_feedforward,
+    ggv_from_lap_archives,
     ggv_from_telemetry,
     seg_lengths,
     signed_curvature_profile,
@@ -57,11 +58,11 @@ from tools.ac_harness.lap_driver import PHASE_LAP, DriveFrame
 from tools.ac_harness.racing_driver import RacingDriver
 
 G = 9.81
-# Schema v2 (#532 Part B) adds the optional ``ggv`` block (per-combo friction plant) alongside the
-# v1 ``constants``. v1 artifacts (Part A: shift points + steering only, no ggv block) still load —
-# their ggv consumption falls back to the generic plant — so Part A artifacts are not invalidated.
-PLANT_SCHEMA_VERSION = 2
-SUPPORTED_PLANT_SCHEMA_VERSIONS = (1, 2)
+# Schema v3 (#543) makes the optional ``ggv`` block uncertainty- and thermal-state-aware. Schema-v1
+# and schema-v2 constants still load, but their absent/point-estimate GGV blocks fall back to the
+# generic runtime plant until a new thermally tagged handshake produces a schema-v3 uncertainty map.
+PLANT_SCHEMA_VERSION = 3
+SUPPORTED_PLANT_SCHEMA_VERSIONS = (1, 2, 3)
 # Constants a persisted plant artifact MUST carry (a fully-passed handshake produces all of them);
 # a partial artifact is rejected on load so `--use-plant full` never silently degrades.
 REQUIRED_PLANT_CONSTANTS = ("ff_sign", "ff_c1", "ff_c2", "rpm_up", "rpm_dn", "r_eff_m")
@@ -1338,17 +1339,13 @@ class HandshakeController:
         self.finished = True
 
     def _build_ggv_block(self) -> dict | None:
-        """Fit the per-combo friction plant from captured rows and safe-envelope-blend the prior.
+        """Build a provisional point fit pending the thermally tagged lap archive (#543).
 
-        Returns ``None`` when no prior was injected (no trusted basis for a safe blend — the ggv
-        driver keeps its generic plant). Otherwise returns a block recording the outcome:
-
-        * ``ok=True`` with a blended ``model`` (a :class:`~tools.ac_harness.ggv_profile.GGVModel`
-          serialized via ``to_dict``) when enough friction rows were captured AND the fit succeeded;
-        * ``ok=False`` with a ``reason`` and ``model=None`` otherwise — a VISIBLE degrade in
-          the artifact + diagnostics, so the consumer falls back to the generic plant without a
-          silent swallow (the ggv block is ADVISORY; unlike the 5 core constants it never gates
-          ``HandshakeResult.ok``).
+        Live physics rows do not contain the canonical #488 tyre channels, so even a successful
+        point fit is diagnostics-only. The block remains ``ok=False`` until
+        :func:`refine_ggv_from_lap_archives` observes the immutable archive and builds the thermal,
+        per-speed-bin uncertainty map. This is advisory and never gates the core handshake
+        constants.
         """
         if self._prior_ggv is None:
             return None
@@ -1371,9 +1368,10 @@ class HandshakeController:
             logger.exception("friction-ID fit failed; ggv block degrades to the generic plant")
             block["reason"] = f"friction fit error: {type(exc).__name__}: {exc}"
             return block
-        block["ok"] = True
-        block["model"] = blended.to_dict()
-        block["reason"] = "ok"
+        # The live rows have no tyre-state channels. Keep the point fit for diagnostics only;
+        # refine_ggv_from_lap_archives replaces it after the immutable #488 archive is observed.
+        block["provisional_model"] = blended.to_dict()
+        block["reason"] = "awaiting thermally tagged lap archive"
         return block
 
     def finalize(self, now: float | None = None) -> None:
@@ -1391,6 +1389,79 @@ class HandshakeController:
 # ---------------------------------------------------------------------------
 # Per-combo plant artifact (durable — NEVER .scratch; see module docstring)
 # ---------------------------------------------------------------------------
+def refine_ggv_from_lap_archives(
+    result: dict,
+    archives: list[str | Path | dict],
+    prior: GGVModel,
+    *,
+    prior_name: str = "generic_gt3_ggv",
+) -> dict:
+    """Replace a handshake's provisional GGV with a thermally gated schema-v3 model.
+
+    ``archives`` may contain paths from ``auto_drive.collect_lap_archives`` or already-loaded dicts
+    for hermetic tests. The result is mutated and returned so evidence and persistence consume the
+    same final block.
+    """
+    loaded: list[dict] = []
+    load_errors: list[str] = []
+    for item in archives:
+        if isinstance(item, dict):
+            loaded.append(item)
+            continue
+        try:
+            payload = json.loads(Path(item).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            load_errors.append(f"{item}: {type(exc).__name__}")
+            continue
+        if isinstance(payload, dict):
+            loaded.append(payload)
+        else:
+            load_errors.append(f"{item}: archive root is not an object")
+    expected_car = str(result.get("car_id") or "")
+    expected_track = str(result.get("track_id") or "")
+    expected_layout = result.get("layout") or None
+    matching: list[dict] = []
+    for payload in loaded:
+        car = payload.get("car") if isinstance(payload.get("car"), dict) else {}
+        track = payload.get("track") if isinstance(payload.get("track"), dict) else {}
+        actual_car = str(car.get("id") or "")
+        actual_track = str(track.get("id") or "")
+        actual_layout = track.get("layout") or None
+        if (
+            actual_car != expected_car
+            or actual_track != expected_track
+            or actual_layout != expected_layout
+        ):
+            load_errors.append(
+                "archive identity mismatch: "
+                f"expected {expected_car}/{expected_track}/{expected_layout or '-'}, "
+                f"got {actual_car}/{actual_track}/{actual_layout or '-'}"
+            )
+            continue
+        matching.append(payload)
+    block: dict = {
+        "ok": False,
+        "model": None,
+        "prior": prior_name,
+        "lap_archives_seen": len(archives),
+        "lap_archives_loaded": len(matching),
+        "load_errors": load_errors,
+    }
+    try:
+        model, summary = ggv_from_lap_archives(matching, prior, prior_name=prior_name)
+    except (ValueError, ZeroDivisionError, KeyError, TypeError) as exc:
+        logger.exception("thermal uncertainty fit failed; ggv block degrades to the generic plant")
+        block["reason"] = f"thermal uncertainty fit error: {type(exc).__name__}: {exc}"
+        result["ggv"] = block
+        return block
+    block.update(summary)
+    block["ok"] = True
+    block["model"] = model.to_dict()
+    block["reason"] = "ok"
+    result["ggv"] = block
+    return block
+
+
 def _setup_stem(setup: str | None) -> str | None:
     """The setup basename without ``.ini`` (or None), for a path-free identity sanity-check."""
     if not setup:
@@ -1467,6 +1538,14 @@ def save_plant_artifact(user_dir: Path, result: dict) -> Path:
     """
     if not result.get("ok"):
         raise ValueError("refusing to persist a failed handshake as a plant artifact")
+    ggv = result.get("ggv")
+    if isinstance(ggv, dict) and ggv.get("ok"):
+        model_data = ggv.get("model")
+        model = GGVModel.from_dict(model_data) if isinstance(model_data, dict) else None
+        if model is None or not model.uncertainty_aware:
+            raise ValueError(
+                "refusing to persist an ok schema-v3 ggv block without uncertainty bins"
+            )
     car_id = str(result.get("car_id") or "")
     track_id = str(result.get("track_id") or "")
     if not car_id or not track_id:
@@ -1586,7 +1665,11 @@ def plant_ggv_model(artifact: dict) -> GGVModel | None:
     if not isinstance(model, dict):
         return None
     try:
-        return GGVModel.from_dict(model)
+        restored = GGVModel.from_dict(model)
+        # Schema-v1/v2 point estimates remain readable for provenance and their measured constants,
+        # but #543 requires runtime friction to carry epistemic uncertainty. Until re-identified,
+        # the caller keeps the generic plant rather than acting on false precision.
+        return restored if restored.uncertainty_aware else None
     except (ValueError, TypeError):
         logger.warning(
             "plant artifact ggv block present but its model is invalid; using the generic plant"

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -999,15 +999,23 @@ class HandshakeController:
                     source = "brake_probe"
                 elif kind == "accel_sweep" and stage == "wot":
                     source = "accel_sweep"
+            completed_laps = getattr(phys, "completed_laps", None)
+            lap_number = None
+            if (
+                isinstance(completed_laps, int)
+                and not isinstance(completed_laps, bool)
+                and completed_laps >= 0
+            ):
+                # Rows gathered before the crossing belong to the lap that the archive will write
+                # as completedLaps + 1. This is absolute AC session state, not a guessed offset.
+                lap_number = completed_laps + 1
             self._friction_rows.append(
                 {
                     "speed_kmh": float(speed),
                     "accg_lat": float(ay),
                     "accg_lon": float(ao),
                     "source": source,
-                    # The archive writes state.lapsCompleted at the crossing, so samples gathered
-                    # during this zero-based controller lap map to archive lap_n = lap_index + 1.
-                    "lap_index": self._laps,
+                    "lap_number": lap_number,
                 }
             )
 

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -758,6 +758,8 @@ class HandshakeController:
         self._friction_packet_id: int | None = None
         self._ratio_samples: dict[int, list[float]] = {}
         self._laps = 0
+        self._completed_laps_baseline: int | None = None
+        self._uses_completed_laps = False
         self._t_start: float | None = None
         self._prev_heading: tuple[float, float] | None = None
         self._prev_now: float | None = None
@@ -817,7 +819,11 @@ class HandshakeController:
             self._speed_hist.pop(0)
 
         self._mine_gear_ratio(now, rpm, gear, speed_kmh)
-        if base.lap_completed:
+        # Pure/off-sim fallback. On the rig, _mine_friction observes AC's authoritative
+        # acpmf_graphics.completedLaps and takes ownership of this counter below; the line-based
+        # driver's wrap heuristic can fire early when a probe rejoins near S/F and must not end a
+        # two-lap thermal handshake after only one real AC lap.
+        if base.lap_completed and not self._uses_completed_laps:
             self._laps += 1
 
         if base.needs_recovery:
@@ -843,7 +849,16 @@ class HandshakeController:
 
         if not self.finished:
             done_probing = not self._pending and self._active is None
-            if (done_probing and len(self._rows) >= self.min_corner_rows) or (
+            # The uncertainty fit is intentionally archive-backed: live physics has the designed
+            # probe rows but not the canonical per-wheel thermal channels. When a GGV prior is
+            # enabled, do not self-terminate merely because the scalar probes finished before the
+            # first S/F crossing. That first crossing only closes the PARTIAL lap containing the
+            # probes and can legitimately yield a sparse/refused archive; continue for the clean
+            # post-probe lap and finish at the existing two-lap cap. Without this gate a fresh rig
+            # run persisted either a prior-only artifact (laps_used=0) or a one-row probe-tail
+            # archive, making the #543 thermal observer impossible to exercise end to end.
+            thermal_lap_ready = self._prior_ggv is None or self._laps >= self.max_laps
+            if (done_probing and len(self._rows) >= self.min_corner_rows and thermal_lap_ready) or (
                 self._laps >= self.max_laps
             ):
                 self._finish(now)
@@ -974,6 +989,16 @@ class HandshakeController:
         phys = self._read_phys()
         if phys is None:
             return
+        completed_laps = getattr(phys, "completed_laps", None)
+        if (
+            isinstance(completed_laps, int)
+            and not isinstance(completed_laps, bool)
+            and completed_laps >= 0
+        ):
+            if self._completed_laps_baseline is None:
+                self._completed_laps_baseline = completed_laps
+            self._uses_completed_laps = True
+            self._laps = max(0, completed_laps - self._completed_laps_baseline)
         speed = getattr(phys, "speed_kmh", None)
         ay = getattr(phys, "accg_lat", None)
         ao = getattr(phys, "accg_lon", None)
@@ -999,7 +1024,6 @@ class HandshakeController:
                     source = "brake_probe"
                 elif kind == "accel_sweep" and stage == "wot":
                     source = "accel_sweep"
-            completed_laps = getattr(phys, "completed_laps", None)
             lap_number = None
             if (
                 isinstance(completed_laps, int)

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1005,6 +1005,9 @@ class HandshakeController:
                     "accg_lat": float(ay),
                     "accg_lon": float(ao),
                     "source": source,
+                    # The archive writes state.lapsCompleted at the crossing, so samples gathered
+                    # during this zero-based controller lap map to archive lap_n = lap_index + 1.
+                    "lap_index": self._laps,
                 }
             )
 
@@ -1371,6 +1374,12 @@ class HandshakeController:
         # The live rows have no tyre-state channels. Keep the point fit for diagnostics only;
         # refine_ggv_from_lap_archives replaces it after the immutable #488 archive is observed.
         block["provisional_model"] = blended.to_dict()
+        # Ephemeral handoff only: refinement consumes these explicitly tagged live probe rows and
+        # replaces the whole block before evidence/persistence. The lap archive proves the thermal
+        # state; these tags prove which longitudinal samples were actually limit-reaching probes.
+        block["provisional_probe_rows"] = [
+            dict(row) for row in self._friction_rows if row.get("source") != "passive"
+        ]
         block["reason"] = "awaiting thermally tagged lap archive"
         return block
 
@@ -1421,6 +1430,7 @@ def refine_ggv_from_lap_archives(
     expected_track = str(result.get("track_id") or "")
     expected_layout = result.get("layout") or None
     matching: list[dict] = []
+    identity_notes: list[str] = []
     for payload in loaded:
         car = payload.get("car") if isinstance(payload.get("car"), dict) else {}
         track = payload.get("track") if isinstance(payload.get("track"), dict) else {}
@@ -1430,7 +1440,7 @@ def refine_ggv_from_lap_archives(
         if (
             actual_car != expected_car
             or actual_track != expected_track
-            or actual_layout != expected_layout
+            or (actual_layout is not None and actual_layout != expected_layout)
         ):
             load_errors.append(
                 "archive identity mismatch: "
@@ -1438,7 +1448,19 @@ def refine_ggv_from_lap_archives(
                 f"got {actual_car}/{actual_track}/{actual_layout or '-'}"
             )
             continue
+        if expected_layout is not None and actual_layout is None:
+            # The current in-game archive schema does not serialize layout. These paths are
+            # restricted to archives written after this run started, while car+track still match;
+            # preserve the missing-layout fact rather than rejecting every multi-layout handshake.
+            identity_notes.append(
+                f"archive {payload.get('lap_uuid') or '?'} omitted layout; "
+                f"accepted current-run {expected_layout!r} context"
+            )
         matching.append(payload)
+    previous_ggv = result.get("ggv") if isinstance(result.get("ggv"), dict) else {}
+    probe_rows = previous_ggv.get("provisional_probe_rows", [])
+    if not isinstance(probe_rows, list):
+        probe_rows = []
     block: dict = {
         "ok": False,
         "model": None,
@@ -1446,9 +1468,12 @@ def refine_ggv_from_lap_archives(
         "lap_archives_seen": len(archives),
         "lap_archives_loaded": len(matching),
         "load_errors": load_errors,
+        "identity_notes": identity_notes,
     }
     try:
-        model, summary = ggv_from_lap_archives(matching, prior, prior_name=prior_name)
+        model, summary = ggv_from_lap_archives(
+            matching, prior, prior_name=prior_name, probe_rows=probe_rows
+        )
     except (ValueError, ZeroDivisionError, KeyError, TypeError) as exc:
         logger.exception("thermal uncertainty fit failed; ggv block degrades to the generic plant")
         block["reason"] = f"thermal uncertainty fit error: {type(exc).__name__}: {exc}"

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1472,6 +1472,7 @@ def refine_ggv_from_lap_archives(
     expected_car = str(result.get("car_id") or "")
     expected_track = str(result.get("track_id") or "")
     expected_layout = result.get("layout") or None
+    expected_setup = _setup_stem(result.get("setup"))
     matching: list[dict] = []
     identity_notes: list[str] = []
     for payload in loaded:
@@ -1480,6 +1481,10 @@ def refine_ggv_from_lap_archives(
         actual_car = str(car.get("id") or "")
         actual_track = str(track.get("id") or "")
         actual_layout = track.get("layout") or None
+        archive_setup = payload.get("setup") if isinstance(payload.get("setup"), dict) else {}
+        snapshot = archive_setup.get("snapshot")
+        snapshot_path = snapshot.get("path") if isinstance(snapshot, dict) else None
+        actual_setup = _setup_stem(archive_setup.get("path") or snapshot_path)
         if (
             actual_car != expected_car
             or actual_track != expected_track
@@ -1491,6 +1496,19 @@ def refine_ggv_from_lap_archives(
                 f"got {actual_car}/{actual_track}/{actual_layout or '-'}"
             )
             continue
+        if not archives_same_run:
+            setup_proven = actual_setup == expected_setup
+            if expected_setup is None and actual_setup is None:
+                # A default setup is provable only when the archive carries no setup content. A
+                # nonempty hash/snapshot with no path is an unidentified custom setup.
+                archive_hash = archive_setup.get("hash")
+                setup_proven = not archive_hash and snapshot in (None, {}, [])
+            if not setup_proven:
+                load_errors.append(
+                    f"archive {payload.get('lap_uuid') or '?'} setup mismatch: "
+                    f"expected {expected_setup or 'default'}, got {actual_setup or 'unidentified'}"
+                )
+                continue
         if expected_layout is not None and actual_layout is None:
             if not archives_same_run:
                 load_errors.append(

--- a/tools/ac_harness/racing_telemetry.py
+++ b/tools/ac_harness/racing_telemetry.py
@@ -57,6 +57,8 @@ class PhysFrame:
     # wheelAngularSpeed[4]@104 (rad/s, FL FR RL RR) — the r_eff / slip-ratio channel (#532 P1
     # handshake). Defaulted so pre-existing positional constructions stay valid.
     wheel_omega: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
+    # Absolute acpmf_graphics completedLaps injected by the rig reader for probe/archive matching.
+    completed_laps: int | None = None
 
 
 @dataclass(frozen=True)

--- a/tools/ac_harness/shared_memory.py
+++ b/tools/ac_harness/shared_memory.py
@@ -78,6 +78,7 @@ from enum import IntEnum
 GRAPHICS_PACKET_ID_OFFSET = 0
 GRAPHICS_STATUS_OFFSET = 4
 GRAPHICS_IS_IN_PIT_OFFSET = 160
+GRAPHICS_COMPLETED_LAPS_OFFSET = 132
 # Minimum bytes that must be readable to decode every field above (isInPit + its 4 bytes).
 GRAPHICS_MIN_BYTES = GRAPHICS_IS_IN_PIT_OFFSET + 4  # 164
 
@@ -168,6 +169,7 @@ class GraphicsSnapshot:
     packet_id: int
     status: AcGameStatus | int
     is_in_pit: bool
+    completed_laps: int | None = None
 
     @property
     def is_live(self) -> bool:
@@ -205,10 +207,12 @@ def parse_graphics(buf: bytes) -> GraphicsSnapshot:
     packet_id = struct.unpack_from("<i", buf, GRAPHICS_PACKET_ID_OFFSET)[0]
     status_raw = struct.unpack_from("<i", buf, GRAPHICS_STATUS_OFFSET)[0]
     is_in_pit_raw = struct.unpack_from("<i", buf, GRAPHICS_IS_IN_PIT_OFFSET)[0]
+    completed_laps = struct.unpack_from("<i", buf, GRAPHICS_COMPLETED_LAPS_OFFSET)[0]
     return GraphicsSnapshot(
         packet_id=packet_id,
         status=AcGameStatus.from_int(status_raw),
         is_in_pit=is_in_pit_raw != 0,
+        completed_laps=completed_laps,
     )
 
 


### PR DESCRIPTION
## Summary
- promote plant-ID to schema v3 with validated per-speed-bin Bayesian grip uncertainty and lower-confidence runtime bounds
- observe immutable #488 tyre telemetry and fit only valid, thermally stable compound/setup/temperature cohorts
- preserve schema-v1/v2 constants while rejecting point-estimate friction at runtime until re-identification
- harden live archive identity, lap-count authority, telemetry isolation, and CSP lap-wrap skew discovered by the rig harness

## Safety contract
- unmeasured bins consume a conservative generic-prior lower bound
- no neighbouring-bin or upward extrapolation; above-map speeds retain the last safe bound
- QSS always consumes `min(point estimate, lower confidence bound)`
- stale car/track/layout archives and mixed compound/setup/thermal cohorts cannot enter the fit

## Verification
- [x] focused suites: 164 passed after live-found fixes
- [x] `make ci-fast`: 2,708 passed, 113 skipped, 87.29% coverage
- [x] live handshake: 2 AC-valid automated laps, 0 recoveries, strict pipeline PASS; schema-v3 artifact with 30 uncertainty bins and `ggv.ok=true`
- [x] live identified plant: `--driver ggv --use-plant full`, AC-valid 123.557 s lap, 199.8 km/h, 0 recoveries/spins, strict pipeline PASS

## Rig evidence
- identification: `.scratch/harness-evidence/20260713T225745Z_ks_porsche_911_gt3_r_2016_magione/report.json`
- identified-plant lap: `.scratch/harness-evidence/20260713T230646Z_ks_porsche_911_gt3_r_2016_magione/report.json`
- plant artifact: `%USERPROFILE%/OneDrive/Documents/Assetto Corsa/plant_id/ks_porsche_911_gt3_r_2016__magione.json`

Closes #543