### PR TITLE
docs(vault): #531 Part D delivered + live-proven, post-merge handoff for PR #590

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -4,6 +4,7 @@ status: active
 memory_tier: canonical
 last_updated: 2026-07-15T02:40:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-582-l3-corner-refinement-2026-07-14.md

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -4,6 +4,7 @@ status: active
 memory_tier: canonical
 last_updated: 2026-07-15T03:05:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-569-frozen-build-identity-bake-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-582-l3-corner-refinement-2026-07-14.md
@@ -90,6 +91,70 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-07-15) — #531 Part D live tyre vitals + TC/ABS (PR #590 MERGED `432c8b4`)
+
+Detail + all rig facts: [[issue-531-partd-live-vitals-2026-07-14]].
+
+Phase 1 shipped a dash that **read `abs_active` while no producer ever sent it** (the intervention
+flash could never fire) and a tyre board whose own header advertised *"core temp / pressure"* over a
+**permanently empty psi slot**. Part D wires the vitals end-to-end: `tyre_pressures_psi`,
+`brake_temps_c`, `tyre_wear_pct` + `tc_active`/`abs_active` on `telemetry_tick`; psi rendered on the
+RACE board; STINT's hardcoded `pressure — · wear —` bound to real values; `flashAbs` generalised to
+`flashTile` for both tiles.
+
+**The bug this caught (measured, not reasoned).** CSP documents `tyreWear` only as *"from 0 to 1"* —
+direction-ambiguous. Read as condition-remaining (1.0 = new) it inverts a fresh set to `100`, and
+`race_management._tyre_advisory` fires **"tyre wear is high"** — with a **voice cue** — at `>= 70`.
+Settled against **321 checked-in lap archives, 4 cars**: every nonzero corner ∈ `0.000268..0.0720`,
+growing from an exact `0.0` ⇒ **wear CONSUMED**, plain ×100, no inversion. The inverted build was
+**reproduced live** emitting `tyre_wear_pct = 100`; post-fix the same peer/car reads `{fl:0,...}`.
+
+**A mistake worth remembering.** I removed `brake_temps_c` as "dead wiring" on a reviewer's MEDIUM —
+both of us reasoned only from the dashboard having no slot. **Codex caught the regression:**
+`race_management._brake_advisory` (`race_management.py:344`) consumes it for brake cues at 650/850 °C.
+Restored in `def338e`. **Durable rule: `telemetry_tick` is a WIRE, not a dashboard feed** — grep
+`tools/ai_sidecar/` before deleting any tick field. Two guards now pin the consumer + the threshold
+headroom. Second-order: a bot finding is a *claim to check*, not a fact — the two reviewers
+contradicted each other and the live code decided it.
+
+**Acceptance criteria CLOSED this session** (live on the P7, both cars driven at Magione):
+
+| Tile | 911 GT3 R | **bmw_m3_gt2** |
+|---|---|---|
+| ABS | `8/12` | **greyed → `NOT FITTED`** (never `0/0`) |
+| TC | `3/12` | **`3/13`** — real range `0..12` ⇒ denominator **13** |
+| BIAS | `68.0%` | `66.0%` |
+| `rpm_max` | `9000` | **`8750`** |
+
+⇒ **car-adaptive electronics (MUST)** and **rpm-banded shift LEDs** are now verified. The denominator
+genuinely differs per car — a hardcoded `/12` would have been silently wrong on the M3 GT2.
+
+**Still open on #531:** the **intervention flash was never seen firing** — `tc_active`/`abs_active`
+emit real booleans live (`false`, not omitted, which proves the CSP field names resolve) but never
+`true`; `--driver ggv` is a flat-out *optimal* driver that may never lock/spin. Then Part D's
+**fuel-per-lap / laps-remaining / predicted-lap** half (deliberately not in #590 — the dash already
+computes burn client-side), and Parts E–I.
+
+**Rig lore (cost real time this session):**
+- **AC pauses when it loses focus** → `dt≈0` → the publisher's accumulator stalls and ticks collapse
+  (**1 tick / 18 s** observed); the dash then correctly shows WAITING. Live tablet captures must be
+  taken **during** a drive — and a side-channel WS peer saw ~0 ticks mid-drive while getting 347 with
+  AC idle, so drive the capture from **inside** the harness run.
+- **The AC user dir is OneDrive-redirected** (`C:\Users\arsen\OneDrive\Documents\Assetto Corsa`).
+  The **321 lap archives** there are a cheap, decisive ground-truth source needing **no AC launch** —
+  they settled the wear scale. Use `auto_drive.resolve_ac_user_dir()`; guessing `Documents/…` finds
+  nothing.
+- **`acs.exe` died in 2 of 5 runs** at ~20 m with identical code; immediate retries drove clean. Sim
+  death is a **flake** — retry before suspecting the diff.
+- Phase 1's `.scratch/dash_feeder.py` (Phase-1 node called it *"reusable for Part F"*) **is gone** —
+  gitignored `.scratch/`. Part F must rebuild it; promote it out of `.scratch/` next time.
+- **`post_merge_sync.sh` requires HEAD=main** and `main` was checked out in another session's
+  worktree (`.codex/worktrees/81f5`) → `sync` and `vault` both failed (exit 20). Vault shipped by
+  branching `vault/post-merge-pr590` from `origin/main` instead — same end-state, no gate bypassed.
+  It also **stashed the untracked vault node** as `post-merge-pr590-wip`; recovered via
+  `git stash apply`. Stash residue from older sessions (`post-merge-pr441-wip`,
+  `post-merge-pr417-detached-residue`) is still sitting in the list.
 
 ## Delivered (2026-07-15) — #569 frozen-EXE build identity CLOSED (PR #586 MERGED `8a895ee`)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
@@ -1,0 +1,179 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-07-14
+updated: 2026-07-14
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/531
+relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-531-phase1-tablet-dash-2026-07-13.md
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+---
+
+# #531 Part D — live tyre vitals + TC/ABS intervention (PR #590)
+
+## The gap Phase 1 left (silent, not failing)
+
+Phase 1 shipped a dash that **read `abs_active` while no producer ever sent it** — the
+electronics intervention flash could never fire — and a tyre board whose own header
+advertised *"core temp / pressure"* over a **permanently empty psi slot**. The STINT page
+carried a hardcoded `pressure — · wear —` string bound to nothing. Nothing errored; the
+board just under-reported forever. `DESIGN_SPEC.md` §6/§11 had already flagged the shape of
+this: *"confirm which the Lua producer actually sends vs the validator merely accepts."*
+
+**Durable lesson:** the validator accepting a field is not evidence anything emits it. A new
+wire contract needs **producer + validator + consumer** updated together (the #547 lesson,
+re-learned). PR #590 adds a test pinning page ↔ producer ↔ validator so a field the dash
+reads can never again be one nobody sends.
+
+## CSP field names — verified on-disk, not recalled
+
+Read from this rig's `extension/internal/lua-sdk/ac_apps/lib.lua` (`ac.StateWheel` /
+`ac.StateCar`), not from memory:
+
+| Vital | CSP field | Note |
+|---|---|---|
+| tyre pressure | `tyrePressure` | dynamic/hot; `tyreStaticPressure` is the cold set value |
+| brake temp | **`discTemperature`** | **NOT** `brakeTemperature` — that SimHub/ACC spelling does not exist and reads nil forever |
+| tyre wear | `tyreWear` | 0..1, direction ambiguous in the SDK — see below |
+| TC/ABS intervention | `tractionControlInAction` / `absInAction` | both *"Physics-only"* → omit key when not a boolean |
+
+## The wear-scale trap (the important finding)
+
+CSP documents `tyreWear` only as *"Tyre wear, from 0 to 1"*. Read as **CONDITION-remaining**
+(1.0 = new) the producer inverts a fresh set to `100`, and
+`race_management._tyre_advisory` fires **"tyre wear is high"** — carrying a **voice cue** —
+at `>= 70`. Every lap on new tyres would announce high wear.
+
+**Measured, not assumed** — 321 checked-in lap archives, 4 cars (911 GT3 R, 488 GT3,
+Huracán GT3, `function_0xff`):
+
+- 340 `tyreWear` corner-columns present; **36 ever nonzero**.
+- Every nonzero value ∈ **0.000268 … 0.0720**, growing from an exact `0.0`.
+- ⇒ **wear CONSUMED** (0 = new) → plain `×100`, **no inversion**. `0.072 → 7.2%` also matches
+  `reference_mock.html`'s illustrative *"7% wear"*.
+
+The inverted build was **reproduced live** on the rig emitting `tyre_wear_pct = 100` on new
+tyres; after the fix the same peer/car reads `{fl:0, fr:0, rl:0, rr:0}`. A lupa test pins the
+measured direction.
+
+> Even after 2 hard laps (199.8 km/h, 5130 m) `tyreWear` stayed exactly `0.00000` while
+> pressure and core temp varied realistically — so "0" is the normal reading on a fresh set,
+> not a dead channel (other sessions do populate it).
+
+## `brake_temps_c` — the mistake I made, and the durable rule from it
+
+Reads a **flat ambient 26 °C** on the 911 GT3 R across a full hard lap — reproducing the
+#488 caveat already documented in `wheel_read.brakeTemp`. Across the same 321 archives only
+**32/340** columns ever vary >1 °C (range 26 → 40 °C). Car/session-dependent, **not a capture
+bug**. The frozen design defines **no RACE/STINT slot** for it.
+
+**The error:** from "the dashboard has no slot" I concluded "nothing consumes it" and, when the
+self-hosted reviewer flagged it as dead wiring (MEDIUM), I **removed it** — without ever
+grepping the sidecar. Codex caught the regression:
+
+```
+race_management.py:155   brake = self._brake_advisory(frame, lap)
+race_management.py:344   temps = _frame_corner_map(frame, "brake_temps_c", "brake_temp_c")
+```
+
+`_brake_advisory` raises brake-management **coaching cues** at `_BRAKE_HOT_C = 650` /
+`_BRAKE_CRITICAL_C = 850`. The removal silently disabled them. Restored in `def338e`.
+
+> **Durable rule: the `telemetry_tick` is a WIRE, not a dashboard feed.** Its consumers are the
+> tablet dash **and** the sidecar's coaching brain (`race_management`). "The dash has no slot"
+> is *not* evidence a field is unused — grep `tools/ai_sidecar/` before deleting any tick field.
+> The anti-dead-wiring guard's direction is **page-consumed ⇒ producer-emitted**; the converse
+> does **not** hold. Two tests now pin `race_management`'s consumption and the threshold headroom.
+
+Streaming it is safe on cars with no brake model: 26 °C is far below 650, so **no false cue** —
+the opposite of the `tyre_wear_pct` inversion, where the wrong value *did* cross its threshold.
+
+**Second-order lesson:** I acted on a reviewer's premise without verifying it. A bot finding is a
+*claim to check*, not a fact — the same discipline the wear scale needed. Two reviewers
+contradicted each other here; the live code decided it, not their authority.
+
+## Rig lore learned this session
+
+- **AC pauses when it loses focus** → `dt≈0` → the publisher's `_due()` accumulator stalls and
+  the tick rate collapses (observed: **1 tick / 18 s**), so the dash correctly shows WAITING.
+  **A live tablet capture must be taken DURING a harness drive**, not after it.
+- **AC user dir is OneDrive-redirected** here: `C:\Users\arsen\OneDrive\Documents\Assetto Corsa`.
+  Lap archives live under `…/cfg/extension/state/lua/app/AC_Copilot_Trainer/ac_copilot_trainer/journal/laps`
+  (321 of them) — a cheap, decisive ground-truth source that needs no AC launch. Use
+  `auto_drive.resolve_ac_user_dir()`; guessing `Documents/…` finds nothing.
+- **`acs.exe` died once at 20 m** with identical code; an immediate retry drove a clean lap
+  (`ok=true`, 133.264 s). Sim death here is a **flake** — retry before suspecting the diff.
+- The **app junction** (`apps/lua/AC_Copilot_Trainer`) served the *primary* checkout, which is
+  parked on another session's branch. It was repointed to this worktree for verification and
+  **must be restored** — running a stale trainer is exactly #575.
+- Phase 1's `.scratch/dash_feeder.py` — which the #531 Phase-1 node called "reusable for
+  Part F" — **is gone**, having lived in gitignored `.scratch/`. The disposability pitfall is
+  real: promote durable tooling out of `.scratch/` or it does not survive the session.
+
+## Verified (observed, live)
+
+Browser-class WS peer + real trainer + real sim (911 GT3 R @ Magione, AG_PC):
+
+```
+tyre_pressures_psi = {fl: 17.37, fr: 17.33, rl: 17.72, rr: 17.64}   REAL, varying
+tyre_wear_pct      = {fl: 0, fr: 0, rl: 0, rr: 0}                   FIXED (was 100)
+brake_temps_c      = {fl: 26, fr: 26, rl: 26, rr: 26}               flat ambient
+rpm_max = 9000                                                      real 911 redline
+```
+
+On the P7 in Fully Kiosk the tyre board renders live per-corner **psi** where it was
+permanently blank; car-adaptive electronics still correct from the real 911 schema
+(`BRAKE BIAS 68.0%`, `TC 3/12`, `ABS 8/12`, **no** TC-CUT/MAP tile). Harness drives:
+`ok=true`, 2 laps @ 199.8 km/h / 5130 m, and `ok=true`, 1 lap 133.264 s.
+
+`make ci-fast` OK (2921 passed, 73 skipped).
+
+## Car-swap acceptance criterion — PASSED (closed this session)
+
+Open since Phase 1. Both cars driven at Magione, tablet on `adb reverse`, electronics from
+`ac.getSetupSpinners()` — no hardcoded ranges.
+
+| Tile | 911 GT3 R | **bmw_m3_gt2** |
+|---|---|---|
+| ABS | `8/12` | **greyed → `NOT FITTED`** (never `0/0`) |
+| TC | `3/12` | **`3/13`** — real range `0..12 step 1` ⇒ denominator **13** |
+| BRAKE BIAS | `68.0%` | `66.0%` (range `52..80`) |
+| TC-CUT / MAP / BOOST | absent | absent |
+| `rpm_max` | `9000` | **`8750`** |
+| fuel capacity | 120 L | 110 L |
+
+> **The denominator genuinely differs between cars (12 vs 13).** A hardcoded `/12` would have
+> been silently wrong on the M3 GT2 — this is precisely why the design forbids hardcoding, and
+> the first live proof of it. `bmw_m3_gt2` IS installed on this rig and is the exact no-ABS car
+> `reference_mock.html` toggles to; its live schema has **no `ABS` section at all** (63 sections).
+
+Also closes: **RACE hero shift LEDs rpm-banded from real `rpm_max`** (9000 vs 8750, both from
+CSP `car.rpmLimiter`).
+
+## NOT verified (stated so the next session doesn't assume it)
+
+**`tc_active` / `abs_active` were never observed `true`** — only `false`. That still proves the
+CSP field names resolve (a wrong name degrades to nil and the key would be **omitted**; the keys
+are present with a real boolean), but the **intervention flash was never seen firing**. Two
+reasons it stayed out of reach this session:
+
+1. `--driver ggv` is a **flat-out friction-circle optimal** driver — it may legitimately never
+   lock a wheel or spin one, so ABS/TC may simply never engage.
+2. Every attempt to tap the WS **during** a drive returned ~0 ticks (`maxspd=0.0`) while the same
+   peer got 347 ticks with AC idle — consistent with the focus/pause effect above. A future
+   attempt should drive the capture from **inside** the harness run rather than a side-channel WS
+   peer, or use a driver that deliberately provokes lock-up.
+
+Also unverified: the **car-swap acceptance criterion** (`bmw_m3_gt2` IS installed — the exact
+no-ABS car the mock uses for `ABS — NOT FITTED`), and `acs.exe` died in 2 of 5 runs (flake; an
+immediate retry drove clean both times).
+
+## Remaining on #531
+
+Part D's **fuel-per-lap / laps-remaining / predicted-lap** fields are NOT in PR #590 — the
+dash already computes burn client-side from lap boundaries (Phase-1 live-verified:
+*18.4 laps left · 2.61 L/lap*), so that half is a separate non-overlapping change on the same
+files. Then Parts E (shift cue + `audio_routing`), F (COACH/MAP/STINT depth + the I/M/O
+spread this PR's STINT binding leaves for later), G (native-audio latency gate), H (SimHub
+fusion, optional), I (mic upstream). Water/oil temp stays DATA-GATED.


### PR DESCRIPTION
Post-merge vault handoff for **PR #590** (#531 Part D — live tyre vitals + TC/ABS intervention), merged `432c8b4`.

Diff is strictly under `docs/01_Vault/**`.

**New node:** `03_Investigations/issue-531-partd-live-vitals-2026-07-14.md` — linked from `Next Session Handoff.md` and `Current Focus.md`.

Records the durable findings, not just the shipping status:

- **The `tyreWear` scale trap.** CSP's *"from 0 to 1"* is direction-ambiguous; read as condition-remaining it inverts a fresh set to `100` and `race_management._tyre_advisory` fires a false **"tyre wear is high"** *voice* cue at `>= 70` — every lap. Settled against **321 checked-in lap archives / 4 cars**: wear CONSUMED, plain ×100, no inversion. Reproduced live pre-fix (`100`), verified post-fix (`0`).
- **`telemetry_tick` is a WIRE, not a dashboard feed.** `race_management._brake_advisory` consumes `brake_temps_c` despite no dash slot. I removed the field as "dead wiring" on a dash-only reading (mine and a reviewer's) and Codex caught the regression — recorded as a mistake, with the rule and two guards.
- **Car-swap criterion CLOSED**: 911 (ABS `8/12`, TC `3/12`, redline `9000`) vs `bmw_m3_gt2` (**ABS NOT FITTED**, TC `3/13`, redline `8750`). The denominator genuinely differs per car.
- **Rig lore:** AC pauses when unfocused → tick collapses to **1 / 18 s** (capture *during* a drive); the AC user dir is **OneDrive-redirected** and its 321 lap archives are cheap ground truth needing no AC launch; `acs.exe` death is a **flake** (2/5 runs — retry before suspecting the diff); Phase 1's `.scratch/dash_feeder.py` is **gone** (gitignored scratch).
- **Honest gap recorded:** the TC/ABS intervention flash was never observed firing.

**Process note for the next steward:** `post_merge_sync.sh` requires `HEAD=main`, but `main` was checked out in another session's worktree (`.codex/worktrees/81f5`), so both `sync` and `vault` exited 20. This branch was cut from `origin/main` instead — same end-state, no gate bypassed (no push to main, docs-only scope). `sync` also stashed the untracked vault node as `post-merge-pr590-wip` (recovered); older stash residue `post-merge-pr441-wip` / `post-merge-pr417-detached-residue` is still in the list.
