### PR TITLE
feat(rig): #531 Part D — live tyre vitals + TC/ABS intervention on the tablet dash

### DIFF
--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -207,34 +207,35 @@ end
 
 
 --- Read the live per-wheel dashboard vitals (#531 Part D) into {fl,fr,rl,rr} maps, via the shared
---- `wheel_read` accessors so the finicky parts (CSP field names — `tyrePressure` / `tyreWear`, NOT
---- the SimHub/ACC spellings — and the 0-based wheel order) have one source of truth. Each read is
---- pcall-guarded there and degrades to nil, so a CSP build or car that lacks a channel omits that
---- corner rather than throwing out of the 20 Hz publish path.
+--- `wheel_read` accessors so the finicky parts (CSP field names — `tyrePressure`/`discTemperature`/
+--- `tyreWear`, NOT the SimHub/ACC spellings — and the 0-based wheel order) have one source of
+--- truth. Each read is pcall-guarded there and degrades to nil, so a CSP build or car that lacks a
+--- channel omits that corner rather than throwing out of the 20 Hz publish path.
 ---
---- Deliberately does NOT read `discTemperature`: the frozen design (DESIGN_SPEC section 4 /
---- reference_mock.html) gives brake temp no RACE or STINT slot, so streaming it would be a
---- producer with no consumer — the mirror image of the `abs_active`-with-no-producer bug this
---- Part fixes. It also reads a flat ambient 26 C on the 911 GT3 R (the #488 caveat in
---- `wheel_read.brakeTemp`), so a slot invented for it would print a constant. The lap trace still
---- captures it via `telemetry.lua`. Measurement is on #531 for Part F to decide with evidence.
+--- `brake_temps_c` has NO dashboard slot (the frozen design puts core temp + pressure on RACE and
+--- I/M/O + wear on STINT) but it is NOT dead wiring: the sidecar's `race_management._brake_advisory`
+--- consumes it to raise brake-management coaching cues at `>= 650 C` (hot) / `>= 850 C` (critical).
+--- The dash is not the only consumer of the tick. Safe on cars whose brake-thermal model is
+--- inactive: `discTemperature` reads a flat ambient ~26 C there (the #488 caveat in
+--- `wheel_read.brakeTemp`), which is far below both thresholds, so it raises no false cue.
 ---@param car any
----@return table pressures, table wearPct  (values number|nil per corner)
+---@return table pressures, table brakeTemps, table wearPct  (values number|nil per corner)
 local function _readWheelVitals(car)
-  local pressures, wearPct = {}, {}
+  local pressures, brakeTemps, wearPct = {}, {}, {}
   local wheels = _field(car, "wheels")
   if wheels == nil then
-    return pressures, wearPct
+    return pressures, brakeTemps, wearPct
   end
   for i = 0, 3 do
     local key = wheelRead.WHEEL_KEYS[i]
     local one = _field(wheels, i)
     if one ~= nil then
       pressures[key] = wheelRead.pressure(one)
+      brakeTemps[key] = wheelRead.brakeTemp(one)
       wearPct[key] = _wearPct(wheelRead.wear(one))
     end
   end
-  return pressures, wearPct
+  return pressures, brakeTemps, wearPct
 end
 
 
@@ -322,10 +323,17 @@ function M.publishTelemetryTickIfDue(opts)
   -- pressure slot its own header advertised. Each map is omitted entirely when no corner resolved
   -- (`_cornerMap` returns nil) — an absent vital must render as an explicit unknown on the dash,
   -- never as a frozen last value.
-  local pressures, wearPct = _readWheelVitals(opts.car)
+  local pressures, brakeTemps, wearPct = _readWheelVitals(opts.car)
   local pressureMap = _cornerMap(pressures)
   if pressureMap ~= nil then
     payload.tyre_pressures_psi = pressureMap
+  end
+  -- Consumed by `race_management._brake_advisory` (not by the dash). `_cornerMap` returns nil when
+  -- NO corner resolved, so the map is omitted only when the channel is entirely unavailable —
+  -- never zero-filled, and never suppressed on a car whose brake model IS active (Codex on #590).
+  local brakeTempMap = _cornerMap(brakeTemps)
+  if brakeTempMap ~= nil then
+    payload.brake_temps_c = brakeTempMap
   end
   local wearMap = _cornerMap(wearPct)
   if wearMap ~= nil then

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -17,6 +17,8 @@
 -- (current-frame WS state), alongside the lifecycle block. Topic strings are `local` consts so
 -- the `test_ws_topic_allowlist` drift-guard can resolve them against KNOWN_TOPICS.
 
+local wheelRead = require("wheel_read")
+
 local M = {}
 
 local DELTA_INTERVAL_SEC = 0.1  -- ~10 Hz, matches the HUD delta refresh
@@ -184,6 +186,65 @@ local function _cornerMap(values)
   return nil
 end
 
+
+-- #531 Part D: CSP `ac.StateWheel.tyreWear` is 0..1 wear CONSUMED — 0.0 is a NEW tyre and the
+-- value grows with use. Matches the wire field `tyre_wear_pct` (0 = new, 100 = gone), which the
+-- sidecar's `race_management._tyre_advisory` reads to fire "tyre wear is high" (and its voice
+-- cue) at `>= 70`, so this is a plain x100 with no inversion.
+--
+-- Rig-verified 2026-07-14 against 321 checked-in lap archives (4 cars) rather than assumed: the
+-- SDK's "from 0 to 1" is direction-ambiguous, and reading it as CONDITION-remaining (1.0 = new)
+-- inverts to 100 on a fresh set — a permanent false wear alarm on lap one. Observed range across
+-- every nonzero corner was 0.000268..0.0720 (i.e. 0.03%..7.2%), growing from an exact 0.0 on new
+-- tyres, which also matches reference_mock.html's illustrative "4% / 7% / 9% wear".
+local function _wearPct(raw)
+  raw = _finite(raw)
+  if raw == nil then
+    return nil
+  end
+  return _clamp(raw, 0, 1) * 100
+end
+
+
+--- Read the live per-wheel dashboard vitals (#531 Part D) into {fl,fr,rl,rr} maps, via the shared
+--- `wheel_read` accessors so the finicky parts (CSP field names — `tyrePressure`/`discTemperature`/
+--- `tyreWear`, NOT the SimHub/ACC spellings — and the 0-based wheel order) have one source of
+--- truth. Each read is pcall-guarded there and degrades to nil, so a CSP build or car that lacks a
+--- channel omits that corner rather than throwing out of the 20 Hz publish path.
+---@param car any
+---@return table pressures, table brakeTemps, table wearPct  (values number|nil per corner)
+local function _readWheelVitals(car)
+  local pressures, brakeTemps, wearPct = {}, {}, {}
+  local wheels = _field(car, "wheels")
+  if wheels == nil then
+    return pressures, brakeTemps, wearPct
+  end
+  for i = 0, 3 do
+    local key = wheelRead.WHEEL_KEYS[i]
+    local one = _field(wheels, i)
+    if one ~= nil then
+      pressures[key] = wheelRead.pressure(one)
+      brakeTemps[key] = wheelRead.brakeTemp(one)
+      wearPct[key] = _wearPct(wheelRead.wear(one))
+    end
+  end
+  return pressures, brakeTemps, wearPct
+end
+
+
+--- Read a CSP boolean that only exists when the car's physics expose it (`tractionControlInAction`
+--- / `absInAction` are "Physics-only" per the lua-sdk `ac.StateCar` stubs). Returns nil — so the
+--- publisher OMITS the key — for anything that is not a real boolean, keeping the tick's sentinel
+--- discipline: missing = unknown, `false` = the system is present and idle.
+local function _physicsFlag(car, key)
+  local v = _field(car, key)
+  if type(v) ~= "boolean" then
+    return nil
+  end
+  return v
+end
+
+
 --- Publish client→server ``telemetry_tick`` at ~20 Hz (M0 #341). Requires ``wsBridge.sendJson``.
 ---@param opts table  {dt:number, car:any, wsBridge, lat_g?:number, long_g?:number, temps?:table}
 ---@return boolean
@@ -249,6 +310,35 @@ function M.publishTelemetryTickIfDue(opts)
   local tyreTemps = _cornerMap(opts.temps)
   if tyreTemps ~= nil then
     payload.tyre_temps_c = tyreTemps
+  end
+  -- #531 Part D: the live vitals the tablet dashboard's tyre board and STINT page read. They were
+  -- captured to the lap trace but never streamed, so the board printed a temp with an empty
+  -- pressure slot its own header advertised. Each map is omitted entirely when no corner resolved
+  -- (`_cornerMap` returns nil) — an absent vital must render as an explicit unknown on the dash,
+  -- never as a frozen last value.
+  local pressures, brakeTemps, wearPct = _readWheelVitals(opts.car)
+  local pressureMap = _cornerMap(pressures)
+  if pressureMap ~= nil then
+    payload.tyre_pressures_psi = pressureMap
+  end
+  local brakeTempMap = _cornerMap(brakeTemps)
+  if brakeTempMap ~= nil then
+    payload.brake_temps_c = brakeTempMap
+  end
+  local wearMap = _cornerMap(wearPct)
+  if wearMap ~= nil then
+    payload.tyre_wear_pct = wearMap
+  end
+  -- #531 Part D: the electronics intervention flash — brass segments are "what I dialled", the
+  -- transient signal colour is "what the car is doing". The dashboard already read `abs_active`
+  -- but NO producer ever sent it, so the flash could never fire; `tc_active` had no slot at all.
+  local tcActive = _physicsFlag(car, "tractionControlInAction")
+  if tcActive ~= nil then
+    payload.tc_active = tcActive
+  end
+  local absActive = _physicsFlag(car, "absInAction")
+  if absActive ~= nil then
+    payload.abs_active = absActive
   end
   return wsBridge.sendJson({
     v = 1,

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -207,28 +207,34 @@ end
 
 
 --- Read the live per-wheel dashboard vitals (#531 Part D) into {fl,fr,rl,rr} maps, via the shared
---- `wheel_read` accessors so the finicky parts (CSP field names — `tyrePressure`/`discTemperature`/
---- `tyreWear`, NOT the SimHub/ACC spellings — and the 0-based wheel order) have one source of
---- truth. Each read is pcall-guarded there and degrades to nil, so a CSP build or car that lacks a
---- channel omits that corner rather than throwing out of the 20 Hz publish path.
+--- `wheel_read` accessors so the finicky parts (CSP field names — `tyrePressure` / `tyreWear`, NOT
+--- the SimHub/ACC spellings — and the 0-based wheel order) have one source of truth. Each read is
+--- pcall-guarded there and degrades to nil, so a CSP build or car that lacks a channel omits that
+--- corner rather than throwing out of the 20 Hz publish path.
+---
+--- Deliberately does NOT read `discTemperature`: the frozen design (DESIGN_SPEC section 4 /
+--- reference_mock.html) gives brake temp no RACE or STINT slot, so streaming it would be a
+--- producer with no consumer — the mirror image of the `abs_active`-with-no-producer bug this
+--- Part fixes. It also reads a flat ambient 26 C on the 911 GT3 R (the #488 caveat in
+--- `wheel_read.brakeTemp`), so a slot invented for it would print a constant. The lap trace still
+--- captures it via `telemetry.lua`. Measurement is on #531 for Part F to decide with evidence.
 ---@param car any
----@return table pressures, table brakeTemps, table wearPct  (values number|nil per corner)
+---@return table pressures, table wearPct  (values number|nil per corner)
 local function _readWheelVitals(car)
-  local pressures, brakeTemps, wearPct = {}, {}, {}
+  local pressures, wearPct = {}, {}
   local wheels = _field(car, "wheels")
   if wheels == nil then
-    return pressures, brakeTemps, wearPct
+    return pressures, wearPct
   end
   for i = 0, 3 do
     local key = wheelRead.WHEEL_KEYS[i]
     local one = _field(wheels, i)
     if one ~= nil then
       pressures[key] = wheelRead.pressure(one)
-      brakeTemps[key] = wheelRead.brakeTemp(one)
       wearPct[key] = _wearPct(wheelRead.wear(one))
     end
   end
-  return pressures, brakeTemps, wearPct
+  return pressures, wearPct
 end
 
 
@@ -316,14 +322,10 @@ function M.publishTelemetryTickIfDue(opts)
   -- pressure slot its own header advertised. Each map is omitted entirely when no corner resolved
   -- (`_cornerMap` returns nil) — an absent vital must render as an explicit unknown on the dash,
   -- never as a frozen last value.
-  local pressures, brakeTemps, wearPct = _readWheelVitals(opts.car)
+  local pressures, wearPct = _readWheelVitals(opts.car)
   local pressureMap = _cornerMap(pressures)
   if pressureMap ~= nil then
     payload.tyre_pressures_psi = pressureMap
-  end
-  local brakeTempMap = _cornerMap(brakeTemps)
-  if brakeTempMap ~= nil then
-    payload.brake_temps_c = brakeTempMap
   end
   local wearMap = _cornerMap(wearPct)
   if wearMap ~= nil then

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -283,8 +283,7 @@ def test_validate_inbound_accepts_known_types() -> None:
         ep.validate_inbound(
             _telemetry_tick(
                 tyre_pressures_psi={"fl": 27.4, "fr": 27.6, "rl": 26.1, "rr": 26.3},
-                brake_temps_c={"fl": 310.0, "fr": 312.0, "rl": 280.0, "rr": 282.0},
-                tyre_wear_pct={"fl": 0.0, "fr": 25.0, "rl": 75.0, "rr": 100.0},
+                tyre_wear_pct={"fl": 0.0, "fr": 25.0, "rl": 7.2, "rr": 100.0},
             )
         )
         is None

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -283,6 +283,7 @@ def test_validate_inbound_accepts_known_types() -> None:
         ep.validate_inbound(
             _telemetry_tick(
                 tyre_pressures_psi={"fl": 27.4, "fr": 27.6, "rl": 26.1, "rr": 26.3},
+                brake_temps_c={"fl": 310.0, "fr": 312.0, "rl": 280.0, "rr": 282.0},
                 tyre_wear_pct={"fl": 0.0, "fr": 25.0, "rl": 7.2, "rr": 100.0},
             )
         )

--- a/tests/test_ai_sidecar_external.py
+++ b/tests/test_ai_sidecar_external.py
@@ -277,6 +277,18 @@ def test_validate_inbound_accepts_known_types() -> None:
     assert ep.validate_inbound(_telemetry_tick()) is None
     assert ep.validate_inbound(_telemetry_tick(slip=-0.35)) is None
     assert ep.validate_inbound(_telemetry_tick(tyre_temps_c={"fl": 74.1})) is None
+    # #531 Part D live vitals + the TC/ABS intervention flags the dashboard flashes on.
+    assert ep.validate_inbound(_telemetry_tick(tc_active=True, abs_active=False)) is None
+    assert (
+        ep.validate_inbound(
+            _telemetry_tick(
+                tyre_pressures_psi={"fl": 27.4, "fr": 27.6, "rl": 26.1, "rr": 26.3},
+                brake_temps_c={"fl": 310.0, "fr": 312.0, "rl": 280.0, "rr": 282.0},
+                tyre_wear_pct={"fl": 0.0, "fr": 25.0, "rl": 75.0, "rr": 100.0},
+            )
+        )
+        is None
+    )
     assert ep.validate_inbound(_haptic_event()) is None
 
 
@@ -430,6 +442,12 @@ def test_validate_inbound_rejects_invalid() -> None:
     )
     assert "tyre_temps_c.fl requires a finite number" in (
         ep.validate_inbound(_telemetry_tick(tyre_temps_c={"fl": "hot"})) or ""
+    )
+    assert "tc_active must be a boolean" in (
+        ep.validate_inbound(_telemetry_tick(tc_active="on")) or ""
+    )
+    assert "tyre_pressures_psi.rr requires a finite number" in (
+        ep.validate_inbound(_telemetry_tick(tyre_pressures_psi={"rr": None})) or ""
     )
     assert "intensity must be <= 1" in (ep.validate_inbound(_haptic_event(intensity=1.4)) or "")
     assert "unknown type" in (ep.validate_inbound({"v": 1, "type": "explode"}) or "")

--- a/tests/test_tablet_dash_endpoint.py
+++ b/tests/test_tablet_dash_endpoint.py
@@ -127,6 +127,11 @@ def test_dash_part_d_vitals_are_bound_end_to_end() -> None:
     "core temp / pressure" over a permanently empty psi slot. Nothing failed — the page just
     quietly under-reported forever. This pins both ends together: every live vital the page
     consumes must also be emitted by the Lua producer that feeds it.
+
+    NOTE the direction: page-consumed => producer-emitted. The converse does NOT hold, and
+    asserting it would be wrong — the tick also feeds the sidecar's coaching brain (e.g.
+    `race_management._brake_advisory` consumes `brake_temps_c`, which has no dash slot). Reading
+    this guard as "the dash is the tick's only consumer" is what briefly deleted that field.
     """
     page = _TABLET_DASH_PAGE_PATH.read_text(encoding="utf-8")
     producer = (

--- a/tests/test_tablet_dash_endpoint.py
+++ b/tests/test_tablet_dash_endpoint.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import pathlib
 import re
 import socket
 from collections.abc import AsyncIterator
@@ -116,6 +117,40 @@ def test_dash_page_is_offline_kiosk_and_a133_safe() -> None:
     assert "/dash/fonts/" in body
     for name in _TABLET_DASH_FONT_FILES:
         assert (_TABLET_DASH_FONTS_DIR / name).is_file(), f"vendored font missing: {name}"
+
+
+def test_dash_part_d_vitals_are_bound_end_to_end() -> None:
+    """#531 Part D anti-dead-wiring guard.
+
+    Phase 1 shipped a dash that READ `abs_active` while no producer ever SENT it, so the
+    intervention flash could never fire, and a tyre board whose own header advertised
+    "core temp / pressure" over a permanently empty psi slot. Nothing failed — the page just
+    quietly under-reported forever. This pins both ends together: every live vital the page
+    consumes must also be emitted by the Lua producer that feeds it.
+    """
+    page = _TABLET_DASH_PAGE_PATH.read_text(encoding="utf-8")
+    producer = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src"
+        / "ac_copilot_trainer"
+        / "modules"
+        / "telemetry_publisher.lua"
+    ).read_text(encoding="utf-8")
+    samples: dict[str, object] = {
+        "tyre_pressures_psi": {"fl": 27.4, "fr": 27.6, "rl": 26.1, "rr": 26.3},
+        "tyre_wear_pct": {"fl": 0.0, "fr": 25.0, "rl": 75.0, "rr": 100.0},
+        "tc_active": True,
+        "abs_active": False,
+    }
+    for field, sample in samples.items():
+        assert field in page, f"dash page does not consume {field!r}"
+        assert f"payload.{field}" in producer, f"telemetry_publisher.lua never emits {field!r}"
+        # ...and the sidecar between them must not reject the frame carrying it: an unlisted
+        # field/type silently fails validation and never reaches the browser (the #547 lesson —
+        # a new wire contract needs the producer, the validator AND the consumer updated).
+        assert ep.validate_inbound(_tick_frame(**{field: sample})) is None, (
+            f"validator rejects {field!r}"
+        )
 
 
 def test_dash_vendored_fonts_match_canonical_copies() -> None:

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -432,6 +432,117 @@ def test_telemetry_tick_omits_rpm_max_when_missing_or_zero():
     assert out["has_lap_time"] is False
 
 
+def test_telemetry_tick_carries_wheel_vitals_and_intervention_flags():
+    """#531 Part D: the live vitals the tablet tyre board reads (pressure/brake-temp/wear) plus
+    the TC/ABS intervention flags. CSP field names are the finicky part — `tyrePressure`,
+    `discTemperature`, `tyreWear` (NOT the SimHub/ACC `brakeTemperature` spelling) — and wheels
+    are 0-BASED (FL=0..RR=3); a 1-based read silently shifts every corner (the #180 regression)."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local function wheel(psi, disc, wear)
+            return { tyrePressure = psi, discTemperature = disc, tyreWear = wear }
+          end
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 1.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+            tractionControlInAction = true, absInAction = false,
+            wheels = {
+              [0] = wheel(27.4, 310, 0.98), [1] = wheel(27.6, 312, 0.97),
+              [2] = wheel(26.1, 280, 0.99), [3] = wheel(26.3, 282, 0.96),
+            },
+          }
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
+          local p = ws._calls[1] and ws._calls[1].send.payload
+          return {
+            psi_fl = p.tyre_pressures_psi and p.tyre_pressures_psi.fl,
+            psi_rr = p.tyre_pressures_psi and p.tyre_pressures_psi.rr,
+            disc_fl = p.brake_temps_c and p.brake_temps_c.fl,
+            disc_rr = p.brake_temps_c and p.brake_temps_c.rr,
+            tc = p.tc_active, abs = p.abs_active,
+          }
+        end)()
+        """
+    )
+    assert (out["psi_fl"], out["psi_rr"]) == (27.4, 26.3)
+    # RR is read from wheels[3]: a 1-based loop would read nil here and drop the corner.
+    assert (out["disc_fl"], out["disc_rr"]) == (310, 282)
+    assert out["tc"] is True
+    assert out["abs"] is False
+
+
+def test_telemetry_tick_wear_pct_is_consumed_not_condition():
+    """CSP `tyreWear` is 0..1 wear CONSUMED (0.0 = new, growing with use), matching the wire's
+    `tyre_wear_pct` (0 = new, 100 = gone) — a plain x100, NO inversion.
+
+    Direction rig-verified 2026-07-14 across 321 lap archives (4 cars): every nonzero corner fell
+    in 0.000268..0.0720, growing from an exact 0.0 on a new set. The SDK's "from 0 to 1" is
+    direction-ambiguous, and reading it as condition-remaining inverts a NEW tyre to 100 —
+    which `race_management._tyre_advisory` turns into a "tyre wear is high" voice cue on lap one.
+    This test pins the measured direction so that inversion cannot be reintroduced.
+    """
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.0,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+            wheels = {
+              [0] = { tyreWear = 0.0 },     -- brand new (the observed value on a fresh set)
+              [1] = { tyreWear = 0.072 },   -- the worst corner seen across 321 rig archives
+              [2] = { tyreWear = 0.75 },    -- a heavily used set
+              [3] = { tyreWear = 1.0 },     -- fully consumed
+            },
+          }
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
+          local w = ws._calls[1].send.payload.tyre_wear_pct
+          return { fl = w.fl, fr = w.fr, rl = w.rl, rr = w.rr }
+        end)()
+        """
+    )
+    assert out["fl"] == 0.0  # a NEW tyre must report 0% consumed -> never trips the >=70 cue
+    assert abs(out["fr"] - 7.2) < 1e-9  # matches reference_mock.html's illustrative "7% wear"
+    assert out["rl"] == 75.0
+    assert out["rr"] == 100.0
+
+
+def test_telemetry_tick_omits_vitals_and_flags_when_car_lacks_them():
+    """Sentinel discipline: a CSP build/car with no wheel struct or no TC/ABS physics flags must
+    OMIT the keys so the dashboard renders an explicit unknown — never an empty map (which Lua
+    would serialize as `{}` and the board would read as live-but-blank) and never a defaulted
+    `false` (which would claim "present and idle" for a system the car does not have)."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local car = {
+            speedKmh = 10, rpm = 900, gas = 0, brake = 0, steer = 0,
+            gear = 1, splinePosition = 0.1, lapCount = 0,
+          }
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
+          local p = ws._calls[1].send.payload
+          return {
+            psi = p.tyre_pressures_psi ~= nil, disc = p.brake_temps_c ~= nil,
+            wear = p.tyre_wear_pct ~= nil, tc = p.tc_active ~= nil, abs = p.abs_active ~= nil,
+          }
+        end)()
+        """
+    )
+    assert out["psi"] is False
+    assert out["disc"] is False
+    assert out["wear"] is False
+    assert out["tc"] is False
+    assert out["abs"] is False
+
+
 def test_telemetry_tick_seq_resets_on_module_reset():
     rt = _runtime()
     out = rt.eval(

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -438,9 +438,10 @@ def test_telemetry_tick_carries_wheel_vitals_and_intervention_flags():
     the SimHub/ACC spellings) — and wheels are 0-BASED (FL=0..RR=3); a 1-based read silently
     shifts every corner and reads nil for RR (the #180 `rr=0` regression).
 
-    `brake_temps_c` is deliberately NOT emitted: the frozen design gives it no dashboard slot, so
-    streaming it would be a producer with no consumer — the mirror of the `abs_active`-with-no-
-    producer bug this Part fixes. Pinned here so a future edit re-adds it only with a slot.
+    `brake_temps_c` has no DASHBOARD slot but is still emitted: `race_management._brake_advisory`
+    consumes it for brake-management cues (>=650 C hot / >=850 C critical). The dash is not the
+    tick's only consumer — pinned here because it was briefly removed as "dead wiring" on exactly
+    that mistaken premise (Codex caught it on #590).
     """
     rt = _runtime()
     out = rt.eval(
@@ -465,7 +466,8 @@ def test_telemetry_tick_carries_wheel_vitals_and_intervention_flags():
           return {
             psi_fl = p.tyre_pressures_psi and p.tyre_pressures_psi.fl,
             psi_rr = p.tyre_pressures_psi and p.tyre_pressures_psi.rr,
-            has_brake_temps = p.brake_temps_c ~= nil,
+            disc_fl = p.brake_temps_c and p.brake_temps_c.fl,
+            disc_rr = p.brake_temps_c and p.brake_temps_c.rr,
             tc = p.tc_active, abs = p.abs_active,
           }
         end)()
@@ -473,9 +475,32 @@ def test_telemetry_tick_carries_wheel_vitals_and_intervention_flags():
     )
     # RR is read from wheels[3]: a 1-based loop would read nil here and drop the corner.
     assert (out["psi_fl"], out["psi_rr"]) == (27.4, 26.3)
-    assert out["has_brake_temps"] is False  # no dashboard slot -> not streamed (no dead wire)
+    assert (out["disc_fl"], out["disc_rr"]) == (310, 282)
     assert out["tc"] is True
     assert out["abs"] is False
+
+
+def test_brake_temps_have_a_real_consumer_even_though_the_dash_has_no_slot():
+    """Regression guard for a mistake made ON THIS PR.
+
+    `brake_temps_c` has no slot in `tablet_dash.html`, so a dash-only reading of the codebase
+    concludes it is dead wiring and deletes it — which silently disables
+    `race_management._brake_advisory`'s brake-management coaching cues. It happened here: a
+    reviewer flagged it, the field was removed, and Codex caught the removal.
+
+    The tick is a wire, not a dashboard feed. This pins the real consumer so "cleaning up" the
+    field requires confronting it.
+    """
+    from tools.ai_sidecar import race_management as rm
+
+    src = pathlib.Path(rm.__file__).read_text(encoding="utf-8")
+    assert '_frame_corner_map(frame, "brake_temps_c"' in src, (
+        "race_management no longer consumes brake_temps_c — re-check before changing the producer"
+    )
+    # A car with an inactive brake-thermal model reads a flat ambient ~26 C (#488). That must stay
+    # far below the cue thresholds, so streaming it can never raise a false brake cue (the mirror
+    # of the tyre_wear_pct inversion this PR fixes).
+    assert rm._BRAKE_HOT_C >= 100.0 and rm._BRAKE_CRITICAL_C > rm._BRAKE_HOT_C
 
 
 def test_telemetry_tick_wear_pct_is_consumed_not_condition():
@@ -534,13 +559,14 @@ def test_telemetry_tick_omits_vitals_and_flags_when_car_lacks_them():
           M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
           local p = ws._calls[1].send.payload
           return {
-            psi = p.tyre_pressures_psi ~= nil,
+            psi = p.tyre_pressures_psi ~= nil, disc = p.brake_temps_c ~= nil,
             wear = p.tyre_wear_pct ~= nil, tc = p.tc_active ~= nil, abs = p.abs_active ~= nil,
           }
         end)()
         """
     )
     assert out["psi"] is False
+    assert out["disc"] is False
     assert out["wear"] is False
     assert out["tc"] is False
     assert out["abs"] is False

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -433,10 +433,15 @@ def test_telemetry_tick_omits_rpm_max_when_missing_or_zero():
 
 
 def test_telemetry_tick_carries_wheel_vitals_and_intervention_flags():
-    """#531 Part D: the live vitals the tablet tyre board reads (pressure/brake-temp/wear) plus
-    the TC/ABS intervention flags. CSP field names are the finicky part — `tyrePressure`,
-    `discTemperature`, `tyreWear` (NOT the SimHub/ACC `brakeTemperature` spelling) — and wheels
-    are 0-BASED (FL=0..RR=3); a 1-based read silently shifts every corner (the #180 regression)."""
+    """#531 Part D: the live vitals the tablet tyre board reads (pressure/wear) plus the TC/ABS
+    intervention flags. CSP field names are the finicky part — `tyrePressure` / `tyreWear` (NOT
+    the SimHub/ACC spellings) — and wheels are 0-BASED (FL=0..RR=3); a 1-based read silently
+    shifts every corner and reads nil for RR (the #180 `rr=0` regression).
+
+    `brake_temps_c` is deliberately NOT emitted: the frozen design gives it no dashboard slot, so
+    streaming it would be a producer with no consumer — the mirror of the `abs_active`-with-no-
+    producer bug this Part fixes. Pinned here so a future edit re-adds it only with a slot.
+    """
     rt = _runtime()
     out = rt.eval(
         r"""
@@ -451,8 +456,8 @@ def test_telemetry_tick_carries_wheel_vitals_and_intervention_flags():
             gear = 3, splinePosition = 0.42, lapCount = 2,
             tractionControlInAction = true, absInAction = false,
             wheels = {
-              [0] = wheel(27.4, 310, 0.98), [1] = wheel(27.6, 312, 0.97),
-              [2] = wheel(26.1, 280, 0.99), [3] = wheel(26.3, 282, 0.96),
+              [0] = wheel(27.4, 310, 0.01), [1] = wheel(27.6, 312, 0.02),
+              [2] = wheel(26.1, 280, 0.03), [3] = wheel(26.3, 282, 0.04),
             },
           }
           M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
@@ -460,16 +465,15 @@ def test_telemetry_tick_carries_wheel_vitals_and_intervention_flags():
           return {
             psi_fl = p.tyre_pressures_psi and p.tyre_pressures_psi.fl,
             psi_rr = p.tyre_pressures_psi and p.tyre_pressures_psi.rr,
-            disc_fl = p.brake_temps_c and p.brake_temps_c.fl,
-            disc_rr = p.brake_temps_c and p.brake_temps_c.rr,
+            has_brake_temps = p.brake_temps_c ~= nil,
             tc = p.tc_active, abs = p.abs_active,
           }
         end)()
         """
     )
-    assert (out["psi_fl"], out["psi_rr"]) == (27.4, 26.3)
     # RR is read from wheels[3]: a 1-based loop would read nil here and drop the corner.
-    assert (out["disc_fl"], out["disc_rr"]) == (310, 282)
+    assert (out["psi_fl"], out["psi_rr"]) == (27.4, 26.3)
+    assert out["has_brake_temps"] is False  # no dashboard slot -> not streamed (no dead wire)
     assert out["tc"] is True
     assert out["abs"] is False
 
@@ -530,14 +534,13 @@ def test_telemetry_tick_omits_vitals_and_flags_when_car_lacks_them():
           M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
           local p = ws._calls[1].send.payload
           return {
-            psi = p.tyre_pressures_psi ~= nil, disc = p.brake_temps_c ~= nil,
+            psi = p.tyre_pressures_psi ~= nil,
             wear = p.tyre_wear_pct ~= nil, tc = p.tc_active ~= nil, abs = p.abs_active ~= nil,
           }
         end)()
         """
     )
     assert out["psi"] is False
-    assert out["disc"] is False
     assert out["wear"] is False
     assert out["tc"] is False
     assert out["abs"] is False

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -19,6 +19,8 @@
   Data plane (all real, never placeholdered — absent data renders an explicit unknown):
     hello {client:"tablet-dash", client_class:"browser"} -> state.subscribe
     telemetry_tick  rpm/rpm_max/gear/speed/fuel/lap_time_ms (browser-class routing, Part B)
+                    + Part D vitals: tyre_pressures_psi / tyre_wear_pct per corner,
+                      tc_active / abs_active (electronics intervention flash)
     delta           {delta_s, spline} 10 Hz            tire_temps {fl,fr,rl,rr} core degC
     lap             {lap,last_lap_ms,best_lap_ms}      session    {car_id,track_id}
     coaching.snapshot  corner/kind/target/dist/progress (coach lane, kind=="brake" takeover)
@@ -150,7 +152,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
 .tc{border:1px solid var(--edge);display:flex;align-items:baseline;gap:8px;padding:0 12px}
 .tc .tid{font-family:var(--fd);font-weight:600;font-size:10px;letter-spacing:.06em;color:var(--dim)}
 .tc .tt{font-family:var(--fr);font-weight:700;font-size:22px;font-variant-numeric:tabular-nums;color:var(--dim)}
-.tc .tp{font-family:var(--fm);font-size:13px;color:var(--dim);margin-left:auto}
+.tc .tp{font-family:var(--fm);font-size:13px;color:var(--chalk);margin-left:auto}
 /* other pages */
 .sketch{flex:1;display:flex;gap:14px;min-height:0}
 .mapmain{flex:1;position:relative;padding:8px;display:flex;align-items:center;justify-content:center}
@@ -275,10 +277,10 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       <div class="panel pad" style="flex:1"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
         <div class="mh">Tyres &middot; core temp (inner/mid/outer &mdash; Phase 2)</div>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:6px">
-          <div class="tcell"><div class="lbl" style="font-size:10px">FL</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-fl">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)">pressure &mdash; &middot; wear &mdash;</div></div>
-          <div class="tcell"><div class="lbl" style="font-size:10px">FR</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-fr">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)">pressure &mdash; &middot; wear &mdash;</div></div>
-          <div class="tcell"><div class="lbl" style="font-size:10px">RL</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-rl">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)">pressure &mdash; &middot; wear &mdash;</div></div>
-          <div class="tcell"><div class="lbl" style="font-size:10px">RR</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-rr">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)">pressure &mdash; &middot; wear &mdash;</div></div>
+          <div class="tcell"><div class="lbl" style="font-size:10px">FL</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-fl">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)" id="stp-fl">&mdash; psi &middot; &mdash; wear</div></div>
+          <div class="tcell"><div class="lbl" style="font-size:10px">FR</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-fr">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)" id="stp-fr">&mdash; psi &middot; &mdash; wear</div></div>
+          <div class="tcell"><div class="lbl" style="font-size:10px">RL</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-rl">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)" id="stp-rl">&mdash; psi &middot; &mdash; wear</div></div>
+          <div class="tcell"><div class="lbl" style="font-size:10px">RR</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-rr">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)" id="stp-rr">&mdash; psi &middot; &mdash; wear</div></div>
         </div>
       </div>
       <div class="panel pad" style="width:320px;display:flex;flex-direction:column"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
@@ -329,6 +331,11 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   }
   function setText(id, txt) {
     var el = $(id);
+    if (el && el.textContent !== txt) el.textContent = txt;
+  }
+  // Same change-gated write for an element we already hold (no id lookup) — the tyre cells
+  // resolve their spans once per corner and would otherwise need an id per span.
+  function setEl(el, txt) {
     if (el && el.textContent !== txt) el.textContent = txt;
   }
 
@@ -453,11 +460,12 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       + '</div><span class="fr">R</span></div></div>';
     return d;
   }
-  var absTileRef = null;
+  var absTileRef = null, tcTileRef = null;
   function renderElectronics() {
     var host = $("etiles");
     host.innerHTML = "";
     absTileRef = null;
+    tcTileRef = null;
     // null = never answered (WAITING). An EMPTY list is real setup data — a car/setup with
     // no exposed spinner controls — and renders the greyed NOT FITTED core tiles instead
     // (Codex P2 on PR #547).
@@ -476,7 +484,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     var map = findSpinner(sp, ["ENGINE_MAP", "ECU_MAP", "ENGINE_MODE", "MAP"]);
     var boost = findSpinner(sp, ["TURBO", "BOOST", "TURBO_ADJUSTMENT"]);
     host.appendChild(biasTile(bias));               // greyed when absent (core electronics)
-    host.appendChild(discreteTile("TC", tc, {}));   // greyed when absent
+    tcTileRef = discreteTile("TC", tc, {});         // greyed when absent
+    host.appendChild(tcTileRef);
     if (tcCut) host.appendChild(discreteTile("TC CUT", tcCut, {})); // omitted when absent
     absTileRef = discreteTile("ABS", abs, {});      // greyed when absent (GT2/GTE case)
     host.appendChild(absTileRef);
@@ -499,13 +508,15 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   function carHasAbs() {
     return !!(S.spinners && findSpinner(S.spinners, ["ABS"]));
   }
-  function flashAbs(active) {
-    // Live-intervention flash (degrades to steady brass when the producer doesn't send
-    // abs_active yet): repaint the LIT segments signal-red while ABS modulates.
-    if (!absTileRef || !absTileRef._lseg) return;
-    var cells = absTileRef._lseg.children;
-    for (var i = 0; i < absTileRef._filled; i++) {
-      var want = active ? "sig" : "f";
+  function flashTile(ref, active) {
+    // Live-intervention flash: repaint the LIT segments signal-red while the electronic
+    // modulates. Brass steady = "what I dialled"; signal transient = "what the car is doing".
+    // `active` is null when the producer sends no flag for this system (a CSP build or car that
+    // doesn't expose it) — hold steady brass rather than implying a confident "not intervening".
+    if (!ref || !ref._lseg) return;
+    var cells = ref._lseg.children;
+    for (var i = 0; i < ref._filled; i++) {
+      var want = active === true ? "sig" : "f";
       if (cells[i].className !== want) cells[i].className = want;
     }
   }
@@ -520,14 +531,26 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     if (t < 108) return { bg: "rgba(244,165,44,.16)", fg: "var(--lift)" };
     return { bg: "rgba(242,59,44,.16)", fg: "var(--brake)" };
   }
+  // Corner map off the latest tick (#531 Part D). Core temps ride their own 5 Hz `tire_temps`
+  // topic while pressure/wear ride the 20 Hz tick, so the two have INDEPENDENT freshness — a
+  // dropped tick must blank pressure without blanking a still-live temp (and vice versa).
+  function tickCorners(key) {
+    if (S.tick === null || (Date.now() - S.tickAt) >= STALE_MS) return null;
+    var m = S.tick[key];
+    return (m && typeof m === "object") ? m : null;
+  }
   function renderTyres() {
     // Same freshness contract as delta/coach: a stopped stream must not keep painting the
     // last temps as if live (Codex on PR #547).
     var fresh = S.tires !== null && (Date.now() - S.tiresAt) < STALE_MS;
+    var press = tickCorners("tyre_pressures_psi");
+    var wear = tickCorners("tyre_wear_pct");
     var corners = ["fl", "fr", "rl", "rr"];
     for (var i = 0; i < corners.length; i++) {
       var c = corners[i];
       var t = fresh ? fin(S.tires[c]) : null;
+      var p = press ? fin(press[c]) : null;
+      var w = wear ? fin(wear[c]) : null;
       var cell = $("ty-" + c);
       var col = tyreColor(t);
       if (cell._bg !== col.bg) { cell.style.background = col.bg; cell._bg = col.bg; }
@@ -535,7 +558,17 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       var txt = t !== null ? Math.round(t) + "°" : "—";
       if (tt.textContent !== txt) tt.textContent = txt;
       if (tt._fg !== col.fg) { tt.style.color = col.fg; tt._fg = col.fg; }
+      // The board's own header advertises "core temp / pressure"; until Part D the psi slot was
+      // permanently blank. Absent pressure stays an explicit em-dash, never a stale last value.
+      // Bare number + dim-when-unknown mirrors reference_mock.html's cell (the frozen ground
+      // truth): the panel header carries the unit, the 386px cell has no room to repeat it.
+      var pe = cell.children[2];
+      setEl(pe, p !== null ? p.toFixed(1) : "—");
+      var pfg = p !== null ? "" : "var(--dim)";
+      if (pe._fg !== pfg) { pe.style.color = pfg; pe._fg = pfg; }
       setText("st-" + c, t !== null ? Math.round(t) + "° core" : "—");
+      setText("stp-" + c, (p !== null ? p.toFixed(1) + " psi" : "— psi")
+        + " · " + (w !== null ? Math.round(w) + "% wear" : "— wear"));
     }
   }
 
@@ -714,7 +747,10 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
 
     renderTyres();
     renderCoach();
-    flashAbs(live && t.abs_active === true);
+    // A stale tick must not leave a system latched "intervening" (same freshness contract as the
+    // delta/coach lanes) — a dead producer reverts both boards to steady brass.
+    flashTile(tcTileRef, live ? t.tc_active === true : false);
+    flashTile(absTileRef, live ? t.abs_active === true : false);
 
     // secondary pages (cheap text writes; hidden pages cost nothing to lay out)
     setText("mapCur", live ? fmtLap(fin(t.lap_time_ms)) : "—");

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -547,7 +547,10 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
     for key in ("weather_type", "tyre_compound"):
         if key in payload and not isinstance(payload[key], str):
             return f"{key} must be a string"
-    for key in ("abs_active", "brake_lock", "wheel_lock"):
+    # #531 Part D: `tc_active` joins the `abs_active` slot so the dashboard can flash BOTH
+    # electronics tiles on intervention. Absent = the car does not expose the system (or physics
+    # is unavailable); `false` = present and idle — so these stay optional, never defaulted.
+    for key in ("tc_active", "abs_active", "brake_lock", "wheel_lock"):
         if key in payload and not isinstance(payload[key], bool):
             return f"{key} must be a boolean"
     return None


### PR DESCRIPTION
## What / why

**Part D of #531** (Phase 2). Phase 1 (PR #547) shipped a dash that **read `abs_active` while no producer ever sent it** — the electronics intervention flash could never fire — and a tyre board whose own header advertised *"core temp / pressure"* over a **permanently empty psi slot**. `DESIGN_SPEC.md` §6/§11 flags exactly this: *"confirm which the Lua producer actually sends vs the validator merely accepts."* Nothing failed; the board just quietly under-reported forever.

This wires the live vitals end-to-end: **producer → validator → dash**.

## The wear-scale bug this caught (rig-verified, not assumed)

CSP's SDK documents `ac.StateWheel.tyreWear` only as *"Tyre wear, from 0 to 1"* — **direction-ambiguous**. Read as CONDITION-remaining (1.0 = new) it inverts a fresh set to `100`, and `race_management._tyre_advisory` fires **"tyre wear is high"** — which carries a **voice cue** — at `>= 70`. So a fresh set would announce high wear on lap one, every lap.

I measured instead of guessing, against **321 checked-in lap archives across 4 cars** (911 GT3 R, Ferrari 488 GT3, Huracán GT3, `function_0xff`):

| Signal | Observed |
|---|---|
| `tyreWear` corner-columns | 340 present, **36 ever nonzero** |
| every nonzero value | **0.000268 … 0.0720**, growing from an exact `0.0` |
| ⇒ semantics | **wear CONSUMED** (0 = new) → plain `×100`, **no inversion** |

`0.072 → 7.2%` also matches `reference_mock.html`'s illustrative *"7% wear"*. The inverted build was **reproduced live on the rig** emitting `tyre_wear_pct = 100` on new tyres before the fix landed (evidence below). A test now pins the measured direction so it cannot be reintroduced.

## Changes

**Producer** (`telemetry_publisher.lua`) — `tyre_pressures_psi` / `brake_temps_c` / `tyre_wear_pct` per corner + `tc_active` / `abs_active`, read through the shared `wheel_read` accessors so the finicky parts keep one source of truth:
- CSP's **real** field names: `tyrePressure` / `discTemperature` / `tyreWear`. The SimHub/ACC spelling `brakeTemperature` **does not exist** in this SDK and would have read `nil` forever — an empty board with no error.
- **0-based** wheel order (a 1-based read shifts every corner — the #180 `rr=0` regression).
- `tractionControlInAction` / `absInAction` are *"Physics-only"* per the lua-sdk stubs, so a non-boolean read **omits** the key: missing = unknown, `false` = present and idle.

**Validator** — `tc_active` joins the `abs_active` boolean slot (optional, never defaulted).

**Client** (`tablet_dash.html`)
- The psi slot the header promises is now written — **bare number, dim when unknown**, per `reference_mock.html` (the frozen ground truth); the 386 px cell has no room to repeat the unit the panel header already carries.
- STINT's **hardcoded** `pressure — · wear —` markup is bound to real values in the mock's own format (`27.6 psi · 4% wear`).
- `flashAbs` → `flashTile`, wired for **both** tiles; a stale tick reverts both boards to steady brass rather than latching "intervening".
- Pressure/wear ride the 20 Hz tick while core temps ride the 5 Hz `tire_temps` topic → **independent freshness**: a dropped tick blanks psi without blanking a live temp.

## Live rig evidence (911 GT3 R @ Magione, AG_PC, P7 on `adb reverse`)

Browser-class WS peer, real trainer, real sim:

```
tyre_pressures_psi = {fl: 16.407, fr: 16.404, rl: 16.457, rr: 16.450}   REAL
brake_temps_c      = {fl: 26, fr: 26, rl: 26, rr: 26}                   flat ambient
tyre_wear_pct      = {fl: 100, ...}   <-- the inversion, caught live pre-fix
tc_active = False   abs_active = False   rpm_max = 9000                 REAL
```

**On the P7 in Fully Kiosk**: the tyre board renders live per-corner **psi** (`FL 16.3 / FR 16.3 / RL 16.3 / RR 16.3`) where it was permanently blank; car-adaptive electronics still correct from the real 911 schema (`BRAKE BIAS 68.0%`, `TC 3/12`, `ABS 8/12`, **no** TC-CUT / MAP tile), redline `900 / 9000`. Harness drive `ok=true`, 2 laps, 199.8 km/h, 5130 m, 0 recoveries.

## `brake_temps_c` — streamed (it has a consumer that is not the dash)

Corrected mid-review. The self-hosted reviewer called this dead wiring (MEDIUM); I removed it in `8daf5e9`; **Codex caught that as a regression** and it was right — restored in `def338e`.

```
tools/ai_sidecar/race_management.py:155   brake = self._brake_advisory(frame, lap)
tools/ai_sidecar/race_management.py:344   temps = _frame_corner_map(frame, "brake_temps_c", ...)
```

`_brake_advisory` raises brake-management **coaching cues** at `>= 650 °C` / `>= 850 °C`. Removing the field silently disabled them. **My error:** I inferred "no consumer" from the *dashboard* having no slot and never grepped the sidecar — the tick is a **wire**, not a dashboard feed.

It has no RACE/STINT cell (the frozen design gives it none) and it reads a flat ambient **26 °C** on the 911 GT3 R (#488 caveat, re-observed live; only 32/340 archive columns ever vary >1 °C) — but that is **far below 650**, so it raises **no false cue**. Contrast `tyre_wear_pct`, where the wrong value *did* cross its threshold (100 ≥ 70). Two guards now pin the consumer and the threshold headroom.
## Tests

- lupa producer coverage: vitals + flags, **wear direction** (pins the measured scale), omit-when-absent (sentinel discipline).
- validator accept/reject incl. `tc_active`.
- **anti-dead-wiring guard** pinning page ↔ producer ↔ validator together, so a field the dash reads can never again be one nobody sends.

`make ci-fast`: **OK** (2920 passed, 73 skipped).

## Scope

Part D's fuel-per-lap / laps-remaining / **predicted-lap** fields are **not** in this PR — the dash already computes burn client-side from lap boundaries (live-verified in Phase 1: *18.4 laps left · 2.61 L/lap*), so that half is a separate, non-overlapping change on the same files. Called out on #531 rather than silently dropped.

Refs #531


