### PR TITLE
feat(harness): #582 L3 corridor-constrained per-corner refinement (beyond-QSS interior)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -154,6 +154,20 @@ python -m tools.ac_harness.auto_drive --car ks_porsche_911_gt3_r_2016 --track ma
 - `--force-identify` re-runs identification; `--rebuild-line` (or `--alien-rebuild-line` on
   `auto_drive`) rebuilds the line cache from the current plant.
 
+### Beyond-QSS per-corner refinement (#529 L3 / #582)
+
+The QSS profile consumes the uncertainty-safe LCB grip (`mean − 1.96·std` per 10 km/h bin), which
+the #577 runs proved binds the lap-time floor. `auto_alien` therefore enables **L3** on every
+alien stage by default (`--no-l3` disables; on `auto_drive` it is the opt-in `--l3` flag): corners
+of the optimized line whose speed range crosses **measured, low-variance** lateral bins get their
+interior re-solved between QSS-pinned entry/exit speeds against grip relaxed toward the posterior
+mean — never above the stability barrier `mean − 1.0·std`, never in prior-dominated bins, and
+never silently: the artifact's `l3` report names every corner as `refined` (chosen z, relaxed
+bins, predicted gain) or `reverted` (reason). The refined profile rides the same artifact,
+provenance gates, and cache revalidation (a tampered refined profile fails the barrier re-check
+and rebuilds); `--no-l3` artifacts are byte-identical to pre-#582 builds. Reality remains the
+judge: the #577 keep-last-valid oracle falsifies a refined profile the car cannot hold.
+
 ## Composing downstream tasks (don't reinvent)
 
 - **Setup A/B**: run twice with different `--setup` names; compare the runs' lap archives with

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -425,3 +425,205 @@ def test_envelope_verification_rejects_overspeed(lane):
     # 100 m/s on a 120 m radius = 8.5 g lateral — far beyond any GT3 envelope.
     with pytest.raises(ValueError, match="exceeds the plant lateral envelope"):
         _verify_lateral_envelope(plane, [100.0] * len(plane), plant)
+
+
+# ---------------------------------------------------------------------------
+# #582 L3 per-corner refinement integration (build / cache identity / verify)
+# ---------------------------------------------------------------------------
+def _stadium_line(n_arc: int = 60, n_straight: int = 60, r: float = 60.0, half_l: float = 150.0):
+    """Two straights + two 60 m half-circles: corners bracketed by straights (unlike the circle)."""
+    pts: list[tuple[float, float, float]] = []
+    for i in range(n_arc):
+        th = -math.pi / 2 + math.pi * i / n_arc
+        pts.append((half_l + r * math.cos(th), 0.0, r * math.sin(th)))
+    for i in range(n_straight):
+        pts.append((half_l - 2 * half_l * i / n_straight, 0.0, r))
+    for i in range(n_arc):
+        th = math.pi / 2 + math.pi * i / n_arc
+        pts.append((-half_l + r * math.cos(th), 0.0, r * math.sin(th)))
+    for i in range(n_straight):
+        pts.append((-half_l + 2 * half_l * i / n_straight, 0.0, -r))
+    return pts
+
+
+def _l3_channel(mean: float, std: float, *, source: str = "prior", n: int = 0) -> dict:
+    safe = max(0.1, mean - 1.96 * std)
+    return {
+        "mean_g": round(mean, 6),
+        "epistemic_std_g": round(std, 6),
+        "safe_g": round(min(mean, safe), 6),
+        "n": n,
+        "source": source,
+    }
+
+
+def _l3_plant():
+    """generic GT3 + a full 30x10 km/h grid with measured lateral evidence at corner speeds."""
+    from dataclasses import replace
+
+    bins = []
+    for i in range(30):
+        lo = i * 10.0
+        measured = 40.0 <= lo and lo + 10.0 <= 200.0
+        bins.append(
+            {
+                "speed_min_kmh": lo,
+                "speed_max_kmh": lo + 10.0,
+                "lateral": _l3_channel(
+                    1.4,
+                    0.1 if measured else 0.2,
+                    source="measured" if measured else "prior",
+                    n=60 if measured else 0,
+                ),
+                "brake": _l3_channel(1.2, 0.15),
+                "drive": _l3_channel(0.5, 0.1),
+            }
+        )
+    return replace(generic_gt3_ggv(), uncertainty_bins=tuple(bins))
+
+
+@pytest.fixture
+def stadium_lane(tmp_path):
+    pts = _stadium_line()
+    path = tmp_path / "fast_lane.ai"
+    _write_fast_lane(path, pts, [6.0] * len(pts), [6.0] * len(pts))
+    return path, pts
+
+
+def test_l3_disabled_is_byte_identical_to_qss_only_artifact(stadium_lane):
+    path, pts = stadium_lane
+    art = build_alien_line_artifact(
+        pts, path, _l3_plant(), _plant_artifact(), car_id="c", track_id="t", iters=200
+    )
+    assert "l3" not in art and "v_target_qss_mps" not in art
+    assert art["params"] == {"margin_m": 1.2, "iters": 200, "v_top_kmh": 240.0}
+
+
+def test_l3_build_refines_corners_and_records_report(stadium_lane):
+    from tools.ac_harness.corner_refine import L3Params
+
+    path, pts = stadium_lane
+    plant = _l3_plant()
+    plain = build_alien_line_artifact(
+        pts, path, plant, _plant_artifact(), car_id="c", track_id="t", iters=200
+    )
+    art = build_alien_line_artifact(
+        pts,
+        path,
+        plant,
+        _plant_artifact(),
+        car_id="c",
+        track_id="t",
+        iters=200,
+        l3_params=L3Params(),
+    )
+    assert art["params"]["l3"] == L3Params().to_dict()
+    assert art["v_target_qss_mps"] == pytest.approx(plain["v_target_mps"])
+    report = art["l3"]
+    assert report["refined_corners"] >= 1
+    refined = [c for c in report["corners"] if c["status"] == "refined"]
+    assert refined and all(c["gain_ms"] > 0 for c in refined)
+    assert report["predicted_gain_ms"] == sum(c["gain_ms"] for c in refined)
+    # The refined profile is never slower than QSS anywhere, and strictly faster somewhere.
+    assert all(
+        v >= q - 1e-9
+        for v, q in zip(art["v_target_mps"], art["v_target_qss_mps"], strict=True)
+    )
+    assert any(
+        v > q + 1e-6
+        for v, q in zip(art["v_target_mps"], art["v_target_qss_mps"], strict=True)
+    )
+
+
+def test_l3_build_reverts_all_without_bracketed_corner(lane):
+    # The constant-curvature circle has no straight to pin against: L3 must keep QSS and say why.
+    from tools.ac_harness.corner_refine import L3Params
+
+    path, pts = lane
+    art = build_alien_line_artifact(
+        pts,
+        path,
+        _l3_plant(),
+        _plant_artifact(),
+        car_id="c",
+        track_id="t",
+        iters=200,
+        l3_params=L3Params(),
+    )
+    assert "no refinable corner window" in art["l3"]["reverted_all"]
+    assert art["v_target_mps"] == pytest.approx(art["v_target_qss_mps"])
+
+
+def test_l3_cache_identity_and_revalidation(tmp_path, stadium_lane):
+    from tools.ac_harness.corner_refine import L3Params
+
+    path, _pts = stadium_lane
+    plant = _l3_plant()
+    plant_art = _plant_artifact()
+    kw = dict(car_id="car_a", track_id="trk", iters=200)
+
+    art1, src1 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    assert src1 == "built" and art1["l3"]["refined_corners"] >= 1
+    _art2, src2 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    assert src2 == "cache"
+
+    # Disabling L3 (or retuning it) is a different cache identity -> honest rebuild.
+    art3, src3 = ensure_alien_line_artifact(tmp_path, path, plant, plant_art, **kw)
+    assert src3 == "built" and "l3" not in art3
+    art4, src4 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(z_ladder=(1.2, 1.0)), **kw
+    )
+    assert src4 == "built" and art4["params"]["l3"]["z_ladder"] == [1.2, 1.0]
+
+    # Tampered refined speeds fail the stability-barrier revalidation -> rebuilt, never driven.
+    _art5, src5 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    cache_path = alien_line_path(tmp_path, "car_a", "trk")
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["v_target_mps"] = [v * 1.5 for v in payload["v_target_mps"]]
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    _art6, src6 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    assert src6 == "built"
+
+    # Tampered l3 params (laxer than the stability floor) reject the cache outright.
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["params"]["l3"]["z_ladder"] = [0.2]
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    loaded = load_alien_line_artifact(
+        tmp_path,
+        "car_a",
+        "trk",
+        expected_plant_provenance=plant_provenance(plant_art),
+        expected_fast_lane_sha12=fast_lane_sha12(path),
+        params=payload["params"],
+    )
+    from tools.ac_harness.alien_line import verify_alien_line_artifact
+    from tools.ac_harness.ggv_profile import load_track_widths
+
+    assert loaded is not None  # identity gates match the tampered params by construction
+    sl, sr = load_track_widths(path)
+    pts_now = loaded["line"]
+    reason = verify_alien_line_artifact(
+        loaded, [tuple(p) for p in _stadium_line()], sl, sr, plant, margin_m=1.2
+    )
+    assert reason is not None and "l3 params invalid" in reason
+    _ = pts_now
+
+    # A refined cache missing its QSS fallback is malformed -> rejected at load.
+    _art7, src7 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    del payload["v_target_qss_mps"]
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    _art8, src8 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    assert src8 == "built"

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -524,6 +524,12 @@ def test_l3_build_refines_corners_and_records_report(stadium_lane):
     refined = [c for c in report["corners"] if c["status"] == "refined"]
     assert refined and all(c["gain_ms"] > 0 for c in refined)
     assert report["predicted_gain_ms"] == sum(c["gain_ms"] for c in refined)
+    # The l3 report carries the DRIVEN profile's utilisation honestly: within the stability
+    # barrier, deliberately beyond the safe envelope inside refined corners (#583 Codex P2) —
+    # while corridor.max_ay_utilisation remains the QSS-vs-safe metric.
+    assert report["max_ay_utilisation_vs_barrier"] <= 1.0 + 1e-4
+    assert report["max_ay_utilisation_vs_safe"] > 1.0
+    assert art["corridor"]["max_ay_utilisation"] <= 1.0 + 1e-6
     # The refined profile is never slower than QSS anywhere, and strictly faster somewhere.
     assert all(
         v >= q - 1e-9 for v, q in zip(art["v_target_mps"], art["v_target_qss_mps"], strict=True)

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -614,6 +614,35 @@ def test_l3_cache_identity_and_revalidation(tmp_path, stadium_lane):
     assert reason is not None and "l3 params invalid" in reason
     _ = pts_now
 
+    # An inflated QSS fallback (above the refined profile) breaks the refined>=QSS build
+    # contract even when both profiles respect their envelopes -> revalidation rejects it
+    # (#583 Codex P2).
+    _artq, srcq = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["v_target_qss_mps"] = [v * 1.01 for v in payload["v_target_mps"]]
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    _artq2, srcq2 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    assert srcq2 == "built"
+
+    # L3 identity without the l3 report/fallback (or vice versa) is inconsistent: an artifact
+    # whose params say L3 must carry the report + fallback, and a plain-identity artifact must
+    # not smuggle one in (#583 Qodo).
+    _arti, _srci = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    del payload["l3"]
+    del payload["v_target_qss_mps"]  # params still say l3 -> must reject, not accept as plain
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    _arti2, srci2 = ensure_alien_line_artifact(
+        tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw
+    )
+    assert srci2 == "built"
+
     # A refined cache missing its QSS fallback is malformed -> rejected at load.
     _art7, src7 = ensure_alien_line_artifact(
         tmp_path, path, plant, plant_art, l3_params=L3Params(), **kw

--- a/tests/test_alien_line.py
+++ b/tests/test_alien_line.py
@@ -526,12 +526,10 @@ def test_l3_build_refines_corners_and_records_report(stadium_lane):
     assert report["predicted_gain_ms"] == sum(c["gain_ms"] for c in refined)
     # The refined profile is never slower than QSS anywhere, and strictly faster somewhere.
     assert all(
-        v >= q - 1e-9
-        for v, q in zip(art["v_target_mps"], art["v_target_qss_mps"], strict=True)
+        v >= q - 1e-9 for v, q in zip(art["v_target_mps"], art["v_target_qss_mps"], strict=True)
     )
     assert any(
-        v > q + 1e-6
-        for v, q in zip(art["v_target_mps"], art["v_target_qss_mps"], strict=True)
+        v > q + 1e-6 for v, q in zip(art["v_target_mps"], art["v_target_qss_mps"], strict=True)
     )
 
 

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -285,6 +285,47 @@ def test_iteration_scale_ladder_caps():
     assert iteration_scale(0.9, 0.05, 40, 1.1) == 1.1
 
 
+# --------------------------------------------------------------------------- #582 L3
+def test_drive_argv_enables_l3_by_default_and_no_l3_disables(tmp_path):
+    drive = drive_argv(_args(tmp_path), tmp_path / "d")
+    assert "--l3" in drive
+    drive = drive_argv(_args(tmp_path, "--no-l3"), tmp_path / "d")
+    assert "--l3" not in drive
+
+
+def test_stage_l3_summary_extraction():
+    from tools.ac_harness.auto_alien import stage_l3_summary
+
+    assert stage_l3_summary(None) is None
+    assert stage_l3_summary({"report": {}}) is None
+    assert stage_l3_summary({"report": {"alien_line": {"qss": {}}}}) is None
+    outcome = {
+        "report": {
+            "alien_line": {
+                "l3": {
+                    "refined_corners": 3,
+                    "reverted_corners": 1,
+                    "predicted_gain_ms": 412,
+                    "corners": [{"corner": 0}],
+                }
+            }
+        }
+    }
+    assert stage_l3_summary(outcome) == {
+        "refined_corners": 3,
+        "reverted_corners": 1,
+        "predicted_gain_ms": 412,
+    }
+    outcome["report"]["alien_line"]["l3"] = {
+        "refined_corners": 0,
+        "reverted_corners": 0,
+        "predicted_gain_ms": 0,
+        "reverted_all": "plant is not uncertainty-aware",
+    }
+    summary = stage_l3_summary(outcome)
+    assert summary["reverted_all"] == "plant is not uncertainty-aware"
+
+
 def _stage_outcome(lap_times, *, recoveries=0, archives=(), stage="done", error=None):
     return {
         "report": {

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -297,10 +297,13 @@ def test_stage_l3_summary_extraction():
     from tools.ac_harness.auto_alien import stage_l3_summary
 
     assert stage_l3_summary(None) is None
-    assert stage_l3_summary({"report": {}}) is None
-    assert stage_l3_summary({"report": {"alien_line": {"qss": {}}}}) is None
+    assert stage_l3_summary({"run": {}}) is None
+    assert stage_l3_summary({"run": {"alien_line": {"qss": {}}}}) is None
+    # write_evidence stores alien-line detail under the TOP-LEVEL run extras, not report
+    # (#583 Codex P2) — a report-nested payload must not match.
+    assert stage_l3_summary({"report": {"alien_line": {"l3": {"refined_corners": 1}}}}) is None
     outcome = {
-        "report": {
+        "run": {
             "alien_line": {
                 "l3": {
                     "refined_corners": 3,
@@ -316,7 +319,7 @@ def test_stage_l3_summary_extraction():
         "reverted_corners": 1,
         "predicted_gain_ms": 412,
     }
-    outcome["report"]["alien_line"]["l3"] = {
+    outcome["run"]["alien_line"]["l3"] = {
         "refined_corners": 0,
         "reverted_corners": 0,
         "predicted_gain_ms": 0,

--- a/tests/test_corner_refine.py
+++ b/tests/test_corner_refine.py
@@ -339,6 +339,23 @@ def test_refine_validates_inputs():
         refine_profile(seg, kappa, v_qss, plant, L3Params(), v_top_ms=0.0)
 
 
+def test_profile_utilisation_reports_scaled_overspeed_beyond_barrier():
+    from tools.ac_harness.corner_refine import profile_utilisation
+
+    plant = _plant()
+    seg, kappa, v_qss = _qss(plant)
+    params = L3Params()
+    v_ref, _report = refine_profile(seg, kappa, v_qss, plant, params, v_top_ms=61.0)
+    barrier = barrier_ggv(plant, params.max_rel_std)
+    # The unscaled refined profile honors the barrier; a ggv_scale>1 overspeed probe (the #577
+    # ladder) must be REPORTED beyond it — the run evidence's driven-utilisation contract (#583).
+    assert profile_utilisation(kappa, v_ref, barrier) <= 1.0 + 1e-6
+    driven = [v * 1.05 for v in v_ref]
+    assert profile_utilisation(kappa, driven, barrier) > 1.0
+    with pytest.raises(ValueError, match="length mismatch"):
+        profile_utilisation(kappa[:-1], v_ref, barrier)
+
+
 def test_verify_refined_profile_catches_tampered_speeds():
     plant = _plant()
     seg, kappa, v_qss = _qss(plant)

--- a/tests/test_corner_refine.py
+++ b/tests/test_corner_refine.py
@@ -212,6 +212,19 @@ def test_segment_merges_adjacent_runs_into_one_window():
     assert windows[0][0] == 77 and windows[0][-1] == 116
 
 
+def test_segment_merges_exactly_touching_padded_runs():
+    # Gap exactly 2*pad: the padded windows touch (no shared index) — the documented contract
+    # says they merge into one window (#583 Qodo).
+    kappa = [0.0] * _N
+    for i in range(80, 95):
+        kappa[i] = _KAPPA_CORNER
+    for i in range(101, 116):  # gap 95..100 = 6 points = 2*pad
+        kappa[i] = _KAPPA_CORNER
+    windows = segment_corners(kappa, kappa_threshold=0.005, pad_points=3, min_corner_points=5)
+    assert len(windows) == 1
+    assert windows[0][0] == 77 and windows[0][-1] == 118
+
+
 def test_segment_no_corner_and_all_corner_return_empty():
     straight = [0.0] * _N
     circle = [_KAPPA_CORNER] * _N
@@ -257,6 +270,19 @@ def test_refine_improves_conservative_corner_within_barrier():
     assert ay_apex > safe_limit  # beyond QSS-safe...
     assert ay_apex <= barrier_limit + 1e-6  # ...but never beyond the barrier
     assert verify_refined_profile([(0.0, 0.0)] * _N, kappa, v_ref, plant, params) is None
+
+
+def test_refined_corner_reports_every_relaxed_channel():
+    plant = _plant()
+    seg, kappa, v_qss = _qss(plant)
+    _v_ref, report = refine_profile(seg, kappa, v_qss, plant, L3Params(), v_top_ms=61.0)
+    corner = report["corners"][0]
+    assert corner["status"] == "refined"
+    # The synthetic plant measures only the lateral channel; brake/drive stay prior — the
+    # per-corner provenance must name exactly the channels the refinement leaned on (#583).
+    assert corner["relaxed_lateral_bins_kmh"]
+    assert corner["relaxed_brake_bins_kmh"] == []
+    assert corner["relaxed_drive_bins_kmh"] == []
 
 
 def test_refine_is_deterministic():

--- a/tests/test_corner_refine.py
+++ b/tests/test_corner_refine.py
@@ -354,6 +354,11 @@ def test_profile_utilisation_reports_scaled_overspeed_beyond_barrier():
     assert profile_utilisation(kappa, driven, barrier) > 1.0
     with pytest.raises(ValueError, match="length mismatch"):
         profile_utilisation(kappa[:-1], v_ref, barrier)
+    # NaN comparisons are False, so an unguarded max() would silently under-report (#583 Qodo).
+    with pytest.raises(ValueError, match="non-finite"):
+        profile_utilisation(kappa, [float("nan")] + v_ref[1:], barrier)
+    with pytest.raises(ValueError, match="non-finite"):
+        profile_utilisation([float("nan")] + kappa[1:], v_ref, barrier)
 
 
 def test_verify_refined_profile_catches_tampered_speeds():

--- a/tests/test_corner_refine.py
+++ b/tests/test_corner_refine.py
@@ -1,0 +1,329 @@
+"""Tests for the #582 L3 beyond-QSS per-corner refinement (corner_refine.py).
+
+All synthetic and off-rig: kappa/seg arrays stand in for a track, a hand-built 30x10 km/h
+uncertainty grid stands in for the #543 plant posterior. The load-bearing assertions mirror the
+issue's acceptance criteria: boundary pinning, evidence gating with named reverts, the stability
+barrier, strict improvement on a provably conservative corner, and byte-level determinism.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from tools.ac_harness.auto_drive import generic_gt3_ggv
+from tools.ac_harness.corner_refine import (
+    DEFAULT_UNCERTAINTY_LCB_Z,
+    Z_STABILITY_FLOOR,
+    L3Params,
+    barrier_ggv,
+    refine_profile,
+    relaxed_ggv,
+    segment_corners,
+    verify_refined_profile,
+)
+from tools.ac_harness.ggv_profile import forward_backward_profile
+
+_N = 200
+_CORNER = range(80, 121)  # one 41-point corner, radius 60 m
+_KAPPA_CORNER = 1.0 / 60.0
+_SEG_M = 5.0
+
+
+def _channel(mean: float, std: float, *, source: str = "prior", n: int = 0) -> dict:
+    safe = max(0.1, mean - 1.96 * std)
+    return {
+        "mean_g": round(mean, 6),
+        "epistemic_std_g": round(std, 6),
+        "safe_g": round(min(mean, safe), 6),
+        "n": n,
+        "source": source,
+    }
+
+
+def _grid(measured_lateral_kmh: tuple[float, float] = (0.0, 0.0), lateral_std: float = 0.1):
+    """The full 30x10 km/h uncertainty grid; lateral bins inside the range are ``measured``."""
+    lo_m, hi_m = measured_lateral_kmh
+    bins = []
+    for i in range(30):
+        lo = i * 10.0
+        hi = lo + 10.0
+        lateral_measured = lo >= lo_m and hi <= hi_m
+        bins.append(
+            {
+                "speed_min_kmh": lo,
+                "speed_max_kmh": hi,
+                "lateral": _channel(
+                    1.4,
+                    lateral_std if lateral_measured else 0.2,
+                    source="measured" if lateral_measured else "prior",
+                    n=60 if lateral_measured else 0,
+                ),
+                "brake": _channel(1.2, 0.15),
+                "drive": _channel(0.5, 0.1),
+            }
+        )
+    return tuple(bins)
+
+
+def _plant(measured_lateral_kmh=(40.0, 200.0), lateral_std: float = 0.1):
+    return replace(generic_gt3_ggv(), uncertainty_bins=_grid(measured_lateral_kmh, lateral_std))
+
+
+def _track():
+    """One corner bracketed by straights: (seg, kappa) arrays for a cyclic 200-point line."""
+    kappa = [_KAPPA_CORNER if i in _CORNER else 0.0 for i in range(_N)]
+    seg = [_SEG_M] * _N
+    return seg, kappa
+
+
+def _qss(plant, v_top_ms: float = 61.0):
+    seg, kappa = _track()
+    v, _ax = forward_backward_profile(kappa, seg, plant, v_top_ms=v_top_ms)
+    return seg, kappa, v
+
+
+# ---------------------------------------------------------------------------
+# L3Params validation
+# ---------------------------------------------------------------------------
+def test_params_defaults_valid_and_roundtrip():
+    params = L3Params()
+    assert params.z_ladder[-1] == Z_STABILITY_FLOOR
+    rebuilt = L3Params.from_dict(params.to_dict())
+    assert rebuilt == params
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"z_ladder": ()},
+        {"z_ladder": (0.5,)},  # below the stability floor
+        {"z_ladder": (2.5,)},  # above the safe LCB z: a derate, not a refinement
+        {"z_ladder": (float("nan"),)},
+        {"kappa_threshold": 0.0},
+        {"kappa_threshold": float("inf")},
+        {"pad_points": -1},
+        {"min_corner_points": 2},
+        {"max_rel_std": 0.0},
+        {"max_rel_std": 0.9},  # above MAX_REL_STD_CEILING
+    ],
+)
+def test_params_rejects_unsafe_values(kwargs):
+    with pytest.raises(ValueError):
+        L3Params(**kwargs)
+
+
+def test_params_from_dict_rejects_tampered_payloads():
+    good = L3Params().to_dict()
+    with pytest.raises(ValueError):
+        L3Params.from_dict(None)
+    with pytest.raises(ValueError):
+        L3Params.from_dict({**good, "schema_version": 99})
+    with pytest.raises(ValueError):
+        L3Params.from_dict({**good, "z_ladder": [0.2]})  # laxer than the floor
+    with pytest.raises(ValueError):
+        L3Params.from_dict({**good, "max_rel_std": 5.0})
+    without_key = {k: v for k, v in good.items() if k != "kappa_threshold"}
+    with pytest.raises(ValueError):
+        L3Params.from_dict(without_key)
+
+
+# ---------------------------------------------------------------------------
+# Relaxed / barrier grip construction
+# ---------------------------------------------------------------------------
+def test_relaxed_ggv_lifts_only_measured_low_variance_bins():
+    plant = _plant(measured_lateral_kmh=(80.0, 120.0))
+    relaxed = relaxed_ggv(plant, Z_STABILITY_FLOOR, 0.25)
+    for orig, new in zip(plant.uncertainty_bins, relaxed.uncertainty_bins, strict=True):
+        for kind in ("lateral", "brake", "drive"):
+            o, r = orig[kind], new[kind]
+            if o["source"] == "measured":
+                expected = o["mean_g"] - Z_STABILITY_FLOOR * o["epistemic_std_g"]
+                assert r["safe_g"] == pytest.approx(expected, abs=1e-6)
+                assert r["safe_g"] > o["safe_g"]  # actually relaxed from the 1.96-z LCB
+                assert r["safe_g"] <= o["mean_g"]  # never above the posterior mean
+            else:
+                assert r == o  # prior bins never relax
+
+
+def test_relaxed_ggv_skips_high_variance_measured_bins():
+    plant = _plant(measured_lateral_kmh=(80.0, 120.0), lateral_std=0.6)  # rel std 0.43 > 0.25
+    relaxed = relaxed_ggv(plant, Z_STABILITY_FLOOR, 0.25)
+    assert relaxed.uncertainty_bins == plant.uncertainty_bins
+
+
+def test_relaxed_ggv_rejects_out_of_range_z():
+    plant = _plant()
+    for z in (0.5, 2.5, float("nan")):
+        with pytest.raises(ValueError, match="relaxation z"):
+            relaxed_ggv(plant, z, 0.25)
+
+
+def test_relaxed_ggv_legacy_plant_passthrough():
+    plant = generic_gt3_ggv()
+    assert relaxed_ggv(plant, Z_STABILITY_FLOOR, 0.25) is plant
+
+
+def test_barrier_dominates_every_relaxation_step():
+    plant = _plant()
+    barrier = barrier_ggv(plant, 0.25)
+    for z in (1.5, 1.2, Z_STABILITY_FLOOR):
+        relaxed = relaxed_ggv(plant, z, 0.25)
+        for v in (20.0, 30.0, 45.0):
+            assert relaxed.ay_max(v) <= barrier.ay_max(v) + 1e-9
+    assert Z_STABILITY_FLOOR < DEFAULT_UNCERTAINTY_LCB_Z
+
+
+# ---------------------------------------------------------------------------
+# Corner segmentation
+# ---------------------------------------------------------------------------
+def test_segment_one_bracketed_corner_with_padding():
+    _seg, kappa = _track()
+    windows = segment_corners(kappa, kappa_threshold=0.005, pad_points=3, min_corner_points=5)
+    assert len(windows) == 1
+    idxs = windows[0]
+    assert idxs[0] == _CORNER.start - 3 and idxs[-1] == _CORNER.stop - 1 + 3
+    assert idxs == list(range(idxs[0], idxs[-1] + 1))
+
+
+def test_segment_corner_wrapping_index_zero():
+    kappa = [0.0] * _N
+    for i in list(range(_N - 10, _N)) + list(range(10)):
+        kappa[i] = _KAPPA_CORNER
+    windows = segment_corners(kappa, kappa_threshold=0.005, pad_points=2, min_corner_points=5)
+    assert len(windows) == 1
+    idxs = windows[0]
+    assert len(idxs) == 20 + 4
+    assert idxs[0] == _N - 12
+    # Consecutive modulo N (the window crosses index 0 without splitting).
+    for a, b in zip(idxs, idxs[1:], strict=False):
+        assert b == (a + 1) % _N
+
+
+def test_segment_merges_adjacent_runs_into_one_window():
+    kappa = [0.0] * _N
+    for i in range(80, 95):
+        kappa[i] = _KAPPA_CORNER
+    for i in range(99, 114):  # 4-point gap < 2*pad
+        kappa[i] = -_KAPPA_CORNER  # opposite direction: an S-chicane is one window
+    windows = segment_corners(kappa, kappa_threshold=0.005, pad_points=3, min_corner_points=5)
+    assert len(windows) == 1
+    assert windows[0][0] == 77 and windows[0][-1] == 116
+
+
+def test_segment_no_corner_and_all_corner_return_empty():
+    straight = [0.0] * _N
+    circle = [_KAPPA_CORNER] * _N
+    assert segment_corners(straight, kappa_threshold=0.005, pad_points=3, min_corner_points=5) == []
+    assert segment_corners(circle, kappa_threshold=0.005, pad_points=3, min_corner_points=5) == []
+
+
+def test_segment_drops_windows_below_min_points():
+    kappa = [0.0] * _N
+    kappa[50] = _KAPPA_CORNER  # 1 corner point + 0 pad = below min
+    assert segment_corners(kappa, kappa_threshold=0.005, pad_points=0, min_corner_points=5) == []
+
+
+# ---------------------------------------------------------------------------
+# refine_profile: the acceptance-criteria core
+# ---------------------------------------------------------------------------
+def test_refine_improves_conservative_corner_within_barrier():
+    plant = _plant()
+    seg, kappa, v_qss = _qss(plant)
+    params = L3Params()
+    v_ref, report = refine_profile(seg, kappa, v_qss, plant, params, v_top_ms=61.0)
+
+    assert report["refined_corners"] == 1 and report["reverted_corners"] == 0
+    corner = report["corners"][0]
+    assert corner["status"] == "refined"
+    assert corner["gain_ms"] > 0 and report["predicted_gain_ms"] == corner["gain_ms"]
+
+    # Boundary pinning: entry/exit speeds equal the QSS values exactly.
+    start, end = corner["start"], corner["end"]
+    assert v_ref[start] == v_qss[start] and v_ref[end] == v_qss[end]
+    # Interior strictly faster at the apex; nowhere slower than QSS; outside untouched.
+    apex = min(range(_N), key=lambda i: v_qss[i])
+    assert v_ref[apex] > v_qss[apex]
+    assert all(v_ref[i] >= v_qss[i] - 1e-9 for i in range(_N))
+    window = set(range(start, end + 1))
+    assert all(v_ref[i] == v_qss[i] for i in range(_N) if i not in window)
+
+    # The refinement genuinely used evidence headroom (beyond the safe LCB envelope) while
+    # respecting the stability barrier (mean - 1.0*std).
+    safe_limit = plant.ay_max(v_ref[apex])
+    barrier_limit = barrier_ggv(plant, params.max_rel_std).ay_max(v_ref[apex])
+    ay_apex = v_ref[apex] * v_ref[apex] * abs(kappa[apex])
+    assert ay_apex > safe_limit  # beyond QSS-safe...
+    assert ay_apex <= barrier_limit + 1e-6  # ...but never beyond the barrier
+    assert verify_refined_profile(
+        [(0.0, 0.0)] * _N, kappa, v_ref, plant, params
+    ) is None
+
+
+def test_refine_is_deterministic():
+    plant = _plant()
+    seg, kappa, v_qss = _qss(plant)
+    out1 = refine_profile(seg, kappa, v_qss, plant, L3Params(), v_top_ms=61.0)
+    out2 = refine_profile(seg, kappa, v_qss, plant, L3Params(), v_top_ms=61.0)
+    assert out1 == out2
+
+
+def test_refine_reverts_unmeasured_corner_with_named_reason():
+    # Measured lateral evidence exists only far above the corner's speed range.
+    plant = _plant(measured_lateral_kmh=(200.0, 250.0))
+    seg, kappa, v_qss = _qss(plant)
+    v_ref, report = refine_profile(seg, kappa, v_qss, plant, L3Params(), v_top_ms=61.0)
+    assert v_ref == v_qss
+    assert report["refined_corners"] == 0 and report["reverted_corners"] == 1
+    corner = report["corners"][0]
+    assert corner["status"] == "reverted"
+    assert "no measured low-variance lateral bin" in corner["reason"]
+
+
+def test_refine_reverts_all_for_legacy_point_model():
+    plant = generic_gt3_ggv()
+    seg, kappa, v_qss = _qss(plant)
+    v_ref, report = refine_profile(seg, kappa, v_qss, plant, L3Params(), v_top_ms=61.0)
+    assert v_ref == v_qss
+    assert "not uncertainty-aware" in report["reverted_all"]
+    assert report["corners"] == []
+
+
+def test_refine_reverts_all_when_no_bracketed_corner():
+    plant = _plant()
+    kappa = [_KAPPA_CORNER] * _N  # a circle: every point is corner, no boundary to pin
+    seg = [_SEG_M] * _N
+    v, _ax = forward_backward_profile(kappa, seg, plant, v_top_ms=61.0)
+    v_ref, report = refine_profile(seg, kappa, v, plant, L3Params(), v_top_ms=61.0)
+    assert v_ref == v
+    assert "no refinable corner window" in report["reverted_all"]
+
+
+def test_refine_validates_inputs():
+    plant = _plant()
+    seg, kappa, v_qss = _qss(plant)
+    with pytest.raises(ValueError, match="length mismatch"):
+        refine_profile(seg[:-1], kappa, v_qss, plant, L3Params(), v_top_ms=61.0)
+    with pytest.raises(ValueError, match="non-finite curvature"):
+        refine_profile(seg, [float("nan")] + kappa[1:], v_qss, plant, L3Params(), v_top_ms=61.0)
+    with pytest.raises(ValueError, match="QSS speed"):
+        refine_profile(seg, kappa, [0.0] + v_qss[1:], plant, L3Params(), v_top_ms=61.0)
+    with pytest.raises(ValueError, match="segment length"):
+        refine_profile([-1.0] + seg[1:], kappa, v_qss, plant, L3Params(), v_top_ms=61.0)
+    with pytest.raises(ValueError, match="v_top_ms"):
+        refine_profile(seg, kappa, v_qss, plant, L3Params(), v_top_ms=0.0)
+
+
+def test_verify_refined_profile_catches_tampered_speeds():
+    plant = _plant()
+    seg, kappa, v_qss = _qss(plant)
+    params = L3Params()
+    v_ref, _report = refine_profile(seg, kappa, v_qss, plant, params, v_top_ms=61.0)
+    plane = [(0.0, 0.0)] * _N
+    assert verify_refined_profile(plane, kappa, v_ref, plant, params) is None
+    hot = [v * 1.5 for v in v_ref]
+    reason = verify_refined_profile(plane, kappa, hot, plant, params)
+    assert reason is not None and "stability barrier" in reason
+    short = verify_refined_profile(plane, kappa, v_ref[:-1], plant, params)
+    assert short is not None and "length mismatch" in short

--- a/tests/test_corner_refine.py
+++ b/tests/test_corner_refine.py
@@ -256,9 +256,7 @@ def test_refine_improves_conservative_corner_within_barrier():
     ay_apex = v_ref[apex] * v_ref[apex] * abs(kappa[apex])
     assert ay_apex > safe_limit  # beyond QSS-safe...
     assert ay_apex <= barrier_limit + 1e-6  # ...but never beyond the barrier
-    assert verify_refined_profile(
-        [(0.0, 0.0)] * _N, kappa, v_ref, plant, params
-    ) is None
+    assert verify_refined_profile([(0.0, 0.0)] * _N, kappa, v_ref, plant, params) is None
 
 
 def test_refine_is_deterministic():

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from tools.ac_harness.corner_refine import (
     L3Params,
     barrier_ggv,
+    profile_utilisation,
     refine_profile,
     verify_refined_profile,
 )
@@ -236,12 +237,10 @@ def build_alien_line_artifact(
         # point of L3, and the number the run evidence must not under-report; #583 Codex P2).
         barrier = barrier_ggv(plant, l3_params.max_rel_std)
         l3_block["max_ay_utilisation_vs_barrier"] = round(
-            max((v * v * abs(kappa[i])) / barrier.ay_max(v) for i, v in enumerate(v_target)),
-            4,
+            profile_utilisation(kappa, v_target, barrier), 4
         )
         l3_block["max_ay_utilisation_vs_safe"] = round(
-            max((v * v * abs(kappa[i])) / plant.ay_max(v) for i, v in enumerate(v_target)),
-            4,
+            profile_utilisation(kappa, v_target, plant), 4
         )
         params["l3"] = l3_params.to_dict()
     artifact = {

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -340,9 +340,18 @@ def load_alien_line_artifact(
         math.isfinite(v) and v > 0 for v in vt
     ):
         return None
-    # A refined (#582) artifact must carry a sane QSS fallback profile alongside the refined one;
-    # a refined artifact missing/corrupting it is rejected like any other malformed payload.
-    if "l3" in payload:
+    # A refined (#582) artifact must carry a sane QSS fallback profile alongside the refined one.
+    # L3-typing is decided by the IDENTITY block (params.l3), not by the presence of the payload
+    # "l3" report: an artifact whose params say L3 but whose l3 report / QSS fallback is missing
+    # is malformed (it would silently drop the fallback + reporting for an L3-identified cache),
+    # and an "l3" report without the params identity is equally inconsistent (#583 Qodo).
+    params_block = payload.get("params")
+    is_l3 = isinstance(params_block, dict) and params_block.get("l3") is not None
+    if is_l3 != ("l3" in payload):
+        return None
+    if is_l3:
+        if not isinstance(payload.get("l3"), dict):
+            return None
         v_qss = payload.get("v_target_qss_mps")
         if not isinstance(v_qss, list) or len(v_qss) != len(vt):
             return None
@@ -398,6 +407,10 @@ def verify_alien_line_artifact(
                 f"cached point {i} outside the corridor bounds: alpha={alpha:.3f} "
                 f"not in [{lo:.3f}, {hi:.3f}]"
             )
+    # L3-typing keys on the identity block (params.l3), consistent with the loader (#583 Qodo).
+    verify_params = payload.get("params") if isinstance(payload.get("params"), dict) else {}
+    if (verify_params.get("l3") is not None) != ("l3" in payload):
+        return "l3 identity/params mismatch: params.l3 and the l3 report must be present together"
     if "l3" in payload:
         # #582: a refined profile deliberately exceeds the safe LCB envelope inside refined
         # corners — its contract is the stability barrier instead, re-derived from the CURRENT
@@ -405,7 +418,7 @@ def verify_alien_line_artifact(
         # ``L3Params.from_dict`` and reject the cache). The persisted QSS fallback must still
         # honor the plain safe envelope.
         try:
-            l3_params = L3Params.from_dict((payload.get("params") or {}).get("l3"))
+            l3_params = L3Params.from_dict(verify_params.get("l3"))
         except ValueError as exc:
             return f"cached l3 params invalid: {exc}"
         v_qss = payload.get("v_target_qss_mps") or []
@@ -418,6 +431,16 @@ def verify_alien_line_artifact(
             _verify_lateral_envelope(cached_plane, v_qss, plant)
         except ValueError as exc:
             return f"cached QSS fallback fails the current plant envelope: {exc}"
+        # The build contract is refined >= QSS pointwise (a reverted corner keeps QSS exactly).
+        # An edited durable JSON that inflates the fallback above the refined profile (or slows
+        # refined points below it) breaks that invariant even when both profiles individually
+        # respect their envelopes — reject it like any other tamper (#583 Codex P2).
+        for i, (v_ref, v_fallback) in enumerate(zip(v_target, v_qss, strict=True)):
+            if v_ref < v_fallback - 1e-6:
+                return (
+                    f"cached refined profile falls below its QSS fallback at point {i}: "
+                    f"{v_ref:.3f} < {v_fallback:.3f} m/s"
+                )
         kappa = curvature_profile(cached_plane)
         reason = verify_refined_profile(cached_plane, kappa, v_target, plant, l3_params)
         if reason is not None:

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -27,7 +27,12 @@ import math
 from datetime import UTC, datetime
 from pathlib import Path
 
-from tools.ac_harness.corner_refine import L3Params, refine_profile, verify_refined_profile
+from tools.ac_harness.corner_refine import (
+    L3Params,
+    barrier_ggv,
+    refine_profile,
+    verify_refined_profile,
+)
 from tools.ac_harness.ggv_profile import (
     GGVModel,
     _unit_normals,
@@ -224,6 +229,20 @@ def build_alien_line_artifact(
         reason = verify_refined_profile(opt_plane, kappa, v_target, plant, l3_params)
         if reason is not None:
             raise ValueError(f"L3-refined profile failed its own barrier verification: {reason}")
+        # corridor.max_ay_utilisation stays the QSS-vs-safe-envelope metric (pinned at <= 1 by
+        # construction). The DRIVEN profile is the refined one, so the l3 report carries its own
+        # utilisation honestly: vs the stability barrier (the refined profile's actual contract,
+        # <= 1) and vs the safe envelope (deliberately > 1 inside refined corners — the whole
+        # point of L3, and the number the run evidence must not under-report; #583 Codex P2).
+        barrier = barrier_ggv(plant, l3_params.max_rel_std)
+        l3_block["max_ay_utilisation_vs_barrier"] = round(
+            max((v * v * abs(kappa[i])) / barrier.ay_max(v) for i, v in enumerate(v_target)),
+            4,
+        )
+        l3_block["max_ay_utilisation_vs_safe"] = round(
+            max((v * v * abs(kappa[i])) / plant.ay_max(v) for i, v in enumerate(v_target)),
+            4,
+        )
         params["l3"] = l3_params.to_dict()
     artifact = {
         "schema_version": ALIEN_LINE_SCHEMA_VERSION,

--- a/tools/ac_harness/alien_line.py
+++ b/tools/ac_harness/alien_line.py
@@ -27,6 +27,7 @@ import math
 from datetime import UTC, datetime
 from pathlib import Path
 
+from tools.ac_harness.corner_refine import L3Params, refine_profile, verify_refined_profile
 from tools.ac_harness.ggv_profile import (
     GGVModel,
     _unit_normals,
@@ -34,6 +35,7 @@ from tools.ac_harness.ggv_profile import (
     ggv_speed_profile_from_model,
     load_track_widths,
     min_curvature_line,
+    seg_lengths,
 )
 from tools.ac_harness.plant_id import combo_artifact_stem
 
@@ -154,6 +156,7 @@ def build_alien_line_artifact(
     margin_m: float = 1.2,
     iters: int = 1200,
     v_top_kmh: float = 240.0,
+    l3_params: L3Params | None = None,
 ) -> dict:
     """Build the combo's optimized line + QSS profile artifact from its identified plant.
 
@@ -161,6 +164,12 @@ def build_alien_line_artifact(
     ``fast_lane.ai`` carrying the corridor extras, ``plant`` the identified (uncertainty-aware)
     friction model and ``plant_artifact`` the full loaded plant payload (for provenance). Raises
     on an invalid corridor or an envelope violation — never returns a degraded artifact.
+
+    ``l3_params`` opts in to the #582 beyond-QSS per-corner refinement: the artifact then carries
+    the refined profile in ``v_target_mps``, the untouched QSS profile in ``v_target_qss_mps``,
+    the per-corner report under ``l3``, and the refinement parameters inside ``params`` (so the
+    cache identity distinguishes refined from plain artifacts). ``None`` (the default) keeps the
+    artifact byte-compatible with pre-#582 builds.
     """
     if len(fast_line) < 3:
         raise ValueError("alien line requires at least 3 fast-line points")
@@ -199,7 +208,24 @@ def build_alien_line_artifact(
     optimized = [(opt_plane[i][0], fast_line[i][1], opt_plane[i][1]) for i in range(len(fast_line))]
     v_target, summ = ggv_speed_profile_from_model(optimized, plant, v_top_kmh=v_top_kmh)
     worst_ay = _verify_lateral_envelope(opt_plane, v_target, plant)
-    return {
+    params: dict = {"margin_m": margin_m, "iters": iters, "v_top_kmh": v_top_kmh}
+    l3_block: dict | None = None
+    v_qss = list(v_target)
+    if l3_params is not None:
+        # #582 L3: refine the QSS interior per corner against the evidence-backed relaxed grip,
+        # then re-verify the refined profile against the stability barrier the same way the
+        # cache-revalidation path will — a build that cannot pass its own verifier must fail
+        # here, never persist (fail loud, never degrade).
+        kappa = curvature_profile(opt_plane)
+        seg = seg_lengths(opt_plane)
+        v_target, l3_block = refine_profile(
+            seg, kappa, v_qss, plant, l3_params, v_top_ms=v_top_kmh / 3.6
+        )
+        reason = verify_refined_profile(opt_plane, kappa, v_target, plant, l3_params)
+        if reason is not None:
+            raise ValueError(f"L3-refined profile failed its own barrier verification: {reason}")
+        params["l3"] = l3_params.to_dict()
+    artifact = {
         "schema_version": ALIEN_LINE_SCHEMA_VERSION,
         "created_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "car_id": car_id,
@@ -208,7 +234,7 @@ def build_alien_line_artifact(
         "setup": setup,
         "plant_provenance": plant_provenance(plant_artifact),
         "fast_lane_sha12": fast_lane_sha12(width_path),
-        "params": {"margin_m": margin_m, "iters": iters, "v_top_kmh": v_top_kmh},
+        "params": params,
         "line": [[p[0], p[1], p[2]] for p in optimized],
         "v_target_mps": list(v_target),
         "qss": summ,
@@ -225,6 +251,10 @@ def build_alien_line_artifact(
             "pinch_points": pinch_points,
         },
     }
+    if l3_block is not None:
+        artifact["v_target_qss_mps"] = v_qss
+        artifact["l3"] = l3_block
+    return artifact
 
 
 def save_alien_line_artifact(
@@ -310,6 +340,19 @@ def load_alien_line_artifact(
         math.isfinite(v) and v > 0 for v in vt
     ):
         return None
+    # A refined (#582) artifact must carry a sane QSS fallback profile alongside the refined one;
+    # a refined artifact missing/corrupting it is rejected like any other malformed payload.
+    if "l3" in payload:
+        v_qss = payload.get("v_target_qss_mps")
+        if not isinstance(v_qss, list) or len(v_qss) != len(vt):
+            return None
+        try:
+            vq = [float(v) for v in v_qss]
+        except (TypeError, ValueError):
+            return None
+        if not all(math.isfinite(v) and v > 0 for v in vq):
+            return None
+        payload["v_target_qss_mps"] = vq
     payload["line"] = pts
     payload["v_target_mps"] = vt
     return payload
@@ -355,6 +398,31 @@ def verify_alien_line_artifact(
                 f"cached point {i} outside the corridor bounds: alpha={alpha:.3f} "
                 f"not in [{lo:.3f}, {hi:.3f}]"
             )
+    if "l3" in payload:
+        # #582: a refined profile deliberately exceeds the safe LCB envelope inside refined
+        # corners — its contract is the stability barrier instead, re-derived from the CURRENT
+        # plant and the artifact's validated refinement params (tampered/laxer params fail
+        # ``L3Params.from_dict`` and reject the cache). The persisted QSS fallback must still
+        # honor the plain safe envelope.
+        try:
+            l3_params = L3Params.from_dict((payload.get("params") or {}).get("l3"))
+        except ValueError as exc:
+            return f"cached l3 params invalid: {exc}"
+        v_qss = payload.get("v_target_qss_mps") or []
+        if len(v_qss) != len(v_target):
+            return (
+                f"cached QSS fallback has {len(v_qss)} points but the refined profile "
+                f"has {len(v_target)}"
+            )
+        try:
+            _verify_lateral_envelope(cached_plane, v_qss, plant)
+        except ValueError as exc:
+            return f"cached QSS fallback fails the current plant envelope: {exc}"
+        kappa = curvature_profile(cached_plane)
+        reason = verify_refined_profile(cached_plane, kappa, v_target, plant, l3_params)
+        if reason is not None:
+            return f"cached refined profile fails the current stability barrier: {reason}"
+        return None
     try:
         _verify_lateral_envelope(cached_plane, v_target, plant)
     except ValueError as exc:
@@ -376,17 +444,22 @@ def ensure_alien_line_artifact(
     margin_m: float = 1.2,
     iters: int = 1200,
     v_top_kmh: float = 240.0,
+    l3_params: L3Params | None = None,
     rebuild: bool = False,
 ) -> tuple[dict, str]:
     """Load the fresh cached alien line or build + persist it. Returns ``(artifact, source)``.
 
     ``source`` is ``"cache"`` or ``"built"`` so callers can log the provenance of what they drive.
+    ``l3_params`` rides the cache identity: enabling (or re-tuning) the #582 refinement changes
+    the expected ``params`` block, so a plain-QSS cache never serves an L3 request and vice versa.
     """
     from tools.ac_harness.ai_line import load_ai_line
 
     prov = plant_provenance(plant_artifact)
     lane_sha = fast_lane_sha12(fast_lane_path)
     params = {"margin_m": margin_m, "iters": iters, "v_top_kmh": v_top_kmh}
+    if l3_params is not None:
+        params["l3"] = l3_params.to_dict()
     fast_line = load_ai_line(fast_lane_path)
     if not rebuild:
         cached = load_alien_line_artifact(
@@ -424,6 +497,7 @@ def ensure_alien_line_artifact(
         margin_m=margin_m,
         iters=iters,
         v_top_kmh=v_top_kmh,
+        l3_params=l3_params,
     )
     save_alien_line_artifact(user_dir, artifact, setup_ini=setup_ini)
     artifact = dict(artifact)

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -171,6 +171,32 @@ def stage_lap_archives(outcome: dict | None) -> list[str]:
     return [str(p) for p in archives if isinstance(p, str) and p]
 
 
+def stage_l3_summary(outcome: dict | None) -> dict | None:
+    """Condensed #582 L3 refinement summary from a drive stage's report, or ``None`` when absent.
+
+    Keeps the composed pipeline report honest about what each stage actually drove: how many
+    corners ran the refined interior, how many reverted to safe-QSS, and the planner's predicted
+    gain — the full per-corner report stays in the stage's own artifact/report.
+    """
+    report = (outcome or {}).get("report")
+    if not isinstance(report, dict):
+        return None
+    alien = report.get("alien_line")
+    if not isinstance(alien, dict):
+        return None
+    l3 = alien.get("l3")
+    if not isinstance(l3, dict):
+        return None
+    summary = {
+        "refined_corners": l3.get("refined_corners"),
+        "reverted_corners": l3.get("reverted_corners"),
+        "predicted_gain_ms": l3.get("predicted_gain_ms"),
+    }
+    if l3.get("reverted_all"):
+        summary["reverted_all"] = l3.get("reverted_all")
+    return summary
+
+
 def load_archive_payloads(paths: list[str]) -> tuple[list[dict], list[str]]:
     """Load lap-archive JSON payloads; unreadable files are reported, never silently dropped."""
     payloads: list[dict] = []
@@ -319,6 +345,9 @@ def run_selfplay(
     )
     base_valid, base_reason = evaluate_selfplay_iteration(0, base_outcome, base_payloads)
     selfplay["base"] = {"valid": base_valid, "reason": base_reason, "lap_times_ms": base_laps}
+    base_l3 = stage_l3_summary(base_outcome)
+    if base_l3 is not None:
+        selfplay["base"]["l3"] = base_l3
     if base_load_errors:
         # Unreadable/corrupt archives must be DISCLOSED, not hidden behind the generic validity
         # reason (#579 Qodo observability; same class as the repo's no-silent-swallowing pitfall).
@@ -475,6 +504,9 @@ def run_selfplay(
         entry["exit_code"] = code
         entry["evidence_dir"] = str(stage_dir)
         outcome = load_stage_outcome(stage_dir)
+        iter_l3 = stage_l3_summary(outcome)
+        if iter_l3 is not None:
+            entry["l3"] = iter_l3
         archives = stage_lap_archives(outcome)
         archive_payloads, load_errors = load_archive_payloads(archives)
         archive_payloads, foreign = combo_filter_payloads(
@@ -622,6 +654,12 @@ def drive_argv(
     ]
     if args.laps > 0:
         argv += ["--laps", str(args.laps)]
+    if not args.no_l3:
+        # #582 L3 rides every alien stage of the pipeline by default: the per-corner refinement
+        # only relaxes measured, low-variance bins under the stability barrier, and the same
+        # keep-last-valid oracle that guards the envelope ladder falsifies a refined profile
+        # that reality rejects.
+        argv.append("--l3")
     if scale > 1.0:
         # Only a self-play iteration override can be > 1 (run_pipeline rejects a bare
         # --ggv-scale > 1, so the one-shot base drive keeps the #572 gate — #579 Codex P1);
@@ -704,6 +742,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=1.1,
         help="self-play envelope ladder cap (hard limit 1.2; >1 probes above the uncertainty-"
         "safe QSS floor, falsification-gated)",
+    )
+    p.add_argument(
+        "--no-l3",
+        action="store_true",
+        help="disable the #582 beyond-QSS per-corner refinement on the alien stages "
+        "(default: enabled — corners without measured low-variance evidence revert to "
+        "safe-QSS per corner anyway, named in the stage report)",
     )
     p.add_argument(
         "--strict", action="store_true", help="alien stage: require session+lap, enforce ordering"

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -177,11 +177,14 @@ def stage_l3_summary(outcome: dict | None) -> dict | None:
     Keeps the composed pipeline report honest about what each stage actually drove: how many
     corners ran the refined interior, how many reverted to safe-QSS, and the planner's predicted
     gain — the full per-corner report stays in the stage's own artifact/report.
+
+    ``write_evidence`` stores the alien-line detail under the TOP-LEVEL ``run`` extras of
+    ``report.json`` (``run.alien_line``), not inside the ``report`` block (#583 Codex P2).
     """
-    report = (outcome or {}).get("report")
-    if not isinstance(report, dict):
+    run = (outcome or {}).get("run")
+    if not isinstance(run, dict):
         return None
-    alien = report.get("alien_line")
+    alien = run.get("alien_line")
     if not isinstance(alien, dict):
         return None
     l3 = alien.get("l3")

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -3056,6 +3056,29 @@ def _resolve_alien_assets(
     }
     l3_report = line_artifact.get("l3")
     if isinstance(l3_report, dict):
+        # The driver multiplies the artifact's v_target by config.ggv_scale AFTER this report
+        # snapshot, so the artifact's own (unscaled) utilisation metrics would under-report an
+        # overspeed probe as within-barrier. Recompute the DRIVEN target's utilisation exactly
+        # against the same barrier; a failure is disclosed in the report, never swallowed
+        # (#583 Codex P2).
+        from tools.ac_harness.corner_refine import barrier_ggv, profile_utilisation
+        from tools.ac_harness.ggv_profile import curvature_profile
+
+        l3_report = dict(l3_report)
+        scale = float(config.ggv_scale)
+        l3_report["ggv_scale"] = scale
+        try:
+            l3p = L3Params.from_dict((line_artifact.get("params") or {}).get("l3"))
+            plane = [(p[0], p[2]) for p in line_artifact["line"]]
+            driven = [float(v) * scale for v in line_artifact["v_target_mps"]]
+            l3_report["driven_max_ay_utilisation_vs_barrier"] = round(
+                profile_utilisation(
+                    curvature_profile(plane), driven, barrier_ggv(plant, l3p.max_rel_std)
+                ),
+                4,
+            )
+        except (TypeError, ValueError, KeyError) as exc:
+            l3_report["driven_utilisation_error"] = f"{type(exc).__name__}: {exc}"
         alien_line_used["l3"] = l3_report
     qss = line_artifact.get("qss") or {}
     print(

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -174,6 +174,10 @@ class AutoDriveConfig:
     # flag only (the one-shot alien path keeps the hard <=1 gate from #572), hard-capped, and
     # every step is falsifiable via the auto_alien keep-last-valid oracle.
     alien_overspeed: bool = False
+    # #582 L3: opt-in beyond-QSS per-corner refinement of the alien-line profile. The refined
+    # v_target rides the same artifact/provenance gates; per-corner revert reasons land in the
+    # artifact's ``l3`` report. Off (default) builds/serves the pre-#582 QSS-only artifact.
+    alien_l3: bool = False
     target_speed_kmh: float = 55.0  # cruise only
     min_corner_speed_kmh: float = 30.0  # cruise only
     # Stall recovery (#459 Part D).
@@ -2727,6 +2731,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="alien: ignore the cached line artifact and rebuild it from the current plant",
     )
     p.add_argument(
+        "--l3",
+        action="store_true",
+        help="alien: #582 beyond-QSS per-corner refinement — relax measured, low-variance grip "
+        "bins from the 1.96-z safe LCB toward the posterior mean (stability floor z=1.0), "
+        "re-solve each corner's interior between QSS-pinned entry/exit speeds, revert to "
+        "safe-QSS per corner when evidence is thin (named in the artifact's l3 report). Off = "
+        "byte-identical pre-#582 QSS artifact",
+    )
+    p.add_argument(
         "--use-plant",
         choices=("off", "auto", "full"),
         default="auto",
@@ -2860,6 +2873,7 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         wait_lap=args.wait_lap or args.laps > 0,
         target_laps=max(0, args.laps),
         alien_overspeed=args.alien_allow_overspeed,
+        alien_l3=args.l3,
         strict=args.strict,
         skip_launch=args.skip_launch,
         hijack_probe_seconds=args.hijack_probe_seconds,
@@ -2954,6 +2968,7 @@ def _resolve_alien_assets(
     bypassing the cache/provenance gates.
     """
     from tools.ac_harness.alien_line import alien_line_path, ensure_alien_line_artifact
+    from tools.ac_harness.corner_refine import L3Params
     from tools.ac_harness.plant_id import (
         load_plant_artifact,
         plant_artifact_path,
@@ -3017,6 +3032,7 @@ def _resolve_alien_assets(
             setup=setup_key,
             setup_ini=config.setup_ini,
             v_top_kmh=config.racing_max_speed_kmh,
+            l3_params=L3Params() if config.alien_l3 else None,
             rebuild=rebuild,
         )
     except (OSError, ValueError) as exc:
@@ -3038,12 +3054,26 @@ def _resolve_alien_assets(
         "qss": line_artifact.get("qss"),
         "corridor": line_artifact.get("corridor"),
     }
+    l3_report = line_artifact.get("l3")
+    if isinstance(l3_report, dict):
+        alien_line_used["l3"] = l3_report
     qss = line_artifact.get("qss") or {}
     print(
         f"auto-drive: alien line {line_source} "
         f"(QSS {qss.get('qss_laptime_s')}s, vmax {qss.get('vmax_kmh')} km/h, "
         f"plant fit {line_artifact.get('plant_provenance', {}).get('sha12')}) <- {alien_path}"
     )
+    if isinstance(l3_report, dict):
+        reverted_all = l3_report.get("reverted_all")
+        if reverted_all:
+            print(f"auto-drive: alien L3 refinement reverted entirely — {reverted_all}")
+        else:
+            print(
+                "auto-drive: alien L3 refined "
+                f"{l3_report.get('refined_corners')} corner(s) "
+                f"({l3_report.get('reverted_corners')} reverted to safe-QSS, "
+                f"predicted gain {l3_report.get('predicted_gain_ms')} ms)"
+            )
     return (None, plant_artifact_used, alien_line_used)
 
 

--- a/tools/ac_harness/corner_refine.py
+++ b/tools/ac_harness/corner_refine.py
@@ -535,6 +535,28 @@ def refine_profile(
     return v_out, report
 
 
+def profile_utilisation(kappa: list[float], v_target: list[float], model: GGVModel) -> float:
+    """Max lateral utilisation of a speed profile vs ``model.ay_max`` (1.0 = on the envelope).
+
+    Pure and reusable: the build reports the refined profile vs the barrier and vs the safe
+    envelope, and the run evidence reports the DRIVEN target (``v_target * ggv_scale``) vs the
+    barrier — a scaled overspeed probe must never be recorded as within-barrier (#583 Codex P2).
+    Raises on a length mismatch or a non-positive envelope (reporting must fail loud, not
+    under-report).
+    """
+    if len(kappa) != len(v_target):
+        raise ValueError(
+            f"profile_utilisation arrays length mismatch: kappa={len(kappa)}, v={len(v_target)}"
+        )
+    worst = 0.0
+    for i, v in enumerate(v_target):
+        limit = model.ay_max(v)
+        if limit <= 0.0:
+            raise ValueError(f"lateral envelope non-positive at point {i} (v={v:.1f} m/s)")
+        worst = max(worst, (v * v * abs(kappa[i])) / limit)
+    return worst
+
+
 def verify_refined_profile(
     plane: list[tuple[float, float]],
     kappa: list[float],

--- a/tools/ac_harness/corner_refine.py
+++ b/tools/ac_harness/corner_refine.py
@@ -260,9 +260,16 @@ def segment_corners(
 
 
 def _cyclic_overlap(s1: int, l1: int, s2: int, l2: int, n: int) -> bool:
+    """Whether two cyclic arcs share an index OR touch (end-to-start adjacency).
+
+    Adjacency counts as overlap on purpose: two padded windows that touch form one contiguous
+    covered arc, and leaving them as separate windows would pin a "boundary" speed at a point
+    that is itself inside the other corner's padded approach (#583 Qodo). Arc 1 is expanded by
+    one index on each side, so a shared-index test also catches exact touching.
+    """
     covered = [False] * n
-    for k in range(l1):
-        covered[(s1 + k) % n] = True
+    for k in range(min(n, l1 + 2)):
+        covered[(s1 - 1 + k) % n] = True
     return any(covered[(s2 + k) % n] for k in range(l2))
 
 
@@ -466,6 +473,11 @@ def refine_profile(
             for b in spanned
             if _relaxable_channel(dict(b["brake"]), params.max_rel_std)
         ]
+        relaxable_drive = [
+            f"{int(b['speed_min_kmh'])}-{int(b['speed_max_kmh'])}"
+            for b in spanned
+            if _relaxable_channel(dict(b["drive"]), params.max_rel_std)
+        ]
         if not relaxable_lateral:
             lo = min(v_window_qss) * 3.6
             hi = max(v_window_qss) * 3.6
@@ -511,6 +523,9 @@ def refine_profile(
         entry["z"] = z
         entry["relaxed_lateral_bins_kmh"] = relaxable_lateral
         entry["relaxed_brake_bins_kmh"] = relaxable_brake
+        # The forward pass consumes relaxed drive bins too (ax_drive_avail) — report them so the
+        # per-corner provenance names every channel the refinement leaned on (#583 Codex P2).
+        entry["relaxed_drive_bins_kmh"] = relaxable_drive
         entry["gain_ms"] = int(round(gain_s * 1000.0))
         entry["v_apex_qss_kmh"] = round(min(v_window_qss) * 3.6, 1)
         entry["v_apex_l3_kmh"] = round(min(speeds) * 3.6, 1)

--- a/tools/ac_harness/corner_refine.py
+++ b/tools/ac_harness/corner_refine.py
@@ -482,9 +482,7 @@ def refine_profile(
         rejected: list[str] = []
         for z in params.z_ladder:
             candidate = _solve_window(idxs, seg, kappa, v_qss, relaxed_by_z[z], v_top_ms)
-            if any(
-                candidate[j] < v_window_qss[j] - _IMPROVE_TOL_MS for j in range(len(idxs))
-            ):
+            if any(candidate[j] < v_window_qss[j] - _IMPROVE_TOL_MS for j in range(len(idxs))):
                 # The friction-ellipse coupling makes pointwise dominance an empirical check,
                 # not an algebraic guarantee: a candidate that dips below QSS anywhere is not
                 # an improvement contract we can keep — reject it honestly.
@@ -499,9 +497,8 @@ def refine_profile(
                 best_candidate = (cand_time, z, candidate)
         if best_candidate is None or best_candidate[0] >= qss_time - 1e-9:
             entry["status"] = "reverted"
-            entry["reason"] = (
-                "no ladder candidate beat the QSS interior"
-                + (f" ({'; '.join(rejected)})" if rejected else " (relaxation had no effect)")
+            entry["reason"] = "no ladder candidate beat the QSS interior" + (
+                f" ({'; '.join(rejected)})" if rejected else " (relaxation had no effect)"
             )
             report["reverted_corners"] += 1
             continue

--- a/tools/ac_harness/corner_refine.py
+++ b/tools/ac_harness/corner_refine.py
@@ -1,0 +1,556 @@
+"""Beyond-QSS per-corner interior refinement (L3, EPIC #529 / #582 — the #577 item-3 follow-up).
+
+The forward-backward QSS profile (:func:`tools.ac_harness.ggv_profile.forward_backward_profile`)
+consumes the **uncertainty-safe** grip curves: with a schema-v3 plant every query returns
+``min(point_model, mean - 1.96*std)`` per 10 km/h bin (#543). That lower-confidence bound is the
+right floor to *drive blind* — and the #577 self-play runs proved it is exactly what binds the lap
+time (both Magione plants collapsed to the same 91.94 s floor: the bins, not the cars, bind).
+
+L3 recovers the evidence-supported headroom **per corner, never globally**:
+
+* **Segmentation** — corners are maximal cyclic windows of the optimized line where the QSS
+  curvature magnitude exceeds a threshold, padded and merged, so every window is bracketed by
+  low-curvature boundary points.
+* **Corridor constraints from QSS** — the QSS speeds at each window's entry/exit points are fixed
+  boundary conditions (pins). Refinement only reshapes the interior between them; straights and
+  un-refined corners keep the QSS profile bit-for-bit.
+* **Evidence gate** — a corner may relax a grip channel only through speed bins whose posterior is
+  ``measured`` with bounded relative epistemic spread. Prior-dominated or high-variance bins stay
+  at the safe LCB. A corner with no relaxable lateral bin in its speed range is NOT refined — the
+  report names the revert reason (never a silent fallback).
+* **Interior re-solve** — a boundary-pinned mini forward-backward pass over the window against the
+  relaxed grip: higher evidence-backed apex speeds and a deeper friction-ellipse trail-brake into
+  them (the backward pass with lateral coupling *is* the trail-brake shape). The z-ladder search
+  is a deterministic grid; a candidate is accepted only when it is pointwise >= the QSS interior
+  and strictly faster over the window.
+* **Stability barrier** — no refined point may exceed ``mean - Z_STABILITY_FLOOR*std`` lateral
+  (the slip-margin proxy available to a point-mass plant), enforced at build AND at every cache
+  re-verification. The chosen ladder z is always >= the floor, so the barrier holds by
+  construction; it is still checked explicitly (defense in depth against future grip-curve
+  changes).
+
+Everything here is offline, deterministic (fixed grids, no RNG) and stdlib-``math`` only, so CI
+verifies it with synthetic lines + synthetic plants, no game. NOT end-to-end RL (council-hardened
+design in the epic body). Falsification of the *driven* outcome stays with the #577
+keep-last-valid oracle in :mod:`tools.ac_harness.auto_alien`.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+
+from tools.ac_harness.ggv_profile import (
+    DEFAULT_UNCERTAINTY_LCB_Z,
+    UNCERTAINTY_CHANNELS,
+    GGVModel,
+)
+
+L3_SCHEMA_VERSION = 1
+
+# The stability floor: refined speeds may never rely on grip above ``mean - 1.0*std``. This is a
+# module constant, not a parameter — a persisted artifact must not be able to talk the verifier
+# into a laxer barrier than the build honored.
+Z_STABILITY_FLOOR = 1.0
+# A measured bin whose epistemic spread exceeds this fraction of its mean is not relaxable: the
+# mean itself is too poorly known to lean on, whatever z says.
+MAX_REL_STD_CEILING = 0.5
+
+DEFAULT_Z_LADDER = (1.5, Z_STABILITY_FLOOR)
+DEFAULT_KAPPA_THRESHOLD = 0.005  # 1/m — corner when the local radius is under ~200 m
+DEFAULT_PAD_POINTS = 3
+DEFAULT_MIN_CORNER_POINTS = 5
+DEFAULT_MAX_REL_STD = 0.25
+_FB_PASSES = 4
+_APEX_FIXED_POINT_ITERS = 8
+_IMPROVE_TOL_MS = 1e-9  # m/s pointwise tolerance for "not slower than QSS"
+_BARRIER_TOL = 1e-6  # float-noise tolerance on the lateral-utilisation barrier
+
+
+@dataclass(frozen=True)
+class L3Params:
+    """Validated refinement parameters; persisted verbatim in the artifact ``params`` block."""
+
+    z_ladder: tuple[float, ...] = DEFAULT_Z_LADDER
+    kappa_threshold: float = DEFAULT_KAPPA_THRESHOLD
+    pad_points: int = DEFAULT_PAD_POINTS
+    min_corner_points: int = DEFAULT_MIN_CORNER_POINTS
+    max_rel_std: float = DEFAULT_MAX_REL_STD
+
+    def __post_init__(self) -> None:
+        ladder = tuple(float(z) for z in self.z_ladder)
+        if not ladder:
+            raise ValueError("l3 z_ladder must not be empty")
+        for z in ladder:
+            if not math.isfinite(z):
+                raise ValueError(f"l3 z_ladder values must be finite (got {z})")
+            if z < Z_STABILITY_FLOOR:
+                raise ValueError(
+                    f"l3 z_ladder value {z} is below the stability floor {Z_STABILITY_FLOOR}"
+                )
+            if z > DEFAULT_UNCERTAINTY_LCB_Z:
+                raise ValueError(
+                    f"l3 z_ladder value {z} exceeds the safe LCB z "
+                    f"{DEFAULT_UNCERTAINTY_LCB_Z} (that would be a derate, not a refinement)"
+                )
+        object.__setattr__(self, "z_ladder", ladder)
+        if not (math.isfinite(self.kappa_threshold) and self.kappa_threshold > 0.0):
+            raise ValueError(
+                f"l3 kappa_threshold must be finite and > 0 (got {self.kappa_threshold})"
+            )
+        if not isinstance(self.pad_points, int) or self.pad_points < 0:
+            raise ValueError(f"l3 pad_points must be an int >= 0 (got {self.pad_points})")
+        if not isinstance(self.min_corner_points, int) or self.min_corner_points < 3:
+            raise ValueError(
+                f"l3 min_corner_points must be an int >= 3 (got {self.min_corner_points})"
+            )
+        if not (math.isfinite(self.max_rel_std) and 0.0 < self.max_rel_std <= MAX_REL_STD_CEILING):
+            raise ValueError(
+                f"l3 max_rel_std must be in (0, {MAX_REL_STD_CEILING}] (got {self.max_rel_std})"
+            )
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": L3_SCHEMA_VERSION,
+            "z_ladder": list(self.z_ladder),
+            "kappa_threshold": self.kappa_threshold,
+            "pad_points": self.pad_points,
+            "min_corner_points": self.min_corner_points,
+            "max_rel_std": self.max_rel_std,
+        }
+
+    @classmethod
+    def from_dict(cls, data: object) -> L3Params:
+        """Rebuild persisted params; raises ``ValueError`` on any tampered/unsafe value.
+
+        Persisted artifacts are untrusted input (the durable JSON is hand-editable): the same
+        validation that guards the build guards the re-verification, so a laxer-than-floor ladder
+        or an absurd ``max_rel_std`` can never talk the verifier into accepting hotter speeds.
+        """
+        if not isinstance(data, dict):
+            raise ValueError("l3 params must be a dict")
+        if data.get("schema_version") != L3_SCHEMA_VERSION:
+            raise ValueError(f"unsupported l3 params schema: {data.get('schema_version')!r}")
+        ladder = data.get("z_ladder")
+        if not isinstance(ladder, (list, tuple)):
+            raise ValueError("l3 params z_ladder must be a list")
+        try:
+            return cls(
+                z_ladder=tuple(float(z) for z in ladder),
+                kappa_threshold=float(data["kappa_threshold"]),
+                pad_points=int(data["pad_points"]),
+                min_corner_points=int(data["min_corner_points"]),
+                max_rel_std=float(data["max_rel_std"]),
+            )
+        except (KeyError, TypeError) as exc:
+            raise ValueError(f"malformed l3 params: {exc}") from exc
+
+
+def _relaxable_channel(channel: dict, max_rel_std: float) -> bool:
+    """Whether one bin/channel posterior carries enough measured evidence to relax."""
+    if channel.get("source") != "measured":
+        return False
+    mean = float(channel["mean_g"])
+    std = float(channel["epistemic_std_g"])
+    return mean > 0.0 and std / mean <= max_rel_std
+
+
+def relaxed_ggv(ggv: GGVModel, z: float, max_rel_std: float) -> GGVModel:
+    """The plant with measured, low-variance bins relaxed from the 1.96-z LCB to ``mean - z*std``.
+
+    Prior-dominated and high-variance bins keep their original ``safe_g`` — evidence never leaks
+    across bins, exactly the #543 contract. The relaxed value never drops below the original safe
+    bound and never exceeds the posterior mean, so the frozen-model validation invariants hold.
+    The point model stays the upper envelope (``_uncertainty_safe_g`` keeps the ``min``).
+    """
+    if not (math.isfinite(z) and Z_STABILITY_FLOOR <= z <= DEFAULT_UNCERTAINTY_LCB_Z):
+        raise ValueError(
+            f"relaxation z must be in [{Z_STABILITY_FLOOR}, {DEFAULT_UNCERTAINTY_LCB_Z}] (got {z})"
+        )
+    if not ggv.uncertainty_bins:
+        return ggv
+    relaxed_bins = []
+    for speed_bin in ggv.uncertainty_bins:
+        out = {
+            "speed_min_kmh": speed_bin["speed_min_kmh"],
+            "speed_max_kmh": speed_bin["speed_max_kmh"],
+        }
+        for kind in UNCERTAINTY_CHANNELS:
+            channel = dict(speed_bin[kind])
+            if _relaxable_channel(channel, max_rel_std):
+                mean = float(channel["mean_g"])
+                std = float(channel["epistemic_std_g"])
+                relaxed = mean - z * std
+                channel["safe_g"] = round(min(mean, max(float(channel["safe_g"]), relaxed)), 6)
+            out[kind] = channel
+        relaxed_bins.append(out)
+    return replace(ggv, uncertainty_bins=tuple(relaxed_bins))
+
+
+def barrier_ggv(ggv: GGVModel, max_rel_std: float) -> GGVModel:
+    """The stability-barrier envelope: the most grip any refined point is allowed to rely on."""
+    return relaxed_ggv(ggv, Z_STABILITY_FLOOR, max_rel_std)
+
+
+def segment_corners(
+    kappa: list[float],
+    *,
+    kappa_threshold: float,
+    pad_points: int,
+    min_corner_points: int,
+) -> list[list[int]]:
+    """Corner windows of a cyclic line: padded maximal runs of ``|kappa| >= threshold``.
+
+    Returns windows as lists of consecutive absolute point indices (cyclic — a window may wrap
+    index 0). Overlapping/adjacent padded runs merge into one window (an S-chicane is one
+    refinement problem, not two overlapping ones). Windows shorter than ``min_corner_points``
+    after padding are dropped. When the merged coverage leaves no low-curvature boundary at all
+    (a kart-track lap that is one long corner), no window is returned — the caller reverts.
+    """
+    n = len(kappa)
+    if n < 3:
+        return []
+    in_corner = [abs(k) >= kappa_threshold for k in kappa]
+    if all(in_corner):
+        return []
+    if not any(in_corner):
+        return []
+    # Maximal cyclic runs: walk from a known out-of-corner anchor so runs never split at index 0.
+    anchor = next(i for i in range(n) if not in_corner[i])
+    runs: list[tuple[int, int]] = []  # (start, length) in absolute indices
+    i = 0
+    while i < n:
+        idx = (anchor + i) % n
+        if in_corner[idx]:
+            start = idx
+            length = 0
+            while i < n and in_corner[(anchor + i) % n]:
+                length += 1
+                i += 1
+            runs.append((start, length))
+        else:
+            i += 1
+    # Pad each run, then merge padded runs that overlap or touch on the cycle.
+    padded = []
+    for start, length in runs:
+        p_start = (start - pad_points) % n
+        p_length = min(n, length + 2 * pad_points)
+        padded.append((p_start, p_length))
+    merged: list[tuple[int, int]] = []
+    for start, length in padded:
+        placed = False
+        while not placed:
+            placed = True
+            for j, (mstart, mlength) in enumerate(merged):
+                if _cyclic_overlap(start, length, mstart, mlength, n):
+                    start, length = _cyclic_union(start, length, mstart, mlength, n)
+                    del merged[j]
+                    placed = False
+                    break
+        merged.append((start, length))
+    windows = []
+    for start, length in sorted(merged):
+        if length < min_corner_points:
+            continue
+        if length >= n - 1:
+            # No usable boundary pins remain; refuse rather than pin inside a corner.
+            return []
+        windows.append([(start + k) % n for k in range(length)])
+    return windows
+
+
+def _cyclic_overlap(s1: int, l1: int, s2: int, l2: int, n: int) -> bool:
+    covered = [False] * n
+    for k in range(l1):
+        covered[(s1 + k) % n] = True
+    return any(covered[(s2 + k) % n] for k in range(l2))
+
+
+def _cyclic_union(s1: int, l1: int, s2: int, l2: int, n: int) -> tuple[int, int]:
+    covered = [False] * n
+    for k in range(l1):
+        covered[(s1 + k) % n] = True
+    for k in range(l2):
+        covered[(s2 + k) % n] = True
+    if all(covered):
+        return (0, n)
+    # The union of two overlapping cyclic arcs is one arc: find its start (a covered point whose
+    # predecessor is uncovered) and walk its length.
+    start = next(i for i in range(n) if covered[i] and not covered[(i - 1) % n])
+    length = 0
+    while covered[(start + length) % n] and length < n:
+        length += 1
+    return (start, length)
+
+
+def _window_time_s(idxs: list[int], seg: list[float], v: list[float]) -> float:
+    """Travel time over a window (same trapezoidal-speed formula as the QSS laptime)."""
+    total = 0.0
+    for j in range(len(idxs) - 1):
+        ds = seg[idxs[j]]
+        total += ds / max(0.5, 0.5 * (v[j] + v[j + 1]))
+    return total
+
+
+def _spanned_bins(ggv: GGVModel, speeds_ms: list[float]) -> list[dict]:
+    """The uncertainty bins the window's speed range passes through (by bin boundaries)."""
+    if not ggv.uncertainty_bins or not speeds_ms:
+        return []
+    lo_kmh = min(speeds_ms) * 3.6
+    hi_kmh = max(speeds_ms) * 3.6
+    spanned = []
+    for speed_bin in ggv.uncertainty_bins:
+        if float(speed_bin["speed_max_kmh"]) <= lo_kmh:
+            continue
+        if float(speed_bin["speed_min_kmh"]) > hi_kmh:
+            continue
+        spanned.append(speed_bin)
+    return spanned
+
+
+def _solve_window(
+    idxs: list[int],
+    seg: list[float],
+    kappa: list[float],
+    v_qss: list[float],
+    model: GGVModel,
+    v_top_ms: float,
+) -> list[float]:
+    """Boundary-pinned forward-backward interior re-solve of one window against ``model``.
+
+    The entry/exit speeds stay the QSS values (the corridor constraints); the interior follows
+    the same apex/backward/forward structure as the global QSS pass, including the
+    friction-ellipse lateral coupling — the backward branch with lateral usage IS the
+    trail-brake shape.
+    """
+    m = len(idxs)
+    v = [0.0] * m
+    v[0] = v_qss[idxs[0]]
+    v[-1] = v_qss[idxs[-1]]
+    for j in range(1, m - 1):
+        k = abs(kappa[idxs[j]])
+        if k > 1e-6:
+            vi = v_top_ms
+            for _ in range(_APEX_FIXED_POINT_ITERS):
+                vi = min(v_top_ms, math.sqrt(model.ay_max(vi) / k))
+            v[j] = max(0.5, vi)
+        else:
+            v[j] = v_top_ms
+    for _ in range(_FB_PASSES):
+        for j in range(m - 2, 0, -1):
+            ds = seg[idxs[j]]
+            if ds <= 1e-6:
+                if v[j + 1] < v[j]:
+                    v[j] = v[j + 1]
+                continue
+            ay_used = v[j] * v[j] * abs(kappa[idxs[j]])
+            ax = model.ax_brake_avail(ay_used, v[j])
+            cap = math.sqrt(v[j + 1] * v[j + 1] + 2.0 * ax * ds)
+            if cap < v[j]:
+                v[j] = cap
+        for j in range(1, m - 1):
+            ds = seg[idxs[j - 1]]
+            if ds <= 1e-6:
+                if v[j - 1] < v[j]:
+                    v[j] = v[j - 1]
+                continue
+            ay_used = v[j - 1] * v[j - 1] * abs(kappa[idxs[j - 1]])
+            ax = model.ax_drive_avail(ay_used, v[j - 1])
+            cap = math.sqrt(v[j - 1] * v[j - 1] + 2.0 * ax * ds)
+            if cap < v[j]:
+                v[j] = cap
+    return v
+
+
+def _barrier_violation(
+    idxs: list[int],
+    kappa: list[float],
+    v: list[float],
+    barrier: GGVModel,
+) -> str | None:
+    """The first stability-barrier violation in a refined window, or ``None``."""
+    for j, i in enumerate(idxs):
+        limit = barrier.ay_max(v[j])
+        if limit <= 0.0:
+            return f"barrier envelope non-positive at point {i} (v={v[j]:.1f} m/s)"
+        ratio = (v[j] * v[j] * abs(kappa[i])) / limit
+        if ratio > 1.0 + _BARRIER_TOL:
+            return (
+                f"lateral utilisation {ratio:.4f}x the stability barrier at point {i} "
+                f"(v={v[j] * 3.6:.1f} km/h)"
+            )
+    return None
+
+
+def refine_profile(
+    seg: list[float],
+    kappa: list[float],
+    v_qss: list[float],
+    ggv: GGVModel,
+    params: L3Params,
+    *,
+    v_top_ms: float,
+) -> tuple[list[float], dict]:
+    """Refine the QSS ``v_target`` per corner; returns ``(v_refined, report)``.
+
+    The report is complete and honest: every segmented corner appears exactly once, either
+    ``refined`` (with the chosen z, the relaxed channels, the predicted gain and the barrier
+    headroom) or ``reverted`` (with the named reason). Points outside refined corners — and every
+    reverted corner's interior — carry the QSS speeds unchanged.
+    """
+    n = len(v_qss)
+    if not (len(seg) == len(kappa) == n):
+        raise ValueError(
+            f"refine_profile arrays length mismatch: seg={len(seg)}, kappa={len(kappa)}, v={n}"
+        )
+    if n < 3:
+        raise ValueError("refine_profile requires at least 3 points")
+    if not (math.isfinite(v_top_ms) and v_top_ms > 0):
+        raise ValueError(f"v_top_ms must be finite and > 0 (got {v_top_ms})")
+    for i in range(n):
+        if not (math.isfinite(seg[i]) and seg[i] >= 0.0):
+            raise ValueError(f"non-finite/negative segment length at point {i}: {seg[i]}")
+        if not math.isfinite(kappa[i]):
+            raise ValueError(f"non-finite curvature at point {i}: {kappa[i]}")
+        if not (math.isfinite(v_qss[i]) and v_qss[i] > 0.0):
+            raise ValueError(f"non-finite/non-positive QSS speed at point {i}: {v_qss[i]}")
+
+    report: dict = {
+        "schema_version": L3_SCHEMA_VERSION,
+        "params": params.to_dict(),
+        "corners": [],
+        "refined_corners": 0,
+        "reverted_corners": 0,
+        "predicted_gain_ms": 0,
+    }
+    v_out = list(v_qss)
+    if not ggv.uncertainty_aware:
+        report["reverted_all"] = "plant is not uncertainty-aware (legacy point model) — QSS kept"
+        return v_out, report
+
+    windows = segment_corners(
+        kappa,
+        kappa_threshold=params.kappa_threshold,
+        pad_points=params.pad_points,
+        min_corner_points=params.min_corner_points,
+    )
+    if not windows:
+        report["reverted_all"] = (
+            "no refinable corner window (line has no bracketed corner at "
+            f"|kappa| >= {params.kappa_threshold})"
+        )
+        return v_out, report
+
+    barrier = barrier_ggv(ggv, params.max_rel_std)
+    relaxed_by_z = {z: relaxed_ggv(ggv, z, params.max_rel_std) for z in params.z_ladder}
+    total_gain_s = 0.0
+    for corner_id, idxs in enumerate(windows):
+        v_window_qss = [v_qss[i] for i in idxs]
+        entry: dict = {
+            "corner": corner_id,
+            "start": idxs[0],
+            "end": idxs[-1],
+            "points": len(idxs),
+            "v_entry_kmh": round(v_window_qss[0] * 3.6, 1),
+            "v_exit_kmh": round(v_window_qss[-1] * 3.6, 1),
+        }
+        report["corners"].append(entry)
+        spanned = _spanned_bins(ggv, v_window_qss)
+        relaxable_lateral = [
+            f"{int(b['speed_min_kmh'])}-{int(b['speed_max_kmh'])}"
+            for b in spanned
+            if _relaxable_channel(dict(b["lateral"]), params.max_rel_std)
+        ]
+        relaxable_brake = [
+            f"{int(b['speed_min_kmh'])}-{int(b['speed_max_kmh'])}"
+            for b in spanned
+            if _relaxable_channel(dict(b["brake"]), params.max_rel_std)
+        ]
+        if not relaxable_lateral:
+            lo = min(v_window_qss) * 3.6
+            hi = max(v_window_qss) * 3.6
+            entry["status"] = "reverted"
+            entry["reason"] = (
+                f"no measured low-variance lateral bin in the corner's {lo:.0f}-{hi:.0f} km/h "
+                "range — safe-QSS kept"
+            )
+            report["reverted_corners"] += 1
+            continue
+
+        qss_time = _window_time_s(idxs, seg, v_window_qss)
+        best_candidate: tuple[float, float, list[float]] | None = None  # (time, z, speeds)
+        rejected: list[str] = []
+        for z in params.z_ladder:
+            candidate = _solve_window(idxs, seg, kappa, v_qss, relaxed_by_z[z], v_top_ms)
+            if any(
+                candidate[j] < v_window_qss[j] - _IMPROVE_TOL_MS for j in range(len(idxs))
+            ):
+                # The friction-ellipse coupling makes pointwise dominance an empirical check,
+                # not an algebraic guarantee: a candidate that dips below QSS anywhere is not
+                # an improvement contract we can keep — reject it honestly.
+                rejected.append(f"z={z}: interior dipped below the QSS profile")
+                continue
+            violation = _barrier_violation(idxs, kappa, candidate, barrier)
+            if violation is not None:
+                rejected.append(f"z={z}: {violation}")
+                continue
+            cand_time = _window_time_s(idxs, seg, candidate)
+            if best_candidate is None or cand_time < best_candidate[0]:
+                best_candidate = (cand_time, z, candidate)
+        if best_candidate is None or best_candidate[0] >= qss_time - 1e-9:
+            entry["status"] = "reverted"
+            entry["reason"] = (
+                "no ladder candidate beat the QSS interior"
+                + (f" ({'; '.join(rejected)})" if rejected else " (relaxation had no effect)")
+            )
+            report["reverted_corners"] += 1
+            continue
+        cand_time, z, speeds = best_candidate
+        for j, i in enumerate(idxs):
+            v_out[i] = speeds[j]
+        gain_s = qss_time - cand_time
+        total_gain_s += gain_s
+        entry["status"] = "refined"
+        entry["z"] = z
+        entry["relaxed_lateral_bins_kmh"] = relaxable_lateral
+        entry["relaxed_brake_bins_kmh"] = relaxable_brake
+        entry["gain_ms"] = int(round(gain_s * 1000.0))
+        entry["v_apex_qss_kmh"] = round(min(v_window_qss) * 3.6, 1)
+        entry["v_apex_l3_kmh"] = round(min(speeds) * 3.6, 1)
+        report["refined_corners"] += 1
+
+    report["predicted_gain_ms"] = int(round(total_gain_s * 1000.0))
+    return v_out, report
+
+
+def verify_refined_profile(
+    plane: list[tuple[float, float]],
+    kappa: list[float],
+    v_target: list[float],
+    ggv: GGVModel,
+    params: L3Params,
+) -> str | None:
+    """Re-verify a refined profile against the CURRENT plant's stability barrier; reason or None.
+
+    The cache-revalidation counterpart of the build-time barrier: every point (refined or not)
+    must respect ``barrier_ggv`` — the barrier dominates the safe envelope, so un-refined points
+    pass trivially, while a tampered durable JSON (or one built from a since-deflated fit) fails
+    loudly and falls through to an honest rebuild.
+    """
+    if len(v_target) != len(plane) or len(kappa) != len(plane):
+        return (
+            f"refined profile arrays length mismatch: plane={len(plane)}, "
+            f"kappa={len(kappa)}, v={len(v_target)}"
+        )
+    barrier = barrier_ggv(ggv, params.max_rel_std)
+    for i, v in enumerate(v_target):
+        limit = barrier.ay_max(v)
+        if limit <= 0.0:
+            return f"barrier envelope non-positive at point {i} (v={v:.1f} m/s)"
+        ratio = (v * v * abs(kappa[i])) / limit
+        if ratio > 1.0 + _BARRIER_TOL:
+            return (
+                f"refined profile exceeds the stability barrier at point {i}: "
+                f"v={v:.2f} m/s -> {ratio:.4f}x (mean - {Z_STABILITY_FLOOR}*std)"
+            )
+    return None

--- a/tools/ac_harness/corner_refine.py
+++ b/tools/ac_harness/corner_refine.py
@@ -550,9 +550,16 @@ def profile_utilisation(kappa: list[float], v_target: list[float], model: GGVMod
         )
     worst = 0.0
     for i, v in enumerate(v_target):
+        # NaN comparisons are False, so max(worst, nan) silently KEEPS worst — exactly the
+        # under-report this function exists to prevent. Reject non-finite inputs loudly
+        # (#583 Qodo).
+        if not (math.isfinite(v) and math.isfinite(kappa[i])):
+            raise ValueError(f"non-finite profile input at point {i}: v={v!r}, kappa={kappa[i]!r}")
         limit = model.ay_max(v)
-        if limit <= 0.0:
-            raise ValueError(f"lateral envelope non-positive at point {i} (v={v:.1f} m/s)")
+        if not math.isfinite(limit) or limit <= 0.0:
+            raise ValueError(
+                f"lateral envelope non-finite/non-positive at point {i} (v={v:.1f} m/s)"
+            )
         worst = max(worst, (v * v * abs(kappa[i])) / limit)
     return worst
 


### PR DESCRIPTION
Closes #582. Follow-up to #577 (PR #579): the unshipped item 3 of the original scope — EPIC #529 Layer 3.

## What

The QSS profile consumes the uncertainty-safe LCB grip everywhere (`mean − 1.96·std` per 10 km/h bin), and the #577 self-play runs proved those bins bind the lap-time floor. This PR adds **L3 — per-corner beyond-QSS interior refinement** that recovers the *evidence-supported* headroom, per corner, never globally:

- **`tools/ac_harness/corner_refine.py`** (new):
  - `segment_corners` — padded, merged maximal cyclic windows of `|κ| ≥ threshold`, each bracketed by low-curvature boundary points (a line with no bracketed corner, e.g. a constant-radius circle, reverts entirely with a named reason).
  - `relaxed_ggv` / `barrier_ggv` — measured, low-relative-variance bins relax from the 1.96-z safe LCB toward the posterior mean; prior/high-variance bins never move (no cross-bin leakage, the #543 contract). `Z_STABILITY_FLOOR = 1.0` is a module constant — persisted params can never talk the verifier below it.
  - `refine_profile` — per corner: QSS entry/exit speeds are fixed pins; a boundary-pinned mini forward-backward re-solve against the relaxed grip reshapes only the interior (the ellipse-coupled backward branch **is** the trail-brake shape). Deterministic z-ladder grid; a candidate is accepted only when pointwise ≥ the QSS interior AND inside the stability barrier AND strictly faster. Every corner appears in the report exactly once — `refined` (chosen z, relaxed bins, gain, apex speeds) or `reverted` (named reason). No RNG anywhere; identical inputs → identical artifacts.
  - `verify_refined_profile` — the cache-revalidation barrier check, re-derived from the **current** plant.
- **`alien_line.py`** — `l3_params` rides `build`/`ensure`/`load`/`verify`: refined profile in `v_target_mps`, untouched QSS fallback in `v_target_qss_mps`, l3 config inside `params` (cache identity distinguishes refined from plain). Tampered refined speeds or laxer-than-floor persisted params fail revalidation → honest rebuild. **L3 off = byte-identical pre-#582 artifact.**
- **`auto_drive`** — `--l3` (default **off**) on the alien path; l3 summary in the report + console.
- **`auto_alien`** — passes `--l3` to every alien stage by default (`--no-l3` opt-out); per-stage l3 summaries in the base/iteration entries. The #577 keep-last-valid oracle falsifies a refined profile reality rejects, unchanged.

## Acceptance criteria (issue #582)

- Boundary pinning + barrier: `test_refine_improves_conservative_corner_within_barrier` (entry/exit exactly QSS; apex beyond safe-LCB but ≤ barrier).
- Named per-corner revert on thin evidence: `test_refine_reverts_unmeasured_corner_with_named_reason`, `test_refine_reverts_all_for_legacy_point_model`.
- Provenance/cache invalidation covers the refined profile: `test_l3_cache_identity_and_revalidation` (params identity, tampered speeds, tampered z-ladder, missing QSS fallback).
- Strict improvement on a provably conservative synthetic corner: `test_l3_build_refines_corners_and_records_report`.
- `--no-l3` byte-identical: `test_l3_disabled_is_byte_identical_to_qss_only_artifact`.
- Determinism: `test_refine_is_deterministic`.

## Verification so far

- `pytest tests/test_corner_refine.py tests/test_alien_line.py tests/test_auto_alien.py` → **79 passed**; `tests/test_ac_harness_auto_drive.py tests/test_ggv_profile.py` → **195 passed**; ruff clean. Full `make ci-fast` next.
- Live Magione re-run (auto_alien with L3 default-on) is the post-merge verification step, per the issue's out-of-scope note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)