### PR TITLE
feat(harness): #531 Part D — make the TC/ABS intervention evidencable from the drive run

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-15T05:10:00Z
+last_updated: 2026-07-15T07:27:45Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-575-stale-app-junction-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
@@ -35,6 +35,16 @@ relates_to:
 # Current focus
 
 **Repo:** ac-copilot-trainer.
+
+**Review-resolved (2026-07-15, active PR):** [#595](https://github.com/agorokh/ac-copilot-trainer/pull/595)
+turns #531 Part D's TC/ABS flash criterion into in-run machine evidence. `tap_frames()` now declares
+the opt-in `observer` client class required for `telemetry_tick` fan-out; reports preserve
+`true` / `false` / `absent` per flag so a missing CSP field cannot masquerade as an idle system.
+Functional-head CI, resolve-gate, GraphQL threads, and the self-hosted review were clean; the
+resolution branch merged current `main`, passed **211 focused tests**, and finished full parity at
+**2,961 passed, 77 skipped, 86.80% coverage, `ci-fast: OK`**. Remaining real-world proof:
+deliberately provoke TC or ABS and observe a positive `true` count in `report.json`. Detail:
+[[issue-531-partd-live-vitals-2026-07-14]].
 
 **Delivered (2026-07-15, latest):** [#575](https://github.com/agorokh/ac-copilot-trainer/issues/575)
 **CLOSED** by PR [#587](https://github.com/agorokh/ac-copilot-trainer/pull/587)

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -37,12 +37,12 @@ relates_to:
 **Repo:** ac-copilot-trainer.
 
 **Review-resolved (2026-07-15, active PR):** [#595](https://github.com/agorokh/ac-copilot-trainer/pull/595)
-turns #531 Part D's TC/ABS flash criterion into in-run machine evidence. `tap_frames()` now declares
-the opt-in `observer` client class required for `telemetry_tick` fan-out; reports preserve
+turns #531 Part D's TC/ABS flash criterion into in-run machine evidence. `run_auto_drive` now opts
+its tap into the `observer` client class required for `telemetry_tick` fan-out; reports preserve
 `true` / `false` / `absent` per flag so a missing CSP field cannot masquerade as an idle system.
 Functional-head CI, resolve-gate, GraphQL threads, and the self-hosted review were clean; the
 resolution branch merged current `main`, passed **211 focused tests**, and finished full parity at
-**2,961 passed, 77 skipped, 86.80% coverage, `ci-fast: OK`**. Remaining real-world proof:
+**2,961 passed, 77 skipped, 86.85% coverage, `ci-fast: OK`**. Remaining real-world proof:
 deliberately provoke TC or ABS and observe a positive `true` count in `report.json`. Detail:
 [[issue-531-partd-live-vitals-2026-07-14]].
 

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -104,9 +104,11 @@ haptic fan-out.
 Resolution evidence on functional head `93685d4`: required CI green, 0 GraphQL threads,
 resolve-gate clean, and the current-SHA self-hosted reviewer reported no medium-or-higher finding.
 Current `main` was merged into the resolution branch and the focused harness/protocol/endpoint
-suite passed **211/211**; full parity passed **2,961 tests, 77 skipped, 86.80% coverage,
-`ci-fast: OK`**. The remaining rig criterion is behavioral, not observability: provoke a real TC or
-ABS event and confirm `report.json` records a positive `true` count. Detail:
+suite passed **211/211**; full parity passed **2,961 tests, 77 skipped, 86.85% coverage,
+`ci-fast: OK`**. Review hardening preserved the generic tap contract: `tap_frames()` is classless
+unless its caller opts in, while `run_auto_drive` explicitly passes `observer`. The remaining rig
+criterion is behavioral, not observability: provoke a real TC or ABS event and confirm
+`report.json` records a positive `true` count. Detail:
 [[issue-531-partd-live-vitals-2026-07-14]].
 
 ## ACTION BEFORE THE NEXT RIG DRIVE (2026-07-15 05:15Z) — the installed app is STALE

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-15T05:15:00Z
+last_updated: 2026-07-15T07:27:45Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-575-stale-app-junction-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
@@ -92,6 +92,22 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Review-resolved (2026-07-15) — #531 Part D intervention evidence (PR #595)
+
+PR [#595](https://github.com/agorokh/ac-copilot-trainer/pull/595) fixes the final intervention-
+capture blind spot: the harness tap now connects as a dedicated `observer`, receives the class-
+routed `telemetry_tick` stream, and writes three-way TC/ABS evidence (`true` / `false` / `absent`)
+into every drive report. Generic classless clients remain unchanged; observers never join the
+haptic fan-out.
+
+Resolution evidence on functional head `93685d4`: required CI green, 0 GraphQL threads,
+resolve-gate clean, and the current-SHA self-hosted reviewer reported no medium-or-higher finding.
+Current `main` was merged into the resolution branch and the focused harness/protocol/endpoint
+suite passed **211/211**; full parity passed **2,961 tests, 77 skipped, 86.80% coverage,
+`ci-fast: OK`**. The remaining rig criterion is behavioral, not observability: provoke a real TC or
+ABS event and confirm `report.json` records a positive `true` count. Detail:
+[[issue-531-partd-live-vitals-2026-07-14]].
 
 ## ACTION BEFORE THE NEXT RIG DRIVE (2026-07-15 05:15Z) — the installed app is STALE
 

--- a/docs/01_Vault/AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
+++ b/docs/01_Vault/AcCopilotTrainer/01_Decisions/external-ws-client-protocol-extension.md
@@ -2,9 +2,10 @@
 type: decision
 status: active
 created: 2026-04-21
-updated: 2026-06-16
+updated: 2026-07-15
 relates_to:
   - AcCopilotTrainer/03_Investigations/csp-web-socket-api.md
+  - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
   - AcCopilotTrainer/10_Rig/esp32-jc3248w535-screen-v1.md
   - AcCopilotTrainer/01_Decisions/_index.md
 ---
@@ -39,12 +40,18 @@ We want a **second** WS client — the rig-mounted ESP32 touchscreen — to read
    | Lua/sidecar → haptics | `haptic_event` | `{ event, channel, intensity, duration_ms, ts_sim? }` |
 
    `client_class` is optional for backward compatibility. Known classes:
-   `external`, `lua`, `screen`, `haptics`, `physical`, `browser`. Legacy
-   firmware clients whose `client` starts with `ac-copilot-screen` are treated
-   as `screen` even when they omit `client_class`. The sidecar uses classes only
-   for high-rate physical-peripheral routing: `telemetry_tick` goes to `screen`,
-   `haptics`, and `physical`; `haptic_event` goes to `haptics` and `physical`.
-   Neither message is echoed back to the Lua peer.
+   `external`, `lua`, `screen`, `haptics`, `physical`, `browser`, `voice`, and
+   `observer`. Legacy firmware clients whose `client` starts with
+   `ac-copilot-screen` are treated as `screen` even when they omit
+   `client_class`.
+
+   High-rate fan-out is opt-in by class. `telemetry_tick` goes to `screen`,
+   `haptics`, `physical`, `browser`, and `observer`; `haptic_event` goes only to
+   actuator classes `haptics` and `physical`. `observer` is the headless harness
+   recorder: it receives ticks but never haptic commands. Keeping it distinct
+   from `external` avoids silently sending 20 Hz telemetry to generic peers,
+   while keeping it distinct from `browser` preserves truthful tablet peer
+   accounting. Neither peripheral message is echoed back to the Lua producer.
 
 3. **Physical peripheral payloads.**
 
@@ -52,9 +59,12 @@ We want a **second** WS client — the rig-mounted ESP32 touchscreen — to read
    cadence: 10-20 Hz, capped by the sidecar at 20 Hz. Required payload fields:
    `speed_kmh`, `rpm`, `gear`, `throttle` (0-1), `brake` (0-1), `steer`
    (-1..1), `lat_g`, and `long_g`. Optional fields include `lap_time_ms`,
-   `slip`, `abs_active`, `brake_lock`, `wheel_lock`, `tyre_temps_c`, and
-   `tyre_pressures_psi`; tyre maps may include any non-empty subset of `fl`,
-   `fr`, `rl`, `rr`.
+   `slip`, `tc_active`, `abs_active`, `brake_lock`, `wheel_lock`,
+   `tyre_temps_c`, `tyre_pressures_psi`, `tyre_wear_pct`, and
+   `brake_temps_c`; corner maps may include any non-empty subset of `fl`, `fr`,
+   `rl`, `rr`. Intervention flags are optional but, when present, must be real
+   booleans: absent means unavailable/not fitted, while `false` means fitted and
+   idle.
 
    `haptic_event` is a bounded actuator command for a haptic peripheral.
    Expected cadence: event-driven, capped by the sidecar at 25 Hz per

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
@@ -156,17 +156,24 @@ CSP `car.rpmLimiter`).
 The remaining capture gap was structural, not a clean-driver coincidence: `telemetry_tick` is
 routed by **client class**, while `HarnessClient.hello()` was classless. No subscription could make
 the in-run tap receive ticks. PR [#595](https://github.com/agorokh/ac-copilot-trainer/pull/595)
-adds an opt-in `observer` class (tick consumer, never a haptic actuator), makes `tap_frames()` use
-it, and persists a three-way `true` / `false` / `absent` summary for `tc_active` and `abs_active`
-in every `AutoDriveReport`. Classless peers remain unchanged and receive no 20 Hz stream.
+adds an opt-in `observer` class (tick consumer, never a haptic actuator), makes `run_auto_drive`
+pass it explicitly to its tap, and persists a three-way `true` / `false` / `absent` summary for
+`tc_active` and `abs_active` in every `AutoDriveReport`. Generic `tap_frames()` callers stay
+classless by default and receive no unsolicited 20 Hz stream.
 
 Resolution evidence on the functional head `93685d4`: required CI green, 0 GraphQL review threads,
 clean resolve-gate ledger, and the current-SHA self-hosted reviewer reported no medium-or-higher
 findings. The resolution branch also merged current `main`; focused harness/protocol/endpoint tests
-passed **211/211**, and full parity passed **2,961 tests, 77 skipped, 86.80% coverage,
+passed **211/211**, and full parity passed **2,961 tests, 77 skipped, 86.85% coverage,
 `ci-fast: OK`**. The actual `true` intervention observation remains a rig-driving criterion, but it
 is now machine-capturable inside the prescribed run instead of requiring a side-channel tap or
 human tablet observation.
+
+Final review hardening caught an important API boundary: making generic `tap_frames()` always use
+`observer` would silently attach an unsolicited 20 Hz stream to every topic-tap caller. The final
+contract keeps `client_class=None` as the generic default and makes `run_auto_drive` pass
+`observer` explicitly. A fake-client test pins both the classless default and explicit opt-in; the
+drive orchestration test separately pins that the composed evidence path opts in.
 
 ## Still not verified (stated so the next session doesn't assume it)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
@@ -3,14 +3,14 @@ type: investigation
 status: active
 memory_tier: canonical
 created: 2026-07-14
-updated: 2026-07-14
+updated: 2026-07-15
 issue: https://github.com/agorokh/ac-copilot-trainer/issues/531
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-531-phase1-tablet-dash-2026-07-13.md
   - AcCopilotTrainer/00_System/Next Session Handoff.md
 ---
 
-# #531 Part D — live tyre vitals + TC/ABS intervention (PR #590)
+# #531 Part D — live tyre vitals + TC/ABS intervention (PRs #590 and #595)
 
 ## The gap Phase 1 left (silent, not failing)
 
@@ -151,7 +151,24 @@ Open since Phase 1. Both cars driven at Magione, tablet on `adb reverse`, electr
 Also closes: **RACE hero shift LEDs rpm-banded from real `rpm_max`** (9000 vs 8750, both from
 CSP `car.rpmLimiter`).
 
-## NOT verified (stated so the next session doesn't assume it)
+## PR #595 — make intervention evidence part of the harness run
+
+The remaining capture gap was structural, not a clean-driver coincidence: `telemetry_tick` is
+routed by **client class**, while `HarnessClient.hello()` was classless. No subscription could make
+the in-run tap receive ticks. PR [#595](https://github.com/agorokh/ac-copilot-trainer/pull/595)
+adds an opt-in `observer` class (tick consumer, never a haptic actuator), makes `tap_frames()` use
+it, and persists a three-way `true` / `false` / `absent` summary for `tc_active` and `abs_active`
+in every `AutoDriveReport`. Classless peers remain unchanged and receive no 20 Hz stream.
+
+Resolution evidence on the functional head `93685d4`: required CI green, 0 GraphQL review threads,
+clean resolve-gate ledger, and the current-SHA self-hosted reviewer reported no medium-or-higher
+findings. The resolution branch also merged current `main`; focused harness/protocol/endpoint tests
+passed **211/211**, and full parity passed **2,961 tests, 77 skipped, 86.80% coverage,
+`ci-fast: OK`**. The actual `true` intervention observation remains a rig-driving criterion, but it
+is now machine-capturable inside the prescribed run instead of requiring a side-channel tap or
+human tablet observation.
+
+## Still not verified (stated so the next session doesn't assume it)
 
 **`tc_active` / `abs_active` were never observed `true`** — only `false`. That still proves the
 CSP field names resolve (a wrong name degrades to nil and the key would be **omitted**; the keys
@@ -160,14 +177,12 @@ reasons it stayed out of reach this session:
 
 1. `--driver ggv` is a **flat-out friction-circle optimal** driver — it may legitimately never
    lock a wheel or spin one, so ABS/TC may simply never engage.
-2. Every attempt to tap the WS **during** a drive returned ~0 ticks (`maxspd=0.0`) while the same
-   peer got 347 ticks with AC idle — consistent with the focus/pause effect above. A future
-   attempt should drive the capture from **inside** the harness run rather than a side-channel WS
-   peer, or use a driver that deliberately provokes lock-up.
+2. The old side-channel attempts returned ~0 ticks during a drive. PR #595 removes that blindness
+   by making the harness's own tap an `observer`; a future rig run should use that path plus a
+   driver that deliberately provokes lock-up or wheelspin.
 
-Also unverified: the **car-swap acceptance criterion** (`bmw_m3_gt2` IS installed — the exact
-no-ABS car the mock uses for `ABS — NOT FITTED`), and `acs.exe` died in 2 of 5 runs (flake; an
-immediate retry drove clean both times).
+The **car-swap acceptance criterion is verified** in the table above. Separately, `acs.exe` died
+in 2 of 5 historical runs; an immediate retry drove clean both times.
 
 ## Remaining on #531
 

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -306,6 +306,11 @@ def test_wait_lap_requires_a_lap_frame():
         )
     )
     assert no_lap.ok is False
+    # The composed drive explicitly opts into the high-rate tick stream for Part-D evidence;
+    # generic tap_frames callers stay classless unless they make the same explicit choice.
+    from tools.ai_sidecar.external_protocol import CLIENT_CLASS_OBSERVER
+
+    assert tap_record["client_class"] == CLIENT_CLASS_OBSERVER
     # The lap wait scales with the drive budget (a Spa lap outlives the 180 s tap default).
     assert tap_record["lap_timeout"] == 420.0
     # lap frame present -> passes.

--- a/tests/test_harness_client.py
+++ b/tests/test_harness_client.py
@@ -252,3 +252,44 @@ def test_connect_retries_then_raises_on_dead_port() -> None:
             await hc.connect(retries=2, retry_delay=0.01)
 
     asyncio.run(_run())
+
+
+# --- #531 Part D: observer class on the hello frame -------------------------------------------
+
+
+def test_hello_omits_client_class_by_default() -> None:
+    """Unchanged behaviour for every pre-existing caller: no class = generic external peer."""
+    hc = HarnessClient("ws://127.0.0.1:1")
+    assert hc.client_class is None
+
+
+def test_hello_declares_observer_class_when_asked() -> None:
+    """The class must reach the WIRE — `telemetry_tick` fan-out keys on it, not on subscriptions."""
+    from tools.ai_sidecar.external_protocol import CLIENT_CLASS_OBSERVER
+
+    sent: list[dict[str, Any]] = []
+
+    async def _run() -> None:
+        async with _running_sidecar() as port:
+            async with HarnessClient(_ws_url(port), client_class=CLIENT_CLASS_OBSERVER) as hc:
+                original = hc.send
+
+                async def _spy(frame: dict[str, Any]) -> None:
+                    sent.append(frame)
+                    await original(frame)
+
+                hc.send = _spy  # type: ignore[method-assign]
+                ack = await hc.hello(timeout=2.0)
+                # The sidecar validates `client_class` against KNOWN_CLIENT_CLASSES and errors on
+                # an unknown one, so a real ack proves the server accepts `observer`.
+                assert ack is not None and ack["type"] == "hello_ack"
+
+    asyncio.run(_run())
+    hello = next(f for f in sent if f.get("type") == "hello")
+    assert hello["client_class"] == CLIENT_CLASS_OBSERVER
+
+
+def test_unknown_client_class_rejected_at_construction() -> None:
+    """Fail loud at the call site rather than sending a frame the sidecar will reject."""
+    with pytest.raises(ValueError, match="unknown client_class"):
+        HarnessClient("ws://127.0.0.1:1", client_class="not-a-real-class")

--- a/tests/test_sequence_probe.py
+++ b/tests/test_sequence_probe.py
@@ -20,6 +20,7 @@ from tools.ac_harness.sequence_probe import (
     STRICT_LIFECYCLE_TOPICS,
     evaluate_sequence,
     frames_from_jsonl,
+    intervention_summary,
 )
 
 
@@ -223,3 +224,71 @@ def test_timed_lap_times_ms_orders_and_skips_untimed_boundaries():
     ]
     assert timed_lap_times_ms(frames) == [95000, 92500, 91800]
     assert timed_lap_times_ms([]) == []
+
+
+# --- #531 Part D: electronics-intervention evidence -------------------------------------------
+#
+# The harness's in-run tap was structurally BLIND to `telemetry_tick`: ticks are routed by CLIENT
+# CLASS, not by `state.subscribe`, and the tap connected with no class. So Part D's TC/ABS
+# intervention criterion could never be evidenced from the prescribed capture path — a prior
+# session attributed the never-observed flash to the driver being too clean, but the recorder
+# could not have seen it either way. These pin the evidence semantics.
+
+
+def _tick(**payload: object) -> dict:
+    """A `telemetry_tick` as an observer-class peer receives it (peripheral frame, not a topic)."""
+    return {"v": 1, "type": "telemetry_tick", "payload": dict(payload)}
+
+
+def test_intervention_summary_counts_fired_idle_and_absent_separately() -> None:
+    frames = [
+        _tick(tc_active=True, abs_active=False),
+        _tick(tc_active=False, abs_active=False),
+        _tick(tc_active=False),  # abs omitted entirely -> absent, NOT idle
+    ]
+    summary = intervention_summary(frames)
+    assert summary["telemetry_ticks"] == 3
+    tc = summary["flags"]["tc_active"]
+    assert (tc["true"], tc["false"], tc["absent"]) == (1, 2, 0)
+    assert tc["fired"] is True and tc["observed"] is True
+    abs_ = summary["flags"]["abs_active"]
+    assert (abs_["true"], abs_["false"], abs_["absent"]) == (0, 2, 1)
+    # Never fired, but the producer DID emit it as a real boolean -> the CSP name resolves.
+    assert abs_["fired"] is False and abs_["observed"] is True
+
+
+def test_intervention_summary_absent_is_not_idle() -> None:
+    """A car without the system (M3 GT2 has no ABS) reads `absent`, never `false`.
+
+    This is the distinction that makes a typo'd CSP field name detectable: a wrong name degrades
+    to nil and the key is dropped, so it would read `absent` — identical to a car that lacks the
+    hardware. Collapsing absent into false would report a broken producer as a clean idle lap.
+    """
+    summary = intervention_summary([_tick(tc_active=False), _tick(tc_active=False)])
+    abs_ = summary["flags"]["abs_active"]
+    assert abs_["absent"] == 2
+    assert abs_["false"] == 0
+    assert abs_["observed"] is False  # never emitted as a boolean at all
+
+
+def test_intervention_summary_ignores_non_tick_frames() -> None:
+    """State snapshots share the stream; only `telemetry_tick` frames carry the flags."""
+    summary = intervention_summary([_f("tire_temps"), _f("lap"), _tick(tc_active=True)])
+    assert summary["telemetry_ticks"] == 1
+    assert summary["flags"]["tc_active"]["true"] == 1
+
+
+def test_intervention_summary_empty_stream_is_zero_not_crash() -> None:
+    summary = intervention_summary([])
+    assert summary["telemetry_ticks"] == 0
+    for flag in ("tc_active", "abs_active"):
+        assert summary["flags"][flag]["fired"] is False
+        assert summary["flags"][flag]["observed"] is False
+
+
+def test_intervention_summary_tolerates_malformed_tick_payload() -> None:
+    """A tick with a non-dict payload must not crash the evidence pass mid-drive."""
+    summary = intervention_summary(
+        [{"v": 1, "type": "telemetry_tick", "payload": None}, _tick(tc_active=True)]
+    )
+    assert summary["telemetry_ticks"] == 1

--- a/tests/test_sequence_probe.py
+++ b/tests/test_sequence_probe.py
@@ -13,6 +13,7 @@ required (it depends on a reference lap), only ever a note.
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 from tools.ac_harness.sequence_probe import (
@@ -21,6 +22,7 @@ from tools.ac_harness.sequence_probe import (
     evaluate_sequence,
     frames_from_jsonl,
     intervention_summary,
+    tap_frames,
 )
 
 
@@ -292,3 +294,35 @@ def test_intervention_summary_tolerates_malformed_tick_payload() -> None:
         [{"v": 1, "type": "telemetry_tick", "payload": None}, _tick(tc_active=True)]
     )
     assert summary["telemetry_ticks"] == 1
+
+
+def test_tap_frames_is_classless_by_default_and_allows_explicit_opt_in(monkeypatch) -> None:
+    """A generic topic tap must not silently join the high-rate peripheral stream."""
+    seen: list[str | None] = []
+
+    class _FakeHarnessClient:
+        def __init__(self, url: str, *, client_class: str | None = None) -> None:
+            del url
+            seen.append(client_class)
+            self.frames: list[dict] = []
+
+        async def connect(self, **kwargs) -> None:  # noqa: ANN003
+            del kwargs
+
+        async def hello(self, **kwargs) -> dict:  # noqa: ANN003
+            del kwargs
+            return {"type": "hello_ack"}
+
+        async def subscribe(self, topics: list[str]) -> None:
+            del topics
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "tools.ai_sidecar.harness_client.HarnessClient",
+        _FakeHarnessClient,
+    )
+    asyncio.run(tap_frames(seconds=0))
+    asyncio.run(tap_frames(seconds=0, client_class="observer"))
+    assert seen == [None, "observer"]

--- a/tests/test_tablet_dash_endpoint.py
+++ b/tests/test_tablet_dash_endpoint.py
@@ -207,6 +207,36 @@ def test_telemetry_tick_classes_include_browser_but_haptics_unchanged() -> None:
     assert ep.CLIENT_CLASS_VOICE not in ep.TELEMETRY_TICK_CLIENT_CLASSES
 
 
+def test_observer_class_receives_ticks_but_drives_no_actuators() -> None:
+    """#531 Part D: the drive harness's in-run tap taps ticks as `observer`.
+
+    Ticks are routed by client class, so without membership here the harness could not observe
+    `telemetry_tick` at ANY topic subscription — which is why Part D's TC/ABS intervention
+    criterion went unevidenced. `observer` must stay out of the haptic fan-out: a recorder has
+    no actuators.
+    """
+    assert ep.CLIENT_CLASS_OBSERVER in ep.KNOWN_CLIENT_CLASSES
+    assert ep.CLIENT_CLASS_OBSERVER in ep.TELEMETRY_TICK_CLIENT_CLASSES
+    assert ep.CLIENT_CLASS_OBSERVER not in ep.HAPTIC_CLIENT_CLASSES
+    # Joining the tick fan-out must stay OPT-IN: widening the generic `external` class instead
+    # would silently start pushing 20 Hz at every pre-existing external peer.
+    assert ep.CLIENT_CLASS_EXTERNAL not in ep.TELEMETRY_TICK_CLIENT_CLASSES
+
+
+def test_harness_tap_declares_the_observer_class() -> None:
+    """Pins the wiring itself, not just the routing table.
+
+    The routing set and the tap's declared class are two halves of one contract; a test on the
+    set alone would still pass with the tap connecting classless (the exact prior bug).
+    """
+    import inspect
+
+    from tools.ac_harness import sequence_probe
+
+    src = inspect.getsource(sequence_probe.tap_frames)
+    assert "CLIENT_CLASS_OBSERVER" in src
+
+
 def _tick_frame(**payload_overrides) -> dict:
     payload = {
         "speed_kmh": 187.0,
@@ -268,10 +298,13 @@ async def _running_sidecar() -> AsyncIterator[int]:
         _reset_external_state()
 
 
-async def _hello(ws, client: str, client_class: str) -> None:
-    await ws.send(
-        json.dumps({"v": 1, "type": "hello", "client": client, "client_class": client_class})
-    )
+async def _hello(ws, client: str, client_class: str | None) -> None:
+    frame: dict = {"v": 1, "type": "hello", "client": client}
+    # `client_class=None` OMITS the key rather than sending an explicit null, so a classless leg
+    # reproduces the exact wire shape of a pre-#531-Part-D peer (e.g. the old harness tap).
+    if client_class is not None:
+        frame["client_class"] = client_class
+    await ws.send(json.dumps(frame))
     ack = json.loads(await ws.recv())
     assert ack["type"] == "hello_ack"
 
@@ -301,6 +334,46 @@ def test_ws_telemetry_tick_routed_to_browser_not_voice() -> None:
     assert got["type"] == ep.TYPE_TELEMETRY_TICK
     assert got["payload"]["rpm_max"] == 8500.0
     assert not voice_got_frame
+
+
+def test_ws_telemetry_tick_routed_to_observer_but_not_to_a_classless_peer() -> None:
+    """#531 Part D: end-to-end proof of the harness-tap blindness AND its fix.
+
+    The drive harness's in-run tap used to connect with NO `client_class`, so the sidecar never
+    fanned `telemetry_tick` to it — the TC/ABS intervention criterion was unevidencable from the
+    prescribed capture path no matter how the driver behaved. The classless leg below is that
+    old peer: it must still receive nothing (joining the fan-out stays opt-in), while the
+    `observer` leg receives the tick carrying the Part D flags.
+    """
+
+    async def _t() -> tuple[dict, bool]:
+        async with _running_sidecar() as port:
+            url = f"ws://127.0.0.1:{port}"
+            async with (
+                ws_connect(url) as lua,
+                ws_connect(url) as observer,
+                ws_connect(url) as classless,
+            ):
+                await _hello(lua, "trainer-lua", "lua")
+                await _hello(observer, "ac-harness", ep.CLIENT_CLASS_OBSERVER)
+                # No class at all — exactly how HarnessClient connected before this change.
+                await _hello(classless, "ac-harness-legacy", None)
+                await lua.send(json.dumps(_tick_frame(tc_active=True, abs_active=False)))
+                got = json.loads(await asyncio.wait_for(observer.recv(), timeout=3.0))
+                classless_got_frame = True
+                try:
+                    await asyncio.wait_for(classless.recv(), timeout=0.5)
+                except TimeoutError:
+                    classless_got_frame = False
+                return got, classless_got_frame
+
+    got, classless_got_frame = asyncio.run(_t())
+    assert got["type"] == ep.TYPE_TELEMETRY_TICK
+    # The three-way contract on the wire: fired=True and idle=False are BOTH present as real
+    # booleans, which is what proves the CSP field names resolve rather than dropping to nil.
+    assert got["payload"]["tc_active"] is True
+    assert got["payload"]["abs_active"] is False
+    assert not classless_got_frame
 
 
 def test_ws_identity_snapshot_replayed_to_late_subscriber() -> None:

--- a/tests/test_tablet_dash_endpoint.py
+++ b/tests/test_tablet_dash_endpoint.py
@@ -223,20 +223,6 @@ def test_observer_class_receives_ticks_but_drives_no_actuators() -> None:
     assert ep.CLIENT_CLASS_EXTERNAL not in ep.TELEMETRY_TICK_CLIENT_CLASSES
 
 
-def test_harness_tap_declares_the_observer_class() -> None:
-    """Pins the wiring itself, not just the routing table.
-
-    The routing set and the tap's declared class are two halves of one contract; a test on the
-    set alone would still pass with the tap connecting classless (the exact prior bug).
-    """
-    import inspect
-
-    from tools.ac_harness import sequence_probe
-
-    src = inspect.getsource(sequence_probe.tap_frames)
-    assert "CLIENT_CLASS_OBSERVER" in src
-
-
 def _tick_frame(**payload_overrides) -> dict:
     payload = {
         "speed_kmh": 187.0,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -71,7 +71,7 @@ from datetime import UTC
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
-from tools.ac_harness.sequence_probe import evaluate_sequence, tap_frames
+from tools.ac_harness.sequence_probe import evaluate_sequence, intervention_summary, tap_frames
 
 if TYPE_CHECKING:
     from tools.ac_harness.ggv_profile import GGVModel
@@ -324,6 +324,12 @@ class AutoDriveReport:
     # iteration verdict, the per-iteration trajectory report).
     lap_times_ms: list[int] = field(default_factory=list)
     laps_requested: int = 0
+    # #531 Part D: electronics-intervention evidence from the `telemetry_tick` stream — per-flag
+    # true/false/absent counts (see sequence_probe.intervention_summary). This is the acceptance
+    # criterion's proof surface: before it, "did the TC/ABS flash fire?" could only be answered by
+    # a human watching the tablet, and the in-run tap could not see the channel at all.
+    # None = the tap did not run (a failure before the pipeline stage), which is NOT "no ticks".
+    intervention: dict | None = None
     # Combo identity + setup verification (#459 Parts A/C) — evidence consumers key on these.
     car_id: str | None = None
     track_id: str | None = None
@@ -375,6 +381,17 @@ class AutoDriveReport:
                 )
             for note in self.notes:
                 lines.append(f"  note: {note}")
+        if self.intervention is not None:
+            ticks = self.intervention.get("telemetry_ticks", 0)
+            flags = self.intervention.get("flags", {})
+            detail = "  ".join(
+                # `absent` is reported explicitly: it is the honest reading for a car that does not
+                # fit the system (the M3 GT2 has no ABS) AND for a CSP field name that failed to
+                # resolve. Collapsing it into `false` would hide a producer bug as a quiet lap.
+                f"{name}: fired={f['true']} idle={f['false']} absent={f['absent']}"
+                for name, f in sorted(flags.items())
+            )
+            lines.append(f"  intervention: telemetry_ticks={ticks}  {detail}")
         if self.error:
             lines.append(f"  error: {self.error}")
         return "\n".join(lines)
@@ -811,6 +828,9 @@ async def run_auto_drive(
     counts: dict[str, int] = {}
     notes: list[str] = []
     grace_applied = False
+    # None until the tap actually returns frames — a tap that raised must not report "0 ticks"
+    # (indistinguishable from a healthy tap on a silent producer). See AutoDriveReport.intervention.
+    intervention: dict | None = None
     # A fuel-less setup is baked but not fuel-confirmed — surface that in the report so a setup
     # A/B run does not read `setup_applied=True` as "independently verified" (#460 review).
     if setup_ack is not None and setup_applied and setup_ack.get("expected_fuel") is None:
@@ -834,6 +854,10 @@ async def run_auto_drive(
                 # budget, whichever first" — so a shortfall ends honestly, never hangs.
                 tap_kwargs["lap_count"] = config.target_laps
         frames = await tap(config.sidecar_url, **tap_kwargs)
+        # #531 Part D: derive the electronics-intervention evidence from the SAME captured stream
+        # the pipeline checks read, so the tick evidence and the sequence verdict can never come
+        # from two different windows.
+        intervention = intervention_summary(frames)
         result = evaluate_sequence(
             frames, strict_lifecycle=config.strict, require_lap=config.wait_lap
         )
@@ -909,6 +933,7 @@ async def run_auto_drive(
         lap_grace_applied=grace_applied,
         lap_times_ms=lap_times_ms,
         laps_requested=config.target_laps,
+        intervention=intervention,
         counts=counts,
         notes=notes,
         error=error,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -72,6 +72,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from tools.ac_harness.sequence_probe import evaluate_sequence, intervention_summary, tap_frames
+from tools.ai_sidecar.external_protocol import CLIENT_CLASS_OBSERVER
 
 if TYPE_CHECKING:
     from tools.ac_harness.ggv_profile import GGVModel
@@ -839,7 +840,14 @@ async def run_auto_drive(
     stage = "done"
     lap_times_ms: list[int] = []
     try:
-        tap_kwargs: dict[str, Any] = dict(seconds=config.tap_seconds, wait_for_lap=config.wait_lap)
+        # #531 Part D: the composed drive is the caller that needs intervention evidence, so it
+        # explicitly opts into the 20 Hz tick fan-out. Keep generic ``tap_frames`` classless by
+        # default: its topic subscription must not silently imply a high-rate peripheral stream.
+        tap_kwargs: dict[str, Any] = dict(
+            seconds=config.tap_seconds,
+            wait_for_lap=config.wait_lap,
+            client_class=CLIENT_CLASS_OBSERVER,
+        )
         if config.wait_lap:
             # The SAME settle + lap deadline the drive budget is sized to (above), so the tap never
             # waits past what the drive thread can still drive (a full lap at pace can exceed

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -324,6 +324,7 @@ async def tap_frames(
     settle_timeout: float = 120.0,
     lap_timeout: float = 180.0,
     lap_count: int | None = None,
+    client_class: str | None = None,
 ) -> list[dict]:
     """Tap the sidecar and return the frames received (live; needs AC driving).
 
@@ -340,18 +341,20 @@ async def tap_frames(
     ``lap_count=None`` keeps the exact legacy ``--wait-lap`` wait (any ``lap`` frame, timed or
     not — the #516 grace/archive logic gates on timed separately).
 
+    ``client_class`` is an explicit peripheral-stream opt-in. The generic tap stays classless by
+    default and therefore receives only its subscribed state topics; ``run_auto_drive`` passes
+    ``observer`` because its Part-D evidence contract also needs the 20 Hz ``telemetry_tick``.
+
     Always closes the client (try/finally) and fails fast on a missing hello handshake. Imported
     lazily so the pure evaluator has no hard dependency on the sidecar client.
     """
-    from tools.ai_sidecar.external_protocol import CLIENT_CLASS_OBSERVER
     from tools.ai_sidecar.harness_client import HarnessClient
 
     if lap_count is not None and lap_count < 1:
         raise ValueError(f"lap_count must be >= 1 (got {lap_count})")
-    # #531 Part D: tap as `observer` so the sidecar fans `telemetry_tick` to us. Ticks are routed
-    # by CLIENT CLASS, not by `state.subscribe` — before this the in-run tap could not see them at
-    # any topic list, so Part D's channels were unevidencable from inside the harness run.
-    hc = HarnessClient(url, client_class=CLIENT_CLASS_OBSERVER)
+    # Ticks are routed by CLIENT CLASS, not by `state.subscribe`. The caller must opt in rather
+    # than having this generic topic tap silently widen itself to the high-rate peripheral stream.
+    hc = HarnessClient(url, client_class=client_class)
     try:
         await hc.connect(retries=40, retry_delay=0.25)
         if await hc.hello(timeout=10) is None:

--- a/tools/ac_harness/sequence_probe.py
+++ b/tools/ac_harness/sequence_probe.py
@@ -223,6 +223,62 @@ def _is_snapshot(frame: dict, topic: str) -> bool:
     )
 
 
+#: Frame type of the high-rate Lua->sidecar telemetry stream. NOT a `state.snapshot` topic — it is
+#: a peripheral frame routed by client class, so it is matched on `type`, not `topic`.
+TELEMETRY_TICK_TYPE = "telemetry_tick"
+
+#: Electronics-intervention flags carried on `telemetry_tick` (#531 Part D).
+INTERVENTION_FLAGS: tuple[str, ...] = ("tc_active", "abs_active")
+
+
+def intervention_summary(frames: list[dict]) -> dict:
+    """Summarize electronics-intervention evidence from the ``telemetry_tick`` stream (#531 Part D).
+
+    Pure over a captured frame list, so it is unit-tested off-sim like ``evaluate_sequence``.
+
+    The three-way split per flag is the whole point and must NOT be collapsed to a boolean.
+    Part D's payload contract makes these flags OPTIONAL and never defaulted:
+
+    * ``absent``  — the producer omitted the key: the car does not expose that system (the M3 GT2
+      has no ABS), or the CSP physics field name did not resolve to a boolean.
+    * ``false``   — present and idle: the system is fitted and reporting, simply not intervening.
+    * ``true``    — intervening: the tile should flash.
+
+    So ``false`` is the load-bearing observation that a field name RESOLVES — a wrong CSP name
+    degrades to ``nil`` and the key is dropped entirely, which reads as ``absent``. Reporting only
+    "did it ever fire" would make a typo'd field name indistinguishable from a clean lap.
+    """
+    ticks = [
+        f
+        for f in frames
+        if isinstance(f, dict)
+        and f.get("type") == TELEMETRY_TICK_TYPE
+        and isinstance(f.get("payload"), dict)
+    ]
+    summary: dict = {"telemetry_ticks": len(ticks), "flags": {}}
+    for flag in INTERVENTION_FLAGS:
+        true_n = false_n = absent_n = 0
+        for f in ticks:
+            value = f["payload"].get(flag)
+            if value is True:
+                true_n += 1
+            elif value is False:
+                false_n += 1
+            else:
+                absent_n += 1
+        summary["flags"][flag] = {
+            "true": true_n,
+            "false": false_n,
+            "absent": absent_n,
+            # `observed` answers "did the producer ever emit this key as a real boolean?" —
+            # i.e. does the CSP field name resolve on this car. Independent of ever firing.
+            "observed": (true_n + false_n) > 0,
+            # `fired` answers the #531 acceptance criterion: was an intervention ever seen?
+            "fired": true_n > 0,
+        }
+    return summary
+
+
 def is_timed_lap_frame(frame: dict) -> bool:
     """Whether a frame is a ``lap`` snapshot carrying a positive time (``payload.last_lap_ms``).
 
@@ -287,11 +343,15 @@ async def tap_frames(
     Always closes the client (try/finally) and fails fast on a missing hello handshake. Imported
     lazily so the pure evaluator has no hard dependency on the sidecar client.
     """
+    from tools.ai_sidecar.external_protocol import CLIENT_CLASS_OBSERVER
     from tools.ai_sidecar.harness_client import HarnessClient
 
     if lap_count is not None and lap_count < 1:
         raise ValueError(f"lap_count must be >= 1 (got {lap_count})")
-    hc = HarnessClient(url)
+    # #531 Part D: tap as `observer` so the sidecar fans `telemetry_tick` to us. Ticks are routed
+    # by CLIENT CLASS, not by `state.subscribe` — before this the in-run tap could not see them at
+    # any topic list, so Part D's channels were unevidencable from inside the harness run.
+    hc = HarnessClient(url, client_class=CLIENT_CLASS_OBSERVER)
     try:
         await hc.connect(retries=40, retry_delay=0.25)
         if await hc.hello(timeout=10) is None:

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -35,6 +35,13 @@ CLIENT_CLASS_BROWSER = "browser"
 # stream (the #340 phrase-bank engine). On the rig the sidecar also drives a VoiceCoach in-process,
 # but a separate `voice`-class WS client is a first-class consumer (e.g. a remote speaker / a tap).
 CLIENT_CLASS_VOICE = "voice"
+# Issue #531 Part D: a headless RECORDER of the live stream — the autonomous drive harness's
+# in-run tap (`tools/ac_harness/sequence_probe.tap_frames`). It needs the same `telemetry_tick`
+# fan-out a dashboard gets, but it has no actuators and no display. Kept distinct from `browser`
+# so server-side peer accounting never conflates the harness with the real tablet, and distinct
+# from `external` so joining the tick fan-out stays OPT-IN: widening `external` would silently
+# start pushing 20 Hz at every existing generic peer.
+CLIENT_CLASS_OBSERVER = "observer"
 KNOWN_CLIENT_CLASSES: frozenset[str] = frozenset(
     {
         CLIENT_CLASS_EXTERNAL,
@@ -44,6 +51,7 @@ KNOWN_CLIENT_CLASSES: frozenset[str] = frozenset(
         CLIENT_CLASS_PHYSICAL,
         CLIENT_CLASS_BROWSER,
         CLIENT_CLASS_VOICE,
+        CLIENT_CLASS_OBSERVER,
     }
 )
 PHYSICAL_CLIENT_CLASSES: frozenset[str] = frozenset(
@@ -55,7 +63,15 @@ HAPTIC_CLIENT_CLASSES: frozenset[str] = frozenset({CLIENT_CLASS_HAPTICS, CLIENT_
 # not by `state.subscribe` — `telemetry_tick` is a peripheral frame type, not a state topic —
 # so browser peers join the physical classes for tick fan-out only. `haptic_event` routing is
 # deliberately unchanged (HAPTIC_CLIENT_CLASSES): a browser has no actuators.
-TELEMETRY_TICK_CLIENT_CLASSES: frozenset[str] = PHYSICAL_CLIENT_CLASSES | {CLIENT_CLASS_BROWSER}
+# Issue #531 Part D: `observer` joins the tick fan-out for the same reason `browser` did — it
+# renders/records the live stream. It is deliberately ABSENT from HAPTIC_CLIENT_CLASSES above:
+# a recorder has no actuators. Without this the drive harness's own in-run tap is structurally
+# blind to `telemetry_tick`, so Part D's channels (tyre psi/wear, brake temps, tc_active,
+# abs_active) could never be evidenced from the prescribed capture path — only eyeballed on glass.
+TELEMETRY_TICK_CLIENT_CLASSES: frozenset[str] = PHYSICAL_CLIENT_CLASSES | {
+    CLIENT_CLASS_BROWSER,
+    CLIENT_CLASS_OBSERVER,
+}
 MAX_SETUP_SNAPSHOT_KEYS = 512
 MAX_SETUP_SNAPSHOT_BYTES = 64_000
 MAX_SETUP_ADVICE_COMPLAINT_LEN = 240

--- a/tools/ai_sidecar/harness_client.py
+++ b/tools/ai_sidecar/harness_client.py
@@ -28,9 +28,11 @@ from typing import Any
 
 from tools.ai_sidecar.external_protocol import (
     AUTH_HEADER,
+    CLIENT_CLASS_KEY,
     CLIENT_HEADER,
     ENVELOPE_KEY,
     ENVELOPE_VERSION,
+    KNOWN_CLIENT_CLASSES,
     TYPE_HELLO,
     TYPE_HELLO_ACK,
     TYPE_KEY,
@@ -88,10 +90,22 @@ class HarnessClient:
     """
 
     def __init__(
-        self, url: str, *, token: str | None = None, client_id: str = "ac-harness"
+        self,
+        url: str,
+        *,
+        token: str | None = None,
+        client_id: str = "ac-harness",
+        client_class: str | None = None,
     ) -> None:
         self.url = url
         self.client_id = client_id
+        # Issue #531 Part D: an optional `hello.client_class`. Omitted by default, which keeps
+        # every existing caller a generic external peer (unchanged behaviour). Pass
+        # CLIENT_CLASS_OBSERVER to join the `telemetry_tick` fan-out — ticks are routed by
+        # client class, NOT by `state.subscribe`, so no topic list can substitute for this.
+        if client_class is not None and client_class not in KNOWN_CLIENT_CLASSES:
+            raise ValueError(f"unknown client_class: {client_class!r}")
+        self.client_class = client_class
         self._headers: dict[str, str] = {CLIENT_HEADER: client_id}
         if token:
             self._headers[AUTH_HEADER] = token
@@ -172,9 +186,14 @@ class HarnessClient:
 
     async def hello(self, *, timeout: float = 5.0) -> dict[str, Any] | None:
         """Send the v1 hello and wait for the sidecar's hello_ack."""
-        await self.send(
-            {ENVELOPE_KEY: ENVELOPE_VERSION, TYPE_KEY: TYPE_HELLO, "client": self.client_id}
-        )
+        frame: dict[str, Any] = {
+            ENVELOPE_KEY: ENVELOPE_VERSION,
+            TYPE_KEY: TYPE_HELLO,
+            "client": self.client_id,
+        }
+        if self.client_class is not None:
+            frame[CLIENT_CLASS_KEY] = self.client_class
+        await self.send(frame)
         return await self.wait_for(lambda f: f.get(TYPE_KEY) == TYPE_HELLO_ACK, timeout=timeout)
 
     async def subscribe(self, topics: list[str], *, timeout: float = 2.0) -> None:


### PR DESCRIPTION
## The finding

**The drive harness's in-run tap was structurally blind to `telemetry_tick`.**

`telemetry_tick` is *not* a subscribable state topic — the sidecar routes it by **client class** (`TELEMETRY_TICK_CLIENT_CLASSES`), which is why it is absent from `KNOWN_TOPICS`. `HarnessClient.hello()` sent `{"client": ...}` with **no `client_class`**, so `sequence_probe.tap_frames` could never receive a tick *at any topic subscription*.

Consequence: Part D's channels (`tyre_pressures_psi`, `tyre_wear_pct`, `brake_temps_c`, `tc_active`, `abs_active`) were **unevidencable from the prescribed capture path** and could only be eyeballed on the tablet.

This is why #531's intervention-flash criterion has never been observed. The [prior session](https://github.com/agorokh/ac-copilot-trainer/issues/531#issuecomment-) attributed it to `--driver ggv` being a flat-out optimal driver that may never lock or spin — but **the recorder could not have seen the flash either way**. That was reasoning about the driver while the recorder was blind.

## What changed

- **`CLIENT_CLASS_OBSERVER`** — a headless *recorder* of the live stream. Kept distinct from `browser` so server-side peer accounting never conflates the harness with the real tablet, and distinct from `external` so joining the tick fan-out stays **opt-in**: widening `external` would silently start pushing 20 Hz at every existing generic peer. Deliberately **absent** from `HAPTIC_CLIENT_CLASSES` — a recorder has no actuators.
- **`HarnessClient(client_class=...)`** — optional, **omitted by default** so every pre-existing caller is byte-identical on the wire. Validated at construction (fail at the call site, not on a frame the sidecar will reject).
- **`tap_frames` taps as `observer`.**
- **`intervention_summary()`** — a pure evaluator over the captured stream, surfaced as `AutoDriveReport.intervention` in every run's `report.json` and in the console summary. The acceptance criterion becomes **machine-checkable in every future run** instead of eyeballed once.

## Why the three-way split is load-bearing

Per-flag counts are `true` / `false` / `absent` and must **not** collapse to a boolean:

| state | meaning |
|---|---|
| `absent` | the producer omitted the key — the car lacks the system (the M3 GT2 has no ABS), **or** the CSP field name failed to resolve to a boolean |
| `false` | present and idle — fitted, reporting, not intervening |
| `true` | intervening — the tile should flash |

`false` is the observation that proves a CSP name **resolves**: a wrong name degrades to `nil` and the key is dropped, which reads as `absent`. Reporting only "did it ever fire" would make a typo'd field name indistinguishable from a clean lap.

## Tests

- Three-way semantics, incl. `absent ≠ idle`, empty stream, malformed payload.
- Routing table: `observer` in tick fan-out, **not** in haptics; `external` still **not** in tick fan-out (the opt-in guard).
- **The tap's declared class** — the routing table alone would still pass with the tap connecting classless (the exact prior bug).
- **End-to-end**: an `observer` peer receives the tick carrying the Part D flags while a **classless** peer (the old harness tap's exact wire shape) still receives nothing.

Counterfactual checked: reverting `observer` out of the routing set fails `test_observer_class_receives_ticks_but_drives_no_actuators`, confirming the test catches the bug it describes.

`make ci-fast`: **OK**.

## Not yet done (this PR is draft until then)

Live rig proof: drive the 911 GT3 R at Magione with an overspeed driver (`--ggv-scale > 1.0`, uncapped for `--driver ggv`) to force wheelspin/lock, and post the resulting `report.json` `intervention` row showing `tc_active.fired > 0`. Until that lands here, the criterion is *evidencable* but not yet *evidenced*.

Refs #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)