### PR TITLE
feat(harness): #577 flying-lap windows + progressive-envelope self-play (attack the QSS floor)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T20:40:00Z
+last_updated: 2026-07-14T20:55:36Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
@@ -34,12 +34,14 @@ relates_to:
 
 **Active (2026-07-14, latest):** PR
 [#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
-[#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) is review-resolved at
-[`5b6d68c`](https://github.com/agorokh/ac-copilot-trainer/commit/5b6d68cc004cca235ad6195e71b9b9abf846b415):
-required checks green, 0/18 unresolved threads, resolve-gate clean after the full cooldown. The
-resolution round fixed handshake combo counting and made self-play plant persistence/revert
-peer-safe and fail-closed. Awaiting merge; then `/post-merge 579`. #577 keeps its separate L3
-per-corner refinement scope open.
+[#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) has its review-resolution branch
+merged with current `main` at `8f1297d`; the latest code fix is
+[`eb3da0b`](https://github.com/agorokh/ac-copilot-trainer/commit/eb3da0b). In addition to the
+peer-safe plant persistence/revert work at `5b6d68c`, direct `auto_drive --laps N` now owns the
+scaled flying-lap time budget and self-play normalizes the optional rig-lock timeout before
+persistence. Local parity is green (**2,863 passed, 77 skipped, 86.69% coverage**). Merge only
+after the current-head post-push cooldown, GraphQL thread audit, resolve-gate, and daemon review
+all converge; then `/post-merge 579`. #577 keeps its separate L3 per-corner refinement scope open.
 
 **Live delivery basis (2026-07-14 evening):** [#577](https://github.com/agorokh/ac-copilot-trainer/issues/577)
 (**EPIC #529 P3** — flying-lap windows + progressive-envelope self-play) implemented and

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T07:31:18Z
+last_updated: 2026-07-14T20:40:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-572-alien-pipeline-2026-07-14.md
@@ -30,6 +30,15 @@ relates_to:
 # Current focus
 
 **Repo:** ac-copilot-trainer.
+
+**Active (2026-07-14, latest):** PR
+[#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
+[#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) is review-resolved at
+[`5b6d68c`](https://github.com/agorokh/ac-copilot-trainer/commit/5b6d68cc004cca235ad6195e71b9b9abf846b415):
+required checks green, 0/18 unresolved threads, resolve-gate clean after the full cooldown. The
+resolution round fixed handshake combo counting and made self-play plant persistence/revert
+peer-safe and fail-closed. Awaiting merge; then `/post-merge 579`. #577 keeps its separate L3
+per-corner refinement scope open.
 
 **Delivered (2026-07-14, latest):** [#572](https://github.com/agorokh/ac-copilot-trainer/issues/572)
 **CLOSED** by PR [#573](https://github.com/agorokh/ac-copilot-trainer/pull/573)

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T20:55:36Z
+last_updated: 2026-07-14T21:48:01Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
@@ -36,10 +36,12 @@ relates_to:
 [#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
 [#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) has its review-resolution branch
 merged with current `main` at `8f1297d`; the latest code fix is
-[`eb3da0b`](https://github.com/agorokh/ac-copilot-trainer/commit/eb3da0b). In addition to the
+[`ed94df0`](https://github.com/agorokh/ac-copilot-trainer/commit/ed94df0). In addition to the
 peer-safe plant persistence/revert work at `5b6d68c`, direct `auto_drive --laps N` now owns the
 scaled flying-lap time budget and self-play normalizes the optional rig-lock timeout before
-persistence. Local parity is green (**2,863 passed, 77 skipped, 86.69% coverage**). Merge only
+persistence. The latest advisory-hardening round rejects invalid explicit drive budgets and keeps
+the already-resolved content-hashed plant path stable if `setup.ini` becomes unreadable during
+persistence. Local parity is green (**2,864 passed, 77 skipped, 86.68% coverage**). Merge only
 after the current-head post-push cooldown, GraphQL thread audit, resolve-gate, and daemon review
 all converge; then `/post-merge 579`. #577 keeps its separate L3 per-corner refinement scope open.
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T21:48:01Z
+last_updated: 2026-07-14T22:01:03Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
@@ -36,12 +36,14 @@ relates_to:
 [#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
 [#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) has its review-resolution branch
 merged with current `main` at `8f1297d`; the latest code fix is
-[`ed94df0`](https://github.com/agorokh/ac-copilot-trainer/commit/ed94df0). In addition to the
+[`28ef8a7`](https://github.com/agorokh/ac-copilot-trainer/commit/28ef8a7). In addition to the
 peer-safe plant persistence/revert work at `5b6d68c`, direct `auto_drive --laps N` now owns the
 scaled flying-lap time budget and self-play normalizes the optional rig-lock timeout before
 persistence. The latest advisory-hardening round rejects invalid explicit drive budgets and keeps
 the already-resolved content-hashed plant path stable if `setup.ini` becomes unreadable during
-persistence. Local parity is green (**2,864 passed, 77 skipped, 86.68% coverage**). Merge only
+persistence. Late persistence I/O errors now mark the ladder and composed pipeline failed, so an
+already-written but unverified candidate can never return green. Local parity is green (**2,865
+passed, 77 skipped, 86.68% coverage**). Merge only
 after the current-head post-push cooldown, GraphQL thread audit, resolve-gate, and daemon review
 all converge; then `/post-merge 579`. #577 keeps its separate L3 per-corner refinement scope open.
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T10:20:00Z
+last_updated: 2026-07-14T20:40:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-572-alien-pipeline-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-543-uncertainty-aware-plant-id-2026-07-13.md
@@ -86,6 +86,25 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Review-resolved (2026-07-14) — PR #579 at `5b6d68c`, awaiting merge
+
+PR [#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
+[#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) is open, non-draft, mergeable,
+and review-resolved at [`5b6d68c`](https://github.com/agorokh/ac-copilot-trainer/commit/5b6d68cc004cca235ad6195e71b9b9abf846b415).
+The final resolution round fixed the keyword-only combo-predicate crash in handshake archive
+counting, moved self-play identity/persist/revert operations behind `plant_id.py` under the
+machine-global rig lock, and made rollback failure fail the composed pipeline instead of returning
+green with a falsified plant. Regression coverage includes caller-resolved setup identity,
+peer-safe conditional persistence/revert, and a forced rollback I/O failure. Local parity:
+**2,863 passed, 77 skipped, 86.69% coverage, `ci-fast: OK`**. Post-push proof after the full
+10-minute cooldown: required checks green, 0/18 unresolved GraphQL threads, resolve-gate clean.
+The current-head daemon HIGH claiming a missing exact-combo plant could still refine was
+replied-invalid with control-flow evidence: `load_plant_artifact` reads that exact path only, so an
+absent path never reaches persist; a peer-created path fails the locked byte comparison.
+
+**Next:** merge PR #579 when desired, then run `/post-merge 579`. Issue #577 remains open for the
+explicitly out-of-scope L3 corridor-constrained per-corner refinement.
 
 ## Delivered (2026-07-14) — #572 one-button alien pipeline CLOSED (PR #573 MERGED `dfd4b7e`) — EPIC #529 P2
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T20:40:00Z
+last_updated: 2026-07-14T20:55:36Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-572-alien-pipeline-2026-07-14.md
@@ -88,24 +88,25 @@ relates_to:
 
 # Next session handoff
 
-## Review-resolved (2026-07-14) — PR #579 at `5b6d68c`, awaiting merge
+## Review resolution resumed (2026-07-14) — PR #579 at `eb3da0b`
 
 PR [#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
-[#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) is open, non-draft, mergeable,
-and review-resolved at [`5b6d68c`](https://github.com/agorokh/ac-copilot-trainer/commit/5b6d68cc004cca235ad6195e71b9b9abf846b415).
-The final resolution round fixed the keyword-only combo-predicate crash in handshake archive
-counting, moved self-play identity/persist/revert operations behind `plant_id.py` under the
-machine-global rig lock, and made rollback failure fail the composed pipeline instead of returning
-green with a falsified plant. Regression coverage includes caller-resolved setup identity,
-peer-safe conditional persistence/revert, and a forced rollback I/O failure. Local parity:
-**2,863 passed, 77 skipped, 86.69% coverage, `ci-fast: OK`**. Post-push proof after the full
-10-minute cooldown: required checks green, 0/18 unresolved GraphQL threads, resolve-gate clean.
-The current-head daemon HIGH claiming a missing exact-combo plant could still refine was
-replied-invalid with control-flow evidence: `load_plant_artifact` reads that exact path only, so an
-absent path never reaches persist; a peer-created path fails the locked byte comparison.
+[#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) is open and non-draft. Its
+resolution branch now includes current `main` (`8f1297d`) and code fix
+[`eb3da0b`](https://github.com/agorokh/ac-copilot-trainer/commit/eb3da0b). The earlier resolution
+round at `5b6d68c` fixed handshake combo counting and made plant persistence/revert peer-safe and
+fail-closed. The resumed round fixes the optional `rig_lock_timeout=None` path before persistence
+and moves the implicit `--laps N` time-budget policy into `auto_drive`, so direct CLI and composed
+alien runs both receive `180 + 240*N` seconds unless the operator passes an explicit budget.
+Regression coverage proves the zero-second lock fallback, direct multi-lap scaling, explicit
+override precedence, and the legacy 300-second non-lap default. Local parity is green:
+**2,863 passed, 77 skipped, 86.69% coverage, `ci-fast: OK`**.
 
-**Next:** merge PR #579 when desired, then run `/post-merge 579`. Issue #577 remains open for the
-explicitly out-of-scope L3 corridor-constrained per-corner refinement.
+**Next:** do not merge until the current-head push completes its full 10-minute cooldown, all
+required checks are green, the complete GraphQL thread ledger is resolved, resolve-gate is clean,
+and the current-SHA daemon body has no unaddressed HIGH finding. Then merge PR #579 when desired
+and run `/post-merge 579`. Issue #577 remains open for the explicitly out-of-scope L3
+corridor-constrained per-corner refinement.
 
 ## Delivery context (2026-07-14 evening) — #577 self-play live proof
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T21:48:01Z
+last_updated: 2026-07-14T22:01:03Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-572-alien-pipeline-2026-07-14.md
@@ -88,12 +88,12 @@ relates_to:
 
 # Next session handoff
 
-## Review resolution resumed (2026-07-14) — PR #579 at `ed94df0`
+## Review resolution resumed (2026-07-14) — PR #579 at `28ef8a7`
 
 PR [#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
 [#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) is open and non-draft. Its
 resolution branch now includes current `main` (`8f1297d`) and code fix
-[`ed94df0`](https://github.com/agorokh/ac-copilot-trainer/commit/ed94df0). The earlier resolution
+[`28ef8a7`](https://github.com/agorokh/ac-copilot-trainer/commit/28ef8a7). The earlier resolution
 round at `5b6d68c` fixed handshake combo counting and made plant persistence/revert peer-safe and
 fail-closed. The resumed round fixes the optional `rig_lock_timeout=None` path before persistence
 and moves the implicit `--laps N` time-budget policy into `auto_drive`, so direct CLI and composed
@@ -101,8 +101,10 @@ alien runs both receive `180 + 240*N` seconds unless the operator passes an expl
 The latest advisory-hardening round rejects non-finite/non-positive explicit budgets and makes
 self-play persistence write the already-resolved content-hashed driven path after stable identity
 validation, avoiding a second `setup.ini` read that could fork or skip the artifact. Regression
-coverage proves both failure boundaries and the stable path under a disappearing setup file.
-Canonical-venv local parity is green: **2,864 passed, 77 skipped, 86.68% coverage,
+coverage proves both failure boundaries and the stable path under a disappearing setup file. The
+final Codex P2 round makes any refine-persistence I/O exception set `selfplay.ok=false`, including a
+failure after the candidate write, so the composed pipeline cannot expose an unverified plant with
+exit 0. Canonical-venv local parity is green: **2,865 passed, 77 skipped, 86.68% coverage,
 `ci-fast: OK`**.
 
 **Next:** do not merge until the current-head push completes its full 10-minute cooldown, all

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-14T20:55:36Z
+last_updated: 2026-07-14T21:48:01Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-572-alien-pipeline-2026-07-14.md
@@ -88,19 +88,22 @@ relates_to:
 
 # Next session handoff
 
-## Review resolution resumed (2026-07-14) — PR #579 at `eb3da0b`
+## Review resolution resumed (2026-07-14) — PR #579 at `ed94df0`
 
 PR [#579](https://github.com/agorokh/ac-copilot-trainer/pull/579) for
 [#577](https://github.com/agorokh/ac-copilot-trainer/issues/577) is open and non-draft. Its
 resolution branch now includes current `main` (`8f1297d`) and code fix
-[`eb3da0b`](https://github.com/agorokh/ac-copilot-trainer/commit/eb3da0b). The earlier resolution
+[`ed94df0`](https://github.com/agorokh/ac-copilot-trainer/commit/ed94df0). The earlier resolution
 round at `5b6d68c` fixed handshake combo counting and made plant persistence/revert peer-safe and
 fail-closed. The resumed round fixes the optional `rig_lock_timeout=None` path before persistence
 and moves the implicit `--laps N` time-budget policy into `auto_drive`, so direct CLI and composed
 alien runs both receive `180 + 240*N` seconds unless the operator passes an explicit budget.
-Regression coverage proves the zero-second lock fallback, direct multi-lap scaling, explicit
-override precedence, and the legacy 300-second non-lap default. Local parity is green:
-**2,863 passed, 77 skipped, 86.69% coverage, `ci-fast: OK`**.
+The latest advisory-hardening round rejects non-finite/non-positive explicit budgets and makes
+self-play persistence write the already-resolved content-hashed driven path after stable identity
+validation, avoiding a second `setup.ini` read that could fork or skip the artifact. Regression
+coverage proves both failure boundaries and the stable path under a disappearing setup file.
+Canonical-venv local parity is green: **2,864 passed, 77 skipped, 86.68% coverage,
+`ci-fast: OK`**.
 
 **Next:** do not merge until the current-head push completes its full 10-minute cooldown, all
 required checks are green, the complete GraphQL thread ledger is resolved, resolve-gate is clean,

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -1592,7 +1592,7 @@ def test_positive_float_flags_reject_bad_values():
     # race_ini_setup_bake_loop, and not as a never-expiring hijack deadline (#482 review). `inf`
     # would make `deadline = monotonic() + probe` never expire — the exact hang #466 removes.
     base = ["--car", "ks_porsche_911_gt3_r_2016", "--track", "spa"]
-    for flag in ("--setup-rebake-interval", "--hijack-probe-seconds"):
+    for flag in ("--setup-rebake-interval", "--hijack-probe-seconds", "--drive-seconds"):
         for bad in ("0", "-0.5", "inf", "nan"):
             with pytest.raises(SystemExit):
                 _build_arg_parser().parse_args(base + [flag, bad])
@@ -2763,6 +2763,11 @@ def test_cli_laps_implies_wait_lap_and_rejects_negative():
         ["--car", "c", "--track", "t", "--laps", "3", "--drive-seconds", "200"]
     )
     assert _config_from_args(explicit).drive_seconds == 200.0
+    from tools.ac_harness.auto_drive import resolve_lap_window_drive_seconds
+
+    for bad in (0.0, -1.0, float("inf"), float("nan")):
+        with pytest.raises(ValueError, match="drive seconds must be finite and > 0"):
+            resolve_lap_window_drive_seconds(bad, 3)
     args = _build_arg_parser().parse_args(["--car", "c", "--track", "t"])
     cfg = _config_from_args(args)
     assert cfg.wait_lap is False and cfg.target_laps == 0 and cfg.drive_seconds == 300.0

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2758,9 +2758,14 @@ def test_cli_laps_implies_wait_lap_and_rejects_negative():
     cfg = _config_from_args(args)
     assert cfg.wait_lap is True
     assert cfg.target_laps == 3
+    assert cfg.drive_seconds == 180.0 + 240.0 * 3
+    explicit = _build_arg_parser().parse_args(
+        ["--car", "c", "--track", "t", "--laps", "3", "--drive-seconds", "200"]
+    )
+    assert _config_from_args(explicit).drive_seconds == 200.0
     args = _build_arg_parser().parse_args(["--car", "c", "--track", "t"])
     cfg = _config_from_args(args)
-    assert cfg.wait_lap is False and cfg.target_laps == 0
+    assert cfg.wait_lap is False and cfg.target_laps == 0 and cfg.drive_seconds == 300.0
     from tools.ac_harness.auto_drive import _main
 
     assert _main(["--car", "c", "--track", "magione", "--laps", "-1"]) == 2

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2807,3 +2807,80 @@ def test_one_lap_batch_requires_a_timed_lap_window():
     assert report.ok is True
     assert record["lap_count"] == 1
     assert report.lap_times_ms == [97000]
+
+
+def test_lap_window_with_zero_timed_laps_fails_honestly():
+    # #579 Codex P2: --laps N + only an untimed boundary must FAIL the run, not exit 0 with an
+    # empty trajectory (require_lap alone is satisfiable by the untimed frame).
+    record: dict = {}
+    frames = [*CONTINUOUS, _snap("session"), _timed_lap_snap(None)]
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, target_laps=1),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, laps=0), record),
+            tap=_tap_returning(frames, record),
+        )
+    )
+    assert report.ok is False
+    assert report.lap_times_ms == []
+    assert any("observed ZERO" in n for n in report.notes)
+
+
+def test_collect_lap_archives_matching_count_is_validity_agnostic(tmp_path):
+    # #579 Qodo + Codex: the batch gate waits for THIS combo's archives (a foreign app/combo's
+    # file must not satisfy it) but never gates on validity (an AC-invalid archive is
+    # falsification evidence that can never turn valid by waiting).
+    import json as _json
+
+    journal = tmp_path / "journal"
+    journal.mkdir()
+
+    def _write(name, car, valid):
+        (journal / name).write_text(
+            _json.dumps(
+                {
+                    "car": {"id": car},
+                    "track": {"id": "imola", "layout": None},
+                    "lap": {"lap_n": 1, "lap_ms": 90000, "is_valid": valid},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    _write("lap_own_invalid.json", "car_a", False)
+    _write("lap_foreign_valid.json", "other_car", True)
+
+    def predicate(payload: dict) -> bool:
+        return str(payload.get("car", {}).get("id")) == "car_a"
+
+    clock = _Clock()
+    # One own-combo (AC-invalid) archive satisfies min_matching_count=1 immediately — validity
+    # never gates the batch poll.
+    found = collect_lap_archives(
+        journal,
+        0.0,
+        wait_for_first=True,
+        min_count=1,
+        min_matching_count=1,
+        valid_archive_predicate=predicate,
+        timeout_s=5.0,
+        _clock=clock.monotonic,
+        _sleep=clock.sleep,
+    )
+    assert len(found) == 2 and clock.now == 0.0  # returned on the first scan, no waiting
+    # A foreign valid archive alone can NOT satisfy the matching gate: the poll runs to its
+    # bounded timeout and returns what exists (honest shortfall, no hang).
+    found = collect_lap_archives(
+        journal,
+        0.0,
+        wait_for_first=True,
+        min_count=1,
+        min_matching_count=2,
+        valid_archive_predicate=predicate,
+        timeout_s=5.0,
+        _clock=clock.monotonic,
+        _sleep=clock.sleep,
+    )
+    assert len(found) == 2 and clock.now >= 5.0  # waited the bounded budget, then honest return

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2787,3 +2787,23 @@ def test_build_driver_alien_overspeed_optin_is_bounded():
         _build_driver(replace(cfg, ggv_scale=ALIEN_MAX_OVERSPEED_SCALE + 0.01), _LINE, None)
     with pytest.raises(ValueError, match="ggv_scale"):
         _build_driver(replace(cfg, alien_overspeed=False), _LINE, None)
+
+
+def test_one_lap_batch_requires_a_timed_lap_window():
+    # #579 daemon HIGH: --laps 1 is a BATCH of one TIMED lap, not the legacy any-boundary wait —
+    # the tap must receive lap_count=1 so an untimed out-lap/teleport boundary cannot end the
+    # window with zero timed laps (which would falsify a healthy self-play iteration).
+    record: dict = {}
+    frames = [*CONTINUOUS, _snap("session"), _timed_lap_snap(97000)]
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, target_laps=1),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, laps=1), record),
+            tap=_tap_returning(frames, record),
+        )
+    )
+    assert report.ok is True
+    assert record["lap_count"] == 1
+    assert report.lap_times_ms == [97000]

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2683,3 +2683,107 @@ def test_cli_new_flags_map_to_config(tmp_path):
     assert cfg.max_recoveries == 3
     assert cfg.progress_stall_seconds == 8.0
     assert cfg.spawn_to_line is False
+
+
+# --------------------------------------------------------------------------- #577 flying-lap window
+def _timed_lap_snap(ms: int | None) -> dict:
+    return {"type": "state.snapshot", "topic": "lap", "v": 1, "payload": {"last_lap_ms": ms}}
+
+
+def test_multi_lap_window_passes_lap_count_and_reports_lap_times():
+    record: dict = {}
+    tap_record: dict = {}
+    frames = [
+        *CONTINUOUS,
+        _snap("session"),
+        _timed_lap_snap(None),  # teleport/out-lap boundary: not counted
+        _timed_lap_snap(95000),
+        _timed_lap_snap(93000),
+        _timed_lap_snap(91500),
+    ]
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, target_laps=3),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, laps=3), record),
+            tap=_tap_returning(frames, tap_record),
+        )
+    )
+    assert report.ok is True
+    assert tap_record["lap_count"] == 3  # the tap holds the window open for the batch
+    assert report.lap_times_ms == [95000, 93000, 91500]
+    assert report.laps_requested == 3
+    assert not any("requested 3" in n for n in report.notes)  # no shortfall note when met
+
+
+def test_multi_lap_window_shortfall_is_noted_not_failed():
+    record: dict = {}
+    frames = [*CONTINUOUS, _snap("session"), _timed_lap_snap(96000)]
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, target_laps=3),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, laps=1), record),
+            tap=_tap_returning(frames, record),
+        )
+    )
+    # "N laps or the time budget, whichever first": one timed lap still satisfies require_lap;
+    # the shortfall is reported honestly for the self-play verdict to consume.
+    assert report.ok is True
+    assert report.lap_times_ms == [96000]
+    assert any("requested 3, observed 1" in n for n in report.notes)
+
+
+def test_single_lap_wait_keeps_legacy_tap_contract():
+    record: dict = {}
+    frames = [*CONTINUOUS, _snap("session"), _snap("lap")]
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, laps=1), record),
+            tap=_tap_returning(frames, record),
+        )
+    )
+    assert report.ok is True
+    assert "lap_count" not in record  # legacy single-lap wait: no batch kwarg
+    assert report.lap_times_ms == []  # untimed boundary carries no trajectory
+
+
+def test_cli_laps_implies_wait_lap_and_rejects_negative():
+    args = _build_arg_parser().parse_args(["--car", "c", "--track", "t", "--laps", "3"])
+    cfg = _config_from_args(args)
+    assert cfg.wait_lap is True
+    assert cfg.target_laps == 3
+    args = _build_arg_parser().parse_args(["--car", "c", "--track", "t"])
+    cfg = _config_from_args(args)
+    assert cfg.wait_lap is False and cfg.target_laps == 0
+    from tools.ac_harness.auto_drive import _main
+
+    assert _main(["--car", "c", "--track", "magione", "--laps", "-1"]) == 2
+
+
+def test_build_driver_alien_overspeed_optin_is_bounded():
+    # #577: the self-play ladder may probe above the uncertainty-safe envelope, but only via the
+    # explicit opt-in and never above the hard cap.
+    from tools.ac_harness.auto_drive import ALIEN_MAX_OVERSPEED_SCALE
+    from tools.ac_harness.racing_driver import RacingDriver
+
+    cfg = _cfg(
+        driver="alien",
+        alien_line=_LINE,
+        alien_v_target=[40.0] * 4,
+        plant_kwargs=dict(_ALIEN_PLANT_KWARGS),
+        ggv_scale=1.1,
+        alien_overspeed=True,
+    )
+    d = _build_driver(cfg, _LINE, None)
+    assert isinstance(d, RacingDriver)
+    assert max(d.profile) == pytest.approx(40.0 * 1.1)
+    with pytest.raises(ValueError, match="ggv_scale"):
+        _build_driver(replace(cfg, ggv_scale=ALIEN_MAX_OVERSPEED_SCALE + 0.01), _LINE, None)
+    with pytest.raises(ValueError, match="ggv_scale"):
+        _build_driver(replace(cfg, alien_overspeed=False), _LINE, None)

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -330,6 +330,12 @@ def test_evaluate_selfplay_iteration_falsification_branches():
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 96000]), bad)
     assert not valid and "AC-invalid lap" in reason and "lap_n=2" in reason
 
+    # A partial archive set leaves counted laps unverifiable -> falsified (#579 Codex P2).
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([95000, 93000, 92000]), [_archive_payload(1)]
+    )
+    assert not valid and "archive count 1 < 3 timed laps" in reason
+
 
 def test_stage_outcome_readers_round_trip(tmp_path):
     stage = tmp_path / "drive"
@@ -350,13 +356,22 @@ def test_pipeline_rejects_bad_selfplay_flags(monkeypatch, tmp_path):
         run_pipeline(_args(tmp_path, "--laps", "-1"), run_stage=_Runner([0]))
     with pytest.raises(ValueError, match="--iterations"):
         run_pipeline(_args(tmp_path, "--iterations", "-2"), run_stage=_Runner([0]))
+    # The base drive keeps the #572 one-shot gate: a bare overspeed scale is rejected here,
+    # never silently forwarded with --alien-allow-overspeed (#579 Codex P1).
+    with pytest.raises(ValueError, match="--ggv-scale"):
+        run_pipeline(_args(tmp_path, "--ggv-scale", "1.05"), run_stage=_Runner([0]))
+    # Self-play needs timed-lap batches; legacy any-boundary --wait-lap cannot provide them.
+    with pytest.raises(ValueError, match="--iterations requires --laps"):
+        run_pipeline(_args(tmp_path, "--iterations", "1"), run_stage=_Runner([0]))
     with pytest.raises(ValueError, match="--scale-step"):
         run_pipeline(
-            _args(tmp_path, "--iterations", "1", "--scale-step", "0"), run_stage=_Runner([0])
+            _args(tmp_path, "--iterations", "1", "--laps", "1", "--scale-step", "0"),
+            run_stage=_Runner([0]),
         )
     with pytest.raises(ValueError, match="--max-scale"):
         run_pipeline(
-            _args(tmp_path, "--iterations", "1", "--max-scale", "1.5"), run_stage=_Runner([0])
+            _args(tmp_path, "--iterations", "1", "--laps", "1", "--max-scale", "1.5"),
+            run_stage=_Runner([0]),
         )
 
 

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -246,3 +246,282 @@ def test_stage_argv_builders(tmp_path):
     assert "--strict" in drive
     assert "--wait-lap" in drive
     assert str(tmp_path / "drive") in drive
+
+
+# --------------------------------------------------------------------------- #577 self-play
+import json as _json
+from pathlib import Path
+
+from tools.ac_harness.auto_alien import (
+    evaluate_selfplay_iteration,
+    iteration_scale,
+    load_stage_outcome,
+    resolve_drive_seconds,
+    stage_lap_archives,
+    stage_lap_times_ms,
+)
+
+
+def test_resolve_drive_seconds_scales_with_lap_window(tmp_path):
+    assert resolve_drive_seconds(_args(tmp_path)) == 300.0
+    assert resolve_drive_seconds(_args(tmp_path, "--laps", "3")) == 180.0 + 240.0 * 3
+    # An explicit budget always wins ("N laps or the time budget, whichever first").
+    assert resolve_drive_seconds(_args(tmp_path, "--laps", "3", "--drive-seconds", "200")) == 200.0
+
+
+def test_drive_argv_carries_lap_window_scale_and_overspeed(tmp_path):
+    args = _args(tmp_path, "--laps", "3")
+    drive = drive_argv(args, tmp_path / "d")
+    assert ["--laps", "3"] == drive[drive.index("--laps") : drive.index("--laps") + 2]
+    assert "--alien-allow-overspeed" not in drive  # scale 0.9: no opt-in
+    drive = drive_argv(args, tmp_path / "d", ggv_scale=1.05)
+    scale_at = drive.index("--ggv-scale")
+    assert ["--ggv-scale", "1.05"] == drive[scale_at : scale_at + 2]
+    assert "--alien-allow-overspeed" in drive  # >1 requires the explicit drive-stage opt-in
+    assert "--alien-rebuild-line" not in drive
+    drive = drive_argv(args, tmp_path / "d", rebuild_line=True)
+    assert "--alien-rebuild-line" in drive
+
+
+def test_iteration_scale_ladder_caps():
+    assert iteration_scale(0.9, 0.05, 1, 1.1) == 0.95
+    assert iteration_scale(0.9, 0.05, 4, 1.1) == 1.1
+    assert iteration_scale(0.9, 0.05, 40, 1.1) == 1.1
+
+
+def _stage_outcome(lap_times, *, recoveries=0, archives=(), stage="done", error=None):
+    return {
+        "report": {
+            "ok": True,
+            "stage": stage,
+            "error": error,
+            "lap_times_ms": list(lap_times),
+            "drive": {"recoveries": recoveries},
+        },
+        "lap_archives": [str(p) for p in archives],
+    }
+
+
+def _archive_payload(lap_n=1, valid=True):
+    return {"lap": {"lap_n": lap_n, "lap_ms": 90000, "is_valid": valid}}
+
+
+def test_evaluate_selfplay_iteration_falsification_branches():
+    ok_payloads = [_archive_payload(1), _archive_payload(2)]
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), ok_payloads)
+    assert valid and "AC-valid" in reason
+
+    valid, reason = evaluate_selfplay_iteration(0, None, ok_payloads)
+    assert not valid and "report missing" in reason
+
+    valid, reason = evaluate_selfplay_iteration(
+        1, _stage_outcome([95000], stage="drive", error="boom"), ok_payloads
+    )
+    assert not valid and "exit 1" in reason and "boom" in reason
+
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([95000], recoveries=2), ok_payloads
+    )
+    assert not valid and "recovery" in reason
+
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([]), ok_payloads)
+    assert not valid and "no timed lap" in reason
+
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000]), [])
+    assert not valid and "no lap archives" in reason
+
+    bad = [_archive_payload(1), _archive_payload(2, valid=False)]
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 96000]), bad)
+    assert not valid and "AC-invalid lap" in reason and "lap_n=2" in reason
+
+
+def test_stage_outcome_readers_round_trip(tmp_path):
+    stage = tmp_path / "drive"
+    stage.mkdir()
+    payload = _stage_outcome([95000], archives=[tmp_path / "lap_1.json"])
+    (stage / "report.json").write_text(_json.dumps(payload), encoding="utf-8")
+    outcome = load_stage_outcome(stage)
+    assert stage_lap_times_ms(outcome) == [95000]
+    assert stage_lap_archives(outcome) == [str(tmp_path / "lap_1.json")]
+    assert load_stage_outcome(tmp_path / "missing") is None
+    assert stage_lap_times_ms(None) == []
+    assert stage_lap_archives(None) == []
+
+
+def test_pipeline_rejects_bad_selfplay_flags(monkeypatch, tmp_path):
+    _usable_plant(monkeypatch, True)
+    with pytest.raises(ValueError, match="--laps"):
+        run_pipeline(_args(tmp_path, "--laps", "-1"), run_stage=_Runner([0]))
+    with pytest.raises(ValueError, match="--iterations"):
+        run_pipeline(_args(tmp_path, "--iterations", "-2"), run_stage=_Runner([0]))
+    with pytest.raises(ValueError, match="--scale-step"):
+        run_pipeline(
+            _args(tmp_path, "--iterations", "1", "--scale-step", "0"), run_stage=_Runner([0])
+        )
+    with pytest.raises(ValueError, match="--max-scale"):
+        run_pipeline(
+            _args(tmp_path, "--iterations", "1", "--max-scale", "1.5"), run_stage=_Runner([0])
+        )
+
+
+class _SelfplayHarness:
+    """Fakes the drive stages + plant persistence for the iterate-loop orchestration tests."""
+
+    def __init__(self, monkeypatch, tmp_path, stage_specs, refine_ok=True):
+        self.tmp_path = tmp_path
+        self.stage_specs = list(stage_specs)  # per drive call: (exit, lap_times, archive_valids)
+        self.refine_ok = refine_ok
+        self.refine_calls: list[list[dict]] = []
+        self.plant_path = tmp_path / "plant_id" / "car_a__trk.json"
+        self.plant_path.parent.mkdir(parents=True, exist_ok=True)
+        self.plant_path.write_text('{"v": "original"}', encoding="utf-8")
+        self.saves = 0
+
+        _usable_plant(monkeypatch, True)
+        monkeypatch.setattr(auto_alien, "wait_sidecar_port_settled", lambda url, **kw: "released")
+        monkeypatch.setattr(auto_alien, "plant_artifact_path", lambda *a, **kw: self.plant_path)
+
+        def fake_refine(artifact, payloads, prior, **kw):
+            self.refine_calls.append(list(payloads))
+            if not self.refine_ok:
+                return None, {"ok": False, "reason": "batch refit degraded (test)"}
+            return {"ok": True}, {"ok": True, "selfplay_merge": {"lateral_bins_raised": 1}}
+
+        def fake_save(user_dir, result):
+            self.saves += 1
+            self.plant_path.write_text(_json.dumps({"v": f"iter{self.saves}"}), encoding="utf-8")
+            return self.plant_path
+
+        import tools.ac_harness.plant_id as plant_id_mod
+
+        monkeypatch.setattr(plant_id_mod, "selfplay_refine_result", fake_refine)
+        monkeypatch.setattr(plant_id_mod, "save_plant_artifact", fake_save)
+
+    def runner(self):
+        state = {"i": 0}
+
+        def run(argv: list[str]) -> int:
+            exit_code, lap_times, archive_valids = self.stage_specs[state["i"]]
+            state["i"] += 1
+            stage_dir = Path(argv[argv.index("--evidence-dir") + 1])
+            stage_dir.mkdir(parents=True, exist_ok=True)
+            paths = []
+            for n, valid in enumerate(archive_valids, start=1):
+                p = stage_dir / f"lap_{n}.json"
+                p.write_text(
+                    _json.dumps({"lap": {"lap_n": n, "lap_ms": 90000, "is_valid": valid}}),
+                    encoding="utf-8",
+                )
+                paths.append(str(p))
+            payload = {
+                "report": {
+                    "ok": exit_code == 0,
+                    "stage": "done" if exit_code == 0 else "drive",
+                    "lap_times_ms": lap_times,
+                    "drive": {"recoveries": 0},
+                },
+                "lap_archives": paths,
+            }
+            (stage_dir / "report.json").write_text(_json.dumps(payload), encoding="utf-8")
+            return exit_code
+
+        return run
+
+
+def test_selfplay_ladder_progresses_and_reports_trajectory(monkeypatch, tmp_path):
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[
+            (0, [95000], [True]),  # base drive
+            (0, [93000], [True]),  # iteration 1
+            (0, [91000], [True]),  # iteration 2
+        ],
+    )
+    args = _args(
+        tmp_path,
+        "--evidence-dir",
+        str(tmp_path / "ev"),
+        "--laps",
+        "1",
+        "--iterations",
+        "2",
+        "--scale-step",
+        "0.05",
+        "--max-scale",
+        "1.1",
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0 and report["ok"]
+    selfplay = report["selfplay"]
+    assert selfplay["stopped"] == "completed"
+    assert selfplay["lap_trajectory_ms"] == [[95000], [93000], [91000]]
+    assert selfplay["best_lap_ms"] == 91000
+    scales = [entry["ggv_scale"] for entry in selfplay["iterations"]]
+    assert scales == [0.95, 1.0]
+    assert all(entry["valid"] for entry in selfplay["iterations"])
+    # Each refine consumed the PREVIOUS drive's batch (provenance-bound self-play).
+    assert len(harness.refine_calls) == 2
+    assert harness.saves == 2
+    # The plant on disk is the last refined fit (no falsification -> no revert).
+    assert _json.loads(harness.plant_path.read_text(encoding="utf-8")) == {"v": "iter2"}
+
+
+def test_selfplay_falsified_step_reverts_plant_and_stops(monkeypatch, tmp_path):
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[
+            (0, [95000], [True]),  # base drive: valid
+            (0, [94000, 96000], [True, False]),  # iteration 1: AC-invalid lap -> falsified
+        ],
+    )
+    args = _args(
+        tmp_path,
+        "--evidence-dir",
+        str(tmp_path / "ev"),
+        "--laps",
+        "2",
+        "--iterations",
+        "3",
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0 and report["ok"]  # the base pipeline passed; the ladder ended honestly
+    selfplay = report["selfplay"]
+    assert "falsified at iteration 1" in selfplay["stopped"]
+    assert "AC-invalid lap" in selfplay["stopped"]
+    assert len(selfplay["iterations"]) == 1  # never silently retried
+    entry = selfplay["iterations"][0]
+    assert entry["valid"] is False and entry["reverted"] is True
+    # Keep-last-valid: the falsified refined fit was rolled back on disk.
+    assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
+
+
+def test_selfplay_refuses_identical_envelope_retry(monkeypatch, tmp_path):
+    # Scale already capped at the base value AND the refit failed -> the envelope cannot change;
+    # driving again would retry the identical envelope, which the ladder must refuse.
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[(0, [95000], [True])],
+        refine_ok=False,
+    )
+    args = _args(
+        tmp_path,
+        "--evidence-dir",
+        str(tmp_path / "ev"),
+        "--laps",
+        "1",
+        "--iterations",
+        "2",
+        "--max-scale",
+        "0.9",
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0
+    selfplay = report["selfplay"]
+    assert "envelope unchanged" in selfplay["stopped"]
+    assert selfplay["iterations"][0].get("skipped") is True
+    assert selfplay["iterations"][0]["refine"]["ok"] is False
+    # The plant was never touched.
+    assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -654,3 +654,28 @@ def test_selfplay_oracle_ignores_foreign_combo_archives(monkeypatch, tmp_path):
         [own, foreign], car_id="car_a", track_id="trk", layout=None
     )
     assert kept == [own] and dropped == 1
+
+
+def test_selfplay_filesystem_error_stops_with_named_reason(monkeypatch, tmp_path):
+    # #579 Qodo reliability: an OSError during the refine persist must surface as an honest
+    # selfplay.stopped reason in the composed report, never crash the pipeline.
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[
+            (0, [95000], [True]),  # base drive
+        ],
+    )
+
+    def exploding_read(*a, **kw):
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(type(harness.plant_path), "read_bytes", exploding_read)
+    args = _args(
+        tmp_path, "--evidence-dir", str(tmp_path / "ev"), "--laps", "1", "--iterations", "2"
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0  # the base pipeline passed; the ladder stopped honestly
+    selfplay = report["selfplay"]
+    assert "filesystem error at iteration 1" in selfplay["stopped"]
+    assert "disk on fire" in selfplay["iterations"][0]["refine"]["reason"]

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -430,15 +430,42 @@ class _SelfplayHarness:
                 return None, {"ok": False, "reason": "batch refit degraded (test)"}
             return {"ok": True}, {"ok": True, "selfplay_merge": dict(self.merge_stats)}
 
-        def fake_save(user_dir, result):
+        def fake_persist(
+            user_dir,
+            result,
+            *,
+            expected_path,
+            expected_current_bytes,
+            lock_timeout=0.0,
+        ):
+            del user_dir, result, lock_timeout
+            if Path(expected_path).read_bytes() != expected_current_bytes:
+                return None, None, "plant artifact changed between load and save (test peer)"
             self.saves += 1
             self.plant_path.write_text(_json.dumps({"v": f"iter{self.saves}"}), encoding="utf-8")
-            return self.plant_path
+            return self.plant_path, self.plant_path.read_bytes(), None
+
+        def fake_revert(
+            path,
+            previous_bytes,
+            *,
+            expected_current_bytes,
+            car_id,
+            track_id,
+            lock_timeout=0.0,
+        ):
+            del car_id, track_id, lock_timeout
+            path = Path(path)
+            if path.read_bytes() != expected_current_bytes:
+                return False
+            path.write_bytes(previous_bytes)
+            return True
 
         import tools.ac_harness.plant_id as plant_id_mod
 
         monkeypatch.setattr(plant_id_mod, "selfplay_refine_result", fake_refine)
-        monkeypatch.setattr(plant_id_mod, "save_plant_artifact", fake_save)
+        monkeypatch.setattr(plant_id_mod, "persist_selfplay_refinement", fake_persist)
+        monkeypatch.setattr(plant_id_mod, "revert_plant_artifact", fake_revert)
 
     def runner(self):
         state = {"i": 0}
@@ -535,6 +562,36 @@ def test_selfplay_falsified_step_reverts_plant_and_stops(monkeypatch, tmp_path):
     assert entry["valid"] is False and entry["reverted"] is True
     # Keep-last-valid: the falsified refined fit was rolled back on disk.
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
+
+
+def test_selfplay_revert_failure_fails_the_pipeline(monkeypatch, tmp_path):
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[
+            (0, [95000], [True]),
+            (0, [94000], [False]),
+        ],
+    )
+
+    def exploding_revert(*args, **kwargs):
+        raise OSError("disk became read-only")
+
+    import tools.ac_harness.plant_id as plant_id_mod
+
+    monkeypatch.setattr(plant_id_mod, "revert_plant_artifact", exploding_revert)
+    args = _args(
+        tmp_path, "--evidence-dir", str(tmp_path / "ev"), "--laps", "1", "--iterations", "1"
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 1 and report["ok"] is False
+    assert report["selfplay"]["ok"] is False
+    assert "rollback failed at iteration 1" in report["error"]
+    entry = report["selfplay"]["iterations"][0]
+    assert entry["reverted"] is False
+    assert "disk became read-only" in entry["revert_error"]
+    # The unsafe candidate remains visible in the test fixture, so a green exit is forbidden.
+    assert harness.plant_path.read_text(encoding="utf-8") != '{"v": "original"}'
 
 
 def test_selfplay_refuses_identical_envelope_retry(monkeypatch, tmp_path):

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -401,6 +401,7 @@ class _SelfplayHarness:
         refine_ok=True,
         merge_stats=None,
         mutate_plant_during_refine=False,
+        persist_error_after_write=False,
     ):
         self.tmp_path = tmp_path
         self.stage_specs = list(stage_specs)  # per drive call: (exit, lap_times, archive_valids)
@@ -412,6 +413,7 @@ class _SelfplayHarness:
             "mu_lat_g_after": 1.5,
         }
         self.mutate_plant_during_refine = mutate_plant_during_refine
+        self.persist_error_after_write = persist_error_after_write
         self.refine_calls: list[list[dict]] = []
         self.persist_lock_timeouts: list[float] = []
         self.plant_path = tmp_path / "plant_id" / "car_a__trk.json"
@@ -445,6 +447,8 @@ class _SelfplayHarness:
                 return None, None, "plant artifact changed between load and save (test peer)"
             self.saves += 1
             self.plant_path.write_text(_json.dumps({"v": f"iter{self.saves}"}), encoding="utf-8")
+            if self.persist_error_after_write:
+                raise OSError("late candidate read failed")
             return self.plant_path, self.plant_path.read_bytes(), None
 
         def fake_revert(
@@ -741,7 +745,28 @@ def test_selfplay_filesystem_error_stops_with_named_reason(monkeypatch, tmp_path
         tmp_path, "--evidence-dir", str(tmp_path / "ev"), "--laps", "1", "--iterations", "2"
     )
     code, report = run_pipeline(args, run_stage=harness.runner())
-    assert code == 0  # the base pipeline passed; the ladder stopped honestly
+    assert code == 1 and report["ok"] is False
     selfplay = report["selfplay"]
+    assert selfplay["ok"] is False
     assert "filesystem error at iteration 1" in selfplay["stopped"]
     assert "disk on fire" in selfplay["iterations"][0]["refine"]["reason"]
+
+
+def test_selfplay_late_persist_error_cannot_return_green(monkeypatch, tmp_path):
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[(0, [95000], [True])],
+        persist_error_after_write=True,
+    )
+    args = _args(
+        tmp_path, "--evidence-dir", str(tmp_path / "ev"), "--laps", "1", "--iterations", "1"
+    )
+
+    code, report = run_pipeline(args, run_stage=harness.runner())
+
+    assert code == 1 and report["ok"] is False
+    assert report["selfplay"]["ok"] is False
+    assert "late candidate read failed" in report["error"]
+    # The candidate may already be on disk, so returning success would expose an unverified plant.
+    assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "iter1"}'

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -298,8 +298,12 @@ def _stage_outcome(lap_times, *, recoveries=0, archives=(), stage="done", error=
     }
 
 
-def _archive_payload(lap_n=1, valid=True):
-    return {"lap": {"lap_n": lap_n, "lap_ms": 90000, "is_valid": valid}}
+def _archive_payload(lap_n=1, valid=True, car="car_a", track="trk"):
+    return {
+        "car": {"id": car},
+        "track": {"id": track, "layout": None},
+        "lap": {"lap_n": lap_n, "lap_ms": 90000, "is_valid": valid},
+    }
 
 
 def test_evaluate_selfplay_iteration_falsification_branches():
@@ -329,6 +333,11 @@ def test_evaluate_selfplay_iteration_falsification_branches():
     bad = [_archive_payload(1), _archive_payload(2, valid=False)]
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 96000]), bad)
     assert not valid and "AC-invalid lap" in reason and "lap_n=2" in reason
+
+    # A payload with no explicit lap-validity verdict fails CLOSED (#579 Qodo).
+    malformed = [_archive_payload(1), {"car": {"id": "car_a"}, "trace": {}}]
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 96000]), malformed)
+    assert not valid and "without a lap-validity verdict" in reason
 
     # A partial archive set leaves counted laps unverifiable -> falsified (#579 Codex P2).
     valid, reason = evaluate_selfplay_iteration(
@@ -436,10 +445,7 @@ class _SelfplayHarness:
             paths = []
             for n, valid in enumerate(archive_valids, start=1):
                 p = stage_dir / f"lap_{n}.json"
-                p.write_text(
-                    _json.dumps({"lap": {"lap_n": n, "lap_ms": 90000, "is_valid": valid}}),
-                    encoding="utf-8",
-                )
+                p.write_text(_json.dumps(_archive_payload(n, valid)), encoding="utf-8")
                 paths.append(str(p))
             payload = {
                 "report": {
@@ -636,3 +642,15 @@ def test_selfplay_refine_save_skipped_when_peer_updates_plant(monkeypatch, tmp_p
     assert harness.saves == 0
     # The peer's newer artifact survived untouched.
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "peer"}'
+
+
+def test_selfplay_oracle_ignores_foreign_combo_archives(monkeypatch, tmp_path):
+    # #579 Codex P2: another app/combo's archive must neither satisfy nor poison the batch.
+    from tools.ac_harness.auto_alien import combo_filter_payloads
+
+    own = _archive_payload(1)
+    foreign = _archive_payload(1, car="other_car", track="other_trk")
+    kept, dropped = combo_filter_payloads(
+        [own, foreign], car_id="car_a", track_id="trk", layout=None
+    )
+    assert kept == [own] and dropped == 1

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -378,10 +378,25 @@ def test_pipeline_rejects_bad_selfplay_flags(monkeypatch, tmp_path):
 class _SelfplayHarness:
     """Fakes the drive stages + plant persistence for the iterate-loop orchestration tests."""
 
-    def __init__(self, monkeypatch, tmp_path, stage_specs, refine_ok=True):
+    def __init__(
+        self,
+        monkeypatch,
+        tmp_path,
+        stage_specs,
+        refine_ok=True,
+        merge_stats=None,
+        mutate_plant_during_refine=False,
+    ):
         self.tmp_path = tmp_path
         self.stage_specs = list(stage_specs)  # per drive call: (exit, lap_times, archive_valids)
         self.refine_ok = refine_ok
+        self.merge_stats = merge_stats or {
+            "lateral_bins_adopted": 0,
+            "lateral_bins_raised": 1,
+            "mu_lat_g_before": 1.5,
+            "mu_lat_g_after": 1.5,
+        }
+        self.mutate_plant_during_refine = mutate_plant_during_refine
         self.refine_calls: list[list[dict]] = []
         self.plant_path = tmp_path / "plant_id" / "car_a__trk.json"
         self.plant_path.parent.mkdir(parents=True, exist_ok=True)
@@ -394,9 +409,11 @@ class _SelfplayHarness:
 
         def fake_refine(artifact, payloads, prior, **kw):
             self.refine_calls.append(list(payloads))
+            if self.mutate_plant_during_refine:
+                self.plant_path.write_text('{"v": "peer"}', encoding="utf-8")
             if not self.refine_ok:
                 return None, {"ok": False, "reason": "batch refit degraded (test)"}
-            return {"ok": True}, {"ok": True, "selfplay_merge": {"lateral_bins_raised": 1}}
+            return {"ok": True}, {"ok": True, "selfplay_merge": dict(self.merge_stats)}
 
         def fake_save(user_dir, result):
             self.saves += 1
@@ -536,3 +553,86 @@ def test_selfplay_refuses_identical_envelope_retry(monkeypatch, tmp_path):
     assert selfplay["iterations"][0]["refine"]["ok"] is False
     # The plant was never touched.
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
+
+
+def test_selfplay_base_drive_must_pass_the_oracle_to_seed_refinement(monkeypatch, tmp_path):
+    # #579 Codex P1: exit 0 with an AC-invalid archived lap must NOT seed iteration 1's refit.
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[
+            (0, [95000], [False]),  # base drive: exit 0 but the archived lap is AC-invalid
+            (0, [93000], [True]),  # iteration 1 drives (scale stepped), no refit batch
+        ],
+    )
+    args = _args(
+        tmp_path, "--evidence-dir", str(tmp_path / "ev"), "--laps", "1", "--iterations", "1"
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0
+    selfplay = report["selfplay"]
+    assert selfplay["base"]["valid"] is False
+    assert "AC-invalid lap" in selfplay["base"]["reason"]
+    assert harness.refine_calls == []  # tainted base evidence never reached the refit
+    entry = selfplay["iterations"][0]
+    assert entry["refine"]["reason"] == "no lap archives from the previous drive"
+    assert entry["valid"] is True  # the ladder itself still ran (scale changed the envelope)
+    assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
+
+
+def test_selfplay_noop_refit_at_scale_cap_stops_instead_of_retrying(monkeypatch, tmp_path):
+    # #579 Codex P2: a refit that changes nothing + a capped scale = the identical physical
+    # envelope; the ladder must stop, and the no-op fit must not even be persisted.
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[(0, [95000], [True])],
+        merge_stats={
+            "lateral_bins_adopted": 0,
+            "lateral_bins_raised": 0,
+            "mu_lat_g_before": 1.5,
+            "mu_lat_g_after": 1.5,
+        },
+    )
+    args = _args(
+        tmp_path,
+        "--evidence-dir",
+        str(tmp_path / "ev"),
+        "--laps",
+        "1",
+        "--iterations",
+        "2",
+        "--max-scale",
+        "0.9",
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0
+    selfplay = report["selfplay"]
+    assert "envelope unchanged" in selfplay["stopped"]
+    assert selfplay["iterations"][0]["refine"]["no_op"] is True
+    assert harness.saves == 0  # the no-op fit was never persisted (no provenance churn)
+    assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
+
+
+def test_selfplay_refine_save_skipped_when_peer_updates_plant(monkeypatch, tmp_path):
+    # #579 Codex P2: a peer refresh between load and save must not be clobbered by a refinement
+    # computed from the stale bytes.
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[
+            (0, [95000], [True]),  # base drive
+            (0, [93000], [True]),  # iteration 1
+        ],
+        mutate_plant_during_refine=True,
+    )
+    args = _args(
+        tmp_path, "--evidence-dir", str(tmp_path / "ev"), "--laps", "1", "--iterations", "1"
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0
+    entry = report["selfplay"]["iterations"][0]
+    assert "save_skipped" in entry["refine"]
+    assert harness.saves == 0
+    # The peer's newer artifact survived untouched.
+    assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "peer"}'

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -2,15 +2,24 @@
 
 from __future__ import annotations
 
+import json as _json
+from pathlib import Path
+
 import pytest
 
 from tools.ac_harness import auto_alien
 from tools.ac_harness.auto_alien import (
     _build_arg_parser,
     drive_argv,
+    evaluate_selfplay_iteration,
     identify_argv,
+    iteration_scale,
+    load_stage_outcome,
     needs_identification,
+    resolve_drive_seconds,
     run_pipeline,
+    stage_lap_archives,
+    stage_lap_times_ms,
 )
 
 
@@ -249,19 +258,6 @@ def test_stage_argv_builders(tmp_path):
 
 
 # --------------------------------------------------------------------------- #577 self-play
-import json as _json
-from pathlib import Path
-
-from tools.ac_harness.auto_alien import (
-    evaluate_selfplay_iteration,
-    iteration_scale,
-    load_stage_outcome,
-    resolve_drive_seconds,
-    stage_lap_archives,
-    stage_lap_times_ms,
-)
-
-
 def test_resolve_drive_seconds_scales_with_lap_window(tmp_path):
     assert resolve_drive_seconds(_args(tmp_path)) == 300.0
     assert resolve_drive_seconds(_args(tmp_path, "--laps", "3")) == 180.0 + 240.0 * 3

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -382,6 +382,12 @@ def test_pipeline_rejects_bad_selfplay_flags(monkeypatch, tmp_path):
             _args(tmp_path, "--iterations", "1", "--laps", "1", "--max-scale", "1.5"),
             run_stage=_Runner([0]),
         )
+    # A cap below the base scale would make iteration 1 an EASIER envelope than the base drive.
+    with pytest.raises(ValueError, match="must be >= --ggv-scale"):
+        run_pipeline(
+            _args(tmp_path, "--iterations", "1", "--laps", "1", "--max-scale", "0.8"),
+            run_stage=_Runner([0]),
+        )
 
 
 class _SelfplayHarness:

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -413,6 +413,7 @@ class _SelfplayHarness:
         }
         self.mutate_plant_during_refine = mutate_plant_during_refine
         self.refine_calls: list[list[dict]] = []
+        self.persist_lock_timeouts: list[float] = []
         self.plant_path = tmp_path / "plant_id" / "car_a__trk.json"
         self.plant_path.parent.mkdir(parents=True, exist_ok=True)
         self.plant_path.write_text('{"v": "original"}', encoding="utf-8")
@@ -438,7 +439,8 @@ class _SelfplayHarness:
             expected_current_bytes,
             lock_timeout=0.0,
         ):
-            del user_dir, result, lock_timeout
+            del user_dir, result
+            self.persist_lock_timeouts.append(lock_timeout)
             if Path(expected_path).read_bytes() != expected_current_bytes:
                 return None, None, "plant artifact changed between load and save (test peer)"
             self.saves += 1
@@ -530,6 +532,7 @@ def test_selfplay_ladder_progresses_and_reports_trajectory(monkeypatch, tmp_path
     # Each refine consumed the PREVIOUS drive's batch (provenance-bound self-play).
     assert len(harness.refine_calls) == 2
     assert harness.saves == 2
+    assert harness.persist_lock_timeouts == [0.0, 0.0]
     # The plant on disk is the last refined fit (no falsification -> no revert).
     assert _json.loads(harness.plant_path.read_text(encoding="utf-8")) == {"v": "iter2"}
 

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -1140,15 +1140,11 @@ def test_merge_selfplay_lateral_monotonic_and_longitudinal_preserved():
     assert current.uncertainty_bins[20]["lateral"]["source"] == "prior"
     assert merged.uncertainty_bins[20]["lateral"] == dict(batch.uncertainty_bins[20]["lateral"])
     # Global monotonicity: no lateral bin ever drops.
-    for cur_bin, merged_bin in zip(
-        current.uncertainty_bins, merged.uncertainty_bins, strict=True
-    ):
+    for cur_bin, merged_bin in zip(current.uncertainty_bins, merged.uncertainty_bins, strict=True):
         assert merged_bin["lateral"]["safe_g"] >= cur_bin["lateral"]["safe_g"]
     # Longitudinal bins: the batch had no probe rows, so brake/drive stay the current model's
     # verbatim (a batch refit must never regress probe-measured braking to the prior).
-    for cur_bin, merged_bin in zip(
-        current.uncertainty_bins, merged.uncertainty_bins, strict=True
-    ):
+    for cur_bin, merged_bin in zip(current.uncertainty_bins, merged.uncertainty_bins, strict=True):
         assert merged_bin["brake"] == dict(cur_bin["brake"])
         assert merged_bin["drive"] == dict(cur_bin["drive"])
     assert stats["lateral_bins_raised"] >= 1

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -1099,3 +1099,97 @@ def test_disjoint_longitudinal_bins_do_not_claim_continuous_support():
     assert m.provenance["brake_speed_range_kmh"] is None
     blended = blend_ggv_safe(m, _prior())
     assert blended.provenance["blend_source"]["brake"] == "prior"
+
+
+# --------------------------------------------------------------------------- #577 self-play merge
+def _selfplay_batch_rows(spec: dict[int, float]) -> list[dict]:
+    """Passive lateral rows for the given {bin_low_kmh: lateral_g} — a self-play drive's evidence
+    (no probe rows: a non-handshake drive never runs brake/accel probes)."""
+    rows: list[dict] = []
+    for low, lat in spec.items():
+        for _ in range(50):
+            rows.append(
+                {"speed_kmh": low + 5.0, "accg_lat": lat, "accg_lon": 0.0, "source": "passive"}
+            )
+    return rows
+
+
+def test_merge_selfplay_lateral_monotonic_and_longitudinal_preserved():
+    from tools.ac_harness.ggv_profile import merge_selfplay_model
+
+    prior = _prior()
+    current = with_binned_uncertainty(prior, _uncertainty_rows(), prior)
+    # Batch: harder cornering at 60-70 (raise), softer at 80-90 (must NOT regress), and fresh
+    # supra-LCB evidence at 200-210 where the current model still runs on the prior (adopt).
+    batch = with_binned_uncertainty(
+        prior, _selfplay_batch_rows({60: 1.35, 80: 0.95, 200: 1.3}), prior
+    )
+    merged, stats = merge_selfplay_model(current, batch)
+    assert merged.uncertainty_aware
+    # 60-70 km/h: both measured, batch proves more grip -> raised to the batch posterior.
+    assert (
+        merged.uncertainty_bins[6]["lateral"]["safe_g"]
+        == batch.uncertainty_bins[6]["lateral"]["safe_g"]
+    )
+    # 80-90 km/h: batch measured LOWER (soft lap) -> the proven envelope is kept.
+    assert (
+        merged.uncertainty_bins[8]["lateral"]["safe_g"]
+        == current.uncertainty_bins[8]["lateral"]["safe_g"]
+    )
+    # 200-210 km/h: prior-source in the current model, measured in the batch -> adopted.
+    assert current.uncertainty_bins[20]["lateral"]["source"] == "prior"
+    assert merged.uncertainty_bins[20]["lateral"] == dict(batch.uncertainty_bins[20]["lateral"])
+    # Global monotonicity: no lateral bin ever drops.
+    for cur_bin, merged_bin in zip(
+        current.uncertainty_bins, merged.uncertainty_bins, strict=True
+    ):
+        assert merged_bin["lateral"]["safe_g"] >= cur_bin["lateral"]["safe_g"]
+    # Longitudinal bins: the batch had no probe rows, so brake/drive stay the current model's
+    # verbatim (a batch refit must never regress probe-measured braking to the prior).
+    for cur_bin, merged_bin in zip(
+        current.uncertainty_bins, merged.uncertainty_bins, strict=True
+    ):
+        assert merged_bin["brake"] == dict(cur_bin["brake"])
+        assert merged_bin["drive"] == dict(cur_bin["drive"])
+    assert stats["lateral_bins_raised"] >= 1
+    assert stats["lateral_bins_adopted"] >= 1
+    assert merged.provenance["selfplay_merges"][-1] == stats
+
+
+def test_merge_selfplay_point_model_never_drops_and_history_accumulates():
+    from dataclasses import replace as dc_replace
+
+    import pytest
+
+    from tools.ac_harness.ggv_profile import merge_selfplay_model
+
+    prior = _prior()
+    current = with_binned_uncertainty(prior, _uncertainty_rows(), prior)
+    softer = with_binned_uncertainty(
+        dc_replace(prior, mu_lat_g=prior.mu_lat_g - 0.3), _selfplay_batch_rows({60: 1.0}), prior
+    )
+    merged, _ = merge_selfplay_model(current, softer)
+    assert merged.mu_lat_g == current.mu_lat_g  # a soft batch never lowers the ceiling
+    harder = with_binned_uncertainty(
+        dc_replace(prior, mu_lat_g=prior.mu_lat_g + 0.1), _selfplay_batch_rows({60: 1.3}), prior
+    )
+    merged2, stats2 = merge_selfplay_model(merged, harder)
+    assert merged2.mu_lat_g == pytest.approx(prior.mu_lat_g + 0.1)
+    assert len(merged2.provenance["selfplay_merges"]) == 2
+    assert merged2.provenance["selfplay_merges"][-1] == stats2
+    # Brake/drive coefficients and the ellipse stay the identified plant's.
+    assert merged2.brake_b0_g == current.brake_b0_g
+    assert merged2.ellipse_n == current.ellipse_n
+
+
+def test_merge_selfplay_requires_uncertainty_aware_models():
+    import pytest
+
+    from tools.ac_harness.ggv_profile import merge_selfplay_model
+
+    prior = _prior()
+    aware = with_binned_uncertainty(prior, _uncertainty_rows(), prior)
+    with pytest.raises(ValueError, match="uncertainty-aware"):
+        merge_selfplay_model(prior, aware)
+    with pytest.raises(ValueError, match="uncertainty-aware"):
+        merge_selfplay_model(aware, prior)

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1233,9 +1233,7 @@ def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):
     assert "schema_version" not in result and "created_utc" not in result
     merged = _GGV.from_dict(result["ggv"]["model"])
     assert merged.uncertainty_aware
-    for cur_bin, new_bin in zip(
-        current.uncertainty_bins, merged.uncertainty_bins, strict=True
-    ):
+    for cur_bin, new_bin in zip(current.uncertainty_bins, merged.uncertainty_bins, strict=True):
         assert new_bin["lateral"]["safe_g"] >= cur_bin["lateral"]["safe_g"]
         assert dict(new_bin["brake"]) == dict(cur_bin["brake"])
     # The refined result persists through the SAME artifact gate every plant rides.

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1149,3 +1149,101 @@ def test_apply_handshake_outcome_success_notes():
     apply_handshake_outcome(report, sink)
     assert report.ok is True
     assert report.notes and "handshake ok" in report.notes[0]
+
+
+# --------------------------------------------------------------------------- #577 self-play refine
+def _selfplay_thermal_archive(lap_uuid: str, *, lateral_g: float = 1.3, lap_n: int = 1) -> dict:
+    """A fit-eligible lap archive for the pipeline's own combo (test_car/test_oval)."""
+    from tools.ac_harness.reference_lap import TRACE_FIELDS
+
+    fields = list(TRACE_FIELDS)
+    samples = []
+    for i in range(600):
+        values = dict.fromkeys(fields, 0.0)
+        speed = 50.0 + float((i // 50) % 11) * 10.0
+        braking = i % 2 == 0
+        values.update(
+            {
+                "spline": i / 600.0,
+                "speed": speed,
+                "eMs": i * 10.0,
+                "brake": 0.8 if braking else 0.0,
+                "throttle": 0.0 if braking else 1.0,
+                "accG_lat": lateral_g,
+                "accG_long": -1.25 if braking else 0.75,
+            }
+        )
+        for wheel in ("fl", "fr", "rl", "rr"):
+            values[f"tyreCoreTemp_{wheel}"] = 90.0
+            values[f"tyreTempInner_{wheel}"] = 92.0
+            values[f"tyreTempMid_{wheel}"] = 90.0
+            values[f"tyreTempOuter_{wheel}"] = 88.0
+            values[f"wheelsPressure_{wheel}"] = 27.0
+            values[f"dy_{wheel}"] = 1.5
+        samples.append([values[field] for field in fields])
+    return {
+        "schema_version": 1,
+        "source": "in_game",
+        "lap_uuid": lap_uuid,
+        "car": {"id": "test_car"},
+        "track": {"id": "test_oval", "layout": None},
+        "lap": {"lap_n": lap_n, "lap_ms": 90000, "is_valid": True},
+        "setup": {"hash": "setup-a"},
+        "tyres": {"compoundIndex": 1, "name": "M", "optimalTempC": 90.0},
+        "trace": {"fields": fields, "samples": samples, "samples_count": len(samples)},
+    }
+
+
+def _selfplay_artifact() -> dict:
+    artifact = _result_dict()
+    artifact["schema_version"] = PLANT_SCHEMA_VERSION
+    artifact["created_utc"] = "2026-07-01T00:00:00Z"
+    artifact["ggv"] = {"ok": True, "model": _uncertain_prior().to_dict(), "reason": "ok"}
+    return artifact
+
+
+def test_selfplay_refine_requires_current_fit_and_archives():
+    from tools.ac_harness.plant_id import selfplay_refine_result
+
+    no_fit = _result_dict()
+    result, block = selfplay_refine_result(no_fit, [], generic_gt3_ggv())
+    assert result is None and "#543" in block["reason"]
+
+    result, block = selfplay_refine_result(_selfplay_artifact(), [], generic_gt3_ggv())
+    assert result is None  # batch refit degraded -> keep last valid, reason named
+    assert block["ok"] is False
+    assert "no thermally consistent" in block["reason"]
+
+
+def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):
+    from tools.ac_harness.ggv_profile import GGVModel as _GGV
+    from tools.ac_harness.plant_id import selfplay_refine_result
+
+    artifact = _selfplay_artifact()
+    current = plant_ggv_model(artifact)
+    archives = [
+        _selfplay_thermal_archive("sp-1", lateral_g=1.35, lap_n=1),
+        _selfplay_thermal_archive("sp-2", lateral_g=1.35, lap_n=2),
+    ]
+    result, block = selfplay_refine_result(artifact, archives, generic_gt3_ggv())
+    assert result is not None
+    assert block["ok"] is True
+    assert "selfplay_merge" in block
+    # Stale identity meta is stripped so save_plant_artifact stamps fresh values.
+    assert "schema_version" not in result and "created_utc" not in result
+    merged = _GGV.from_dict(result["ggv"]["model"])
+    assert merged.uncertainty_aware
+    for cur_bin, new_bin in zip(
+        current.uncertainty_bins, merged.uncertainty_bins, strict=True
+    ):
+        assert new_bin["lateral"]["safe_g"] >= cur_bin["lateral"]["safe_g"]
+        assert dict(new_bin["brake"]) == dict(cur_bin["brake"])
+    # The refined result persists through the SAME artifact gate every plant rides.
+    path = save_plant_artifact(tmp_path, result)
+    reloaded = load_plant_artifact(tmp_path, "test_car", "test_oval")
+    assert reloaded is not None
+    assert plant_ggv_model(reloaded) is not None
+    assert reloaded["ggv"]["selfplay_merge"] == block["selfplay_merge"]
+    assert path.exists()
+    # The original artifact object was never mutated (deep-copied inside).
+    assert artifact["ggv"]["reason"] == "ok"

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1245,3 +1245,72 @@ def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):
     assert path.exists()
     # The original artifact object was never mutated (deep-copied inside).
     assert artifact["ggv"]["reason"] == "ok"
+
+
+def test_selfplay_refine_owns_the_caller_resolved_setup_identity(tmp_path):
+    from tools.ac_harness.plant_id import selfplay_refine_result
+
+    setup_ini = tmp_path / "moved-setup.ini"
+    setup_ini.write_text("[GEARS]\nFINAL=3.4\n", encoding="utf-8")
+    artifact = _selfplay_artifact()
+    artifact["setup"] = "moved-setup"
+    artifact["setup_ini"] = "C:/old-host/creator-path.ini"
+    archives = [
+        _selfplay_thermal_archive("sp-identity-1", lateral_g=1.35, lap_n=1),
+        _selfplay_thermal_archive("sp-identity-2", lateral_g=1.35, lap_n=2),
+    ]
+    result, block = selfplay_refine_result(
+        artifact,
+        archives,
+        generic_gt3_ggv(),
+        setup_ini=setup_ini,
+    )
+    assert block["ok"] is True and result is not None
+    assert result["setup_ini"] == str(setup_ini)
+    assert artifact["setup_ini"] == "C:/old-host/creator-path.ini"
+
+
+def test_selfplay_persist_and_revert_are_peer_safe(monkeypatch, tmp_path):
+    from tools.ac_harness import rig_lock
+    from tools.ac_harness.plant_id import persist_selfplay_refinement, revert_plant_artifact
+
+    monkeypatch.setattr(
+        rig_lock,
+        "default_rig_session_lock_path",
+        lambda: tmp_path / "state" / "rig-session.lock",
+    )
+    artifact = _selfplay_artifact()
+    path = save_plant_artifact(tmp_path, artifact)
+    previous_bytes = path.read_bytes()
+    candidate = load_plant_artifact(tmp_path, "test_car", "test_oval")
+    assert candidate is not None
+    candidate.pop("schema_version", None)
+    candidate.pop("created_utc", None)
+    candidate["ggv"]["reason"] = "ok (self-play test candidate)"
+
+    saved, candidate_bytes, skipped = persist_selfplay_refinement(
+        tmp_path,
+        candidate,
+        expected_path=path,
+        expected_current_bytes=previous_bytes,
+    )
+    assert saved == path and candidate_bytes == path.read_bytes() and skipped is None
+    assert revert_plant_artifact(
+        path,
+        previous_bytes,
+        expected_current_bytes=candidate_bytes,
+        car_id="test_car",
+        track_id="test_oval",
+    )
+    assert path.read_bytes() == previous_bytes
+
+    path.write_text('{"peer": true}', encoding="utf-8")
+    saved, candidate_bytes, skipped = persist_selfplay_refinement(
+        tmp_path,
+        candidate,
+        expected_path=path,
+        expected_current_bytes=previous_bytes,
+    )
+    assert saved is None and candidate_bytes is None
+    assert "changed between load and save" in str(skipped)
+    assert path.read_text(encoding="utf-8") == '{"peer": true}'

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -8,6 +8,7 @@ failure path. No game, no Windows, no I/O beyond tmp_path.
 
 from __future__ import annotations
 
+import json
 import math
 from types import SimpleNamespace
 
@@ -1314,3 +1315,36 @@ def test_selfplay_persist_and_revert_are_peer_safe(monkeypatch, tmp_path):
     assert saved is None and candidate_bytes is None
     assert "changed between load and save" in str(skipped)
     assert path.read_text(encoding="utf-8") == '{"peer": true}'
+
+
+def test_selfplay_persist_keeps_resolved_path_when_setup_becomes_unreadable(monkeypatch, tmp_path):
+    from tools.ac_harness import rig_lock
+    from tools.ac_harness.plant_id import persist_selfplay_refinement
+
+    monkeypatch.setattr(
+        rig_lock,
+        "default_rig_session_lock_path",
+        lambda: tmp_path / "state" / "rig-session.lock",
+    )
+    setup_ini = tmp_path / "race-setup.ini"
+    setup_ini.write_text("[GEARS]\nFINAL=3.4\n", encoding="utf-8")
+    artifact = _selfplay_artifact()
+    artifact["setup"] = "race-setup"
+    artifact["setup_ini"] = str(setup_ini)
+    path = save_plant_artifact(tmp_path, artifact)
+    previous_bytes = path.read_bytes()
+    candidate = json.loads(previous_bytes)
+    candidate["ggv"]["reason"] = "ok (self-play setup-race candidate)"
+
+    # The driven identity was resolved while the setup was readable. Persistence must not derive
+    # a different, unhashed filename if that same file disappears before the conditional write.
+    setup_ini.unlink()
+    saved, candidate_bytes, skipped = persist_selfplay_refinement(
+        tmp_path,
+        candidate,
+        expected_path=path,
+        expected_current_bytes=previous_bytes,
+    )
+    assert saved == path and candidate_bytes == path.read_bytes() and skipped is None
+    assert path.exists()
+    assert not (tmp_path / "plant_id" / "test_car__test_oval__setup-race-setup.json").exists()

--- a/tests/test_sequence_probe.py
+++ b/tests/test_sequence_probe.py
@@ -188,3 +188,38 @@ def test_frames_from_jsonl_round_trip(tmp_path):
     p.write_text("\n".join(lines) + "\n", encoding="utf-8")
     frames = frames_from_jsonl(str(p))
     assert [f["topic"] for f in frames] == ["connection", "session", "lap"]
+
+
+# --------------------------------------------------------------------------- #577 timed-lap helpers
+def _timed_lap(ms: int | float | None) -> dict:
+    frame = _f("lap")
+    frame["payload"] = {"last_lap_ms": ms}
+    return frame
+
+
+def test_is_timed_lap_frame_requires_snapshot_lap_topic_and_positive_time():
+    from tools.ac_harness.sequence_probe import is_timed_lap_frame
+
+    assert is_timed_lap_frame(_timed_lap(91234)) is True
+    assert is_timed_lap_frame(_timed_lap(None)) is False  # out-lap / teleport boundary
+    assert is_timed_lap_frame(_timed_lap(0)) is False
+    assert is_timed_lap_frame(_timed_lap("nope")) is False
+    assert is_timed_lap_frame(_f("lap")) is False  # no payload time
+    assert is_timed_lap_frame(_f("tire_temps")) is False
+    assert is_timed_lap_frame(_other("lap")) is False  # non-snapshot never counts
+
+
+def test_timed_lap_times_ms_orders_and_skips_untimed_boundaries():
+    from tools.ac_harness.sequence_probe import timed_lap_times_ms
+
+    frames = [
+        _f("connection"),
+        _timed_lap(None),  # out-lap boundary: no time, not counted
+        _timed_lap(95000),
+        _f("coaching.snapshot"),
+        _timed_lap(92500.7),  # float ms from the wire -> int
+        _other("lap"),  # diagnostic frame: never counts
+        _timed_lap(91800),
+    ]
+    assert timed_lap_times_ms(frames) == [95000, 92500, 91800]
+    assert timed_lap_times_ms([]) == []

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -305,12 +305,16 @@ def run_selfplay(
     # would promote a plant the falsification oracle would reject (#579 Codex P1). An invalid
     # base still allows the ladder to run — each iteration changes the envelope via scale and is
     # itself falsification-gated — it just refines from nothing until a valid batch exists.
-    base_payloads, _base_load_errors = load_archive_payloads(stage_lap_archives(base_outcome))
+    base_payloads, base_load_errors = load_archive_payloads(stage_lap_archives(base_outcome))
     base_payloads, base_foreign = combo_filter_payloads(
         base_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
     )
     base_valid, base_reason = evaluate_selfplay_iteration(0, base_outcome, base_payloads)
     selfplay["base"] = {"valid": base_valid, "reason": base_reason, "lap_times_ms": base_laps}
+    if base_load_errors:
+        # Unreadable/corrupt archives must be DISCLOSED, not hidden behind the generic validity
+        # reason (#579 Qodo observability; same class as the repo's no-silent-swallowing pitfall).
+        selfplay["base"]["archive_load_errors"] = base_load_errors
     if base_foreign:
         selfplay["base"]["foreign_archives_dropped"] = base_foreign
     # An oracle-invalid base's laps are marked unusable by this very report — they must not seed

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -37,7 +37,7 @@ from pathlib import Path
 
 from tools.ac_harness.auto_drive import (
     ALIEN_MAX_OVERSPEED_SCALE,
-    _archive_matches_combo,
+    archive_matches_combo,
     resolve_ac_user_dir,
     resolve_setup_ini,
     validate_ac_id,
@@ -198,7 +198,7 @@ def combo_filter_payloads(
     kept = [
         p
         for p in payloads
-        if _archive_matches_combo(p, car_id=car_id, track_id=track_id, layout=layout)
+        if archive_matches_combo(p, car_id=car_id, track_id=track_id, layout=layout)
     ]
     return kept, len(payloads) - len(kept)
 

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -443,6 +443,7 @@ def run_selfplay(
             # once artifact I/O errors, so the ladder stops with the named reason.
             entry.setdefault("refine", {})["ok"] = False
             entry["refine"]["reason"] = f"filesystem error during refine persist: {exc}"
+            selfplay["ok"] = False
             selfplay["stopped"] = (
                 f"filesystem error at iteration {index} ({exc}) — self-play stopped "
                 "(keep-last-valid integrity cannot be guaranteed past an I/O failure)"

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 from tools.ac_harness.auto_drive import (
     ALIEN_MAX_OVERSPEED_SCALE,
+    _archive_matches_combo,
     resolve_ac_user_dir,
     resolve_setup_ini,
     validate_ac_id,
@@ -186,6 +187,22 @@ def load_archive_payloads(paths: list[str]) -> tuple[list[dict], list[str]]:
     return payloads, errors
 
 
+def combo_filter_payloads(
+    payloads: list[dict], *, car_id: str, track_id: str, layout: str | None
+) -> tuple[list[dict], int]:
+    """Keep only this combo's archive payloads; returns ``(kept, dropped_count)``.
+
+    The multi-dir archive scan can surface another app/combo's fresh files; those must never
+    count as this batch's evidence for the oracle or the refit (#579 Codex P2).
+    """
+    kept = [
+        p
+        for p in payloads
+        if _archive_matches_combo(p, car_id=car_id, track_id=track_id, layout=layout)
+    ]
+    return kept, len(payloads) - len(kept)
+
+
 def evaluate_selfplay_iteration(
     exit_code: int, outcome: dict | None, archive_payloads: list[dict]
 ) -> tuple[bool, str]:
@@ -212,19 +229,29 @@ def evaluate_selfplay_iteration(
         return False, "no timed lap completed within the drive budget"
     if not archive_payloads:
         return False, "no lap archives collected (cannot verify lap validity or refine)"
-    if len(archive_payloads) < len(lap_times):
+    # Fail closed on verifiability (#579 Qodo): only a payload carrying an explicit lap-validity
+    # verdict counts as evidence — a malformed/partial object must not satisfy the batch.
+    verifiable = 0
+    for payload in archive_payloads:
+        lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
+        validity = lap.get("is_valid")
+        if validity is False:
+            lap_n = lap.get("lap_n")
+            return False, f"AC-invalid lap in the batch (lap_n={lap_n})"
+        if validity is not True:
+            return False, (
+                "archive payload without a lap-validity verdict "
+                "(malformed/partial lap archive — fail closed)"
+            )
+        verifiable += 1
+    if verifiable < len(lap_times):
         # Every counted lap must be verifiable: a partial archive set (writer flake / poll
         # timeout) leaves timed laps whose validity cannot be proven, and refining from it
         # would under-represent the batch (#579 Codex P2).
         return False, (
-            f"archive count {len(archive_payloads)} < {len(lap_times)} timed laps "
+            f"archive count {verifiable} < {len(lap_times)} timed laps "
             "(cannot verify every counted lap)"
         )
-    for payload in archive_payloads:
-        lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
-        if lap.get("is_valid") is False:
-            lap_n = lap.get("lap_n")
-            return False, f"AC-invalid lap in the batch (lap_n={lap_n})"
     return True, (f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries")
 
 
@@ -273,15 +300,22 @@ def run_selfplay(
     }
     base_laps = stage_lap_times_ms(base_outcome)
     selfplay["lap_trajectory_ms"].append(base_laps)
-    best: int | None = min(base_laps) if base_laps else None
     # The base drive must pass the SAME oracle before its archives may seed refinement: exit 0
     # does not preclude recoveries or AC-invalid archived laps, and refining from that evidence
     # would promote a plant the falsification oracle would reject (#579 Codex P1). An invalid
     # base still allows the ladder to run — each iteration changes the envelope via scale and is
     # itself falsification-gated — it just refines from nothing until a valid batch exists.
     base_payloads, _base_load_errors = load_archive_payloads(stage_lap_archives(base_outcome))
+    base_payloads, base_foreign = combo_filter_payloads(
+        base_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
+    )
     base_valid, base_reason = evaluate_selfplay_iteration(0, base_outcome, base_payloads)
     selfplay["base"] = {"valid": base_valid, "reason": base_reason, "lap_times_ms": base_laps}
+    if base_foreign:
+        selfplay["base"]["foreign_archives_dropped"] = base_foreign
+    # An oracle-invalid base's laps are marked unusable by this very report — they must not seed
+    # the performance summary either (#579 Codex P2).
+    best: int | None = min(base_laps) if (base_laps and base_valid) else None
     prev_archives = stage_lap_archives(base_outcome) if base_valid else []
     if not base_valid:
         print(
@@ -316,6 +350,12 @@ def run_selfplay(
                 }
             else:
                 archive_payloads, load_errors = load_archive_payloads(prev_archives)
+                archive_payloads, foreign = combo_filter_payloads(
+                    archive_payloads,
+                    car_id=args.car,
+                    track_id=args.track,
+                    layout=args.track_layout,
+                )
                 result, block = selfplay_refine_result(
                     artifact, archive_payloads, generic_gt3_ggv(), prior_name="generic_gt3_ggv"
                 )
@@ -324,6 +364,8 @@ def run_selfplay(
                 }
                 if load_errors:
                     entry["refine"]["archive_load_errors"] = load_errors
+                if foreign:
+                    entry["refine"]["foreign_archives_dropped"] = foreign
                 merge_stats = block.get("selfplay_merge", {}) if result is not None else {}
                 merge_changed = bool(
                     merge_stats.get("lateral_bins_adopted")
@@ -355,10 +397,21 @@ def run_selfplay(
                             f"{entry['refine']['save_skipped']}"
                         )
                     else:
+                        # Re-key the save with the CALLER-resolved setup identity: a portable/
+                        # moved artifact keeps its creator's absolute setup_ini path, and saving
+                        # under that stale key would write a DIFFERENT plant filename than the
+                        # one this pipeline loads and drives (#579 Codex P2).
+                        result["setup_ini"] = str(setup_ini) if setup_ini else None
                         last_valid_bytes = pre_refine_bytes
                         saved = save_plant_artifact(user_dir, result)
                         candidate_bytes = Path(saved).read_bytes()
                         refined = True
+                        if Path(saved) != Path(plant_path):
+                            entry["refine"]["save_path_mismatch"] = str(saved)
+                            print(
+                                f"auto-alien: WARNING — refined plant saved to {saved}, "
+                                f"expected {plant_path} (setup identity drift?)"
+                            )
                         print(
                             f"auto-alien: iteration {index} plant refined "
                             f"(lateral bins adopted={merge_stats.get('lateral_bins_adopted')} "
@@ -396,8 +449,13 @@ def run_selfplay(
         outcome = load_stage_outcome(stage_dir)
         archives = stage_lap_archives(outcome)
         archive_payloads, load_errors = load_archive_payloads(archives)
+        archive_payloads, foreign = combo_filter_payloads(
+            archive_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
+        )
         if load_errors:
             entry["archive_load_errors"] = load_errors
+        if foreign:
+            entry["foreign_archives_dropped"] = foreign
         lap_times = stage_lap_times_ms(outcome)
         entry["lap_times_ms"] = lap_times
         selfplay["lap_trajectory_ms"].append(lap_times)

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -282,7 +282,12 @@ def run_selfplay(
     than re-driving the identical envelope.
     """
     from tools.ac_harness.auto_drive import generic_gt3_ggv
-    from tools.ac_harness.plant_id import save_plant_artifact, selfplay_refine_result
+    from tools.ac_harness.plant_id import (
+        persist_selfplay_refinement,
+        revert_plant_artifact,
+        selfplay_refine_result,
+    )
+    from tools.ac_harness.rig_lock import RigSessionBusy
 
     plant_path = plant_artifact_path(
         user_dir, args.car, args.track, setup_key, setup_ini, layout=args.track_layout
@@ -294,6 +299,7 @@ def run_selfplay(
         "scale_step": args.scale_step,
         "max_scale": args.max_scale,
         "iterations": [],
+        "ok": True,
         "stopped": "completed",
         "lap_trajectory_ms": [],
         "best_lap_ms": None,
@@ -368,7 +374,11 @@ def run_selfplay(
                         layout=args.track_layout,
                     )
                     result, block = selfplay_refine_result(
-                        artifact, archive_payloads, generic_gt3_ggv(), prior_name="generic_gt3_ggv"
+                        artifact,
+                        archive_payloads,
+                        generic_gt3_ggv(),
+                        prior_name="generic_gt3_ggv",
+                        setup_ini=setup_ini,
                     )
                     entry["refine"] = {
                         k: v for k, v in block.items() if k not in ("model", "tyre_states")
@@ -398,46 +408,22 @@ def run_selfplay(
                             "change) — plant left as-is"
                         )
                     elif result is not None:
-                        current_bytes = plant_path.read_bytes() if plant_path.exists() else None
-                        # Re-key the save with the CALLER-resolved setup identity: a portable/
-                        # moved artifact keeps its creator's absolute setup_ini path, and saving
-                        # under that stale key would write a DIFFERENT plant filename than the
-                        # one this pipeline loads and drives (#579 Codex P2).
-                        result["setup_ini"] = str(setup_ini) if setup_ini else None
-                        expected_path = plant_artifact_path(
+                        saved, persisted_bytes, save_skipped = persist_selfplay_refinement(
                             user_dir,
-                            str(result.get("car_id") or ""),
-                            str(result.get("track_id") or ""),
-                            result.get("setup"),
-                            result.get("setup_ini"),
-                            layout=result.get("layout"),
+                            result,
+                            expected_path=plant_path,
+                            expected_current_bytes=pre_refine_bytes,
+                            lock_timeout=args.rig_lock_timeout,
                         )
-                        if current_bytes != pre_refine_bytes:
-                            entry["refine"]["save_skipped"] = (
-                                "plant artifact changed between load and save (peer "
-                                "re-identification?) — refinement of stale bytes not persisted"
-                            )
-                            print(
-                                f"auto-alien: iteration {index} refine save SKIPPED — "
-                                f"{entry['refine']['save_skipped']}"
-                            )
-                        elif Path(expected_path) != Path(plant_path):
-                            # Refuse a forked plant file OUTRIGHT: writing the refinement under
-                            # a different identity key would leave the driven plant untouched
-                            # and strand a falsified candidate at a path the revert cannot
-                            # reach (#579 daemon HIGH).
-                            entry["refine"]["save_skipped"] = (
-                                f"refined identity keys to {expected_path}, not the driven "
-                                f"plant {plant_path} — refusing a forked plant file"
-                            )
+                        if save_skipped:
+                            entry["refine"]["save_skipped"] = save_skipped
                             print(
                                 f"auto-alien: iteration {index} refine save SKIPPED — "
                                 f"{entry['refine']['save_skipped']}"
                             )
                         else:
                             last_valid_bytes = pre_refine_bytes
-                            saved = save_plant_artifact(user_dir, result)
-                            candidate_bytes = Path(saved).read_bytes()
+                            candidate_bytes = persisted_bytes
                             refined = True
                             print(
                                 f"auto-alien: iteration {index} plant refined "
@@ -450,7 +436,7 @@ def run_selfplay(
                             f"auto-alien: iteration {index} refine FAILED — keeping the "
                             f"last-valid plant ({block.get('reason')})"
                         )
-        except OSError as exc:
+        except (OSError, RigSessionBusy) as exc:
             # Fail loud IN the report: keep-last-valid integrity can no longer be guaranteed
             # once artifact I/O errors, so the ladder stops with the named reason.
             entry.setdefault("refine", {})["ok"] = False
@@ -510,11 +496,14 @@ def run_selfplay(
             entry["falsified"] = reason
             if refined and last_valid_bytes is not None:
                 try:
-                    current = plant_path.read_bytes() if plant_path.exists() else b""
-                    if current == candidate_bytes:
-                        tmp = plant_path.with_suffix(".json.tmp")
-                        tmp.write_bytes(last_valid_bytes)
-                        tmp.replace(plant_path)
+                    if revert_plant_artifact(
+                        plant_path,
+                        last_valid_bytes,
+                        expected_current_bytes=candidate_bytes,
+                        car_id=args.car,
+                        track_id=args.track,
+                        lock_timeout=args.rig_lock_timeout,
+                    ):
                         entry["reverted"] = True
                         print(
                             f"auto-alien: iteration {index} FALSIFIED ({reason}) — plant "
@@ -530,11 +519,12 @@ def run_selfplay(
                             f"auto-alien: iteration {index} FALSIFIED ({reason}); "
                             f"{entry['revert_skipped']}"
                         )
-                except OSError as exc:
-                    # The falsified candidate may still be on disk — say so loudly in the
-                    # report rather than crash before it is written (#579 Qodo reliability).
+                except (OSError, RigSessionBusy) as exc:
+                    # The falsified candidate may still be on disk.  This is a pipeline failure,
+                    # not an honest early stop: future alien runs could consume unsafe state.
                     entry["reverted"] = False
-                    entry["revert_error"] = f"filesystem error during revert: {exc}"
+                    entry["revert_error"] = f"artifact rollback failed: {type(exc).__name__}: {exc}"
+                    selfplay["ok"] = False
                     print(
                         f"auto-alien: iteration {index} FALSIFIED ({reason}); REVERT FAILED — "
                         f"{entry['revert_error']} (the falsified fit may still be persisted; "
@@ -545,7 +535,13 @@ def run_selfplay(
                     f"auto-alien: iteration {index} FALSIFIED ({reason}) — plant unchanged "
                     "this iteration (nothing to revert)"
                 )
-            selfplay["stopped"] = f"falsified at iteration {index}: {reason}"
+            if selfplay["ok"]:
+                selfplay["stopped"] = f"falsified at iteration {index}: {reason}"
+            else:
+                selfplay["stopped"] = (
+                    f"rollback failed at iteration {index}: {entry['revert_error']} "
+                    f"(falsified: {reason})"
+                )
             break
 
         print(
@@ -883,6 +879,10 @@ def run_pipeline(
             setup_ini=setup_ini,
             base_outcome=base_outcome,
         )
+        if not report["selfplay"].get("ok", True):
+            report["error"] = report["selfplay"]["stopped"]
+            report["ok"] = False
+            return 1, report
         best = report["selfplay"].get("best_lap_ms")
         print(
             f"auto-alien: selfplay done — {report['selfplay']['stopped']}"

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -333,99 +333,134 @@ def run_selfplay(
         selfplay["iterations"].append(entry)
 
         # 1) Refine the plant from the previous drive's batch (keep-last-valid on any failure).
+        #    All artifact I/O is OSError-guarded: a filesystem failure must surface as an honest
+        #    stopped reason in the composed report, never crash the pipeline before the report
+        #    is written (#579 Qodo reliability).
         refined = False
         last_valid_bytes: bytes | None = None
         candidate_bytes: bytes | None = None
-        if not prev_archives:
-            entry["refine"] = {"ok": False, "reason": "no lap archives from the previous drive"}
-        else:
-            # Snapshot the artifact bytes BEFORE loading: the refine-save runs outside the drive
-            # stage's machine-global rig lock, so a peer worktree may refresh the same plant
-            # between our load and our save — persisting a refinement of stale bytes would
-            # silently clobber the peer's newer fit (#579 Codex P2).
-            pre_refine_bytes = plant_path.read_bytes() if plant_path.exists() else None
-            artifact = load_plant_artifact(
-                user_dir, args.car, args.track, setup_key, setup_ini, layout=args.track_layout
-            )
-            if artifact is None:
+        try:
+            if not prev_archives:
                 entry["refine"] = {
                     "ok": False,
-                    "reason": f"plant artifact unloadable ({plant_path})",
+                    "reason": "no lap archives from the previous drive",
                 }
             else:
-                archive_payloads, load_errors = load_archive_payloads(prev_archives)
-                archive_payloads, foreign = combo_filter_payloads(
-                    archive_payloads,
-                    car_id=args.car,
-                    track_id=args.track,
-                    layout=args.track_layout,
+                # Snapshot the artifact bytes BEFORE loading: the refine-save runs outside the
+                # drive stage's machine-global rig lock, so a peer worktree may refresh the same
+                # plant between our load and our save — persisting a refinement of stale bytes
+                # would silently clobber the peer's newer fit (#579 Codex P2).
+                pre_refine_bytes = plant_path.read_bytes() if plant_path.exists() else None
+                artifact = load_plant_artifact(
+                    user_dir, args.car, args.track, setup_key, setup_ini, layout=args.track_layout
                 )
-                result, block = selfplay_refine_result(
-                    artifact, archive_payloads, generic_gt3_ggv(), prior_name="generic_gt3_ggv"
-                )
-                entry["refine"] = {
-                    k: v for k, v in block.items() if k not in ("model", "tyre_states")
-                }
-                if load_errors:
-                    entry["refine"]["archive_load_errors"] = load_errors
-                if foreign:
-                    entry["refine"]["foreign_archives_dropped"] = foreign
-                merge_stats = block.get("selfplay_merge", {}) if result is not None else {}
-                merge_changed = bool(
-                    merge_stats.get("lateral_bins_adopted")
-                    or merge_stats.get("lateral_bins_raised")
-                    or (
-                        merge_stats.get("mu_lat_g_after", 0.0)
-                        > merge_stats.get("mu_lat_g_before", 0.0)
+                if artifact is None:
+                    entry["refine"] = {
+                        "ok": False,
+                        "reason": f"plant artifact unloadable ({plant_path})",
+                    }
+                else:
+                    archive_payloads, load_errors = load_archive_payloads(prev_archives)
+                    archive_payloads, foreign = combo_filter_payloads(
+                        archive_payloads,
+                        car_id=args.car,
+                        track_id=args.track,
+                        layout=args.track_layout,
                     )
-                )
-                if result is not None and not merge_changed:
-                    # A refit that changed nothing (no bin adopted/raised, ceiling unchanged) is
-                    # a no-op: persisting it would only churn provenance (a pointless identical
-                    # line rebuild) while the PHYSICAL envelope stays the same — which must not
-                    # count as "the envelope changed" for the retry guard (#579 Codex P2).
-                    entry["refine"]["no_op"] = True
-                    print(
-                        f"auto-alien: iteration {index} refit was a no-op (no envelope change) "
-                        "— plant left as-is"
+                    result, block = selfplay_refine_result(
+                        artifact, archive_payloads, generic_gt3_ggv(), prior_name="generic_gt3_ggv"
                     )
-                elif result is not None:
-                    current_bytes = plant_path.read_bytes() if plant_path.exists() else None
-                    if current_bytes != pre_refine_bytes:
-                        entry["refine"]["save_skipped"] = (
-                            "plant artifact changed between load and save (peer "
-                            "re-identification?) — refinement of stale bytes not persisted"
+                    entry["refine"] = {
+                        k: v for k, v in block.items() if k not in ("model", "tyre_states")
+                    }
+                    if load_errors:
+                        entry["refine"]["archive_load_errors"] = load_errors
+                    if foreign:
+                        entry["refine"]["foreign_archives_dropped"] = foreign
+                    merge_stats = block.get("selfplay_merge", {}) if result is not None else {}
+                    merge_changed = bool(
+                        merge_stats.get("lateral_bins_adopted")
+                        or merge_stats.get("lateral_bins_raised")
+                        or (
+                            merge_stats.get("mu_lat_g_after", 0.0)
+                            > merge_stats.get("mu_lat_g_before", 0.0)
                         )
+                    )
+                    if result is not None and not merge_changed:
+                        # A refit that changed nothing (no bin adopted/raised, ceiling unchanged)
+                        # is a no-op: persisting it would only churn provenance (a pointless
+                        # identical line rebuild) while the PHYSICAL envelope stays the same —
+                        # which must not count as "the envelope changed" for the retry guard
+                        # (#579 Codex P2).
+                        entry["refine"]["no_op"] = True
                         print(
-                            f"auto-alien: iteration {index} refine save SKIPPED — "
-                            f"{entry['refine']['save_skipped']}"
+                            f"auto-alien: iteration {index} refit was a no-op (no envelope "
+                            "change) — plant left as-is"
                         )
-                    else:
+                    elif result is not None:
+                        current_bytes = plant_path.read_bytes() if plant_path.exists() else None
                         # Re-key the save with the CALLER-resolved setup identity: a portable/
                         # moved artifact keeps its creator's absolute setup_ini path, and saving
                         # under that stale key would write a DIFFERENT plant filename than the
                         # one this pipeline loads and drives (#579 Codex P2).
                         result["setup_ini"] = str(setup_ini) if setup_ini else None
-                        last_valid_bytes = pre_refine_bytes
-                        saved = save_plant_artifact(user_dir, result)
-                        candidate_bytes = Path(saved).read_bytes()
-                        refined = True
-                        if Path(saved) != Path(plant_path):
-                            entry["refine"]["save_path_mismatch"] = str(saved)
-                            print(
-                                f"auto-alien: WARNING — refined plant saved to {saved}, "
-                                f"expected {plant_path} (setup identity drift?)"
-                            )
-                        print(
-                            f"auto-alien: iteration {index} plant refined "
-                            f"(lateral bins adopted={merge_stats.get('lateral_bins_adopted')} "
-                            f"raised={merge_stats.get('lateral_bins_raised')}) -> {saved}"
+                        expected_path = plant_artifact_path(
+                            user_dir,
+                            str(result.get("car_id") or ""),
+                            str(result.get("track_id") or ""),
+                            result.get("setup"),
+                            result.get("setup_ini"),
+                            layout=result.get("layout"),
                         )
-                else:
-                    print(
-                        f"auto-alien: iteration {index} refine FAILED — keeping the last-valid "
-                        f"plant ({block.get('reason')})"
-                    )
+                        if current_bytes != pre_refine_bytes:
+                            entry["refine"]["save_skipped"] = (
+                                "plant artifact changed between load and save (peer "
+                                "re-identification?) — refinement of stale bytes not persisted"
+                            )
+                            print(
+                                f"auto-alien: iteration {index} refine save SKIPPED — "
+                                f"{entry['refine']['save_skipped']}"
+                            )
+                        elif Path(expected_path) != Path(plant_path):
+                            # Refuse a forked plant file OUTRIGHT: writing the refinement under
+                            # a different identity key would leave the driven plant untouched
+                            # and strand a falsified candidate at a path the revert cannot
+                            # reach (#579 daemon HIGH).
+                            entry["refine"]["save_skipped"] = (
+                                f"refined identity keys to {expected_path}, not the driven "
+                                f"plant {plant_path} — refusing a forked plant file"
+                            )
+                            print(
+                                f"auto-alien: iteration {index} refine save SKIPPED — "
+                                f"{entry['refine']['save_skipped']}"
+                            )
+                        else:
+                            last_valid_bytes = pre_refine_bytes
+                            saved = save_plant_artifact(user_dir, result)
+                            candidate_bytes = Path(saved).read_bytes()
+                            refined = True
+                            print(
+                                f"auto-alien: iteration {index} plant refined "
+                                f"(lateral bins adopted="
+                                f"{merge_stats.get('lateral_bins_adopted')} "
+                                f"raised={merge_stats.get('lateral_bins_raised')}) -> {saved}"
+                            )
+                    else:
+                        print(
+                            f"auto-alien: iteration {index} refine FAILED — keeping the "
+                            f"last-valid plant ({block.get('reason')})"
+                        )
+        except OSError as exc:
+            # Fail loud IN the report: keep-last-valid integrity can no longer be guaranteed
+            # once artifact I/O errors, so the ladder stops with the named reason.
+            entry.setdefault("refine", {})["ok"] = False
+            entry["refine"]["reason"] = f"filesystem error during refine persist: {exc}"
+            selfplay["stopped"] = (
+                f"filesystem error at iteration {index} ({exc}) — self-play stopped "
+                "(keep-last-valid integrity cannot be guaranteed past an I/O failure)"
+            )
+            print(f"auto-alien: selfplay stop — {selfplay['stopped']}")
+            break
 
         # 2) Refuse to re-drive an identical envelope: no refit AND no scale movement means the
         #    step could only repeat the previous iteration verbatim (#577 AC: never silently
@@ -474,25 +509,36 @@ def run_selfplay(
             #    may have re-identified the combo meanwhile.
             entry["falsified"] = reason
             if refined and last_valid_bytes is not None:
-                current = plant_path.read_bytes() if plant_path.exists() else b""
-                if current == candidate_bytes:
-                    tmp = plant_path.with_suffix(".json.tmp")
-                    tmp.write_bytes(last_valid_bytes)
-                    tmp.replace(plant_path)
-                    entry["reverted"] = True
-                    print(
-                        f"auto-alien: iteration {index} FALSIFIED ({reason}) — plant reverted "
-                        "to the last-valid fit"
-                    )
-                else:
+                try:
+                    current = plant_path.read_bytes() if plant_path.exists() else b""
+                    if current == candidate_bytes:
+                        tmp = plant_path.with_suffix(".json.tmp")
+                        tmp.write_bytes(last_valid_bytes)
+                        tmp.replace(plant_path)
+                        entry["reverted"] = True
+                        print(
+                            f"auto-alien: iteration {index} FALSIFIED ({reason}) — plant "
+                            "reverted to the last-valid fit"
+                        )
+                    else:
+                        entry["reverted"] = False
+                        entry["revert_skipped"] = (
+                            "plant artifact changed since this iteration persisted it "
+                            "(peer re-identification?) — revert skipped"
+                        )
+                        print(
+                            f"auto-alien: iteration {index} FALSIFIED ({reason}); "
+                            f"{entry['revert_skipped']}"
+                        )
+                except OSError as exc:
+                    # The falsified candidate may still be on disk — say so loudly in the
+                    # report rather than crash before it is written (#579 Qodo reliability).
                     entry["reverted"] = False
-                    entry["revert_skipped"] = (
-                        "plant artifact changed since this iteration persisted it "
-                        "(peer re-identification?) — revert skipped"
-                    )
+                    entry["revert_error"] = f"filesystem error during revert: {exc}"
                     print(
-                        f"auto-alien: iteration {index} FALSIFIED ({reason}); "
-                        f"{entry['revert_skipped']}"
+                        f"auto-alien: iteration {index} FALSIFIED ({reason}); REVERT FAILED — "
+                        f"{entry['revert_error']} (the falsified fit may still be persisted; "
+                        "re-run --force-identify to rebuild the plant)"
                     )
             else:
                 print(

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -212,6 +212,14 @@ def evaluate_selfplay_iteration(
         return False, "no timed lap completed within the drive budget"
     if not archive_payloads:
         return False, "no lap archives collected (cannot verify lap validity or refine)"
+    if len(archive_payloads) < len(lap_times):
+        # Every counted lap must be verifiable: a partial archive set (writer flake / poll
+        # timeout) leaves timed laps whose validity cannot be proven, and refining from it
+        # would under-represent the batch (#579 Codex P2).
+        return False, (
+            f"archive count {len(archive_payloads)} < {len(lap_times)} timed laps "
+            "(cannot verify every counted lap)"
+        )
     for payload in archive_payloads:
         lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
         if lap.get("is_valid") is False:
@@ -471,8 +479,10 @@ def drive_argv(
     if args.laps > 0:
         argv += ["--laps", str(args.laps)]
     if scale > 1.0:
-        # The self-play ladder may probe above the uncertainty-safe envelope; the drive stage
-        # keeps its hard 1.2 cap and the falsification oracle guards every step (#577).
+        # Only a self-play iteration override can be > 1 (run_pipeline rejects a bare
+        # --ggv-scale > 1, so the one-shot base drive keeps the #572 gate — #579 Codex P1);
+        # the drive stage still enforces its hard 1.2 cap and the falsification oracle guards
+        # every step (#577).
         argv.append("--alien-allow-overspeed")
     if args.strict:
         argv.append("--strict")
@@ -589,9 +599,22 @@ def run_pipeline(
         raise ValueError(f"--laps must be >= 0 (got {args.laps})")
     if args.iterations < 0:
         raise ValueError(f"--iterations must be >= 0 (got {args.iterations})")
+    # The BASE drive keeps the #572 one-shot gate: above-1 envelopes are reachable only through
+    # the falsification-gated self-play ladder (per-iteration scale overrides), never by passing
+    # a bare --ggv-scale > 1 (#579 Codex P1).
+    if not 0.0 < args.ggv_scale <= 1.0:
+        raise ValueError(
+            f"--ggv-scale must be in (0, 1] (got {args.ggv_scale}); envelopes above 1 are "
+            "reachable only via the --iterations keep-last-valid ladder (--max-scale)"
+        )
     if args.iterations > 0:
         import math as _math
 
+        if args.laps < 1:
+            raise ValueError(
+                "--iterations requires --laps >= 1 (self-play refines from timed-lap batches; "
+                "the legacy any-boundary --wait-lap window cannot provide them)"
+            )
         if not (_math.isfinite(args.scale_step) and args.scale_step > 0):
             raise ValueError(f"--scale-step must be finite and > 0 (got {args.scale_step})")
         if not (_math.isfinite(args.max_scale) and 0 < args.max_scale <= ALIEN_MAX_OVERSPEED_SCALE):

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -217,9 +217,7 @@ def evaluate_selfplay_iteration(
         if lap.get("is_valid") is False:
             lap_n = lap.get("lap_n")
             return False, f"AC-invalid lap in the batch (lap_n={lap_n})"
-    return True, (
-        f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries"
-    )
+    return True, (f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries")
 
 
 def iteration_scale(base: float, step: float, index: int, cap: float) -> float:
@@ -596,10 +594,7 @@ def run_pipeline(
 
         if not (_math.isfinite(args.scale_step) and args.scale_step > 0):
             raise ValueError(f"--scale-step must be finite and > 0 (got {args.scale_step})")
-        if not (
-            _math.isfinite(args.max_scale)
-            and 0 < args.max_scale <= ALIEN_MAX_OVERSPEED_SCALE
-        ):
+        if not (_math.isfinite(args.max_scale) and 0 < args.max_scale <= ALIEN_MAX_OVERSPEED_SCALE):
             raise ValueError(
                 f"--max-scale must be in (0, {ALIEN_MAX_OVERSPEED_SCALE}] (got {args.max_scale})"
             )

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -274,7 +274,20 @@ def run_selfplay(
     base_laps = stage_lap_times_ms(base_outcome)
     selfplay["lap_trajectory_ms"].append(base_laps)
     best: int | None = min(base_laps) if base_laps else None
-    prev_archives = stage_lap_archives(base_outcome)
+    # The base drive must pass the SAME oracle before its archives may seed refinement: exit 0
+    # does not preclude recoveries or AC-invalid archived laps, and refining from that evidence
+    # would promote a plant the falsification oracle would reject (#579 Codex P1). An invalid
+    # base still allows the ladder to run — each iteration changes the envelope via scale and is
+    # itself falsification-gated — it just refines from nothing until a valid batch exists.
+    base_payloads, _base_load_errors = load_archive_payloads(stage_lap_archives(base_outcome))
+    base_valid, base_reason = evaluate_selfplay_iteration(0, base_outcome, base_payloads)
+    selfplay["base"] = {"valid": base_valid, "reason": base_reason, "lap_times_ms": base_laps}
+    prev_archives = stage_lap_archives(base_outcome) if base_valid else []
+    if not base_valid:
+        print(
+            f"auto-alien: base drive not usable as refinement evidence ({base_reason}) — "
+            "the ladder starts without a refit batch"
+        )
     prev_scale = args.ggv_scale
     for index in range(1, args.iterations + 1):
         scale = iteration_scale(args.ggv_scale, args.scale_step, index, args.max_scale)
@@ -288,6 +301,11 @@ def run_selfplay(
         if not prev_archives:
             entry["refine"] = {"ok": False, "reason": "no lap archives from the previous drive"}
         else:
+            # Snapshot the artifact bytes BEFORE loading: the refine-save runs outside the drive
+            # stage's machine-global rig lock, so a peer worktree may refresh the same plant
+            # between our load and our save — persisting a refinement of stale bytes would
+            # silently clobber the peer's newer fit (#579 Codex P2).
+            pre_refine_bytes = plant_path.read_bytes() if plant_path.exists() else None
             artifact = load_plant_artifact(
                 user_dir, args.car, args.track, setup_key, setup_ini, layout=args.track_layout
             )
@@ -306,17 +324,46 @@ def run_selfplay(
                 }
                 if load_errors:
                     entry["refine"]["archive_load_errors"] = load_errors
-                if result is not None:
-                    last_valid_bytes = plant_path.read_bytes()
-                    saved = save_plant_artifact(user_dir, result)
-                    candidate_bytes = Path(saved).read_bytes()
-                    refined = True
-                    merge_stats = block.get("selfplay_merge", {})
-                    print(
-                        f"auto-alien: iteration {index} plant refined "
-                        f"(lateral bins adopted={merge_stats.get('lateral_bins_adopted')} "
-                        f"raised={merge_stats.get('lateral_bins_raised')}) -> {saved}"
+                merge_stats = block.get("selfplay_merge", {}) if result is not None else {}
+                merge_changed = bool(
+                    merge_stats.get("lateral_bins_adopted")
+                    or merge_stats.get("lateral_bins_raised")
+                    or (
+                        merge_stats.get("mu_lat_g_after", 0.0)
+                        > merge_stats.get("mu_lat_g_before", 0.0)
                     )
+                )
+                if result is not None and not merge_changed:
+                    # A refit that changed nothing (no bin adopted/raised, ceiling unchanged) is
+                    # a no-op: persisting it would only churn provenance (a pointless identical
+                    # line rebuild) while the PHYSICAL envelope stays the same — which must not
+                    # count as "the envelope changed" for the retry guard (#579 Codex P2).
+                    entry["refine"]["no_op"] = True
+                    print(
+                        f"auto-alien: iteration {index} refit was a no-op (no envelope change) "
+                        "— plant left as-is"
+                    )
+                elif result is not None:
+                    current_bytes = plant_path.read_bytes() if plant_path.exists() else None
+                    if current_bytes != pre_refine_bytes:
+                        entry["refine"]["save_skipped"] = (
+                            "plant artifact changed between load and save (peer "
+                            "re-identification?) — refinement of stale bytes not persisted"
+                        )
+                        print(
+                            f"auto-alien: iteration {index} refine save SKIPPED — "
+                            f"{entry['refine']['save_skipped']}"
+                        )
+                    else:
+                        last_valid_bytes = pre_refine_bytes
+                        saved = save_plant_artifact(user_dir, result)
+                        candidate_bytes = Path(saved).read_bytes()
+                        refined = True
+                        print(
+                            f"auto-alien: iteration {index} plant refined "
+                            f"(lateral bins adopted={merge_stats.get('lateral_bins_adopted')} "
+                            f"raised={merge_stats.get('lateral_bins_raised')}) -> {saved}"
+                        )
                 else:
                     print(
                         f"auto-alien: iteration {index} refine FAILED — keeping the last-valid "

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -15,6 +15,16 @@ car/track combo from nothing to an autonomously driven lap on its own optimized 
 
 Stage failures abort the pipeline honestly (the failed stage named, its exit code propagated) —
 there is no silent degrade to the stock line or the generic plant anywhere in this path.
+
+#577 (EPIC #529 P3) adds **flying-lap windows** (``--laps N`` — the drive stage holds its window
+open through N timed laps, per-lap times in the report) and **progressive-envelope self-play**
+(``--iterations K``): after the base drive, each iteration refines the friction fit from the
+previous drive's lap archives only (monotonic merge — measured lateral bins tighten, longitudinal
+evidence is never lost), persists it through the canonical plant gates (invalidating the cached
+alien line via the fit provenance hash), steps the ggv-scale envelope ladder, and drives the
+rebuilt line. Every step is falsifiable: an invalid lap / spin / failed stage reverts the plant to
+the last-valid fit (the #244 keep-last-valid pattern) and the report names the falsification —
+the ladder never silently retries the same envelope.
 """
 
 from __future__ import annotations
@@ -25,8 +35,17 @@ import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from tools.ac_harness.auto_drive import resolve_ac_user_dir, resolve_setup_ini, validate_ac_id
-from tools.ac_harness.plant_id import load_plant_artifact, plant_ready_for_full_consumption
+from tools.ac_harness.auto_drive import (
+    ALIEN_MAX_OVERSPEED_SCALE,
+    resolve_ac_user_dir,
+    resolve_setup_ini,
+    validate_ac_id,
+)
+from tools.ac_harness.plant_id import (
+    load_plant_artifact,
+    plant_artifact_path,
+    plant_ready_for_full_consumption,
+)
 
 StageRunner = Callable[[list[str]], int]
 
@@ -115,6 +134,273 @@ def needs_identification(
     return False, "plant artifact present with uncertainty-aware friction fit"
 
 
+# ---------------------------------------------------------------------------
+# #577 progressive-envelope self-play (pure/injectable — unit-tested off-rig).
+# ---------------------------------------------------------------------------
+
+
+def load_stage_outcome(stage_dir: Path) -> dict | None:
+    """The stage's ``report.json`` payload (report + lap_archives extras), or ``None``."""
+    try:
+        payload = json.loads((Path(stage_dir) / "report.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def stage_lap_times_ms(outcome: dict | None) -> list[int]:
+    """Per-lap times (ms) the stage's tap observed, from the stage report."""
+    report = (outcome or {}).get("report")
+    times = report.get("lap_times_ms") if isinstance(report, dict) else None
+    if not isinstance(times, list):
+        return []
+    out: list[int] = []
+    for value in times:
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+            out.append(int(value))
+    return out
+
+
+def stage_lap_archives(outcome: dict | None) -> list[str]:
+    """The stage's collected lap-archive paths (already run-scoped + combo-matched)."""
+    archives = (outcome or {}).get("lap_archives")
+    if not isinstance(archives, list):
+        return []
+    return [str(p) for p in archives if isinstance(p, str) and p]
+
+
+def load_archive_payloads(paths: list[str]) -> tuple[list[dict], list[str]]:
+    """Load lap-archive JSON payloads; unreadable files are reported, never silently dropped."""
+    payloads: list[dict] = []
+    errors: list[str] = []
+    for path in paths:
+        try:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            errors.append(f"{path}: {type(exc).__name__}")
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+        else:
+            errors.append(f"{path}: archive root is not an object")
+    return payloads, errors
+
+
+def evaluate_selfplay_iteration(
+    exit_code: int, outcome: dict | None, archive_payloads: list[dict]
+) -> tuple[bool, str]:
+    """The keep-last-valid falsification oracle for one envelope step (pure; #577/#244).
+
+    An iteration is VALID only when the drive stage passed, the car never needed a recovery,
+    at least one TIMED lap completed with its archive present, and no counted lap is AC-invalid.
+    Anything else falsifies the step — the caller reverts to the last-valid plant and reports
+    the named reason (never a silent retry of the same envelope).
+    """
+    if outcome is None:
+        return False, "stage report missing (drive stage did not produce report.json)"
+    report = outcome.get("report") if isinstance(outcome.get("report"), dict) else {}
+    if exit_code != 0:
+        stage = report.get("stage")
+        error = report.get("error")
+        return False, f"drive stage failed (exit {exit_code}, stage={stage}, error={error})"
+    drive = report.get("drive") if isinstance(report.get("drive"), dict) else {}
+    recoveries = drive.get("recoveries")
+    if isinstance(recoveries, (int, float)) and recoveries > 0:
+        return False, f"{int(recoveries)} recovery(ies) during the envelope step (spin/stall)"
+    lap_times = stage_lap_times_ms(outcome)
+    if not lap_times:
+        return False, "no timed lap completed within the drive budget"
+    if not archive_payloads:
+        return False, "no lap archives collected (cannot verify lap validity or refine)"
+    for payload in archive_payloads:
+        lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
+        if lap.get("is_valid") is False:
+            lap_n = lap.get("lap_n")
+            return False, f"AC-invalid lap in the batch (lap_n={lap_n})"
+    return True, (
+        f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries"
+    )
+
+
+def iteration_scale(base: float, step: float, index: int, cap: float) -> float:
+    """The envelope ladder's ggv-scale for iteration ``index`` (1-based), capped."""
+    return round(min(base + step * index, cap), 6)
+
+
+def run_selfplay(
+    args: argparse.Namespace,
+    *,
+    run_stage: StageRunner,
+    evidence_root: Path,
+    user_dir: Path,
+    setup_key: str | None,
+    setup_ini: str | Path | None,
+    base_outcome: dict | None,
+) -> dict:
+    """Drive the #577 refine -> rebuild -> drive self-play ladder; returns the selfplay report.
+
+    Iteration ``i`` refines the plant from the PREVIOUS valid drive's lap archives (provenance-
+    bound to the pipeline's own stages), persists it through ``save_plant_artifact`` (the fit
+    provenance hash change invalidates the cached alien line, so the next drive rebuilds the
+    line/QSS against the updated plant), steps the envelope ladder's ggv-scale, and drives again.
+    A falsified step (see :func:`evaluate_selfplay_iteration`) reverts the plant to the last
+    valid artifact bytes and stops — the report names the falsification. A step that cannot
+    change the envelope at all (scale already capped AND the refit failed) stops honestly rather
+    than re-driving the identical envelope.
+    """
+    from tools.ac_harness.auto_drive import generic_gt3_ggv
+    from tools.ac_harness.plant_id import save_plant_artifact, selfplay_refine_result
+
+    plant_path = plant_artifact_path(
+        user_dir, args.car, args.track, setup_key, setup_ini, layout=args.track_layout
+    )
+    selfplay: dict = {
+        "iterations_requested": args.iterations,
+        "laps_per_iteration": args.laps,
+        "base_scale": args.ggv_scale,
+        "scale_step": args.scale_step,
+        "max_scale": args.max_scale,
+        "iterations": [],
+        "stopped": "completed",
+        "lap_trajectory_ms": [],
+        "best_lap_ms": None,
+    }
+    base_laps = stage_lap_times_ms(base_outcome)
+    selfplay["lap_trajectory_ms"].append(base_laps)
+    best: int | None = min(base_laps) if base_laps else None
+    prev_archives = stage_lap_archives(base_outcome)
+    prev_scale = args.ggv_scale
+    for index in range(1, args.iterations + 1):
+        scale = iteration_scale(args.ggv_scale, args.scale_step, index, args.max_scale)
+        entry: dict = {"index": index, "ggv_scale": scale}
+        selfplay["iterations"].append(entry)
+
+        # 1) Refine the plant from the previous drive's batch (keep-last-valid on any failure).
+        refined = False
+        last_valid_bytes: bytes | None = None
+        candidate_bytes: bytes | None = None
+        if not prev_archives:
+            entry["refine"] = {"ok": False, "reason": "no lap archives from the previous drive"}
+        else:
+            artifact = load_plant_artifact(
+                user_dir, args.car, args.track, setup_key, setup_ini, layout=args.track_layout
+            )
+            if artifact is None:
+                entry["refine"] = {
+                    "ok": False,
+                    "reason": f"plant artifact unloadable ({plant_path})",
+                }
+            else:
+                archive_payloads, load_errors = load_archive_payloads(prev_archives)
+                result, block = selfplay_refine_result(
+                    artifact, archive_payloads, generic_gt3_ggv(), prior_name="generic_gt3_ggv"
+                )
+                entry["refine"] = {
+                    k: v for k, v in block.items() if k not in ("model", "tyre_states")
+                }
+                if load_errors:
+                    entry["refine"]["archive_load_errors"] = load_errors
+                if result is not None:
+                    last_valid_bytes = plant_path.read_bytes()
+                    saved = save_plant_artifact(user_dir, result)
+                    candidate_bytes = Path(saved).read_bytes()
+                    refined = True
+                    merge_stats = block.get("selfplay_merge", {})
+                    print(
+                        f"auto-alien: iteration {index} plant refined "
+                        f"(lateral bins adopted={merge_stats.get('lateral_bins_adopted')} "
+                        f"raised={merge_stats.get('lateral_bins_raised')}) -> {saved}"
+                    )
+                else:
+                    print(
+                        f"auto-alien: iteration {index} refine FAILED — keeping the last-valid "
+                        f"plant ({block.get('reason')})"
+                    )
+
+        # 2) Refuse to re-drive an identical envelope: no refit AND no scale movement means the
+        #    step could only repeat the previous iteration verbatim (#577 AC: never silently
+        #    retry the same envelope).
+        if not refined and scale == prev_scale:
+            selfplay["stopped"] = (
+                f"envelope unchanged at iteration {index} (scale capped at {scale} and the "
+                "refit did not change the plant) — refusing to retry the same envelope"
+            )
+            entry["skipped"] = True
+            print(f"auto-alien: selfplay stop — {selfplay['stopped']}")
+            break
+
+        # 3) Drive the (possibly rebuilt) line at this iteration's envelope.
+        settled = wait_sidecar_port_settled(args.sidecar_url or DEFAULT_SIDECAR_URL)
+        entry["sidecar_port_before"] = settled
+        stage_dir = Path(evidence_root) / f"iter{index:02d}"
+        print(
+            f"auto-alien: iteration {index}/{args.iterations} drive "
+            f"(ggv_scale={scale}, laps={args.laps or 1})"
+        )
+        code = run_stage(drive_argv(args, stage_dir, ggv_scale=scale))
+        entry["exit_code"] = code
+        entry["evidence_dir"] = str(stage_dir)
+        outcome = load_stage_outcome(stage_dir)
+        archives = stage_lap_archives(outcome)
+        archive_payloads, load_errors = load_archive_payloads(archives)
+        if load_errors:
+            entry["archive_load_errors"] = load_errors
+        lap_times = stage_lap_times_ms(outcome)
+        entry["lap_times_ms"] = lap_times
+        selfplay["lap_trajectory_ms"].append(lap_times)
+        valid, reason = evaluate_selfplay_iteration(code, outcome, archive_payloads)
+        entry["valid"] = valid
+        entry["reason"] = reason
+
+        if not valid:
+            # 4) Keep-last-valid: revert the refined plant so the falsified envelope never
+            #    becomes the combo's persisted fit (#244 pattern). Only touch the artifact when
+            #    it is still byte-identical to what THIS iteration persisted — a peer worktree
+            #    may have re-identified the combo meanwhile.
+            entry["falsified"] = reason
+            if refined and last_valid_bytes is not None:
+                current = plant_path.read_bytes() if plant_path.exists() else b""
+                if current == candidate_bytes:
+                    tmp = plant_path.with_suffix(".json.tmp")
+                    tmp.write_bytes(last_valid_bytes)
+                    tmp.replace(plant_path)
+                    entry["reverted"] = True
+                    print(
+                        f"auto-alien: iteration {index} FALSIFIED ({reason}) — plant reverted "
+                        "to the last-valid fit"
+                    )
+                else:
+                    entry["reverted"] = False
+                    entry["revert_skipped"] = (
+                        "plant artifact changed since this iteration persisted it "
+                        "(peer re-identification?) — revert skipped"
+                    )
+                    print(
+                        f"auto-alien: iteration {index} FALSIFIED ({reason}); "
+                        f"{entry['revert_skipped']}"
+                    )
+            else:
+                print(
+                    f"auto-alien: iteration {index} FALSIFIED ({reason}) — plant unchanged "
+                    "this iteration (nothing to revert)"
+                )
+            selfplay["stopped"] = f"falsified at iteration {index}: {reason}"
+            break
+
+        print(
+            f"auto-alien: iteration {index} VALID — laps "
+            + ", ".join(f"{ms / 1000.0:.3f}s" for ms in lap_times)
+        )
+        if lap_times:
+            it_best = min(lap_times)
+            best = it_best if best is None else min(best, it_best)
+        prev_archives = archives
+        prev_scale = scale
+
+    selfplay["best_lap_ms"] = best
+    return selfplay
+
+
 def _passthrough_args(args: argparse.Namespace) -> list[str]:
     """CLI flags shared verbatim by both stages (combo identity + rig plumbing)."""
     out = ["--car", args.car, "--track", args.track]
@@ -147,23 +433,53 @@ def identify_argv(args: argparse.Namespace, evidence_dir: Path) -> list[str]:
     return argv
 
 
-def drive_argv(args: argparse.Namespace, evidence_dir: Path) -> list[str]:
+def resolve_drive_seconds(args: argparse.Namespace) -> float:
+    """The alien stage's drive budget; scales with the flying-lap window when not explicit.
+
+    ``--drive-seconds`` stays authoritative when passed. The default single-lap budget (300 s)
+    cannot fit a multi-lap window (3 Magione laps + standing start already exceed it, Spa far
+    more), so a ``--laps N`` run without an explicit budget gets ``180 + 240*N`` — generous per
+    lap (Spa ~214 s) because the budget is only a cap: the tap closes the window at the Nth lap.
+    """
+    if args.drive_seconds is not None:
+        return float(args.drive_seconds)
+    if args.laps > 0:
+        return 180.0 + 240.0 * args.laps
+    return 300.0
+
+
+def drive_argv(
+    args: argparse.Namespace,
+    evidence_dir: Path,
+    *,
+    ggv_scale: float | None = None,
+    rebuild_line: bool | None = None,
+) -> list[str]:
+    """The alien drive stage's argv; ``ggv_scale`` overrides per self-play iteration (#577)."""
+    scale = args.ggv_scale if ggv_scale is None else ggv_scale
     argv = _passthrough_args(args) + [
         "--driver",
         "alien",
         "--evidence-dir",
         str(evidence_dir),
         "--drive-seconds",
-        str(args.drive_seconds),
+        str(resolve_drive_seconds(args)),
         "--max-speed",
         str(args.max_speed),
         "--ggv-scale",
-        str(args.ggv_scale),
+        str(scale),
         "--wait-lap",
     ]
+    if args.laps > 0:
+        argv += ["--laps", str(args.laps)]
+    if scale > 1.0:
+        # The self-play ladder may probe above the uncertainty-safe envelope; the drive stage
+        # keeps its hard 1.2 cap and the falsification oracle guards every step (#577).
+        argv.append("--alien-allow-overspeed")
     if args.strict:
         argv.append("--strict")
-    if args.rebuild_line:
+    rebuild = args.rebuild_line if rebuild_line is None else rebuild_line
+    if rebuild:
         argv.append("--alien-rebuild-line")
     return argv
 
@@ -201,11 +517,41 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="drive budget for the identification stage (default: auto_drive's default)",
     )
     p.add_argument(
-        "--drive-seconds", type=float, default=300.0, help="drive budget for the alien lap stage"
+        "--drive-seconds",
+        type=float,
+        default=None,
+        help="drive budget for the alien lap stage (default: 300, or 180+240*laps with --laps)",
     )
     p.add_argument("--max-speed", type=float, default=240.0, help="alien drive speed cap (km/h)")
     p.add_argument(
         "--ggv-scale", type=float, default=0.9, help="safety margin on the QSS min-time profile"
+    )
+    p.add_argument(
+        "--laps",
+        type=int,
+        default=0,
+        help="#577 flying-lap window: drive until N TIMED laps complete (or the drive budget); "
+        "per-lap times land in the stage report. 0 = legacy single-lap",
+    )
+    p.add_argument(
+        "--iterations",
+        type=int,
+        default=0,
+        help="#577 progressive-envelope self-play: after the base drive, run K refine->rebuild->"
+        "drive iterations with keep-last-valid falsification (0 = off)",
+    )
+    p.add_argument(
+        "--scale-step",
+        type=float,
+        default=0.05,
+        help="per-iteration ggv-scale increment for the self-play envelope ladder (#244 pattern)",
+    )
+    p.add_argument(
+        "--max-scale",
+        type=float,
+        default=1.1,
+        help="self-play envelope ladder cap (hard limit 1.2; >1 probes above the uncertainty-"
+        "safe QSS floor, falsification-gated)",
     )
     p.add_argument(
         "--strict", action="store_true", help="alien stage: require session+lap, enforce ordering"
@@ -241,6 +587,22 @@ def run_pipeline(
     validate_ac_id("track", args.track)
     if args.track_layout:
         validate_ac_id("layout", args.track_layout)
+    if args.laps < 0:
+        raise ValueError(f"--laps must be >= 0 (got {args.laps})")
+    if args.iterations < 0:
+        raise ValueError(f"--iterations must be >= 0 (got {args.iterations})")
+    if args.iterations > 0:
+        import math as _math
+
+        if not (_math.isfinite(args.scale_step) and args.scale_step > 0):
+            raise ValueError(f"--scale-step must be finite and > 0 (got {args.scale_step})")
+        if not (
+            _math.isfinite(args.max_scale)
+            and 0 < args.max_scale <= ALIEN_MAX_OVERSPEED_SCALE
+        ):
+            raise ValueError(
+                f"--max-scale must be in (0, {ALIEN_MAX_OVERSPEED_SCALE}] (got {args.max_scale})"
+            )
     user_dir = resolve_ac_user_dir(args.ac_user_dir)
     setup_key = Path(args.setup).stem if args.setup else None
     setup_ini = None
@@ -321,6 +683,31 @@ def run_pipeline(
         report["error"] = f"alien drive stage failed (exit {code})"
         print(f"auto-alien: FAIL — {report['error']}")
         return code or 1, report
+
+    if args.iterations > 0:
+        # #577 progressive-envelope self-play. A falsified/stopped ladder is a VALID pipeline
+        # outcome — the base drive passed and the report names exactly where and why the ladder
+        # ended (keep-last-valid already restored the plant). Only the base stages gate exit.
+        base_outcome = load_stage_outcome(stage_dir)
+        base_laps = stage_lap_times_ms(base_outcome)
+        print(
+            "auto-alien: base drive laps "
+            + (", ".join(f"{ms / 1000.0:.3f}s" for ms in base_laps) if base_laps else "(none)")
+        )
+        report["selfplay"] = run_selfplay(
+            args,
+            run_stage=run_stage,
+            evidence_root=evidence_root,
+            user_dir=user_dir,
+            setup_key=setup_key,
+            setup_ini=setup_ini,
+            base_outcome=base_outcome,
+        )
+        best = report["selfplay"].get("best_lap_ms")
+        print(
+            f"auto-alien: selfplay done — {report['selfplay']['stopped']}"
+            + (f"; best lap {best / 1000.0:.3f}s" if isinstance(best, int) else "")
+        )
 
     report["ok"] = True
     return 0, report

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -39,6 +39,7 @@ from tools.ac_harness.auto_drive import (
     ALIEN_MAX_OVERSPEED_SCALE,
     archive_matches_combo,
     resolve_ac_user_dir,
+    resolve_lap_window_drive_seconds,
     resolve_setup_ini,
     validate_ac_id,
 )
@@ -292,6 +293,7 @@ def run_selfplay(
     plant_path = plant_artifact_path(
         user_dir, args.car, args.track, setup_key, setup_ini, layout=args.track_layout
     )
+    lock_timeout = args.rig_lock_timeout if args.rig_lock_timeout is not None else 0.0
     selfplay: dict = {
         "iterations_requested": args.iterations,
         "laps_per_iteration": args.laps,
@@ -413,7 +415,7 @@ def run_selfplay(
                             result,
                             expected_path=plant_path,
                             expected_current_bytes=pre_refine_bytes,
-                            lock_timeout=args.rig_lock_timeout,
+                            lock_timeout=lock_timeout,
                         )
                         if save_skipped:
                             entry["refine"]["save_skipped"] = save_skipped
@@ -502,7 +504,7 @@ def run_selfplay(
                         expected_current_bytes=candidate_bytes,
                         car_id=args.car,
                         track_id=args.track,
-                        lock_timeout=args.rig_lock_timeout,
+                        lock_timeout=lock_timeout,
                     ):
                         entry["reverted"] = True
                         print(
@@ -591,18 +593,8 @@ def identify_argv(args: argparse.Namespace, evidence_dir: Path) -> list[str]:
 
 
 def resolve_drive_seconds(args: argparse.Namespace) -> float:
-    """The alien stage's drive budget; scales with the flying-lap window when not explicit.
-
-    ``--drive-seconds`` stays authoritative when passed. The default single-lap budget (300 s)
-    cannot fit a multi-lap window (3 Magione laps + standing start already exceed it, Spa far
-    more), so a ``--laps N`` run without an explicit budget gets ``180 + 240*N`` — generous per
-    lap (Spa ~214 s) because the budget is only a cap: the tap closes the window at the Nth lap.
-    """
-    if args.drive_seconds is not None:
-        return float(args.drive_seconds)
-    if args.laps > 0:
-        return 180.0 + 240.0 * args.laps
-    return 300.0
+    """Delegate the composed alien stage to ``auto_drive``'s budget contract."""
+    return resolve_lap_window_drive_seconds(args.drive_seconds, args.laps)
 
 
 def drive_argv(

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -776,6 +776,13 @@ def run_pipeline(
             raise ValueError(
                 f"--max-scale must be in (0, {ALIEN_MAX_OVERSPEED_SCALE}] (got {args.max_scale})"
             )
+        if args.max_scale < args.ggv_scale:
+            # A cap below the base would make "iteration 1" an EASIER envelope than the base
+            # drive — a regression probe, not the progressive ladder (#579 Codex P2).
+            raise ValueError(
+                f"--max-scale ({args.max_scale}) must be >= --ggv-scale ({args.ggv_scale}); "
+                "the ladder only steps upward from the base envelope"
+            )
     user_dir = resolve_ac_user_dir(args.ac_user_dir)
     setup_key = Path(args.setup).stem if args.setup else None
     setup_ini = None

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -820,10 +820,12 @@ async def run_auto_drive(
             # the 180 s default, Spa ~7 km); #459 F / #516.
             tap_kwargs["settle_timeout"] = tap_settle_s
             tap_kwargs["lap_timeout"] = lap_deadline
-            if config.target_laps > 1:
-                # #577 flying-lap window: hold the tap open until N timed laps (or the shared
-                # deadline). The deadline stays the drive-budget-derived one — "N laps or the
-                # time budget, whichever first" — so a shortfall ends honestly, never hangs.
+            if config.target_laps > 0:
+                # #577 flying-lap window: hold the tap open until N TIMED laps (or the shared
+                # deadline). Includes N == 1 — a requested one-lap batch must not exit on an
+                # untimed out-lap/teleport boundary the way plain --wait-lap may (#579 daemon
+                # HIGH). The deadline stays the drive-budget-derived one — "N laps or the time
+                # budget, whichever first" — so a shortfall ends honestly, never hangs.
                 tap_kwargs["lap_count"] = config.target_laps
         frames = await tap(config.sidecar_url, **tap_kwargs)
         result = evaluate_sequence(
@@ -837,7 +839,7 @@ async def run_auto_drive(
             from tools.ac_harness.sequence_probe import timed_lap_times_ms
 
             lap_times_ms = timed_lap_times_ms(frames)
-            if config.target_laps > 1 and len(lap_times_ms) < config.target_laps:
+            if config.target_laps > 0 and len(lap_times_ms) < config.target_laps:
                 notes.append(
                     f"laps: requested {config.target_laps}, observed "
                     f"{len(lap_times_ms)} timed within the drive budget"
@@ -3294,18 +3296,20 @@ def _main_impl(
             layout=config.track_layout,
         )
 
-    # Legacy single-lap (--wait-lap) runs keep their exact pre-#577 poll (any first archive,
-    # short constant timeout); only handshake and multi-lap batches gate on combo-matched counts.
-    multi_lap_batch = timed_laps_observed > 1 or handshake_laps_used > 0
+    # Legacy --wait-lap runs (no --laps) keep their exact pre-#577 poll (any first archive,
+    # short constant timeout). Batch semantics key on INTENT (--laps requested / handshake), not
+    # on the observed count — a requested 1-lap batch still gets the strict combo-matched
+    # validation its archives_same_run=True provenance depends on (#579 daemon MEDIUM).
+    batch_mode = config.target_laps > 0 or handshake_laps_used > 0
     lap_archives = collect_lap_archives(
         None,
         run_started_epoch,
         resolve=lambda: candidate_journal_laps_dirs(user_dir),
         wait_for_first=wait_for_archives,
         min_count=max(1, expected_archives),
-        min_valid_count=expected_archives if multi_lap_batch else None,
+        min_valid_count=expected_archives if batch_mode and expected_archives > 0 else None,
         valid_archive_predicate=archive_matches_combo,
-        timeout_s=20.0 if multi_lap_batch else 8.0,
+        timeout_s=20.0 if batch_mode else 8.0,
     )
     # Report the dir the archive was actually found in (correct even for a renamed install), so the
     # metadata matches the multi-dir scan, not the canonical-preferring discover (#516 review).

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2737,7 +2737,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--pace", type=float, default=0.9, help="racing: fraction of AI-line speed")
     p.add_argument("--ggv-scale", type=float, default=0.9, help="ggv: safety margin on min-time")
     p.add_argument("--max-speed", type=float, default=240.0, help="racing/ggv: speed cap (km/h)")
-    p.add_argument("--drive-seconds", type=float, default=300.0)
+    p.add_argument(
+        "--drive-seconds",
+        type=float,
+        default=None,
+        help="drive time budget (default: 300, or 180+240*laps for a flying-lap window)",
+    )
     p.add_argument(
         "--lap-finalize-grace-s",
         type=_nonneg_float,
@@ -2845,7 +2850,7 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         pace=args.pace,
         ggv_scale=args.ggv_scale,
         racing_max_speed_kmh=args.max_speed,
-        drive_seconds=args.drive_seconds,
+        drive_seconds=resolve_lap_window_drive_seconds(args.drive_seconds, args.laps),
         lap_finalize_grace_s=args.lap_finalize_grace_s,
         target_speed_kmh=args.target_speed,
         min_corner_speed_kmh=args.min_corner,
@@ -2865,6 +2870,20 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
     if args.ac_root is not None:
         kwargs["ac_root"] = args.ac_root
     return AutoDriveConfig(**kwargs)
+
+
+def resolve_lap_window_drive_seconds(explicit: float | None, target_laps: int) -> float:
+    """Return the stage-owned drive budget for a direct or composed flying-lap run.
+
+    An explicit budget remains authoritative. Otherwise the legacy path keeps 300 seconds and
+    ``--laps N`` gets enough headroom for a standing start plus N Spa-length laps. Keeping this
+    rule in ``auto_drive`` ensures direct CLI users and orchestrators share one contract.
+    """
+    if explicit is not None:
+        return float(explicit)
+    if target_laps > 0:
+        return 180.0 + 240.0 * target_laps
+    return 300.0
 
 
 def _alien_prerequisites_error(config: AutoDriveConfig, user_dir: Path) -> str | None:

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2762,8 +2762,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--alien-allow-overspeed",
         action="store_true",
-        help="#577 self-play only: permit --ggv-scale in (1, 1.2] on the alien path as a "
-        "deliberate, falsifiable envelope probe (the one-shot alien path keeps the <=1 gate)",
+        help="EXPERT opt-in (#577): permit --ggv-scale in (1, 1.2] on the alien path — drives "
+        "ABOVE the uncertainty-safe envelope. The keep-last-valid falsification protection "
+        "exists only under auto_alien --iterations (which passes this per ladder step); a "
+        "direct overspeed drive carries spin/damage risk on the operator",
     )
     p.add_argument("--strict", action="store_true", help="require session+lap, enforce ordering")
     p.add_argument("--skip-launch", action="store_true", help="AC already LIVE; only hijack+drive")
@@ -3372,7 +3374,10 @@ def _main_impl(
         min_matching_count=(
             expected_archives if batch_mode and expected_archives > 0 and config.car_id else None
         ),
-        valid_archive_predicate=archive_matches_combo,
+        # Defensive: without a car identity the predicate can never match, so it must not gate
+        # ANY counting path (min_valid_count is handshake-only and handshake requires --car, so
+        # this is unreachable today — kept consistent regardless; #579 daemon MEDIUM).
+        valid_archive_predicate=archive_matches_combo if config.car_id else None,
         timeout_s=20.0 if batch_mode else 8.0,
     )
     # Report the dir the archive was actually found in (correct even for a renamed install), so the

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -106,6 +106,14 @@ def resolve_ac_user_dir(explicit: Path | None = None, *, home: Path | None = Non
     return candidates[0]
 
 
+# #577: hard cap on the deliberate self-play overspeed probe (ggv_scale above 1 on the alien
+# path). The uncertainty-safe QSS envelope is a lower-confidence bound, so a bounded supra-LCB
+# probe is how self-play generates the evidence that raises the measured bins — but 1.2x speed
+# is 1.44x lateral g, already an aggressive single step; anything above is a config error, not
+# a braver probe. Requires the explicit --alien-allow-overspeed opt-in (auto_alien iterate mode).
+ALIEN_MAX_OVERSPEED_SCALE = 1.2
+
+
 @dataclass
 class AutoDriveConfig:
     """Inputs for one autonomous drive+assert run, parametrized by car/track/preset/setup."""
@@ -159,6 +167,13 @@ class AutoDriveConfig:
         240.0  # racing/ggv: cap (above any GT speed; lets it use top gears)
     )
     ggv_scale: float = 0.9  # ggv: safety margin on the min-time profile (flat-out * scale)
+    # #577 progressive-envelope self-play: allow the alien path to run a deliberate, bounded
+    # overspeed probe (ggv_scale in (1, ALIEN_MAX_OVERSPEED_SCALE]) — the uncertainty-safe QSS
+    # floor is a lower-confidence bound, and driving slightly above it is how the self-play loop
+    # generates the supra-LCB lateral evidence that raises the measured bins. Guarded: opt-in
+    # flag only (the one-shot alien path keeps the hard <=1 gate from #572), hard-capped, and
+    # every step is falsifiable via the auto_alien keep-last-valid oracle.
+    alien_overspeed: bool = False
     target_speed_kmh: float = 55.0  # cruise only
     min_corner_speed_kmh: float = 30.0  # cruise only
     # Stall recovery (#459 Part D).
@@ -176,6 +191,10 @@ class AutoDriveConfig:
     # Assertion.
     tap_seconds: float = 30.0
     wait_lap: bool = False
+    # #577 flying-lap windows: keep the tap window open until this many TIMED laps complete
+    # (or the drive budget expires — whichever first). 0 = legacy single-lap --wait-lap
+    # semantics. Setting it >0 implies wait_lap (the CLI enforces this coupling).
+    target_laps: int = 0
     strict: bool = False
     # Launch / hijack robustness (the early-LIVE race plus CM's setup race.ini regeneration).
     # A setup run keeps race.ini re-baked through the CM launch window; if the session still fails
@@ -294,6 +313,11 @@ class AutoDriveReport:
     # archive). The single source of truth the evidence-bundle poll gates on, so the grace condition
     # and the poll condition can never diverge (#515/#516 review).
     lap_grace_applied: bool = False
+    # #577: per-lap times (ms, stream order) of every TIMED lap boundary the tap observed, plus
+    # the requested lap budget — the flying-lap-window evidence consumers key on (the self-play
+    # iteration verdict, the per-iteration trajectory report).
+    lap_times_ms: list[int] = field(default_factory=list)
+    laps_requested: int = 0
     # Combo identity + setup verification (#459 Parts A/C) — evidence consumers key on these.
     car_id: str | None = None
     track_id: str | None = None
@@ -333,6 +357,10 @@ class AutoDriveReport:
                 + (f" spawn_teleport={d.spawn_teleport}" if d.spawn_teleport else "")
                 + (f" reason={d.reason}" if d.reason else "")
             )
+        if self.lap_times_ms:
+            times = ", ".join(f"{ms / 1000.0:.3f}s" for ms in self.lap_times_ms)
+            requested = f" (requested {self.laps_requested})" if self.laps_requested else ""
+            lines.append(f"  laps timed: {len(self.lap_times_ms)}{requested}: {times}")
         if self.sequence_ok is not None:
             lines.append(f"  pipeline: {'ok' if self.sequence_ok else 'FAILED'}")
             if self.counts:
@@ -783,6 +811,7 @@ async def run_auto_drive(
         notes.append(f"setup baked but UNCONFIRMED: {setup_ack.get('detail', 'no fuel key')}")
     error: str | None = None
     stage = "done"
+    lap_times_ms: list[int] = []
     try:
         tap_kwargs: dict[str, Any] = dict(seconds=config.tap_seconds, wait_for_lap=config.wait_lap)
         if config.wait_lap:
@@ -791,6 +820,11 @@ async def run_auto_drive(
             # the 180 s default, Spa ~7 km); #459 F / #516.
             tap_kwargs["settle_timeout"] = tap_settle_s
             tap_kwargs["lap_timeout"] = lap_deadline
+            if config.target_laps > 1:
+                # #577 flying-lap window: hold the tap open until N timed laps (or the shared
+                # deadline). The deadline stays the drive-budget-derived one — "N laps or the
+                # time budget, whichever first" — so a shortfall ends honestly, never hangs.
+                tap_kwargs["lap_count"] = config.target_laps
         frames = await tap(config.sidecar_url, **tap_kwargs)
         result = evaluate_sequence(
             frames, strict_lifecycle=config.strict, require_lap=config.wait_lap
@@ -798,6 +832,16 @@ async def run_auto_drive(
         seq_ok = result.ok
         counts = dict(result.counts)
         notes = list(result.notes)
+        # #577: the per-lap trajectory is report evidence whenever the lap machinery ran.
+        if config.wait_lap:
+            from tools.ac_harness.sequence_probe import timed_lap_times_ms
+
+            lap_times_ms = timed_lap_times_ms(frames)
+            if config.target_laps > 1 and len(lap_times_ms) < config.target_laps:
+                notes.append(
+                    f"laps: requested {config.target_laps}, observed "
+                    f"{len(lap_times_ms)} timed within the drive budget"
+                )
         grace_applied = bool(
             config.wait_lap and _has_timed_lap(frames) and config.lap_finalize_grace_s > 0
         )
@@ -846,6 +890,8 @@ async def run_auto_drive(
         drive=stats,
         sequence_ok=seq_ok,
         lap_grace_applied=grace_applied,
+        lap_times_ms=lap_times_ms,
+        laps_requested=config.target_laps,
         counts=counts,
         notes=notes,
         error=error,
@@ -1988,10 +2034,13 @@ def _build_driver(config: AutoDriveConfig, fast_line: list, speed_profile: list 
             )
         # The stored v_target is envelope-verified at build time; scaling above 1 would push
         # corner speeds past the verified plant envelope AFTER that check (#572 Codex review).
-        if not 0.0 < config.ggv_scale <= 1.0:
+        # #577: config.alien_overspeed opts in to a bounded supra-envelope probe (self-play only;
+        # every step falsifiable via the auto_alien keep-last-valid oracle).
+        scale_cap = ALIEN_MAX_OVERSPEED_SCALE if config.alien_overspeed else 1.0
+        if not 0.0 < config.ggv_scale <= scale_cap:
             raise ValueError(
-                f"alien driver requires 0 < ggv_scale <= 1 (got {config.ggv_scale}); the scale "
-                "is a safety margin under the envelope-verified profile"
+                f"alien driver requires 0 < ggv_scale <= {scale_cap} (got {config.ggv_scale}); "
+                "the scale is a safety margin under the envelope-verified profile"
             )
         v_target = [v * config.ggv_scale for v in config.alien_v_target]
         return RacingDriver.from_ggv_profile(config.alien_line, v_target, **config.plant_kwargs)
@@ -2652,6 +2701,20 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--min-corner", type=float, default=30.0, help="cruise min corner speed (km/h)")
     p.add_argument("--tap-seconds", type=float, default=30.0)
     p.add_argument("--wait-lap", action="store_true", help="assert a completed lap (real motion)")
+    p.add_argument(
+        "--laps",
+        type=int,
+        default=0,
+        help="#577 flying-lap window: keep driving until this many TIMED laps complete (or "
+        "--drive-seconds expires, whichever first); implies --wait-lap; per-lap times land in "
+        "the report. 0 = legacy single-lap --wait-lap semantics",
+    )
+    p.add_argument(
+        "--alien-allow-overspeed",
+        action="store_true",
+        help="#577 self-play only: permit --ggv-scale in (1, 1.2] on the alien path as a "
+        "deliberate, falsifiable envelope probe (the one-shot alien path keeps the <=1 gate)",
+    )
     p.add_argument("--strict", action="store_true", help="require session+lap, enforce ordering")
     p.add_argument("--skip-launch", action="store_true", help="AC already LIVE; only hijack+drive")
     p.add_argument(
@@ -2737,7 +2800,11 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         target_speed_kmh=args.target_speed,
         min_corner_speed_kmh=args.min_corner,
         tap_seconds=args.tap_seconds,
-        wait_lap=args.wait_lap,
+        # --laps implies the lap-wait machinery: a multi-lap window without wait_lap would tap a
+        # fixed 30 s and never see lap 2 (#577).
+        wait_lap=args.wait_lap or args.laps > 0,
+        target_laps=max(0, args.laps),
+        alien_overspeed=args.alien_allow_overspeed,
         strict=args.strict,
         skip_launch=args.skip_launch,
         hijack_probe_seconds=args.hijack_probe_seconds,
@@ -2915,6 +2982,9 @@ def _main_impl(
     if args.cm_preset is None and not args.car:
         print("auto-drive: pass --car (preset is generated) or --cm-preset (hand-authored)")
         return 2
+    if args.laps < 0:
+        print(f"auto-drive: --laps must be >= 0 (got {args.laps})")
+        return 2
     config = _config_from_args(args)
     try:
         # Ids become path segments (evidence dir, preset, setups) — reject path-shaped input
@@ -2961,14 +3031,25 @@ def _main_impl(
 
     # #572: reject an overspeed scale on the alien path BEFORE any launch work. The alien QSS
     # profile is envelope-verified at build time; a scale above 1 would multiply corner speeds
-    # past the verified plant envelope after that check (Codex review).
+    # past the verified plant envelope after that check (Codex review). #577 self-play may opt
+    # in to a bounded overspeed probe (the LCB envelope is deliberately conservative; supra-LCB
+    # evidence is what raises the measured bins) — capped and falsification-gated by auto_alien.
     alien_line_used: dict | None = None
-    if config.driver == "alien" and not 0.0 < config.ggv_scale <= 1.0:
-        print(
-            f"auto-drive: --driver alien requires 0 < --ggv-scale <= 1 (got {config.ggv_scale}); "
-            "the scale is a safety margin under the envelope-verified profile, never above it"
-        )
-        return 2
+    if config.driver == "alien":
+        scale_cap = ALIEN_MAX_OVERSPEED_SCALE if config.alien_overspeed else 1.0
+        if not 0.0 < config.ggv_scale <= scale_cap:
+            print(
+                f"auto-drive: --driver alien requires 0 < --ggv-scale <= {scale_cap} "
+                f"(got {config.ggv_scale}"
+                + ("" if config.alien_overspeed else "; --alien-allow-overspeed lifts to 1.2")
+                + ")"
+            )
+            return 2
+        if config.ggv_scale > 1.0:
+            print(
+                f"auto-drive: ALIEN OVERSPEED PROBE — ggv_scale={config.ggv_scale} drives above "
+                "the uncertainty-safe QSS envelope (bounded, falsification-gated self-play step)"
+            )
 
     car_tag = config.car_id or "car"
     evidence_dir = args.evidence_dir or (
@@ -3199,6 +3280,11 @@ def _main_impl(
             if isinstance(value, int) and not isinstance(value, bool) and value > 0:
                 handshake_laps_used = value
     wait_for_archives = report.lap_grace_applied or handshake_laps_used > 0
+    # #577 flying-lap window: every timed lap the tap observed should have an archive — the
+    # trainer archives each timed boundary, and the self-play refine consumes the full batch.
+    # The poll waits for that count (bounded), not merely the first archive.
+    timed_laps_observed = len(report.lap_times_ms)
+    expected_archives = max(handshake_laps_used, timed_laps_observed)
 
     def archive_matches_combo(payload: dict) -> bool:
         return _archive_matches_combo(
@@ -3208,15 +3294,18 @@ def _main_impl(
             layout=config.track_layout,
         )
 
+    # Legacy single-lap (--wait-lap) runs keep their exact pre-#577 poll (any first archive,
+    # short constant timeout); only handshake and multi-lap batches gate on combo-matched counts.
+    multi_lap_batch = timed_laps_observed > 1 or handshake_laps_used > 0
     lap_archives = collect_lap_archives(
         None,
         run_started_epoch,
         resolve=lambda: candidate_journal_laps_dirs(user_dir),
         wait_for_first=wait_for_archives,
-        min_count=max(1, handshake_laps_used),
-        min_valid_count=handshake_laps_used if handshake_laps_used > 0 else None,
+        min_count=max(1, expected_archives),
+        min_valid_count=expected_archives if multi_lap_batch else None,
         valid_archive_predicate=archive_matches_combo,
-        timeout_s=20.0 if handshake_laps_used > 0 else 8.0,
+        timeout_s=20.0 if multi_lap_batch else 8.0,
     )
     # Report the dir the archive was actually found in (correct even for a renamed install), so the
     # metadata matches the multi-dir scan, not the canonical-preferring discover (#516 review).

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -839,7 +839,16 @@ async def run_auto_drive(
             from tools.ac_harness.sequence_probe import timed_lap_times_ms
 
             lap_times_ms = timed_lap_times_ms(frames)
-            if config.target_laps > 0 and len(lap_times_ms) < config.target_laps:
+            if config.target_laps > 0 and not lap_times_ms:
+                # --laps N contracts for TIMED laps. require_lap alone is satisfiable by an
+                # untimed out-lap/teleport boundary, which would exit 0 with an empty
+                # trajectory — a false green for the requested window (#579 Codex P2).
+                seq_ok = False
+                notes.append(
+                    f"laps: requested {config.target_laps} timed, observed ZERO — "
+                    "the window produced no timed lap (untimed boundaries do not count)"
+                )
+            elif config.target_laps > 0 and len(lap_times_ms) < config.target_laps:
                 notes.append(
                     f"laps: requested {config.target_laps}, observed "
                     f"{len(lap_times_ms)} timed within the drive budget"
@@ -1560,6 +1569,7 @@ def collect_lap_archives(
     wait_for_first: bool = False,
     min_count: int = 1,
     min_valid_count: int | None = None,
+    min_matching_count: int | None = None,
     valid_archive_predicate: Callable[[dict], bool] | None = None,
     timeout_s: float = 8.0,
     poll_s: float = 0.5,
@@ -1605,11 +1615,29 @@ def collect_lap_archives(
         or min_valid_count < 1
     ):
         raise ValueError("min_valid_count must be a positive integer or None")
+    if min_matching_count is not None and (
+        isinstance(min_matching_count, bool)
+        or not isinstance(min_matching_count, int)
+        or min_matching_count < 1
+    ):
+        raise ValueError("min_matching_count must be a positive integer or None")
 
     def _enough(paths: list[str]) -> bool:
-        return len(paths) >= min_count and (
-            min_valid_count is None
-            or _count_valid_lap_archives(paths, valid_archive_predicate) >= min_valid_count
+        # ``min_matching_count`` gates on the predicate ALONE (validity-agnostic): a #577
+        # flying-lap batch must wait for THIS combo's archives — the multi-dir resolver can see
+        # another app/combo's fresh files — but must not gate on validity (an AC-invalid lap's
+        # archive is falsification evidence that never turns valid; #579 Qodo + Codex).
+        return (
+            len(paths) >= min_count
+            and (
+                min_valid_count is None
+                or _count_valid_lap_archives(paths, valid_archive_predicate) >= min_valid_count
+            )
+            and (
+                min_matching_count is None
+                or _count_matching_lap_archives(paths, valid_archive_predicate)
+                >= min_matching_count
+            )
         )
 
     found = _scan_lap_archives(_current(), since_epoch)
@@ -1640,6 +1668,26 @@ def _count_valid_lap_archives(
             and lap.get("is_valid") is True
             and (predicate is None or predicate(payload))
         ):
+            count += 1
+    return count
+
+
+def _count_matching_lap_archives(
+    paths: list[str], predicate: Callable[[dict], bool] | None = None
+) -> int:
+    """Count finalized archive files matching ``predicate``, regardless of lap validity.
+
+    The #577 flying-lap batch gate: an AC-INVALID lap's archive still counts (it is the
+    falsification evidence the self-play verdict needs), but a foreign app/combo's archive
+    must not satisfy the batch (#579 Codex).
+    """
+    count = 0
+    for item in paths:
+        try:
+            payload = json.loads(Path(item).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and (predicate is None or predicate(payload)):
             count += 1
     return count
 
@@ -3281,10 +3329,17 @@ def _main_impl(
             value = pending_result.get("laps_used")
             if isinstance(value, int) and not isinstance(value, bool) and value > 0:
                 handshake_laps_used = value
-    wait_for_archives = report.lap_grace_applied or handshake_laps_used > 0
     # #577 flying-lap window: every timed lap the tap observed should have an archive — the
     # trainer archives each timed boundary, and the self-play refine consumes the full batch.
-    # The poll waits for that count (bounded), not merely the first archive.
+    # The poll waits for that count (bounded), not merely the first archive. Batch semantics key
+    # on INTENT (--laps requested / handshake), not on the observed count — a requested 1-lap
+    # batch still gets the strict combo-matched validation its archives_same_run=True provenance
+    # depends on (#579 daemon MEDIUM).
+    batch_mode = config.target_laps > 0 or handshake_laps_used > 0
+    # A batch run must also WAIT for its archives even when the grace didn't fire (e.g.
+    # --lap-finalize-grace-s 0): grace-or-handshake alone would skip the poll and falsely
+    # falsify the iteration on missing evidence (#579 daemon HIGH).
+    wait_for_archives = report.lap_grace_applied or batch_mode
     timed_laps_observed = len(report.lap_times_ms)
     expected_archives = max(handshake_laps_used, timed_laps_observed)
 
@@ -3296,11 +3351,6 @@ def _main_impl(
             layout=config.track_layout,
         )
 
-    # Legacy --wait-lap runs (no --laps) keep their exact pre-#577 poll (any first archive,
-    # short constant timeout). Batch semantics key on INTENT (--laps requested / handshake), not
-    # on the observed count — a requested 1-lap batch still gets the strict combo-matched
-    # validation its archives_same_run=True provenance depends on (#579 daemon MEDIUM).
-    batch_mode = config.target_laps > 0 or handshake_laps_used > 0
     lap_archives = collect_lap_archives(
         None,
         run_started_epoch,
@@ -3311,8 +3361,12 @@ def _main_impl(
         # set). A flying-lap batch must not gate on validity: an AC-invalid lap still writes its
         # archive, that archive IS the falsification evidence the self-play verdict needs
         # promptly, and no amount of waiting turns it valid — gating on it would stall the poll
-        # to full timeout on every falsified batch (#579 Qodo).
+        # to full timeout on every falsified batch (#579 Qodo). The batch DOES gate on the
+        # combo-matched count (validity-agnostic): the multi-dir resolver can see another
+        # app/combo's fresh archives, which must not satisfy the batch before this combo's own
+        # writer finishes (#579 Codex P2).
         min_valid_count=handshake_laps_used if handshake_laps_used > 0 else None,
+        min_matching_count=expected_archives if batch_mode and expected_archives > 0 else None,
         valid_archive_predicate=archive_matches_combo,
         timeout_s=20.0 if batch_mode else 8.0,
     )

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1692,9 +1692,7 @@ def _count_matching_lap_archives(
     return count
 
 
-def _archive_matches_combo(
-    payload: dict, *, car_id: str, track_id: str, layout: str | None
-) -> bool:
+def archive_matches_combo(payload: dict, *, car_id: str, track_id: str, layout: str | None) -> bool:
     """Return whether a current-run archive can belong to the requested combo."""
     car = payload.get("car") if isinstance(payload.get("car"), dict) else {}
     track = payload.get("track") if isinstance(payload.get("track"), dict) else {}
@@ -3345,8 +3343,8 @@ def _main_impl(
     timed_laps_observed = len(report.lap_times_ms)
     expected_archives = max(handshake_laps_used, timed_laps_observed)
 
-    def archive_matches_combo(payload: dict) -> bool:
-        return _archive_matches_combo(
+    def _combo_predicate(payload: dict) -> bool:
+        return archive_matches_combo(
             payload,
             car_id=config.car_id,
             track_id=config.track_id,
@@ -3377,7 +3375,7 @@ def _main_impl(
         # Defensive: without a car identity the predicate can never match, so it must not gate
         # ANY counting path (min_valid_count is handshake-only and handshake requires --car, so
         # this is unreachable today — kept consistent regardless; #579 daemon MEDIUM).
-        valid_archive_predicate=archive_matches_combo if config.car_id else None,
+        valid_archive_predicate=_combo_predicate if config.car_id else None,
         timeout_s=20.0 if batch_mode else 8.0,
     )
     # Report the dir the archive was actually found in (correct even for a renamed install), so the

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -3366,7 +3366,12 @@ def _main_impl(
         # app/combo's fresh archives, which must not satisfy the batch before this combo's own
         # writer finishes (#579 Codex P2).
         min_valid_count=handshake_laps_used if handshake_laps_used > 0 else None,
-        min_matching_count=expected_archives if batch_mode and expected_archives > 0 else None,
+        # The combo gate needs a car identity to match against: a preset-only run (--cm-preset
+        # without --car) has none, so the predicate could never match and the poll would always
+        # burn its full timeout (#579 Qodo perf).
+        min_matching_count=(
+            expected_archives if batch_mode and expected_archives > 0 and config.car_id else None
+        ),
         valid_archive_predicate=archive_matches_combo,
         timeout_s=20.0 if batch_mode else 8.0,
     )

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -3307,7 +3307,12 @@ def _main_impl(
         resolve=lambda: candidate_journal_laps_dirs(user_dir),
         wait_for_first=wait_for_archives,
         min_count=max(1, expected_archives),
-        min_valid_count=expected_archives if batch_mode and expected_archives > 0 else None,
+        # Valid-count gating is HANDSHAKE-only (the fit must never promote from a partial valid
+        # set). A flying-lap batch must not gate on validity: an AC-invalid lap still writes its
+        # archive, that archive IS the falsification evidence the self-play verdict needs
+        # promptly, and no amount of waiting turns it valid — gating on it would stall the poll
+        # to full timeout on every falsified batch (#579 Qodo).
+        min_valid_count=handshake_laps_used if handshake_laps_used > 0 else None,
         valid_archive_predicate=archive_matches_combo,
         timeout_s=20.0 if batch_mode else 8.0,
     )

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -3414,11 +3414,12 @@ def _main_impl(
         # The handshake result flows out via DriveStats.payload (report.drive.payload), not a
         # config side-channel (daemon review).
         sink = dict(report.drive.payload) if report.drive and report.drive.payload else {}
+        matching_valid_archives = _count_valid_lap_archives(lap_archives, _combo_predicate)
         if (
             sink.get("ok")
             and isinstance(sink.get("result"), dict)
             and handshake_laps_used > 0
-            and _count_valid_lap_archives(lap_archives, archive_matches_combo) < handshake_laps_used
+            and matching_valid_archives < handshake_laps_used
         ):
             # The bounded writer wait expired with a partial lap set. Do not promote a model from
             # lap 1 while the thermal/probe-relevant lap 2 is absent; constants may still persist.
@@ -3427,7 +3428,7 @@ def _main_impl(
                 "model": None,
                 "reason": (
                     "incomplete handshake lap archive set: "
-                    f"{_count_valid_lap_archives(lap_archives, archive_matches_combo)} "
+                    f"{matching_valid_archives} "
                     f"matching valid < {handshake_laps_used}"
                 ),
             }

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -2739,7 +2739,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--max-speed", type=float, default=240.0, help="racing/ggv: speed cap (km/h)")
     p.add_argument(
         "--drive-seconds",
-        type=float,
+        type=_positive_float,
         default=None,
         help="drive time budget (default: 300, or 180+240*laps for a flying-lap window)",
     )
@@ -2880,7 +2880,10 @@ def resolve_lap_window_drive_seconds(explicit: float | None, target_laps: int) -
     rule in ``auto_drive`` ensures direct CLI users and orchestrators share one contract.
     """
     if explicit is not None:
-        return float(explicit)
+        value = float(explicit)
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"drive seconds must be finite and > 0 (got {explicit!r})")
+        return value
     if target_laps > 0:
         return 180.0 + 240.0 * target_laps
     return 300.0

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -700,10 +700,13 @@ def merge_selfplay_model(current: GGVModel, batch: GGVModel) -> tuple[GGVModel, 
     handshake laps already proved, and adopting it verbatim would ratchet the plant (and every
     QSS profile built from it) downward. Merge rules, per speed bin:
 
-    * **lateral** — measured evidence wins over prior; when BOTH are measured, keep the posterior
-      with the higher ``safe_g`` (grip once proven stays proven within the combo's cohort; the
-      keep-last-valid falsification oracle in ``auto_alien`` is the safety valve when a raised
-      envelope turns out wrong on track).
+    * **lateral** — a batch posterior is adopted ONLY when it raises ``safe_g`` (strict
+      monotonicity). Measured provenance alone is not enough: a lap driven at 0.81x the planned
+      envelope "measures" less grip than even the prior's lower-confidence bound already grants,
+      and adopting it would ratchet the envelope (and every QSS profile built from it) downward.
+      Grip once proven stays proven within the combo's cohort; the keep-last-valid falsification
+      oracle in ``auto_alien`` is the safety valve when a raised envelope turns out wrong on
+      track.
     * **brake / drive** — always the current model's bins: longitudinal bins only learn from
       controlled probes (``brake_probe`` / ``accel_sweep`` rows), which a non-handshake self-play
       drive never produces, so a batch refit can only regress them to the prior.
@@ -737,14 +740,15 @@ def merge_selfplay_model(current: GGVModel, batch: GGVModel) -> tuple[GGVModel, 
         new_lat = dict(new_bin["lateral"])
         cur_measured = cur_lat.get("source") == "measured"
         new_measured = new_lat.get("source") == "measured"
-        if new_measured and not cur_measured:
+        # Strictly monotone: only a measured batch posterior that RAISES safe_g wins. A measured-
+        # but-lower posterior (a soft lap, or evidence below the prior's own LCB) never regresses
+        # the envelope.
+        if new_measured and float(new_lat["safe_g"]) > float(cur_lat["safe_g"]):
             lateral = new_lat
-            lateral_adopted += 1
-        elif new_measured and cur_measured and float(new_lat["safe_g"]) > float(
-            cur_lat["safe_g"]
-        ):
-            lateral = new_lat
-            lateral_raised += 1
+            if cur_measured:
+                lateral_raised += 1
+            else:
+                lateral_adopted += 1
         else:
             lateral = cur_lat
         merged_bins.append(

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -691,6 +691,92 @@ def with_binned_uncertainty(
     return replace(point_model, provenance=provenance, uncertainty_bins=tuple(bins))
 
 
+def merge_selfplay_model(current: GGVModel, batch: GGVModel) -> tuple[GGVModel, dict]:
+    """Merge one self-play batch refit into the current identified plant, monotonically (#577).
+
+    The self-play loop drives the alien line, refits the friction envelope from ONLY that batch's
+    lap archives, and must never *lose* previously proven grip to a smaller/softer batch: a lap
+    driven at 0.9x the planned envelope produces measured lateral evidence BELOW what the
+    handshake laps already proved, and adopting it verbatim would ratchet the plant (and every
+    QSS profile built from it) downward. Merge rules, per speed bin:
+
+    * **lateral** — measured evidence wins over prior; when BOTH are measured, keep the posterior
+      with the higher ``safe_g`` (grip once proven stays proven within the combo's cohort; the
+      keep-last-valid falsification oracle in ``auto_alien`` is the safety valve when a raised
+      envelope turns out wrong on track).
+    * **brake / drive** — always the current model's bins: longitudinal bins only learn from
+      controlled probes (``brake_probe`` / ``accel_sweep`` rows), which a non-handshake self-play
+      drive never produces, so a batch refit can only regress them to the prior.
+
+    Top-level lateral grip takes ``max(current, batch)`` (the point model is the operating
+    ceiling the bins derate — proven-harder cornering may raise it, a soft batch never lowers
+    it); every other coefficient, the caps, ``ellipse_n`` and the supported-longitudinal
+    overrides stay the current model's. Both models must carry the identical uncertainty-bin
+    grid (same schema-v3 fit pipeline) — anything else is a wiring bug and raises.
+    """
+    if not current.uncertainty_aware or not batch.uncertainty_aware:
+        raise ValueError("selfplay merge requires two uncertainty-aware (schema-v3) models")
+    if len(current.uncertainty_bins) != len(batch.uncertainty_bins):
+        raise ValueError(
+            "selfplay merge: uncertainty-bin grids differ "
+            f"({len(current.uncertainty_bins)} vs {len(batch.uncertainty_bins)} bins)"
+        )
+    merged_bins: list[dict] = []
+    lateral_adopted = 0
+    lateral_raised = 0
+    for cur_bin, new_bin in zip(current.uncertainty_bins, batch.uncertainty_bins, strict=True):
+        if not math.isclose(
+            float(cur_bin["speed_min_kmh"]), float(new_bin["speed_min_kmh"])
+        ) or not math.isclose(float(cur_bin["speed_max_kmh"]), float(new_bin["speed_max_kmh"])):
+            raise ValueError(
+                "selfplay merge: bin speed ranges differ "
+                f"({cur_bin['speed_min_kmh']}-{cur_bin['speed_max_kmh']} vs "
+                f"{new_bin['speed_min_kmh']}-{new_bin['speed_max_kmh']} km/h)"
+            )
+        cur_lat = dict(cur_bin["lateral"])
+        new_lat = dict(new_bin["lateral"])
+        cur_measured = cur_lat.get("source") == "measured"
+        new_measured = new_lat.get("source") == "measured"
+        if new_measured and not cur_measured:
+            lateral = new_lat
+            lateral_adopted += 1
+        elif new_measured and cur_measured and float(new_lat["safe_g"]) > float(
+            cur_lat["safe_g"]
+        ):
+            lateral = new_lat
+            lateral_raised += 1
+        else:
+            lateral = cur_lat
+        merged_bins.append(
+            {
+                "speed_min_kmh": float(cur_bin["speed_min_kmh"]),
+                "speed_max_kmh": float(cur_bin["speed_max_kmh"]),
+                "lateral": lateral,
+                "brake": dict(cur_bin["brake"]),
+                "drive": dict(cur_bin["drive"]),
+            }
+        )
+    mu_before = current.mu_lat_g
+    mu_after = max(current.mu_lat_g, batch.mu_lat_g)
+    provenance = copy.deepcopy(current.provenance)
+    history = provenance.setdefault("selfplay_merges", [])
+    stats = {
+        "lateral_bins_adopted": lateral_adopted,
+        "lateral_bins_raised": lateral_raised,
+        "mu_lat_g_before": round(mu_before, 6),
+        "mu_lat_g_after": round(mu_after, 6),
+        "batch_mu_lat_g": round(batch.mu_lat_g, 6),
+    }
+    history.append(stats)
+    merged = replace(
+        current,
+        mu_lat_g=mu_after,
+        provenance=provenance,
+        uncertainty_bins=tuple(merged_bins),
+    )
+    return merged, dict(stats)
+
+
 def observe_lap_tyre_state(
     archive: dict,
     *,

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -52,6 +52,7 @@ from tools.ac_harness.ggv_profile import (
     fit_steer_feedforward,
     ggv_from_lap_archives,
     ggv_from_telemetry,
+    merge_selfplay_model,
     seg_lengths,
     signed_curvature_profile,
 )
@@ -1558,6 +1559,66 @@ def refine_ggv_from_lap_archives(
     block["reason"] = "ok"
     result["ggv"] = block
     return block
+
+
+def selfplay_refine_result(
+    artifact: dict,
+    archives: list[str | Path | dict],
+    prior: GGVModel,
+    *,
+    prior_name: str = "generic_gt3_ggv",
+) -> tuple[dict | None, dict]:
+    """Refit from ONE self-play lap batch and merge monotonically into the plant (#577).
+
+    ``artifact`` is the combo's loaded plant artifact (the persisted handshake result). The batch
+    ``archives`` must be provenance-bound to the pipeline's own drive stage (collected by the same
+    run, combo-matched) — that is the ``archives_same_run=True`` contract. Returns
+    ``(result_to_persist, refine_block)``:
+
+    * on success, ``result_to_persist`` is a deep-copied result whose ``ggv`` block carries the
+      monotonically merged model (see :func:`~tools.ac_harness.ggv_profile.merge_selfplay_model`);
+      persist it through :func:`save_plant_artifact` — the SAME gate every plant rides — so the
+      plant-fit provenance hash changes and every cached alien line derived from the previous fit
+      invalidates.
+    * on any failure (no current fit, batch refit degraded, bin-grid mismatch),
+      ``result_to_persist`` is ``None`` and the block names the reason — the caller keeps the
+      last-valid plant and MUST say so (never a silent fallback).
+    """
+    import copy
+
+    current = plant_ggv_model(artifact)
+    if current is None:
+        return None, {
+            "ok": False,
+            "reason": "artifact has no uncertainty-aware friction fit to refine (#543)",
+        }
+    result = copy.deepcopy(artifact)
+    # save_plant_artifact stamps fresh schema_version/created_utc; stale copies must not shadow
+    # them (dict-splat order puts result keys last).
+    result.pop("schema_version", None)
+    result.pop("created_utc", None)
+    block = refine_ggv_from_lap_archives(
+        result,
+        archives,
+        prior,
+        prior_name=prior_name,
+        archives_same_run=True,
+    )
+    if not block.get("ok"):
+        return None, block
+    try:
+        batch_model = GGVModel.from_dict(block["model"])
+        merged, merge_stats = merge_selfplay_model(current, batch_model)
+    except (ValueError, TypeError) as exc:
+        return None, {
+            "ok": False,
+            "reason": f"selfplay merge failed: {type(exc).__name__}: {exc}",
+            "batch_refit": {k: v for k, v in block.items() if k != "model"},
+        }
+    block["model"] = merged.to_dict()
+    block["selfplay_merge"] = merge_stats
+    block["reason"] = "ok (self-play monotonic merge)"
+    return result, block
 
 
 def _setup_stem(setup: str | None) -> str | None:

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1711,12 +1711,8 @@ def plant_artifact_path(
     return Path(user_dir) / "plant_id" / f"{stem}.json"
 
 
-def save_plant_artifact(user_dir: Path, result: dict) -> Path:
-    """Persist a PASSED handshake result as the combo's plant artifact (atomic write).
-
-    The artifact is keyed by car+track+layout+setup. ``layout=None`` keeps the exact legacy
-    car+track+setup filename so existing single-layout artifacts remain loadable.
-    """
+def _plant_artifact_payload(result: dict) -> dict:
+    """Validate one plant result and stamp its persisted schema metadata."""
     if not result.get("ok"):
         raise ValueError("refusing to persist a failed handshake as a plant artifact")
     ggv = result.get("ggv")
@@ -1731,22 +1727,38 @@ def save_plant_artifact(user_dir: Path, result: dict) -> Path:
     track_id = str(result.get("track_id") or "")
     if not car_id or not track_id:
         raise ValueError(f"plant artifact needs car_id and track_id (got {car_id!r}/{track_id!r})")
-    setup = result.get("setup")
-    setup_ini = result.get("setup_ini")
-    layout = result.get("layout")
     from datetime import UTC, datetime
 
-    payload = {
+    return {
         "schema_version": PLANT_SCHEMA_VERSION,
         "created_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         **result,
     }
-    path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
+
+
+def _write_plant_payload(path: Path, payload: dict) -> Path:
+    """Atomically write an already-validated payload to an already-resolved artifact path."""
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     tmp.replace(path)
     return path
+
+
+def save_plant_artifact(user_dir: Path, result: dict) -> Path:
+    """Persist a PASSED handshake result as the combo's plant artifact (atomic write).
+
+    The artifact is keyed by car+track+layout+setup. ``layout=None`` keeps the exact legacy
+    car+track+setup filename so existing single-layout artifacts remain loadable.
+    """
+    payload = _plant_artifact_payload(result)
+    car_id = str(payload["car_id"])
+    track_id = str(payload["track_id"])
+    setup = payload.get("setup")
+    setup_ini = payload.get("setup_ini")
+    layout = payload.get("layout")
+    path = plant_artifact_path(user_dir, car_id, track_id, setup, setup_ini, layout=layout)
+    return _write_plant_payload(path, payload)
 
 
 def persist_selfplay_refinement(
@@ -1760,9 +1772,10 @@ def persist_selfplay_refinement(
     """Conditionally persist one self-play refinement under machine-global ownership.
 
     The caller refined ``expected_current_bytes``.  Holding the same cross-worktree rig lock used
-    by handshake producers closes the compare/write race with another harness before the canonical
-    :func:`save_plant_artifact` gate runs.  A peer update or identity drift is a clean skip, not an
-    overwrite.  Artifact path derivation and raw I/O stay owned by this module.
+    by handshake producers closes the compare/write race with another harness. The driven path is
+    already content-hash-resolved, so persistence validates stable identity fields against the
+    loaded artifact and writes that exact path without re-reading a setup file. A peer update or
+    identity drift is a clean skip, not an overwrite. Raw I/O stays owned by this module.
     """
     from tools.ac_harness.rig_lock import (
         RigSessionLock,
@@ -1770,28 +1783,40 @@ def persist_selfplay_refinement(
         default_rig_session_lock_path,
     )
 
-    car_id = str(result.get("car_id") or "")
-    track_id = str(result.get("track_id") or "")
-    path = plant_artifact_path(
-        user_dir,
-        car_id,
-        track_id,
-        result.get("setup"),
-        result.get("setup_ini"),
-        layout=result.get("layout"),
-    )
+    payload = _plant_artifact_payload(result)
+    car_id = str(payload["car_id"])
+    track_id = str(payload["track_id"])
     expected = Path(expected_path)
-    if path != expected:
+    plant_root = (Path(user_dir) / "plant_id").resolve()
+    try:
+        expected.resolve().relative_to(plant_root)
+    except ValueError:
         return (
             None,
             None,
-            f"refined identity keys to {path}, not the driven plant {expected} — "
-            "refusing a forked plant file",
+            f"driven plant {expected} is outside approved root {plant_root} — refusing persist",
+        )
+    try:
+        driven_payload = json.loads(expected_current_bytes) if expected_current_bytes else None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        driven_payload = None
+    if not isinstance(driven_payload, dict):
+        return None, None, "driven plant bytes are absent or malformed — refusing persist"
+    identity_fields = ("car_id", "track_id", "layout")
+    identity_matches = all(payload.get(key) == driven_payload.get(key) for key in identity_fields)
+    identity_matches = identity_matches and _setup_stem(payload.get("setup")) == _setup_stem(
+        driven_payload.get("setup")
+    )
+    if not identity_matches:
+        return (
+            None,
+            None,
+            "refined non-hash identity differs from the driven plant — refusing persist",
         )
 
     owner = RigSessionOwner(pid=os.getpid(), cwd=str(Path.cwd()), car=car_id, track=track_id)
     with RigSessionLock(default_rig_session_lock_path(), owner=owner, timeout=lock_timeout):
-        current_bytes = path.read_bytes() if path.exists() else None
+        current_bytes = expected.read_bytes() if expected.exists() else None
         if current_bytes != expected_current_bytes:
             return (
                 None,
@@ -1799,7 +1824,7 @@ def persist_selfplay_refinement(
                 "plant artifact changed between load and save (peer re-identification?) — "
                 "refinement of stale bytes not persisted",
             )
-        saved = save_plant_artifact(user_dir, result)
+        saved = _write_plant_payload(expected, payload)
         return saved, saved.read_bytes(), None
 
 

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -39,6 +39,7 @@ import hashlib
 import json
 import logging
 import math
+import os
 import re
 import uuid
 from dataclasses import asdict, dataclass
@@ -1567,6 +1568,7 @@ def selfplay_refine_result(
     prior: GGVModel,
     *,
     prior_name: str = "generic_gt3_ggv",
+    setup_ini: str | Path | None = None,
 ) -> tuple[dict | None, dict]:
     """Refit from ONE self-play lap batch and merge monotonically into the plant (#577).
 
@@ -1597,6 +1599,10 @@ def selfplay_refine_result(
     # them (dict-splat order puts result keys last).
     result.pop("schema_version", None)
     result.pop("created_utc", None)
+    # A portable artifact can retain its creator's absolute setup path.  Self-play persistence
+    # must use the caller-resolved identity so a moved setup cannot fork the refined plant into a
+    # different filename.  Keep this schema/identity mutation inside the artifact owner module.
+    result["setup_ini"] = str(setup_ini) if setup_ini else None
     block = refine_ggv_from_lap_archives(
         result,
         archives,
@@ -1741,6 +1747,92 @@ def save_plant_artifact(user_dir: Path, result: dict) -> Path:
     tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     tmp.replace(path)
     return path
+
+
+def persist_selfplay_refinement(
+    user_dir: Path,
+    result: dict,
+    *,
+    expected_path: str | Path,
+    expected_current_bytes: bytes | None,
+    lock_timeout: float = 0.0,
+) -> tuple[Path | None, bytes | None, str | None]:
+    """Conditionally persist one self-play refinement under machine-global ownership.
+
+    The caller refined ``expected_current_bytes``.  Holding the same cross-worktree rig lock used
+    by handshake producers closes the compare/write race with another harness before the canonical
+    :func:`save_plant_artifact` gate runs.  A peer update or identity drift is a clean skip, not an
+    overwrite.  Artifact path derivation and raw I/O stay owned by this module.
+    """
+    from tools.ac_harness.rig_lock import (
+        RigSessionLock,
+        RigSessionOwner,
+        default_rig_session_lock_path,
+    )
+
+    car_id = str(result.get("car_id") or "")
+    track_id = str(result.get("track_id") or "")
+    path = plant_artifact_path(
+        user_dir,
+        car_id,
+        track_id,
+        result.get("setup"),
+        result.get("setup_ini"),
+        layout=result.get("layout"),
+    )
+    expected = Path(expected_path)
+    if path != expected:
+        return (
+            None,
+            None,
+            f"refined identity keys to {path}, not the driven plant {expected} — "
+            "refusing a forked plant file",
+        )
+
+    owner = RigSessionOwner(pid=os.getpid(), cwd=str(Path.cwd()), car=car_id, track=track_id)
+    with RigSessionLock(default_rig_session_lock_path(), owner=owner, timeout=lock_timeout):
+        current_bytes = path.read_bytes() if path.exists() else None
+        if current_bytes != expected_current_bytes:
+            return (
+                None,
+                None,
+                "plant artifact changed between load and save (peer re-identification?) — "
+                "refinement of stale bytes not persisted",
+            )
+        saved = save_plant_artifact(user_dir, result)
+        return saved, saved.read_bytes(), None
+
+
+def revert_plant_artifact(
+    path: str | Path,
+    previous_bytes: bytes,
+    *,
+    expected_current_bytes: bytes | None,
+    car_id: str,
+    track_id: str,
+    lock_timeout: float = 0.0,
+) -> bool:
+    """Restore a last-valid plant iff this iteration's candidate is still current.
+
+    Returns ``False`` when a peer replaced the candidate first; in that case restoring our older
+    bytes would be the unsafe action.  I/O failures propagate so the orchestrator can fail closed.
+    """
+    from tools.ac_harness.rig_lock import (
+        RigSessionLock,
+        RigSessionOwner,
+        default_rig_session_lock_path,
+    )
+
+    artifact_path = Path(path)
+    owner = RigSessionOwner(pid=os.getpid(), cwd=str(Path.cwd()), car=car_id, track=track_id)
+    with RigSessionLock(default_rig_session_lock_path(), owner=owner, timeout=lock_timeout):
+        current_bytes = artifact_path.read_bytes() if artifact_path.exists() else b""
+        if current_bytes != expected_current_bytes:
+            return False
+        tmp = artifact_path.with_suffix(".json.tmp")
+        tmp.write_bytes(previous_bytes)
+        tmp.replace(artifact_path)
+        return True
 
 
 def load_plant_artifact(

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -267,7 +267,7 @@ async def tap_frames(
     wait_for_lap: bool = False,
     settle_timeout: float = 120.0,
     lap_timeout: float = 180.0,
-    lap_count: int = 1,
+    lap_count: int | None = None,
 ) -> list[dict]:
     """Tap the sidecar and return the frames received (live; needs AC driving).
 
@@ -275,20 +275,21 @@ async def tap_frames(
     ``settle_timeout``) for the car to be on track, then waits (up to ``lap_timeout``) for a ``lap``
     frame — so a slow real lap is captured rather than false-failing a fixed 20 s window.
 
-    ``lap_count > 1`` (#577 flying-lap windows): keep the window open until that many TIMED lap
-    boundaries (``payload.last_lap_ms > 0``) arrive, sharing ONE ``lap_timeout`` deadline for the
-    whole batch — the drive's ``--drive-seconds`` budget stays the honest cap ("N laps or the time
-    budget, whichever first"). A deadline expiry with at least one lap already seen returns the
-    frames collected so far rather than raising: the run continues to evaluation, where the
-    shortfall is reported honestly. ``lap_count == 1`` keeps the exact legacy single-lap wait
-    (any ``lap`` frame, timed or not — the #516 grace/archive logic gates on timed separately).
+    ``lap_count`` (#577 flying-lap windows): an explicit N >= 1 keeps the window open until that
+    many TIMED lap boundaries (``payload.last_lap_ms > 0``) arrive — including N == 1, so a
+    requested one-lap batch never exits on an untimed out-lap/teleport boundary (#579 daemon
+    HIGH). One ``lap_timeout`` deadline covers the whole batch — the drive's ``--drive-seconds``
+    budget stays the honest cap ("N laps or the time budget, whichever first"); a deadline expiry
+    returns the frames collected so far and the shortfall is reported honestly downstream.
+    ``lap_count=None`` keeps the exact legacy ``--wait-lap`` wait (any ``lap`` frame, timed or
+    not — the #516 grace/archive logic gates on timed separately).
 
     Always closes the client (try/finally) and fails fast on a missing hello handshake. Imported
     lazily so the pure evaluator has no hard dependency on the sidecar client.
     """
     from tools.ai_sidecar.harness_client import HarnessClient
 
-    if lap_count < 1:
+    if lap_count is not None and lap_count < 1:
         raise ValueError(f"lap_count must be >= 1 (got {lap_count})")
     hc = HarnessClient(url)
     try:
@@ -303,7 +304,7 @@ async def tap_frames(
                 lambda f: any(_is_snapshot(f, t) for t in _CONTINUOUS_SET),
                 timeout=settle_timeout,
             )
-            if lap_count == 1:
+            if lap_count is None:
                 await hc.wait_for(lambda f: _is_snapshot(f, "lap"), timeout=lap_timeout)
             else:
                 # `wait_for` returns None on timeout (never raises) — mirror the single-lap

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -223,6 +223,43 @@ def _is_snapshot(frame: dict, topic: str) -> bool:
     )
 
 
+def is_timed_lap_frame(frame: dict) -> bool:
+    """Whether a frame is a ``lap`` snapshot carrying a positive time (``payload.last_lap_ms``).
+
+    An out-lap / teleport boundary still emits a ``lap`` frame but with no time; only a TIMED
+    boundary counts as a completed lap for the #577 multi-lap window (the trainer only archives
+    timed laps, so counting untimed boundaries would overclaim the collected evidence).
+    """
+    if not _is_snapshot(frame, "lap"):
+        return False
+    payload = frame.get("payload")
+    ms = payload.get("last_lap_ms") if isinstance(payload, dict) else None
+    try:
+        return ms is not None and float(ms) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def timed_lap_times_ms(frames: list[dict]) -> list[int]:
+    """Per-lap times (ms, stream order) of every timed ``lap`` boundary in the frame stream.
+
+    Pure — the #577 report consumes this so a multi-lap run carries its full lap-time
+    trajectory, not just "a lap happened". Each ``lap`` snapshot is one boundary event
+    (the trainer emits it once per completed lap; it is not re-emitted on subscribe).
+    """
+    out: list[int] = []
+    for frame in frames:
+        if not is_timed_lap_frame(frame):
+            continue
+        payload = frame.get("payload")
+        ms = payload.get("last_lap_ms") if isinstance(payload, dict) else None
+        try:
+            out.append(int(float(ms)))
+        except (TypeError, ValueError):  # pragma: no cover - is_timed_lap_frame already vetted
+            continue
+    return out
+
+
 async def tap_frames(
     url: str = "ws://127.0.0.1:8765",
     *,
@@ -230,6 +267,7 @@ async def tap_frames(
     wait_for_lap: bool = False,
     settle_timeout: float = 120.0,
     lap_timeout: float = 180.0,
+    lap_count: int = 1,
 ) -> list[dict]:
     """Tap the sidecar and return the frames received (live; needs AC driving).
 
@@ -237,11 +275,21 @@ async def tap_frames(
     ``settle_timeout``) for the car to be on track, then waits (up to ``lap_timeout``) for a ``lap``
     frame — so a slow real lap is captured rather than false-failing a fixed 20 s window.
 
+    ``lap_count > 1`` (#577 flying-lap windows): keep the window open until that many TIMED lap
+    boundaries (``payload.last_lap_ms > 0``) arrive, sharing ONE ``lap_timeout`` deadline for the
+    whole batch — the drive's ``--drive-seconds`` budget stays the honest cap ("N laps or the time
+    budget, whichever first"). A deadline expiry with at least one lap already seen returns the
+    frames collected so far rather than raising: the run continues to evaluation, where the
+    shortfall is reported honestly. ``lap_count == 1`` keeps the exact legacy single-lap wait
+    (any ``lap`` frame, timed or not — the #516 grace/archive logic gates on timed separately).
+
     Always closes the client (try/finally) and fails fast on a missing hello handshake. Imported
     lazily so the pure evaluator has no hard dependency on the sidecar client.
     """
     from tools.ai_sidecar.harness_client import HarnessClient
 
+    if lap_count < 1:
+        raise ValueError(f"lap_count must be >= 1 (got {lap_count})")
     hc = HarnessClient(url)
     try:
         await hc.connect(retries=40, retry_delay=0.25)
@@ -249,13 +297,28 @@ async def tap_frames(
             raise RuntimeError("sidecar hello handshake timed out (no hello_ack)")
         await hc.subscribe(list(ALL_TAP_TOPICS))
         if wait_for_lap:
-            # Wait for the car to be on track (any continuous topic), then for a lap boundary.
+            # Wait for the car to be on track (any continuous topic), then for lap boundaries.
             # `wait_for` consumes from a separate queue; `hc.frames` still accrues the full stream.
             await hc.wait_for(
                 lambda f: any(_is_snapshot(f, t) for t in _CONTINUOUS_SET),
                 timeout=settle_timeout,
             )
-            await hc.wait_for(lambda f: _is_snapshot(f, "lap"), timeout=lap_timeout)
+            if lap_count == 1:
+                await hc.wait_for(lambda f: _is_snapshot(f, "lap"), timeout=lap_timeout)
+            else:
+                # `wait_for` returns None on timeout (never raises) — mirror the single-lap
+                # contract: return whatever was collected and let evaluate_sequence /
+                # the report surface the shortfall honestly (require_lap fails at 0 laps).
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + lap_timeout
+                seen = 0
+                while seen < lap_count:
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        break  # partial batch: reported downstream, laps so far kept
+                    if await hc.wait_for(is_timed_lap_frame, timeout=remaining) is None:
+                        break
+                    seen += 1
         else:
             await asyncio.sleep(seconds)
         return list(hc.frames)


### PR DESCRIPTION
Closes #577 (EPIC #529 P3). Depends on merged #572 (`dfd4b7e`).

## What

Attacks the conservative QSS floor (both Magione plants collapse to the same 91.94 s floor — the uncertainty bins bind, not the cars) with the two mechanisms the issue specifies:

### 1. Flying-lap windows (`--laps N`, `auto_drive`)
- The `--wait-lap` tap can now hold its window open until **N TIMED laps** complete (`payload.last_lap_ms > 0` — untimed teleport/out-lap boundaries never count), or the `--drive-seconds` budget expires, whichever first. `lap_count == 1` keeps the exact legacy single-lap wait.
- Per-lap times land in the report (`lap_times_ms` + `laps_requested`, plus a summary line); a shortfall is an honest note, not a hang.
- Multi-lap batches wait for **combo-matched archives per timed lap** (the self-play refine consumes the full batch); the legacy single-lap poll is unchanged.

### 2. Progressive-envelope self-play (`--iterations K`, `auto_alien`)
Each iteration: **refine → rebuild → drive**, all falsifiable:
- **Refine** (`plant_id.selfplay_refine_result` + `ggv_profile.merge_selfplay_model`): refits the friction envelope from ONLY the previous drive's lap archives (provenance-bound: run-scoped + combo-matched by the stage itself), then merges **strictly monotonically** — a lateral bin is adopted only when its measured posterior *raises* `safe_g` (a lap driven at 0.81× the planned envelope "measures" less grip than even the prior's LCB grants; adopting it would ratchet the plant downward — caught by the first test draft). Brake/drive bins are preserved verbatim (longitudinal bins only learn from controlled probes, which a non-handshake drive never produces). `mu_lat_g` never drops.
- **Persist** through the canonical `save_plant_artifact` gates — the plant-fit provenance hash changes, so every cached alien line derived from the previous fit invalidates and the next drive rebuilds line+QSS against the updated plant. No side-channel "refined" files.
- **Envelope ladder**: per-iteration `ggv_scale` step (default +0.05, capped by `--max-scale`, hard limit 1.2 via the drive stage's explicit `--alien-allow-overspeed` opt-in — the one-shot alien path keeps its #572 `<=1` gate). Driving slightly above the LCB envelope is how the loop generates the supra-LCB evidence that raises the measured bins.
- **Keep-last-valid falsification oracle** (the #244 pattern): a failed stage / any recovery / no timed lap / an AC-invalid lap falsifies the step — the plant reverts to the last-valid artifact bytes (peer-modification guarded) and the ladder stops with the named reason. An envelope that cannot change (scale capped AND refit failed) refuses the identical retry.
- Per-iteration lap-time trajectory + refine/merge stats + falsification reasons in `alien_report.json`.

## Acceptance criteria mapping

- `--laps 3` window + per-lap times + per-lap archives → Part 1 (unit-tested: window kwarg, trajectory, shortfall note, archive batch count).
- Iterate refines from those archives only, line cache invalidates via the existing plant-fit hash gate, next iteration drives the rebuilt profile, per-iteration trajectory in the report → Part 2 (unit-tested end-to-end with an injected stage runner).
- Falsified envelope step → keep-last-valid revert + named falsification, never a silent same-envelope retry → unit-tested (revert on AC-invalid lap; identical-envelope refusal).
- Magione + GT3 monotonic-improvement live run → rig verification follows on this PR/issue (evidence comment) before the issue closes; the code path is the unmodified `python -m tools.ac_harness.auto_alien --car <gt3> --track magione --laps 3 --iterations K`.
- `make ci-fast` green locally (envelope-progression logic fully unit-tested off-rig).

## Known-pitfall compliance

- **No silent exception swallowing**: every refine/rebuild failure is named in the iteration entry and the `stopped` reason; fallback to the previous profile always says so.
- **State consistency**: refined plants ride `save_plant_artifact`; line invalidation rides the existing provenance hash. Iteration artifacts live under `Documents/Assetto Corsa/` (plant/line trees), never `.scratch/`.
- **No aero re-chase**: the refinement lever is the measured lateral bins tightening (`k_aero_lat` stays 0, enforced by `GGVModel.from_dict`).

## Out of scope (per issue)

L3 corridor-constrained per-corner refinement (issue "What" item 3 — no AC attached) remains open scope on #577 after this lands; L4 stint layer; LLM scientist (P4); coachable frontier (P5); setup-search floor attack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
