### PR TITLE
docs(vault): #570 route registry delivered + live-proven, post-merge handoff for PR #585

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,9 +2,10 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-15T00:45:00Z
+last_updated: 2026-07-15T02:40:00Z
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-582-l3-corner-refinement-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-572-alien-pipeline-2026-07-14.md
@@ -33,7 +34,19 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
-**Delivered (2026-07-15, latest):** [#582](https://github.com/agorokh/ac-copilot-trainer/issues/582)
+**Delivered (2026-07-15, latest):** [#570](https://github.com/agorokh/ac-copilot-trainer/issues/570)
+**CLOSED** by PR [#585](https://github.com/agorokh/ac-copilot-trainer/pull/585)
+([`2dbf7d8`](https://github.com/agorokh/ac-copilot-trainer/commit/2dbf7d8)) — the sidecar's
+`/health` endpoint advertisement is now **derived** from the `server._ROUTES` registry that also
+drives dispatch, so a route can no longer be served without appearing in `/health` (no
+`advertise=False` opt-out exists). Exact-before-prefix dispatch; import-time registry validation.
+Found en route: the parallel structure had **already drifted** — 4 paths were routed but
+unadvertised (`/healthz`, `/voice/clips/`, `/voice/dispatches`, `/voice/echoes`); advertised set
+6 → 9. Live-proven on merged main (`build_commit: 2dbf7d8`): all 9 routes serve, `/health`
+reconciles against source, real font 200/82956 B, unrouted → 426. Detail:
+[[issue-570-route-registry-2026-07-15]].
+
+**Prior (2026-07-15):** [#582](https://github.com/agorokh/ac-copilot-trainer/issues/582)
 **CLOSED** by PR [#583](https://github.com/agorokh/ac-copilot-trainer/pull/583)
 ([`b2ef740`](https://github.com/agorokh/ac-copilot-trainer/commit/b2ef740)) — **EPIC #529 Layer 3**
 corridor-constrained per-corner refinement (the #577 item-3 follow-up). Evidence-gated relaxation

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-15T00:45:00Z
+last_updated: 2026-07-15T02:40:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-582-l3-corner-refinement-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-577-alien-selfplay-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-572-alien-pipeline-2026-07-14.md
@@ -2189,6 +2190,45 @@ tap spike; **never** automate the user's plaintext Cognito token. No runtime cou
 [PR #334](https://github.com/agorokh/ac-copilot-trainer/pull/334) (implements
 [#333](https://github.com/agorokh/ac-copilot-trainer/issues/333)) —
 `tools/ai_sidecar/coaching_oracle.py` + `tt_overlay_ocr.ps1` + tests; bot review resolved.
+
+---
+
+## Resume here (2026-07-15 — #570 sidecar route registry MERGED + live-proven on merged main)
+
+**This iteration's merge:** **[#570](https://github.com/agorokh/ac-copilot-trainer/issues/570)
+CLOSED / PR [#585](https://github.com/agorokh/ac-copilot-trainer/pull/585) MERGED** `2026-07-15T02:33:20Z`
+as squash [`2dbf7d8`](https://github.com/agorokh/ac-copilot-trainer/commit/2dbf7d8145dbbbb0accedcbe5a5b3c48de54a4b9).
+The sidecar's served-endpoint surface is now ONE structure: `server._ROUTES` (frozen `_Route`
+records) drives **both** handler dispatch and the `/health` advertisement, with
+`SERVED_ENDPOINTS` derived from it. **No `advertise=False` opt-out exists** — a route cannot be
+served without appearing in `/health`, which is what #567/#568 stale-build detection reads.
+
+**The issue undersold the gap.** It called this "nice-to-have — the drift guard already prevents
+the silent-omission failure mode." The guard only enforces **advertised → routed**; nothing
+enforced the reverse. And the parallel structure had **already drifted on main**: `/healthz`,
+`/voice/clips/`, `/voice/dispatches`, `/voice/echoes` were routed but unadvertised. Advertised
+set 6 → 9 (safe — no consumer does exact-set equality; `supervisor.probe_tablet` probes reality
+with a real `GET /tablet/dash`).
+
+**Reviewer caught the recursive version of the same bug.** `ws-ops-cursor-reviewer` (Gemini 3.1
+Pro) MEDIUM on `50eb378`: prefix handlers hardcoded their own route string
+(`path[len("/dash/fonts/"):]`) — parallel structure *reintroduced one layer down*. Fixed in
+`12f730b` (router pre-strips, passes `tail`). **Durable lesson: when a registry owns a string,
+nothing downstream may restate it.**
+
+**Verified on the MERGED artifact** (not the branch): sidecar booted from `origin/main` reported
+`build_commit: 2dbf7d8` and advertised all 9 routes; the live `/health` set reconciles against
+the `_ROUTES` source (`match: True`); real font `/dash/fonts/Saira-Bold.ttf` → 200/82956 B;
+`/healthz` → 200 but unadvertised; `/voice/typo` + `/unrouted` → 426. `make ci-fast` OK
+(2912 passed). Detail: [[issue-570-route-registry-2026-07-15]].
+
+**No follow-ups filed** — reviewer findings were fixed under the parent PR (they bore on this
+outcome); no separable scope surfaced.
+
+**Note for the next session:** local `main` in the primary checkout is pinned by another worktree
+(`~/.codex/worktrees/81f5/ac-copilot-trainer`), so `git pull --ff-only` on `main` aborts there —
+this is the known cross-worktree ownership friction ([[issue-555-cross-worktree-rig-ownership-2026-07-13]]).
+`origin/main` is correct at `2dbf7d8`; verification was done against `origin/main` directly.
 
 ---
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
@@ -1,0 +1,91 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-07-15
+updated: 2026-07-15
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/570
+relates_to:
+  - AcCopilotTrainer/03_Investigations/tablet-dash-connection-hardening-2026-07-14.md
+  - AcCopilotTrainer/03_Investigations/issue-531-phase1-tablet-dash-2026-07-13.md
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+---
+
+# #570 — sidecar `/health` advertisement driven by the route registry
+
+**Delivered.** PR [#585](https://github.com/agorokh/ac-copilot-trainer/pull/585) MERGED
+`2026-07-15T02:33:20Z` as squash
+[`2dbf7d8`](https://github.com/agorokh/ac-copilot-trainer/commit/2dbf7d8145dbbbb0accedcbe5a5b3c48de54a4b9);
+issue #570 CLOSED. Follow-up from #568 (self-hosted reviewer, recurring MEDIUM).
+
+## The real gap (worse than the issue body said)
+
+The issue framed this as "nice-to-have — the drift guard already prevents the silent-omission
+failure mode." That was **half true**. `test_served_endpoints_are_actually_routed` enforces
+**advertised → routed** (a bogus advertisement 426s). Nothing enforced the **reverse**: a route
+served but silently absent from `/health`, which is exactly what the #567/#568 stale-build
+detection reads.
+
+That gap was already real on main: **4 paths were routed but unadvertised** — `/healthz`,
+`/voice/clips/`, `/voice/dispatches`, `/voice/echoes`. So the parallel structure had already
+drifted, undetected, before anyone refactored anything.
+
+## What shipped
+
+`server._ROUTES` — a tuple of frozen `_Route(path, handler, prefix, token_gated, aliases)` —
+drives **both** dispatch and advertisement:
+
+- `SERVED_ENDPOINTS = tuple(route.path for route in _ROUTES)` is **derived**. **No
+  `advertise=False` opt-out exists** — an opt-out is the hole the issue asked to close.
+  Advertised set grew 6 → 9 (safe: no consumer does exact-set equality; all use `in`, and
+  `supervisor.probe_tablet` deliberately probes reality with a real `GET /tablet/dash`).
+- **Exact-match first, then prefixes** — a prefix can never shadow a more specific exact route.
+  The old if-chain encoded that precedence by hand (`/voice/manifest.json` before
+  `/voice/clips/`); it is now structural.
+- `_index_routes` validates at import: duplicate paths/aliases, overlapping prefixes, and
+  aliases on a prefix route all raise. Ambiguity is a startup error, not a route that silently
+  never fires.
+- Blanket `/voice/*` + `/dash/*` token gate → per-route `token_gated=True`.
+- **Aliases** (`/healthz`) route to an advertised route's handler and are not advertised.
+
+## The recursive bug the reviewer caught
+
+The self-hosted reviewer (`ws-ops-cursor-reviewer`, Gemini 3.1 Pro) flagged a **MEDIUM** on
+`50eb378`: prefix handlers hardcoded their own route string (`path[len("/dash/fonts/"):]`) to
+slice the suffix — **duplicating registry state**. That is *the same parallel-structure drift
+#570 exists to remove*, reintroduced one layer down. Fixed in `12f730b`: the router pre-strips
+the matched route's path and passes `tail`; handlers never restate their path (`tail` is `""`
+for exact routes). Also per that review, pure registry unit tests moved to
+`tests/test_ai_sidecar_routes.py`; `/health` payload assertions stayed in the observability suite.
+
+**Lesson:** collapsing a parallel structure at one level can silently recreate it at the next.
+When a registry owns a string, nothing downstream may restate that string.
+
+## Verification (observed, on the MERGED artifact)
+
+Sidecar booted from `origin/main` via its own entrypoint (`python -m tools.ai_sidecar`), which
+self-reported `build_commit: 2dbf7d8` — the merge commit itself:
+
+- `/health` advertises all **9** registry routes; the live set **reconciles against the
+  `_ROUTES` declarations in `origin/main` source** (`match: True`).
+- Every advertised route serves (no 426). `/healthz` → 200 yet absent from `endpoints`.
+- Real vendored font `/dash/fonts/Saira-Bold.ttf` → **200, 82956 bytes** (proves the
+  tail-stripping fix against reality). `nope.ttf` → 404 (handler-owned, not fall-through).
+- `/voice/typo`, `/unrouted` → **426** (correct WS fall-through).
+
+**Non-vacuous guard:** `test_health_advertises_every_registered_route` was mutation-checked —
+dropping one route from the derived tuple reds it (`Right contains one more item:
+'/voice/echoes'`), so it genuinely catches #570's failure mode.
+
+**Differential proof of the token-gate delta:** the one behavior change claimed "equivalent"
+(unregistered paths under `/voice/`, `/dash/` now fall straight to the WS `token_check`) was
+proven, not argued: `test_unregistered_path_under_gated_prefix_still_refused` passes against
+**both** this branch's registry **and** `origin/main`'s pre-refactor inline chain.
+
+`make ci-fast` OK (2912 passed, 77 skipped). Required checks green on head `12f730b`;
+0 unresolved review threads; merged after a full 10-min cooldown.
+
+## Follow-up
+
+None filed. The reviewer's findings were fixed under the parent PR rather than deferred — they
+bore on this outcome. No separable scope surfaced.


### PR DESCRIPTION
Post-merge vault SAVE for PR #585 (issue #570 CLOSED, squash [`2dbf7d8`](https://github.com/agorokh/ac-copilot-trainer/commit/2dbf7d8145dbbbb0accedcbe5a5b3c48de54a4b9)).

Diff is strictly under `docs/01_Vault/**` — `vault-only` auto-merge.

## What this records

- **New node** `03_Investigations/issue-570-route-registry-2026-07-15.md`.
- **Current Focus** + **Next Session Handoff** resume block.

## Two findings worth persisting

1. **The issue body undersold the gap.** #570 called itself "nice-to-have — the drift guard already prevents the silent-omission failure mode." The guard only enforces **advertised → routed**; nothing enforced the reverse. The parallel structure had **already drifted on main**: `/healthz`, `/voice/clips/`, `/voice/dispatches`, `/voice/echoes` were served but unadvertised.

2. **Collapsing a parallel structure can silently recreate it one level down.** The self-hosted reviewer's MEDIUM caught prefix handlers restating their own route string (`path[len("/dash/fonts/"):]`) — the exact drift #570 removes, reintroduced inside the handlers. Durable rule captured: *when a registry owns a string, nothing downstream may restate it.*

## Evidence is from the merged artifact

Verification was run against a sidecar booted from `origin/main` (self-reported `build_commit: 2dbf7d8` — the merge commit), not the feature branch: all 9 registry routes serve, the live `/health` set reconciles against the `_ROUTES` source (`match: True`), real font `/dash/fonts/Saira-Bold.ttf` → 200 / 82956 bytes, `/healthz` → 200 yet unadvertised, `/voice/typo` + `/unrouted` → 426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)