### PR TITLE
fix(harness): Preflight damaged car content before launch (#603)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -15,7 +15,7 @@ one command.
 
 ```bash
 # Prove the autonomous DRIVE (live-verified: Spa flat-out, gears 1→6, reference coaching):
-python -m tools.ac_harness.auto_drive --car ks_porsche_911_gt3_r_2016 --track spa \
+python -m tools.ac_harness.auto_drive --car bmw_m3_gt2 --track magione \
     --driver ggv --wait-lap
 
 # Prove a car SETUP applies + is verified, then complete an autonomous lap:
@@ -27,7 +27,10 @@ The full loop each command owns:
 
 1. **Preflight** — content installed, CSP `[CUSTOM_AI] ENABLED=1`, Content Manager present,
    setup resolvable, preset↔CLI combo consistency. Fails fast with an actionable message
-   (`--preflight-only` runs just this gate).
+   (`--preflight-only` runs just this gate). Selected-car validation follows AC's complete
+   read-only launch chain: a readable packed `data.acd` or unpacked `data/` source must expose
+   `lods.ini`, and every `[LOD_n] FILE=` must name a present, non-empty `.kn5`. A content failure
+   stops before launch.
 2. **Sidecar** — reuses a listening sidecar (e.g. the Game Point launcher's supervised child on
    `:8765`); auto-starts a loopback `tools.ai_sidecar` otherwise (`--no-sidecar-autostart` to
    forbid; `--keep-sidecar` to leave it running).
@@ -65,7 +68,7 @@ Default bundle: `.scratch/harness-evidence/<utc>_<car>_<track>/` (override `--ev
 
 | Artifact | Content |
 |---|---|
-| `report.json` | Final `AutoDriveReport` plus full `attempts` history (a recovered sim death remains measurable), combo/setup ack, drive stats incl. `recoveries`/`spawn_teleport` and bounded `control_trace`, WS frame counts, preset/sidecar provenance, HUD verdict, and lap-archive paths |
+| `report.json` | Final `AutoDriveReport` plus full `attempts` history (a recovered sim death remains measurable), combo/setup ack, drive stats incl. `recoveries`/`spawn_teleport` and bounded `control_trace`, WS frame counts, preset/sidecar provenance, HUD verdict, and lap-archive paths. A fatal preflight also writes this artifact with `stage=preflight`, `launched=false`, no drive/attempt, and `preflight.classification=non_drive_preflight_failure`, explicitly excluded from drive and sim-death denominators. |
 | `generated.cmpreset` | The exact preset launched (when generated) |
 | `hud.png` | Post-run HUD capture (`--hud-region full|left|coaching`) with liveness verdict |
 | `lap_archives` (in report.json) | Paths of `journal/laps/lap_*.json` written during the run — full telemetry traces for session review / setup comparison |
@@ -225,6 +228,7 @@ launch, probe outcome, and re-bake stats so a recycle's timing is visible.
 
 | Symptom | Cause / fix |
 |---|---|
+| Preflight `car_data` / `car_lods` / `car_lod_file` failure | The selected car is locally damaged even if its folder and some `.kn5` models remain. For a stock/Kunos car, use Steam **Assetto Corsa > Properties > Installed Files > Verify integrity**; for a mod, reinstall its original package through Content Manager. Do not borrow another car's `data.acd` (the archive key depends on the folder name). Re-run `python -m tools.ac_harness.auto_drive --car <id> --track <id> --preflight-only`; it must report `preflight ok` before a matrix drive. |
 | Preflight `custom_ai` failure | Set `[CUSTOM_AI] ENABLED=1` in `<AC root>/extension/config/new_behaviour.ini` (user `cfg/extension/new_behaviour.ini` overrides when it carries the key) |
 | `stage=setup`, `applied=False`, fuel mismatch | The launch bake didn't take — check `race.ini [CAR_0] _EXT_SETUP_FILENAME` points at the setup and the CM launch reached LIVE; the setup's `[FUEL] VALUE` is the expected number |
 | `--setup` run: setup `applied=True` but `stage=hijack` | The car stalled at AC's non-hijackable "0 seconds" overlay through every launch cycle (the setup re-bake breaks CM's immediate-start, #466). The setup is applied/verified. The harness fast-fails each stalled cycle and **recycles a fresh launch**; if it still exhausts `max_launches`, reboot the rig (degraded from many hard `acs.exe` kills) and rerun. (A keypress nudge to clear the overlay was tried in-sim and verified NOT to dismiss it, #466 — the relaunch is the only recovery.) |

--- a/tests/test_ac_content.py
+++ b/tests/test_ac_content.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import struct
 from pathlib import Path
 
-from tools.ac_content import acd_key, read_car_data_member, unpack_acd
+from tools.ac_content import CarDataSource, acd_key, read_car_data_member, unpack_acd
 
 
 def _build_acd(folder_name: str, members: dict[str, bytes]) -> bytes:
@@ -43,6 +43,26 @@ def test_member_lookup_reads_unpacked_source_when_archive_is_absent(tmp_path: Pa
     (car_dir / "data" / "LoDs.InI").write_bytes(expected)
 
     assert read_car_data_member(car_dir, "lods.ini") == expected
+
+
+def test_unpacked_accessor_reads_only_requested_member(tmp_path: Path, monkeypatch) -> None:
+    car_dir = tmp_path / "lazy_car"
+    (car_dir / "data").mkdir(parents=True)
+    (car_dir / "data" / "lods.ini").write_bytes(b"wanted")
+    (car_dir / "data" / "large-unrelated.bin").write_bytes(b"unrelated")
+    original_read_bytes = Path.read_bytes
+    reads: list[str] = []
+
+    def guarded_read_bytes(path: Path) -> bytes:
+        reads.append(path.name)
+        if path.name == "large-unrelated.bin":
+            raise AssertionError("unrequested unpacked member was eagerly loaded")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+
+    assert CarDataSource(car_dir).read_member("lods.ini") == b"wanted"
+    assert reads == ["lods.ini"]
 
 
 def test_member_lookup_prefers_packed_source_when_both_exist(tmp_path: Path) -> None:

--- a/tests/test_ac_content.py
+++ b/tests/test_ac_content.py
@@ -36,14 +36,31 @@ def test_unpack_and_member_lookup_support_packed_source(tmp_path: Path) -> None:
     assert read_car_data_member(car_dir, "LODS.INI") == lods
 
 
-def test_member_lookup_prefers_unpacked_source(tmp_path: Path) -> None:
+def test_member_lookup_reads_unpacked_source_when_archive_is_absent(tmp_path: Path) -> None:
     car_dir = tmp_path / "unpacked_car"
     (car_dir / "data").mkdir(parents=True)
     expected = b"[LOD_0]\nFILE=unpacked_car.kn5\n"
     (car_dir / "data" / "LoDs.InI").write_bytes(expected)
-    (car_dir / "data.acd").write_bytes(b"malformed")
 
     assert read_car_data_member(car_dir, "lods.ini") == expected
+
+
+def test_member_lookup_prefers_packed_source_when_both_exist(tmp_path: Path) -> None:
+    car_dir = tmp_path / "dual_source_car"
+    (car_dir / "data").mkdir(parents=True)
+    (car_dir / "data" / "lods.ini").write_bytes(b"unpacked")
+    packed = _build_acd(car_dir.name, {"lods.ini": b"packed"})
+    (car_dir / "data.acd").write_bytes(packed)
+
+    assert read_car_data_member(car_dir, "lods.ini") == b"packed"
+
+
+def test_nested_packed_member_does_not_alias_root_member(tmp_path: Path) -> None:
+    car_dir = tmp_path / "nested_car"
+    car_dir.mkdir()
+    (car_dir / "data.acd").write_bytes(_build_acd(car_dir.name, {"nested/lods.ini": b"nested"}))
+
+    assert read_car_data_member(car_dir, "lods.ini") is None
 
 
 def test_member_lookup_rejects_paths_and_malformed_archives(tmp_path: Path) -> None:

--- a/tests/test_ac_content.py
+++ b/tests/test_ac_content.py
@@ -1,0 +1,56 @@
+"""Hermetic coverage for shared Assetto Corsa car-content access."""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+from tools.ac_content import acd_key, read_car_data_member, unpack_acd
+
+
+def _build_acd(folder_name: str, members: dict[str, bytes]) -> bytes:
+    key_ord = [ord(char) for char in acd_key(folder_name)]
+    blob = bytearray(struct.pack("<ll", -1111, 42))
+    for name, content in members.items():
+        name_bytes = name.encode()
+        blob.extend(struct.pack("<I", len(name_bytes)))
+        blob.extend(name_bytes)
+        blob.extend(struct.pack("<I", len(content)))
+        for index, value in enumerate(content):
+            blob.extend(struct.pack("<I", (value + key_ord[index % len(key_ord)]) & 0xFF))
+    return bytes(blob)
+
+
+def test_acd_key_matches_known_stock_car_value() -> None:
+    assert acd_key("bmw_m3_gt2") == "177-166-216-52-166-192-73-51"
+
+
+def test_unpack_and_member_lookup_support_packed_source(tmp_path: Path) -> None:
+    car_dir = tmp_path / "synth_car"
+    car_dir.mkdir()
+    lods = b"[LOD_0]\nFILE=synth_car.kn5\n"
+    packed = _build_acd(car_dir.name, {"LoDs.InI": lods, "other.ini": b"ok"})
+    (car_dir / "data.acd").write_bytes(packed)
+
+    assert unpack_acd(packed, car_dir.name)["LoDs.InI"] == lods
+    assert read_car_data_member(car_dir, "LODS.INI") == lods
+
+
+def test_member_lookup_prefers_unpacked_source(tmp_path: Path) -> None:
+    car_dir = tmp_path / "unpacked_car"
+    (car_dir / "data").mkdir(parents=True)
+    expected = b"[LOD_0]\nFILE=unpacked_car.kn5\n"
+    (car_dir / "data" / "LoDs.InI").write_bytes(expected)
+    (car_dir / "data.acd").write_bytes(b"malformed")
+
+    assert read_car_data_member(car_dir, "lods.ini") == expected
+
+
+def test_member_lookup_rejects_paths_and_malformed_archives(tmp_path: Path) -> None:
+    car_dir = tmp_path / "broken_car"
+    car_dir.mkdir()
+    (car_dir / "data.acd").write_bytes(b"bad")
+
+    assert read_car_data_member(car_dir, "../lods.ini") is None
+    assert read_car_data_member(car_dir, "nested/lods.ini") is None
+    assert read_car_data_member(car_dir, "lods.ini") is None

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2414,6 +2414,37 @@ def test_preset_only_preflight_failure_keeps_car_identity_in_default_evidence(
     assert payload["preflight"]["classification"] == "non_drive_preflight_failure"
 
 
+def test_undecodable_preset_is_evidenced_instead_of_crashing(tmp_path, monkeypatch):
+    ac_root, user, cm = _fake_rig(tmp_path)
+    preset = tmp_path / "invalid-encoding.cmpreset"
+    preset.write_bytes(b'{"CarId":"broken-\xff"}')
+    monkeypatch.chdir(tmp_path)
+
+    rc = _main(
+        [
+            "--cm-preset",
+            str(preset),
+            "--track",
+            "spa",
+            "--ac-root",
+            str(ac_root),
+            "--ac-user-dir",
+            str(user),
+            "--cm-exe",
+            str(cm),
+            "--preflight-only",
+        ]
+    )
+
+    assert rc == 2
+    reports = list((tmp_path / ".scratch" / "harness-evidence").glob("*/report.json"))
+    assert len(reports) == 1
+    assert "_car_spa" in reports[0].parent.name
+    payload = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert payload["report"]["car_id"] is None
+    assert any(issue["check"] == "preset" for issue in payload["preflight"]["issues"])
+
+
 def test_preflight_app_version_drift_is_a_warning_not_an_error(tmp_path):
     """#575: a drifted app is loud but never bricks the run — --strict-app-version is the gate."""
     ac_root, user, cm = _fake_rig(tmp_path)

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2325,6 +2325,27 @@ def test_car_content_preflight_rejects_unusable_lod_configuration(
     assert [issue.check for issue in issues] == [expected_check]
 
 
+def test_car_content_preflight_accepts_inline_comment_on_lod_file(tmp_path):
+    ac_root, _user, _cm = _fake_rig(tmp_path)
+    car_dir = ac_root / "content" / "cars" / "ks_porsche_911_gt3_r_2016"
+    (car_dir / "data" / "lods.ini").write_text(
+        "[LOD_0]\nFILE=ks_porsche_911_gt3_r_2016.kn5 ; main model\nIN=0\nOUT=2000\n"
+    )
+
+    assert car_content_preflight(car_dir) == []
+
+
+def test_car_content_preflight_reports_effective_packed_source(tmp_path):
+    ac_root, _user, _cm = _fake_rig(tmp_path)
+    car_dir = ac_root / "content" / "cars" / "ks_porsche_911_gt3_r_2016"
+    (car_dir / "data.acd").write_bytes(b"malformed")
+
+    issues = car_content_preflight(car_dir)
+
+    assert [issue.check for issue in issues] == ["car_lods"]
+    assert str(car_dir / "data.acd") in issues[0].message
+
+
 def test_cli_persists_non_drive_preflight_failure_without_launch(tmp_path, monkeypatch):
     ac_root, user, cm = _fake_rig(tmp_path)
     car_id = "ks_porsche_911_gt3_r_2016"

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -2375,6 +2375,45 @@ def test_cli_persists_non_drive_preflight_failure_without_launch(tmp_path, monke
     }
 
 
+def test_preset_only_preflight_failure_keeps_car_identity_in_default_evidence(
+    tmp_path, monkeypatch
+):
+    ac_root, user, cm = _fake_rig(tmp_path)
+    car_id = "ks_porsche_911_gt3_r_2016"
+    shutil.rmtree(ac_root / "content" / "cars" / car_id / "data")
+    preset = tmp_path / "damaged.cmpreset"
+    preset.write_text(json.dumps({"CarId": car_id, "TrackId": "spa"}), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "tools.ac_harness.auto_drive.rig_launch",
+        lambda _config: pytest.fail("damaged preset car must fail before launch"),
+    )
+
+    rc = _main(
+        [
+            "--cm-preset",
+            str(preset),
+            "--track",
+            "spa",
+            "--ac-root",
+            str(ac_root),
+            "--ac-user-dir",
+            str(user),
+            "--cm-exe",
+            str(cm),
+            "--preflight-only",
+        ]
+    )
+
+    assert rc == 2
+    reports = list((tmp_path / ".scratch" / "harness-evidence").glob("*/report.json"))
+    assert len(reports) == 1
+    assert car_id in reports[0].parent.name
+    payload = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert payload["report"]["car_id"] == car_id
+    assert payload["preflight"]["classification"] == "non_drive_preflight_failure"
+
+
 def test_preflight_app_version_drift_is_a_warning_not_an_error(tmp_path):
     """#575: a drifted app is loud but never bricks the run — --strict-app-version is the gate."""
     ac_root, user, cm = _fake_rig(tmp_path)

--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -8,6 +8,7 @@ reporting — is verified with no Assetto Corsa, no Windows, and no real sidecar
 from __future__ import annotations
 
 import asyncio
+import json
 import pathlib
 import shutil
 import threading
@@ -26,6 +27,7 @@ from tools.ac_harness.auto_drive import (
     _build_arg_parser,
     _build_driver,
     _config_from_args,
+    _main,
     _wait_live,
     app_install_provenance,
     app_provenance_recheck,
@@ -34,6 +36,7 @@ from tools.ac_harness.auto_drive import (
     bake_setup_into_race_ini,
     build_practice_preset,
     candidate_journal_laps_dirs,
+    car_content_preflight,
     collect_lap_archives,
     compose_failure_reason,
     custom_ai_enabled,
@@ -2254,7 +2257,12 @@ def _fake_rig(tmp_path, *, custom_ai="ENABLED=1\n"):
     ac_root = tmp_path / "ac"
     (ac_root / "content" / "tracks" / "spa" / "ai").mkdir(parents=True)
     (ac_root / "content" / "tracks" / "spa" / "ai" / "fast_lane.ai").write_bytes(b"x")
-    (ac_root / "content" / "cars" / "ks_porsche_911_gt3_r_2016").mkdir(parents=True)
+    car_dir = ac_root / "content" / "cars" / "ks_porsche_911_gt3_r_2016"
+    (car_dir / "data").mkdir(parents=True)
+    (car_dir / "data" / "lods.ini").write_text(
+        "[LOD_0]\nFILE=ks_porsche_911_gt3_r_2016.kn5\nIN=0\nOUT=2000\n"
+    )
+    (car_dir / "ks_porsche_911_gt3_r_2016.kn5").write_bytes(b"healthy model")
     (ac_root / "extension" / "config").mkdir(parents=True)
     (ac_root / "extension" / "config" / "new_behaviour.ini").write_text(
         f"[CUSTOM_AI]\n; hidden\n{custom_ai}"
@@ -2283,6 +2291,88 @@ def test_preflight_passes_on_complete_rig(tmp_path):
         cm_preset=None,
     )
     assert preflight(cfg, app_provenance=_match_provenance()) == []
+
+
+def test_car_content_preflight_classifies_missing_data_source(tmp_path):
+    ac_root, _user, _cm = _fake_rig(tmp_path)
+    car_dir = ac_root / "content" / "cars" / "ks_porsche_911_gt3_r_2016"
+    shutil.rmtree(car_dir / "data")
+
+    issues = car_content_preflight(car_dir)
+
+    assert [issue.check for issue in issues] == ["car_data"]
+    assert "neither data.acd nor an unpacked data/" in issues[0].message
+    assert "Restore" in issues[0].message
+
+
+@pytest.mark.parametrize(
+    ("lods_text", "expected_check"),
+    [
+        ("[HEADER]\nVERSION=1\n", "car_lods"),
+        ("[LOD_0]\nFILE=missing.kn5\nIN=0\nOUT=2000\n", "car_lod_file"),
+        ("[LOD_0]\nFILE=../outside.kn5\nIN=0\nOUT=2000\n", "car_lods"),
+    ],
+)
+def test_car_content_preflight_rejects_unusable_lod_configuration(
+    tmp_path, lods_text, expected_check
+):
+    ac_root, _user, _cm = _fake_rig(tmp_path)
+    car_dir = ac_root / "content" / "cars" / "ks_porsche_911_gt3_r_2016"
+    (car_dir / "data" / "lods.ini").write_text(lods_text)
+
+    issues = car_content_preflight(car_dir)
+
+    assert [issue.check for issue in issues] == [expected_check]
+
+
+def test_cli_persists_non_drive_preflight_failure_without_launch(tmp_path, monkeypatch):
+    ac_root, user, cm = _fake_rig(tmp_path)
+    car_id = "ks_porsche_911_gt3_r_2016"
+    shutil.rmtree(ac_root / "content" / "cars" / car_id / "data")
+    evidence = tmp_path / "evidence"
+    monkeypatch.setattr(
+        "tools.ac_harness.auto_drive.rig_launch",
+        lambda _config: pytest.fail("damaged content must fail before launch"),
+    )
+
+    rc = _main(
+        [
+            "--car",
+            car_id,
+            "--track",
+            "spa",
+            "--ac-root",
+            str(ac_root),
+            "--ac-user-dir",
+            str(user),
+            "--cm-exe",
+            str(cm),
+            "--evidence-dir",
+            str(evidence),
+            "--preflight-only",
+        ]
+    )
+
+    assert rc == 2
+    payload = json.loads((evidence / "report.json").read_text(encoding="utf-8"))
+    assert payload["report"]["stage"] == "preflight"
+    assert payload["report"]["launched"] is False
+    assert payload["report"]["drive"] is None
+    assert payload["report"]["attempts"] == []
+    assert "[car_data]" in payload["report"]["reason"]
+    assert payload["preflight"] == {
+        "status": "failed",
+        "classification": "non_drive_preflight_failure",
+        "counts_as_drive_run": False,
+        "counts_as_sim_death": False,
+        "issues": [
+            {
+                "check": "car_data",
+                "message": payload["preflight"]["issues"][0]["message"],
+                "severity": "error",
+            }
+        ],
+    }
 
 
 def test_preflight_app_version_drift_is_a_warning_not_an_error(tmp_path):
@@ -2583,6 +2673,25 @@ def test_preflight_detects_preset_combo_mismatch(tmp_path):
     checks = {i.check for i in preflight(cfg)}
     assert "preset_track_mismatch" in checks
     assert "preset_car_mismatch" in checks
+
+
+def test_preflight_validates_car_selected_only_by_hand_authored_preset(tmp_path):
+    ac_root, user, cm = _fake_rig(tmp_path)
+    preset = tmp_path / "missing-car.cmpreset"
+    preset.write_text(json.dumps({"CarId": "missing_mod", "TrackId": "spa"}))
+    cfg = _cfg(
+        ac_root=ac_root,
+        ac_user_dir=user,
+        cm_exe=cm,
+        track_id="spa",
+        car_id=None,
+        cm_preset=preset,
+    )
+
+    issues = preflight(cfg, app_provenance=_match_provenance())
+
+    assert [issue.check for issue in issues] == ["car"]
+    assert "missing_mod" in issues[0].message
 
 
 def test_preflight_flags_missing_cm_preset(tmp_path):

--- a/tests/test_tyre_specs.py
+++ b/tests/test_tyre_specs.py
@@ -15,6 +15,7 @@ import pytest
 from tools.ai_sidecar.tyre_specs import (
     TyreSpec,
     _acd_key,
+    read_car_data_member,
     read_tyre_specs,
 )
 
@@ -122,6 +123,7 @@ def synth_car(tmp_path: Path) -> Path:
     acd = _build_acd(
         folder,
         {
+            "lods.ini": "[LOD_0]\nFILE=synth_test_car.kn5\nIN=0\nOUT=2000\n",
             "tyres.ini": _SYNTH_TYRES_INI,
             "tcurve_r888.lut": _SYNTH_R888_LUT,
             "tcurve_slick.lut": _SYNTH_SLICK_LUT,
@@ -153,6 +155,18 @@ def test_acd_roundtrip_compound0(synth_car: Path) -> None:
         dy_ref=1.42,
         optimal_temp_c=85.0,  # peak of the 3-point PERFORMANCE_CURVE
         version=7,
+    )
+
+
+def test_read_car_data_member_supports_packed_and_unpacked_sources(synth_car: Path) -> None:
+    packed = read_car_data_member(synth_car, "LODS.INI")
+    assert packed is not None and b"FILE=synth_test_car.kn5" in packed
+
+    unpacked = synth_car.parent / "unpacked_car"
+    (unpacked / "data").mkdir(parents=True)
+    (unpacked / "data" / "LoDs.InI").write_bytes(b"[LOD_0]\nFILE=unpacked_car.kn5\n")
+    assert (
+        read_car_data_member(unpacked, "lods.ini") == (unpacked / "data" / "LoDs.InI").read_bytes()
     )
 
 

--- a/tests/test_tyre_specs.py
+++ b/tests/test_tyre_specs.py
@@ -12,12 +12,8 @@ from pathlib import Path
 
 import pytest
 
-from tools.ai_sidecar.tyre_specs import (
-    TyreSpec,
-    _acd_key,
-    read_car_data_member,
-    read_tyre_specs,
-)
+from tools.ac_content import acd_key
+from tools.ai_sidecar.tyre_specs import TyreSpec, read_tyre_specs
 
 # --------------------------------------------------------------------------------------------------
 # Synthetic ACD encoder (mirror-image of the reader's decrypt path)
@@ -43,7 +39,7 @@ def _build_acd(folder_name: str, members: dict[str, str], with_version: bool = T
     Layout: optional ``[-1111][version]`` prefix, then per member
     ``[name_len:uint32][name][content_len:uint32][content int32s]``.
     """
-    key = _acd_key(folder_name)
+    key = acd_key(folder_name)
     blob = bytearray()
     if with_version:
         blob += struct.pack("<l", -1111)
@@ -155,18 +151,6 @@ def test_acd_roundtrip_compound0(synth_car: Path) -> None:
         dy_ref=1.42,
         optimal_temp_c=85.0,  # peak of the 3-point PERFORMANCE_CURVE
         version=7,
-    )
-
-
-def test_read_car_data_member_supports_packed_and_unpacked_sources(synth_car: Path) -> None:
-    packed = read_car_data_member(synth_car, "LODS.INI")
-    assert packed is not None and b"FILE=synth_test_car.kn5" in packed
-
-    unpacked = synth_car.parent / "unpacked_car"
-    (unpacked / "data").mkdir(parents=True)
-    (unpacked / "data" / "LoDs.InI").write_bytes(b"[LOD_0]\nFILE=unpacked_car.kn5\n")
-    assert (
-        read_car_data_member(unpacked, "lods.ini") == (unpacked / "data" / "LoDs.InI").read_bytes()
     )
 
 

--- a/tools/ac_content.py
+++ b/tools/ac_content.py
@@ -1,0 +1,136 @@
+"""Read-only access to Assetto Corsa car data in unpacked or ``data.acd`` form."""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+_ACD_DUMMY_LEADING = -1111
+
+
+def acd_key(folder_name: str) -> str:
+    """Derive the ACD obfuscation key string from the car folder name."""
+    o = [ord(c) for c in folder_name]
+    n = len(o)
+
+    p1 = sum(o) & 0xFF
+
+    p2 = 0
+    i = 0
+    while i < n - 1:
+        p2 = p2 * o[i]
+        i += 1
+        p2 -= o[i]
+        i += 1
+    p2 &= 0xFF
+
+    p3 = 0
+    i = 1
+    while i < n - 3:
+        p3 *= o[i]
+        i += 1
+        p3 = -(abs(p3) // (o[i] + 0x1B)) if p3 < 0 else p3 // (o[i] + 0x1B)
+        i -= 2
+        p3 += -0x1B - o[i]
+        i += 4
+    p3 &= 0xFF
+
+    p4 = 0x1683
+    for value in o[1:]:
+        p4 -= value
+    p4 &= 0xFF
+
+    p5 = 0x42
+    i = 1
+    while i < n - 4:
+        p5 = (o[i - 1] + 0xF) * (p5 * (o[i] + 0xF)) + 0x16
+        i += 4
+    p5 &= 0xFF
+
+    p6 = 0x65
+    for value in o[: max(0, n - 2) : 2]:
+        p6 -= value
+    p6 &= 0xFF
+
+    p7 = 0xAB
+    for value in o[: max(0, n - 2) : 2]:
+        p7 %= value
+    p7 &= 0xFF
+
+    p8 = 0xAB
+    i = 0
+    while i < n - 1:
+        p8 //= o[i]
+        i += 1
+        p8 += o[i]
+    p8 &= 0xFF
+
+    return f"{p1}-{p2}-{p3}-{p4}-{p5}-{p6}-{p7}-{p8}"
+
+
+def unpack_acd(data: bytes, folder_name: str) -> dict[str, bytes]:
+    """De-obfuscate a raw ``data.acd`` blob into ``{filename: content_bytes}``."""
+    key_ord = [ord(char) for char in acd_key(folder_name)]
+    if not key_ord:
+        raise ValueError("empty ACD key")
+
+    files: dict[str, bytes] = {}
+    pos = 0
+    total = len(data)
+    (lead,) = struct.unpack_from("<l", data, pos)
+    if lead == _ACD_DUMMY_LEADING:
+        pos += 8
+
+    while pos < total:
+        (name_len,) = struct.unpack_from("<I", data, pos)
+        pos += 4
+        if name_len == 0 or pos + name_len > total:
+            break
+        name = data[pos : pos + name_len].decode("utf-8", "replace")
+        pos += name_len
+
+        (content_len,) = struct.unpack_from("<I", data, pos)
+        pos += 4
+        content_span = content_len * 4
+        if pos + content_span > total:
+            break
+
+        out = bytearray(content_len)
+        for index in range(content_len):
+            low = data[pos + index * 4]
+            out[index] = (low - key_ord[index % len(key_ord)]) & 0xFF
+        pos += content_span
+        files[name] = bytes(out)
+
+    return files
+
+
+def read_car_data_member(car_dir: str | Path, member_name: str) -> bytes | None:
+    """Read one member from a car's effective ``data/`` or packed ``data.acd`` source.
+
+    The lookup is case-insensitive, read-only, and returns ``None`` for a missing or malformed
+    source/member.
+    """
+    try:
+        path = Path(car_dir)
+        normalized = member_name.replace("\\", "/")
+        if not normalized or "/" in normalized or normalized in (".", ".."):
+            return None
+        wanted = normalized.lower()
+
+        data_dir = path / "data"
+        if data_dir.is_dir():
+            for child in data_dir.iterdir():
+                if child.is_file() and child.name.lower() == wanted:
+                    return child.read_bytes()
+            return None
+
+        acd_path = path / "data.acd"
+        if not acd_path.is_file():
+            return None
+        for name, content in unpack_acd(acd_path.read_bytes(), path.name).items():
+            if name.replace("\\", "/").rsplit("/", 1)[-1].lower() == wanted:
+                return content
+    except (OSError, TypeError, ValueError, struct.error, IndexError):
+        return None
+    return None

--- a/tools/ac_content.py
+++ b/tools/ac_content.py
@@ -105,31 +105,46 @@ def unpack_acd(data: bytes, folder_name: str) -> dict[str, bytes]:
     return files
 
 
-def read_car_data_member(car_dir: str | Path, member_name: str) -> bytes | None:
-    """Read one member from a car's effective ``data/`` or packed ``data.acd`` source.
+def read_car_data_archive(car_dir: str | Path) -> dict[str, bytes] | None:
+    """Read a car's effective flat data archive without modifying content.
 
-    The lookup is case-insensitive, read-only, and returns ``None`` for a missing or malformed
-    source/member.
+    Assetto Corsa gives ``data.acd`` precedence when both packed and unpacked sources exist; an
+    unpacked ``data/`` folder becomes effective only when the archive is absent.  Preserve that
+    launch behavior even when the packed archive is malformed rather than silently falling back
+    to content the game would not load.
     """
     try:
         path = Path(car_dir)
+        acd_path = path / "data.acd"
+        if acd_path.is_file():
+            return unpack_acd(acd_path.read_bytes(), path.name)
+
+        data_dir = path / "data"
+        if data_dir.is_dir():
+            return {
+                child.name: child.read_bytes() for child in data_dir.iterdir() if child.is_file()
+            }
+    except (OSError, TypeError, ValueError, struct.error, IndexError):
+        return None
+    return None
+
+
+def read_car_data_member(car_dir: str | Path, member_name: str) -> bytes | None:
+    """Read one flat member from the car data source Assetto Corsa will use.
+
+    The lookup is case-insensitive, read-only, and returns ``None`` for a missing or malformed
+    source/member. Nested archive paths never alias a root-level member.
+    """
+    try:
         normalized = member_name.replace("\\", "/")
         if not normalized or "/" in normalized or normalized in (".", ".."):
             return None
         wanted = normalized.lower()
-
-        data_dir = path / "data"
-        if data_dir.is_dir():
-            for child in data_dir.iterdir():
-                if child.is_file() and child.name.lower() == wanted:
-                    return child.read_bytes()
+        archive = read_car_data_archive(car_dir)
+        if archive is None:
             return None
-
-        acd_path = path / "data.acd"
-        if not acd_path.is_file():
-            return None
-        for name, content in unpack_acd(acd_path.read_bytes(), path.name).items():
-            if name.replace("\\", "/").rsplit("/", 1)[-1].lower() == wanted:
+        for name, content in archive.items():
+            if name.replace("\\", "/").lower() == wanted:
                 return content
     except (OSError, TypeError, ValueError, struct.error, IndexError):
         return None

--- a/tools/ac_content.py
+++ b/tools/ac_content.py
@@ -105,28 +105,54 @@ def unpack_acd(data: bytes, folder_name: str) -> dict[str, bytes]:
     return files
 
 
-def read_car_data_archive(car_dir: str | Path) -> dict[str, bytes] | None:
-    """Read a car's effective flat data archive without modifying content.
+class CarDataSource:
+    """Lazy flat-member accessor for the data source Assetto Corsa will load.
 
-    Assetto Corsa gives ``data.acd`` precedence when both packed and unpacked sources exist; an
-    unpacked ``data/`` folder becomes effective only when the archive is absent.  Preserve that
-    launch behavior even when the packed archive is malformed rather than silently falling back
-    to content the game would not load.
+    ``data.acd`` has precedence when present. Packed members are decoded at most once per accessor;
+    unpacked files are read only when explicitly requested. Both forms expose the same root-level,
+    case-insensitive contract, so nested packed entries cannot behave differently from ``data/``.
     """
-    try:
-        path = Path(car_dir)
-        acd_path = path / "data.acd"
-        if acd_path.is_file():
-            return unpack_acd(acd_path.read_bytes(), path.name)
 
-        data_dir = path / "data"
-        if data_dir.is_dir():
-            return {
-                child.name: child.read_bytes() for child in data_dir.iterdir() if child.is_file()
-            }
-    except (OSError, TypeError, ValueError, struct.error, IndexError):
+    def __init__(self, car_dir: str | Path) -> None:
+        self.car_dir = Path(car_dir)
+        self._packed_loaded = False
+        self._packed_members: dict[str, bytes] | None = None
+
+    @staticmethod
+    def _member_key(member_name: str) -> str | None:
+        normalized = member_name.replace("\\", "/")
+        if not normalized or "/" in normalized or normalized in (".", ".."):
+            return None
+        return normalized.lower()
+
+    def read_member(self, member_name: str) -> bytes | None:
+        """Read one flat member without falling back to an inactive data source."""
+        try:
+            wanted = self._member_key(member_name)
+            if wanted is None:
+                return None
+
+            acd_path = self.car_dir / "data.acd"
+            if acd_path.is_file():
+                if not self._packed_loaded:
+                    self._packed_loaded = True
+                    self._packed_members = unpack_acd(acd_path.read_bytes(), self.car_dir.name)
+                if self._packed_members is None:
+                    return None
+                for name, content in self._packed_members.items():
+                    normalized = name.replace("\\", "/")
+                    if "/" not in normalized and normalized.lower() == wanted:
+                        return content
+                return None
+
+            data_dir = self.car_dir / "data"
+            if data_dir.is_dir():
+                for child in data_dir.iterdir():
+                    if child.is_file() and child.name.lower() == wanted:
+                        return child.read_bytes()
+        except (OSError, TypeError, ValueError, struct.error, IndexError):
+            return None
         return None
-    return None
 
 
 def read_car_data_member(car_dir: str | Path, member_name: str) -> bytes | None:
@@ -136,16 +162,7 @@ def read_car_data_member(car_dir: str | Path, member_name: str) -> bytes | None:
     source/member. Nested archive paths never alias a root-level member.
     """
     try:
-        normalized = member_name.replace("\\", "/")
-        if not normalized or "/" in normalized or normalized in (".", ".."):
-            return None
-        wanted = normalized.lower()
-        archive = read_car_data_archive(car_dir)
-        if archive is None:
-            return None
-        for name, content in archive.items():
-            if name.replace("\\", "/").lower() == wanted:
-                return content
+        return CarDataSource(car_dir).read_member(member_name)
     except (OSError, TypeError, ValueError, struct.error, IndexError):
         return None
     return None

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -71,6 +71,7 @@ from datetime import UTC
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Protocol
 
+from tools.ac_content import read_car_data_member
 from tools.ac_harness.sequence_probe import (
     Check,
     evaluate_sequence,
@@ -78,7 +79,6 @@ from tools.ac_harness.sequence_probe import (
     tap_frames,
 )
 from tools.ai_sidecar.external_protocol import CLIENT_CLASS_OBSERVER
-from tools.ai_sidecar.tyre_specs import read_car_data_member
 
 if TYPE_CHECKING:
     from tools.ac_harness.ggv_profile import GGVModel

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1964,6 +1964,35 @@ def custom_ai_enabled(ac_root: Path, user_dir: Path) -> tuple[bool | None, str]:
     return None, "no [CUSTOM_AI] ENABLED key in " + " or ".join(str(c) for c in candidates)
 
 
+def _read_cm_preset_selection(path: str | Path) -> tuple[str | None, str | None]:
+    """Return ``(car_id, track_id)`` from a readable Quick Drive preset.
+
+    Parsing remains side-effect free so callers can use the effective selection for evidence
+    metadata without mutating the explicit CLI configuration.  Read/JSON errors intentionally
+    propagate: :func:`preflight` turns them into actionable rows, while early evidence naming
+    can safely fall back to generic tags.
+    """
+    preset = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(preset, dict):
+        raise TypeError("Quick Drive preset root must be a JSON object")
+    car_id = str(preset.get("CarId") or "").strip() or None
+    track_id = str(preset.get("TrackId") or "").strip() or None
+    return car_id, track_id
+
+
+def _effective_car_id(config: AutoDriveConfig) -> str | None:
+    """Resolve the selected car for read-only evidence attribution."""
+    if config.car_id:
+        return config.car_id
+    if config.cm_preset is None or not Path(config.cm_preset).is_file():
+        return None
+    try:
+        preset_car, _preset_track = _read_cm_preset_selection(config.cm_preset)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return None
+    return preset_car
+
+
 def preflight(
     config: AutoDriveConfig, *, app_provenance: AppInstallProvenance | None = None
 ) -> list[PreflightIssue]:
@@ -1979,7 +2008,7 @@ def preflight(
     """
     issues: list[PreflightIssue] = []
     user_dir = resolve_ac_user_dir(config.ac_user_dir)
-    selected_car_id = config.car_id
+    selected_car_id = _effective_car_id(config)
 
     if not config.ac_root.is_dir():
         issues.append(
@@ -2008,16 +2037,12 @@ def preflight(
         )
     elif config.cm_preset is not None and Path(config.cm_preset).is_file():
         try:
-            preset = json.loads(Path(config.cm_preset).read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+            preset_car, preset_track = _read_cm_preset_selection(config.cm_preset)
+        except (OSError, json.JSONDecodeError, TypeError) as exc:
             issues.append(
                 PreflightIssue("preset", f"unreadable Quick Drive preset {config.cm_preset}: {exc}")
             )
         else:
-            preset_track = str(preset.get("TrackId") or "")
-            preset_car = str(preset.get("CarId") or "")
-            if selected_car_id is None and preset_car:
-                selected_car_id = preset_car
             # Compare the FULL TrackId incl. layout: on a multi-layout track a preset launching a
             # different layout than --track-layout would drive the wrong fast_lane.ai (#460 review).
             want_track = config.track_id.lower()
@@ -3934,7 +3959,15 @@ def _main_impl(
                 "the uncertainty-safe QSS envelope (bounded, falsification-gated self-play step)"
             )
 
-    car_tag = config.car_id or "car"
+    effective_car_id = _effective_car_id(config)
+    car_tag = "car"
+    if effective_car_id:
+        try:
+            validate_ac_id("car", effective_car_id)
+        except ValueError:
+            pass  # preflight will report the invalid preset id; never use it as a path segment
+        else:
+            car_tag = effective_car_id
     evidence_dir = args.evidence_dir or (
         Path(".scratch") / "harness-evidence" / f"{_utc_stamp()}_{car_tag}_{config.track_id}"
     )
@@ -3988,7 +4021,7 @@ def _main_impl(
             hijacked=False,
             drive=None,
             error=error,
-            car_id=config.car_id,
+            car_id=effective_car_id,
             track_id=config.track_id,
             setup_requested=config.setup,
         )

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1576,7 +1576,7 @@ def car_content_preflight(car_dir: Path) -> list[PreflightIssue]:
         ]
 
     lods_raw = read_car_data_member(car_dir, "lods.ini")
-    source = data_dir if data_dir.is_dir() else data_acd
+    source = data_acd if data_acd.is_file() else data_dir
     if not lods_raw:
         return [
             PreflightIssue(
@@ -1591,7 +1591,9 @@ def car_content_preflight(car_dir: Path) -> list[PreflightIssue]:
             lods_text = lods_raw.decode("utf-8-sig")
         except UnicodeDecodeError:
             lods_text = lods_raw.decode("cp1252")
-        parser = configparser.ConfigParser(strict=False, interpolation=None)
+        parser = configparser.ConfigParser(
+            strict=False, interpolation=None, inline_comment_prefixes=(";", "#")
+        )
         parser.read_string(lods_text)
     except (UnicodeDecodeError, configparser.Error) as exc:
         return [PreflightIssue("car_lods", f"car lods.ini is unreadable ({source}): {exc}")]

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -68,7 +68,7 @@ from collections.abc import Awaitable, Callable, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Protocol
 
 from tools.ac_harness.sequence_probe import (
@@ -78,6 +78,7 @@ from tools.ac_harness.sequence_probe import (
     tap_frames,
 )
 from tools.ai_sidecar.external_protocol import CLIENT_CLASS_OBSERVER
+from tools.ai_sidecar.tyre_specs import read_car_data_member
 
 if TYPE_CHECKING:
     from tools.ac_harness.ggv_profile import GGVModel
@@ -1554,6 +1555,98 @@ class PreflightIssue:
     severity: str = "error"
 
 
+def car_content_preflight(car_dir: Path) -> list[PreflightIssue]:
+    """Validate the selected car's read-only launch chain: data -> LOD config -> KN5s.
+
+    A car directory and its model files can survive a damaged Content Manager operation while
+    ``data.acd`` (or unpacked ``data/``) disappears.  AC then aborts before a drivable session, so
+    the harness must classify that as a non-drive content failure instead of paying launch timeouts
+    or contaminating drive/sim-death denominators (#603).
+    """
+    data_dir = car_dir / "data"
+    data_acd = car_dir / "data.acd"
+    if not data_dir.is_dir() and not data_acd.is_file():
+        return [
+            PreflightIssue(
+                "car_data",
+                f"car content is damaged: {car_dir} has neither data.acd nor an unpacked data/ "
+                "folder. Restore the car or verify its files in Steam/Content Manager before "
+                "running the harness.",
+            )
+        ]
+
+    lods_raw = read_car_data_member(car_dir, "lods.ini")
+    source = data_dir if data_dir.is_dir() else data_acd
+    if not lods_raw:
+        return [
+            PreflightIssue(
+                "car_lods",
+                f"car content is damaged: {source} is unreadable or has no lods.ini. Restore "
+                "the car or verify its files in Steam/Content Manager before running the harness.",
+            )
+        ]
+
+    try:
+        try:
+            lods_text = lods_raw.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            lods_text = lods_raw.decode("cp1252")
+        parser = configparser.ConfigParser(strict=False, interpolation=None)
+        parser.read_string(lods_text)
+    except (UnicodeDecodeError, configparser.Error) as exc:
+        return [PreflightIssue("car_lods", f"car lods.ini is unreadable ({source}): {exc}")]
+
+    sections = [section for section in parser.sections() if re.fullmatch(r"LOD_\d+", section, re.I)]
+    if not sections:
+        return [
+            PreflightIssue(
+                "car_lods",
+                f"car lods.ini in {source} has no [LOD_n] entries; restore or verify the car.",
+            )
+        ]
+
+    invalid: list[str] = []
+    missing: list[str] = []
+    for section in sections:
+        raw_ref = parser.get(section, "FILE", fallback="").strip().strip('"')
+        normalized = raw_ref.replace("\\", "/")
+        ref = PurePosixPath(normalized)
+        if (
+            not normalized
+            or normalized.startswith("/")
+            or re.match(r"^[A-Za-z]:", normalized)
+            or ".." in ref.parts
+            or ref.suffix.lower() != ".kn5"
+        ):
+            invalid.append(f"{section}.FILE={raw_ref or '<missing>'}")
+            continue
+        candidate = car_dir.joinpath(*ref.parts)
+        try:
+            usable = candidate.is_file() and candidate.stat().st_size > 0
+        except OSError:
+            usable = False
+        if not usable:
+            missing.append(str(ref))
+
+    if invalid:
+        return [
+            PreflightIssue(
+                "car_lods",
+                "car lods.ini has invalid LOD model entries: " + ", ".join(invalid[:4]),
+            )
+        ]
+    if missing:
+        return [
+            PreflightIssue(
+                "car_lod_file",
+                "car content is damaged: lods.ini references missing/empty model file(s): "
+                + ", ".join(missing[:4])
+                + ". Restore or verify the car files before running the harness.",
+            )
+        ]
+    return []
+
+
 # ---------------------------------------------------------------------------
 # Installed-app provenance (#575).
 #
@@ -1886,6 +1979,7 @@ def preflight(
     """
     issues: list[PreflightIssue] = []
     user_dir = resolve_ac_user_dir(config.ac_user_dir)
+    selected_car_id = config.car_id
 
     if not config.ac_root.is_dir():
         issues.append(
@@ -1902,13 +1996,6 @@ def preflight(
             issues.append(PreflightIssue("track", str(exc)))
     else:
         issues.append(PreflightIssue("track", "no track id (pass --track)"))
-
-    if config.car_id:
-        car_dir = config.ac_root / "content" / "cars" / config.car_id
-        if not car_dir.is_dir():
-            issues.append(
-                PreflightIssue("car", f"car content not installed: {car_dir} (check --car id)")
-            )
 
     if config.cm_preset is not None and not Path(config.cm_preset).is_file():
         # A missing --cm-preset must fail here, not later as an uncaught FileNotFoundError from
@@ -1929,6 +2016,8 @@ def preflight(
         else:
             preset_track = str(preset.get("TrackId") or "")
             preset_car = str(preset.get("CarId") or "")
+            if selected_car_id is None and preset_car:
+                selected_car_id = preset_car
             # Compare the FULL TrackId incl. layout: on a multi-layout track a preset launching a
             # different layout than --track-layout would drive the wrong fast_lane.ai (#460 review).
             want_track = config.track_id.lower()
@@ -1955,6 +2044,27 @@ def preflight(
                         f"--car {config.car_id!r} but preset launches CarId {preset_car!r}",
                     )
                 )
+
+    # Validate the actual selected car whether it came from --car or a hand-authored preset.
+    # Preset-only runs are a supported launch path; letting them bypass content validation would
+    # preserve the same full-timeout failure under a different CLI spelling (#603).
+    if selected_car_id:
+        try:
+            validate_ac_id("car", selected_car_id)
+        except ValueError as exc:
+            issues.append(PreflightIssue("car", str(exc)))
+        else:
+            car_dir = config.ac_root / "content" / "cars" / selected_car_id
+            if not car_dir.is_dir():
+                issues.append(
+                    PreflightIssue("car", f"car content not installed: {car_dir} (check car id)")
+                )
+            else:
+                issues.extend(car_content_preflight(car_dir))
+    elif config.cm_preset is not None and Path(config.cm_preset).is_file():
+        issues.append(
+            PreflightIssue("car", "Quick Drive preset has no CarId and --car was not provided")
+        )
 
     provenance = (
         app_install_provenance(config.ac_root) if app_provenance is None else app_provenance
@@ -3864,6 +3974,45 @@ def _main_impl(
         print("auto-drive: PREFLIGHT FAILED")
         for issue in fatal:
             print(f"  [{issue.check}] {issue.message}")
+        # A launch never started, so this is explicitly a non-drive outcome. Persist that
+        # distinction in the normal evidence surface: downstream reliability summaries can skip
+        # it without guessing from console text, and it can never inflate drive or sim-death
+        # denominators (#603).
+        error = "preflight failed: " + " | ".join(
+            f"[{issue.check}] {issue.message}" for issue in fatal
+        )
+        preflight_report = AutoDriveReport(
+            ok=False,
+            stage="preflight",
+            launched=False,
+            hijacked=False,
+            drive=None,
+            error=error,
+            car_id=config.car_id,
+            track_id=config.track_id,
+            setup_requested=config.setup,
+        )
+        report_path = write_evidence(
+            evidence_dir,
+            preflight_report,
+            extras={
+                "run": {
+                    "argv": list(argv) if argv is not None else None,
+                    "cm_preset": str(config.cm_preset),
+                    "driver": config.driver,
+                    "app_install": app_provenance.to_dict(),
+                },
+                "preflight": {
+                    "status": "failed",
+                    "classification": "non_drive_preflight_failure",
+                    "counts_as_drive_run": False,
+                    "counts_as_sim_death": False,
+                    "issues": [asdict(issue) for issue in fatal],
+                },
+            },
+        )
+        print(preflight_report.summary())
+        print(f"  evidence: {report_path}")
         return 2
     print("auto-drive: preflight ok")
     if args.preflight_only:

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -1972,7 +1972,7 @@ def _read_cm_preset_selection(path: str | Path) -> tuple[str | None, str | None]
     propagate: :func:`preflight` turns them into actionable rows, while early evidence naming
     can safely fall back to generic tags.
     """
-    preset = json.loads(Path(path).read_text(encoding="utf-8"))
+    preset = json.loads(Path(path).read_text(encoding="utf-8-sig"))
     if not isinstance(preset, dict):
         raise TypeError("Quick Drive preset root must be a JSON object")
     car_id = str(preset.get("CarId") or "").strip() or None
@@ -1988,7 +1988,7 @@ def _effective_car_id(config: AutoDriveConfig) -> str | None:
         return None
     try:
         preset_car, _preset_track = _read_cm_preset_selection(config.cm_preset)
-    except (OSError, json.JSONDecodeError, TypeError):
+    except (OSError, UnicodeError, ValueError, TypeError):
         return None
     return preset_car
 
@@ -2038,7 +2038,7 @@ def preflight(
     elif config.cm_preset is not None and Path(config.cm_preset).is_file():
         try:
             preset_car, preset_track = _read_cm_preset_selection(config.cm_preset)
-        except (OSError, json.JSONDecodeError, TypeError) as exc:
+        except (OSError, UnicodeError, ValueError, TypeError) as exc:
             issues.append(
                 PreflightIssue("preset", f"unreadable Quick Drive preset {config.cm_preset}: {exc}")
             )

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -19,11 +19,10 @@ and never raises — the sidecar must not crash on one bad car.
 from __future__ import annotations
 
 import re
-import struct
 from dataclasses import dataclass
 from pathlib import Path
 
-from tools.ac_content import unpack_acd
+from tools.ac_content import read_car_data_archive
 
 #: Compound index N maps to sections ``[FRONT_N]`` / ``[REAR_N]``; N==0 also matches bare
 #: ``[FRONT]`` / ``[REAR]`` (AC treats the unsuffixed section as compound 0). Thermal curve lives in
@@ -77,8 +76,8 @@ def _decode_text(raw: bytes) -> str:
 def _load_archive(car_dir: Path) -> dict[str, str] | None:
     """Return ``{member_name: text}`` for the car, or ``None`` if no source is readable.
 
-    Prefers an unpacked ``data/`` folder (any car that has been extracted); otherwise decrypts
-    ``data.acd`` using the car FOLDER NAME as the key. Result cached per ``car_dir``.
+    Uses the same effective-source precedence as Assetto Corsa: packed ``data.acd`` when present,
+    otherwise a flat unpacked ``data/`` folder. Result cached per ``car_dir``.
     """
     cache_key = str(car_dir)
     if cache_key in _ARCHIVE_CACHE:
@@ -86,30 +85,18 @@ def _load_archive(car_dir: Path) -> dict[str, str] | None:
 
     archive: dict[str, str] | None = None
     try:
-        # Prefer an unpacked data/ folder. Read the small data files (tyres.ini + any .lut) up
-        # front, lowercasing member names so every downstream lookup is case-insensitive — AC mods
-        # ship TYRES.INI / Tyres.ini too, and a case-exact check misses them on a case-sensitive FS.
-        data_dir = car_dir / "data"
-        members: dict[str, str] = {}
-        if data_dir.is_dir():
-            for child in data_dir.iterdir():
-                if child.is_file() and child.suffix.lower() in (".ini", ".lut"):
-                    try:
-                        members[child.name.lower()] = _decode_text(child.read_bytes())
-                    except OSError:
-                        continue
-        if "tyres.ini" in members:
-            archive = members
-        else:
-            acd_path = car_dir / "data.acd"
-            if acd_path.is_file():
-                raw = acd_path.read_bytes()
-                unpacked = unpack_acd(raw, car_dir.name)  # key derived from THIS folder's name
-                # Lowercase member names for the same case-insensitive lookups downstream.
-                lowered = {name.lower(): blob for name, blob in unpacked.items()}
-                if "tyres.ini" in lowered:
-                    archive = {name: _decode_text(blob) for name, blob in lowered.items()}
-    except (OSError, ValueError, struct.error, IndexError):
+        members = read_car_data_archive(car_dir)
+        if members is not None:
+            # Only root-level INI/LUT members participate, matching the unpacked flat directory.
+            lowered = {
+                normalized.lower(): blob
+                for name, blob in members.items()
+                if "/" not in (normalized := name.replace("\\", "/"))
+                and Path(normalized).suffix.lower() in (".ini", ".lut")
+            }
+            if "tyres.ini" in lowered:
+                archive = {name: _decode_text(blob) for name, blob in lowered.items()}
+    except (OSError, ValueError, IndexError):
         archive = None
 
     # Bounded insert: evict the oldest entry (dict preserves insertion order) when at capacity.

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -230,6 +230,41 @@ def _decode_text(raw: bytes) -> str:
     return raw.decode("utf-8", "replace")
 
 
+def read_car_data_member(car_dir: str | Path, member_name: str) -> bytes | None:
+    """Read one file from a car's effective ``data/`` or packed ``data.acd`` source.
+
+    Assetto Corsa content can be installed in either form.  Keep the packed-container knowledge
+    here, beside :func:`_acd_unpack`, so callers such as the autonomous-harness preflight do not
+    couple themselves to a private decoder or reimplement the ACD format.  The lookup is
+    case-insensitive (matching AC on Windows), read-only, and returns ``None`` for a missing or
+    malformed source/member.
+    """
+    try:
+        path = Path(car_dir)
+        normalized = member_name.replace("\\", "/")
+        if not normalized or "/" in normalized or normalized in (".", ".."):
+            return None
+        wanted = normalized.lower()
+
+        data_dir = path / "data"
+        if data_dir.is_dir():
+            for child in data_dir.iterdir():
+                if child.is_file() and child.name.lower() == wanted:
+                    return child.read_bytes()
+            return None
+
+        acd_path = path / "data.acd"
+        if not acd_path.is_file():
+            return None
+        unpacked = _acd_unpack(acd_path.read_bytes(), path.name)
+        for name, content in unpacked.items():
+            if name.replace("\\", "/").rsplit("/", 1)[-1].lower() == wanted:
+                return content
+    except (OSError, TypeError, ValueError, struct.error, IndexError):
+        return None
+    return None
+
+
 def _load_archive(car_dir: Path) -> dict[str, str] | None:
     """Return ``{member_name: text}`` for the car, or ``None`` if no source is readable.
 

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -8,22 +8,9 @@ references, and the car-specific optimal core temperature baked into the thermal
 `PERFORMANCE_CURVE` — so downstream coaching can key off the *actual* compound the driver
 selected (``ac.getCar().compoundIndex`` / setup ``[TYRES] VALUE``) instead of a generic guess.
 
-On this rig every stock/Kunos car ships **only** ``data.acd`` (no unpacked ``data/`` folder), so
-this module must decrypt the packed+obfuscated ACD container itself. Pure stdlib, Windows-safe.
-
-ACD format (confirmed by decrypting the real ``ks_porsche_911_gt3_r_2016/data.acd`` — see the
-Part-B investigation note). Canonical reference: the ``bovis/acd_extractor`` Ruby implementation
-and aluigi's ZenHAX writeup (``zenhax.com/viewtopic.php?t=90``).
-
-* **Key** — derived from the CAR FOLDER NAME string via 8 small integer algorithms, then rendered
-  as the dash-joined decimal string ``"p1-p2-...-p8"``. The *string* is the key material, so its
-  length is variable (25 chars for the 911), and de-obfuscation indexes byte-by-byte into it.
-* **Container** — leading ``int32``: if it equals ``-1111`` a version ``int32`` follows, otherwise
-  it is already the first filename length. Then repeating records:
-  ``[name_len:uint32][name bytes][content_len:uint32][content]`` where content is stored as
-  ``content_len`` little-endian ``int32``s — only each int's low byte carries the obfuscated char.
-* **De-obfuscation** — ``char = (stored_low_byte - key_ord[i % len(key)]) mod 256`` (subtraction,
-  NOT XOR; empirically verified — XOR yields garbage).
+Stock/Kunos cars commonly ship only ``data.acd`` rather than an unpacked ``data/`` folder.
+The domain-neutral :mod:`tools.ac_content` module owns that packed-container format; this module
+only resolves tyre-specific members from the decoded archive.
 
 Everything is wrapped so a malformed / renamed / missing car degrades to ``None`` (or None-fields)
 and never raises — the sidecar must not crash on one bad car.
@@ -36,7 +23,8 @@ import struct
 from dataclasses import dataclass
 from pathlib import Path
 
-_ACD_DUMMY_LEADING = -1111
+from tools.ac_content import unpack_acd
+
 #: Compound index N maps to sections ``[FRONT_N]`` / ``[REAR_N]``; N==0 also matches bare
 #: ``[FRONT]`` / ``[REAR]`` (AC treats the unsuffixed section as compound 0). Thermal curve lives in
 #: the sibling ``[THERMAL_FRONT*]`` section.
@@ -64,150 +52,6 @@ class TyreSpec:
 
 
 # --------------------------------------------------------------------------------------------------
-# ACD decryption (folder-name key + container unpack)
-# --------------------------------------------------------------------------------------------------
-
-
-def _acd_key(folder_name: str) -> str:
-    """Derive the ACD obfuscation key string from the car folder name.
-
-    Verbatim port of the 8-part integer algorithm from the canonical ``bovis/acd_extractor``
-    ``Cipher.get_key``. Returns the dash-joined decimal string used as key material.
-    """
-    o = [ord(c) for c in folder_name]
-    n = len(o)
-
-    # PART 1: sum of all ordinals
-    p1 = 0
-    for i in range(n):
-        p1 += o[i]
-    p1 &= 0xFF
-
-    # PART 2: alternating multiply / subtract over pairs
-    p2 = 0
-    i = 0
-    while i < n - 1:
-        p2 = p2 * o[i]
-        i += 1
-        p2 = p2 - o[i]
-        i += 1
-    p2 &= 0xFF
-
-    # PART 3: multiply / integer-divide / subtract with +0x1b offset (truncate-toward-zero divide)
-    p3 = 0
-    i = 1
-    while i < n - 3:
-        p3 = p3 * o[i]
-        i += 1
-        if p3 < 0:
-            p3 = -(abs(p3) // (o[i] + 0x1B))
-        else:
-            p3 = p3 // (o[i] + 0x1B)
-        i -= 2
-        p3 = p3 + (-(0x1B) - o[i])
-        i += 4
-    p3 &= 0xFF
-
-    # PART 4: 0x1683 minus ordinals from index 1
-    p4 = 0x1683
-    i = 1
-    while i < n:
-        p4 = p4 - o[i]
-        i += 1
-    p4 &= 0xFF
-
-    # PART 5: 0x42 seeded multiply/add chain with 0xf / 0x16 offsets, stride 4
-    p5 = 0x42
-    i = 1
-    while i < n - 4:
-        a = p5 * (o[i] + 0xF)
-        i -= 1
-        b = o[i]
-        i += 1
-        b = b + 0xF
-        b = b * a
-        b = b + 0x16
-        p5 = b
-        i += 4
-    p5 &= 0xFF
-
-    # PART 6: 0x65 minus every other ordinal
-    p6 = 0x65
-    i = 0
-    while i < n - 2:
-        p6 = p6 - o[i]
-        i += 2
-    p6 &= 0xFF
-
-    # PART 7: 0xab modulo every other ordinal
-    p7 = 0xAB
-    i = 0
-    while i < n - 2:
-        p7 = p7 % o[i]
-        i += 2
-    p7 &= 0xFF
-
-    # PART 8: 0xab alternating integer-divide / add
-    p8 = 0xAB
-    i = 0
-    while i < n - 1:
-        p8 = p8 // o[i]
-        i += 1
-        p8 = p8 + o[i]
-    p8 &= 0xFF
-
-    return f"{p1}-{p2}-{p3}-{p4}-{p5}-{p6}-{p7}-{p8}"
-
-
-def _acd_unpack(data: bytes, folder_name: str) -> dict[str, bytes]:
-    """De-obfuscate a raw ``data.acd`` blob into ``{filename: content_bytes}``.
-
-    Raises on truncation/format errors; callers wrap this and degrade to ``None``.
-    """
-    key = _acd_key(folder_name)
-    key_ord = [ord(c) for c in key]
-    klen = len(key_ord)
-    if klen == 0:  # empty folder name -> unusable key
-        raise ValueError("empty ACD key")
-
-    files: dict[str, bytes] = {}
-    pos = 0
-    total = len(data)
-
-    # Leading int: -1111 => a version int follows; otherwise it IS the first filename length.
-    (lead,) = struct.unpack_from("<l", data, pos)
-    if lead == _ACD_DUMMY_LEADING:
-        pos += 4  # consume the -1111 marker
-        pos += 4  # consume the version int (not needed for extraction)
-
-    while pos < total:
-        (name_len,) = struct.unpack_from("<I", data, pos)
-        pos += 4
-        # A bogus length (obfuscation drift / trailing padding) would overrun — bail cleanly.
-        if name_len == 0 or pos + name_len > total:
-            break
-        name = data[pos : pos + name_len].decode("utf-8", "replace")
-        pos += name_len
-
-        (content_len,) = struct.unpack_from("<I", data, pos)
-        pos += 4
-        content_span = content_len * 4
-        if pos + content_span > total:
-            break
-
-        out = bytearray(content_len)
-        base = pos
-        for j in range(content_len):
-            low = data[base + j * 4]  # low byte of each int32 carries the obfuscated char
-            out[j] = (low - key_ord[j % klen]) & 0xFF
-        pos += content_span
-
-        files[name] = bytes(out)
-
-    return files
-
-
-# --------------------------------------------------------------------------------------------------
 # tyres.ini resolution + tolerant INI parsing
 # --------------------------------------------------------------------------------------------------
 
@@ -228,41 +72,6 @@ def _decode_text(raw: bytes) -> str:
         except UnicodeDecodeError:
             continue
     return raw.decode("utf-8", "replace")
-
-
-def read_car_data_member(car_dir: str | Path, member_name: str) -> bytes | None:
-    """Read one file from a car's effective ``data/`` or packed ``data.acd`` source.
-
-    Assetto Corsa content can be installed in either form.  Keep the packed-container knowledge
-    here, beside :func:`_acd_unpack`, so callers such as the autonomous-harness preflight do not
-    couple themselves to a private decoder or reimplement the ACD format.  The lookup is
-    case-insensitive (matching AC on Windows), read-only, and returns ``None`` for a missing or
-    malformed source/member.
-    """
-    try:
-        path = Path(car_dir)
-        normalized = member_name.replace("\\", "/")
-        if not normalized or "/" in normalized or normalized in (".", ".."):
-            return None
-        wanted = normalized.lower()
-
-        data_dir = path / "data"
-        if data_dir.is_dir():
-            for child in data_dir.iterdir():
-                if child.is_file() and child.name.lower() == wanted:
-                    return child.read_bytes()
-            return None
-
-        acd_path = path / "data.acd"
-        if not acd_path.is_file():
-            return None
-        unpacked = _acd_unpack(acd_path.read_bytes(), path.name)
-        for name, content in unpacked.items():
-            if name.replace("\\", "/").rsplit("/", 1)[-1].lower() == wanted:
-                return content
-    except (OSError, TypeError, ValueError, struct.error, IndexError):
-        return None
-    return None
 
 
 def _load_archive(car_dir: Path) -> dict[str, str] | None:
@@ -295,7 +104,7 @@ def _load_archive(car_dir: Path) -> dict[str, str] | None:
             acd_path = car_dir / "data.acd"
             if acd_path.is_file():
                 raw = acd_path.read_bytes()
-                unpacked = _acd_unpack(raw, car_dir.name)  # key derived from THIS folder's name
+                unpacked = unpack_acd(raw, car_dir.name)  # key derived from THIS folder's name
                 # Lowercase member names for the same case-insensitive lookups downstream.
                 lowered = {name.lower(): blob for name, blob in unpacked.items()}
                 if "tyres.ini" in lowered:

--- a/tools/ai_sidecar/tyre_specs.py
+++ b/tools/ai_sidecar/tyre_specs.py
@@ -22,7 +22,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from tools.ac_content import read_car_data_archive
+from tools.ac_content import CarDataSource
 
 #: Compound index N maps to sections ``[FRONT_N]`` / ``[REAR_N]``; N==0 also matches bare
 #: ``[FRONT]`` / ``[REAR]`` (AC treats the unsuffixed section as compound 0). Thermal curve lives in
@@ -85,17 +85,23 @@ def _load_archive(car_dir: Path) -> dict[str, str] | None:
 
     archive: dict[str, str] | None = None
     try:
-        members = read_car_data_archive(car_dir)
-        if members is not None:
-            # Only root-level INI/LUT members participate, matching the unpacked flat directory.
-            lowered = {
-                normalized.lower(): blob
-                for name, blob in members.items()
-                if "/" not in (normalized := name.replace("\\", "/"))
-                and Path(normalized).suffix.lower() in (".ini", ".lut")
-            }
-            if "tyres.ini" in lowered:
-                archive = {name: _decode_text(blob) for name, blob in lowered.items()}
+        source = CarDataSource(car_dir)
+        tyres_raw = source.read_member("tyres.ini")
+        if tyres_raw is not None:
+            tyres_text = _decode_text(tyres_raw)
+            archive = {"tyres.ini": tyres_text}
+            # Load only LUTs explicitly referenced by tyres.ini. The accessor caches one packed
+            # decode but reads no unrelated unpacked files, keeping sidecar startup bounded.
+            for section in _parse_ini_sections(tyres_text).values():
+                curve = section.get("PERFORMANCE_CURVE", "").strip()
+                if not curve.lower().endswith(".lut"):
+                    continue
+                member = curve.replace("\\", "/").rsplit("/", 1)[-1]
+                if member.lower() in archive:
+                    continue
+                lut_raw = source.read_member(member)
+                if lut_raw is not None:
+                    archive[member.lower()] = _decode_text(lut_raw)
     except (OSError, ValueError, IndexError):
         archive = None
 
@@ -245,8 +251,8 @@ def _optimal_temp_from_curve(
 def read_tyre_specs(car_dir: str | Path, compound_index: int) -> TyreSpec | None:
     """Resolve ``tyres.ini`` for ``car_dir``; return the :class:`TyreSpec` for ``compound_index``.
 
-    Source preference: unpacked ``data/tyres.ini`` if present, else decrypt ``data.acd`` (folder
-    name is the key). Parses ``[FRONT_<N>]`` (bare ``[FRONT]`` for N==0), falling back to
+    Source preference matches AC: packed ``data.acd`` when present, otherwise unpacked
+    ``data/tyres.ini``. Parses ``[FRONT_<N>]`` (bare ``[FRONT]`` for N==0), falling back to
     ``[REAR_<N>]`` for any key the front section omits. Optimal core temp is the peak of the
     matching ``[THERMAL_FRONT_<N>]`` (or ``[THERMAL_REAR_<N>]``) ``PERFORMANCE_CURVE``.
 


### PR DESCRIPTION
Closes #603.

## Outcome
- validate the selected car from `--car` or a hand-authored preset against the effective packed `data.acd` or unpacked `data/` source AC will load
- require readable root `lods.ini` with `[LOD_n]` entries, comment-tolerant `FILE=` values, and present non-empty referenced `.kn5` files
- persist fatal preflights as `non_drive_preflight_failure` evidence with explicit drive/sim-death denominator exclusions
- preserve preset-only car identity in the failure report and safe default evidence-directory tag; malformed encodings remain evidenced
- keep generic ACD/source/member access in a lazy shared `CarDataSource` used by the harness and tyre reader
- document stock/mod repair and `--preflight-only` recheck procedure

## Verification
- `make ci-fast`: 2,980 passed, 113 skipped, 87.60% coverage; format, lint, Bandit, secret, policy, agent, and CSP checks green
- focused harness/content/tyre suite: 222 passed
- real rig damaged `ks_porsche_911_gt3_r_2016`: exit 2, `[car_data]`, `stage=preflight`, `launched=false`, `drive=null`, zero attempts, explicit denominator flags false
- real rig preset-only Porsche: default evidence path and `report.car_id` both retain `ks_porsche_911_gt3_r_2016`
- real rig healthy packed `bmw_m3_gt2`: real ACD/`lods.ini`/KN5 chain validates, `preflight ok`, exit 0
- real dual-source Cayman: packed and unpacked payloads differ; effective resolver selects packed archive without reading unrelated unpacked files