### PR TITLE
refactor(sidecar): drive /health endpoint advertisement from a routing registry (#570)

### DIFF
--- a/tests/test_ai_sidecar_observability.py
+++ b/tests/test_ai_sidecar_observability.py
@@ -24,11 +24,14 @@ from websockets.asyncio.server import serve as ws_serve  # noqa: E402
 
 from tools.ai_sidecar import external_protocol as ep  # noqa: E402
 from tools.ai_sidecar import observability as obs  # noqa: E402
+from tools.ai_sidecar import server as srv  # noqa: E402
 from tools.ai_sidecar.server import (  # noqa: E402
+    _ROUTES,
     SERVED_ENDPOINTS,
     _external_peer_classes,
     _external_peers,
     _handler,
+    _Route,
     make_process_request,
     set_voice_runtime_status,
 )
@@ -127,6 +130,84 @@ def test_served_endpoints_are_actually_routed() -> None:
     assert all(code != 426 for code in codes.values()), (
         f"advertised endpoint not routed by the server (426 = fell through to WS): {codes}"
     )
+
+
+def test_health_advertises_every_registered_route() -> None:
+    """Issue #570: ONE registry drives dispatch AND advertisement, so /health's endpoint set
+    is exactly the registered route set — not a hand-written tuple that can omit a route.
+    Asserted against a REAL server payload (through build_health_json + JSON), so a caller
+    that stops passing the derived list, or a re-introduced advertise opt-out, fails here."""
+
+    async def _run() -> str:
+        async with _running_sidecar() as port:
+            return (await asyncio.to_thread(_http_get, port, "/health"))[2]
+
+    advertised = json.loads(asyncio.run(_run()))["endpoints"]
+    assert advertised == [route.path for route in _ROUTES]
+
+
+def test_route_aliases_are_routed_but_not_advertised() -> None:
+    """An alias resolves to an advertised route's handler, so it is not independent surface:
+    /healthz must serve health yet stay out of the advertised set (issue #570)."""
+
+    async def _run() -> tuple[int, list[str], str]:
+        async with _running_sidecar() as port:
+            return await asyncio.to_thread(_http_get, port, "/healthz")
+
+    status, _content_types, body = asyncio.run(_run())
+    assert status == 200
+    assert json.loads(body)["status"] == "ok"
+    assert "/healthz" not in SERVED_ENDPOINTS
+    assert "/healthz" not in json.loads(body)["endpoints"]
+
+
+def test_match_route_prefers_exact_over_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A prefix route must never shadow a more specific exact route — the inline if-chain
+    encoded that precedence by hand; the registry must enforce it structurally (issue #570)."""
+    exact_route = _Route("/voice/special", srv._route_voice_echoes)
+    prefix_route = _Route("/voice/", srv._route_voice_clip, prefix=True)
+    exact, prefixes = srv._index_routes((exact_route, prefix_route))
+    monkeypatch.setattr(srv, "_EXACT_ROUTES", exact)
+    monkeypatch.setattr(srv, "_PREFIX_ROUTES", prefixes)
+
+    assert srv._match_route("/voice/special") is exact_route
+    assert srv._match_route("/voice/other") is prefix_route
+    assert srv._match_route("/unrouted") is None
+
+
+@pytest.mark.parametrize(
+    ("routes", "message"),
+    [
+        pytest.param(
+            (_Route("/a", srv._route_health), _Route("/a", srv._route_metrics)),
+            "duplicate route registration",
+            id="duplicate-path",
+        ),
+        pytest.param(
+            (_Route("/a", srv._route_health, aliases=("/b",)), _Route("/b", srv._route_metrics)),
+            "duplicate route registration",
+            id="alias-collides-with-path",
+        ),
+        pytest.param(
+            (
+                _Route("/a/", srv._route_health, prefix=True),
+                _Route("/a/b/", srv._route_metrics, prefix=True),
+            ),
+            "ambiguous overlapping prefix",
+            id="overlapping-prefixes",
+        ),
+        pytest.param(
+            (_Route("/a/", srv._route_health, prefix=True, aliases=("/x",)),),
+            "cannot declare aliases",
+            id="alias-on-prefix-route",
+        ),
+    ],
+)
+def test_index_routes_rejects_ambiguous_registry(routes: tuple[_Route, ...], message: str) -> None:
+    """The registry is validated at import, so an ambiguous declaration is a startup error
+    rather than a route that silently never fires (fail loud, per the governance base)."""
+    with pytest.raises(ValueError, match=message):
+        srv._index_routes(routes)
 
 
 def test_build_health_json_reflects_browser_peers() -> None:

--- a/tests/test_ai_sidecar_observability.py
+++ b/tests/test_ai_sidecar_observability.py
@@ -24,14 +24,12 @@ from websockets.asyncio.server import serve as ws_serve  # noqa: E402
 
 from tools.ai_sidecar import external_protocol as ep  # noqa: E402
 from tools.ai_sidecar import observability as obs  # noqa: E402
-from tools.ai_sidecar import server as srv  # noqa: E402
 from tools.ai_sidecar.server import (  # noqa: E402
     _ROUTES,
     SERVED_ENDPOINTS,
     _external_peer_classes,
     _external_peers,
     _handler,
-    _Route,
     make_process_request,
     set_voice_runtime_status,
 )
@@ -159,55 +157,6 @@ def test_route_aliases_are_routed_but_not_advertised() -> None:
     assert json.loads(body)["status"] == "ok"
     assert "/healthz" not in SERVED_ENDPOINTS
     assert "/healthz" not in json.loads(body)["endpoints"]
-
-
-def test_match_route_prefers_exact_over_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A prefix route must never shadow a more specific exact route — the inline if-chain
-    encoded that precedence by hand; the registry must enforce it structurally (issue #570)."""
-    exact_route = _Route("/voice/special", srv._route_voice_echoes)
-    prefix_route = _Route("/voice/", srv._route_voice_clip, prefix=True)
-    exact, prefixes = srv._index_routes((exact_route, prefix_route))
-    monkeypatch.setattr(srv, "_EXACT_ROUTES", exact)
-    monkeypatch.setattr(srv, "_PREFIX_ROUTES", prefixes)
-
-    assert srv._match_route("/voice/special") is exact_route
-    assert srv._match_route("/voice/other") is prefix_route
-    assert srv._match_route("/unrouted") is None
-
-
-@pytest.mark.parametrize(
-    ("routes", "message"),
-    [
-        pytest.param(
-            (_Route("/a", srv._route_health), _Route("/a", srv._route_metrics)),
-            "duplicate route registration",
-            id="duplicate-path",
-        ),
-        pytest.param(
-            (_Route("/a", srv._route_health, aliases=("/b",)), _Route("/b", srv._route_metrics)),
-            "duplicate route registration",
-            id="alias-collides-with-path",
-        ),
-        pytest.param(
-            (
-                _Route("/a/", srv._route_health, prefix=True),
-                _Route("/a/b/", srv._route_metrics, prefix=True),
-            ),
-            "ambiguous overlapping prefix",
-            id="overlapping-prefixes",
-        ),
-        pytest.param(
-            (_Route("/a/", srv._route_health, prefix=True, aliases=("/x",)),),
-            "cannot declare aliases",
-            id="alias-on-prefix-route",
-        ),
-    ],
-)
-def test_index_routes_rejects_ambiguous_registry(routes: tuple[_Route, ...], message: str) -> None:
-    """The registry is validated at import, so an ambiguous declaration is a startup error
-    rather than a route that silently never fires (fail loud, per the governance base)."""
-    with pytest.raises(ValueError, match=message):
-        srv._index_routes(routes)
 
 
 def test_build_health_json_reflects_browser_peers() -> None:

--- a/tests/test_ai_sidecar_routes.py
+++ b/tests/test_ai_sidecar_routes.py
@@ -1,0 +1,101 @@
+"""HTTP route registry unit tests (issue #570).
+
+``server._ROUTES`` is the single structure driving BOTH handler dispatch and the ``/health``
+endpoint advertisement. These cover the registry's own invariants — validation, precedence,
+and prefix stripping. The ``/health`` payload side (what the advertisement actually says over
+the wire) lives in ``test_ai_sidecar_observability.py`` next to the other health assertions.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+
+from tools.ai_sidecar import server as srv
+from tools.ai_sidecar.server import _Route
+
+
+def test_match_route_prefers_exact_over_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A prefix route must never shadow a more specific exact route. The old inline if-chain
+    encoded that precedence by hand (``/voice/manifest.json`` was checked before the
+    ``/voice/clips/`` prefix); the registry must enforce it structurally."""
+    exact_route = _Route("/voice/special", srv._route_voice_echoes)
+    prefix_route = _Route("/voice/", srv._route_voice_clip, prefix=True)
+    exact, prefixes = srv._index_routes((exact_route, prefix_route))
+    monkeypatch.setattr(srv, "_EXACT_ROUTES", exact)
+    monkeypatch.setattr(srv, "_PREFIX_ROUTES", prefixes)
+
+    assert srv._match_route("/voice/special") is exact_route
+    assert srv._match_route("/voice/other") is prefix_route
+    assert srv._match_route("/unrouted") is None
+
+
+def test_prefix_handler_receives_stripped_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The router strips the matched route's own path before invoking the handler, so a
+    prefix handler never restates its route string. Hardcoding ``path[len("/dash/fonts/"):]``
+    inside the handler would duplicate registry state and silently mis-slice if the
+    registry path changed — the very drift #570 removes (self-hosted reviewer, MEDIUM)."""
+    seen: list[str] = []
+
+    def _spy(connection: object, request: object, tail: str) -> object:
+        seen.append(tail)
+        return srv._http_response(connection, HTTPStatus.OK, "ok", "text/plain")
+
+    prefix_route = _Route("/dash/fonts/", _spy, prefix=True)
+    exact_route = _Route("/metrics", _spy)
+    exact, prefixes = srv._index_routes((exact_route, prefix_route))
+    monkeypatch.setattr(srv, "_EXACT_ROUTES", exact)
+    monkeypatch.setattr(srv, "_PREFIX_ROUTES", prefixes)
+
+    handler = srv.make_process_request(None)
+
+    class _Conn:
+        def respond(self, status: HTTPStatus, text: str) -> object:
+            return type("R", (), {"status": status, "headers": {}, "body": text.encode()})()
+
+    class _Req:
+        def __init__(self, path: str) -> None:
+            self.path = path
+            self.headers: dict[str, str] = {}
+
+    handler(_Conn(), _Req("/dash/fonts/Chakra%20Petch.ttf"))
+    handler(_Conn(), _Req("/metrics"))
+
+    # Prefix route -> its own path stripped; exact route -> nothing meaningful to pass.
+    assert seen == ["Chakra%20Petch.ttf", ""]
+
+
+@pytest.mark.parametrize(
+    ("routes", "message"),
+    [
+        pytest.param(
+            (_Route("/a", srv._route_health), _Route("/a", srv._route_metrics)),
+            "duplicate route registration",
+            id="duplicate-path",
+        ),
+        pytest.param(
+            (_Route("/a", srv._route_health, aliases=("/b",)), _Route("/b", srv._route_metrics)),
+            "duplicate route registration",
+            id="alias-collides-with-path",
+        ),
+        pytest.param(
+            (
+                _Route("/a/", srv._route_health, prefix=True),
+                _Route("/a/b/", srv._route_metrics, prefix=True),
+            ),
+            "ambiguous overlapping prefix",
+            id="overlapping-prefixes",
+        ),
+        pytest.param(
+            (_Route("/a/", srv._route_health, prefix=True, aliases=("/x",)),),
+            "cannot declare aliases",
+            id="alias-on-prefix-route",
+        ),
+    ],
+)
+def test_index_routes_rejects_ambiguous_registry(routes: tuple[_Route, ...], message: str) -> None:
+    """The registry is indexed at import, so an ambiguous declaration is a startup error
+    rather than a route that silently never fires (fail loud, per the governance base)."""
+    with pytest.raises(ValueError, match=message):
+        srv._index_routes(routes)

--- a/tests/test_voice_tablet_endpoint.py
+++ b/tests/test_voice_tablet_endpoint.py
@@ -375,6 +375,25 @@ def test_http_voice_routes_token_gated_for_non_loopback(tmp_path: Path) -> None:
     assert _get("/tablet/voice").status == HTTPStatus.OK
 
 
+def test_unregistered_path_under_gated_prefix_still_refused(tmp_path: Path) -> None:
+    """Issue #570: the blanket ``path.startswith("/voice/") or path.startswith("/dash/")``
+    gate became per-route ``token_gated``, so an UNREGISTERED path under those prefixes no
+    longer hits the route gate — it falls through to the WS upgrade, whose ``token_check``
+    applies the same rule. Pin that the fall-through is equivalent: a non-loopback client
+    with no/bad token is still refused rather than silently upgraded."""
+    bake_bank(tmp_path, ToneBackend())
+    server._set_voice_web_bank(tmp_path)
+    assert _get("/voice/typo", token="sekret").status == HTTPStatus.UNAUTHORIZED
+    assert _get("/dash/typo", token="sekret").status == HTTPStatus.UNAUTHORIZED
+    assert (
+        _get("/voice/typo", token="sekret", headers={"X-AC-Copilot-Token": "wrong"})
+    ).status == HTTPStatus.UNAUTHORIZED
+    # A valid token proceeds to the real upgrade (None = continue the handshake), as before.
+    assert _get("/voice/typo", token="sekret", headers={"X-AC-Copilot-Token": "sekret"}) is None
+    # No token configured (loopback-only bind enforced at startup) -> straight to the upgrade.
+    assert _get("/voice/typo") is None
+
+
 def test_http_dispatch_and_echo_logs() -> None:
     server._voice_dispatch_log.append({"seq": 9, "clip_id": "x"})
     server._voice_echo_log.append({"seq": 9, "clip_id": "x", "t_server_ms": 1.0})

--- a/tools/ai_sidecar/observability.py
+++ b/tools/ai_sidecar/observability.py
@@ -130,8 +130,9 @@ def build_health_json(
     so the launcher can tell a tablet dashboard is actually connected (not just
     that the tunnel is up). ``endpoints`` is the **caller's** canonical route
     list — the single source of truth lives next to the handlers in
-    ``server.make_process_request`` (``server.SERVED_ENDPOINTS``), not here — so a
-    new route can't be served yet silently omitted from ``/health`` (#568 review).
+    ``server.SERVED_ENDPOINTS``, which is derived from the ``server._ROUTES``
+    registry that also drives dispatch (#570), not here — so a new route can't be
+    served yet silently omitted from ``/health`` (#568 review).
     """
     payload: dict[str, object] = {
         "status": "ok",

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -1076,9 +1076,12 @@ class _Route:
     """One HTTP route served ahead of the WebSocket upgrade.
 
     ``prefix`` routes match on ``path.startswith(self.path)``; exact routes match verbatim.
-    Every handler takes ``(connection, request, path)`` and returns a websockets response —
-    prefix handlers use ``path`` to strip their own prefix. Dispatch is exact-first, so a
-    prefix route can never shadow a more specific exact route.
+    Every handler takes ``(connection, request, tail)`` and returns a websockets response.
+    ``tail`` is the request path with this route's own ``path`` already stripped by the
+    router (so a prefix handler never restates its route string — that would be the same
+    parallel-structure drift #570 removes); it is ``""`` for an exact route, which no
+    handler needs. Dispatch is exact-first, so a prefix route can never shadow a more
+    specific exact route.
 
     ``token_gated`` routes carry product content (bank audio, the tablet pages, dispatch/echo
     logs), so on an authenticated external bind they honor the same ``X-AC-Copilot-Token`` as
@@ -1094,7 +1097,7 @@ class _Route:
     aliases: tuple[str, ...] = ()
 
 
-def _route_health(connection: Any, request: Any, path: str) -> Any:
+def _route_health(connection: Any, request: Any, tail: str) -> Any:
     connected_peers, screen_peers = _peer_counts()
     return _http_response(
         connection,
@@ -1110,7 +1113,7 @@ def _route_health(connection: Any, request: Any, path: str) -> Any:
     )
 
 
-def _route_metrics(connection: Any, request: Any, path: str) -> Any:
+def _route_metrics(connection: Any, request: Any, tail: str) -> Any:
     connected_peers, screen_peers = _peer_counts()
     return _http_response(
         connection,
@@ -1120,7 +1123,7 @@ def _route_metrics(connection: Any, request: Any, path: str) -> Any:
     )
 
 
-def _route_tablet_voice(connection: Any, request: Any, path: str) -> Any:
+def _route_tablet_voice(connection: Any, request: Any, tail: str) -> Any:
     page = _tablet_voice_page()
     if page is None:
         return _http_response(
@@ -1129,7 +1132,7 @@ def _route_tablet_voice(connection: Any, request: Any, path: str) -> Any:
     return _http_response(connection, HTTPStatus.OK, page, "text/html; charset=utf-8")
 
 
-def _route_tablet_dash(connection: Any, request: Any, path: str) -> Any:
+def _route_tablet_dash(connection: Any, request: Any, tail: str) -> Any:
     page = _tablet_dash_page()
     if page is None:
         return _http_response(
@@ -1138,10 +1141,10 @@ def _route_tablet_dash(connection: Any, request: Any, path: str) -> Any:
     return _http_response(connection, HTTPStatus.OK, page, "text/html; charset=utf-8")
 
 
-def _route_dash_font(connection: Any, request: Any, path: str) -> Any:
+def _route_dash_font(connection: Any, request: Any, tail: str) -> Any:
     # Exact-match against the vendored-font allow-list (names never contain
     # separators), so a decoded "../x" simply isn't in the set — no traversal.
-    name = urllib.parse.unquote(path[len("/dash/fonts/") :])
+    name = urllib.parse.unquote(tail)
     if name not in _TABLET_DASH_FONT_FILES:
         return _http_response(connection, HTTPStatus.NOT_FOUND, "unknown font\n", "text/plain")
     try:
@@ -1151,7 +1154,7 @@ def _route_dash_font(connection: Any, request: Any, path: str) -> Any:
     return _http_response_bytes(connection, HTTPStatus.OK, data, "font/ttf")
 
 
-def _route_voice_manifest(connection: Any, request: Any, path: str) -> Any:
+def _route_voice_manifest(connection: Any, request: Any, tail: str) -> Any:
     bank_dir = _voice_bank_dir
     if bank_dir is None:
         return _http_response(
@@ -1166,13 +1169,13 @@ def _route_voice_manifest(connection: Any, request: Any, path: str) -> Any:
     return _http_response(connection, HTTPStatus.OK, body, "application/json")
 
 
-def _route_voice_clip(connection: Any, request: Any, path: str) -> Any:
+def _route_voice_clip(connection: Any, request: Any, tail: str) -> Any:
     bank_dir = _voice_bank_dir
     # The page requests encodeURIComponent(file); decode before the allow-list so
     # the cross-boundary contract holds for any manifest filename. Exact-match
     # against manifest entries (which never contain separators) still forbids
     # traversal — a decoded "../x" simply isn't in the set (PR #519 review).
-    name = urllib.parse.unquote(path[len("/voice/clips/") :])
+    name = urllib.parse.unquote(tail)
     if bank_dir is None or name not in _voice_clip_files:
         return _http_response(connection, HTTPStatus.NOT_FOUND, "unknown clip\n", "text/plain")
     try:
@@ -1182,7 +1185,7 @@ def _route_voice_clip(connection: Any, request: Any, path: str) -> Any:
     return _http_response_bytes(connection, HTTPStatus.OK, data, "audio/wav")
 
 
-def _route_voice_dispatches(connection: Any, request: Any, path: str) -> Any:
+def _route_voice_dispatches(connection: Any, request: Any, tail: str) -> Any:
     return _http_response(
         connection,
         HTTPStatus.OK,
@@ -1191,7 +1194,7 @@ def _route_voice_dispatches(connection: Any, request: Any, path: str) -> Any:
     )
 
 
-def _route_voice_echoes(connection: Any, request: Any, path: str) -> Any:
+def _route_voice_echoes(connection: Any, request: Any, tail: str) -> Any:
     return _http_response(
         connection,
         HTTPStatus.OK,
@@ -1285,7 +1288,8 @@ def make_process_request(token: str | None):
                         "missing or invalid X-AC-Copilot-Token\n",
                         "text/plain",
                     )
-            return route.handler(connection, request, path)
+            tail = path[len(route.path) :] if route.prefix else ""
+            return route.handler(connection, request, tail)
         # A rig-screen sighting rides on the WS upgrade (the client header is on
         # the upgrade request), then the token gate applies if one is configured.
         if request.headers.get(CLIENT_HEADER):

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -1056,69 +1056,227 @@ def _http_response_bytes(
     return response
 
 
-# Canonical set of HTTP routes served by ``_process_request`` below — the single source of
-# truth for the sidecar's served-endpoint surface. Passed into ``build_health_json`` so
-# ``/health`` advertises exactly what THIS build serves (issue #567/#568): a stale binary's
-# compiled-in list omits a route it can't serve, and the launcher self-test / drift guard
-# key off this. Keep it in lockstep with the ``path == …`` / ``path.startswith(…)`` handlers.
-SERVED_ENDPOINTS: tuple[str, ...] = (
-    "/health",
-    "/metrics",
-    "/tablet/dash",
-    "/tablet/voice",
-    "/dash/fonts/",
-    "/voice/manifest.json",
+# --- HTTP route registry -----------------------------------------------------------------
+#
+# ONE structure drives BOTH handler dispatch AND the ``/health`` endpoint advertisement
+# (issue #570). Previously the dispatch was a chain of inline ``path == …`` /
+# ``path.startswith(…)`` checks running parallel to a hand-written ``SERVED_ENDPOINTS``
+# tuple, with only a drift-guard test holding the two in lockstep. ``SERVED_ENDPOINTS`` is
+# now DERIVED from ``_ROUTES``, so a route cannot be served without appearing in ``/health``
+# — the stale-build detection of #567/#568 (an old binary's compiled-in list omits the routes
+# it can't serve) cannot silently rot as routes are added.
+#
+# There is deliberately NO ``advertise=False`` escape hatch: an opt-out is the exact hole
+# this closes. An ALIAS (``/healthz``) is routed but not advertised — it resolves to an
+# advertised route's handler, so it is not independent surface.
+
+
+@dataclass(frozen=True)
+class _Route:
+    """One HTTP route served ahead of the WebSocket upgrade.
+
+    ``prefix`` routes match on ``path.startswith(self.path)``; exact routes match verbatim.
+    Every handler takes ``(connection, request, path)`` and returns a websockets response —
+    prefix handlers use ``path`` to strip their own prefix. Dispatch is exact-first, so a
+    prefix route can never shadow a more specific exact route.
+
+    ``token_gated`` routes carry product content (bank audio, the tablet pages, dispatch/echo
+    logs), so on an authenticated external bind they honor the same ``X-AC-Copilot-Token`` as
+    the WS upgrade: loopback (the USB ``adb reverse`` deployment) passes untokened; a LAN
+    client needs the header (PR #519 review). ``/health`` and ``/metrics`` are read-only and
+    secret-free, so they stay open — the launcher probes them untokened.
+    """
+
+    path: str
+    handler: Callable[[Any, Any, str], Any]
+    prefix: bool = False
+    token_gated: bool = False
+    aliases: tuple[str, ...] = ()
+
+
+def _route_health(connection: Any, request: Any, path: str) -> Any:
+    connected_peers, screen_peers = _peer_counts()
+    return _http_response(
+        connection,
+        HTTPStatus.OK,
+        observability.build_health_json(
+            connected_peers,
+            screen_peers=screen_peers,
+            browser_peers=_browser_peer_count(),
+            endpoints=SERVED_ENDPOINTS,
+            voice=public_voice_runtime_status(),
+        ),
+        observability.HEALTH_CONTENT_TYPE,
+    )
+
+
+def _route_metrics(connection: Any, request: Any, path: str) -> Any:
+    connected_peers, screen_peers = _peer_counts()
+    return _http_response(
+        connection,
+        HTTPStatus.OK,
+        observability.build_metrics_text(connected_peers, screen_peers=screen_peers),
+        observability.PROM_CONTENT_TYPE,
+    )
+
+
+def _route_tablet_voice(connection: Any, request: Any, path: str) -> Any:
+    page = _tablet_voice_page()
+    if page is None:
+        return _http_response(
+            connection, HTTPStatus.NOT_FOUND, "tablet page unavailable\n", "text/plain"
+        )
+    return _http_response(connection, HTTPStatus.OK, page, "text/html; charset=utf-8")
+
+
+def _route_tablet_dash(connection: Any, request: Any, path: str) -> Any:
+    page = _tablet_dash_page()
+    if page is None:
+        return _http_response(
+            connection, HTTPStatus.NOT_FOUND, "dash page unavailable\n", "text/plain"
+        )
+    return _http_response(connection, HTTPStatus.OK, page, "text/html; charset=utf-8")
+
+
+def _route_dash_font(connection: Any, request: Any, path: str) -> Any:
+    # Exact-match against the vendored-font allow-list (names never contain
+    # separators), so a decoded "../x" simply isn't in the set — no traversal.
+    name = urllib.parse.unquote(path[len("/dash/fonts/") :])
+    if name not in _TABLET_DASH_FONT_FILES:
+        return _http_response(connection, HTTPStatus.NOT_FOUND, "unknown font\n", "text/plain")
+    try:
+        data = (_TABLET_DASH_FONTS_DIR / name).read_bytes()
+    except OSError:
+        return _http_response(connection, HTTPStatus.NOT_FOUND, "font unavailable\n", "text/plain")
+    return _http_response_bytes(connection, HTTPStatus.OK, data, "font/ttf")
+
+
+def _route_voice_manifest(connection: Any, request: Any, path: str) -> Any:
+    bank_dir = _voice_bank_dir
+    if bank_dir is None:
+        return _http_response(
+            connection, HTTPStatus.NOT_FOUND, "no voice bank configured\n", "text/plain"
+        )
+    try:
+        body = (bank_dir / "manifest.json").read_text(encoding="utf-8")
+    except OSError:
+        return _http_response(
+            connection, HTTPStatus.NOT_FOUND, "manifest unavailable\n", "text/plain"
+        )
+    return _http_response(connection, HTTPStatus.OK, body, "application/json")
+
+
+def _route_voice_clip(connection: Any, request: Any, path: str) -> Any:
+    bank_dir = _voice_bank_dir
+    # The page requests encodeURIComponent(file); decode before the allow-list so
+    # the cross-boundary contract holds for any manifest filename. Exact-match
+    # against manifest entries (which never contain separators) still forbids
+    # traversal — a decoded "../x" simply isn't in the set (PR #519 review).
+    name = urllib.parse.unquote(path[len("/voice/clips/") :])
+    if bank_dir is None or name not in _voice_clip_files:
+        return _http_response(connection, HTTPStatus.NOT_FOUND, "unknown clip\n", "text/plain")
+    try:
+        data = (bank_dir / name).read_bytes()
+    except OSError:
+        return _http_response(connection, HTTPStatus.NOT_FOUND, "clip unavailable\n", "text/plain")
+    return _http_response_bytes(connection, HTTPStatus.OK, data, "audio/wav")
+
+
+def _route_voice_dispatches(connection: Any, request: Any, path: str) -> Any:
+    return _http_response(
+        connection,
+        HTTPStatus.OK,
+        json.dumps({"dispatches": list(_voice_dispatch_log)}),
+        "application/json",
+    )
+
+
+def _route_voice_echoes(connection: Any, request: Any, path: str) -> Any:
+    return _http_response(
+        connection,
+        HTTPStatus.OK,
+        json.dumps({"echoes": list(_voice_echo_log)}),
+        "application/json",
+    )
+
+
+# Declaration order is the ``/health`` advertisement order. Issue #511 Part D added the tablet
+# voice endpoint; issue #531 Part A the tablet GT dashboard page + its vendored fonts.
+_ROUTES: tuple[_Route, ...] = (
+    _Route("/health", _route_health, aliases=("/healthz",)),
+    _Route("/metrics", _route_metrics),
+    _Route("/tablet/dash", _route_tablet_dash, token_gated=True),
+    _Route("/tablet/voice", _route_tablet_voice, token_gated=True),
+    _Route("/dash/fonts/", _route_dash_font, prefix=True, token_gated=True),
+    _Route("/voice/manifest.json", _route_voice_manifest, token_gated=True),
+    _Route("/voice/clips/", _route_voice_clip, prefix=True, token_gated=True),
+    _Route("/voice/dispatches", _route_voice_dispatches, token_gated=True),
+    _Route("/voice/echoes", _route_voice_echoes, token_gated=True),
 )
+
+
+def _index_routes(routes: tuple[_Route, ...]) -> tuple[dict[str, _Route], tuple[_Route, ...]]:
+    """Split the registry into an exact-match table and an ordered prefix list.
+
+    Runs at import so an ambiguous registry is a startup error rather than a route that
+    silently never fires: duplicate paths/aliases and overlapping prefixes both raise.
+    Aliases on a prefix route are meaningless (the prefix already spans them) and raise too.
+    """
+    exact: dict[str, _Route] = {}
+    prefixes: list[_Route] = []
+    for route in routes:
+        if route.prefix:
+            if route.aliases:
+                raise ValueError(f"prefix route {route.path!r} cannot declare aliases")
+            for other in prefixes:
+                if route.path.startswith(other.path) or other.path.startswith(route.path):
+                    raise ValueError(
+                        f"ambiguous overlapping prefix routes: {other.path!r} vs {route.path!r}"
+                    )
+            prefixes.append(route)
+            continue
+        for key in (route.path, *route.aliases):
+            if key in exact:
+                raise ValueError(f"duplicate route registration: {key!r}")
+            exact[key] = route
+    return exact, tuple(prefixes)
+
+
+_EXACT_ROUTES, _PREFIX_ROUTES = _index_routes(_ROUTES)
+
+# DERIVED from the registry — dispatch and advertisement are now the same structure and
+# cannot drift (issue #570). Consumed by ``build_health_json(endpoints=…)``; the launcher
+# self-test and the drift guard key off it.
+SERVED_ENDPOINTS: tuple[str, ...] = tuple(route.path for route in _ROUTES)
+
+
+def _match_route(path: str) -> _Route | None:
+    """Resolve a request path to its route — exact match first, then prefixes."""
+    route = _EXACT_ROUTES.get(path)
+    if route is not None:
+        return route
+    for candidate in _PREFIX_ROUTES:
+        if path.startswith(candidate.path):
+            return candidate
+    return None
 
 
 def make_process_request(token: str | None):
     """Build the websockets ``process_request`` hook.
 
-    Serves ``GET /health`` and ``GET /metrics`` as plain HTTP on the SAME port as
-    the WebSocket (short-circuiting the upgrade so they never enter ``_handler``),
-    then falls through to the optional token gate (``make_token_check``) for a real
-    WS upgrade. Installed UNCONDITIONALLY so the endpoints work even in the default
-    no-token loopback deployment. Read-only ``/health`` and ``/metrics`` carry no
-    secrets and are intentionally not token-gated; the WS upgrade keeps the gate.
+    Serves the ``_ROUTES`` registry as plain HTTP on the SAME port as the WebSocket
+    (short-circuiting the upgrade so those paths never enter ``_handler``), then falls
+    through to the optional token gate (``make_token_check``) for a real WS upgrade.
+    Installed UNCONDITIONALLY so the endpoints work even in the default no-token loopback
+    deployment.
     """
     token_check = make_token_check(token)
 
     def _process_request(connection: Any, request: Any) -> Any:
         path = (getattr(request, "path", "") or "").split("?", 1)[0]
-        if path in ("/health", "/healthz"):
-            connected_peers, screen_peers = _peer_counts()
-            return _http_response(
-                connection,
-                HTTPStatus.OK,
-                observability.build_health_json(
-                    connected_peers,
-                    screen_peers=screen_peers,
-                    browser_peers=_browser_peer_count(),
-                    endpoints=SERVED_ENDPOINTS,
-                    voice=public_voice_runtime_status(),
-                ),
-                observability.HEALTH_CONTENT_TYPE,
-            )
-        if path == "/metrics":
-            connected_peers, screen_peers = _peer_counts()
-            return _http_response(
-                connection,
-                HTTPStatus.OK,
-                observability.build_metrics_text(connected_peers, screen_peers=screen_peers),
-                observability.PROM_CONTENT_TYPE,
-            )
-        # Issue #511 Part D — tablet voice endpoint. Read-only and secret-free, but unlike
-        # /health it carries product content (bank audio, dispatch/echo logs), so on an
-        # authenticated external bind these routes honor the same token as the WS upgrade:
-        # loopback (the USB `adb reverse` deployment) passes untokened; a LAN client needs
-        # the X-AC-Copilot-Token header (PR #519 review). Clip serving stays exact-match
-        # against the manifest allow-list — no traversal surface.
-        if (
-            path in ("/tablet/voice", "/tablet/dash")
-            or path.startswith("/voice/")
-            or path.startswith("/dash/")
-        ):
-            if token and not _is_loopback_peer(connection):
+        route = _match_route(path)
+        if route is not None:
+            if route.token_gated and token and not _is_loopback_peer(connection):
                 supplied = request.headers.get(AUTH_HEADER)
                 if supplied is None or not secrets.compare_digest(supplied, token):
                     return _http_response(
@@ -1127,81 +1285,7 @@ def make_process_request(token: str | None):
                         "missing or invalid X-AC-Copilot-Token\n",
                         "text/plain",
                     )
-        if path == "/tablet/voice":
-            page = _tablet_voice_page()
-            if page is None:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "tablet page unavailable\n", "text/plain"
-                )
-            return _http_response(connection, HTTPStatus.OK, page, "text/html; charset=utf-8")
-        # Issue #531 Part A — the tablet GT dashboard page + its vendored fonts.
-        if path == "/tablet/dash":
-            page = _tablet_dash_page()
-            if page is None:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "dash page unavailable\n", "text/plain"
-                )
-            return _http_response(connection, HTTPStatus.OK, page, "text/html; charset=utf-8")
-        if path.startswith("/dash/fonts/"):
-            # Exact-match against the vendored-font allow-list (names never contain
-            # separators), so a decoded "../x" simply isn't in the set — no traversal.
-            name = urllib.parse.unquote(path[len("/dash/fonts/") :])
-            if name not in _TABLET_DASH_FONT_FILES:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "unknown font\n", "text/plain"
-                )
-            try:
-                data = (_TABLET_DASH_FONTS_DIR / name).read_bytes()
-            except OSError:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "font unavailable\n", "text/plain"
-                )
-            return _http_response_bytes(connection, HTTPStatus.OK, data, "font/ttf")
-        if path == "/voice/manifest.json":
-            bank_dir = _voice_bank_dir
-            if bank_dir is None:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "no voice bank configured\n", "text/plain"
-                )
-            try:
-                body = (bank_dir / "manifest.json").read_text(encoding="utf-8")
-            except OSError:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "manifest unavailable\n", "text/plain"
-                )
-            return _http_response(connection, HTTPStatus.OK, body, "application/json")
-        if path.startswith("/voice/clips/"):
-            bank_dir = _voice_bank_dir
-            # The page requests encodeURIComponent(file); decode before the allow-list so
-            # the cross-boundary contract holds for any manifest filename. Exact-match
-            # against manifest entries (which never contain separators) still forbids
-            # traversal — a decoded "../x" simply isn't in the set (PR #519 review).
-            name = urllib.parse.unquote(path[len("/voice/clips/") :])
-            if bank_dir is None or name not in _voice_clip_files:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "unknown clip\n", "text/plain"
-                )
-            try:
-                data = (bank_dir / name).read_bytes()
-            except OSError:
-                return _http_response(
-                    connection, HTTPStatus.NOT_FOUND, "clip unavailable\n", "text/plain"
-                )
-            return _http_response_bytes(connection, HTTPStatus.OK, data, "audio/wav")
-        if path == "/voice/dispatches":
-            return _http_response(
-                connection,
-                HTTPStatus.OK,
-                json.dumps({"dispatches": list(_voice_dispatch_log)}),
-                "application/json",
-            )
-        if path == "/voice/echoes":
-            return _http_response(
-                connection,
-                HTTPStatus.OK,
-                json.dumps({"echoes": list(_voice_echo_log)}),
-                "application/json",
-            )
+            return route.handler(connection, request, path)
         # A rig-screen sighting rides on the WS upgrade (the client header is on
         # the upgrade request), then the token gate applies if one is configured.
         if request.headers.get(CLIENT_HEADER):


### PR DESCRIPTION
Closes #570. Follow-up from #568 (self-hosted reviewer, recurring MEDIUM).

## Why

`server.SERVED_ENDPOINTS` was the single source of truth for the advertised endpoint set, but the *dispatch* in `make_process_request` still used an inline `if path == …` / `path.startswith(…)` chain **parallel** to the tuple. The drift guard (`test_served_endpoints_are_actually_routed`) enforced advertised→routed, so it caught a bogus advertisement — but nothing caught the reverse: a route served yet silently absent from `/health`, which is precisely what the #567/#568 stale-build detection depends on.

That gap was already real: **4 paths were routed but unadvertised** — `/healthz`, `/voice/clips/`, `/voice/dispatches`, `/voice/echoes`.

## What

One `_ROUTES` registry of frozen `_Route(path, handler, prefix, token_gated, aliases)` records drives **both** dispatch and advertisement:

- **`SERVED_ENDPOINTS` is derived** — `tuple(route.path for route in _ROUTES)`. A route now *cannot* be added without appearing in `/health`. There is deliberately **no `advertise=False` opt-out**: an opt-out is the hole this closes. Aliases (`/healthz`) are routed but not advertised — an alias resolves to an advertised route's handler, so it adds no independent surface.
- **Exact-match first, then prefixes** — a prefix route can never shadow a more specific exact route. The if-chain encoded that precedence by hand (`/voice/manifest.json` before `/voice/clips/`); it is now structural.
- **`_index_routes` validates at import** and raises on duplicate paths/aliases, overlapping prefixes, and aliases on a prefix route — an ambiguous declaration is a startup error, not a route that silently never fires (fail loud).
- **Per-route `token_gated=True`** replaces the blanket `path in ("/tablet/voice","/tablet/dash") or path.startswith("/voice/") or path.startswith("/dash/")` gate.

### Behavior deltas (both intentional)

1. **The advertised set grows 6 → 9**: `/voice/clips/`, `/voice/dispatches`, `/voice/echoes` are now advertised because they are genuinely served. No consumer does exact-set equality — all use `in` membership (`tests/test_rig_launcher.py`, `probe_tablet`), and `supervisor.probe_tablet` deliberately probes reality with a real `GET /tablet/dash` rather than trusting the list. More truthful advertisement strictly improves stale-build detection.
2. **Unregistered paths under `/voice/` or `/dash/`** (e.g. a typo'd `/voice/typo`) no longer hit the route token gate before falling through; they fall straight to the WS upgrade + `token_check`. **Equivalent in every case**, because `token_check` applies the same rule: loopback exempt, 401 on missing/bad token from external, and a plain GET reaching the bare WS handler yields 426 either way.

## Tests

`tests/test_ai_sidecar_observability.py` (+6):
- `test_health_advertises_every_registered_route` — the #570 core invariant, asserted against a **real server payload** (through `build_health_json` + JSON), so a re-introduced hand-written tuple or advertise opt-out fails here. **Mutation-checked:** dropping one route from the derived tuple reds this test with `Right contains one more item: '/voice/echoes'`.
- `test_route_aliases_are_routed_but_not_advertised` — `/healthz` serves health, stays out of the advertised set.
- `test_match_route_prefers_exact_over_prefix` — prefix never shadows exact.
- `test_index_routes_rejects_ambiguous_registry[4 cases]` — duplicate path, alias/path collision, overlapping prefixes, alias on a prefix route.

The pre-existing `test_served_endpoints_are_actually_routed` now automatically covers the 3 newly-advertised routes.

`make ci-fast`: **OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)