### PR TITLE
fix(docs): retire residual digest-pinned GitHub-MCP mentions in TOOLCHAIN (governance-hub#274)

### DIFF
--- a/docs/00_Core/TOOLCHAIN.md
+++ b/docs/00_Core/TOOLCHAIN.md
@@ -12,7 +12,7 @@ This template assumes **multiple surfaces** for the same repo. Policies in `AGEN
 
 - **Rules:** `.cursorrules` + `.cursor/rules/*.mdc`.
 - **Skills:** `.cursor/skills/` mirrors `.claude/skills/` for discoverability — **keep both copies in sync** when you edit a skill.
-- **MCP:** **`.cursor/mcp.json`** mirrors repo **`.mcp.json`** (same servers; GitHub image pinned by **digest** for reproducibility). Cursor may also use user-level MCP settings — prefer the project file for team parity with Claude Code.
+- **MCP:** **`.cursor/mcp.json`** mirrors repo **`.mcp.json`** (same servers, wrapper-launched). Cursor may also use user-level MCP settings — prefer the project file for team parity with Claude Code.
 - **Bugbot:** `.cursor/BUGBOT.md` (if you use Cursor Bugbot).
 
 ## Claude Code (CLI / IDE extension)
@@ -34,7 +34,7 @@ Desktop does **not** automatically load repo-root `.mcp.json` the same way Claud
 
 | Location | Typical use |
 |----------|-------------|
-| Repo `.mcp.json` | **Claude Code** project-scoped MCP (versioned, team-shared); GitHub server uses a **digest-pinned** Docker image |
+| Repo `.mcp.json` | **Claude Code** project-scoped MCP (versioned, team-shared; wrapper-launched repo-local servers only) |
 | `.cursor/mcp.json` | **Cursor** project-scoped MCP mirror (keep in sync with `.mcp.json`) |
 | `~/.claude.json` | User-level MCP for Claude Code |
 | Desktop config file | **Claude Desktop** MCP |


### PR DESCRIPTION
Micro follow-up to #611 (merged): the fleet-wide residual sweep (canonical fix: agorokh/template-repo@498575d on template-repo#522) flagged two remaining TOOLCHAIN.md lines describing the retired digest-pinned GitHub MCP Docker image. Audit stays 0 violations / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)