### PR TITLE
docs(vault): rig maintenance — Porsche data.acd restored (not a code regression)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-16T03:20:00Z
+last_updated: 2026-07-16T07:30:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/rig-porsche-data-acd-restore-2026-07-16.md
   - AcCopilotTrainer/03_Investigations/issue-602-portaudio-fixed-layout-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-603-car-content-preflight-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-596-pit-stall-sim-death-2026-07-15.md
@@ -97,6 +98,15 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Rig maintenance (2026-07-16) — Porsche `data.acd` restored, tablet dash was collateral
+
+The "damaged, LODs list missing" Porsche (#603's trigger) was rig content damage, not a code
+regression: CM's extended-physics patch had renamed `data.acd` → `data.acd~cm_bak_ep` (2026-07-14
+23:47) without writing a replacement. Backup verified via `tools.ac_content` and copied back;
+`--preflight-only` now passes with app provenance `match`. Tablet dash server was healthy the whole
+time (`/tablet/dash` 200) — it was blank only because no race could launch. Detail:
+[[rig-porsche-data-acd-restore-2026-07-16]]. Keep CM "extended physics" unchecked for this car.
 
 ## Delivered (2026-07-16) — #602 fixed-layout voice recovery CLOSED (PR #606)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/rig-porsche-data-acd-restore-2026-07-16.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/rig-porsche-data-acd-restore-2026-07-16.md
@@ -1,0 +1,47 @@
+---
+type: investigation
+status: complete
+memory_tier: canonical
+created: 2026-07-16
+updated: 2026-07-16
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/03_Investigations/issue-603-car-content-preflight-2026-07-15.md
+  - AcCopilotTrainer/00_System/glossary/install-paths.md
+---
+
+# Rig maintenance — restored `ks_porsche_911_gt3_r_2016/data.acd` (2026-07-16)
+
+## Symptom
+
+Operator report: tablet dash "not working at all" and the primary test Porsche fails to launch.
+Content Manager dialog: *car "ks_porsche_911_gt3_r_2016" is damaged, LODs list is missing* —
+suspected as a code regression from the 2026-07-15 merges.
+
+## Root cause (rig content, NOT a code regression)
+
+`%AC_ROOT%\content\cars\ks_porsche_911_gt3_r_2016\` had **no `data.acd` and no unpacked `data/`**
+— only `data.acd~cm_bak_ep` (241,806 B). The `~cm_bak_ep` suffix is Content Manager's backup made
+when its **extended-physics data patch** rewrites car data: CM renamed the original away and the
+patched replacement never landed (folder mtime 2026-07-14 23:47). With zero data sources, AC cannot
+read `lods.ini` → the "LODs list is missing" dialog. This is the same damage the #596 rig session
+observed on 2026-07-15 and #603 turned into a launch preflight (PR #607). The 07-15 merges only
+*detect* the condition; they did not cause it.
+
+The tablet dash was collateral: sidecar healthy (`/health` ok, `/tablet/dash` → 200, screen peer
+connected) but no race ever launched, so it had no telemetry to render.
+
+## Fix
+
+- Verified `data.acd~cm_bak_ep` decodes as a valid packed ACD via `tools.ac_content.unpack_acd`
+  (70 members, `lods.ini` with LOD_0..3, all referenced `.kn5` present on disk).
+- **Copied** it back to `data.acd` (backup file preserved, byte-identical).
+- `python -m tools.ac_harness.auto_drive --car ks_porsche_911_gt3_r_2016 --track magione
+  --preflight-only` → `preflight ok`, app provenance `match`.
+
+## Prevention
+
+Before launching this car from CM, leave "extended physics (experimental)" **unchecked** for car
+data — the CM patch path is what renamed `data.acd` away. If the patch is ever wanted, confirm
+`data.acd` (or a complete unpacked `data/`) exists afterwards, or run the #603
+`--preflight-only` gate before driving.


### PR DESCRIPTION
Vault-only SAVE for the 2026-07-16 triage session.

**What happened:** operator reported the tablet dash dead and the primary test Porsche (`ks_porsche_911_gt3_r_2016`) failing to launch with *damaged, LODs list is missing* — suspected as a regression from the 07-15 merges.

**Root cause:** rig content damage, not code. CM's extended-physics patch renamed `data.acd` → `data.acd~cm_bak_ep` on 2026-07-14 23:47 and never wrote a replacement; with no data source AC can't read `lods.ini`. Same damage the #596 session observed and #603/PR #607 turned into a preflight. Tablet dash was collateral (sidecar healthy, no race → no telemetry).

**Fix applied on the rig:** backup verified as a valid packed ACD via `tools.ac_content`, copied back to `data.acd` (backup preserved); `auto_drive --preflight-only` now passes with app provenance `match`.

Diff is strictly under `docs/01_Vault/**` — eligible for vault-automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)