### PR TITLE
docs(vault): #575 stale-app-junction delivered + live-proven, post-merge handoff for PR #587

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,8 +2,9 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-15T02:40:00Z
+last_updated: 2026-07-15T05:10:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-575-stale-app-junction-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
   - AcCopilotTrainer/00_System/Next Session Handoff.md
   - AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
@@ -35,7 +36,23 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
-**Delivered (2026-07-15, latest):** [#570](https://github.com/agorokh/ac-copilot-trainer/issues/570)
+**Delivered (2026-07-15, latest):** [#575](https://github.com/agorokh/ac-copilot-trainer/issues/575)
+**CLOSED** by PR [#587](https://github.com/agorokh/ac-copilot-trainer/pull/587)
+([`b51e1d5`](https://github.com/agorokh/ac-copilot-trainer/commit/b51e1d5)) — harness preflight now
+detects a **stale AC app junction**: it compares the installed trainer app against the harness's own
+`src/ac_copilot_trainer` by **content digest** (not commit — two checkouts can share a HEAD and still
+differ), measured **under the rig lock**, and records `extras.run.app_install` in every evidence
+bundle. Four states (`match`/`drift`/`absent`/`unverifiable`); `--strict-app-version` fails on drift +
+unverifiable, never on absent. With [#569](https://github.com/agorokh/ac-copilot-trainer/issues/569)
+(`8a895ee`) the stale-build problem is now closed on **both** halves — frozen EXE and Lua app.
+
+**Live-proven, and still true:** the rig junction moved **three times during that session** (primary →
+#531's worktree carrying an uncommitted `telemetry_publisher.lua` edit → restored), with both
+worktrees at the **same commit**. The junction is volatile shared state; do not repoint it while
+another session owns the rig ([#555](https://github.com/agorokh/ac-copilot-trainer/issues/555)).
+Detail: [issue-575-stale-app-junction-2026-07-15.md](../03_Investigations/issue-575-stale-app-junction-2026-07-15.md).
+
+**Previously delivered (2026-07-15):** [#570](https://github.com/agorokh/ac-copilot-trainer/issues/570)
 **CLOSED** by PR [#585](https://github.com/agorokh/ac-copilot-trainer/pull/585)
 ([`2dbf7d8`](https://github.com/agorokh/ac-copilot-trainer/commit/2dbf7d8)) — the sidecar's
 `/health` endpoint advertisement is now **derived** from the `server._ROUTES` registry that also

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-15T03:05:00Z
+last_updated: 2026-07-15T05:10:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-575-stale-app-junction-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-569-frozen-build-identity-bake-2026-07-14.md
   - AcCopilotTrainer/03_Investigations/issue-570-route-registry-2026-07-15.md
@@ -91,6 +92,39 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-07-15) — #575 stale AC app junction detection (PR #587 MERGED `b51e1d5`)
+
+Issue [#575](https://github.com/agorokh/ac-copilot-trainer/issues/575) **CLOSED**. `preflight()` in
+`tools/ac_harness/auto_drive.py` now compares the AC-installed trainer app against the harness's own
+`src/ac_copilot_trainer` and records `extras.run.app_install` in every evidence bundle. Detail:
+[issue-575-stale-app-junction-2026-07-15.md](../03_Investigations/issue-575-stale-app-junction-2026-07-15.md).
+
+**Four provenance states** — `match` / `drift` / `absent` / `unverifiable`. Warning by default;
+`--strict-app-version` (passed through both `auto_alien` stages) fails on `drift` + `unverifiable`
+but **not** `absent` (nothing installed can run the wrong code). Verdict is a **content digest**, not
+a commit compare, and it is measured **under the rig lock**.
+
+**With [#569](https://github.com/agorokh/ac-copilot-trainer/issues/569) (PR #586 `8a895ee`, CLOSED
+02:57Z) the stale-build problem is closed on both halves** — the frozen Game Point EXE bakes
+`build_commit`, and the Lua app junction now asserts its provenance. Both artifacts the rig executes
+can say which build they are.
+
+**Three things worth carrying forward:**
+
+1. **The rig junction is volatile shared state.** It moved **three times during that one session** —
+   primary checkout → #531's worktree (carrying an *uncommitted* `telemetry_publisher.lua` edit) →
+   restored. Both worktrees sat at the **same commit**, so a `git rev-parse HEAD` compare (the
+   issue's own suggested implementation) would have reported "up to date". Only the content digest
+   caught it. Do not repoint the junction while another session owns the rig
+   ([#555](https://github.com/agorokh/ac-copilot-trainer/issues/555)).
+2. **Any read of shared rig state that gates a decision or lands in evidence belongs under the rig
+   lock.** Provenance was first measured pre-lock; two reviewers independently caught the TOCTOU. The
+   precedent already existed one block below (plant/line resolution is post-lock for the same reason).
+3. **False-drift normalization matters more than detection.** The first draft reported drift on the
+   real rig twice for benign reasons (`__pycache__` inside the app tree; `*.bat text eol=crlf` making
+   `start_sidecar.bat` differ at an identical commit). A check that cries wolf is worse than none —
+   it trains the operator to ignore the one time it is real.
 
 ## Delivered (2026-07-15) — #531 Part D live tyre vitals + TC/ABS (PR #590 MERGED `432c8b4`)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/_index.md
@@ -2,7 +2,7 @@
 type: index
 status: active
 created: 2026-04-08
-updated: 2026-07-14
+updated: 2026-07-15
 relates_to:
   - AcCopilotTrainer/00_System/Next Session Handoff.md
 ---
@@ -13,6 +13,7 @@ Technical deep-dives and root-cause analyses from development sessions.
 
 | Node | Summary |
 |------|---------|
+| [issue-575-stale-app-junction-2026-07-15.md](issue-575-stale-app-junction-2026-07-15.md) | **#575 CLOSED** by PR #587 (`b51e1d5`) — harness preflight detects a stale AC app junction: the installed Lua app is compared to the harness's own `src/ac_copilot_trainer` by **content digest** (not commit — two checkouts can share a HEAD and still differ), measured **under the rig lock** (TOCTOU caught by two reviewers), recorded as `extras.run.app_install`. Four states `match`/`drift`/`absent`/`unverifiable`; `--strict-app-version` fails on drift+unverifiable, never on absent. False-drift normalizations found by running it against the real rig: `__pycache__` in the app tree, and `*.bat text eol=crlf` making `start_sidecar.bat` differ at an identical commit. **Live true positive:** the junction moved 3× in one session (a peer worktree repointed it at #531's tree with an uncommitted `telemetry_publisher.lua` edit, then restored) — same commit both sides, so a HEAD compare would have missed it. With #569 (`8a895ee`) the stale-build problem is closed on both halves (frozen EXE + Lua app). |
 | [issue-582-l3-corner-refinement-2026-07-14.md](issue-582-l3-corner-refinement-2026-07-14.md) | **#582 CLOSED** by PR #583 (`b2ef740`) — EPIC #529 Layer 3 (the #577 item-3 follow-up): `corner_refine.py` relaxes measured low-variance grip bins from the 1.96-z LCB toward the posterior mean (hard z=1.0 stability floor), boundary-pinned per-corner interior re-solve, named per-corner reverts, refined profile rides the same artifact/provenance/verify gates. Live merged-main proof: `auto-alien: OK`, 107.0→101.7→**96.621 s**, all 7 Magione corners honestly reverted (no measured corner-speed lateral bins yet), iter-2 refit → provenance-gated line rebuild fired live. Gain unlocks as self-play flips corner-speed bins to measured. |
 | [issue-577-alien-selfplay-2026-07-14.md](issue-577-alien-selfplay-2026-07-14.md) | **#577 CLOSED** by PR #579 (`5b8fe0a`) — EPIC #529 P3: `auto_drive --laps N` flying-lap windows + `auto_alien --iterations K` progressive-envelope self-play (refine from own valid batch → provenance-gated rebuild → bounded scale ladder, keep-last-valid falsification). Live rig proof 92.567 s Magione, strictly monotonic ladder, all laps AC-valid. Item 3 (L3) shipped separately as #582. |
 | [issue-572-alien-pipeline-2026-07-14.md](issue-572-alien-pipeline-2026-07-14.md) | **#572 CLOSED** by PR #573 (`dfd4b7e`) — EPIC #529 P2: one-button alien pipeline. `python -m tools.ac_harness.auto_alien` composes handshake→plant-ID→min-curvature line QP→QSS→drive; per-combo line cache keyed by plant identity + fit/fast_lane content hashes, content-revalidated (corridor + envelope) on every hit; shared `plant_ready_for_full_consumption` gate across all three consumers. Live rig PASS through the unmodified path: AC-valid lap, 200.2 km/h, zero recoveries; optimized line −1.76 s QSS vs stock on Magione. Next: G1 on unseen combos. |

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-575-stale-app-junction-2026-07-15.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-575-stale-app-junction-2026-07-15.md
@@ -1,0 +1,162 @@
+---
+type: investigation
+status: active
+memory_tier: canonical
+created: 2026-07-15
+updated: 2026-07-15
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/575
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/00_System/glossary/install-paths.md
+---
+
+# Issue #575 — detect a stale AC app junction (harness preflight)
+
+## Summary
+
+The trainer app is installed as a junction
+(`<ac_root>/apps/lua/AC_Copilot_Trainer` -> `<checkout>/src/ac_copilot_trainer`) while the harness
+runs from its **own** checkout (usually a worktree). Nothing detected when the two disagreed, so the
+rig silently executed app code the harness never saw. `preflight()` in
+`tools/ac_harness/auto_drive.py` now compares the installed tree against the harness's own
+`src/ac_copilot_trainer` and records `extras.run.app_install` in the evidence bundle.
+
+Delivered by PR [#587](https://github.com/agorokh/ac-copilot-trainer/pull/587).
+
+## Root cause of the original damage (EPIC #529 G1, 2026-07-14)
+
+The junction target sat at `73ebe82` (PR #492, 2026-07-03 — ten days stale). Lap archives were
+written with `car: "function_0xff"` (the callable-surface class #543 fixed), and a handshake run
+produced **zero** valid lap archives, so the #543 friction fit could not promote and the #572
+one-button pipeline correctly FAILed after an otherwise-clean 2-lap session. Hand-fixed that session
+by detaching the primary checkout at the merged tip — but a hand-sync is not detection.
+
+## Design: content digest, not a commit compare
+
+Two checkouts can share a `HEAD` and still differ (dirty tree), and a junction may point at a non-git
+export. So the **verdict is a content digest**; commits ride along as human-readable provenance so the
+warning can name both versions.
+
+**This choice was vindicated live** (see the true positive below): a concurrent session's worktree
+sat at the *same commit* as ours while carrying an uncommitted Lua edit. The commit-compare the issue
+originally proposed (`git rev-parse HEAD` on both sides) would have reported "up to date" and missed
+it entirely.
+
+`PreflightIssue` gained `severity` (default `"error"`, so every pre-#575 check stays fatal).
+
+## Provenance is FOUR states, because strictness must split "unknown"
+
+PR #587 review (Codex P2) caught that `--strict-app-version` promoted every `app_version` row to
+fatal while the dataclass docstring claimed unknown never fails — code and docs disagreed. The
+reviewer proposed gating on `drift` only; a Council pass (dissent 0.5) found a better resolution:
+**"unknown" conflated two states with opposite risk profiles** ("presence vs identity").
+
+| status | meaning | default | `--strict-app-version` |
+|---|---|---|---|
+| `match` | content equal | pass | pass |
+| `drift` | proven different | warn | **fail** |
+| `absent` | no app installed | warn | **pass** |
+| `unverifiable` | app installed, version not establishable | warn | **fail** |
+
+- **`absent`** — nothing installed can run the wrong code; a rig that doesn't run the Lua app is a
+  legitimate config and must not be bricked by the flag.
+- **`unverifiable`** — an app *is* installed but can't be compared (unreadable tree; harness has no
+  source). Strict fails: a flag whose purpose is evidence integrity must not go green on "something
+  is installed and I cannot tell what" — that is the silent false-confidence failure #575 exists to
+  kill. Absence of proof is not proof of match, but absence of an *app* is not absence of proof.
+
+Strictness gates on `AppInstallProvenance.blocks_strict` (the verdict), never on the row's presence.
+`unverifiable` is narrow: a plain **copied** (non-junction, non-git) install is content-compared and
+resolves to `match`/`drift` correctly.
+
+## The two false-drift normalizations (found only by running it against the real rig)
+
+A version check that cries wolf trains the operator to ignore the one time it is real — which is the
+failure #575 exists to prevent. The first draft reported **drift on the real rig where there was
+none**, twice:
+
+1. **`__pycache__/*.pyc`** — the primary checkout carries it *inside* `src/ac_copilot_trainer`; a
+   worktree does not. The AC Lua runtime never reads it. Now skipped.
+2. **Line endings** — `.gitattributes` has `*.bat text eol=crlf`, and `start_sidecar.bat` differed
+   between the primary checkout and a worktree **at the identical commit `8a3283f`**, purely in EOLs
+   (exactly 41 bytes across 41 lines). Text is now compared EOL-insensitively; **binary is detected by
+   a NUL byte** (git's own heuristic) and still hashes byte-exact, so a font/PNG differing by one byte
+   is still drift.
+
+Both are locked by regression tests, along with the inverse (a real one-character `.lua` edit is still
+drift; a pure rename with identical bytes is still drift).
+
+## Live verification (real rig, unmodified CLI path)
+
+| scenario | result |
+|---|---|
+| Real rig junction -> primary checkout | `provenance: match`, `preflight ok`, exit `0` **even under `--strict-app-version`** |
+| Real junction -> real checkout of `73ebe82` (the incident commit), default | `drift`, names `73ebe823d945` (installed) vs `8a3283f74c56` (harness), exit `0` |
+| same + `--strict-app-version` | `PREFLIGHT FAILED [app_version]`, exit `2` |
+| app absent | `absent`, `blocks_strict=False`, warning, no crash |
+
+The drift case used a **real junction** to a **real git worktree** of the stale commit — not a mock.
+
+## Provenance must be measured UNDER the rig lock (PR #587 review, Qodo)
+
+The first draft computed provenance **before** `RigSessionLock.acquire()`. The installed app is
+**shared rig state**, so a peer worktree can repoint the junction while we block on the lock:
+
+- a pre-lock `match` could **bypass** `--strict-app-version` on an app that drifted since, and
+- `extras.run.app_install` could record a version the rig never ran — the evidence bundle lying
+  retroactively, which is worse than no bundle.
+
+**The precedent already existed one block below the lock** and was walked past: plant/line artifact
+resolution is deliberately post-lock because "a peer worktree may have re-identified this combo while
+we waited on the lock, and resolving pre-lock would drive a stale in-memory plant". **Rule to
+generalize: any read of shared rig state that gates a decision or lands in evidence belongs under the
+rig lock.**
+
+Fix: re-measure after `acquire()`; the post-lock verdict gates strict and lands in the bundle. The
+pre-lock check stays as fast feedback (`--preflight-only` returns before the lock, unaffected). A
+verdict that *changes* across the lock wait is surfaced on its own line. The decision is the pure
+`app_provenance_recheck()` because `_main_impl` is `# pragma: no cover - rig-only CLI wiring` and AC3
+requires rig-free unit coverage.
+
+## The unplanned live true positive (the best evidence)
+
+Mid-session the rig's junction was **concurrently repointed** by another session
+(`autonomous-deliver-531-187940`, branch `feat/issue-531-partd-live-vitals`), whose worktree carries
+an **uncommitted** edit to `src/ac_copilot_trainer/modules/telemetry_publisher.lua`. The check
+reported `drift` and named that worktree unprompted.
+
+Two lessons, both load-bearing:
+
+1. **Both worktrees were at the same commit.** A `git rev-parse HEAD` compare would have said "up to
+   date". Only the content digest caught it. This is the concrete justification for the design.
+2. **The rig junction is shared, mutable, cross-session state** — see
+   `issue-555-cross-worktree-rig-ownership`. A session can silently inherit another session's
+   in-progress app. That is precisely #575's failure mode, and it is *live and recurring*, not
+   historical.
+
+Do **not** repoint the junction to your own worktree while another session owns the rig.
+
+## Rig-ops note (important)
+
+Test junctions were removed with `cmd /c rmdir` (**unlinks** the junction) and never with a recursive
+delete — `Remove-Item -Recurse` / `rm -rf` on a junction can traverse into the **target**, and two of
+the test junctions pointed at the **real AC install** (`content`, `extension`). The real AC install and
+the rig's real app junction were both confirmed intact afterward.
+
+## Out of scope
+
+- Auto-syncing the checkout (state mutation of another worktree is an operator action) — and
+  doubly so given the live finding above: a peer session may own the junction.
+
+## The stale-build problem is now closed on BOTH halves
+
+Verified live 2026-07-15 (`gh issue view 569 --repo agorokh/ac-copilot-trainer --json state` →
+`CLOSED` at 02:57:49Z; `gh pr view 586` → `MERGED` `8a895ee`) — #569 landed *during* this PR's own
+session, so do not carry it forward as pending:
+
+| half | mechanism | status |
+|---|---|---|
+| Frozen Game Point EXE | `/health build_commit` + `--self-test` (#567/#568), `build_commit` baked into the EXE ([#569](https://github.com/agorokh/ac-copilot-trainer/issues/569), PR #586 `8a895ee`) | **CLOSED** |
+| Lua app junction | preflight content-digest provenance + `--strict-app-version` ([#575](https://github.com/agorokh/ac-copilot-trainer/issues/575), PR #587 `b51e1d5`) | **CLOSED** |
+
+Both artifacts the rig executes can now assert which build they are.


### PR DESCRIPTION
Post-merge vault handoff for PR #587 (issue #575 CLOSED, merged `b51e1d5`).

Vault-only: the diff is strictly under `docs/01_Vault/**`.

## What this records

- New investigation node `issue-575-stale-app-junction-2026-07-15.md`, registered in the investigations `_index.md`.
- Delivery moved into `Next Session Handoff.md` + `Current Focus.md`.

## Three things the next session shouldn't rediscover

1. **The rig junction is volatile shared state** — it moved **three times during one session** (primary checkout → #531's worktree carrying an *uncommitted* `telemetry_publisher.lua` edit → restored). Both worktrees sat at the **same commit**, so the `git rev-parse HEAD` compare #575 originally suggested would have reported "up to date". Only the content digest caught it. Links to #555.
2. **Any read of shared rig state that gates a decision or lands in evidence belongs under the rig lock** — the pre-lock TOCTOU, caught by two independent reviewers. The precedent already existed one block below (plant/line resolution).
3. **False-drift normalization matters more than detection** — the first draft reported drift on the real rig twice for benign reasons (`__pycache__` in the app tree; `*.bat text eol=crlf`). A check that cries wolf is worse than no check.

## Reconciled against live state

#569 is **CLOSED** (`gh issue view 569` → `CLOSED` 02:57:49Z; `gh pr view 586` → `MERGED` `8a895ee`) — it landed *during* this session, so it's recorded as delivered rather than carried forward as the pending "other half". The stale-build problem is now closed on **both** halves: frozen Game Point EXE (#569) and Lua app junction (#575).

Rebased onto current `origin/main` so the #531 Part D, #569, and #570 handoff entries that landed meanwhile are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)