### PR TITLE
feat(harness): #572 — one-button alien pipeline (plant-ID → optimized line → QSS → drive)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -123,6 +123,37 @@ core/surface temperature changes lateral behaviour and pressure tracks temperatu
 [SAE tyre core/surface temperature study](https://saemobilus.sae.org/articles/influence-tire-core-surface-temperature-lateral-tire-characteristics-2014-01-0074), and
 [SAE tyre temperature/pressure study](https://saemobilus.sae.org/papers/estimating-tire-pressure-based-different-tire-temperature-measurement-points-2024-01-5002).
 
+## One-button alien pipeline (#529 P2 / #572 — plant-ID → optimized line → QSS → drive)
+
+`auto_alien` composes the handshake and the drive into one command: it ensures the combo's
+identified plant (running the handshake+ID session first when the artifact is missing, forced,
+or lacks the uncertainty-aware friction fit), then drives the **min-curvature optimized line**
+with the QSS min-time profile computed against that plant:
+
+```bash
+# Nothing pre-existing needed — identifies the plant if absent, then drives the optimized line:
+python -m tools.ac_harness.auto_alien --car ks_porsche_911_gt3_r_2016 --track magione
+
+# The drive stage alone (requires the plant artifact; builds/reuses the line cache):
+python -m tools.ac_harness.auto_drive --car ks_porsche_911_gt3_r_2016 --track magione \
+    --driver alien --wait-lap
+```
+
+- The optimized line + profile persist as a per-combo artifact under
+  `<AC user data>/alien_line/<car>__<track>[__layout-…][__setup-…].json` — the **same identity
+  stem as the plant artifact** (car+track+layout+setup content hash), plus two provenance gates:
+  the exact plant-fit content hash and the `fast_lane.ai` content hash. A re-identified plant, a
+  re-baked AI line, or changed build params rejects the cache and rebuilds; a stale line is never
+  silently driven.
+- The corridor (`sideLeft`/`sideRight` from the AiPointExtra block) is validated before the QP —
+  a drifted binary layout fails loudly instead of producing an off-track "optimized" line — and
+  the built profile is re-verified against the plant's lateral envelope.
+- Stage failures abort the pipeline honestly (`alien_report.json` names the failed stage and its
+  evidence bundle). There is no fallback to the stock line or the generic plant anywhere in the
+  alien path; `--driver alien` without a usable plant exits with instructions, it never degrades.
+- `--force-identify` re-runs identification; `--rebuild-line` (or `--alien-rebuild-line` on
+  `auto_drive`) rebuilds the line cache from the current plant.
+
 ## Composing downstream tasks (don't reinvent)
 
 - **Setup A/B**: run twice with different `--setup` names; compare the runs' lap archives with

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -644,6 +644,41 @@ def test_build_driver_ggv_builds_min_time_racingdriver():
     assert d.max_gear >= 6  # top gears available for flat-out straights
 
 
+_ALIEN_PLANT_KWARGS = {
+    "steering_mode": "curvature_ff",
+    "ff_sign": -1.0,
+    "ff_c1": -5.1,
+    "ff_c2": -0.0033,
+    "rpm_up": 8500.0,
+    "rpm_dn": 6200.0,
+}
+
+
+def test_build_driver_alien_tracks_resolved_line_and_profile():
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    cfg = _cfg(
+        driver="alien",
+        alien_line=_LINE,
+        alien_v_target=[50.0, 40.0, 45.0, 40.0],
+        plant_kwargs=dict(_ALIEN_PLANT_KWARGS),
+        ggv_scale=0.9,
+    )
+    d = _build_driver(cfg, _LINE, None)
+    assert isinstance(d, RacingDriver)
+    # ggv_scale applies at construction: the profile the driver tracks is the scaled optimum.
+    assert max(d.profile) == pytest.approx(50.0 * 0.9)
+
+
+def test_build_driver_alien_requires_line_and_plant():
+    with pytest.raises(ValueError, match="alien-line artifact"):
+        _build_driver(_cfg(driver="alien", plant_kwargs=dict(_ALIEN_PLANT_KWARGS)), _LINE, None)
+    with pytest.raises(ValueError, match="measured plant constants"):
+        _build_driver(
+            _cfg(driver="alien", alien_line=_LINE, alien_v_target=[40.0] * 4), _LINE, None
+        )
+
+
 def test_generic_gt3_ggv_is_realistic():
     from tools.ac_harness.ggv_profile import GGVModel
 

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import pathlib
 import threading
+from dataclasses import replace
 
 import pytest
 
@@ -677,6 +678,22 @@ def test_build_driver_alien_requires_line_and_plant():
         _build_driver(
             _cfg(driver="alien", alien_line=_LINE, alien_v_target=[40.0] * 4), _LINE, None
         )
+
+
+def test_build_driver_alien_rejects_overspeed_scale():
+    # The artifact's v_target is envelope-verified at build time; a scale above 1 would push
+    # corner speeds past the verified plant envelope after that check.
+    cfg = _cfg(
+        driver="alien",
+        alien_line=_LINE,
+        alien_v_target=[40.0] * 4,
+        plant_kwargs=dict(_ALIEN_PLANT_KWARGS),
+        ggv_scale=1.1,
+    )
+    with pytest.raises(ValueError, match="ggv_scale"):
+        _build_driver(cfg, _LINE, None)
+    with pytest.raises(ValueError, match="ggv_scale"):
+        _build_driver(replace(cfg, ggv_scale=0.0), _LINE, None)
 
 
 def test_generic_gt3_ggv_is_realistic():

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -1,0 +1,293 @@
+"""Tests for the #572 alien-line artifact: build, corridor validation, cache identity gates."""
+
+from __future__ import annotations
+
+import json
+import math
+import struct
+
+import pytest
+
+from tools.ac_harness.alien_line import (
+    ALIEN_LINE_SCHEMA_VERSION,
+    alien_line_path,
+    build_alien_line_artifact,
+    ensure_alien_line_artifact,
+    fast_lane_sha12,
+    load_alien_line_artifact,
+    plant_provenance,
+    save_alien_line_artifact,
+    validate_corridor,
+)
+from tools.ac_harness.auto_drive import generic_gt3_ggv
+
+_N = 240
+_R = 120.0
+
+
+def _circle_line(n: int = _N, r: float = _R) -> list[tuple[float, float, float]]:
+    return [
+        (r * math.cos(2 * math.pi * i / n), 0.0, r * math.sin(2 * math.pi * i / n))
+        for i in range(n)
+    ]
+
+
+def _write_fast_lane(path, pts, side_left, side_right) -> None:
+    """Minimal valid fast_lane.ai: v7 header + 20-byte points + 72-byte AiPointExtra block."""
+    buf = bytearray(struct.pack("<4i", 7, len(pts), 0, len(pts)))
+    for x, y, z in pts:
+        buf += struct.pack("<3f", x, y, z)
+        buf += struct.pack("<f", 0.0)  # length
+        buf += struct.pack("<i", 0)  # id
+    buf += struct.pack("<i", len(pts))  # lap extra
+    for i in range(len(pts)):
+        extra = bytearray(72)
+        struct.pack_into("<2f", extra, 20, side_left[i], side_right[i])
+        buf += extra
+    path.write_bytes(bytes(buf))
+
+
+def _plant_artifact(seed: str = "a") -> dict:
+    return {"schema_version": 3, "created_utc": "2026-07-14T00:00:00Z", "constants": {"k": seed}}
+
+
+@pytest.fixture
+def lane(tmp_path):
+    pts = _circle_line()
+    path = tmp_path / "fast_lane.ai"
+    _write_fast_lane(path, pts, [6.0] * _N, [6.0] * _N)
+    return path, pts
+
+
+def test_build_artifact_stays_in_corridor_and_respects_envelope(lane):
+    path, pts = lane
+    plant = generic_gt3_ggv()
+    art = build_alien_line_artifact(
+        pts,
+        path,
+        plant,
+        _plant_artifact(),
+        car_id="car_a",
+        track_id="trk",
+        margin_m=1.0,
+        iters=400,
+        v_top_kmh=220.0,
+    )
+    assert art["schema_version"] == ALIEN_LINE_SCHEMA_VERSION
+    assert len(art["line"]) == _N and len(art["v_target_mps"]) == _N
+    # Every optimized point stays within (side - margin) of its base point (corridor bound).
+    for base, opt in zip(pts, art["line"], strict=True):
+        off = math.hypot(opt[0] - base[0], opt[2] - base[2])
+        assert off <= 6.0 - 1.0 + 1e-6
+        assert opt[1] == base[1]  # y carried through
+    assert art["qss"]["qss_laptime_s"] > 0
+    assert art["corridor"]["max_ay_utilisation"] <= 1.0 + 1e-6
+    assert all(v > 0 and math.isfinite(v) for v in art["v_target_mps"])
+    # On a constant-curvature circle the corner speed must sit on the lateral envelope,
+    # not above it: v^2 * kappa <= ay_max(v) [m/s^2] everywhere (checked by the builder).
+    v0 = art["v_target_mps"][0]
+    assert v0 * v0 * (1.0 / _R) <= plant.ay_max(v0) * 1.05
+
+
+def test_build_rejects_short_line(lane):
+    path, _ = lane
+    with pytest.raises(ValueError, match="at least 3"):
+        build_alien_line_artifact(
+            [(0.0, 0.0, 0.0)], path, generic_gt3_ggv(), _plant_artifact(), car_id="c", track_id="t"
+        )
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "match"),
+    [
+        ([float("nan")] + [6.0] * (_N - 1), [6.0] * _N, "non-finite"),
+        ([-1.0] + [6.0] * (_N - 1), [6.0] * _N, "absurd"),
+        ([120.0] + [6.0] * (_N - 1), [6.0] * _N, "absurd"),
+        ([1.0] + [6.0] * (_N - 1), [1.0] + [6.0] * (_N - 1), "narrower than a car"),
+        ([6.0] * (_N - 1), [6.0] * _N, "length mismatch"),
+    ],
+)
+def test_validate_corridor_fails_loud(left, right, match):
+    with pytest.raises(ValueError, match=match):
+        validate_corridor(left, right, _N)
+
+
+def test_build_fails_loud_on_garbage_corridor(tmp_path):
+    pts = _circle_line()
+    path = tmp_path / "fast_lane.ai"
+    # A drifted AiPointExtra layout parses "successfully" into absurd widths.
+    _write_fast_lane(path, pts, [4242.0] * _N, [6.0] * _N)
+    with pytest.raises(ValueError, match="absurd corridor width"):
+        build_alien_line_artifact(
+            pts, path, generic_gt3_ggv(), _plant_artifact(), car_id="c", track_id="t"
+        )
+
+
+def _build_and_save(tmp_path, lane, plant_art, **kw):
+    path, pts = lane
+    art = build_alien_line_artifact(
+        pts,
+        path,
+        generic_gt3_ggv(),
+        plant_art,
+        car_id="car_a",
+        track_id="trk",
+        iters=200,
+        **kw,
+    )
+    save_alien_line_artifact(tmp_path, art)
+    return art
+
+
+def test_cache_roundtrip_and_identity_gates(tmp_path, lane):
+    path, _pts = lane
+    plant_art = _plant_artifact()
+    art = _build_and_save(tmp_path, lane, plant_art)
+    prov = plant_provenance(plant_art)
+    sha = fast_lane_sha12(path)
+    params = art["params"]
+
+    loaded = load_alien_line_artifact(
+        tmp_path,
+        "car_a",
+        "trk",
+        expected_plant_provenance=prov,
+        expected_fast_lane_sha12=sha,
+        params=params,
+    )
+    assert loaded is not None
+    assert isinstance(loaded["line"][0], tuple)
+    assert loaded["v_target_mps"] == pytest.approx(art["v_target_mps"])
+
+    # A re-identified plant (different fit content) rejects the cache.
+    stale_prov = plant_provenance(_plant_artifact(seed="b"))
+    assert (
+        load_alien_line_artifact(
+            tmp_path,
+            "car_a",
+            "trk",
+            expected_plant_provenance=stale_prov,
+            expected_fast_lane_sha12=sha,
+            params=params,
+        )
+        is None
+    )
+    # A re-baked AI line rejects the cache.
+    assert (
+        load_alien_line_artifact(
+            tmp_path,
+            "car_a",
+            "trk",
+            expected_plant_provenance=prov,
+            expected_fast_lane_sha12="0" * 12,
+            params=params,
+        )
+        is None
+    )
+    # Changed build params reject the cache.
+    assert (
+        load_alien_line_artifact(
+            tmp_path,
+            "car_a",
+            "trk",
+            expected_plant_provenance=prov,
+            expected_fast_lane_sha12=sha,
+            params={**params, "margin_m": 2.0},
+        )
+        is None
+    )
+    # Another combo / layout never sees this cache (separate identity-keyed file).
+    assert (
+        load_alien_line_artifact(
+            tmp_path,
+            "car_b",
+            "trk",
+            expected_plant_provenance=prov,
+            expected_fast_lane_sha12=sha,
+            params=params,
+        )
+        is None
+    )
+    assert (
+        load_alien_line_artifact(
+            tmp_path,
+            "car_a",
+            "trk",
+            layout="gp",
+            expected_plant_provenance=prov,
+            expected_fast_lane_sha12=sha,
+            params=params,
+        )
+        is None
+    )
+
+
+def test_cache_rejects_corruption_and_schema_drift(tmp_path, lane):
+    path, _pts = lane
+    plant_art = _plant_artifact()
+    art = _build_and_save(tmp_path, lane, plant_art)
+    prov = plant_provenance(plant_art)
+    sha = fast_lane_sha12(path)
+    cache_path = alien_line_path(tmp_path, "car_a", "trk")
+
+    def load():
+        return load_alien_line_artifact(
+            tmp_path,
+            "car_a",
+            "trk",
+            expected_plant_provenance=prov,
+            expected_fast_lane_sha12=sha,
+            params=art["params"],
+        )
+
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["schema_version"] = ALIEN_LINE_SCHEMA_VERSION + 1
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert load() is None
+
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["schema_version"] = ALIEN_LINE_SCHEMA_VERSION
+    payload["v_target_mps"][3] = float("nan")
+    cache_path.write_text(json.dumps(payload), encoding="utf-8", errors="ignore")
+    # json can't serialize nan by default -> write via allow_nan (json.dumps default allows it)
+    assert load() is None
+
+    cache_path.write_text("{not json", encoding="utf-8")
+    assert load() is None
+
+
+def test_ensure_builds_then_caches_then_invalidates(tmp_path, lane):
+    path, _pts = lane
+    plant = generic_gt3_ggv()
+    plant_art = _plant_artifact()
+    kw = dict(car_id="car_a", track_id="trk", iters=200)
+
+    art1, src1 = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, **kw)
+    assert src1 == "built"
+    assert alien_line_path(tmp_path, "car_a", "trk").exists()
+
+    art2, src2 = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, **kw)
+    assert src2 == "cache"
+    assert art2["v_target_mps"] == pytest.approx(art1["v_target_mps"])
+
+    _art3, src3 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, rebuild=True, **kw
+    )
+    assert src3 == "built"
+
+    # A re-identified plant invalidates the cache without an explicit rebuild.
+    _art4, src4 = ensure_alien_line_artifact(
+        tmp_path, path, plant, _plant_artifact(seed="b"), **kw
+    )
+    assert src4 == "built"
+
+
+def test_envelope_verification_rejects_overspeed(lane):
+    from tools.ac_harness.alien_line import _verify_lateral_envelope
+
+    _path, pts = lane
+    plane = [(p[0], p[2]) for p in pts]
+    plant = generic_gt3_ggv()
+    # 100 m/s on a 120 m radius = 8.5 g lateral — far beyond any GT3 envelope.
+    with pytest.raises(ValueError, match="exceeds the plant lateral envelope"):
+        _verify_lateral_envelope(plane, [100.0] * len(plane), plant)

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -278,6 +278,91 @@ def test_ensure_builds_then_caches_then_invalidates(tmp_path, lane):
     assert src4 == "built"
 
 
+def test_pinch_points_counted_and_clearance_never_reduced(tmp_path):
+    pts = _circle_line()
+    path = tmp_path / "fast_lane.ai"
+    # Left side inside the default margin on a stretch of points: a wall-hugging stock line.
+    sl = [0.5 if i < 20 else 6.0 for i in range(_N)]
+    _write_fast_lane(path, pts, sl, [6.0] * _N)
+    art = build_alien_line_artifact(
+        pts,
+        path,
+        generic_gt3_ggv(),
+        _plant_artifact(),
+        car_id="c",
+        track_id="t",
+        margin_m=1.2,
+        iters=200,
+    )
+    assert art["corridor"]["pinch_points"] == 20
+    # At pinched points the line may only hold or improve the stock clearance toward that edge:
+    # the signed offset toward the pinched (left) side must be <= 0 within tolerance.
+    base = [(p[0], p[2]) for p in pts]
+    from tools.ac_harness.ggv_profile import _unit_normals
+
+    normals = _unit_normals(base)
+    for i in range(20):
+        dx = art["line"][i][0] - base[i][0]
+        dz = art["line"][i][2] - base[i][1]
+        alpha = dx * normals[i][0] + dz * normals[i][1]
+        assert alpha <= 1e-6  # never toward the pinched left edge
+
+
+def test_cache_content_revalidated_on_hit(tmp_path, lane):
+    path, _pts = lane
+    plant = generic_gt3_ggv()
+    plant_art = _plant_artifact()
+    kw = dict(car_id="car_a", track_id="trk", iters=200)
+    _art, src = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, **kw)
+    assert src == "built"
+
+    # Tamper the cached profile: inflate every v_target 2x. Identity/provenance hashes still
+    # match (they gate the INPUTS, not the artifact content) — revalidation must catch it.
+    cache_path = alien_line_path(tmp_path, "car_a", "trk")
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["v_target_mps"] = [v * 2.0 for v in payload["v_target_mps"]]
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    _art2, src2 = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, **kw)
+    assert src2 == "built"  # rejected + rebuilt, never driven
+
+    # Tamper the geometry: shove one point far off the corridor.
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["line"][10][0] += 25.0
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    _art3, src3 = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, **kw)
+    assert src3 == "built"
+
+    # Untampered cache still hits.
+    _art4, src4 = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, **kw)
+    assert src4 == "cache"
+
+
+def test_verify_alien_line_artifact_reasons(lane):
+    from tools.ac_harness.alien_line import verify_alien_line_artifact
+
+    path, pts = lane
+    plant = generic_gt3_ggv()
+    art = build_alien_line_artifact(
+        pts, path, plant, _plant_artifact(), car_id="c", track_id="t", iters=200
+    )
+    sl = [6.0] * _N
+    sr = [6.0] * _N
+    ok_payload = {"line": art["line"], "v_target_mps": art["v_target_mps"]}
+    assert verify_alien_line_artifact(ok_payload, pts, sl, sr, plant, margin_m=1.2) is None
+
+    short = {"line": art["line"][:-1], "v_target_mps": art["v_target_mps"][:-1]}
+    assert "points" in verify_alien_line_artifact(short, pts, sl, sr, plant, margin_m=1.2)
+
+    bad_geo = {"line": list(art["line"]), "v_target_mps": art["v_target_mps"]}
+    bad_geo["line"][5] = (art["line"][5][0] + 25.0, art["line"][5][1], art["line"][5][2] + 25.0)
+    assert "not a lateral offset" in verify_alien_line_artifact(
+        bad_geo, pts, sl, sr, plant, margin_m=1.2
+    )
+
+    hot = {"line": art["line"], "v_target_mps": [v * 2.0 for v in art["v_target_mps"]]}
+    assert "envelope" in verify_alien_line_artifact(hot, pts, sl, sr, plant, margin_m=1.2)
+
+
 def test_envelope_verification_rejects_overspeed(lane):
     from tools.ac_harness.alien_line import _verify_lateral_envelope
 

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -270,15 +270,11 @@ def test_ensure_builds_then_caches_then_invalidates(tmp_path, lane):
     assert src2 == "cache"
     assert art2["v_target_mps"] == pytest.approx(art1["v_target_mps"])
 
-    _art3, src3 = ensure_alien_line_artifact(
-        tmp_path, path, plant, plant_art, rebuild=True, **kw
-    )
+    _art3, src3 = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, rebuild=True, **kw)
     assert src3 == "built"
 
     # A re-identified plant invalidates the cache without an explicit rebuild.
-    _art4, src4 = ensure_alien_line_artifact(
-        tmp_path, path, plant, _plant_artifact(seed="b"), **kw
-    )
+    _art4, src4 = ensure_alien_line_artifact(tmp_path, path, plant, _plant_artifact(seed="b"), **kw)
     assert src4 == "built"
 
 

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -363,6 +363,59 @@ def test_verify_alien_line_artifact_reasons(lane):
     assert "envelope" in verify_alien_line_artifact(hot, pts, sl, sr, plant, margin_m=1.2)
 
 
+def test_build_rejects_degenerate_params(lane):
+    path, pts = lane
+    plant = generic_gt3_ggv()
+    for bad_vtop in (0.0, -10.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="v_top_kmh"):
+            build_alien_line_artifact(
+                pts, path, plant, _plant_artifact(), car_id="c", track_id="t", v_top_kmh=bad_vtop
+            )
+    with pytest.raises(ValueError, match="margin_m"):
+        build_alien_line_artifact(
+            pts, path, plant, _plant_artifact(), car_id="c", track_id="t", margin_m=float("nan")
+        )
+    with pytest.raises(ValueError, match="iters"):
+        build_alien_line_artifact(
+            pts, path, plant, _plant_artifact(), car_id="c", track_id="t", iters=0
+        )
+
+
+def test_alien_prerequisites_error_paths(tmp_path, monkeypatch):
+    # Qodo testability finding (#572): the --preflight-only alien readiness check is unit-tested
+    # off-rig — no plant, corridor garbage, and the fully-ready path.
+    from tools.ac_harness import auto_drive as ad
+    from tools.ac_harness import plant_id as pid
+    from tools.ac_harness.auto_drive import AutoDriveConfig, _alien_prerequisites_error
+
+    cfg = AutoDriveConfig(track_id="trk", car_id="car_a", driver="alien")
+
+    # Empty user dir: the real load path finds no artifact.
+    msg = _alien_prerequisites_error(cfg, tmp_path)
+    assert msg is not None and "no plant artifact" in msg
+
+    # Plant ready (patched at the shared gate), corridor absurd -> loud corridor message.
+    monkeypatch.setattr(pid, "load_plant_artifact", lambda *a, **kw: {"ok": True})
+    monkeypatch.setattr(
+        pid, "plant_ready_for_full_consumption", lambda art, *, require_friction_fit: None
+    )
+    pts = _circle_line()
+    bad_lane = tmp_path / "bad" / "fast_lane.ai"
+    bad_lane.parent.mkdir()
+    _write_fast_lane(bad_lane, pts, [4242.0] * _N, [6.0] * _N)
+    monkeypatch.setattr(ad, "resolve_fast_lane", lambda *a, **kw: bad_lane)
+    msg = _alien_prerequisites_error(cfg, tmp_path)
+    assert msg is not None and "absurd corridor" in msg
+
+    # Fully ready: valid plant + valid corridor -> None, and nothing was written.
+    good_lane = tmp_path / "good" / "fast_lane.ai"
+    good_lane.parent.mkdir()
+    _write_fast_lane(good_lane, pts, [6.0] * _N, [6.0] * _N)
+    monkeypatch.setattr(ad, "resolve_fast_lane", lambda *a, **kw: good_lane)
+    assert _alien_prerequisites_error(cfg, tmp_path) is None
+    assert not (tmp_path / "alien_line").exists()  # read-only: no cache write
+
+
 def test_envelope_verification_rejects_overspeed(lane):
     from tools.ac_harness.alien_line import _verify_lateral_envelope
 

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -45,7 +45,11 @@ def _usable_plant(monkeypatch, usable: bool | list[bool]):
         return {"fit": idx} if seq[idx] else None
 
     monkeypatch.setattr(auto_alien, "load_plant_artifact", fake_load)
-    monkeypatch.setattr(auto_alien, "plant_ggv_model", lambda art: object())
+    monkeypatch.setattr(
+        auto_alien,
+        "plant_ready_for_full_consumption",
+        lambda art, *, require_friction_fit: None if art else "no plant artifact for this combo",
+    )
 
 
 def test_needs_identification_reasons(monkeypatch, tmp_path):
@@ -58,11 +62,27 @@ def test_needs_identification_reasons(monkeypatch, tmp_path):
     assert needed and "forced" in why
 
 
-def test_needs_identification_when_fit_missing(monkeypatch, tmp_path):
+def test_needs_identification_uses_the_drive_stage_readiness_gate(monkeypatch, tmp_path):
+    # The gate is the SHARED plant_ready_for_full_consumption — any reason it returns
+    # (missing fit, incomplete steering constants) triggers the handshake stage, so the
+    # pipeline can never skip identification for a plant the drive stage would reject.
     monkeypatch.setattr(auto_alien, "load_plant_artifact", lambda *a, **kw: {"fit": 0})
-    monkeypatch.setattr(auto_alien, "plant_ggv_model", lambda art: None)
+    monkeypatch.setattr(
+        auto_alien,
+        "plant_ready_for_full_consumption",
+        lambda art, *, require_friction_fit: (
+            "plant artifact has no uncertainty-aware friction fit (#543)"
+        ),
+    )
     needed, why = needs_identification(tmp_path, "c", "t", None, None, layout=None)
     assert needed and "uncertainty-aware" in why
+    monkeypatch.setattr(
+        auto_alien,
+        "plant_ready_for_full_consumption",
+        lambda art, *, require_friction_fit: "plant artifact missing measured steering constants",
+    )
+    needed, why = needs_identification(tmp_path, "c", "t", None, None, layout=None)
+    assert needed and "steering constants" in why
 
 
 def test_pipeline_skips_identification_when_plant_usable(monkeypatch, tmp_path):
@@ -85,7 +105,11 @@ def test_pipeline_runs_identification_then_drive(monkeypatch, tmp_path):
     monkeypatch.setattr(
         auto_alien, "load_plant_artifact", lambda *a, **kw: {"x": 1} if state["usable"] else None
     )
-    monkeypatch.setattr(auto_alien, "plant_ggv_model", lambda art: object())
+    monkeypatch.setattr(
+        auto_alien,
+        "plant_ready_for_full_consumption",
+        lambda art, *, require_friction_fit: None if art else "no plant artifact for this combo",
+    )
     settled_urls: list[str] = []
     monkeypatch.setattr(
         auto_alien,

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -1,0 +1,172 @@
+"""Tests for the #572 one-button alien pipeline orchestration (no rig needed)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.ac_harness import auto_alien
+from tools.ac_harness.auto_alien import (
+    _build_arg_parser,
+    drive_argv,
+    identify_argv,
+    needs_identification,
+    run_pipeline,
+)
+
+
+def _args(tmp_path, *extra: str):
+    argv = ["--car", "car_a", "--track", "trk", "--ac-user-dir", str(tmp_path), *extra]
+    return _build_arg_parser().parse_args(argv)
+
+
+class _Runner:
+    """Records stage argvs; scripted exit codes; optional side effect per call."""
+
+    def __init__(self, codes: list[int], on_call=None):
+        self.codes = list(codes)
+        self.calls: list[list[str]] = []
+        self.on_call = on_call
+
+    def __call__(self, argv: list[str]) -> int:
+        self.calls.append(list(argv))
+        if self.on_call:
+            self.on_call(argv)
+        return self.codes.pop(0)
+
+
+def _usable_plant(monkeypatch, usable: bool | list[bool]):
+    """Patch the plant lookup auto_alien uses. ``usable`` may be a sequence (per lookup)."""
+    seq = usable if isinstance(usable, list) else [usable]
+    state = {"i": 0}
+
+    def fake_load(*a, **kw):
+        idx = min(state["i"], len(seq) - 1)
+        state["i"] += 1
+        return {"fit": idx} if seq[idx] else None
+
+    monkeypatch.setattr(auto_alien, "load_plant_artifact", fake_load)
+    monkeypatch.setattr(auto_alien, "plant_ggv_model", lambda art: object())
+
+
+def test_needs_identification_reasons(monkeypatch, tmp_path):
+    _usable_plant(monkeypatch, [False, True])
+    needed, why = needs_identification(tmp_path, "c", "t", None, None, layout=None)
+    assert needed and "no plant artifact" in why
+    needed, why = needs_identification(tmp_path, "c", "t", None, None, layout=None)
+    assert not needed
+    needed, why = needs_identification(tmp_path, "c", "t", None, None, layout=None, force=True)
+    assert needed and "forced" in why
+
+
+def test_needs_identification_when_fit_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(auto_alien, "load_plant_artifact", lambda *a, **kw: {"fit": 0})
+    monkeypatch.setattr(auto_alien, "plant_ggv_model", lambda art: None)
+    needed, why = needs_identification(tmp_path, "c", "t", None, None, layout=None)
+    assert needed and "uncertainty-aware" in why
+
+
+def test_pipeline_skips_identification_when_plant_usable(monkeypatch, tmp_path):
+    _usable_plant(monkeypatch, True)
+    runner = _Runner([0])
+    args = _args(tmp_path, "--evidence-dir", str(tmp_path / "ev"))
+    code, report = run_pipeline(args, run_stage=runner)
+    assert code == 0 and report["ok"]
+    assert not report["identification_needed"]
+    assert len(runner.calls) == 1
+    drive = runner.calls[0]
+    assert ["--driver", "alien"] == drive[drive.index("--driver") : drive.index("--driver") + 2]
+    assert "--wait-lap" in drive
+    assert "identify" not in report["stages"]
+
+
+def test_pipeline_runs_identification_then_drive(monkeypatch, tmp_path):
+    # Plant unusable until the handshake stage "persists" it (flip on the runner's side effect).
+    state = {"usable": False}
+    monkeypatch.setattr(
+        auto_alien, "load_plant_artifact", lambda *a, **kw: {"x": 1} if state["usable"] else None
+    )
+    monkeypatch.setattr(auto_alien, "plant_ggv_model", lambda art: object())
+
+    def persist(argv):
+        if "handshake" in argv:
+            state["usable"] = True
+
+    runner = _Runner([0, 0], on_call=persist)
+    args = _args(tmp_path, "--evidence-dir", str(tmp_path / "ev"))
+    code, report = run_pipeline(args, run_stage=runner)
+    assert code == 0 and report["ok"]
+    assert report["identification_needed"]
+    assert len(runner.calls) == 2
+    assert "handshake" in runner.calls[0]
+    assert "alien" in runner.calls[1]
+    assert report["stages"]["identify"]["exit_code"] == 0
+    assert report["stages"]["drive"]["exit_code"] == 0
+
+
+def test_pipeline_aborts_when_identification_fails(monkeypatch, tmp_path):
+    _usable_plant(monkeypatch, False)
+    runner = _Runner([3])
+    code, report = run_pipeline(_args(tmp_path), run_stage=runner)
+    assert code == 3 and not report["ok"]
+    assert "identification stage failed" in report["error"]
+    assert len(runner.calls) == 1  # the drive stage never ran
+
+
+def test_pipeline_aborts_when_plant_still_unusable_after_identify(monkeypatch, tmp_path):
+    _usable_plant(monkeypatch, False)  # stays unusable even after the stage exits 0
+    runner = _Runner([0])
+    code, report = run_pipeline(_args(tmp_path), run_stage=runner)
+    assert code == 1 and not report["ok"]
+    assert "still unusable" in report["error"]
+    assert len(runner.calls) == 1
+
+
+def test_pipeline_propagates_drive_failure(monkeypatch, tmp_path):
+    _usable_plant(monkeypatch, True)
+    runner = _Runner([1])
+    code, report = run_pipeline(_args(tmp_path), run_stage=runner)
+    assert code == 1 and not report["ok"]
+    assert "drive stage failed" in report["error"]
+
+
+def test_force_identify_runs_handshake_even_with_usable_plant(monkeypatch, tmp_path):
+    _usable_plant(monkeypatch, True)
+    runner = _Runner([0, 0])
+    code, report = run_pipeline(_args(tmp_path, "--force-identify"), run_stage=runner)
+    assert code == 0 and report["ok"]
+    assert "handshake" in runner.calls[0]
+    assert "forced" in report["identification_reason"]
+
+
+def test_pipeline_rejects_path_shaped_ids(tmp_path):
+    args = _args(tmp_path)
+    args.car = "../evil"
+    with pytest.raises(ValueError, match="car"):
+        run_pipeline(args, run_stage=_Runner([0]))
+
+
+def test_stage_argv_builders(tmp_path):
+    args = _args(
+        tmp_path,
+        "--track-layout",
+        "gp",
+        "--setup",
+        "MySetup",
+        "--rebuild-line",
+        "--strict",
+        "--identify-seconds",
+        "420",
+        "--rig-lock-timeout",
+        "30",
+    )
+    ident = identify_argv(args, tmp_path / "identify")
+    assert ["--driver", "handshake"] == ident[ident.index("--driver") : ident.index("--driver") + 2]
+    assert ["--drive-seconds", "420.0"] == ident[-2:]
+    assert "--track-layout" in ident and "--setup" in ident and "--rig-lock-timeout" in ident
+
+    drive = drive_argv(args, tmp_path / "drive")
+    assert ["--driver", "alien"] == drive[drive.index("--driver") : drive.index("--driver") + 2]
+    assert "--alien-rebuild-line" in drive
+    assert "--strict" in drive
+    assert "--wait-lap" in drive
+    assert str(tmp_path / "drive") in drive

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -86,6 +86,12 @@ def test_pipeline_runs_identification_then_drive(monkeypatch, tmp_path):
         auto_alien, "load_plant_artifact", lambda *a, **kw: {"x": 1} if state["usable"] else None
     )
     monkeypatch.setattr(auto_alien, "plant_ggv_model", lambda art: object())
+    settled_urls: list[str] = []
+    monkeypatch.setattr(
+        auto_alien,
+        "wait_sidecar_port_settled",
+        lambda url, **kw: settled_urls.append(url) or "released",
+    )
 
     def persist(argv):
         if "handshake" in argv:
@@ -101,6 +107,52 @@ def test_pipeline_runs_identification_then_drive(monkeypatch, tmp_path):
     assert "alien" in runner.calls[1]
     assert report["stages"]["identify"]["exit_code"] == 0
     assert report["stages"]["drive"]["exit_code"] == 0
+    # The sidecar port settle runs between the stages (drive never adopts a dying sidecar).
+    assert settled_urls == [auto_alien.DEFAULT_SIDECAR_URL]
+    assert report["sidecar_port_between_stages"] == "released"
+
+
+def test_wait_sidecar_port_settled_released_and_stable_and_timeout():
+    from tools.ac_harness.auto_alien import wait_sidecar_port_settled
+
+    clock = {"t": 0.0}
+
+    def now():
+        return clock["t"]
+
+    def sleep(s):
+        clock["t"] += s
+
+    # Port answers twice then dies -> released (the terminated stage sidecar let go).
+    answers = iter([True, True, False])
+    assert (
+        wait_sidecar_port_settled(
+            "ws://127.0.0.1:8765", probe=lambda u: next(answers), sleep=sleep, now=now
+        )
+        == "released"
+    )
+    # Port answers continuously -> stable pre-existing sidecar, safe to adopt.
+    clock["t"] = 0.0
+    assert (
+        wait_sidecar_port_settled(
+            "ws://127.0.0.1:8765", probe=lambda u: True, sleep=sleep, now=now, stable_s=2.0
+        )
+        == "stable"
+    )
+    # Port answers but never reaches the stability window within the budget -> timeout
+    # (the pipeline proceeds; the drive stage's own sidecar handling takes over).
+    clock["t"] = 0.0
+    assert (
+        wait_sidecar_port_settled(
+            "ws://127.0.0.1:8765",
+            probe=lambda u: True,
+            sleep=sleep,
+            now=now,
+            timeout_s=3.0,
+            stable_s=10.0,
+        )
+        == "timeout"
+    )
 
 
 def test_pipeline_aborts_when_identification_fails(monkeypatch, tmp_path):

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -30,6 +30,7 @@ from tools.ac_harness.plant_id import (
     plant_artifact_path,
     plant_driver_kwargs,
     plant_ggv_model,
+    plant_ready_for_full_consumption,
     refine_ggv_from_lap_archives,
     save_plant_artifact,
 )
@@ -1111,6 +1112,27 @@ def test_plant_driver_kwargs_auto_vs_full(tmp_path):
     assert full["ff_sign"] == 1.0
     assert full["ff_c1"] == 6.0
     assert full["ff_c2"] == 0.015
+
+
+def test_plant_ready_for_full_consumption_shared_gate(tmp_path):
+    # The single readiness gate shared by the alien resolution, the alien preflight, and
+    # auto_alien.needs_identification (#572 daemon review) — the three sites must see the
+    # identical verdict for the identical artifact.
+    assert "no plant artifact" in plant_ready_for_full_consumption(None, require_friction_fit=True)
+    save_plant_artifact(tmp_path, _result_dict())
+    artifact = load_plant_artifact(tmp_path, "test_car", "test_oval")
+    # Complete measured constants, no friction fit: ggv `--use-plant full` semantics pass...
+    assert plant_ready_for_full_consumption(artifact, require_friction_fit=False) is None
+    # ...but the alien path additionally demands the #543 uncertainty-aware fit.
+    assert "uncertainty-aware" in plant_ready_for_full_consumption(
+        artifact, require_friction_fit=True
+    )
+    # Incomplete steering constants fail regardless of the fit requirement.
+    broken = dict(artifact)
+    broken["constants"] = {k: v for k, v in artifact["constants"].items() if k not in ("ff_c1",)}
+    assert "steering constants" in plant_ready_for_full_consumption(
+        broken, require_friction_fit=False
+    )
 
 
 def test_apply_handshake_outcome_empty_sink():

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -164,6 +164,14 @@ def build_alien_line_artifact(
     """
     if len(fast_line) < 3:
         raise ValueError("alien line requires at least 3 fast-line points")
+    # A zero / negative / non-finite speed cap would make the QSS profiler emit degenerate
+    # v_target values that pass the lateral-envelope check trivially (#572 Codex review).
+    if not (math.isfinite(v_top_kmh) and v_top_kmh > 0):
+        raise ValueError(f"v_top_kmh must be finite and > 0 (got {v_top_kmh})")
+    if not (math.isfinite(margin_m) and margin_m >= 0):
+        raise ValueError(f"margin_m must be finite and >= 0 (got {margin_m})")
+    if iters <= 0:
+        raise ValueError(f"iters must be > 0 (got {iters})")
     plane = [(p[0], p[2]) for p in fast_line]
     side_left, side_right = load_track_widths(width_path)
     validate_corridor(side_left, side_right, len(plane))

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -5,7 +5,8 @@ durable, identity-gated artifact next to the plant artifact:
 
 * **Build** — min-curvature line within the track corridor (``min_curvature_line`` bounded by the
   ``fast_lane.ai`` ``sideLeft``/``sideRight`` extras), then the forward-backward QSS min-time speed
-  profile against the combo's identified uncertainty-aware :class:`~tools.ac_harness.ggv_profile.GGVModel`.
+  profile against the combo's identified uncertainty-aware
+  :class:`~tools.ac_harness.ggv_profile.GGVModel`.
 * **Cache** — persisted under ``Documents/Assetto Corsa/alien_line/`` (durable AC state, NEVER
   ``.scratch/`` — a gitignored scratch dir is disposable by contract and this repo has already lost
   runtime state to a cleanup once). Keyed by the same combo identity stem as the plant artifact
@@ -168,9 +169,7 @@ def build_alien_line_artifact(
     opt_plane, alpha = min_curvature_line(
         plane, side_left, side_right, margin_m=margin_m, iters=iters
     )
-    optimized = [
-        (opt_plane[i][0], fast_line[i][1], opt_plane[i][1]) for i in range(len(fast_line))
-    ]
+    optimized = [(opt_plane[i][0], fast_line[i][1], opt_plane[i][1]) for i in range(len(fast_line))]
     v_target, summ = ggv_speed_profile_from_model(optimized, plant, v_top_kmh=v_top_kmh)
     worst_ay = _verify_lateral_envelope(opt_plane, v_target, plant)
     return {

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -1,0 +1,344 @@
+"""Per-combo optimized racing line + QSS profile artifact (#572, EPIC #529 P2).
+
+Composes the line-QP + QSS stages that already exist in :mod:`tools.ac_harness.ggv_profile` into a
+durable, identity-gated artifact next to the plant artifact:
+
+* **Build** — min-curvature line within the track corridor (``min_curvature_line`` bounded by the
+  ``fast_lane.ai`` ``sideLeft``/``sideRight`` extras), then the forward-backward QSS min-time speed
+  profile against the combo's identified uncertainty-aware :class:`~tools.ac_harness.ggv_profile.GGVModel`.
+* **Cache** — persisted under ``Documents/Assetto Corsa/alien_line/`` (durable AC state, NEVER
+  ``.scratch/`` — a gitignored scratch dir is disposable by contract and this repo has already lost
+  runtime state to a cleanup once). Keyed by the same combo identity stem as the plant artifact
+  (:func:`tools.ac_harness.plant_id.combo_artifact_stem`) PLUS the exact plant fit provenance and
+  the ``fast_lane.ai`` content hash, so a re-identified plant or a re-baked AI line can never
+  silently serve a stale optimized line.
+* **Validate** — corridor widths are checked before the QP (the AiPointExtra layout drifts across
+  CSP/track-tool versions; absurd widths must fail loudly, not produce an off-track line), and the
+  built profile is checked against the plant's lateral envelope (fail loud, never degrade).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tools.ac_harness.ggv_profile import (
+    GGVModel,
+    curvature_profile,
+    ggv_speed_profile_from_model,
+    load_track_widths,
+    min_curvature_line,
+)
+from tools.ac_harness.plant_id import combo_artifact_stem
+
+logger = logging.getLogger(__name__)
+
+ALIEN_LINE_SCHEMA_VERSION = 1
+
+# Corridor sanity bounds (metres). ``sideLeft``/``sideRight`` are per-point distances from the AI
+# line to each track edge. A parse of a drifted AiPointExtra layout produces garbage well outside
+# these: negative widths, kilometre-scale floats, NaN. Real circuits run ~4 m (kart track) to
+# ~40 m (runway/oval apron) total width.
+_SIDE_MAX_M = 60.0
+_TOTAL_WIDTH_MIN_M = 3.0
+# The QSS profile must respect the plant's lateral envelope by construction; tolerate only float
+# noise when re-verifying it (fail loud on anything larger — that is a solver/plant bug).
+_ENVELOPE_TOL = 1e-6
+
+
+def alien_line_path(
+    user_dir: Path,
+    car_id: str,
+    track_id: str,
+    setup: str | None = None,
+    setup_ini: str | Path | None = None,
+    *,
+    layout: str | None = None,
+) -> Path:
+    """The combo's alien-line artifact path (same identity stem as the plant artifact)."""
+    stem = combo_artifact_stem(car_id, track_id, setup, setup_ini, layout=layout)
+    return Path(user_dir) / "alien_line" / f"{stem}.json"
+
+
+def plant_provenance(plant_artifact: dict) -> dict:
+    """Stable provenance of the exact plant fit an alien line was computed from.
+
+    A content hash over the canonical-JSON plant artifact (plus its ``created_utc`` for a human-
+    readable anchor). Any re-identification — new probes, new thermal cohorts, schema bump —
+    changes the hash, which invalidates every cached line derived from the previous fit.
+    """
+    canonical = json.dumps(plant_artifact, sort_keys=True, separators=(",", ":"))
+    return {
+        "created_utc": plant_artifact.get("created_utc"),
+        "sha12": hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12],
+    }
+
+
+def fast_lane_sha12(path: str | Path) -> str:
+    """First 12 hex of the SHA-256 of the ``fast_lane.ai`` bytes (the corridor+geometry source)."""
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()[:12]
+
+
+def validate_corridor(
+    side_left: list[float], side_right: list[float], n_points: int, *, source: str = "fast_lane.ai"
+) -> None:
+    """Reject a corridor that cannot be a real track before the QP consumes it.
+
+    The AiPointExtra stride/offsets drift across CSP / track-tool versions (see
+    :func:`~tools.ac_harness.ggv_profile.load_track_widths`); a same-size layout change parses
+    "successfully" into garbage. Garbage in the corridor means the "optimized" line leaves the
+    track — so fail loudly here, never downstream as a mysterious off-track drive.
+    """
+    if len(side_left) != n_points or len(side_right) != n_points:
+        raise ValueError(
+            f"corridor length mismatch vs line points in {source}: "
+            f"left={len(side_left)}, right={len(side_right)}, line={n_points}"
+        )
+    for i, (sl, sr) in enumerate(zip(side_left, side_right, strict=True)):
+        if not (math.isfinite(sl) and math.isfinite(sr)):
+            raise ValueError(f"non-finite corridor width at point {i} in {source}: {sl}/{sr}")
+        if sl < 0.0 or sr < 0.0 or sl > _SIDE_MAX_M or sr > _SIDE_MAX_M:
+            raise ValueError(
+                f"absurd corridor width at point {i} in {source}: sideLeft={sl:.2f} "
+                f"sideRight={sr:.2f} (expected 0..{_SIDE_MAX_M:.0f} m per side — "
+                "AiPointExtra layout drift? re-derive the offsets)"
+            )
+        if (sl + sr) < _TOTAL_WIDTH_MIN_M:
+            raise ValueError(
+                f"corridor narrower than a car at point {i} in {source}: "
+                f"total={sl + sr:.2f} m < {_TOTAL_WIDTH_MIN_M} m"
+            )
+
+
+def _verify_lateral_envelope(
+    plane: list[tuple[float, float]], v_target: list[float], plant: GGVModel
+) -> float:
+    """Max lateral utilisation of the profile vs the plant envelope; raises when exceeded.
+
+    ``forward_backward_profile`` caps corner speed at ``v = sqrt(ay_max/|kappa|)`` by construction,
+    so anything beyond float noise here is a solver or plant regression — the exact class of bug
+    that spins the live car. Returns the max ``ay_used/ay_max`` ratio for the report.
+    """
+    kappa = curvature_profile(plane)
+    worst = 0.0
+    for i, v in enumerate(v_target):
+        ay_limit = plant.ay_max(v)  # m/s^2 (GGVModel.ay_max applies G internally)
+        if ay_limit <= 0:
+            raise ValueError(f"plant lateral envelope non-positive at point {i} (v={v:.1f} m/s)")
+        ratio = (v * v * abs(kappa[i])) / ay_limit
+        worst = max(worst, ratio)
+        if ratio > 1.0 + _ENVELOPE_TOL:
+            raise ValueError(
+                f"QSS profile exceeds the plant lateral envelope at point {i}: "
+                f"v={v:.2f} m/s, kappa={kappa[i]:.5f} -> {ratio:.4f}x ay_max"
+            )
+    return worst
+
+
+def build_alien_line_artifact(
+    fast_line: list[tuple[float, float, float]],
+    width_path: str | Path,
+    plant: GGVModel,
+    plant_artifact: dict,
+    *,
+    car_id: str,
+    track_id: str,
+    layout: str | None = None,
+    setup: str | None = None,
+    margin_m: float = 1.2,
+    iters: int = 1200,
+    v_top_kmh: float = 240.0,
+) -> dict:
+    """Build the combo's optimized line + QSS profile artifact from its identified plant.
+
+    Pure and off-rig testable: ``fast_line`` is the stock AI line geometry, ``width_path`` the
+    ``fast_lane.ai`` carrying the corridor extras, ``plant`` the identified (uncertainty-aware)
+    friction model and ``plant_artifact`` the full loaded plant payload (for provenance). Raises
+    on an invalid corridor or an envelope violation — never returns a degraded artifact.
+    """
+    if len(fast_line) < 3:
+        raise ValueError("alien line requires at least 3 fast-line points")
+    plane = [(p[0], p[2]) for p in fast_line]
+    side_left, side_right = load_track_widths(width_path)
+    validate_corridor(side_left, side_right, len(plane))
+    opt_plane, alpha = min_curvature_line(
+        plane, side_left, side_right, margin_m=margin_m, iters=iters
+    )
+    optimized = [
+        (opt_plane[i][0], fast_line[i][1], opt_plane[i][1]) for i in range(len(fast_line))
+    ]
+    v_target, summ = ggv_speed_profile_from_model(optimized, plant, v_top_kmh=v_top_kmh)
+    worst_ay = _verify_lateral_envelope(opt_plane, v_target, plant)
+    return {
+        "schema_version": ALIEN_LINE_SCHEMA_VERSION,
+        "created_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "car_id": car_id,
+        "track_id": track_id,
+        "layout": layout,
+        "setup": setup,
+        "plant_provenance": plant_provenance(plant_artifact),
+        "fast_lane_sha12": fast_lane_sha12(width_path),
+        "params": {"margin_m": margin_m, "iters": iters, "v_top_kmh": v_top_kmh},
+        "line": [[p[0], p[1], p[2]] for p in optimized],
+        "v_target_mps": list(v_target),
+        "qss": summ,
+        "corridor": {
+            "points": len(plane),
+            "max_offset_m": round(max(abs(a) for a in alpha), 2),
+            "min_total_width_m": round(
+                min(sl + sr for sl, sr in zip(side_left, side_right, strict=True)), 2
+            ),
+            "max_ay_utilisation": round(worst_ay, 4),
+        },
+    }
+
+
+def save_alien_line_artifact(
+    user_dir: Path, artifact: dict, *, setup_ini: str | Path | None = None
+) -> Path:
+    """Persist the alien-line artifact atomically next to the plant artifact tree.
+
+    ``setup_ini`` must be the same resolved INI the caller keys plant lookups with — the filename
+    embeds its content hash, so save and load resolve the identical identity stem.
+    """
+    for key in ("car_id", "track_id"):
+        if not artifact.get(key):
+            raise ValueError(f"alien line artifact needs {key}")
+    path = alien_line_path(
+        Path(user_dir),
+        str(artifact["car_id"]),
+        str(artifact["track_id"]),
+        artifact.get("setup"),
+        setup_ini,
+        layout=artifact.get("layout"),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def load_alien_line_artifact(
+    user_dir: Path,
+    car_id: str,
+    track_id: str,
+    setup: str | None = None,
+    setup_ini: str | Path | None = None,
+    *,
+    layout: str | None = None,
+    expected_plant_provenance: dict,
+    expected_fast_lane_sha12: str,
+    params: dict | None = None,
+) -> dict | None:
+    """Load + validate the combo's cached alien line; ``None`` when absent or identity-stale.
+
+    Staleness gates (each one alone rejects the cache — a stale line is never silently driven):
+    schema version, combo identity, the exact plant fit provenance, the ``fast_lane.ai`` content
+    hash, the build params, and finite line/profile geometry.
+    """
+    try:
+        path = alien_line_path(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict) or payload.get("schema_version") != ALIEN_LINE_SCHEMA_VERSION:
+        return None
+    if payload.get("car_id") != car_id or payload.get("track_id") != track_id:
+        return None
+    if payload.get("layout") != layout:
+        return None
+    prov = payload.get("plant_provenance")
+    if not isinstance(prov, dict) or prov.get("sha12") != expected_plant_provenance.get("sha12"):
+        logger.info("alien line cache rejected: plant fit changed since the line was built")
+        return None
+    if payload.get("fast_lane_sha12") != expected_fast_lane_sha12:
+        logger.info("alien line cache rejected: fast_lane.ai content changed")
+        return None
+    if params is not None and payload.get("params") != params:
+        logger.info("alien line cache rejected: build params changed")
+        return None
+    line = payload.get("line")
+    v_target = payload.get("v_target_mps")
+    if (
+        not isinstance(line, list)
+        or not isinstance(v_target, list)
+        or len(line) < 3
+        or len(line) != len(v_target)
+    ):
+        return None
+    try:
+        pts = [(float(p[0]), float(p[1]), float(p[2])) for p in line]
+        vt = [float(v) for v in v_target]
+    except (TypeError, ValueError, IndexError):
+        return None
+    if not all(math.isfinite(c) for p in pts for c in p) or not all(
+        math.isfinite(v) and v > 0 for v in vt
+    ):
+        return None
+    payload["line"] = pts
+    payload["v_target_mps"] = vt
+    return payload
+
+
+def ensure_alien_line_artifact(
+    user_dir: Path,
+    fast_lane_path: str | Path,
+    plant: GGVModel,
+    plant_artifact: dict,
+    *,
+    car_id: str,
+    track_id: str,
+    layout: str | None = None,
+    setup: str | None = None,
+    setup_ini: str | Path | None = None,
+    margin_m: float = 1.2,
+    iters: int = 1200,
+    v_top_kmh: float = 240.0,
+    rebuild: bool = False,
+) -> tuple[dict, str]:
+    """Load the fresh cached alien line or build + persist it. Returns ``(artifact, source)``.
+
+    ``source`` is ``"cache"`` or ``"built"`` so callers can log the provenance of what they drive.
+    """
+    prov = plant_provenance(plant_artifact)
+    lane_sha = fast_lane_sha12(fast_lane_path)
+    params = {"margin_m": margin_m, "iters": iters, "v_top_kmh": v_top_kmh}
+    if not rebuild:
+        cached = load_alien_line_artifact(
+            user_dir,
+            car_id,
+            track_id,
+            setup,
+            setup_ini,
+            layout=layout,
+            expected_plant_provenance=prov,
+            expected_fast_lane_sha12=lane_sha,
+            params=params,
+        )
+        if cached is not None:
+            return cached, "cache"
+    from tools.ac_harness.ai_line import load_ai_line
+
+    fast_line = load_ai_line(fast_lane_path)
+    artifact = build_alien_line_artifact(
+        fast_line,
+        fast_lane_path,
+        plant,
+        plant_artifact,
+        car_id=car_id,
+        track_id=track_id,
+        layout=layout,
+        setup=setup,
+        margin_m=margin_m,
+        iters=iters,
+        v_top_kmh=v_top_kmh,
+    )
+    save_alien_line_artifact(user_dir, artifact, setup_ini=setup_ini)
+    artifact = dict(artifact)
+    artifact["line"] = [tuple(p) for p in artifact["line"]]
+    return artifact, "built"

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from tools.ac_harness.ggv_profile import (
     GGVModel,
+    _unit_normals,
     curvature_profile,
     ggv_speed_profile_from_model,
     load_track_widths,
@@ -169,6 +170,24 @@ def build_alien_line_artifact(
     opt_plane, alpha = min_curvature_line(
         plane, side_left, side_right, margin_m=margin_m, iters=iters
     )
+    # Defensive post-QP bound check: the optimizer must never have moved a point closer to an
+    # edge than min(stock clearance, margin). At a pinch point (a side already inside the margin
+    # on the STOCK line — e.g. a wall-hugging chicane) the bound toward that edge collapses to 0,
+    # so the line can only hold or IMPROVE the stock clearance there — AC's own drivable
+    # fast_lane is the ground-truth floor. Pinch points are counted in the corridor stats rather
+    # than rejected (rejecting would brick every track whose stock line touches a wall once)
+    # (#572 Codex review).
+    pinch_points = 0
+    for i, a in enumerate(alpha):
+        lo = min(0.0, -(side_right[i] - margin_m))
+        hi = max(0.0, side_left[i] - margin_m)
+        if not lo - 1e-9 <= a <= hi + 1e-9:
+            raise ValueError(
+                f"optimizer offset out of corridor bounds at point {i}: "
+                f"alpha={a:.3f} not in [{lo:.3f}, {hi:.3f}]"
+            )
+        if side_left[i] < margin_m or side_right[i] < margin_m:
+            pinch_points += 1
     optimized = [(opt_plane[i][0], fast_line[i][1], opt_plane[i][1]) for i in range(len(fast_line))]
     v_target, summ = ggv_speed_profile_from_model(optimized, plant, v_top_kmh=v_top_kmh)
     worst_ay = _verify_lateral_envelope(opt_plane, v_target, plant)
@@ -192,6 +211,10 @@ def build_alien_line_artifact(
                 min(sl + sr for sl, sr in zip(side_left, side_right, strict=True)), 2
             ),
             "max_ay_utilisation": round(worst_ay, 4),
+            # Points where the STOCK line itself sits inside the margin of an edge: the bound
+            # toward that edge is 0, so the optimized line holds or improves stock clearance —
+            # never worse than AC's own drivable line.
+            "pinch_points": pinch_points,
         },
     }
 
@@ -284,6 +307,53 @@ def load_alien_line_artifact(
     return payload
 
 
+def verify_alien_line_artifact(
+    payload: dict,
+    fast_line: list[tuple[float, float, float]],
+    side_left: list[float],
+    side_right: list[float],
+    plant: GGVModel,
+    *,
+    margin_m: float,
+) -> str | None:
+    """Re-verify a cached artifact against the CURRENT corridor and plant; reason or ``None``.
+
+    Matching identity/provenance hashes prove the inputs did not change — not that the cached
+    geometry/profile is sound (an edited or corrupted durable JSON, or one written by a buggy
+    earlier build, keeps its hashes). Re-run the same safety checks the build path applies before
+    the cache is ever driven (#572 Codex review): every cached point must be a purely-lateral,
+    in-bounds offset of the current stock line, and the cached profile must respect the current
+    plant's lateral envelope.
+    """
+    line = payload.get("line") or []
+    v_target = payload.get("v_target_mps") or []
+    if len(line) != len(fast_line):
+        return f"cached line has {len(line)} points but fast_lane has {len(fast_line)}"
+    base = [(p[0], p[2]) for p in fast_line]
+    normals = _unit_normals(base)
+    cached_plane = [(p[0], p[2]) for p in line]
+    for i, (bx, bz) in enumerate(base):
+        dx = cached_plane[i][0] - bx
+        dz = cached_plane[i][1] - bz
+        nx, nz = normals[i]
+        alpha = dx * nx + dz * nz
+        residual = math.hypot(dx - alpha * nx, dz - alpha * nz)
+        if residual > 0.5:
+            return f"cached point {i} is not a lateral offset of the stock line ({residual:.2f} m)"
+        lo = min(0.0, -(side_right[i] - margin_m))
+        hi = max(0.0, side_left[i] - margin_m)
+        if not lo - 1e-6 <= alpha <= hi + 1e-6:
+            return (
+                f"cached point {i} outside the corridor bounds: alpha={alpha:.3f} "
+                f"not in [{lo:.3f}, {hi:.3f}]"
+            )
+    try:
+        _verify_lateral_envelope(cached_plane, v_target, plant)
+    except ValueError as exc:
+        return f"cached profile fails the current plant envelope: {exc}"
+    return None
+
+
 def ensure_alien_line_artifact(
     user_dir: Path,
     fast_lane_path: str | Path,
@@ -304,9 +374,12 @@ def ensure_alien_line_artifact(
 
     ``source`` is ``"cache"`` or ``"built"`` so callers can log the provenance of what they drive.
     """
+    from tools.ac_harness.ai_line import load_ai_line
+
     prov = plant_provenance(plant_artifact)
     lane_sha = fast_lane_sha12(fast_lane_path)
     params = {"margin_m": margin_m, "iters": iters, "v_top_kmh": v_top_kmh}
+    fast_line = load_ai_line(fast_lane_path)
     if not rebuild:
         cached = load_alien_line_artifact(
             user_dir,
@@ -320,10 +393,17 @@ def ensure_alien_line_artifact(
             params=params,
         )
         if cached is not None:
-            return cached, "cache"
-    from tools.ac_harness.ai_line import load_ai_line
-
-    fast_line = load_ai_line(fast_lane_path)
+            # Hashes prove the inputs match; re-verify the cached CONTENT against the current
+            # corridor + plant before it is ever driven (an edited/corrupted durable JSON keeps
+            # its hashes). A failed verification falls through to an honest rebuild.
+            side_left, side_right = load_track_widths(fast_lane_path)
+            validate_corridor(side_left, side_right, len(fast_line))
+            reason = verify_alien_line_artifact(
+                cached, fast_line, side_left, side_right, plant, margin_m=margin_m
+            )
+            if reason is None:
+                return cached, "cache"
+            logger.warning("alien line cache failed revalidation (%s); rebuilding", reason)
     artifact = build_alien_line_artifact(
         fast_line,
         fast_lane_path,

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -26,7 +26,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from tools.ac_harness.auto_drive import resolve_ac_user_dir, resolve_setup_ini, validate_ac_id
-from tools.ac_harness.plant_id import load_plant_artifact, plant_ggv_model
+from tools.ac_harness.plant_id import load_plant_artifact, plant_ready_for_full_consumption
 
 StageRunner = Callable[[list[str]], int]
 
@@ -100,16 +100,18 @@ def needs_identification(
 ) -> tuple[bool, str]:
     """Whether the identification stage must run, with the human-readable reason.
 
-    True when the plant artifact is absent, when it carries no uncertainty-aware friction fit
-    (#543 — a v1/v2 or degraded fit must be re-identified, not extrapolated), or when forced.
+    True when the plant artifact fails the SAME readiness gate the alien drive stage enforces
+    (:func:`~tools.ac_harness.plant_id.plant_ready_for_full_consumption` — absent artifact,
+    missing #543 uncertainty-aware friction fit, or incomplete measured steering constants), or
+    when forced. Sharing the drive stage's exact gate means this can never skip the handshake
+    for a plant the drive stage would then reject (#572 daemon HIGH).
     """
     if force:
         return True, "forced (--force-identify)"
     artifact = load_plant_artifact(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
-    if artifact is None:
-        return True, "no plant artifact for this combo"
-    if plant_ggv_model(artifact) is None:
-        return True, "plant artifact has no uncertainty-aware friction fit (#543)"
+    reason = plant_ready_for_full_consumption(artifact, require_friction_fit=True)
+    if reason is not None:
+        return True, reason
     return False, "plant artifact present with uncertainty-aware friction fit"
 
 

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -52,9 +52,7 @@ def needs_identification(
     """
     if force:
         return True, "forced (--force-identify)"
-    artifact = load_plant_artifact(
-        user_dir, car_id, track_id, setup, setup_ini, layout=layout
-    )
+    artifact = load_plant_artifact(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
     if artifact is None:
         return True, "no plant artifact for this combo"
     if plant_ggv_model(artifact) is None:
@@ -167,7 +165,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--evidence-dir",
         type=Path,
         default=None,
-        help="pipeline evidence root (default: .scratch/harness-evidence/<ts>_alien_<car>_<track>/)",
+        help="pipeline evidence root (default: .scratch/harness-evidence/<ts>_alien_...)",
     )
     return p
 

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -30,9 +30,62 @@ from tools.ac_harness.plant_id import load_plant_artifact, plant_ggv_model
 
 StageRunner = Callable[[list[str]], int]
 
+DEFAULT_SIDECAR_URL = "ws://127.0.0.1:8765"
+
 
 def _utc_stamp() -> str:
     return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def _probe_tcp(url: str) -> bool:
+    """Whether something is listening on the sidecar URL's host:port right now."""
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8765
+    try:
+        with socket.create_connection((host, port), timeout=1.0):
+            return True
+    except OSError:
+        return False
+
+
+def wait_sidecar_port_settled(
+    url: str,
+    *,
+    probe: Callable[[str], bool] | None = None,
+    timeout_s: float = 12.0,
+    stable_s: float = 4.0,
+    poll_s: float = 0.5,
+    sleep=time.sleep,
+    now=time.monotonic,
+) -> str:
+    """Let the previous stage's auto-started sidecar finish dying before the next stage starts.
+
+    The identify stage may auto-start a loopback sidecar that ``auto_drive`` terminates on stage
+    exit; starting the drive stage immediately can observe the dying process's port as listening
+    and adopt it, only for it to exit under the tap (#572 Codex review). Two settled states:
+
+    * port stops answering within ``timeout_s`` → released (the next stage auto-starts its own);
+    * port answers continuously for ``stable_s`` → a stable pre-existing sidecar (one the stage
+      did not terminate) → safe to adopt.
+    """
+    check = probe or _probe_tcp
+    deadline = now() + timeout_s
+    stable_since: float | None = None
+    while now() < deadline:
+        if check(url):
+            t = now()
+            if stable_since is None:
+                stable_since = t
+            elif t - stable_since >= stable_s:
+                return "stable"
+        else:
+            return "released"
+        sleep(poll_s)
+    return "timeout"
 
 
 def needs_identification(
@@ -253,6 +306,11 @@ def run_pipeline(
             print(f"auto-alien: FAIL — {report['error']}")
             return 1, report
         print("auto-alien: plant artifact verified after identification")
+        # The identify stage may have auto-started (and then terminated) a loopback sidecar;
+        # let its port settle so the drive stage never adopts a dying process (#572 review).
+        settled = wait_sidecar_port_settled(args.sidecar_url or DEFAULT_SIDECAR_URL)
+        report["sidecar_port_between_stages"] = settled
+        print(f"auto-alien: sidecar port between stages: {settled}")
 
     stage_dir = evidence_root / "drive"
     code = run_stage(drive_argv(args, stage_dir))

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -1,0 +1,294 @@
+"""One-button alien pipeline (#572, EPIC #529 P2): plant-ID -> optimized line -> QSS -> drive.
+
+``python -m tools.ac_harness.auto_alien --car <car> --track <track> [--setup <name>]`` takes any
+car/track combo from nothing to an autonomously driven lap on its own optimized racing line:
+
+1. **Ensure plant** — load the combo's identified plant artifact; when it is missing, lacks the
+   uncertainty-aware friction fit (#543), or ``--force-identify`` is set, run the #532 handshake +
+   identification session first (a full ``auto_drive --driver handshake`` cycle).
+2. **Line + profile + drive** — run ``auto_drive --driver alien``, which builds or reuses the
+   identity/provenance-gated alien-line artifact (min-curvature QP within the corridor + QSS
+   min-time profile against the identified plant) and drives it with the full measured plant
+   controller.
+3. **Report** — write a composed machine-readable ``alien_report.json`` naming each stage's
+   verdict and evidence bundle.
+
+Stage failures abort the pipeline honestly (the failed stage named, its exit code propagated) —
+there is no silent degrade to the stock line or the generic plant anywhere in this path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from tools.ac_harness.auto_drive import resolve_ac_user_dir, resolve_setup_ini, validate_ac_id
+from tools.ac_harness.plant_id import load_plant_artifact, plant_ggv_model
+
+StageRunner = Callable[[list[str]], int]
+
+
+def _utc_stamp() -> str:
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+
+def needs_identification(
+    user_dir: Path,
+    car_id: str,
+    track_id: str,
+    setup: str | None,
+    setup_ini: str | Path | None,
+    *,
+    layout: str | None,
+    force: bool = False,
+) -> tuple[bool, str]:
+    """Whether the identification stage must run, with the human-readable reason.
+
+    True when the plant artifact is absent, when it carries no uncertainty-aware friction fit
+    (#543 — a v1/v2 or degraded fit must be re-identified, not extrapolated), or when forced.
+    """
+    if force:
+        return True, "forced (--force-identify)"
+    artifact = load_plant_artifact(
+        user_dir, car_id, track_id, setup, setup_ini, layout=layout
+    )
+    if artifact is None:
+        return True, "no plant artifact for this combo"
+    if plant_ggv_model(artifact) is None:
+        return True, "plant artifact has no uncertainty-aware friction fit (#543)"
+    return False, "plant artifact present with uncertainty-aware friction fit"
+
+
+def _passthrough_args(args: argparse.Namespace) -> list[str]:
+    """CLI flags shared verbatim by both stages (combo identity + rig plumbing)."""
+    out = ["--car", args.car, "--track", args.track]
+    if args.track_layout:
+        out += ["--track-layout", args.track_layout]
+    if args.setup:
+        out += ["--setup", args.setup]
+    if args.ac_root:
+        out += ["--ac-root", str(args.ac_root)]
+    if args.ac_user_dir:
+        out += ["--ac-user-dir", str(args.ac_user_dir)]
+    if args.cm_exe:
+        out += ["--cm-exe", str(args.cm_exe)]
+    if args.sidecar_url:
+        out += ["--sidecar-url", args.sidecar_url]
+    if args.rig_lock_timeout is not None:
+        out += ["--rig-lock-timeout", str(args.rig_lock_timeout)]
+    return out
+
+
+def identify_argv(args: argparse.Namespace, evidence_dir: Path) -> list[str]:
+    argv = _passthrough_args(args) + [
+        "--driver",
+        "handshake",
+        "--evidence-dir",
+        str(evidence_dir),
+    ]
+    if args.identify_seconds is not None:
+        argv += ["--drive-seconds", str(args.identify_seconds)]
+    return argv
+
+
+def drive_argv(args: argparse.Namespace, evidence_dir: Path) -> list[str]:
+    argv = _passthrough_args(args) + [
+        "--driver",
+        "alien",
+        "--evidence-dir",
+        str(evidence_dir),
+        "--drive-seconds",
+        str(args.drive_seconds),
+        "--max-speed",
+        str(args.max_speed),
+        "--ggv-scale",
+        str(args.ggv_scale),
+        "--wait-lap",
+    ]
+    if args.strict:
+        argv.append("--strict")
+    if args.rebuild_line:
+        argv.append("--alien-rebuild-line")
+    return argv
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "One-button alien pipeline (#572): ensure the combo's identified plant "
+            "(runs the #532/#543 handshake+ID session when needed), then drive the "
+            "optimized min-curvature line + identified-plant QSS profile."
+        )
+    )
+    p.add_argument("--car", required=True, help="AC car id (e.g. ks_porsche_911_gt3_r_2016)")
+    p.add_argument("--track", required=True, help="AC track id (e.g. magione)")
+    p.add_argument("--track-layout", default=None, help="layout subdir for multi-layout tracks")
+    p.add_argument("--setup", default=None, help="car setup name (plant identity includes it)")
+    p.add_argument("--ac-root", type=Path, default=None, help="AC content root (Steam install)")
+    p.add_argument("--ac-user-dir", type=Path, default=None, help="AC user data root")
+    p.add_argument("--cm-exe", type=Path, default=None, help="Content Manager.exe path")
+    p.add_argument("--sidecar-url", default=None)
+    p.add_argument(
+        "--force-identify",
+        action="store_true",
+        help="re-run the handshake+identification session even when a usable plant exists",
+    )
+    p.add_argument(
+        "--rebuild-line",
+        action="store_true",
+        help="ignore the cached alien-line artifact and rebuild it from the current plant",
+    )
+    p.add_argument(
+        "--identify-seconds",
+        type=float,
+        default=None,
+        help="drive budget for the identification stage (default: auto_drive's default)",
+    )
+    p.add_argument(
+        "--drive-seconds", type=float, default=300.0, help="drive budget for the alien lap stage"
+    )
+    p.add_argument("--max-speed", type=float, default=240.0, help="alien drive speed cap (km/h)")
+    p.add_argument(
+        "--ggv-scale", type=float, default=0.9, help="safety margin on the QSS min-time profile"
+    )
+    p.add_argument(
+        "--strict", action="store_true", help="alien stage: require session+lap, enforce ordering"
+    )
+    p.add_argument(
+        "--rig-lock-timeout",
+        type=float,
+        default=None,
+        help="seconds to wait for another auto-drive process to release the single-rig lock",
+    )
+    p.add_argument(
+        "--evidence-dir",
+        type=Path,
+        default=None,
+        help="pipeline evidence root (default: .scratch/harness-evidence/<ts>_alien_<car>_<track>/)",
+    )
+    return p
+
+
+def run_pipeline(
+    args: argparse.Namespace, *, run_stage: StageRunner | None = None
+) -> tuple[int, dict]:
+    """Execute the staged pipeline; returns ``(exit_code, report_dict)``.
+
+    ``run_stage`` is injectable (defaults to :func:`tools.ac_harness.auto_drive._main`) so the
+    orchestration — stage planning, abort-on-failure, re-verification after identification — is
+    unit-testable without a rig.
+    """
+    if run_stage is None:
+        from tools.ac_harness.auto_drive import _main as run_stage  # pragma: no cover - rig glue
+
+    validate_ac_id("car", args.car)
+    validate_ac_id("track", args.track)
+    if args.track_layout:
+        validate_ac_id("layout", args.track_layout)
+    user_dir = resolve_ac_user_dir(args.ac_user_dir)
+    setup_key = Path(args.setup).stem if args.setup else None
+    setup_ini = None
+    if args.setup:
+        try:
+            setup_ini = resolve_setup_ini(
+                user_dir, args.car, args.track, args.setup, layout=args.track_layout
+            )
+        except (FileNotFoundError, ValueError):
+            setup_ini = None  # unresolved -> basename-only identity key (matches auto_drive)
+
+    evidence_root = args.evidence_dir or (
+        Path(".scratch") / "harness-evidence" / f"{_utc_stamp()}_alien_{args.car}_{args.track}"
+    )
+    evidence_root.mkdir(parents=True, exist_ok=True)
+
+    report: dict = {
+        "pipeline": "alien",
+        "issue": 572,
+        "evidence_root": str(evidence_root),
+        "car": args.car,
+        "track": args.track,
+        "layout": args.track_layout,
+        "setup": setup_key,
+        "started_utc": _utc_stamp(),
+        "stages": {},
+        "ok": False,
+    }
+
+    identify, why = needs_identification(
+        user_dir,
+        args.car,
+        args.track,
+        setup_key,
+        setup_ini,
+        layout=args.track_layout,
+        force=args.force_identify,
+    )
+    report["identification_needed"] = identify
+    report["identification_reason"] = why
+    print(f"auto-alien: identification {'REQUIRED' if identify else 'skipped'} — {why}")
+
+    if identify:
+        stage_dir = evidence_root / "identify"
+        code = run_stage(identify_argv(args, stage_dir))
+        report["stages"]["identify"] = {"exit_code": code, "evidence_dir": str(stage_dir)}
+        if code != 0:
+            report["error"] = f"identification stage failed (exit {code})"
+            print(f"auto-alien: FAIL — {report['error']}")
+            return code or 1, report
+        # Re-verify the artifact the stage claims to have persisted — the drive stage must never
+        # start on a plant that is still missing or fit-degraded (fail loud, never degrade).
+        still_needed, why_after = needs_identification(
+            user_dir,
+            args.car,
+            args.track,
+            setup_key,
+            setup_ini,
+            layout=args.track_layout,
+        )
+        if still_needed:
+            report["error"] = (
+                f"identification stage exited 0 but the plant is still unusable: {why_after}"
+            )
+            print(f"auto-alien: FAIL — {report['error']}")
+            return 1, report
+        print("auto-alien: plant artifact verified after identification")
+
+    stage_dir = evidence_root / "drive"
+    code = run_stage(drive_argv(args, stage_dir))
+    report["stages"]["drive"] = {"exit_code": code, "evidence_dir": str(stage_dir)}
+    if code != 0:
+        report["error"] = f"alien drive stage failed (exit {code})"
+        print(f"auto-alien: FAIL — {report['error']}")
+        return code or 1, report
+
+    report["ok"] = True
+    return 0, report
+
+
+def _main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-only CLI wiring
+    args = _build_arg_parser().parse_args(argv)
+    try:
+        code, report = run_pipeline(args)
+    except ValueError as exc:
+        print(f"auto-alien: {exc}")
+        return 2
+    report_path = Path(report["evidence_root"]) / "alien_report.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    verdict = "OK" if report.get("ok") else f"FAIL ({report.get('error')})"
+    print(f"auto-alien: {verdict}")
+    print(f"  report: {report_path}")
+    return code
+
+
+if __name__ == "__main__":  # pragma: no cover - rig-only CLI wiring
+    import sys
+    from pathlib import Path as _Path
+
+    _repo_root = str(_Path(__file__).resolve().parents[2])
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
+    raise SystemExit(_main(sys.argv[1:]))

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -147,6 +147,13 @@ class AutoDriveConfig:
     # ggv path INSTEAD of generic_gt3_ggv() when the loaded artifact carries a fitted ggv block.
     # None => generic plant.
     plant_ggv: GGVModel | None = None
+    # #572 alien pipeline: the combo's optimized line + QSS profile resolved by the CLI from the
+    # alien-line artifact (built/cached against the identified plant). ``driver="alien"`` REQUIRES
+    # both — there is no silent fallback to the stock fast_lane geometry (a degrade the alien
+    # pipeline exists to end). Points are (x, y, z) in the fast_lane frame; v_target is m/s per
+    # point (unscaled physics optimum; ggv_scale applies at driver construction).
+    alien_line: list | None = None
+    alien_v_target: list | None = None
     pace: float = 0.9  # racing: fraction of the AI line's speed profile to target
     racing_max_speed_kmh: float = (
         240.0  # racing/ggv: cap (above any GT speed; lets it use top gears)
@@ -1963,6 +1970,24 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
         # #532: consume the combo's machine-measured plant constants when the CLI resolved an
         # artifact (shift points always; measured curvature-FF steering with --use-plant full).
         return RacingDriver.from_ggv_profile(fast_line, v_target, **(config.plant_kwargs or {}))
+    if config.driver == "alien":
+        from tools.ac_harness.racing_driver import RacingDriver
+
+        # #572: drive the combo's optimized line + identified-plant QSS profile. Both come from
+        # the alien-line artifact the CLI resolved (built/cached with identity + provenance
+        # gates); missing state here is a wiring bug, not a degrade point — fail loud.
+        if not config.alien_line or not config.alien_v_target:
+            raise ValueError(
+                "alien driver requires the optimized line + v_target from the alien-line "
+                "artifact (CLI resolution missing)"
+            )
+        if not config.plant_kwargs:
+            raise ValueError(
+                "alien driver requires the combo's measured plant constants "
+                "(ff_sign/ff_c1/ff_c2 + shift points) — run --driver handshake first"
+            )
+        v_target = [v * config.ggv_scale for v in config.alien_v_target]
+        return RacingDriver.from_ggv_profile(config.alien_line, v_target, **config.plant_kwargs)
     if config.driver == "handshake":
         from tools.ac_harness.plant_id import HandshakeController
 
@@ -1996,7 +2021,8 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
             prior_ggv_name="generic_gt3_ggv",
         )
     raise ValueError(
-        f"unknown driver {config.driver!r} (expected 'ggv', 'racing', 'cruise', or 'handshake')"
+        f"unknown driver {config.driver!r} "
+        "(expected 'ggv', 'racing', 'cruise', 'handshake', or 'alien')"
     )
 
 
@@ -2139,6 +2165,11 @@ def rig_drive(  # pragma: no cover - rig-only
 
     fast_path = resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
     line = load_ai_line(fast_path)
+    # #572 alien: spawn/teleport/recovery target the OPTIMIZED geometry the controller tracks,
+    # not the stock centre line — a recovery teleport onto the stock line would drop the car up
+    # to the full corridor width off its own racing line.
+    if config.driver == "alien" and config.alien_line:
+        line = config.alien_line
     speed_profile = None
     if config.driver in ("racing", "handshake"):
         from tools.ac_harness.racing_driver import load_speed_profile
@@ -2577,11 +2608,19 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--sidecar-url", default="ws://127.0.0.1:8765")
     p.add_argument(
         "--driver",
-        choices=("ggv", "racing", "cruise", "handshake"),
+        choices=("ggv", "racing", "cruise", "handshake", "alien"),
         default="racing",
         help="ggv = flat-out min-time (top gears, 200+); racing = AI-line pace (default); "
         "cruise = slow 1st-gear lane-keeper; handshake = #532 plant-ID probes (measures "
-        "ff_sign/steer-FF/shift points/r_eff in <=2 laps, persists a per-combo plant artifact)",
+        "ff_sign/steer-FF/shift points/r_eff in <=2 laps, persists a per-combo plant artifact); "
+        "alien = #572 optimized min-curvature line + identified-plant QSS profile (requires the "
+        "combo's plant artifact incl. uncertainty-aware friction fit; builds/caches the line "
+        "artifact under Documents/Assetto Corsa/alien_line/)",
+    )
+    p.add_argument(
+        "--alien-rebuild-line",
+        action="store_true",
+        help="alien: ignore the cached line artifact and rebuild it from the current plant",
     )
     p.add_argument(
         "--use-plant",
@@ -2730,8 +2769,11 @@ def _main_impl(
     # handshake would run the whole rig drive and then crash in ``save_plant_artifact`` with an
     # empty car id (Codex review), and ``--use-plant full`` would silently skip its own hard
     # requirement and drive on generic constants.
-    if config.driver == "handshake" and not config.car_id:
-        print("auto-drive: --driver handshake requires --car (the plant artifact is keyed by car)")
+    if config.driver in ("handshake", "alien") and not config.car_id:
+        print(
+            f"auto-drive: --driver {config.driver} requires --car "
+            "(the plant artifact is keyed by car)"
+        )
         return 2
     if config.driver == "ggv" and args.use_plant == "full" and not config.car_id:
         print("auto-drive: --use-plant full requires --car (plant lookup is keyed by car+track)")
@@ -2806,6 +2848,102 @@ def _main_impl(
             return 2
         else:
             print("auto-drive: no plant artifact for this combo; using the generic GT3 plant")
+
+    # #572 alien pipeline: resolve the identified plant (mandatory, full-steering semantics) and
+    # the optimized line + QSS profile artifact (cache-or-build, identity + provenance gated).
+    alien_line_used: dict | None = None
+    if config.driver == "alien":
+        from tools.ac_harness.alien_line import alien_line_path, ensure_alien_line_artifact
+        from tools.ac_harness.plant_id import (
+            load_plant_artifact,
+            plant_artifact_path,
+            plant_driver_kwargs,
+            plant_ggv_model,
+        )
+
+        setup_key = Path(config.setup).stem if config.setup else None
+        artifact = load_plant_artifact(
+            user_dir,
+            config.car_id,
+            config.track_id,
+            setup_key,
+            config.setup_ini,
+            layout=config.track_layout,
+        )
+        if artifact is None:
+            print(
+                "auto-drive: --driver alien requires this combo's plant artifact "
+                f"({plant_artifact_path(user_dir, config.car_id, config.track_id, setup_key, config.setup_ini, layout=config.track_layout)}); "
+                "run --driver handshake first (or python -m tools.ac_harness.auto_alien for the "
+                "one-button pipeline)"
+            )
+            return 2
+        plant = plant_ggv_model(artifact)
+        if plant is None:
+            print(
+                "auto-drive: this combo's plant artifact has no uncertainty-aware friction fit; "
+                "re-run --driver handshake (#543) before the alien drive"
+            )
+            return 2
+        # Alien implies the full measured plant: curvature-FF steering + shift points. A missing
+        # steering constant raises inside plant_driver_kwargs — surface it as a CLI error.
+        try:
+            config.plant_kwargs = plant_driver_kwargs(artifact, steer=True)
+        except ValueError as exc:
+            print(f"auto-drive: {exc}")
+            return 2
+        config.plant_ggv = plant
+        plant_artifact_used = str(
+            plant_artifact_path(
+                user_dir,
+                config.car_id,
+                config.track_id,
+                setup_key,
+                config.setup_ini,
+                layout=config.track_layout,
+            )
+        )
+        fast_path = resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
+        try:
+            line_artifact, line_source = ensure_alien_line_artifact(
+                user_dir,
+                fast_path,
+                plant,
+                artifact,
+                car_id=config.car_id,
+                track_id=config.track_id,
+                layout=config.track_layout,
+                setup=setup_key,
+                setup_ini=config.setup_ini,
+                v_top_kmh=config.racing_max_speed_kmh,
+                rebuild=args.alien_rebuild_line,
+            )
+        except (OSError, ValueError) as exc:
+            print(f"auto-drive: alien line build failed — {exc}")
+            return 2
+        config.alien_line = line_artifact["line"]
+        config.alien_v_target = line_artifact["v_target_mps"]
+        alien_path = alien_line_path(
+            user_dir,
+            config.car_id,
+            config.track_id,
+            setup_key,
+            config.setup_ini,
+            layout=config.track_layout,
+        )
+        alien_line_used = {
+            "path": str(alien_path),
+            "source": line_source,
+            "plant_provenance": line_artifact.get("plant_provenance"),
+            "qss": line_artifact.get("qss"),
+            "corridor": line_artifact.get("corridor"),
+        }
+        qss = line_artifact.get("qss") or {}
+        print(
+            f"auto-drive: alien line {line_source} "
+            f"(QSS {qss.get('qss_laptime_s')}s, vmax {qss.get('vmax_kmh')} km/h, "
+            f"plant fit {line_artifact.get('plant_provenance', {}).get('sha12')}) <- {alien_path}"
+        )
 
     car_tag = config.car_id or "car"
     evidence_dir = args.evidence_dir or (
@@ -2962,6 +3100,7 @@ def _main_impl(
             "driver": config.driver,
             "use_plant": args.use_plant,
             "plant_artifact": plant_artifact_used,
+            "alien_line": alien_line_used,
             "sidecar": sidecar_detail,
         },
         "hud": hud,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2871,9 +2871,16 @@ def _main_impl(
             layout=config.track_layout,
         )
         if artifact is None:
+            expected = plant_artifact_path(
+                user_dir,
+                config.car_id,
+                config.track_id,
+                setup_key,
+                config.setup_ini,
+                layout=config.track_layout,
+            )
             print(
-                "auto-drive: --driver alien requires this combo's plant artifact "
-                f"({plant_artifact_path(user_dir, config.car_id, config.track_id, setup_key, config.setup_ini, layout=config.track_layout)}); "
+                f"auto-drive: --driver alien requires this combo's plant artifact ({expected}); "
                 "run --driver handshake first (or python -m tools.ac_harness.auto_alien for the "
                 "one-button pipeline)"
             )

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2753,15 +2753,17 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
 def _alien_prerequisites_error(config: AutoDriveConfig, user_dir: Path) -> str | None:
     """Read-only alien readiness check for ``--preflight-only``; message or ``None`` when ready.
 
-    Validates what the post-lock resolution will require — a loadable plant artifact with the
-    uncertainty-aware friction fit + measured steering constants, and a resolvable ``fast_lane.ai``
-    — WITHOUT building or persisting the line cache (preflight must never write state).
+    Validates what the post-lock resolution will require — a plant artifact passing the shared
+    readiness gate (:func:`~tools.ac_harness.plant_id.plant_ready_for_full_consumption`), a
+    resolvable ``fast_lane.ai``, and a sane parsed corridor — WITHOUT building or persisting the
+    line cache (preflight must never write state).
     """
+    from tools.ac_harness.alien_line import validate_corridor
+    from tools.ac_harness.ggv_profile import load_track_widths
     from tools.ac_harness.plant_id import (
         load_plant_artifact,
         plant_artifact_path,
-        plant_driver_kwargs,
-        plant_ggv_model,
+        plant_ready_for_full_consumption,
     )
 
     setup_key = Path(config.setup).stem if config.setup else None
@@ -2773,27 +2775,27 @@ def _alien_prerequisites_error(config: AutoDriveConfig, user_dir: Path) -> str |
         config.setup_ini,
         layout=config.track_layout,
     )
-    if artifact is None:
-        expected = plant_artifact_path(
-            user_dir,
-            config.car_id,
-            config.track_id,
-            setup_key,
-            config.setup_ini,
-            layout=config.track_layout,
-        )
-        return f"no plant artifact for this combo ({expected}); run --driver handshake first"
-    if plant_ggv_model(artifact) is None:
-        return (
-            "plant artifact has no uncertainty-aware friction fit; re-run --driver handshake (#543)"
-        )
+    reason = plant_ready_for_full_consumption(artifact, require_friction_fit=True)
+    if reason is not None:
+        if artifact is None:
+            expected = plant_artifact_path(
+                user_dir,
+                config.car_id,
+                config.track_id,
+                setup_key,
+                config.setup_ini,
+                layout=config.track_layout,
+            )
+            reason = f"{reason} ({expected}); run --driver handshake first"
+        return reason
     try:
-        plant_driver_kwargs(artifact, steer=True)
-    except ValueError as exc:
-        return str(exc)
-    try:
-        resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
-    except FileNotFoundError as exc:
+        from tools.ac_harness.ai_line import load_ai_line
+
+        fast_path = resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
+        line = load_ai_line(fast_path)
+        side_left, side_right = load_track_widths(fast_path)
+        validate_corridor(side_left, side_right, len(line), source=str(fast_path))
+    except (FileNotFoundError, ValueError) as exc:
         return str(exc)
     return None
 
@@ -2818,6 +2820,7 @@ def _resolve_alien_assets(
         plant_artifact_path,
         plant_driver_kwargs,
         plant_ggv_model,
+        plant_ready_for_full_consumption,
     )
 
     setup_key = Path(config.setup).stem if config.setup else None
@@ -2829,36 +2832,28 @@ def _resolve_alien_assets(
         config.setup_ini,
         layout=config.track_layout,
     )
-    if artifact is None:
-        expected = plant_artifact_path(
-            user_dir,
-            config.car_id,
-            config.track_id,
-            setup_key,
-            config.setup_ini,
-            layout=config.track_layout,
-        )
-        return (
-            f"--driver alien requires this combo's plant artifact ({expected}); "
-            "run --driver handshake first (or python -m tools.ac_harness.auto_alien for the "
-            "one-button pipeline)",
-            None,
-            None,
-        )
+    # Alien implies the full measured plant: the #543 uncertainty-aware friction fit + the
+    # measured curvature-FF steering and shift points. One shared readiness gate — the same one
+    # auto_alien.needs_identification and the alien preflight consult (#572 daemon review).
+    reason = plant_ready_for_full_consumption(artifact, require_friction_fit=True)
+    if reason is not None:
+        if artifact is None:
+            expected = plant_artifact_path(
+                user_dir,
+                config.car_id,
+                config.track_id,
+                setup_key,
+                config.setup_ini,
+                layout=config.track_layout,
+            )
+            reason = (
+                f"--driver alien requires this combo's plant artifact ({expected}); "
+                "run --driver handshake first (or python -m tools.ac_harness.auto_alien for "
+                "the one-button pipeline)"
+            )
+        return (reason, None, None)
+    config.plant_kwargs = plant_driver_kwargs(artifact, steer=True)
     plant = plant_ggv_model(artifact)
-    if plant is None:
-        return (
-            "this combo's plant artifact has no uncertainty-aware friction fit; "
-            "re-run --driver handshake (#543) before the alien drive",
-            None,
-            None,
-        )
-    # Alien implies the full measured plant: curvature-FF steering + shift points. A missing
-    # steering constant raises inside plant_driver_kwargs — surface it as a CLI error.
-    try:
-        config.plant_kwargs = plant_driver_kwargs(artifact, steer=True)
-    except ValueError as exc:
-        return (str(exc), None, None)
     config.plant_ggv = plant
     plant_artifact_used = str(
         plant_artifact_path(
@@ -3009,7 +3004,33 @@ def _main_impl(
             if alien_issue is not None:
                 print(f"auto-drive: ALIEN PREFLIGHT FAILED — {alien_issue}")
                 return 2
-            print("auto-drive: alien prerequisites ok (plant artifact + fast_lane)")
+            print("auto-drive: alien prerequisites ok (plant artifact + fast_lane corridor)")
+        elif config.driver == "ggv" and args.use_plant == "full":
+            # #572: --use-plant full is a hard plant requirement — a preflight-only readiness
+            # gate must not report green for a run that would exit at post-lock resolution.
+            from tools.ac_harness.plant_id import (
+                load_plant_artifact,
+                plant_ready_for_full_consumption,
+            )
+
+            full_artifact = load_plant_artifact(
+                user_dir,
+                config.car_id,
+                config.track_id,
+                Path(config.setup).stem if config.setup else None,
+                config.setup_ini,
+                layout=config.track_layout,
+            )
+            full_reason = plant_ready_for_full_consumption(
+                full_artifact, require_friction_fit=False
+            )
+            if full_reason is not None:
+                print(
+                    f"auto-drive: PREFLIGHT FAILED — --use-plant full: {full_reason}; "
+                    "run --driver handshake first"
+                )
+                return 2
+            print("auto-drive: --use-plant full prerequisites ok (plant artifact)")
         return 0
 
     if config.setup:

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2750,6 +2750,54 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
     return AutoDriveConfig(**kwargs)
 
 
+def _alien_prerequisites_error(config: AutoDriveConfig, user_dir: Path) -> str | None:
+    """Read-only alien readiness check for ``--preflight-only``; message or ``None`` when ready.
+
+    Validates what the post-lock resolution will require — a loadable plant artifact with the
+    uncertainty-aware friction fit + measured steering constants, and a resolvable ``fast_lane.ai``
+    — WITHOUT building or persisting the line cache (preflight must never write state).
+    """
+    from tools.ac_harness.plant_id import (
+        load_plant_artifact,
+        plant_artifact_path,
+        plant_driver_kwargs,
+        plant_ggv_model,
+    )
+
+    setup_key = Path(config.setup).stem if config.setup else None
+    artifact = load_plant_artifact(
+        user_dir,
+        config.car_id,
+        config.track_id,
+        setup_key,
+        config.setup_ini,
+        layout=config.track_layout,
+    )
+    if artifact is None:
+        expected = plant_artifact_path(
+            user_dir,
+            config.car_id,
+            config.track_id,
+            setup_key,
+            config.setup_ini,
+            layout=config.track_layout,
+        )
+        return f"no plant artifact for this combo ({expected}); run --driver handshake first"
+    if plant_ggv_model(artifact) is None:
+        return (
+            "plant artifact has no uncertainty-aware friction fit; re-run --driver handshake (#543)"
+        )
+    try:
+        plant_driver_kwargs(artifact, steer=True)
+    except ValueError as exc:
+        return str(exc)
+    try:
+        resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
+    except FileNotFoundError as exc:
+        return str(exc)
+    return None
+
+
 def _resolve_alien_assets(
     config: AutoDriveConfig, user_dir: Path, *, rebuild: bool
 ) -> tuple[str | None, str | None, dict | None]:
@@ -2953,6 +3001,15 @@ def _main_impl(
         return 2
     print("auto-drive: preflight ok")
     if args.preflight_only:
+        # #572: an alien readiness gate must include the alien prerequisites, or preflight-only
+        # reports a false green for a drive that would exit at resolution (Codex review). Read-only
+        # — validates the plant artifact + fast_lane without building or writing the line cache.
+        if config.driver == "alien":
+            alien_issue = _alien_prerequisites_error(config, user_dir)
+            if alien_issue is not None:
+                print(f"auto-drive: ALIEN PREFLIGHT FAILED — {alien_issue}")
+                return 2
+            print("auto-drive: alien prerequisites ok (plant artifact + fast_lane)")
         return 0
 
     if config.setup:

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1986,6 +1986,13 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
                 "alien driver requires the combo's measured plant constants "
                 "(ff_sign/ff_c1/ff_c2 + shift points) — run --driver handshake first"
             )
+        # The stored v_target is envelope-verified at build time; scaling above 1 would push
+        # corner speeds past the verified plant envelope AFTER that check (#572 Codex review).
+        if not 0.0 < config.ggv_scale <= 1.0:
+            raise ValueError(
+                f"alien driver requires 0 < ggv_scale <= 1 (got {config.ggv_scale}); the scale "
+                "is a safety margin under the envelope-verified profile"
+            )
         v_target = [v * config.ggv_scale for v in config.alien_v_target]
         return RacingDriver.from_ggv_profile(config.alien_line, v_target, **config.plant_kwargs)
     if config.driver == "handshake":
@@ -2743,6 +2750,121 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
     return AutoDriveConfig(**kwargs)
 
 
+def _resolve_alien_assets(
+    config: AutoDriveConfig, user_dir: Path, *, rebuild: bool
+) -> tuple[str | None, str | None, dict | None]:
+    """Resolve the alien drive's plant + optimized-line artifacts from current on-disk state.
+
+    Returns ``(error, plant_artifact_used, alien_line_used)`` — ``error`` is a printable message
+    (caller exits 2) or ``None`` on success, in which case ``config.plant_kwargs`` /
+    ``config.plant_ggv`` / ``config.alien_line`` / ``config.alien_v_target`` are populated.
+
+    MUST be called **after the machine-global rig lock is held** (#572 Codex review): a peer
+    worktree waiting on the lock may re-identify the same combo; resolving before the lock could
+    drive an in-memory plant/line that a newer on-disk plant artifact has already superseded,
+    bypassing the cache/provenance gates.
+    """
+    from tools.ac_harness.alien_line import alien_line_path, ensure_alien_line_artifact
+    from tools.ac_harness.plant_id import (
+        load_plant_artifact,
+        plant_artifact_path,
+        plant_driver_kwargs,
+        plant_ggv_model,
+    )
+
+    setup_key = Path(config.setup).stem if config.setup else None
+    artifact = load_plant_artifact(
+        user_dir,
+        config.car_id,
+        config.track_id,
+        setup_key,
+        config.setup_ini,
+        layout=config.track_layout,
+    )
+    if artifact is None:
+        expected = plant_artifact_path(
+            user_dir,
+            config.car_id,
+            config.track_id,
+            setup_key,
+            config.setup_ini,
+            layout=config.track_layout,
+        )
+        return (
+            f"--driver alien requires this combo's plant artifact ({expected}); "
+            "run --driver handshake first (or python -m tools.ac_harness.auto_alien for the "
+            "one-button pipeline)",
+            None,
+            None,
+        )
+    plant = plant_ggv_model(artifact)
+    if plant is None:
+        return (
+            "this combo's plant artifact has no uncertainty-aware friction fit; "
+            "re-run --driver handshake (#543) before the alien drive",
+            None,
+            None,
+        )
+    # Alien implies the full measured plant: curvature-FF steering + shift points. A missing
+    # steering constant raises inside plant_driver_kwargs — surface it as a CLI error.
+    try:
+        config.plant_kwargs = plant_driver_kwargs(artifact, steer=True)
+    except ValueError as exc:
+        return (str(exc), None, None)
+    config.plant_ggv = plant
+    plant_artifact_used = str(
+        plant_artifact_path(
+            user_dir,
+            config.car_id,
+            config.track_id,
+            setup_key,
+            config.setup_ini,
+            layout=config.track_layout,
+        )
+    )
+    try:
+        fast_path = resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
+        line_artifact, line_source = ensure_alien_line_artifact(
+            user_dir,
+            fast_path,
+            plant,
+            artifact,
+            car_id=config.car_id,
+            track_id=config.track_id,
+            layout=config.track_layout,
+            setup=setup_key,
+            setup_ini=config.setup_ini,
+            v_top_kmh=config.racing_max_speed_kmh,
+            rebuild=rebuild,
+        )
+    except (OSError, ValueError) as exc:
+        return (f"alien line build failed — {exc}", plant_artifact_used, None)
+    config.alien_line = line_artifact["line"]
+    config.alien_v_target = line_artifact["v_target_mps"]
+    alien_path = alien_line_path(
+        user_dir,
+        config.car_id,
+        config.track_id,
+        setup_key,
+        config.setup_ini,
+        layout=config.track_layout,
+    )
+    alien_line_used = {
+        "path": str(alien_path),
+        "source": line_source,
+        "plant_provenance": line_artifact.get("plant_provenance"),
+        "qss": line_artifact.get("qss"),
+        "corridor": line_artifact.get("corridor"),
+    }
+    qss = line_artifact.get("qss") or {}
+    print(
+        f"auto-drive: alien line {line_source} "
+        f"(QSS {qss.get('qss_laptime_s')}s, vmax {qss.get('vmax_kmh')} km/h, "
+        f"plant fit {line_artifact.get('plant_provenance', {}).get('sha12')}) <- {alien_path}"
+    )
+    return (None, plant_artifact_used, alien_line_used)
+
+
 def _main_impl(
     argv: list[str] | None, cleanup: ExitStack
 ) -> int:  # pragma: no cover - rig-only CLI wiring
@@ -2849,108 +2971,16 @@ def _main_impl(
         else:
             print("auto-drive: no plant artifact for this combo; using the generic GT3 plant")
 
-    # #572 alien pipeline: resolve the identified plant (mandatory, full-steering semantics) and
-    # the optimized line + QSS profile artifact (cache-or-build, identity + provenance gated).
+    # #572: reject an overspeed scale on the alien path BEFORE any launch work. The alien QSS
+    # profile is envelope-verified at build time; a scale above 1 would multiply corner speeds
+    # past the verified plant envelope after that check (Codex review).
     alien_line_used: dict | None = None
-    if config.driver == "alien":
-        from tools.ac_harness.alien_line import alien_line_path, ensure_alien_line_artifact
-        from tools.ac_harness.plant_id import (
-            load_plant_artifact,
-            plant_artifact_path,
-            plant_driver_kwargs,
-            plant_ggv_model,
-        )
-
-        setup_key = Path(config.setup).stem if config.setup else None
-        artifact = load_plant_artifact(
-            user_dir,
-            config.car_id,
-            config.track_id,
-            setup_key,
-            config.setup_ini,
-            layout=config.track_layout,
-        )
-        if artifact is None:
-            expected = plant_artifact_path(
-                user_dir,
-                config.car_id,
-                config.track_id,
-                setup_key,
-                config.setup_ini,
-                layout=config.track_layout,
-            )
-            print(
-                f"auto-drive: --driver alien requires this combo's plant artifact ({expected}); "
-                "run --driver handshake first (or python -m tools.ac_harness.auto_alien for the "
-                "one-button pipeline)"
-            )
-            return 2
-        plant = plant_ggv_model(artifact)
-        if plant is None:
-            print(
-                "auto-drive: this combo's plant artifact has no uncertainty-aware friction fit; "
-                "re-run --driver handshake (#543) before the alien drive"
-            )
-            return 2
-        # Alien implies the full measured plant: curvature-FF steering + shift points. A missing
-        # steering constant raises inside plant_driver_kwargs — surface it as a CLI error.
-        try:
-            config.plant_kwargs = plant_driver_kwargs(artifact, steer=True)
-        except ValueError as exc:
-            print(f"auto-drive: {exc}")
-            return 2
-        config.plant_ggv = plant
-        plant_artifact_used = str(
-            plant_artifact_path(
-                user_dir,
-                config.car_id,
-                config.track_id,
-                setup_key,
-                config.setup_ini,
-                layout=config.track_layout,
-            )
-        )
-        fast_path = resolve_fast_lane(config.ac_root, config.track_id, config.track_layout)
-        try:
-            line_artifact, line_source = ensure_alien_line_artifact(
-                user_dir,
-                fast_path,
-                plant,
-                artifact,
-                car_id=config.car_id,
-                track_id=config.track_id,
-                layout=config.track_layout,
-                setup=setup_key,
-                setup_ini=config.setup_ini,
-                v_top_kmh=config.racing_max_speed_kmh,
-                rebuild=args.alien_rebuild_line,
-            )
-        except (OSError, ValueError) as exc:
-            print(f"auto-drive: alien line build failed — {exc}")
-            return 2
-        config.alien_line = line_artifact["line"]
-        config.alien_v_target = line_artifact["v_target_mps"]
-        alien_path = alien_line_path(
-            user_dir,
-            config.car_id,
-            config.track_id,
-            setup_key,
-            config.setup_ini,
-            layout=config.track_layout,
-        )
-        alien_line_used = {
-            "path": str(alien_path),
-            "source": line_source,
-            "plant_provenance": line_artifact.get("plant_provenance"),
-            "qss": line_artifact.get("qss"),
-            "corridor": line_artifact.get("corridor"),
-        }
-        qss = line_artifact.get("qss") or {}
+    if config.driver == "alien" and not 0.0 < config.ggv_scale <= 1.0:
         print(
-            f"auto-drive: alien line {line_source} "
-            f"(QSS {qss.get('qss_laptime_s')}s, vmax {qss.get('vmax_kmh')} km/h, "
-            f"plant fit {line_artifact.get('plant_provenance', {}).get('sha12')}) <- {alien_path}"
+            f"auto-drive: --driver alien requires 0 < --ggv-scale <= 1 (got {config.ggv_scale}); "
+            "the scale is a safety margin under the envelope-verified profile, never above it"
         )
+        return 2
 
     car_tag = config.car_id or "car"
     evidence_dir = args.evidence_dir or (
@@ -3019,6 +3049,19 @@ def _main_impl(
         return 3
     cleanup.callback(rig_lock.release)
     print(f"auto-drive: rig lock acquired -> {rig_lock.path}")
+
+    # #572 alien pipeline: resolve the identified plant (mandatory, full-steering semantics) and
+    # the optimized line + QSS profile artifact (cache-or-build, identity + provenance gated).
+    # Deliberately AFTER preflight (actionable content errors, and --preflight-only never writes
+    # the line cache) and AFTER the rig lock (a peer worktree may have re-identified this combo
+    # while we waited — resolve from the on-disk state we now own) (#572 Codex review).
+    if config.driver == "alien":
+        alien_error, plant_artifact_used, alien_line_used = _resolve_alien_assets(
+            config, user_dir, rebuild=args.alien_rebuild_line
+        )
+        if alien_error is not None:
+            print(f"auto-drive: {alien_error}")
+            return 2
 
     sidecar_proc = None
     try:

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2914,62 +2914,7 @@ def _main_impl(
         except (FileNotFoundError, ValueError):
             config.setup_ini = None  # unresolved -> basename-only key (best effort)
 
-    # #532: resolve the combo's identified plant for the ggv path. `auto` silently falls back to
-    # the generic plant when no artifact exists; `full` REQUIRES one (measured steering must never
-    # silently degrade to hand constants — that is the failure mode the handshake exists to end).
     plant_artifact_used: str | None = None
-    if config.driver == "ggv" and args.use_plant != "off" and config.car_id:
-        from tools.ac_harness.plant_id import (
-            load_plant_artifact,
-            plant_artifact_path,
-            plant_driver_kwargs,
-            plant_ggv_model,
-        )
-
-        # Key by layout plus setup CONTENT (#532/#552): neither another physical course nor another
-        # setup may reuse this plant. Uses the same track_layout + config.setup_ini identity that
-        # the handshake result carries into save_plant_artifact.
-        setup_key = Path(config.setup).stem if config.setup else None
-        setup_ini_key = config.setup_ini
-        artifact = load_plant_artifact(
-            user_dir,
-            config.car_id,
-            config.track_id,
-            setup_key,
-            setup_ini_key,
-            layout=config.track_layout,
-        )
-        if artifact is not None:
-            config.plant_kwargs = plant_driver_kwargs(artifact, steer=args.use_plant == "full")
-            # #532 Part B: also consume the identified friction plant (GGVModel) when the artifact
-            # carries a fitted ggv block. Applies on `auto` and `full` alike — the friction plant
-            # shapes the SPEED profile, orthogonal to the steering mode. None => generic plant.
-            config.plant_ggv = plant_ggv_model(artifact)
-            plant_artifact_used = str(
-                plant_artifact_path(
-                    user_dir,
-                    config.car_id,
-                    config.track_id,
-                    setup_key,
-                    setup_ini_key,
-                    layout=config.track_layout,
-                )
-            )
-            ggv_note = (
-                "identified friction plant" if config.plant_ggv is not None else "generic plant"
-            )
-            print(
-                f"auto-drive: plant artifact loaded ({args.use_plant}: "
-                f"{sorted(config.plant_kwargs)}; {ggv_note}) <- {plant_artifact_used}"
-            )
-        elif args.use_plant == "full":
-            print(
-                "auto-drive: --use-plant full requires a plant artifact for this combo; "
-                "run --driver handshake first"
-            )
-            return 2
-        else:
-            print("auto-drive: no plant artifact for this combo; using the generic GT3 plant")
 
     # #572: reject an overspeed scale on the alien path BEFORE any launch work. The alien QSS
     # profile is envelope-verified at build time; a scale above 1 would multiply corner speeds
@@ -3050,11 +2995,70 @@ def _main_impl(
     cleanup.callback(rig_lock.release)
     print(f"auto-drive: rig lock acquired -> {rig_lock.path}")
 
+    # Plant/line artifact resolution happens AFTER preflight (actionable content errors, and
+    # --preflight-only never writes state) and AFTER the machine-global rig lock, for EVERY
+    # consumer of the plant artifact: a peer worktree may have re-identified this combo while we
+    # waited on the lock, and resolving pre-lock would drive a stale in-memory plant that the
+    # on-disk artifact has already superseded (#572 Codex + daemon review — same rule for the
+    # ggv path, not just alien).
+    if config.driver == "ggv" and args.use_plant != "off" and config.car_id:
+        # #532: `auto` silently falls back to the generic plant when no artifact exists; `full`
+        # REQUIRES one (measured steering must never silently degrade to hand constants — that is
+        # the failure mode the handshake exists to end).
+        from tools.ac_harness.plant_id import (
+            load_plant_artifact,
+            plant_artifact_path,
+            plant_driver_kwargs,
+            plant_ggv_model,
+        )
+
+        # Key by layout plus setup CONTENT (#532/#552): neither another physical course nor another
+        # setup may reuse this plant. Uses the same track_layout + config.setup_ini identity that
+        # the handshake result carries into save_plant_artifact.
+        setup_key = Path(config.setup).stem if config.setup else None
+        setup_ini_key = config.setup_ini
+        artifact = load_plant_artifact(
+            user_dir,
+            config.car_id,
+            config.track_id,
+            setup_key,
+            setup_ini_key,
+            layout=config.track_layout,
+        )
+        if artifact is not None:
+            config.plant_kwargs = plant_driver_kwargs(artifact, steer=args.use_plant == "full")
+            # #532 Part B: also consume the identified friction plant (GGVModel) when the artifact
+            # carries a fitted ggv block. Applies on `auto` and `full` alike — the friction plant
+            # shapes the SPEED profile, orthogonal to the steering mode. None => generic plant.
+            config.plant_ggv = plant_ggv_model(artifact)
+            plant_artifact_used = str(
+                plant_artifact_path(
+                    user_dir,
+                    config.car_id,
+                    config.track_id,
+                    setup_key,
+                    setup_ini_key,
+                    layout=config.track_layout,
+                )
+            )
+            ggv_note = (
+                "identified friction plant" if config.plant_ggv is not None else "generic plant"
+            )
+            print(
+                f"auto-drive: plant artifact loaded ({args.use_plant}: "
+                f"{sorted(config.plant_kwargs)}; {ggv_note}) <- {plant_artifact_used}"
+            )
+        elif args.use_plant == "full":
+            print(
+                "auto-drive: --use-plant full requires a plant artifact for this combo; "
+                "run --driver handshake first"
+            )
+            return 2
+        else:
+            print("auto-drive: no plant artifact for this combo; using the generic GT3 plant")
+
     # #572 alien pipeline: resolve the identified plant (mandatory, full-steering semantics) and
     # the optimized line + QSS profile artifact (cache-or-build, identity + provenance gated).
-    # Deliberately AFTER preflight (actionable content errors, and --preflight-only never writes
-    # the line cache) and AFTER the rig lock (a peer worktree may have re-identified this combo
-    # while we waited — resolve from the on-disk state we now own) (#572 Codex review).
     if config.driver == "alien":
         alien_error, plant_artifact_used, alien_line_used = _resolve_alien_assets(
             config, user_dir, rebuild=args.alien_rebuild_line

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1615,6 +1615,22 @@ def _layout_key(layout: str | None) -> str:
     return f"__layout-{layout}"
 
 
+def combo_artifact_stem(
+    car_id: str,
+    track_id: str,
+    setup: str | None = None,
+    setup_ini: str | Path | None = None,
+    *,
+    layout: str | None = None,
+) -> str:
+    """Filename-safe identity stem shared by every per-combo artifact (plant, alien line).
+
+    Derived artifacts (e.g. the #572 alien line cache) MUST key their files with this exact stem so
+    their identity can never drift from the plant artifact they were computed from.
+    """
+    return f"{car_id}__{track_id}{_layout_key(layout)}{_setup_key(setup, setup_ini)}"
+
+
 def plant_artifact_path(
     user_dir: Path,
     car_id: str,
@@ -1624,8 +1640,8 @@ def plant_artifact_path(
     *,
     layout: str | None = None,
 ) -> Path:
-    filename = f"{car_id}__{track_id}{_layout_key(layout)}{_setup_key(setup, setup_ini)}.json"
-    return Path(user_dir) / "plant_id" / filename
+    stem = combo_artifact_stem(car_id, track_id, setup, setup_ini, layout=layout)
+    return Path(user_dir) / "plant_id" / f"{stem}.json"
 
 
 def save_plant_artifact(user_dir: Path, result: dict) -> Path:

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1791,6 +1791,28 @@ def plant_ggv_model(artifact: dict) -> GGVModel | None:
         return None
 
 
+def plant_ready_for_full_consumption(
+    artifact: dict | None, *, require_friction_fit: bool
+) -> str | None:
+    """Single source of truth for "can this plant drive a measured-steering run" (#572 daemon).
+
+    Returns ``None`` when ready, else the human-readable reason. Used by the alien resolution,
+    the alien preflight, and ``auto_alien.needs_identification`` so the three sites can never
+    drift apart. ``require_friction_fit=True`` (the alien path) additionally demands the #543
+    uncertainty-aware friction fit; the ggv ``--use-plant full`` path only needs the measured
+    steering constants (its speed profile may legitimately use the generic plant).
+    """
+    if artifact is None:
+        return "no plant artifact for this combo"
+    if require_friction_fit and plant_ggv_model(artifact) is None:
+        return "plant artifact has no uncertainty-aware friction fit (#543)"
+    try:
+        plant_driver_kwargs(artifact, steer=True)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
 def apply_handshake_outcome(report, sink: dict) -> None:
     """Fold the handshake outcome into an ``AutoDriveReport``-shaped object (duck-typed).
 


### PR DESCRIPTION
Closes #572 (EPIC #529 P2 — "one-button alien").

## What

Composes the merged P1 stages (#532 handshake, #543 uncertainty-aware plant ID) with the previously-dead line-QP into a one-command pipeline that takes any car/track combo from nothing to an autonomous drive on its own optimized racing line:

- **`tools/ac_harness/alien_line.py` (new)** — per-combo optimized-line artifact: min-curvature QP (`min_curvature_line`) bounded by the validated `fast_lane.ai` corridor, QSS min-time profile against the identified uncertainty-aware `GGVModel`, persisted under `Documents/Assetto Corsa/alien_line/` (durable, never `.scratch/`). Cache identity = the plant's combo stem (car+track+layout+setup content hash) **plus** the exact plant-fit content hash **plus** the `fast_lane.ai` content hash **plus** build params — any drift rejects and rebuilds; a stale line is never silently driven.
- **`auto_drive --driver alien`** — mandatory plant artifact (incl. the #543 uncertainty fit; exits with instructions when absent — no degrade to generic constants or the stock line), full measured steering (`ff_sign/ff_c1/ff_c2` + shift points), and spawn/teleport/recovery target the **optimized** geometry, not the stock centre line.
- **`tools/ac_harness/auto_alien.py` (new)** — the one-button orchestrator: runs the handshake+identification session first when the plant is missing/degraded/forced, **re-verifies the artifact on disk** before driving, then runs the alien drive; writes a composed `alien_report.json`. Stage failures abort with the stage named and exit code propagated.
- `plant_id.combo_artifact_stem` extracted so derived artifacts share the exact plant identity (no second identity implementation to drift).

## Safety properties (issue pitfalls addressed)

- **Corridor validation before the QP** — the AiPointExtra binary layout drifts across CSP/track-tool versions; non-finite/absurd/too-narrow widths raise with the layout-drift hint instead of producing an off-track "optimized" line.
- **Lateral-envelope re-verification** — the built profile is checked point-by-point against the plant's `ay_max` (the 1.6g-cliff class of bug fails the build, it never reaches the car).
- **No silent exception swallowing** — every stage failure names the stage; `--use-plant full` semantics are hard requirements on the alien path.
- **Durable cache placement** — next to the plant artifact under the AC user dir, never a gitignored scratch path.

## Tests

68 new tests across `tests/test_alien_line.py`, `tests/test_auto_alien.py`, plus `_build_driver` alien coverage in `tests/test_ac_harness_auto_drive.py`: corridor bounds (optimized points within side−margin by construction, verified geometrically), envelope respect, every cache identity gate (plant provenance / fast_lane sha / params / combo / layout / corruption / schema drift), ensure build→cache→invalidate flow, and full pipeline orchestration (skip-when-usable, identify-then-drive, abort-on-identify-failure, still-unusable-after-identify, drive-failure propagation, force-identify).

`make ci-fast` green locally (full suite + ruff + policy checks).

## Remaining (Part C, this PR's live gate)

Live G1-evidence run on the rig via the unmodified path (`python -m tools.ac_harness.auto_alien --car … --track …`) — will be posted as evidence on #572 before the epic gate advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
