### PR TITLE
fix(harness): #596 Part C — auto_drive ok=False always carries an actionable reason

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -3344,3 +3344,73 @@ def test_report_json_carries_reason_and_checks(tmp_path):
     assert payload["checks"] == [
         {"name": "present:tire_temps", "ok": False, "detail": "never seen"}
     ]
+
+
+# ---------------------------------------------------------------------------
+# #596 Part C — codex review on PR #598: the invariant must survive POST-CONSTRUCTION mutation.
+# ---------------------------------------------------------------------------
+
+
+def test_handshake_outcome_failure_still_carries_a_reason():
+    """`apply_handshake_outcome` flips ok->False on an already-built report (#532).
+
+    __post_init__ has long since run with ok=True, so guarding construction alone would ship
+    `ok=false, reason=""` — the #596 bug through a different door (codex on PR #598).
+    """
+    from tools.ac_harness.plant_id import apply_handshake_outcome
+
+    report = AutoDriveReport(ok=True, stage="done", drive=DriveStats(drove=True), sequence_ok=True)
+    assert report.reason == ""
+
+    apply_handshake_outcome(report, {})  # empty sink -> handshake produced no result
+
+    assert report.ok is False
+    assert report.stage == "handshake"
+    # The consumption surfaces re-derive it; neither may emit an empty reason.
+    assert report.to_dict()["reason"] != ""
+    assert "handshake produced no result" in report.to_dict()["reason"]
+    assert "handshake produced no result" in report.summary()
+
+
+def test_handshake_probe_failure_reason_names_the_failed_probes():
+    from tools.ac_harness.plant_id import apply_handshake_outcome
+
+    report = AutoDriveReport(ok=True, stage="done", drive=DriveStats(drove=True), sequence_ok=True)
+    apply_handshake_outcome(
+        report,
+        {
+            "ok": False,
+            "result": {
+                "measurements": [{"name": "brake_probe", "passed": False, "detail": "no decel"}]
+            },
+        },
+    )
+    assert report.ok is False
+    assert "brake_probe" in report.to_dict()["reason"]
+
+
+def test_zero_timed_laps_reason_names_the_lap_window_assert_not_see_notes():
+    """`--laps N` with only untimed boundaries: all Checks pass, so the caller-side assert is the
+    ONLY failing one. It must name itself in `reason` (codex on PR #598)."""
+    record: dict = {}
+    # A full CONTINUOUS + session + lap stream: every evaluate_sequence Check passes, but the lap
+    # frame carries no timed lap, so the --laps 1 window assert fires.
+    frames = [*CONTINUOUS, _snap("session"), _snap("lap")]
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(wait_lap=True, target_laps=1),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, laps=1), record),
+            tap=_tap_returning(frames),
+        )
+    )
+
+    assert report.ok is False
+    assert report.sequence_ok is False
+    assert "laps:timed-window" in report.reason
+    assert "observed ZERO" in report.reason
+    assert "see notes" not in report.reason
+    # It rides the normal failed-check path, so the bundle carries it like any other assert.
+    assert [c.name for c in report.checks if not c.ok] == ["laps:timed-window"]

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -35,9 +35,11 @@ from tools.ac_harness.auto_drive import (
     build_practice_preset,
     candidate_journal_laps_dirs,
     collect_lap_archives,
+    compose_failure_reason,
     custom_ai_enabled,
     default_ac_root,
     drive_leg_succeeded,
+    drive_veto_reason,
     fuel_matches,
     generic_gt3_ggv,
     known_journal_laps_dir,
@@ -55,6 +57,7 @@ from tools.ac_harness.auto_drive import (
     write_evidence,
     write_setup_baked_race_ini,
 )
+from tools.ac_harness.sequence_probe import Check
 from tools.ac_harness.shared_memory import AcGameStatus, GraphicsSnapshot, PhysicsSnapshot
 
 # A tiny closed square line + a per-point speed profile, for driver-construction tests.
@@ -3172,3 +3175,172 @@ def test_collect_lap_archives_matching_count_is_validity_agnostic(tmp_path):
         _sleep=clock.sleep,
     )
     assert len(found) == 2 and clock.now >= 5.0  # waited the bounded budget, then honest return
+
+
+# ---------------------------------------------------------------------------
+# #596 Part C — `ok=False` ALWAYS carries a non-empty, actionable reason.
+#
+# The rig repro (issue #596, run 4 of 6): the car drove 2 laps / 6138 m at 199.8 km/h and wrote a
+# valid 112.275 s lap archive, yet the run reported `ok=False` with an EMPTY `reason` and
+# `sim_dead=False`. The drive leg had not failed — the pipeline had — but the only `reason` field
+# lived on DriveStats, and `evaluate_sequence`'s per-check verdicts were dropped before reaching the
+# report. The bundle was therefore indistinguishable from a real fault and could not be triaged.
+# ---------------------------------------------------------------------------
+
+
+def _seq_frames_missing(topic: str) -> list[dict]:
+    """A CONTINUOUS stream with `topic` absent — fails `present:<topic>` and nothing else."""
+    return [f for f in CONTINUOUS if f["topic"] != topic] + [_snap("session"), _snap("lap")]
+
+
+def test_run4_repro_pipeline_failure_names_the_failing_check_not_an_empty_reason():
+    """The exact #596 run-4 shape: a clean drive, a failed pipeline, previously an empty reason."""
+    record: dict = {}
+    drove_two_laps = DriveStats(drove=True, laps=2, total_distance_m=6138.0, max_speed_kmh=199.8)
+
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(drove_two_laps, record),
+            # tire_temps never arrives -> the pipeline fails while the drive is plainly fine.
+            tap=_tap_returning(_seq_frames_missing("tire_temps")),
+        )
+    )
+
+    assert report.ok is False
+    assert report.sequence_ok is False
+    # The drive leg itself is clean — this is what made run 4 unattributable.
+    assert report.drive is not None and report.drive.drove is True
+    assert report.drive.sim_dead is False
+    assert report.drive.reason == ""
+
+    # The acceptance criterion: the report says exactly which assert failed.
+    assert report.reason != "", "ok=False must never carry an empty reason (#596 Part C)"
+    assert "pipeline" in report.reason
+    assert "present:tire_temps" in report.reason
+    assert "never seen" in report.reason
+
+    # The per-check verdicts reach the bundle instead of being dropped on the floor.
+    failed = [c for c in report.checks if not c.ok]
+    assert [c.name for c in failed] == ["present:tire_temps"]
+
+
+def test_reason_is_empty_on_a_clean_run():
+    record: dict = {}
+    report = asyncio.run(
+        run_auto_drive(
+            _cfg(),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, laps=1), record),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+    assert report.ok is True
+    assert report.reason == ""
+
+
+@pytest.mark.parametrize(
+    "stats",
+    [
+        pytest.param(None, id="no-drive-leg"),
+        pytest.param(DriveStats(drove=False), id="never-drove"),
+        pytest.param(DriveStats(drove=True, sim_dead=True), id="sim-dead"),
+        pytest.param(DriveStats(drove=True, session_replaced=True), id="session-replaced"),
+        pytest.param(
+            DriveStats(drove=True, recovery_capped=True, recoveries=7, total_distance_m=456.0),
+            id="recovery-capped",
+        ),
+    ],
+)
+def test_every_drive_leg_veto_reports_a_non_empty_reason(stats):
+    """Mirrors drive_leg_succeeded veto-for-veto: a veto can never fire with nothing to say."""
+    assert drive_leg_succeeded(stats) is False, "test fixture must actually be a veto"
+    assert drive_veto_reason(stats) != ""
+    report = AutoDriveReport(ok=False, stage="drive", drive=stats, sequence_ok=True)
+    assert report.reason != ""
+
+
+def test_recovery_cap_reason_survives_into_the_report_with_the_stall_location():
+    """#596 Part A's honest failure must stay readable — the cap reports WHERE it stalled."""
+    stats = DriveStats(
+        drove=True,
+        recovery_capped=True,
+        recoveries=7,
+        total_distance_m=456.0,
+        reason="recovery cap (6) exceeded at 456m",
+    )
+    report = AutoDriveReport(ok=False, stage="drive", drive=stats, sequence_ok=True)
+    assert report.reason == "recovery cap (6) exceeded at 456m"
+    assert "456m" in report.summary()
+
+
+def test_drive_veto_outranks_a_pipeline_failure_it_caused():
+    """A dead sim makes the pipeline fail as a CONSEQUENCE — name the cause, not the symptom."""
+    stats = DriveStats(drove=True, sim_dead=True, reason="acpmf_physics packet_id stagnant")
+    reason = compose_failure_reason(
+        error=None,
+        seq_ok=False,
+        checks=[Check("present:tire_temps", False, "never seen")],
+        stats=stats,
+    )
+    assert reason == "acpmf_physics packet_id stagnant"
+    assert "tire_temps" not in reason
+
+
+def test_stage_error_outranks_every_other_cause():
+    """A raised stage failure is the root cause; the later legs never honestly ran."""
+    reason = compose_failure_reason(
+        error="setup verify failed: fuel 30.0 != 45.0",
+        seq_ok=False,
+        checks=[Check("present:lap", False, "never seen")],
+        stats=DriveStats(drove=False),
+    )
+    assert reason == "setup verify failed: fuel 30.0 != 45.0"
+
+
+def test_early_exit_failure_paths_derive_a_reason_from_their_error():
+    """Every early-exit return (preflight/launch/hijack/setup) sets `error` but no `reason`.
+
+    __post_init__ is the single choke point that keeps them honest, so a failure path cannot
+    reintroduce the run-4 bug by forgetting to set one.
+    """
+    for stage, err in (
+        ("launch", "sim never reached LIVE"),
+        ("hijack", "no Car0 in 5.0s"),
+        ("setup", "setup requested but no applier wired"),
+    ):
+        report = AutoDriveReport(ok=False, stage=stage, error=err)
+        assert report.reason == err, f"{stage} must carry its error as the reason"
+
+
+def test_reason_never_empty_even_if_a_future_veto_is_added_to_the_ok_gate():
+    """The composer's last resort: a wrong reason is triageable, an empty one is not."""
+    reason = compose_failure_reason(
+        error=None, seq_ok=True, checks=[], stats=DriveStats(drove=True)
+    )
+    assert reason != ""
+
+
+def test_report_json_carries_reason_and_checks(tmp_path):
+    """The evidence bundle is what an autonomous agent triages — the fields must serialize."""
+    import json
+
+    stats = DriveStats(drove=True, laps=2, total_distance_m=6138.0)
+    report = AutoDriveReport(
+        ok=False,
+        stage="done",
+        drive=stats,
+        sequence_ok=False,
+        checks=[Check("present:tire_temps", False, "never seen")],
+    )
+    out = write_evidence(tmp_path, report)
+    payload = json.loads(out.read_text(encoding="utf-8"))["report"]
+
+    assert payload["reason"] != ""
+    assert "present:tire_temps" in payload["reason"]
+    assert payload["checks"] == [
+        {"name": "present:tire_temps", "ok": False, "detail": "never seen"}
+    ]

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -3261,11 +3261,17 @@ def test_reason_is_empty_on_a_clean_run():
     ],
 )
 def test_every_drive_leg_veto_reports_a_non_empty_reason(stats):
-    """Mirrors drive_leg_succeeded veto-for-veto: a veto can never fire with nothing to say."""
+    """The boolean gate and actionable veto reason are exact inverses."""
     assert drive_leg_succeeded(stats) is False, "test fixture must actually be a veto"
     assert drive_veto_reason(stats) != ""
     report = AutoDriveReport(ok=False, stage="drive", drive=stats, sequence_ok=True)
     assert report.reason != ""
+
+
+def test_clean_drive_leg_has_no_veto_even_when_it_records_an_informational_reason():
+    stats = DriveStats(drove=True, laps=1, reason="driver finished")
+    assert drive_veto_reason(stats) == ""
+    assert drive_leg_succeeded(stats) is True
 
 
 def test_recovery_cap_reason_survives_into_the_report_with_the_stall_location():

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -71,7 +71,7 @@ from datetime import UTC
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
-from tools.ac_harness.sequence_probe import evaluate_sequence, tap_frames
+from tools.ac_harness.sequence_probe import Check, evaluate_sequence, tap_frames
 
 if TYPE_CHECKING:
     from tools.ac_harness.ggv_profile import GGVModel
@@ -276,6 +276,82 @@ def drive_leg_succeeded(stats: DriveStats | None) -> bool:
     )
 
 
+def drive_veto_reason(stats: DriveStats | None) -> str:
+    """The drive-leg half of :func:`compose_failure_reason` — "" when the drive leg is clean.
+
+    Mirrors :func:`drive_leg_succeeded` veto-for-veto, in the same order, so a veto can never fire
+    with nothing to say. Each branch prefers the reason the drive loop already recorded (it carries
+    the live detail — the stall distance, the stagnant packet) and falls back to a description of
+    the veto itself, because an empty ``reason`` is exactly the #596 Part C failure.
+    """
+    if stats is None:
+        return "drive: no drive leg ran (the hijack never landed)"
+    if stats.sim_dead:
+        return stats.reason or "drive: acs.exe died mid-run (acpmf_physics packet_id stagnant)"
+    if stats.session_replaced:
+        return stats.reason or (
+            f"drive: another launch replaced this session (sim_pid={stats.sim_pid}, "
+            f"unexpected={stats.unexpected_sim_pids})"
+        )
+    if stats.recovery_capped:
+        return stats.reason or (
+            f"drive: recovery cap exceeded after {stats.recoveries} recoveries "
+            f"at {stats.total_distance_m:.0f}m"
+        )
+    if not stats.drove:
+        return stats.reason or (
+            f"drive: car never cleared the distance/speed floor "
+            f"(dist={stats.total_distance_m:.0f}m max_speed={stats.max_speed_kmh:.1f}km/h)"
+        )
+    return ""
+
+
+def compose_failure_reason(
+    *,
+    error: str | None,
+    seq_ok: bool | None,
+    checks: list[Check],
+    stats: DriveStats | None,
+) -> str:
+    """The single actionable root cause of a failed run — "" only when nothing failed (#596 Part C).
+
+    The #596 repro: a run drove 2 laps / 6138 m and wrote a valid lap archive, yet reported
+    ``ok=False`` with an **empty** reason, because the only ``reason`` field lived on
+    :class:`DriveStats` and the drive leg had not failed — the *pipeline* had. The failing
+    :class:`Check` was computed by :func:`evaluate_sequence` and then dropped on the floor, so the
+    bundle could not be triaged at all: indistinguishable from a real fault.
+
+    Precedence is "most authoritative cause first", matching the gate in :func:`run_auto_drive`
+    (``bool(seq_ok) and drive_leg_succeeded(stats) and error is None``):
+
+    1. ``error`` — a raised stage failure is the root cause; the later legs never honestly ran.
+    2. a **drive-leg veto** — a dead/stalled sim makes the pipeline fail *as a consequence*, so
+       reporting "tire_temps never seen" over "acs.exe died" would name the symptom, not the cause.
+    3. the **pipeline** verdict — name the exact failing checks (the #596 Part C acceptance
+       criterion: "says exactly which assert failed").
+
+    The final fallback can only be reached if a future caller adds a veto to the ``ok`` gate without
+    adding it here; it stays non-empty on purpose — a wrong reason is triageable, an empty one is
+    not.
+    """
+    if error:
+        return error
+    veto = drive_veto_reason(stats)
+    if veto:
+        return veto
+    if seq_ok is False:
+        failed = [c for c in checks if not c.ok]
+        if failed:
+            detail = "; ".join(f"{c.name} ({c.detail})" for c in failed)
+            return f"pipeline: failed {len(failed)}/{len(checks)} checks: {detail}"
+        # seq_ok was forced False by a caller-side assert (e.g. the #579 timed-lap window) that
+        # records its finding in notes rather than as a Check.
+        return "pipeline: sequence verdict FAILED (see notes for the failing assert)"
+    if seq_ok is None:
+        return "pipeline: no sequence verdict — the tap/eval never completed"
+    return "run failed with no identified cause (report this — the reason composer has a gap)"
+
+
 def should_try_line_teleport_on_recovery(
     *, spawn_to_line_enabled: bool, car_off_line: bool, line_teleport_known_good: bool
 ) -> bool:
@@ -315,6 +391,14 @@ class AutoDriveReport:
     counts: dict[str, int] = field(default_factory=dict)
     notes: list[str] = field(default_factory=list)
     error: str | None = None
+    # #596 Part C: the run-level root cause. INVARIANT — non-empty whenever `ok` is False, empty
+    # whenever it is True (pinned by `test_reason_is_non_empty_for_every_failure_mode`). This is the
+    # field an autonomous agent triages on: `drive.reason` only ever spoke for the drive leg, so a
+    # pipeline-vetoed run that drove fine reported FAIL with nothing to act on.
+    reason: str = ""
+    # #596 Part C: the per-check verdicts from `evaluate_sequence` — previously computed and
+    # dropped, which is why a failed pipeline could not name its own failing assert in report.json.
+    checks: list[Check] = field(default_factory=list)
     # Whether the post-lap grace-drive ran (drove past S/F so the async writer finalizes the lap
     # archive). The single source of truth the evidence-bundle poll gates on, so the grace condition
     # and the poll condition can never diverge (#515/#516 review).
@@ -331,8 +415,28 @@ class AutoDriveReport:
     setup_applied: bool | None = None  # None = no setup requested
     setup_ack: dict | None = None  # the in-sim `setup.load.ack` (name/path/error)
 
+    def __post_init__(self) -> None:
+        """Enforce the #596 Part C invariant at the ONE choke point every construction passes.
+
+        The early-exit returns (preflight / launch / hijack / setup) build their own report and
+        would each have to remember to set a reason; the run 4 bug was precisely a failure path that
+        set `ok=False` and left the explanation somewhere nobody read. Deriving it here means a
+        future failure path cannot reintroduce an empty reason by forgetting — it has to actively
+        pass a wrong one.
+        """
+        if not self.ok and not self.reason:
+            self.reason = compose_failure_reason(
+                error=self.error,
+                seq_ok=self.sequence_ok,
+                checks=self.checks,
+                stats=self.drive,
+            )
+
     def summary(self) -> str:
         lines = [f"auto-drive: {'PASS' if self.ok else 'FAIL'} (stage={self.stage})"]
+        # #596 Part C: lead a FAIL with its root cause — the operator reads this line, not the JSON.
+        if self.reason:
+            lines.append(f"  reason: {self.reason}")
         combo = " ".join(
             part
             for part in (
@@ -809,6 +913,7 @@ async def run_auto_drive(
     stats = DriveStats(reason="drive did not run")
     seq_ok: bool | None = None
     counts: dict[str, int] = {}
+    checks: list[Check] = []
     notes: list[str] = []
     grace_applied = False
     # A fuel-less setup is baked but not fuel-confirmed — surface that in the report so a setup
@@ -839,6 +944,7 @@ async def run_auto_drive(
         )
         seq_ok = result.ok
         counts = dict(result.counts)
+        checks = list(result.checks)
         notes = list(result.notes)
         # #577: the per-lap trajectory is report evidence whenever the lap machinery ran.
         if config.wait_lap:
@@ -899,6 +1005,8 @@ async def run_auto_drive(
     # drive-leg vetoes (drove / sim_dead / recovery_capped) live in drive_leg_succeeded so this gate
     # and the false-green KPI corpus that exercises them cannot drift apart (#528).
     ok = bool(seq_ok) and drive_leg_succeeded(stats) and error is None
+    # #596 Part C: `reason` is derived in __post_init__ from these same inputs — the one choke point
+    # every construction site shares — so it cannot drift from the `ok` gate computed just above.
     return AutoDriveReport(
         ok=ok,
         stage=stage,
@@ -906,6 +1014,7 @@ async def run_auto_drive(
         hijacked=True,
         drive=stats,
         sequence_ok=seq_ok,
+        checks=checks,
         lap_grace_applied=grace_applied,
         lap_times_ms=lap_times_ms,
         laps_requested=config.target_laps,

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -269,26 +269,21 @@ def drive_leg_succeeded(stats: DriveStats | None) -> bool:
     * ``stats.recovery_capped`` — the car kept stalling until the recovery cap; it never sustained
       progress whatever the totals say (the pit-start recovery-cap stall, #528).
 
-    :func:`run_auto_drive` composes this with the pipeline verdict and error state; the false-green
-    KPI corpus (`false_green_kpi.py`) exercises it directly, so dropping a veto here surfaces as a
-    leaked broken scenario rather than a silent false green.
+    :func:`drive_veto_reason` is the single source of truth for these vetoes; this boolean gate is
+    its exact inverse. :func:`run_auto_drive` composes it with the pipeline verdict and error state,
+    while the false-green KPI corpus (`false_green_kpi.py`) exercises it directly.
     """
-    return (
-        bool(stats)
-        and stats.drove
-        and not stats.sim_dead
-        and not stats.session_replaced
-        and not stats.recovery_capped
-    )
+    return drive_veto_reason(stats) == ""
 
 
 def drive_veto_reason(stats: DriveStats | None) -> str:
     """The drive-leg half of :func:`compose_failure_reason` — "" when the drive leg is clean.
 
-    Mirrors :func:`drive_leg_succeeded` veto-for-veto, in the same order, so a veto can never fire
-    with nothing to say. Each branch prefers the reason the drive loop already recorded (it carries
-    the live detail — the stall distance, the stagnant packet) and falls back to a description of
-    the veto itself, because an empty ``reason`` is exactly the #596 Part C failure.
+    This is the single source of truth consumed by :func:`drive_leg_succeeded`, so a new veto cannot
+    make the run fail without also supplying a reason. Each branch prefers the reason the drive loop
+    already recorded (it carries the live detail — the stall distance, the stagnant packet) and
+    falls back to a description of the veto itself, because an empty ``reason`` is exactly the #596
+    Part C failure.
     """
     if stats is None:
         return "drive: no drive leg ran (the hijack never landed)"

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -424,6 +424,20 @@ class AutoDriveReport:
         future failure path cannot reintroduce an empty reason by forgetting — it has to actively
         pass a wrong one.
         """
+        self._ensure_reason()
+
+    def _ensure_reason(self) -> None:
+        """Re-derive `reason` whenever the invariant would otherwise be violated.
+
+        Construction is NOT the only way a report comes to fail. `apply_handshake_outcome` (#532)
+        flips `ok` to False and sets `error` on an ALREADY-BUILT report, long after __post_init__
+        ran — so a handshake failure would still ship `ok=false, reason=""`, the exact #596 bug
+        through a different door (codex on PR #598). Guarding construction alone is not enough.
+
+        So the invariant is re-checked at every CONSUMPTION surface (`to_dict`, `summary`): any
+        mutation must eventually be serialized or printed to matter, and both go through here.
+        Idempotent, and it never overwrites a reason that is already set.
+        """
         if not self.ok and not self.reason:
             self.reason = compose_failure_reason(
                 error=self.error,
@@ -433,6 +447,7 @@ class AutoDriveReport:
             )
 
     def summary(self) -> str:
+        self._ensure_reason()
         lines = [f"auto-drive: {'PASS' if self.ok else 'FAIL'} (stage={self.stage})"]
         # #596 Part C: lead a FAIL with its root cause — the operator reads this line, not the JSON.
         if self.reason:
@@ -485,6 +500,9 @@ class AutoDriveReport:
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-serializable form for the evidence bundle (``report.json``)."""
+        # The bundle is what an autonomous agent triages on, so the #596 Part C invariant is
+        # enforced HERE — after any post-construction mutation (e.g. apply_handshake_outcome).
+        self._ensure_reason()
         return asdict(self)
 
 
@@ -956,6 +974,19 @@ async def run_auto_drive(
                 # untimed out-lap/teleport boundary, which would exit 0 with an empty
                 # trajectory — a false green for the requested window (#579 Codex P2).
                 seq_ok = False
+                # #596 Part C: record the caller-side assert as a real Check, not only a note.
+                # It is the one pipeline failure `evaluate_sequence` cannot see (it owns the topic
+                # contract, not the lap-window contract), and a reason that said "see notes" would
+                # make the harness's own `--laps N` guard the single least-triageable failure mode
+                # (codex on PR #598). As a Check it names itself through the normal reason path.
+                checks.append(
+                    Check(
+                        "laps:timed-window",
+                        False,
+                        f"requested {config.target_laps} timed, observed ZERO "
+                        "(untimed out-lap/teleport boundaries do not count)",
+                    )
+                )
                 notes.append(
                     f"laps: requested {config.target_laps} timed, observed ZERO — "
                     "the window produced no timed lap (untimed boundaries do not count)"


### PR DESCRIPTION
## What

Closes **Part C** of #596: `ok=False` must ALWAYS carry a non-empty, actionable `reason`, and a drive that completes laps but fails the pipeline assert must say **exactly which assert failed**.

## The repro (issue #596, run 4 of 6)

The car drove **2 laps / 6138 m at 199.8 km/h** and wrote a valid **112.275 s** lap archive — yet the run reported `ok=False`, `sim_dead=False`, and an **empty `reason`**. Its only notes were informational (`session: count=1`, `delta: not in window`). Untriageable from the bundle, and indistinguishable from a real fault.

## Root cause — two halves, both in the report path

1. **The only `reason` lived on `DriveStats`**, so it spoke for the *drive leg* alone. Run 4's drive leg was clean; the **pipeline** vetoed. Nothing owned the run-level cause, so `ok=False` had literally nothing to say.
2. **The failing check's identity was computed and then dropped.** `evaluate_sequence` already returns `Check(name, ok, detail)` per assert — precisely "which assert failed" — but `run_auto_drive` kept only `result.ok` / `counts` / `notes` and discarded `result.checks`.

So the information the acceptance criterion asks for already existed; it just never reached `report.json`.

## The fix

| Change | Why |
|---|---|
| `AutoDriveReport.reason` | **Invariant: non-empty iff `ok is False`.** The field an agent triages on. |
| Derived in **`__post_init__`** | The **one choke point** every construction shares. The 7 early-exit returns (preflight/launch/hijack/setup) set `error` but no `reason` — deriving centrally means a future failure path cannot reintroduce the bug by *forgetting*; it would have to actively pass a wrong reason. |
| `AutoDriveReport.checks` | The per-check verdicts now reach the bundle. |
| `compose_failure_reason` / `drive_veto_reason` (pure) | Precedence **error > drive-leg veto > pipeline**: a dead sim makes the pipeline fail *as a consequence*, so we name the **cause** ("acs.exe died"), not the **symptom** ("tire_temps never seen"). `drive_veto_reason` mirrors `drive_leg_succeeded` veto-for-veto so a veto can never fire mute. |
| `summary()` leads a FAIL with its reason | The operator reads this line, not the JSON. |

## Verification

- **Mutation-checked, not just green:** with `__post_init__` disabled the new tests fail with `AssertionError: assert '' != ''` — reproducing the original run-4 symptom exactly. They fail on the broken code and pass on the fixed code.
- New tests pin: the run-4 shape (clean drive + failed pipeline → reason names `present:tire_temps (never seen)`), every drive-leg veto (parametrized against `drive_leg_succeeded`), both precedence rules, the early-exit paths, and `report.json` serialization.
- `make ci-fast` green · 190 harness/sequence tests pass · `false_green_kpi` clean (incl. `report_path_swallow`).
- Live rig verification (real `auto_drive` run on AG_PC) to follow on this PR before merge.

## Scope

Part C only. **Part A** (pit-start stall) and **Part B** (`acs.exe` death rate + bounded relaunch) need live rig data and follow separately — same file group, sequential PRs to avoid conflicts.

Refs #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)