### PR TITLE
fix(harness): recover #596 pit stalls and sim deaths

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -50,7 +50,8 @@ The full loop each command owns:
 5. **Drive** — `--driver ggv` (flat-out friction-circle min-time), `racing` (AI-line pace,
    default), or `cruise` (slow lane-keeper). Guards: sim-death detection, a **no-progress
    watchdog** (recovers stalls regardless of throttle), a **recovery cap** (default 6) that fails
-   honestly with the stall location, and spawn-to-line teleport for pit-box starts
+   honestly with the stall location, a bounded 2 Hz **control trace** (gear/RPM/controls/position +
+   forced recovery events), and spawn-to-line teleport for pit-box starts
    (`--no-spawn-line` to disable).
 6. **Assert** — taps the sidecar WS and asserts the live producer contract
    (`connection`/`tire_temps`/`coaching.snapshot`; `--wait-lap` additionally requires a completed
@@ -63,7 +64,7 @@ Default bundle: `.scratch/harness-evidence/<utc>_<car>_<track>/` (override `--ev
 
 | Artifact | Content |
 |---|---|
-| `report.json` | Full `AutoDriveReport` (pass/fail + stage, combo, `setup_requested/applied` + in-sim ack, drive stats incl. `recoveries`/`spawn_teleport`, WS frame counts) plus run extras: preset used, sidecar provenance, HUD verdict, lap-archive paths |
+| `report.json` | Full `AutoDriveReport` (pass/fail + stage, combo, `setup_requested/applied` + in-sim ack, drive stats incl. `recoveries`/`spawn_teleport` and bounded `control_trace`, WS frame counts) plus run extras: preset used, sidecar provenance, HUD verdict, lap-archive paths |
 | `generated.cmpreset` | The exact preset launched (when generated) |
 | `hud.png` | Post-run HUD capture (`--hud-region full|left|coaching`) with liveness verdict |
 | `lap_archives` (in report.json) | Paths of `journal/laps/lap_*.json` written during the run — full telemetry traces for session review / setup comparison |
@@ -229,7 +230,7 @@ launch, probe outcome, and re-bake stats so a recycle's timing is visible.
 | CM clicks/launch do nothing | **Foreground steal**: minimize the agent/terminal window; AC's fullscreen menu covers CM — the harness kills stale `acs.exe` before each launch |
 | "Steam API failed to initialize" | Steam elevation mismatch — restart Steam **non-elevated** (`steam -shutdown`, relaunch via `explorer.exe`) |
 | `setup.load` error "no loopback Lua peer connected" | The trainer app isn't (yet) connected to the sidecar — the harness retries for `setup_timeout`; persistent = app not installed/enabled in CSP |
-| Run FAILS with `recovery cap exceeded at <N>m` | Real stall: the car repeatedly stopped at the same spot. Inspect `hud.png` + the stall distance; do **not** raise the cap to make it "pass" |
+| Run FAILS with `recovery cap exceeded at <N>m` | Real stall: the car repeatedly stopped at the same spot. Inspect `hud.png` plus `report.drive.control_trace` (especially the forced `recovery:*` rows); do **not** raise the cap to make it "pass" |
 | Two agents, one rig | **Yield**: a single AC instance cannot serve two autonomous sessions (see the issue-277 investigation). Check for a running `acs.exe`/peer sidecar before launching |
 | Sidecar port already in use | That's usually the Game Point launcher's supervised sidecar — the harness reuses it; don't spawn a second |
 

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -48,7 +48,8 @@ The full loop each command owns:
    setup with no `[FUEL]` section is reported baked-but-unconfirmed. The re-bake loop writes only
    under `Documents/Assetto Corsa/cfg`; it does not mutate the AC/CSP install tree.
 5. **Drive** — `--driver ggv` (flat-out friction-circle min-time), `racing` (AI-line pace,
-   default), or `cruise` (slow lane-keeper). Guards: sim-death detection, a **no-progress
+   default), or `cruise` (slow lane-keeper). Guards: sim-death detection plus one bounded fresh
+   full-launch retry by default (`--sim-death-retries 0` disables), a **no-progress
    watchdog** (recovers stalls regardless of throttle), a **recovery cap** (default 6) that fails
    honestly with the stall location, a bounded 2 Hz **control trace** (gear/RPM/controls/position +
    forced recovery events), and spawn-to-line teleport for pit-box starts
@@ -64,7 +65,7 @@ Default bundle: `.scratch/harness-evidence/<utc>_<car>_<track>/` (override `--ev
 
 | Artifact | Content |
 |---|---|
-| `report.json` | Full `AutoDriveReport` (pass/fail + stage, combo, `setup_requested/applied` + in-sim ack, drive stats incl. `recoveries`/`spawn_teleport` and bounded `control_trace`, WS frame counts) plus run extras: preset used, sidecar provenance, HUD verdict, lap-archive paths |
+| `report.json` | Final `AutoDriveReport` plus full `attempts` history (a recovered sim death remains measurable), combo/setup ack, drive stats incl. `recoveries`/`spawn_teleport` and bounded `control_trace`, WS frame counts, preset/sidecar provenance, HUD verdict, and lap-archive paths |
 | `generated.cmpreset` | The exact preset launched (when generated) |
 | `hud.png` | Post-run HUD capture (`--hud-region full|left|coaching`) with liveness verdict |
 | `lap_archives` (in report.json) | Paths of `journal/laps/lap_*.json` written during the run — full telemetry traces for session review / setup comparison |
@@ -231,6 +232,7 @@ launch, probe outcome, and re-bake stats so a recycle's timing is visible.
 | "Steam API failed to initialize" | Steam elevation mismatch — restart Steam **non-elevated** (`steam -shutdown`, relaunch via `explorer.exe`) |
 | `setup.load` error "no loopback Lua peer connected" | The trainer app isn't (yet) connected to the sidecar — the harness retries for `setup_timeout`; persistent = app not installed/enabled in CSP |
 | Run FAILS with `recovery cap exceeded at <N>m` | Real stall: the car repeatedly stopped at the same spot. Inspect `hud.png` plus `report.drive.control_trace` (especially the forced `recovery:*` rows); do **not** raise the cap to make it "pass" |
+| `acs.exe` dies mid-drive | The main physics packet watchdog fails that attempt and the CLI automatically runs one fresh full launch (bounded by `--sim-death-retries`). Inspect `report.attempts`: every failed attempt, reason, and control trace is retained even when the final attempt passes. |
 | Two agents, one rig | **Yield**: a single AC instance cannot serve two autonomous sessions (see the issue-277 investigation). Check for a running `acs.exe`/peer sidecar before launching |
 | Sidecar port already in use | That's usually the Game Point launcher's supervised sidecar — the harness reuses it; don't spawn a second |
 

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -52,6 +52,7 @@ from tools.ac_harness.auto_drive import (
     rig_hijack,
     rig_launch,
     run_auto_drive,
+    run_auto_drive_with_sim_retries,
     should_try_line_teleport_on_recovery,
     verify_setup_ack,
     write_evidence,
@@ -567,6 +568,148 @@ def test_sim_dead_vetoes_success_even_when_drove_true():
     )
     assert report.sequence_ok is True
     assert report.ok is False  # sim_dead vetoes despite drove=True
+
+
+def test_sim_death_retries_full_launch_and_preserves_failed_attempt():
+    launches: list[int] = []
+    controllers: list[FakeController] = []
+    outcomes = iter(
+        [
+            DriveStats(drove=True, sim_dead=True, reason="acs.exe died on packet 41"),
+            DriveStats(drove=True, laps=1, total_distance_m=900.0),
+        ]
+    )
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(config.sim_death_retries)
+        return True, "live"
+
+    def _hijack(config):  # noqa: ANN001
+        controller = FakeController()
+        controllers.append(controller)
+        return controller
+
+    def _drive(controller, config, stop):  # noqa: ANN001
+        stop.wait(timeout=2.0)
+        return next(outcomes)
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _cfg(sim_death_retries=1),
+            launch=_launch,
+            hijack=_hijack,
+            drive=_drive,
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+
+    assert report.ok is True
+    assert len(launches) == 2
+    assert len(report.attempts) == 2
+    assert report.attempts[0]["ok"] is False
+    assert report.attempts[0]["drive"]["sim_dead"] is True
+    assert "packet 41" in report.attempts[0]["reason"]
+    assert report.attempts[1]["ok"] is True
+    assert all(attempt["attempts"] == [] for attempt in report.attempts)
+    assert all(controller.closed for controller in controllers)
+
+
+@pytest.mark.parametrize(
+    "config_kwargs,stats",
+    [
+        ({"skip_launch": True}, DriveStats(drove=True, sim_dead=True)),
+        ({}, DriveStats(drove=True, sim_dead=True, session_replaced=True)),
+        ({}, DriveStats(drove=True, sim_dead=True, recovery_capped=True)),
+    ],
+)
+def test_sim_death_retry_refuses_non_retryable_run_states(config_kwargs, stats):
+    launches: list[int] = []
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _cfg(sim_death_retries=2, **config_kwargs),
+            launch=_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(stats, {}),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+
+    assert report.ok is False
+    assert len(report.attempts) == 1
+    assert len(launches) == (0 if config_kwargs.get("skip_launch") else 1)
+
+
+def test_sim_death_retry_budget_exhaustion_is_an_evidenced_failure():
+    launches: list[int] = []
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _cfg(sim_death_retries=1),
+            launch=_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(
+                DriveStats(drove=True, sim_dead=True, reason="packet frozen"), {}
+            ),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+
+    assert report.ok is False
+    assert len(launches) == 2
+    assert len(report.attempts) == 2
+    assert all(attempt["drive"]["sim_dead"] is True for attempt in report.attempts)
+
+
+def test_sim_death_retry_does_not_mask_a_pipeline_exception(monkeypatch):
+    from tools.ac_harness import auto_drive
+
+    calls: list[int] = []
+
+    async def _failed_attempt(config, **kwargs):  # noqa: ANN001
+        calls.append(1)
+        return AutoDriveReport(
+            ok=False,
+            stage="pipeline",
+            drive=DriveStats(drove=True, sim_dead=True),
+            error="pipeline: tap exploded",
+        )
+
+    monkeypatch.setattr(auto_drive, "run_auto_drive", _failed_attempt)
+    report = asyncio.run(
+        auto_drive.run_auto_drive_with_sim_retries(
+            _cfg(sim_death_retries=2),
+            launch=_ok_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True), {}),
+            tap=_tap_returning(CONTINUOUS),
+        )
+    )
+
+    assert calls == [1]
+    assert report.error == "pipeline: tap exploded"
+    assert len(report.attempts) == 1
+
+
+def test_programmatic_sim_death_retry_budget_rejects_negative_values():
+    with pytest.raises(ValueError, match="must be >= 0"):
+        asyncio.run(
+            run_auto_drive_with_sim_retries(
+                _cfg(sim_death_retries=-1),
+                launch=_ok_launch,
+                hijack=lambda c: FakeController(),
+                drive=_drive_returning(DriveStats(drove=True), {}),
+                tap=_tap_returning(CONTINUOUS),
+            )
+        )
 
 
 def test_drive_exception_closes_controller_and_reports_drive_stage():
@@ -2978,6 +3121,8 @@ def test_cli_new_flags_map_to_config(tmp_path):
             "3",
             "--progress-stall-seconds",
             "8",
+            "--sim-death-retries",
+            "2",
             "--no-spawn-line",
         ]
     )
@@ -2988,7 +3133,14 @@ def test_cli_new_flags_map_to_config(tmp_path):
     assert cfg.driver == "ggv"
     assert cfg.max_recoveries == 3
     assert cfg.progress_stall_seconds == 8.0
+    assert cfg.sim_death_retries == 2
     assert cfg.spawn_to_line is False
+
+
+@pytest.mark.parametrize("bad", ["-1", "1.5", "nan"])
+def test_cli_rejects_invalid_sim_death_retry_budgets(bad):
+    with pytest.raises(SystemExit):
+        _build_arg_parser().parse_args(["--track", "spa", "--sim-death-retries", bad])
 
 
 # --------------------------------------------------------------------------- #577 flying-lap window

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2560,13 +2560,33 @@ def test_write_evidence_bundles_report_and_extras(tmp_path):
         track_id="spa",
         setup_requested="Realistic_BB_v3",
         setup_applied=True,
-        drive=DriveStats(drove=True, total_distance_m=7004.0, recoveries=1),
+        drive=DriveStats(
+            drove=True,
+            total_distance_m=7004.0,
+            recoveries=1,
+            control_trace=[
+                {
+                    "t_s": 12.5,
+                    "distance_m": 456.0,
+                    "speed_kmh": 0.0,
+                    "rpm": 900.0,
+                    "gear": 5,
+                    "gas": 0.6,
+                    "brake": 0.0,
+                    "steer": 0.1,
+                    "phase": "OUT",
+                    "event": "recovery:progress_watchdog:line_teleport",
+                }
+            ],
+        ),
     )
     out = write_evidence(tmp_path / "ev", report, extras={"hud": {"rendering": True}})
     payload = _json.loads(out.read_text(encoding="utf-8"))
     assert payload["report"]["ok"] is True
     assert payload["report"]["setup_applied"] is True
     assert payload["report"]["drive"]["recoveries"] == 1
+    assert payload["report"]["drive"]["control_trace"][0]["gear"] == 5
+    assert payload["report"]["drive"]["control_trace"][0]["event"].startswith("recovery:")
     assert payload["hud"]["rendering"] is True
 
 

--- a/tests/test_ac_harness_racing_driver.py
+++ b/tests/test_ac_harness_racing_driver.py
@@ -256,6 +256,15 @@ def test_gear_pulse_shifts_out_of_neutral_then_up_then_down():
     assert d._gear_pulse(3000, 4, 90.0, 9.0) == (False, True)  # down past rpm_dn
 
 
+def test_gear_pulse_downshifts_a_stationary_high_gear_car():
+    """#596 Part A: 0 km/h in 4th must not be a permanent gear/speed latch."""
+
+    d = RacingDriver(_straight_line(10), [40.0] * 10, max_speed_kmh=200.0)
+    assert d._gear_pulse(900, 4, 0.0, 1.0) == (False, True)
+    assert d._gear_pulse(900, 3, 0.0, 1.3) == (False, True)
+    assert d._gear_pulse(900, 2, 0.0, 1.6) == (False, False)  # stop at 1st, never N/R
+
+
 def test_default_upshift_fires_below_first_gear_rev_limiter():
     # Live on the GT3 R, 1st gear's rev limiter plateaus at ~7400 rpm. If the shift point sits ABOVE
     # it, the car bounces off the limiter stuck in 1st (observed) — the default must be below it.

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -121,6 +121,15 @@ def resolve_ac_user_dir(explicit: Path | None = None, *, home: Path | None = Non
 # a braver probe. Requires the explicit --alien-allow-overspeed opt-in (auto_alien iterate mode).
 ALIEN_MAX_OVERSPEED_SCALE = 1.2
 
+# #596 Part A: retain a bounded, low-rate controller trace in every evidence bundle.  The drive
+# loop runs at ~80 Hz, so dumping every frame would turn a five-minute report into tens of
+# thousands of rows.  Two samples/second plus forced recovery events is enough to reconstruct the
+# 450-580 m stall while keeping the JSON comfortably reviewable.  When an unusually long drive
+# exceeds the cap, keep the most recent samples: the state immediately before a failure is the
+# diagnostically valuable window.
+CONTROL_TRACE_INTERVAL_S = 0.5
+CONTROL_TRACE_MAX_SAMPLES = 2048
+
 
 @dataclass
 class AutoDriveConfig:
@@ -250,6 +259,11 @@ class DriveStats:
     recovery_capped: bool = False  # True when max_recoveries was exhausted (vetoes success)
     spawn_teleport: str = ""  # "" (not attempted) | "ok" | "failed" | "skipped (on line)"
     reason: str = ""
+    # #596 Part A: bounded 2 Hz state+command trace, with every recovery forced into the stream.
+    # This makes a capped stall diagnosable from report.json (gear/RPM/controls/position/action)
+    # instead of leaving only the final distance and a screenshot.
+    control_trace: list[dict[str, Any]] = field(default_factory=list)
+    control_trace_truncated: bool = False
     # Driver-specific result payload flowing OUT through the normal return value (not a config
     # side-channel): the #532 handshake result (ok/result/constants/diagnostics) lands here.
     payload: dict = field(default_factory=dict)
@@ -2754,6 +2768,7 @@ def rig_drive(  # pragma: no cover - rig-only
     driver = _build_driver(config, line, speed_profile)
     stats = DriveStats()
     watchdog = ProgressWatchdog(stall_seconds=config.progress_stall_seconds)
+    last_control_trace_s = -math.inf
     line_teleport_works: bool | None = None
     # Whether the car is currently OFF the racing line — set at an off-line spawn (pit box / offset
     # grid slot) AND whenever a recovery teleports it back to the pits (itself off-line). Recovery
@@ -2779,8 +2794,48 @@ def rig_drive(  # pragma: no cover - rig-only
             else:
                 stats.spawn_teleport = "skipped (on line)"
 
-    def _recover(now: float) -> bool:
-        """Shared recovery for driver-flagged stuck AND watchdog stalls. False = cap exceeded."""
+    def _record_control_trace(
+        now: float,
+        cd: dict[str, Any],
+        frame: Any,
+        *,
+        event: str = "control",
+        force: bool = False,
+    ) -> None:
+        """Append one bounded state+command sample; recovery events bypass the 2 Hz throttle."""
+
+        nonlocal last_control_trace_s
+        if not force and now - last_control_trace_s < CONTROL_TRACE_INTERVAL_S:
+            return
+        if len(stats.control_trace) >= CONTROL_TRACE_MAX_SAMPLES:
+            # Keep the failure-adjacent tail for very long runs.  The truncation bit prevents a
+            # consumer from mistaking the retained window for a complete drive trace.
+            stats.control_trace.pop(0)
+            stats.control_trace_truncated = True
+        position = cd.get("position")
+        stats.control_trace.append(
+            {
+                "t_s": round(float(now), 3),
+                "distance_m": round(float(stats.total_distance_m), 3),
+                "position": (
+                    [round(float(value), 4) for value in position]
+                    if isinstance(position, (list, tuple)) and len(position) == 3
+                    else None
+                ),
+                "speed_kmh": round(float(cd.get("speed_kmh", 0.0)), 3),
+                "rpm": round(float(cd.get("rpm", 0.0)), 1),
+                "gear": int(cd.get("gear", 0)),
+                "gas": round(float(frame.gas), 4),
+                "brake": round(float(frame.brake), 4),
+                "steer": round(float(frame.steer), 4),
+                "phase": str(frame.phase),
+                "event": event,
+            }
+        )
+        last_control_trace_s = now
+
+    def _recover(now: float) -> tuple[bool, str]:
+        """Shared recovery for driver/watchdog stalls; return ``(within_cap, action)``."""
         nonlocal line_teleport_works, off_line
         stats.recoveries += 1
         if stats.recoveries > config.max_recoveries:
@@ -2788,7 +2843,7 @@ def rig_drive(  # pragma: no cover - rig-only
             stats.reason = (
                 f"recovery cap ({config.max_recoveries}) exceeded at {stats.total_distance_m:.0f}m"
             )
-            return False
+            return False, "cap_exceeded"
         recovered_to_line = False
         # Retry the racing-line teleport whenever the car is off the line — an off-line spawn OR a
         # prior recovery that teleported it into the pits — or a prior line teleport is known good.
@@ -2812,7 +2867,7 @@ def rig_drive(  # pragma: no cover - rig-only
             off_line = True  # teleport_to_pits leaves the car off-line (in the pits)
         driver.on_recovery()
         watchdog.reset(time.monotonic() - t0, stats.total_distance_m)
-        return True
+        return True, "line_teleport" if recovered_to_line else "teleport_to_pits"
 
     # Sim-death keys on the MAIN acpmf_physics packet_id, NOT the Car0 (Custom-AI) one: live-found
     # (Spa 2026-07-02) that CSP does NOT bump Car0.packet_id every frame — it stays constant while a
@@ -2968,7 +3023,16 @@ def rig_drive(  # pragma: no cover - rig-only
                 break
             stalled = watchdog.update(stats.total_distance_m, now)
             if frame.needs_recovery or stalled:
-                if not _recover(now):
+                trigger = "driver_stuck" if frame.needs_recovery else "progress_watchdog"
+                recovered, action = _recover(now)
+                _record_control_trace(
+                    now,
+                    cd,
+                    frame,
+                    event=f"recovery:{trigger}:{action}",
+                    force=True,
+                )
+                if not recovered:
                     break
                 prev_plane = None  # do not count the teleport as travelled distance
                 continue
@@ -2992,6 +3056,7 @@ def rig_drive(  # pragma: no cover - rig-only
             prev_plane = plane
             if frame.lap_completed:
                 stats.laps += 1
+            _record_control_trace(now, cd, frame)
             time.sleep(0.012)
     finally:
         # Close the final sub-second race at timeout/driver completion too; rig teardown has not

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -236,6 +236,10 @@ class AutoDriveConfig:
     hijack_attempts: int = 3  # recreate CarControls0 N times — beats the early-LIVE hijack race
     # Sim-death guard.
     sim_dead_seconds: float = 4.0
+    # #596 Part B: acs.exe death is an intermittent rig failure, not a controller verdict.  Retry
+    # the entire launch->hijack->drive attempt once by default; the wrapper retains every attempt
+    # in report.json so a recovered crash is measured rather than hidden.
+    sim_death_retries: int = 1
     skip_launch: bool = False
 
 
@@ -430,6 +434,10 @@ class AutoDriveReport:
     setup_requested: str | None = None
     setup_applied: bool | None = None  # None = no setup requested
     setup_ack: dict | None = None  # the in-sim `setup.load.ack` (name/path/error)
+    # #596 Part B: complete per-attempt reports from the bounded sim-death retry wrapper.  The
+    # final report stays at the top level for backward compatibility; this list makes a recovered
+    # crash visible and preserves its control trace/checks instead of laundering it into PASS.
+    attempts: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def reason(self) -> str:
@@ -484,6 +492,17 @@ class AutoDriveReport:
                 + (f" unexpected_sim_pids={d.unexpected_sim_pids}" if d.unexpected_sim_pids else "")
                 + (f" spawn_teleport={d.spawn_teleport}" if d.spawn_teleport else "")
                 + (f" reason={d.reason}" if d.reason else "")
+            )
+        if self.attempts:
+            sim_deaths = sum(
+                1
+                for attempt in self.attempts
+                if isinstance(attempt.get("drive"), dict)
+                and attempt["drive"].get("sim_dead") is True
+            )
+            lines.append(
+                f"  attempts: {len(self.attempts)} (detected sim deaths={sim_deaths}, "
+                f"retry budget={max(len(self.attempts) - 1, 0)} used)"
             )
         if self.lap_times_ms:
             times = ", ".join(f"{ms / 1000.0:.3f}s" for ms in self.lap_times_ms)
@@ -1087,6 +1106,76 @@ async def run_auto_drive(
         setup_ack=setup_ack,
         **identity,
     )
+
+
+async def run_auto_drive_with_sim_retries(
+    config: AutoDriveConfig,
+    *,
+    launch: LaunchFn,
+    hijack: HijackFn,
+    drive: DriveFn,
+    tap: TapFn = tap_frames,
+    apply_setup: ApplySetupFn | None = None,
+    verify_track: VerifyTrackFn | None = None,
+    restart_launcher: RestartLauncherFn | None = None,
+) -> AutoDriveReport:
+    """Run the full attempt again after a detected ``acs.exe`` death, bounded and evidenced.
+
+    A frozen main-physics packet is already the harness's authoritative death oracle.  Retrying
+    inside the drive loop would reuse a dead controller/shared-memory session and blur two runs;
+    instead, this coordinator lets :func:`run_auto_drive` finish its normal controller teardown and
+    starts the complete launch->hijack->drive->tap path again.  The caller holds the machine-global
+    rig lock across this wrapper, so no peer worktree can claim the rig between attempts.
+
+    Only a pure sim death is retryable.  A session replacement means another launch took ownership;
+    a recovery cap is a controller/track failure; a pipeline failure is an assertion failure; and
+    ``--skip-launch`` has no launch leg to repeat.  Those remain honest terminal failures.
+    """
+
+    retry_budget = int(config.sim_death_retries)
+    if retry_budget < 0:
+        raise ValueError("sim_death_retries must be >= 0")
+    attempt_reports: list[dict[str, Any]] = []
+    for attempt_idx in range(retry_budget + 1):
+        report = await run_auto_drive(
+            config,
+            launch=launch,
+            hijack=hijack,
+            drive=drive,
+            tap=tap,
+            apply_setup=apply_setup,
+            verify_track=verify_track,
+            restart_launcher=restart_launcher,
+        )
+        # Snapshot BEFORE assigning the aggregate list, so nested attempts do not recursively
+        # contain themselves.  This is the full attempt (checks, trace, cause), not a lossy summary.
+        attempt_reports.append(_attempt_snapshot(report))
+        sim_death = bool(
+            report.drive is not None
+            and report.drive.sim_dead
+            and not report.drive.session_replaced
+            and not report.drive.recovery_capped
+            and report.error is None
+        )
+        can_retry = sim_death and not config.skip_launch and attempt_idx < retry_budget
+        if can_retry:
+            _log(
+                "sim death: retrying a fresh full launch "
+                f"(attempt {attempt_idx + 2}/{retry_budget + 1})"
+            )
+            continue
+        report.attempts = attempt_reports
+        return report
+
+    raise AssertionError("sim-death retry loop exhausted without returning a report")
+
+
+def _attempt_snapshot(report: AutoDriveReport) -> dict[str, Any]:
+    """Serialize one attempt without recursively embedding the aggregate attempt history."""
+
+    payload = report.to_dict()
+    payload["attempts"] = []
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -3197,6 +3286,18 @@ def _nonneg_float(value: str) -> float:
     return parsed
 
 
+def _nonneg_int(value: str) -> int:
+    """argparse type: a non-negative integer (``0`` disables a bounded retry feature)."""
+
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"must be an integer >= 0, got {value!r}") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"must be an integer >= 0, got {value!r}")
+    return parsed
+
+
 def _build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Composed autonomous self-test (#154 Part G): drive any car/track + assert"
@@ -3358,6 +3459,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="no forward progress for this long triggers a recovery (any throttle)",
     )
     p.add_argument(
+        "--sim-death-retries",
+        type=_nonneg_int,
+        default=AutoDriveConfig.sim_death_retries,
+        help="fresh full-launch retries after acs.exe death (default: 1; 0 disables)",
+    )
+    p.add_argument(
         "--no-spawn-line",
         action="store_true",
         help="do not teleport a pit-box spawn onto the racing line (use the OUT-phase pit exit)",
@@ -3419,6 +3526,7 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         hijack_probe_seconds=args.hijack_probe_seconds,
         max_recoveries=args.max_recoveries,
         progress_stall_seconds=args.progress_stall_seconds,
+        sim_death_retries=args.sim_death_retries,
         spawn_to_line=not args.no_spawn_line,
     )
     if args.ac_root is not None:
@@ -3937,7 +4045,7 @@ def _main_impl(
 
         run_started_epoch = time.time()
         report = asyncio.run(
-            run_auto_drive(
+            run_auto_drive_with_sim_retries(
                 config,
                 launch=rig_launch,
                 hijack=rig_hijack,
@@ -4118,6 +4226,11 @@ def _main_impl(
             note = "handshake probes passed but the drive was vetoed — plant NOT persisted"
             report.notes.append(note)
             print(f"auto-drive: {note}")
+    # Handshake post-processing above can change the final verdict after the retry wrapper took
+    # its attempt snapshot. Refresh only the final attempt so the aggregate and top-level report
+    # have the same final truth; earlier failed attempts remain immutable evidence.
+    if report.attempts:
+        report.attempts[-1] = _attempt_snapshot(report)
     report_path = write_evidence(evidence_dir, report, extras=extras)
 
     print(report.summary())

--- a/tools/ac_harness/racing_driver.py
+++ b/tools/ac_harness/racing_driver.py
@@ -621,7 +621,13 @@ class RacingDriver:
         if rpm > self.rpm_up and gear < self.max_gear and speed_kmh > 20.0:
             self._last_shift_s = now
             return (True, False)
-        if rpm < self.rpm_dn and gear > 2 and speed_kmh > 5.0:
+        # #596 Part A: never couple the ability to select a usable gear to already moving.  The
+        # practice-start flake can over-slow the car at the first braking complex and leave it at
+        # 0 km/h in 4th/5th.  The old ``speed_kmh > 5`` guard then made recovery impossible: a car
+        # cannot pull past 5 km/h in that gear, so it can never qualify for the downshift that
+        # would let it move.  Low RPM + the existing pulse cooldown are the safe downshift gates;
+        # ``gear > 2`` stops at AC gear 2 (1st), never neutral/reverse.
+        if rpm < self.rpm_dn and gear > 2:
             self._last_shift_s = now
             return (False, True)
         return (False, False)


### PR DESCRIPTION
Closes #596

## Outcome

- **Part A — pit-start stall:** identified the permanent feedback latch: at low RPM in 3rd+ gear, the driver required `speed_kmh > 5` before downshifting, but a stopped high-gear car cannot accelerate past that threshold. Downshifts now depend on low RPM + the existing pulse cooldown and stop at first gear.
- **Part B — sim death:** the CLI now retries one complete launch → hijack → drive → tap attempt after a pure `acs.exe` death. It keeps the machine-global rig lock and stores every full attempt (reason, checks, controls, trace) in `report.json`; takeover, recovery-cap, skip-launch, and raised pipeline failures remain terminal.
- **Part C — actionable failure reason:** already delivered by #598; this PR composes with that report contract.
- Added a bounded 2 Hz control/command trace and explicit forced-recovery events for durable diagnosis.

## Live rig evidence

- **13 natural drive runs measured:** the issue's original 6-run sample plus 7 new PR-branch drive runs. Raw `acs.exe` deaths: **2/13**, both in the original sample; **0/7** new natural runs died.
- Post-fix practice starts passed on **2 cars / 2 tracks**: BMW M3 GT2 at Magione and Imola, plus Ferrari 458 GT2 at Magione. Successful distances were 724–3,093 m, with zero recovery caps.
- Traces through the reported 456 m region contain **zero stopped-high-gear samples**. Representative crossings: M3/Magione 454.3 m at 92.4 km/h in 4th; Ferrari/Magione 461.7 m at 79.6 km/h in 2nd; M3/Imola 454.1 m at 200.6 km/h.
- Controlled failure injection: killed live PID 18868 after 284 m. Attempt 1 recorded `acpmf_physics packet_id stagnant (acs.exe died)` with 36 trace samples; the bounded retry launched PID 936 and passed at 2,295 m with 178 samples. The bundle preserved both attempts.
- Launch-stage trials that never exposed Car0 were excluded from the drive/death denominator. CSP crash evidence identified the local Porsche install as damaged (`LODs list is missing`), not a controller stall.

## Verification

- `python -m pytest tests/test_ac_harness_auto_drive.py tests/test_ac_harness_racing_driver.py -q` — **211 passed**
- `make ci-fast` — **2,963 passed, 113 skipped, 87.61% coverage; Ruff, Bandit, and policy checks clean**
- Real HUD captures reported rendering for every completed run and were visually inspected.