### PR TITLE
docs(vault): correct a mis-linked cross-reference in the #570 handoff

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2225,10 +2225,14 @@ the `_ROUTES` source (`match: True`); real font `/dash/fonts/Saira-Bold.ttf` →
 **No follow-ups filed** — reviewer findings were fixed under the parent PR (they bore on this
 outcome); no separable scope surfaced.
 
-**Note for the next session:** local `main` in the primary checkout is pinned by another worktree
-(`~/.codex/worktrees/81f5/ac-copilot-trainer`), so `git pull --ff-only` on `main` aborts there —
-this is the known cross-worktree ownership friction ([[issue-555-cross-worktree-rig-ownership-2026-07-13]]).
-`origin/main` is correct at `2dbf7d8`; verification was done against `origin/main` directly.
+**Note for the next session:** local `main` in the primary checkout is checked out by another
+worktree (`~/.codex/worktrees/81f5/ac-copilot-trainer`), so `git checkout main` / `git pull
+--ff-only` abort there with `'main' is already used by worktree at ...`. This is **ordinary git
+worktree semantics, not a defect** — one branch, one worktree. It is **unrelated to
+[[issue-555-cross-worktree-rig-ownership-2026-07-13]]** (that issue is CLOSED and concerns
+concurrent worktree *CM/AC launches* replacing a live autonomous drive — a rig-concurrency bug,
+not a git checkout constraint). Nothing to fix: verify against `origin/main` directly
+(`git grep <symbol> $(git rev-parse origin/main)`), which is the stronger check anyway.
 
 ---
 


### PR DESCRIPTION
Correction to the handoff shipped in #588. Diff is strictly under `docs/01_Vault/**` — `vault-only` auto-merge.

## What was wrong

The #570 resume block noted that `git checkout main` aborts in the primary checkout and attributed it to "the known cross-worktree ownership friction ([[issue-555-cross-worktree-rig-ownership-2026-07-13]])".

Reconciled against live state rather than memory:

```
$ gh issue view 555 --repo agorokh/ac-copilot-trainer --json state,title
issue555: CLOSED — fix(harness): concurrent worktree CM launch can replace a live autonomous drive mid-run
```

#555 is **CLOSED** and is about concurrent worktree **CM/AC launches** clobbering a live autonomous drive — a rig-concurrency bug. It has nothing to do with git refusing to check out a branch already checked out in another worktree.

## What it says now

That behavior is **ordinary git worktree semantics** (one branch, one worktree) — not a defect, not #555, nothing to fix. The note now says so explicitly and points to the correct practice: verify against `origin/main` directly with `git grep <symbol> $(git rev-parse origin/main)`, which is the stronger check anyway.

## Why bother

A wrong cross-link in `Next Session Handoff.md` is exactly the issue-body-drift that poisons the next session's grounding, and Tier-2 feeds Tier-3 ingest — so a false narrative would propagate into the substrate. Caught by running the closing reconciliation gate over my *own* handoff text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)