### PR TITLE
docs(vault): rig maintenance — tablet tunnel keeper armed (dash outage root cause)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -4,6 +4,7 @@ status: active
 memory_tier: canonical
 last_updated: 2026-07-16T07:30:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/rig-tablet-tunnel-keeper-armed-2026-07-16.md
   - AcCopilotTrainer/03_Investigations/rig-porsche-data-acd-restore-2026-07-16.md
   - AcCopilotTrainer/03_Investigations/issue-602-portaudio-fixed-layout-2026-07-15.md
   - AcCopilotTrainer/03_Investigations/issue-603-car-content-preflight-2026-07-15.md
@@ -107,6 +108,14 @@ regression: CM's extended-physics patch had renamed `data.acd` → `data.acd~cm_
 `--preflight-only` now passes with app provenance `match`. Tablet dash server was healthy the whole
 time (`/tablet/dash` 200) — it was blank only because no race could launch. Detail:
 [[rig-porsche-data-acd-restore-2026-07-16]]. Keep CM "extended physics" unchecked for this car.
+
+**Follow-up (same day):** the dash stayed dead after the car fix — the adb daemon was down and the
+reverse tunnel gone, and the #567 keeper was dormant because `AC_COPILOT_MANAGE_TABLET_TUNNEL` was
+never set on the rig. Now armed durably (`setx`, User scope), Game Point relaunched with `--start`,
+and self-heal proven live (`adb reverse --remove-all` → keeper re-asserted within the 5 s poll
+tick, tablet stayed connected). Detail: [[rig-tablet-tunnel-keeper-armed-2026-07-16]]. Running EXE
+is still `8a895ee-dirty` (pre-#602: voice disabled) — the EXE rebuild from merged main remains the
+open rig step.
 
 ## Delivered (2026-07-16) — #602 fixed-layout voice recovery CLOSED (PR #606)
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/rig-tablet-tunnel-keeper-armed-2026-07-16.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/rig-tablet-tunnel-keeper-armed-2026-07-16.md
@@ -1,0 +1,53 @@
+---
+type: investigation
+status: complete
+memory_tier: canonical
+created: 2026-07-16
+updated: 2026-07-16
+relates_to:
+  - AcCopilotTrainer/00_System/Next Session Handoff.md
+  - AcCopilotTrainer/03_Investigations/rig-porsche-data-acd-restore-2026-07-16.md
+  - AcCopilotTrainer/00_System/glossary/install-paths.md
+---
+
+# Rig maintenance — tablet dash outage: tunnel keeper was shipped but never armed (2026-07-16)
+
+## Symptom
+
+After the Porsche `data.acd` restore, the tablet dashboard stayed dead. Sidecar was healthy
+(`/health` ok, `/tablet/dash` 200) but `browser_peers=0`.
+
+## Root cause
+
+The PC-side **adb daemon was not running** and `adb reverse --list` was empty — the tablet's
+`localhost:8765` had no path to the PC. The #567 self-healing tunnel keeper
+(`tools/rig_launcher/tablet_tunnel.py`, PR #568) would have healed this, but it is **opt-in** via
+`AC_COPILOT_MANAGE_TABLET_TUNNEL=1` and that variable was **never set on the rig** (not in User or
+Machine env; the Game Point EXE is launched bare with no wrapper). The keeper shipped 2026-07-14
+and has been dormant ever since — the handoff's "one `AC_COPILOT_MANAGE_TABLET_TUNNEL=1` launch"
+step was still pending.
+
+## Fix (rig ops, no code change)
+
+1. `adb reverse tcp:8765 tcp:8765` re-asserted manually → tablet reconnected in <10 s
+   (the dash page's WS reconnect backoff caps at 10 s).
+2. `setx AC_COPILOT_MANAGE_TABLET_TUNNEL 1` — **persisted at User scope**, so every future
+   Game Point launch (including the desktop shortcut) arms the keeper.
+3. Game Point relaunched with the flag + `--start` (starts the sidecar without waiting for the
+   GUI START press). Both peers reconnected: `screen_peers=1`, `browser_peers=1`.
+
+## Self-heal proven live
+
+`adb reverse --remove-all` with the launcher open → the 5 s GUI poll tick
+(`_GUI_POLL_INTERVAL_MS`, app.py) re-asserted `UsbFfs tcp:8765 tcp:8765` and the tablet stayed
+connected (`browser_peers=1`). An adb daemon death / USB replug / tablet sleep now heals without
+operator action **as long as the launcher window is open**.
+
+## Residuals
+
+- Running EXE is still `8a895ee-dirty` (2026-07-15 03:00) — predates the #602 voice fix, so voice
+  remains `disabled (rtmixer)`. The pending handoff step "rebuild the packaged EXE from merged
+  main" still stands; the tunnel-flag half of that step is now done durably.
+- The launcher GUI does not auto-start the sidecar (operator presses START, or pass `--start`).
+  Two `AC-Copilot-Game-Point.exe` processes are normal (PyInstaller onefile bootstrap pair);
+  the sidecar child is a third process with `--sidecar-child`.


### PR DESCRIPTION
Second half of today's rig triage (first half: PR #610, Porsche data.acd).

**Symptom:** dash stayed dead after the car fix — sidecar healthy, `browser_peers=0`.

**Root cause:** PC adb daemon down, reverse tunnel gone, and the #567 self-healing keeper (`tools/rig_launcher/tablet_tunnel.py`) dormant because `AC_COPILOT_MANAGE_TABLET_TUNNEL` was never set on the rig.

**Fix:** tunnel re-asserted; flag persisted at User scope via `setx`; Game Point relaunched with `--start`; self-heal proven live (`adb reverse --remove-all` → keeper re-asserted within the 5 s poll tick, tablet stayed connected).

Diff strictly under `docs/01_Vault/**` — eligible for vault-automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)