### PR TITLE
feat(harness): detect stale AC app junction in preflight (#575)

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import asyncio
 import pathlib
+import shutil
 import threading
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
 from tools.ac_harness.auto_drive import (
+    AppInstallProvenance,
     AutoDriveConfig,
     AutoDriveReport,
     DriveStats,
@@ -24,6 +27,8 @@ from tools.ac_harness.auto_drive import (
     _build_driver,
     _config_from_args,
     _wait_live,
+    app_install_provenance,
+    app_tree_digest,
     bake_setup_into_race_ini,
     build_practice_preset,
     candidate_journal_laps_dirs,
@@ -2108,6 +2113,11 @@ def _fake_rig(tmp_path, *, custom_ai="ENABLED=1\n"):
     return ac_root, user, cm
 
 
+def _match_provenance() -> AppInstallProvenance:
+    """A provenance verdict that raises no preflight row (the app matches the harness)."""
+    return AppInstallProvenance(status="match", detail="installed app matches this checkout")
+
+
 def test_preflight_passes_on_complete_rig(tmp_path):
     ac_root, user, cm = _fake_rig(tmp_path)
     cfg = _cfg(
@@ -2119,7 +2129,194 @@ def test_preflight_passes_on_complete_rig(tmp_path):
         setup="Realistic_BB_v3",
         cm_preset=None,
     )
-    assert preflight(cfg) == []
+    assert preflight(cfg, app_provenance=_match_provenance()) == []
+
+
+def test_preflight_app_version_drift_is_a_warning_not_an_error(tmp_path):
+    """#575: a drifted app is loud but never bricks the run — --strict-app-version is the gate."""
+    ac_root, user, cm = _fake_rig(tmp_path)
+    cfg = _cfg(
+        ac_root=ac_root,
+        ac_user_dir=user,
+        cm_exe=cm,
+        track_id="spa",
+        car_id="ks_porsche_911_gt3_r_2016",
+        setup="Realistic_BB_v3",
+        cm_preset=None,
+    )
+    drifted = AppInstallProvenance(status="drift", detail="installed app differs: abc vs def")
+    issues = preflight(cfg, app_provenance=drifted)
+    assert [(i.check, i.severity) for i in issues] == [("app_version", "warning")]
+    assert "differs" in issues[0].message
+
+
+def test_preflight_app_version_unknown_provenance_is_reported_not_fatal(tmp_path):
+    """#575 AC2: a non-junction / absent install degrades to a warning, never an error."""
+    ac_root, user, cm = _fake_rig(tmp_path)
+    cfg = _cfg(
+        ac_root=ac_root,
+        ac_user_dir=user,
+        cm_exe=cm,
+        track_id="spa",
+        car_id="ks_porsche_911_gt3_r_2016",
+        setup="Realistic_BB_v3",
+        cm_preset=None,
+    )
+    unknown = AppInstallProvenance(status="unknown", detail="app not installed at <ac_root>/apps")
+    issues = preflight(cfg, app_provenance=unknown)
+    assert [(i.check, i.severity) for i in issues] == [("app_version", "warning")]
+
+
+def _app_tree(root: Path, *, body: str = "-- v1\n") -> Path:
+    """A minimal trainer app source tree at ``<root>/src/ac_copilot_trainer``."""
+    src = root / "src" / "ac_copilot_trainer"
+    (src / "modules").mkdir(parents=True)
+    (src / "ac_copilot_trainer.lua").write_text(body, encoding="utf-8")
+    (src / "manifest.ini").write_text("[ABOUT]\nNAME=AC Copilot Trainer\n", encoding="utf-8")
+    (src / "modules" / "hud.lua").write_text("-- hud\n", encoding="utf-8")
+    return src
+
+
+def _install_app(ac_root: Path, src: Path) -> Path:
+    """Copy an app tree to the AC install path (stands in for the rig's junction)."""
+    installed = ac_root / "apps" / "lua" / "AC_Copilot_Trainer"
+    installed.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, installed)
+    return installed
+
+
+def test_app_install_provenance_reports_match(tmp_path):
+    """#575: identical content on both sides is a match, and names the version."""
+    harness = tmp_path / "harness"
+    src = _app_tree(harness)
+    ac_root = tmp_path / "ac"
+    _install_app(ac_root, src)
+
+    prov = app_install_provenance(ac_root, harness_root=harness)
+    assert prov.status == "match"
+    assert prov.installed_digest == prov.harness_digest
+    assert prov.installed_digest is not None
+
+
+def test_app_install_provenance_detects_drift_and_names_both_versions(tmp_path):
+    """#575 AC1: differing app content is drift, and the message names installed + harness."""
+    harness = tmp_path / "harness"
+    _app_tree(harness, body="-- current\n")
+    stale = tmp_path / "stale"
+    stale_src = _app_tree(stale, body="-- ten days old\n")
+    ac_root = tmp_path / "ac"
+    _install_app(ac_root, stale_src)
+
+    prov = app_install_provenance(ac_root, harness_root=harness)
+    assert prov.status == "drift"
+    assert prov.installed_digest != prov.harness_digest
+    # The warning must name both sides so the operator can act without spelunking.
+    assert str(ac_root / "apps" / "lua" / "AC_Copilot_Trainer") in prov.detail
+    assert str(harness / "src" / "ac_copilot_trainer") in prov.detail
+
+
+def test_app_install_provenance_detects_a_pure_rename_as_drift(tmp_path):
+    """Identical bytes under a different name is a real drift — the digest is path-sensitive."""
+    harness = tmp_path / "harness"
+    _app_tree(harness)
+    other = tmp_path / "other"
+    other_src = _app_tree(other)
+    (other_src / "modules" / "hud.lua").rename(other_src / "modules" / "hud_old.lua")
+    ac_root = tmp_path / "ac"
+    _install_app(ac_root, other_src)
+
+    assert app_install_provenance(ac_root, harness_root=harness).status == "drift"
+
+
+def test_app_install_provenance_unknown_when_app_not_installed(tmp_path):
+    """#575 AC2: no install at all → unknown provenance, actionable message, no crash."""
+    harness = tmp_path / "harness"
+    _app_tree(harness)
+    ac_root = tmp_path / "ac"
+    ac_root.mkdir()
+
+    prov = app_install_provenance(ac_root, harness_root=harness)
+    assert prov.status == "unknown"
+    assert prov.installed_digest is None
+    assert prov.harness_digest is not None  # the harness side is still established
+    assert "not installed" in prov.detail
+
+
+def test_app_install_provenance_unknown_when_harness_has_no_app_source(tmp_path):
+    """A harness checkout without src/ac_copilot_trainer cannot compare — unknown, not drift."""
+    harness = tmp_path / "harness"
+    harness.mkdir()
+    other = tmp_path / "other"
+    src = _app_tree(other)
+    ac_root = tmp_path / "ac"
+    _install_app(ac_root, src)
+
+    prov = app_install_provenance(ac_root, harness_root=harness)
+    assert prov.status == "unknown"
+    assert prov.harness_digest is None
+    assert prov.installed_digest is not None
+
+
+def test_app_install_provenance_ignores_pycache_build_noise(tmp_path):
+    """Observed on the rig: the primary checkout carries __pycache__ a worktree does not.
+
+    That is build noise the AC Lua runtime never reads — hashing it would report false drift on
+    every run and train the operator to ignore the warning.
+    """
+    harness = tmp_path / "harness"
+    src = _app_tree(harness)
+    ac_root = tmp_path / "ac"
+    installed = _install_app(ac_root, src)
+    (installed / "__pycache__").mkdir()
+    (installed / "__pycache__" / "__init__.cpython-313.pyc").write_bytes(b"\x00noise")
+
+    assert app_install_provenance(ac_root, harness_root=harness).status == "match"
+
+
+def test_app_install_provenance_ignores_line_ending_normalization(tmp_path):
+    """Observed live on the rig: `start_sidecar.bat` differed between the primary checkout and a
+    worktree AT THE SAME COMMIT, purely in EOLs (`.gitattributes` has `*.bat text eol=crlf`).
+
+    Raw-byte hashing would report drift on every run here; an always-wrong warning trains the
+    operator to ignore the one time it is real.
+    """
+    harness = tmp_path / "harness"
+    src = _app_tree(harness)
+    (src / "start_sidecar.bat").write_bytes(b"@echo off\nset X=1\n")
+    ac_root = tmp_path / "ac"
+    installed = _install_app(ac_root, src)
+    # Same content, CRLF — what a checkout under different eol settings produces.
+    (installed / "start_sidecar.bat").write_bytes(b"@echo off\r\nset X=1\r\n")
+
+    assert app_install_provenance(ac_root, harness_root=harness).status == "match"
+
+
+def test_app_install_provenance_still_catches_real_text_edits(tmp_path):
+    """EOL-insensitivity must not swallow a genuine one-character logic change."""
+    harness = tmp_path / "harness"
+    src = _app_tree(harness)
+    (src / "modules" / "hud.lua").write_bytes(b"local speed = 1\n")
+    ac_root = tmp_path / "ac"
+    installed = _install_app(ac_root, src)
+    (installed / "modules" / "hud.lua").write_bytes(b"local speed = 2\r\n")
+
+    assert app_install_provenance(ac_root, harness_root=harness).status == "drift"
+
+
+def test_app_tree_digest_hashes_binary_assets_byte_exact(tmp_path):
+    """A font/PNG that differs by one byte is drift — CRLF normalization must not touch binary."""
+    a = tmp_path / "a" / "src" / "ac_copilot_trainer"
+    b = tmp_path / "b" / "src" / "ac_copilot_trainer"
+    for root, blob in ((a, b"\x00\r\n\x01"), (b, b"\x00\n\x01")):
+        root.mkdir(parents=True)
+        (root / "content").mkdir()
+        (root / "content" / "font.ttf").write_bytes(blob)
+
+    assert app_tree_digest(a) != app_tree_digest(b)
+
+
+def test_app_tree_digest_is_none_for_a_missing_tree(tmp_path):
+    assert app_tree_digest(tmp_path / "nope") is None
 
 
 def test_preflight_reports_missing_content_and_disabled_custom_ai(tmp_path):

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -28,6 +28,7 @@ from tools.ac_harness.auto_drive import (
     _config_from_args,
     _wait_live,
     app_install_provenance,
+    app_provenance_recheck,
     app_tree_digest,
     bake_setup_into_race_ini,
     build_practice_preset,
@@ -2180,6 +2181,45 @@ def test_strict_gates_on_the_verdict_not_merely_on_the_row():
         for s in ("match", "drift", "absent", "unverifiable")
     }
     assert blocks == {"match": False, "drift": True, "absent": False, "unverifiable": True}
+
+
+def _prov(status: str) -> AppInstallProvenance:
+    return AppInstallProvenance(status=status, detail=f"detail for {status}")
+
+
+def test_post_lock_recheck_closes_the_strict_bypass():
+    """PR #587 review: a pre-lock `match` must not bypass strict on an app that drifted since.
+
+    The install is shared rig state — a peer worktree can repoint the junction while we block on
+    the machine-global lock. Observed live during this PR's own verification.
+    """
+    note, fatal = app_provenance_recheck(_prov("match"), _prov("drift"), strict=True)
+    assert fatal is True
+    assert note is not None and "match -> drift" in note
+
+
+def test_post_lock_recheck_clears_a_stale_pre_lock_drift():
+    """The inverse race: a peer FIXED the install while we waited — do not false-fail on it."""
+    note, fatal = app_provenance_recheck(_prov("drift"), _prov("match"), strict=True)
+    assert fatal is False
+    assert note is not None and "drift -> match" in note
+
+
+def test_post_lock_recheck_is_quiet_and_non_fatal_when_nothing_changed():
+    assert app_provenance_recheck(_prov("match"), _prov("match"), strict=True) == (None, False)
+
+
+def test_post_lock_recheck_never_fails_without_the_strict_flag():
+    """Default stays warn-only: the race is reported, but a drift alone never aborts the drive."""
+    note, fatal = app_provenance_recheck(_prov("match"), _prov("drift"), strict=False)
+    assert fatal is False
+    assert note is not None  # still surfaced
+
+
+def test_post_lock_recheck_absent_still_never_blocks_strict():
+    """`absent` keeps its non-fatal semantics on the post-lock path too."""
+    _note, fatal = app_provenance_recheck(_prov("match"), _prov("absent"), strict=True)
+    assert fatal is False
 
 
 def _app_tree(root: Path, *, body: str = "-- v1\n") -> Path:

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2150,8 +2150,9 @@ def test_preflight_app_version_drift_is_a_warning_not_an_error(tmp_path):
     assert "differs" in issues[0].message
 
 
-def test_preflight_app_version_unknown_provenance_is_reported_not_fatal(tmp_path):
-    """#575 AC2: a non-junction / absent install degrades to a warning, never an error."""
+@pytest.mark.parametrize("status", ["absent", "unverifiable"])
+def test_preflight_unestablished_provenance_is_reported_not_fatal(tmp_path, status):
+    """#575 AC2: an install whose version cannot be established degrades to a warning, not error."""
     ac_root, user, cm = _fake_rig(tmp_path)
     cfg = _cfg(
         ac_root=ac_root,
@@ -2162,9 +2163,23 @@ def test_preflight_app_version_unknown_provenance_is_reported_not_fatal(tmp_path
         setup="Realistic_BB_v3",
         cm_preset=None,
     )
-    unknown = AppInstallProvenance(status="unknown", detail="app not installed at <ac_root>/apps")
-    issues = preflight(cfg, app_provenance=unknown)
+    prov = AppInstallProvenance(status=status, detail="version not established")
+    issues = preflight(cfg, app_provenance=prov)
     assert [(i.check, i.severity) for i in issues] == [("app_version", "warning")]
+
+
+def test_strict_gates_on_the_verdict_not_merely_on_the_row():
+    """PR #587 review: --strict-app-version must distinguish absent from unverifiable.
+
+    An ABSENT app cannot run the wrong code, so strict still only warns. An app that is present
+    but UNVERIFIABLE may already be the stale one — strict must fail, or a flag whose whole
+    purpose is evidence integrity would go green on "something is installed, I cannot tell what".
+    """
+    blocks = {
+        s: AppInstallProvenance(status=s, detail="x").blocks_strict
+        for s in ("match", "drift", "absent", "unverifiable")
+    }
+    assert blocks == {"match": False, "drift": True, "absent": False, "unverifiable": True}
 
 
 def _app_tree(root: Path, *, body: str = "-- v1\n") -> Path:
@@ -2228,22 +2243,23 @@ def test_app_install_provenance_detects_a_pure_rename_as_drift(tmp_path):
     assert app_install_provenance(ac_root, harness_root=harness).status == "drift"
 
 
-def test_app_install_provenance_unknown_when_app_not_installed(tmp_path):
-    """#575 AC2: no install at all → unknown provenance, actionable message, no crash."""
+def test_app_install_provenance_absent_when_app_not_installed(tmp_path):
+    """#575 AC2: no install at all → `absent`, actionable message, no crash, never strict-fatal."""
     harness = tmp_path / "harness"
     _app_tree(harness)
     ac_root = tmp_path / "ac"
     ac_root.mkdir()
 
     prov = app_install_provenance(ac_root, harness_root=harness)
-    assert prov.status == "unknown"
+    assert prov.status == "absent"
+    assert prov.blocks_strict is False  # nothing installed can run the wrong code
     assert prov.installed_digest is None
     assert prov.harness_digest is not None  # the harness side is still established
     assert "not installed" in prov.detail
 
 
-def test_app_install_provenance_unknown_when_harness_has_no_app_source(tmp_path):
-    """A harness checkout without src/ac_copilot_trainer cannot compare — unknown, not drift."""
+def test_app_install_provenance_unverifiable_when_harness_has_no_app_source(tmp_path):
+    """An app IS installed but cannot be compared — `unverifiable`, and strict must fail on it."""
     harness = tmp_path / "harness"
     harness.mkdir()
     other = tmp_path / "other"
@@ -2252,7 +2268,8 @@ def test_app_install_provenance_unknown_when_harness_has_no_app_source(tmp_path)
     _install_app(ac_root, src)
 
     prov = app_install_provenance(ac_root, harness_root=harness)
-    assert prov.status == "unknown"
+    assert prov.status == "unverifiable"
+    assert prov.blocks_strict is True  # an installed app of unknown version may be the stale one
     assert prov.harness_digest is None
     assert prov.installed_digest is not None
 

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -30,6 +30,7 @@ from tools.ac_harness.auto_drive import (
     app_install_provenance,
     app_provenance_recheck,
     app_tree_digest,
+    app_version_preflight_fatal,
     bake_setup_into_race_ini,
     build_practice_preset,
     candidate_journal_laps_dirs,
@@ -2185,6 +2186,29 @@ def test_strict_gates_on_the_verdict_not_merely_on_the_row():
 
 def _prov(status: str) -> AppInstallProvenance:
     return AppInstallProvenance(status=status, detail=f"detail for {status}")
+
+
+def test_preflight_only_may_abort_strict_on_the_pre_lock_verdict():
+    """--preflight-only takes no rig lock, so the pre-lock verdict is all it will ever have."""
+    assert app_version_preflight_fatal(_prov("drift"), strict=True, preflight_only=True) is True
+    assert (
+        app_version_preflight_fatal(_prov("unverifiable"), strict=True, preflight_only=True) is True
+    )
+    assert app_version_preflight_fatal(_prov("absent"), strict=True, preflight_only=True) is False
+    assert app_version_preflight_fatal(_prov("drift"), strict=False, preflight_only=True) is False
+
+
+def test_a_real_strict_drive_never_aborts_on_the_pre_lock_verdict():
+    """PR #587 review: a peer holding the rig lock may fix the install before we acquire it.
+
+    Aborting pre-lock would false-fail on a drift that is already gone by drive time — and it
+    would make the post-lock recheck unreachable, which is what made the drift->match recovery
+    below dead code in the first draft.
+    """
+    for status in ("drift", "unverifiable"):
+        assert (
+            app_version_preflight_fatal(_prov(status), strict=True, preflight_only=False) is False
+        )
 
 
 def test_post_lock_recheck_closes_the_strict_bypass():

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -613,6 +613,10 @@ def _passthrough_args(args: argparse.Namespace) -> list[str]:
         out += ["--sidecar-url", args.sidecar_url]
     if args.rig_lock_timeout is not None:
         out += ["--rig-lock-timeout", str(args.rig_lock_timeout)]
+    if args.strict_app_version:
+        # #575: both stages must agree on the app version — an identification session run against
+        # a stale app produces the plant artifact the drive stage then trusts.
+        out.append("--strict-app-version")
     return out
 
 
@@ -689,6 +693,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--track", required=True, help="AC track id (e.g. magione)")
     p.add_argument("--track-layout", default=None, help="layout subdir for multi-layout tracks")
     p.add_argument("--setup", default=None, help="car setup name (plant identity includes it)")
+    p.add_argument(
+        "--strict-app-version",
+        action="store_true",
+        help="fail preflight on every stage when the AC-installed trainer app does not match "
+        "this checkout (default: warn) (#575)",
+    )
     p.add_argument("--ac-root", type=Path, default=None, help="AC content root (Steam install)")
     p.add_argument("--ac-user-dir", type=Path, default=None, help="AC user data root")
     p.add_argument("--cm-exe", type=Path, default=None, help="Content Manager.exe path")

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -55,11 +55,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import configparser
+import hashlib
 import json
 import logging
 import math
 import os
 import re
+import subprocess
 import threading
 import time
 from collections.abc import Awaitable, Callable, Iterator
@@ -1281,10 +1283,233 @@ def build_practice_preset(
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class PreflightIssue:
-    """One failed preflight assertion, with an actionable message."""
+    """One failed preflight assertion, with an actionable message.
+
+    ``severity`` is ``"error"`` (the run cannot proceed) or ``"warning"`` (loud, but the run may
+    proceed unless the caller opts into strictness). Default ``"error"`` keeps every pre-#575
+    check fatal.
+    """
 
     check: str
     message: str
+    severity: str = "error"
+
+
+# ---------------------------------------------------------------------------
+# Installed-app provenance (#575).
+#
+# The trainer app is installed as a junction:
+#     <ac_root>/apps/lua/AC_Copilot_Trainer -> <some checkout>/src/ac_copilot_trainer
+# The harness runs from its OWN checkout (often a worktree), so the two can silently disagree —
+# the rig then executes an app version the harness never saw. Observed damage (EPIC #529 G1): the
+# junction target sat ten days stale, lap archives were written with `car: "function_0xff"`, and
+# the #543 friction fit could not promote because zero valid archives matched.
+#
+# The verdict is a CONTENT digest, not a commit compare: the two checkouts can share a HEAD and
+# still differ (dirty tree), and a junction may point at a non-git export. Commits are carried
+# alongside as human-readable provenance so the warning can name both versions.
+# ---------------------------------------------------------------------------
+APP_INSTALL_RELPATH = ("apps", "lua", "AC_Copilot_Trainer")
+APP_SOURCE_RELPATH = ("src", "ac_copilot_trainer")
+
+# Build noise that lives inside the source tree but is never app payload: the AC Lua runtime never
+# reads it, and it differs between checkouts for reasons that are not a version drift. Observed on
+# the rig: the primary checkout carries `src/ac_copilot_trainer/__pycache__/*.pyc` that a worktree
+# does not — hashing it would report false drift on every run.
+_APP_DIGEST_IGNORED_DIRS = frozenset({"__pycache__", ".git"})
+_APP_DIGEST_IGNORED_SUFFIXES = frozenset({".pyc", ".pyo"})
+_APP_DIGEST_IGNORED_NAMES = frozenset({".DS_Store", "Thumbs.db"})
+
+
+def _app_digest_bytes(data: bytes) -> bytes:
+    """Normalize a file's bytes for version comparison: CRLF -> LF in text, binary untouched.
+
+    Two checkouts of the SAME commit can legitimately hold different line endings — `.gitattributes`
+    (`*.bat text eol=crlf`) normalizes on checkout, and a tree cloned under different settings keeps
+    the other ending. Observed on the rig: `start_sidecar.bat` differed between the primary checkout
+    and a worktree at the identical commit, purely in EOLs. Hashing raw bytes would therefore report
+    drift on every run here — and a check that always cries wolf trains the operator to ignore the
+    one time it is real, which is the failure #575 exists to prevent.
+
+    Binary detection mirrors git's: a NUL byte means binary (fonts, PNGs), hashed byte-exact.
+    """
+    if b"\x00" in data:
+        return data
+    return data.replace(b"\r\n", b"\n")
+
+
+def harness_repo_root() -> Path:
+    """Repo root of the checkout this harness module was imported from."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _app_digest_includes(rel: Path) -> bool:
+    """True when a tree-relative path is app payload (see the ignore sets above)."""
+    if _APP_DIGEST_IGNORED_DIRS & set(rel.parts[:-1]):
+        return False
+    return rel.suffix.lower() not in _APP_DIGEST_IGNORED_SUFFIXES and (
+        rel.name not in _APP_DIGEST_IGNORED_NAMES
+    )
+
+
+def app_tree_digest(root: Path) -> str | None:
+    """Content digest of an app tree, or ``None`` when it cannot be read.
+
+    Order-independent and path-sensitive: a rename with identical bytes is a real drift and must
+    not hash equal. Text is compared EOL-insensitively (see :func:`_app_digest_bytes`). Follows the
+    junction, so passing the install path digests the target.
+    """
+    if not root.is_dir():
+        return None
+    entries: list[tuple[str, bytes]] = []
+    try:
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(root)
+            if not _app_digest_includes(rel):
+                continue
+            payload = _app_digest_bytes(path.read_bytes())
+            entries.append((rel.as_posix(), hashlib.sha256(payload).digest()))
+    except OSError:
+        return None  # unreadable tree — provenance is unknown, never a crash (#575 AC2)
+    digest = hashlib.sha256()
+    for rel_posix, file_digest in sorted(entries):
+        digest.update(rel_posix.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_digest)
+    return digest.hexdigest()
+
+
+def _git_head(path: Path) -> str | None:
+    """``HEAD`` of the checkout containing ``path``; ``None`` when it is not one (or git is gone).
+
+    ``git -C`` walks up to the repo root, so any path inside a checkout resolves it.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _short(commit: str | None, digest: str | None) -> str:
+    """Human-readable version tag: the commit when the tree is a checkout, else the digest."""
+    if commit:
+        return commit[:12]
+    if digest:
+        return f"content:{digest[:12]}"
+    return "unknown"
+
+
+@dataclass(frozen=True)
+class AppInstallProvenance:
+    """Whether the AC-installed trainer app matches the harness's own checkout.
+
+    ``status`` is ``"match"``, ``"drift"``, or ``"unknown"`` (not installed, unreadable, or a
+    harness checkout without a source tree). ``unknown`` never fails the run — it is reported so
+    the operator knows the rig's app version was not established.
+    """
+
+    status: str
+    detail: str
+    installed_path: str | None = None
+    installed_target: str | None = None
+    installed_digest: str | None = None
+    installed_commit: str | None = None
+    harness_path: str | None = None
+    harness_digest: str | None = None
+    harness_commit: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def app_install_provenance(ac_root: Path, harness_root: Path | None = None) -> AppInstallProvenance:
+    """Compare the AC-installed trainer app against the harness's own ``src/ac_copilot_trainer``.
+
+    Pure over the filesystem (plus a read-only ``git rev-parse``); safe to call from preflight.
+    """
+    root = harness_repo_root() if harness_root is None else harness_root
+    harness_src = root.joinpath(*APP_SOURCE_RELPATH)
+    installed = ac_root.joinpath(*APP_INSTALL_RELPATH)
+
+    harness_digest = app_tree_digest(harness_src)
+    harness_commit = _git_head(root) if harness_src.is_dir() else None
+    common = {
+        "installed_path": str(installed),
+        "harness_path": str(harness_src),
+        "harness_digest": harness_digest,
+        "harness_commit": harness_commit,
+    }
+
+    if not installed.is_dir():
+        return AppInstallProvenance(
+            status="unknown",
+            detail=(
+                f"trainer app is not installed at {installed} — the rig's app version cannot be "
+                "established. Install it as a junction to this checkout's "
+                f"{harness_src} (mklink /J), or ignore if this rig does not run the Lua app."
+            ),
+            **common,
+        )
+
+    # A junction is not a symlink to Python (is_symlink() is False), so compare the real path.
+    resolved = Path(os.path.realpath(installed))
+    target = str(resolved) if resolved != Path(os.path.abspath(installed)) else None
+    installed_digest = app_tree_digest(installed)
+    installed_commit = _git_head(resolved)
+    common.update(
+        installed_target=target,
+        installed_digest=installed_digest,
+        installed_commit=installed_commit,
+    )
+
+    if harness_digest is None:
+        return AppInstallProvenance(
+            status="unknown",
+            detail=(
+                f"harness checkout has no readable app source at {harness_src} — cannot compare "
+                f"against the installed app at {installed}."
+            ),
+            **common,
+        )
+    if installed_digest is None:
+        return AppInstallProvenance(
+            status="unknown",
+            detail=f"installed app at {installed} is not readable — app version not established.",
+            **common,
+        )
+    if installed_digest == harness_digest:
+        return AppInstallProvenance(
+            status="match",
+            detail=(
+                f"installed app matches this harness checkout "
+                f"({_short(harness_commit, harness_digest)})"
+            ),
+            **common,
+        )
+
+    installed_where = target or str(installed)
+    return AppInstallProvenance(
+        status="drift",
+        detail=(
+            "INSTALLED TRAINER APP DIFFERS FROM THIS HARNESS CHECKOUT — the rig would run app "
+            f"code the harness never saw. Installed: {installed_where} at "
+            f"{_short(installed_commit, installed_digest)}. Harness: {harness_src} at "
+            f"{_short(harness_commit, harness_digest)}. Point the junction at this checkout, or "
+            "sync the installed checkout, before trusting this run's lap archives."
+        ),
+        **common,
+    )
 
 
 def custom_ai_enabled(ac_root: Path, user_dir: Path) -> tuple[bool | None, str]:
@@ -1315,12 +1540,18 @@ def custom_ai_enabled(ac_root: Path, user_dir: Path) -> tuple[bool | None, str]:
     return None, "no [CUSTOM_AI] ENABLED key in " + " or ".join(str(c) for c in candidates)
 
 
-def preflight(config: AutoDriveConfig) -> list[PreflightIssue]:
-    """Assert every launch precondition with an actionable message (empty list = go).
+def preflight(
+    config: AutoDriveConfig, *, app_provenance: AppInstallProvenance | None = None
+) -> list[PreflightIssue]:
+    """Assert every launch precondition with an actionable message (no error rows = go).
 
     Covers the tribal-lore failure modes that used to surface as mid-run mysteries: missing
     content, a preset whose CarId/TrackId disagree with the CLI, CSP Custom AI disabled (the
-    hijack silently no-ops), a missing Content Manager, and an unresolvable setup.
+    hijack silently no-ops), a missing Content Manager, an unresolvable setup, and an installed
+    trainer app that disagrees with this checkout (#575).
+
+    ``app_provenance`` is injectable so the CLI can compute it once and also record it in the
+    evidence bundle; it is resolved from ``config.ac_root`` when omitted.
     """
     issues: list[PreflightIssue] = []
     user_dir = resolve_ac_user_dir(config.ac_user_dir)
@@ -1393,6 +1624,15 @@ def preflight(config: AutoDriveConfig) -> list[PreflightIssue]:
                         f"--car {config.car_id!r} but preset launches CarId {preset_car!r}",
                     )
                 )
+
+    provenance = (
+        app_install_provenance(config.ac_root) if app_provenance is None else app_provenance
+    )
+    if provenance.status != "match":
+        # Warning, not an error: a drifted app still drives, and an unknown-provenance install
+        # (non-junction export, app not installed) must never brick the rig. --strict-app-version
+        # promotes this to fatal for runs whose evidence depends on the app version (#575).
+        issues.append(PreflightIssue("app_version", provenance.detail, severity="warning"))
 
     enabled, detail = custom_ai_enabled(config.ac_root, user_dir)
     if enabled is not True:
@@ -2784,6 +3024,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "direct overspeed drive carries spin/damage risk on the operator",
     )
     p.add_argument("--strict", action="store_true", help="require session+lap, enforce ordering")
+    p.add_argument(
+        "--strict-app-version",
+        action="store_true",
+        help="fail preflight when the AC-installed trainer app does not match this checkout "
+        "(default: warn). Use for runs whose evidence depends on the rig running THIS app (#575)",
+    )
     p.add_argument("--skip-launch", action="store_true", help="AC already LIVE; only hijack+drive")
     p.add_argument(
         "--hijack-probe-seconds",
@@ -3194,10 +3440,20 @@ def _main_impl(
         )
         config.cm_preset = preset_path
 
-    issues = preflight(config)
-    if issues:
+    app_provenance = app_install_provenance(config.ac_root)
+    print(f"auto-drive: installed app provenance: {app_provenance.status}")
+    issues = preflight(config, app_provenance=app_provenance)
+    # #575: an app_version row is a warning by default; --strict-app-version makes it fatal for
+    # runs whose evidence is only meaningful if the rig ran THIS checkout's app.
+    fatal: list[PreflightIssue] = []
+    for issue in issues:
+        if issue.severity == "error" or (args.strict_app_version and issue.check == "app_version"):
+            fatal.append(issue)
+        else:
+            print(f"auto-drive: PREFLIGHT WARNING [{issue.check}] {issue.message}")
+    if fatal:
         print("auto-drive: PREFLIGHT FAILED")
-        for issue in issues:
+        for issue in fatal:
             print(f"  [{issue.check}] {issue.message}")
         return 2
     print("auto-drive: preflight ok")
@@ -3469,6 +3725,9 @@ def _main_impl(
             "plant_artifact": plant_artifact_used,
             "alien_line": alien_line_used,
             "sidecar": sidecar_detail,
+            # #575: the app version the rig actually ran. Without it, a bundle cannot be trusted
+            # retroactively — a stale junction silently invalidates every archive it produced.
+            "app_install": app_provenance.to_dict(),
         },
         "hud": hud,
         "lap_archives": lap_archives,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1542,6 +1542,32 @@ def app_install_provenance(ac_root: Path, harness_root: Path | None = None) -> A
     )
 
 
+def app_provenance_recheck(
+    before: AppInstallProvenance,
+    after: AppInstallProvenance,
+    *,
+    strict: bool,
+) -> tuple[str | None, bool]:
+    """Decide a post-rig-lock provenance re-measurement: ``(race_note, fatal)``.
+
+    The installed app is shared rig state. A peer worktree can repoint the junction while we block
+    on the machine-global lock, so the verdict that gates ``--strict-app-version`` and lands in the
+    evidence bundle must be the one measured **under** the lock — otherwise a pre-lock ``match``
+    bypasses strict on an app that has since drifted, and the bundle records a version the rig
+    never ran (PR #587 review; same reasoning as the plant/line post-lock resolution).
+
+    ``race_note`` is non-None when the verdict changed across the lock wait — worth surfacing on
+    its own, since it is the #575 failure mode caught in the act.
+    """
+    note: str | None = None
+    if after.status != before.status:
+        note = (
+            f"app provenance CHANGED while waiting for the rig lock: {before.status} -> "
+            f"{after.status} (a peer worktree touched the install). {after.detail}"
+        )
+    return note, bool(strict and after.blocks_strict)
+
+
 def custom_ai_enabled(ac_root: Path, user_dir: Path) -> tuple[bool | None, str]:
     """Report whether CSP's Custom AI subsystem is enabled (``[CUSTOM_AI] ENABLED=1``).
 
@@ -3568,6 +3594,24 @@ def _main_impl(
         return 3
     cleanup.callback(rig_lock.release)
     print(f"auto-drive: rig lock acquired -> {rig_lock.path}")
+
+    # #575 (PR #587 review): the installed app is shared rig state, so its provenance must be
+    # measured UNDER the lock — same reasoning as the plant/line resolution below. The pre-lock
+    # verdict above is fast feedback only: a peer worktree can repoint the junction while we block
+    # here, which would both record a false verdict in the evidence bundle and let a pre-lock
+    # `match` bypass --strict-app-version on an app that drifted since. (Observed live: a peer
+    # worktree repointed the junction mid-session during this PR's own verification.)
+    pre_lock_provenance = app_provenance
+    app_provenance = app_install_provenance(config.ac_root)  # the verdict the drive actually runs
+    race_note, app_version_fatal = app_provenance_recheck(
+        pre_lock_provenance, app_provenance, strict=args.strict_app_version
+    )
+    if race_note:
+        print(f"auto-drive: {race_note}")
+    if app_version_fatal:
+        print("auto-drive: PREFLIGHT FAILED (post-lock re-check)")
+        print(f"  [app_version] {app_provenance.detail}")
+        return 2
 
     # Plant/line artifact resolution happens AFTER preflight (actionable content errors, and
     # --preflight-only never writes state) and AFTER the machine-global rig lock, for EVERY

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1542,6 +1542,22 @@ def app_install_provenance(ac_root: Path, harness_root: Path | None = None) -> A
     )
 
 
+def app_version_preflight_fatal(
+    provenance: AppInstallProvenance, *, strict: bool, preflight_only: bool
+) -> bool:
+    """Whether the PRE-rig-lock ``app_version`` row should abort the run.
+
+    Only ``--preflight-only`` may abort here: it takes no rig lock, so the pre-lock verdict is the
+    only measurement it will ever have, and a readiness probe that cannot fail is useless.
+
+    A real drive must NOT abort pre-lock. A peer worktree holding the lock may fix or repoint the
+    install before we acquire it, so a pre-lock drift can be stale by the time the drive would
+    start — aborting on it is a false-fail, and it would also make the post-lock recheck
+    unreachable. Real drives gate on :func:`app_provenance_recheck` instead (PR #587 review).
+    """
+    return bool(strict and preflight_only and provenance.blocks_strict)
+
+
 def app_provenance_recheck(
     before: AppInstallProvenance,
     after: AppInstallProvenance,
@@ -3503,8 +3519,12 @@ def _main_impl(
     # #575: an app_version row is a warning by default; --strict-app-version makes it fatal for
     # runs whose evidence is only meaningful if the rig ran THIS checkout's app. Strictness gates
     # on the PROVENANCE VERDICT, not merely on the row's presence: an `absent` app cannot run the
-    # wrong code, so it stays a warning even under strict (PR #587 review).
-    strict_app_fatal = args.strict_app_version and app_provenance.blocks_strict
+    # wrong code, so it stays a warning even under strict (PR #587 review). A real drive defers
+    # the strict abort to the post-lock recheck; only --preflight-only (which takes no lock, so
+    # gets no later measurement) may abort on the pre-lock verdict.
+    strict_app_fatal = app_version_preflight_fatal(
+        app_provenance, strict=args.strict_app_version, preflight_only=args.preflight_only
+    )
     fatal: list[PreflightIssue] = []
     for issue in issues:
         if issue.severity == "error" or (strict_app_fatal and issue.check == "app_version"):

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1410,13 +1410,30 @@ def _short(commit: str | None, digest: str | None) -> str:
     return "unknown"
 
 
+# Statuses that `--strict-app-version` treats as fatal. The split matters: an app that is ABSENT
+# cannot run the wrong code, but an app that is PRESENT AND UNVERIFIABLE might already be the stale
+# one — and a strictness flag that greens on "something is installed but I cannot tell what" would
+# reintroduce the exact silent-false-confidence failure #575 exists to kill. Absence of proof is not
+# proof of match, but absence of an app is not absence of proof.
+APP_PROVENANCE_STRICT_FATAL = frozenset({"drift", "unverifiable"})
+
+
 @dataclass(frozen=True)
 class AppInstallProvenance:
     """Whether the AC-installed trainer app matches the harness's own checkout.
 
-    ``status`` is ``"match"``, ``"drift"``, or ``"unknown"`` (not installed, unreadable, or a
-    harness checkout without a source tree). ``unknown`` never fails the run — it is reported so
-    the operator knows the rig's app version was not established.
+    ``status`` is one of:
+
+    - ``match`` — installed content equals the harness's own app source.
+    - ``drift`` — proven different. Warns; fatal under ``--strict-app-version``.
+    - ``absent`` — no app installed. Nothing can run the wrong code, so this warns even under
+      strict; a rig that does not run the Lua app is a legitimate configuration.
+    - ``unverifiable`` — an app IS installed but its version cannot be established (unreadable
+      tree, or a harness checkout with no app source to compare against). Warns by default; fatal
+      under strict, because the installed app may already be the stale one.
+
+    ``absent`` and ``unverifiable`` are the two halves of what a coarser design would call
+    "unknown" — they are split because strictness must treat them oppositely (PR #587 review).
     """
 
     status: str
@@ -1428,6 +1445,11 @@ class AppInstallProvenance:
     harness_path: str | None = None
     harness_digest: str | None = None
     harness_commit: str | None = None
+
+    @property
+    def blocks_strict(self) -> bool:
+        """True when ``--strict-app-version`` should fail the run on this verdict."""
+        return self.status in APP_PROVENANCE_STRICT_FATAL
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -1452,12 +1474,14 @@ def app_install_provenance(ac_root: Path, harness_root: Path | None = None) -> A
     }
 
     if not installed.is_dir():
+        # ABSENT, not unverifiable: no app is installed, so none can run the wrong code. Non-fatal
+        # even under strict — a rig that does not run the Lua app is a legitimate configuration.
         return AppInstallProvenance(
-            status="unknown",
+            status="absent",
             detail=(
-                f"trainer app is not installed at {installed} — the rig's app version cannot be "
-                "established. Install it as a junction to this checkout's "
-                f"{harness_src} (mklink /J), or ignore if this rig does not run the Lua app."
+                f"trainer app is not installed at {installed} — no in-sim app will run. Install it "
+                f"as a junction to this checkout's {harness_src} (mklink /J), or ignore if this "
+                "rig does not run the Lua app."
             ),
             **common,
         )
@@ -1472,20 +1496,27 @@ def app_install_provenance(ac_root: Path, harness_root: Path | None = None) -> A
         installed_digest=installed_digest,
         installed_commit=installed_commit,
     )
+    installed_where = target or str(installed)
 
+    # Below here an app IS installed, so any failure to establish its version is UNVERIFIABLE, not
+    # absent: the rig will run that app, and it may already be the stale one.
     if harness_digest is None:
         return AppInstallProvenance(
-            status="unknown",
+            status="unverifiable",
             detail=(
-                f"harness checkout has no readable app source at {harness_src} — cannot compare "
-                f"against the installed app at {installed}."
+                f"an app is installed at {installed_where} but this harness checkout has no "
+                f"readable app source at {harness_src} to compare it against — the rig's app "
+                "version cannot be established."
             ),
             **common,
         )
     if installed_digest is None:
         return AppInstallProvenance(
-            status="unknown",
-            detail=f"installed app at {installed} is not readable — app version not established.",
+            status="unverifiable",
+            detail=(
+                f"an app is installed at {installed} but its content is not readable — the rig's "
+                "app version cannot be established."
+            ),
             **common,
         )
     if installed_digest == harness_digest:
@@ -1498,7 +1529,6 @@ def app_install_provenance(ac_root: Path, harness_root: Path | None = None) -> A
             **common,
         )
 
-    installed_where = target or str(installed)
     return AppInstallProvenance(
         status="drift",
         detail=(
@@ -3027,8 +3057,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--strict-app-version",
         action="store_true",
-        help="fail preflight when the AC-installed trainer app does not match this checkout "
-        "(default: warn). Use for runs whose evidence depends on the rig running THIS app (#575)",
+        help="fail preflight when the AC-installed trainer app is not proven to match this "
+        "checkout — drift, or installed-but-unverifiable (default: warn). An absent app still "
+        "only warns. Use for runs whose evidence depends on the rig running THIS app (#575)",
     )
     p.add_argument("--skip-launch", action="store_true", help="AC already LIVE; only hijack+drive")
     p.add_argument(
@@ -3444,10 +3475,13 @@ def _main_impl(
     print(f"auto-drive: installed app provenance: {app_provenance.status}")
     issues = preflight(config, app_provenance=app_provenance)
     # #575: an app_version row is a warning by default; --strict-app-version makes it fatal for
-    # runs whose evidence is only meaningful if the rig ran THIS checkout's app.
+    # runs whose evidence is only meaningful if the rig ran THIS checkout's app. Strictness gates
+    # on the PROVENANCE VERDICT, not merely on the row's presence: an `absent` app cannot run the
+    # wrong code, so it stays a warning even under strict (PR #587 review).
+    strict_app_fatal = args.strict_app_version and app_provenance.blocks_strict
     fatal: list[PreflightIssue] = []
     for issue in issues:
-        if issue.severity == "error" or (args.strict_app_version and issue.check == "app_version"):
+        if issue.severity == "error" or (strict_app_fatal and issue.check == "app_version"):
             fatal.append(issue)
         else:
             print(f"auto-drive: PREFLIGHT WARNING [{issue.check}] {issue.message}")


### PR DESCRIPTION
Closes #575.

## What

The trainer app is installed as a junction — `<ac_root>/apps/lua/AC_Copilot_Trainer -> <checkout>/src/ac_copilot_trainer` — while the harness runs from its **own** checkout (usually a worktree). Nothing detected when those two disagreed, so the rig silently ran an old app while the harness assumed current behavior.

**Observed damage (2026-07-14, EPIC #529 G1):** the junction target sat at `73ebe82` (PR #492, ten days stale). Lap archives were written with `car: "function_0xff"` — the exact callable-surface class #543 fixed — and a handshake run produced zero valid archives, so the #543 friction fit could not promote and the #572 one-button pipeline correctly FAILed after an otherwise-clean session.

`preflight()` now resolves the junction, compares the installed app tree against the harness's own `src/ac_copilot_trainer`, and records `extras.run.app_install` in the evidence bundle so a bundle can be trusted retroactively.

- **drift** → loud warning naming *both* versions; `--strict-app-version` (passed through both `auto_alien` stages) promotes it to fatal.
- **unknown** (non-junction export, app absent, unreadable) → reported, never fatal, never crashes.

## Why a content digest, not a commit compare

Two checkouts can share a `HEAD` and still differ (dirty tree), and a junction may point at a non-git export. Commits ride along as human-readable provenance so the warning can name both versions.

## Two normalizations — both found by running it against the real rig

A version check that cries wolf trains the operator to ignore the one time it's real, which is the failure this issue exists to prevent. Running the first draft against the actual rig reported **drift** where there was none, twice:

1. **`__pycache__/*.pyc`** — the primary checkout carries it *inside* the app tree; a worktree does not. The AC Lua runtime never reads it.
2. **Line endings** — `.gitattributes` sets `*.bat text eol=crlf`, and `start_sidecar.bat` differed between the primary checkout and a worktree **at the identical commit**, purely in EOLs (exactly 41 bytes across 41 lines). Text is now compared EOL-insensitively; binary (NUL-bearing: fonts, PNGs) still hashes byte-exact, and a real one-character logic edit is still drift. Both are locked by regression tests.

## Verification (live, on the rig, through the unmodified CLI path)

| scenario | result |
|---|---|
| **Real rig junction** → primary checkout | `provenance: match`, `preflight ok`, exit `0` **even under `--strict-app-version`** (no false positive) |
| **Real junction → real checkout of `73ebe82`** (the incident commit), default | `drift`, warns naming `73ebe823d945` (installed) vs `8a3283f74c56` (harness), exit `0` |
| same, `--strict-app-version` | `PREFLIGHT FAILED [app_version]`, exit `2` |
| app absent | `unknown`, `app_version` row is a warning, no crash |

The drift case was reproduced with a **real junction** to a **real git checkout** of the stale commit, not a mock. Test junctions were unlinked with `rmdir` (never traversed) and the real AC install + rig junction were confirmed intact afterward.

`make ci-fast`: **2928 passed**, 73 skipped.

## Out of scope

Auto-syncing the checkout (state mutation of another worktree is an operator action) and the frozen-EXE half (#569).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
