### PR TITLE
feat(sidecar): #531 Part D remainder + Part E — race.status fields, shift cues, audio_routing

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2520,6 +2520,9 @@ function script.update(dt)
         deltaS = rawDelta,
         spline = spNow,
         wsBridge = wsBridge,
+        -- #531 Part D remainder: the baseline this delta is measured against, so the
+        -- sidecar's predicted lap never mixes it with a different lap time.
+        referenceLapMs = state.activeReferenceLapMs,
       })
     end
   end)

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2545,6 +2545,9 @@ function script.update(dt)
       lat_g = liveChassis.accG_lat,
       long_g = liveChassis.accG_long,
       temps = currentTireTemps,
+      -- #531 Part E: the learned shift profile (#442) rides the tick as `shift_rpm` so the
+      -- sidecar's shift observer cues from the same model the in-game HUD teaches.
+      shiftProfile = state.shiftProfile,
     })
   end)
   -- Round 10: drain any corner_advice replies into state.cornerAdvisories.

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -18,6 +18,7 @@
 -- the `test_ws_topic_allowlist` drift-guard can resolve them against KNOWN_TOPICS.
 
 local wheelRead = require("wheel_read")
+local shiftProfileModel = require("shift_profile")
 
 local M = {}
 
@@ -253,7 +254,7 @@ end
 
 
 --- Publish client→server ``telemetry_tick`` at ~20 Hz (M0 #341). Requires ``wsBridge.sendJson``.
----@param opts table  {dt:number, car:any, wsBridge, lat_g?:number, long_g?:number, temps?:table}
+---@param opts table  {dt:number, car:any, wsBridge, lat_g?:number, long_g?:number, temps?:table, shiftProfile?:table}
 ---@return boolean
 function M.publishTelemetryTickIfDue(opts)
   if type(opts) ~= "table" then
@@ -301,6 +302,19 @@ function M.publishTelemetryTickIfDue(opts)
   local rpmMax = _finite(_field(car, "rpmLimiter"))
   if rpmMax ~= nil and rpmMax > 0 then
     payload.rpm_max = rpmMax
+  end
+  -- #531 Part E: the shift-profile model's resolved upshift target rides the tick so the
+  -- sidecar shift observer cues from the same LEARNED per-gear point the in-game HUD
+  -- teaches (#442), not a re-derived limiter fraction. Only meaningful in a forward gear;
+  -- resolveShiftTarget returns nil when neither a learned profile nor a limiter is known,
+  -- in which case both keys are omitted (unknown, never 0).
+  if gear >= 1 then
+    local shiftRpm, _, shiftProvenance =
+      shiftProfileModel.resolveShiftTarget(opts.shiftProfile, gear, rpmMax)
+    if shiftRpm ~= nil and shiftRpm > 0 then
+      payload.shift_rpm = shiftRpm
+      payload.shift_rpm_source = shiftProvenance
+    end
   end
   local lapTimeMs = _finite(_field(car, "lapTimeMs"))
   if lapTimeMs ~= nil and lapTimeMs >= 0 then

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -93,9 +93,18 @@ function M.publishDeltaIfDue(opts)
   if not due then
     return false
   end
+  -- #531 Part D remainder: the delta's OWN baseline (the active reference trace's lap time)
+  -- rides with it so the sidecar's predicted lap adds the gap to the RIGHT lap time — the
+  -- stint best is the wrong baseline when an imported reference drives the delta. Omitted
+  -- when unknown (never 0).
+  local referenceLapMs = _finite(opts.referenceLapMs)
+  if referenceLapMs ~= nil and referenceLapMs <= 0 then
+    referenceLapMs = nil
+  end
   return wsBridge.publishTopic(TOPIC_DELTA, {
     delta_s = deltaS,
     spline = _finite(opts.spline),  -- omit a non-finite spline rather than emit unserializable JSON (#185)
+    reference_lap_ms = referenceLapMs,
   }) == true
 end
 

--- a/tests/test_audio_routing.py
+++ b/tests/test_audio_routing.py
@@ -25,19 +25,22 @@ def test_calm_alert_and_unknown_route_tablet() -> None:
     assert audio_routing_for_register("bogus") == AUDIO_ROUTING_TABLET_NATIVE
 
 
-def test_voice_dispatch_payload_carries_audio_routing() -> None:
-    dispatch = VoiceDispatch(
-        seq=1,
-        clip_id="late_brake.act.urgent.c3",
-        kind="late_brake",
-        urgency="act",
-        register="urgent",
-        corner=3,
-        text="Brake!",
-        duration_ms=420.0,
-        t_wall_ms=1_000.0,
-        t_mono_ms=2_000.0,
-    )
-    payload = dispatch.to_payload()
-    assert payload["audio_routing"] == AUDIO_ROUTING_AUTHORITATIVE_PC
-    assert payload["clip_id"] == "late_brake.act.urgent.c3"
+def test_voice_dispatch_payload_is_always_pc_owned() -> None:
+    """coaching.voice frames exist only AFTER the PC playback sounded the clip — the routing
+    on this stream is authoritative_pc by construction, regardless of register; a
+    register-based hint would invite the tablet to re-speak a clip the PC just played
+    (Codex on PR #615)."""
+    for register in ("urgent", "calm"):
+        dispatch = VoiceDispatch(
+            seq=1,
+            clip_id=f"fuel_status.info.{register}",
+            kind="fuel_status",
+            urgency="info",
+            register=register,
+            corner=None,
+            text="Fuel.",
+            duration_ms=420.0,
+            t_wall_ms=1_000.0,
+            t_mono_ms=2_000.0,
+        )
+        assert dispatch.to_payload()["audio_routing"] == AUDIO_ROUTING_AUTHORITATIVE_PC

--- a/tests/test_audio_routing.py
+++ b/tests/test_audio_routing.py
@@ -1,0 +1,43 @@
+"""#531 Part E: register -> audio_routing policy + its ride on the voice dispatch payload."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.registers import (
+    AUDIO_ROUTING_AUTHORITATIVE_PC,
+    AUDIO_ROUTING_TABLET_NATIVE,
+    audio_routing_for_register,
+)
+from tools.ai_sidecar.voice.dispatch import VoiceDispatch
+
+
+def test_urgent_and_critical_stay_on_the_pc() -> None:
+    assert audio_routing_for_register("urgent") == AUDIO_ROUTING_AUTHORITATIVE_PC
+    assert audio_routing_for_register("critical") == AUDIO_ROUTING_AUTHORITATIVE_PC
+    # Legacy alias resolves through the same ladder.
+    assert audio_routing_for_register("firm") == AUDIO_ROUTING_AUTHORITATIVE_PC
+
+
+def test_calm_alert_and_unknown_route_tablet() -> None:
+    assert audio_routing_for_register("calm") == AUDIO_ROUTING_TABLET_NATIVE
+    assert audio_routing_for_register("alert") == AUDIO_ROUTING_TABLET_NATIVE
+    # An unknown register ranks 0 (calm) — routing must fail toward the glanceable tier,
+    # never claim the critical PC path for a malformed producer.
+    assert audio_routing_for_register("bogus") == AUDIO_ROUTING_TABLET_NATIVE
+
+
+def test_voice_dispatch_payload_carries_audio_routing() -> None:
+    dispatch = VoiceDispatch(
+        seq=1,
+        clip_id="late_brake.act.urgent.c3",
+        kind="late_brake",
+        urgency="act",
+        register="urgent",
+        corner=3,
+        text="Brake!",
+        duration_ms=420.0,
+        t_wall_ms=1_000.0,
+        t_mono_ms=2_000.0,
+    )
+    payload = dispatch.to_payload()
+    assert payload["audio_routing"] == AUDIO_ROUTING_AUTHORITATIVE_PC
+    assert payload["clip_id"] == "late_brake.act.urgent.c3"

--- a/tests/test_race_management.py
+++ b/tests/test_race_management.py
@@ -155,3 +155,41 @@ def test_conditions_strategy_wet_and_deduped() -> None:
     assert cue.urgency == "act"
     assert cue.detail["classification"] == "wet_regime"
     assert second == []
+
+
+# ------------------------------------------------------------------- fuel_status (#531 Part D)
+def test_fuel_status_surfaces_clean_fields_without_cue_gating() -> None:
+    """#531 Part D remainder: the same numbers the fuel cue buries in `detail`, as an
+    ungated first-class read for the race.status topic."""
+    observer = RaceManagementObserver()
+
+    observer.observe(_tick(lap=0, fuel_l=10.0))
+    observer.observe(_tick(lap=1, fuel_l=8.0))
+
+    status = observer.fuel_status(_tick(lap=1, fuel_l=8.0, target_laps_remaining=3.0))
+    assert status == {
+        "fuel_l": 8.0,
+        "fuel_per_lap_l": 2.0,
+        "laps_remaining": 4.0,
+        "samples": 1,
+        "fuel_per_lap_source": "observed_laps",
+        "target_laps_remaining": 3.0,
+    }
+    # Ungated: an identical second read returns the same fields (no dedup key consumed).
+    assert observer.fuel_status(_tick(lap=1, fuel_l=8.0, target_laps_remaining=3.0)) == status
+
+
+def test_fuel_status_none_without_fuel_or_burn() -> None:
+    observer = RaceManagementObserver()
+    assert observer.fuel_status(_tick(lap=0)) is None  # no fuel channel
+    assert observer.fuel_status(_tick(lap=0, fuel_l=10.0)) is None  # no burn measurable yet
+
+
+def test_fuel_status_does_not_consume_the_advisory_dedup() -> None:
+    """Reading status must never swallow the cue: the advisory still fires after reads."""
+    observer = RaceManagementObserver()
+    observer.observe(_tick(lap=0, fuel_l=10.0))
+    observer.fuel_status(_tick(lap=1, fuel_l=8.0, target_laps_remaining=5.0))
+
+    out = observer.observe(_tick(lap=1, fuel_l=8.0, target_laps_remaining=5.0))
+    assert [a.kind for a in out] == ["fuel_save"]

--- a/tests/test_race_status.py
+++ b/tests/test_race_status.py
@@ -33,15 +33,31 @@ def test_fuel_fields_pass_through_and_persist_across_missing_frames() -> None:
     assert snap == {"fuel_l": 42.0, "fuel_per_lap_l": 2.6, "laps_remaining": 16.15}
 
 
-def test_predicted_lap_needs_best_and_fresh_delta() -> None:
+def test_fuel_cleared_when_channel_live_but_burn_reset() -> None:
+    """Lap rollback / refuel: fuel_status() goes None while the channel still reports — the
+    prior stint's numbers must drop, not freeze (Codex on PR #615)."""
+    tracker, _clock = _tracker()
+    tracker.note_fuel({"fuel_l": 42.0, "fuel_per_lap_l": 2.6, "laps_remaining": 16.15})
+    tracker.note_fuel(None, channel_live=True)
+    assert tracker.snapshot() is None
+
+
+def test_predicted_lap_needs_reference_baseline_and_fresh_delta() -> None:
+    """Predicted = the delta's OWN reference lap + the gap — never the stint best, which is
+    the wrong baseline under an imported reference (Codex on PR #615)."""
     tracker, clock = _tracker()
     tracker.note_lap({"lap": 4, "best_lap_ms": 112275.0, "last_lap_ms": 113000.0})
     assert "predicted_lap_ms" not in (tracker.snapshot() or {})
 
+    # A delta WITHOUT its baseline never predicts — even with a stint best on file.
     tracker.note_delta({"delta_s": 0.5, "spline": 0.3})
+    assert "predicted_lap_ms" not in tracker.snapshot()
+
+    # A 90 s reference chased at +5 s predicts ~95 s, NOT stint-best 112 s + 5.
+    tracker.note_delta({"delta_s": 5.0, "spline": 0.3, "reference_lap_ms": 90000.0})
     snap = tracker.snapshot()
-    assert snap["predicted_lap_ms"] == 112775
-    assert snap["delta_s"] == 0.5
+    assert snap["predicted_lap_ms"] == 95000
+    assert snap["delta_s"] == 5.0
     assert snap["lap"] == 4
 
     # The delta producer stopping drops the prediction — never a frozen value.
@@ -54,12 +70,28 @@ def test_predicted_lap_needs_best_and_fresh_delta() -> None:
 
 def test_negative_delta_predicts_faster_lap_but_never_nonpositive() -> None:
     tracker, _clock = _tracker()
-    tracker.note_lap({"best_lap_ms": 100000.0})
-    tracker.note_delta({"delta_s": -1.2})
+    tracker.note_delta({"delta_s": -1.2, "reference_lap_ms": 100000.0})
     assert tracker.snapshot()["predicted_lap_ms"] == 98800
 
-    tracker.note_delta({"delta_s": -200.0})  # nonsense reference: prediction suppressed
+    # nonsense reference: prediction suppressed
+    tracker.note_delta({"delta_s": -200.0, "reference_lap_ms": 100000.0})
     assert "predicted_lap_ms" not in tracker.snapshot()
+
+
+def test_session_replay_does_not_reset_but_identity_change_does() -> None:
+    """The bridge re-emits `session` to late subscribers — only a REAL identity change may
+    drop the fusion (Codex on PR #615)."""
+    tracker, _clock = _tracker()
+    ident = {"car_id": "911", "track_id": "magione", "session_index": 0}
+    tracker.note_session(ident)
+    tracker.note_fuel({"fuel_l": 10.0, "fuel_per_lap_l": 2.0, "laps_remaining": 5.0})
+    tracker.note_lap({"best_lap_ms": 112000.0})
+
+    tracker.note_session(dict(ident))  # replay to a late subscriber: state survives
+    assert tracker.snapshot() is not None
+
+    tracker.note_session({"car_id": "m3", "track_id": "magione", "session_index": 0})
+    assert tracker.snapshot() is None
 
 
 def test_lap_sentinels_ignored() -> None:

--- a/tests/test_race_status.py
+++ b/tests/test_race_status.py
@@ -1,0 +1,90 @@
+"""#531 Part D remainder: fused race.status tracker (fuel / best / delta / predicted lap)."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.race_status import DELTA_FRESH_S, RaceStatusTracker
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 50.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _tracker() -> tuple[RaceStatusTracker, _Clock]:
+    clock = _Clock()
+    return RaceStatusTracker(clock=clock), clock
+
+
+def test_empty_tracker_snapshots_none() -> None:
+    tracker, _clock = _tracker()
+    assert tracker.snapshot() is None
+    assert tracker.snapshot_if_changed() is None
+
+
+def test_fuel_fields_pass_through_and_persist_across_missing_frames() -> None:
+    tracker, _clock = _tracker()
+    tracker.note_fuel({"fuel_l": 42.0, "fuel_per_lap_l": 2.6, "laps_remaining": 16.15})
+    tracker.note_fuel(None)  # a frame without the fuel channel keeps the measurement
+
+    snap = tracker.snapshot()
+    assert snap == {"fuel_l": 42.0, "fuel_per_lap_l": 2.6, "laps_remaining": 16.15}
+
+
+def test_predicted_lap_needs_best_and_fresh_delta() -> None:
+    tracker, clock = _tracker()
+    tracker.note_lap({"lap": 4, "best_lap_ms": 112275.0, "last_lap_ms": 113000.0})
+    assert "predicted_lap_ms" not in (tracker.snapshot() or {})
+
+    tracker.note_delta({"delta_s": 0.5, "spline": 0.3})
+    snap = tracker.snapshot()
+    assert snap["predicted_lap_ms"] == 112775
+    assert snap["delta_s"] == 0.5
+    assert snap["lap"] == 4
+
+    # The delta producer stopping drops the prediction — never a frozen value.
+    clock.t += DELTA_FRESH_S + 1
+    snap = tracker.snapshot()
+    assert "predicted_lap_ms" not in snap
+    assert "delta_s" not in snap
+    assert snap["best_lap_ms"] == 112275.0
+
+
+def test_negative_delta_predicts_faster_lap_but_never_nonpositive() -> None:
+    tracker, _clock = _tracker()
+    tracker.note_lap({"best_lap_ms": 100000.0})
+    tracker.note_delta({"delta_s": -1.2})
+    assert tracker.snapshot()["predicted_lap_ms"] == 98800
+
+    tracker.note_delta({"delta_s": -200.0})  # nonsense reference: prediction suppressed
+    assert "predicted_lap_ms" not in tracker.snapshot()
+
+
+def test_lap_sentinels_ignored() -> None:
+    tracker, _clock = _tracker()
+    tracker.note_lap({"best_lap_ms": 0, "last_lap_ms": -5, "lap": -1})
+    assert tracker.snapshot() is None
+
+
+def test_snapshot_if_changed_dedups_identical_payloads() -> None:
+    tracker, _clock = _tracker()
+    tracker.note_fuel({"fuel_l": 10.0, "fuel_per_lap_l": 2.0, "laps_remaining": 5.0})
+
+    assert tracker.snapshot_if_changed() is not None
+    assert tracker.snapshot_if_changed() is None  # unchanged -> quiet
+
+    tracker.note_fuel({"fuel_l": 9.5, "fuel_per_lap_l": 2.0, "laps_remaining": 4.75})
+    assert tracker.snapshot_if_changed() is not None
+
+
+def test_reset_clears_everything() -> None:
+    tracker, _clock = _tracker()
+    tracker.note_fuel({"fuel_l": 10.0, "fuel_per_lap_l": 2.0, "laps_remaining": 5.0})
+    tracker.note_lap({"best_lap_ms": 90000.0})
+    tracker.note_delta({"delta_s": 0.1})
+    assert tracker.snapshot() is not None
+
+    tracker.reset()
+    assert tracker.snapshot() is None

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -680,9 +680,35 @@ def test_race_status_published_from_tick_fuel_change_gated(monkeypatch):
 
 
 def test_relay_taps_feed_race_status_predicted_lap(monkeypatch):
-    """The Lua delta/lap topics flowing through the relay feed the predicted-lap fusion."""
+    """The Lua delta/lap topics flowing through the relay feed the predicted-lap fusion —
+    anchored on the delta's own reference baseline, not the stint best."""
     server._race_status.reset()
     server._race_status.note_lap({"lap": 3, "best_lap_ms": 112000.0})
-    server._race_status.note_delta({"delta_s": 0.5})
+    server._race_status.note_delta({"delta_s": 0.5, "reference_lap_ms": 110000.0})
     snap = server._race_status.snapshot()
-    assert snap["predicted_lap_ms"] == 112500
+    assert snap["predicted_lap_ms"] == 110500
+
+
+def test_release_observer_feed_resets_shift_and_race_status(monkeypatch):
+    """A producer swap must not inherit the previous stream's armed gears or fuel/delta
+    fusion (Codex on PR #615)."""
+    monkeypatch.setattr(server, "_observer_feed_peer", "ws-owner")
+    monkeypatch.setattr(server, "_observer", None)
+    monkeypatch.setattr(server, "_coach_runtime", None)
+    server.set_race_manager(None)
+
+    class _Resettable:
+        def __init__(self):
+            self.resets = 0
+
+        def reset(self):
+            self.resets += 1
+
+    shift = _Resettable()
+    monkeypatch.setattr(server, "_shift_observer", shift)
+    server._race_status.reset()
+    server._race_status.note_fuel({"fuel_l": 10.0, "fuel_per_lap_l": 2.0, "laps_remaining": 5.0})
+
+    server._release_observer_feed("ws-owner")
+    assert shift.resets == 1
+    assert server._race_status.snapshot() is None

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -558,10 +558,24 @@ def test_cue_payload_carries_audio_routing_by_register(monkeypatch):
     _reset_feed(monkeypatch)
     server._race_status.reset()
     advisories = [
-        Advisory(kind="late_brake", corner=1, spline=0.1, urgency="act", message="m",
-                 detail={}, register="urgent"),
-        Advisory(kind="fuel_status", corner=-1, spline=0.1, urgency="info", message="m",
-                 detail={}, register="calm"),
+        Advisory(
+            kind="late_brake",
+            corner=1,
+            spline=0.1,
+            urgency="act",
+            message="m",
+            detail={},
+            register="urgent",
+        ),
+        Advisory(
+            kind="fuel_status",
+            corner=-1,
+            spline=0.1,
+            urgency="info",
+            message="m",
+            detail={},
+            register="calm",
+        ),
     ]
     observer = _FakeObserver(advisories)
     monkeypatch.setattr(server, "_observer", observer)
@@ -583,8 +597,17 @@ def test_shift_observer_cues_broadcast_but_never_reach_voice(monkeypatch):
     monkeypatch.setattr(server, "_observer", None)
     server.set_race_manager(None)
     shift = _FakeObserver(
-        [Advisory(kind="upshift", corner=-1, spline=0.2, urgency="act", message="Shift up.",
-                  detail={}, register="calm")]
+        [
+            Advisory(
+                kind="upshift",
+                corner=-1,
+                spline=0.2,
+                urgency="act",
+                message="Shift up.",
+                detail={},
+                register="calm",
+            )
+        ]
     )
     monkeypatch.setattr(server, "_shift_observer", shift)
 

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -550,3 +550,116 @@ def test_calibration_inactive_when_coach_v2_owns_the_cue_path(monkeypatch):
     assert server._brake_calibration_active() is False
     monkeypatch.setattr(server, "_coach_runtime", None)
     assert server._brake_calibration_active() is True
+
+
+# ---------------------------------------------------------------- #531 Part D/E server wiring
+def test_cue_payload_carries_audio_routing_by_register(monkeypatch):
+    """#531 Part E: urgent/critical cues route authoritative_pc; calm/alert tablet_native."""
+    _reset_feed(monkeypatch)
+    server._race_status.reset()
+    advisories = [
+        Advisory(kind="late_brake", corner=1, spline=0.1, urgency="act", message="m",
+                 detail={}, register="urgent"),
+        Advisory(kind="fuel_status", corner=-1, spline=0.1, urgency="info", message="m",
+                 detail={}, register="calm"),
+    ]
+    observer = _FakeObserver(advisories)
+    monkeypatch.setattr(server, "_observer", observer)
+    monkeypatch.setattr(server, "_shift_observer", None)
+    sent = _capture_broadcast(monkeypatch)
+
+    frame = {"type": "telemetry_tick", "payload": {"spline": 0.1, "speed_kmh": 100}}
+    asyncio.run(_run_publish_cues(frame, exclude="ws-1"))
+
+    routings = {f["payload"]["kind"]: f["payload"]["audio_routing"] for f, _ in sent}
+    assert routings == {"late_brake": "authoritative_pc", "fuel_status": "tablet_native"}
+
+
+def test_shift_observer_cues_broadcast_but_never_reach_voice(monkeypatch):
+    """#531 Part E: upshift/downshift fan out on coaching.cue, but are NOT submitted to the
+    in-process voice coach (no baked clips — the resolver would warn-and-drop per straight)."""
+    _reset_feed(monkeypatch)
+    server._race_status.reset()
+    monkeypatch.setattr(server, "_observer", None)
+    server.set_race_manager(None)
+    shift = _FakeObserver(
+        [Advisory(kind="upshift", corner=-1, spline=0.2, urgency="act", message="Shift up.",
+                  detail={}, register="calm")]
+    )
+    monkeypatch.setattr(server, "_shift_observer", shift)
+
+    class _RecordingCoach:
+        def __init__(self):
+            self.seen = []
+
+        def subscribe(self, advisory):
+            self.seen.append(advisory)
+
+    coach = _RecordingCoach()
+    monkeypatch.setattr(server, "_voice_coach", coach)
+    sent = _capture_broadcast(monkeypatch)
+
+    frame = {"type": "telemetry_tick", "payload": {"rpm": 8800, "gear": 3, "throttle": 0.9}}
+    asyncio.run(_run_publish_cues(frame, exclude="ws-1"))
+
+    kinds = [f["payload"]["kind"] for f, _ in sent if f.get("topic") == "coaching.cue"]
+    assert kinds == ["upshift"]
+    assert sent[0][0]["payload"]["audio_routing"] == "tablet_native"
+    assert coach.seen == []  # not in the voice vocabulary -> never submitted
+
+
+def test_vocabulary_kinds_still_reach_voice(monkeypatch):
+    _reset_feed(monkeypatch)
+    server._race_status.reset()
+    monkeypatch.setattr(server, "_observer", _FakeObserver([_adv(kind="late_brake")]))
+    monkeypatch.setattr(server, "_shift_observer", None)
+
+    class _RecordingCoach:
+        def __init__(self):
+            self.seen = []
+
+        def subscribe(self, advisory):
+            self.seen.append(advisory)
+
+    coach = _RecordingCoach()
+    monkeypatch.setattr(server, "_voice_coach", coach)
+    _capture_broadcast(monkeypatch)
+
+    frame = {"type": "telemetry_tick", "payload": {"spline": 0.5, "speed_kmh": 100}}
+    asyncio.run(_run_publish_cues(frame, exclude="ws-1"))
+    assert [a.kind for a in coach.seen] == ["late_brake"]
+
+
+def test_race_status_published_from_tick_fuel_change_gated(monkeypatch):
+    """#531 Part D remainder: the tick path publishes race.status once per change, quiet on
+    identical payloads."""
+    _reset_feed(monkeypatch)
+    server._race_status.reset()
+    monkeypatch.setattr(server, "_observer", None)
+    monkeypatch.setattr(server, "_shift_observer", None)
+    sent = _capture_broadcast(monkeypatch)
+
+    def _tick_frame(lap, fuel):
+        return {"type": "telemetry_tick", "payload": {"lap": lap, "fuel_l": fuel}}
+
+    asyncio.run(_run_publish_cues(_tick_frame(0, 10.0), exclude="ws-1"))
+    server._peripheral_rate_limiter.reset()  # bypass the 1 Hz cap for the test
+    asyncio.run(_run_publish_cues(_tick_frame(1, 8.0), exclude="ws-1"))
+    server._peripheral_rate_limiter.reset()
+    asyncio.run(_run_publish_cues(_tick_frame(1, 8.0), exclude="ws-1"))
+
+    status_frames = [f for f, _ in sent if f.get("topic") == "race.status"]
+    assert len(status_frames) == 1
+    payload = status_frames[0]["payload"]
+    assert payload["fuel_per_lap_l"] == 2.0
+    assert payload["laps_remaining"] == 4.0
+    assert status_frames[0]["source"] == "sidecar.race_status"
+
+
+def test_relay_taps_feed_race_status_predicted_lap(monkeypatch):
+    """The Lua delta/lap topics flowing through the relay feed the predicted-lap fusion."""
+    server._race_status.reset()
+    server._race_status.note_lap({"lap": 3, "best_lap_ms": 112000.0})
+    server._race_status.note_delta({"delta_s": 0.5})
+    snap = server._race_status.snapshot()
+    assert snap["predicted_lap_ms"] == 112500

--- a/tests/test_shift_observer.py
+++ b/tests/test_shift_observer.py
@@ -1,0 +1,146 @@
+"""#531 Part E: live upshift/downshift cues from the telemetry tick."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.shift_observer import (
+    DEFAULT_SHIFT_ZONE_FRAC,
+    DOWNSHIFT_COOLDOWN_S,
+    DOWNSHIFT_SUSTAIN_S,
+    UPSHIFT_COOLDOWN_S,
+    ShiftObserver,
+)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 100.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _tick(**payload):
+    base = {
+        "speed_kmh": 140.0,
+        "rpm": 5000.0,
+        "throttle": 0.9,
+        "brake": 0.0,
+        "gear": 3,
+        "rpm_max": 9000.0,
+        "spline": 0.4,
+    }
+    base.update(payload)
+    return {"type": "telemetry_tick", "payload": base}
+
+
+def _observer() -> tuple[ShiftObserver, _Clock]:
+    clock = _Clock()
+    return ShiftObserver(clock=clock), clock
+
+
+def test_upshift_fires_once_per_gear_engagement_from_learned_target() -> None:
+    obs, clock = _observer()
+
+    assert obs.observe(_tick(rpm=7000, shift_rpm=7400, shift_rpm_source="learned")) == []
+    out = obs.observe(_tick(rpm=7450, shift_rpm=7400, shift_rpm_source="learned"))
+    assert [a.kind for a in out] == ["upshift"]
+    assert out[0].register == "calm"
+    assert out[0].detail["shift_rpm"] == 7400
+    assert out[0].detail["shift_rpm_source"] == "learned"
+
+    # Still over the target in the same gear: no repeat.
+    clock.t += UPSHIFT_COOLDOWN_S + 1
+    assert obs.observe(_tick(rpm=7500, shift_rpm=7400)) == []
+
+    # Gear change re-arms; next gear's target reached fires again.
+    clock.t += UPSHIFT_COOLDOWN_S + 1
+    assert obs.observe(_tick(gear=4, rpm=6000, shift_rpm=7400)) == []
+    out = obs.observe(_tick(gear=4, rpm=7500, shift_rpm=7400))
+    assert [a.kind for a in out] == ["upshift"]
+
+
+def test_upshift_falls_back_to_limiter_heuristic_without_shift_rpm() -> None:
+    obs, _clock = _observer()
+    threshold = 9000.0 * DEFAULT_SHIFT_ZONE_FRAC
+
+    assert obs.observe(_tick(rpm=threshold - 100)) == []
+    out = obs.observe(_tick(rpm=threshold + 50))
+    assert [a.kind for a in out] == ["upshift"]
+    assert out[0].detail["shift_rpm_source"] == "heuristic"
+
+
+def test_upshift_needs_throttle_and_no_braking() -> None:
+    obs, _clock = _observer()
+    assert obs.observe(_tick(rpm=8900, throttle=0.2)) == []
+    assert obs.observe(_tick(rpm=8900, brake=0.6)) == []
+
+
+def test_upshift_cooldown_spans_gear_bounce() -> None:
+    obs, clock = _observer()
+    out = obs.observe(_tick(rpm=8500))
+    assert [a.kind for a in out] == ["upshift"]
+    # Immediate bounce to another gear and back over target: cooldown suppresses.
+    clock.t += 0.2
+    assert obs.observe(_tick(gear=4, rpm=8500)) == []
+
+
+def test_no_cue_without_rpm_max_or_learned_target() -> None:
+    obs, _clock = _observer()
+    frame = _tick(rpm=8900)
+    del frame["payload"]["rpm_max"]
+    assert obs.observe(frame) == []
+
+
+def test_neutral_and_missing_channels_are_silent() -> None:
+    obs, _clock = _observer()
+    assert obs.observe(_tick(gear=0, rpm=8900)) == []
+    frame = _tick()
+    del frame["payload"]["rpm"]
+    assert obs.observe(frame) == []
+
+
+def test_downshift_bog_requires_sustain_and_cooldown() -> None:
+    obs, clock = _observer()
+    bog = dict(rpm=2500.0, gear=4, throttle=0.9, speed_kmh=90.0)  # target 8280, 40% = 3312
+
+    assert obs.observe(_tick(**bog)) == []  # bog starts, not sustained yet
+    clock.t += DOWNSHIFT_SUSTAIN_S + 0.1
+    out = obs.observe(_tick(**bog))
+    assert [a.kind for a in out] == ["downshift"]
+    assert out[0].detail["classification"] == "bog_heuristic"
+
+    # Sustained bog again inside the cooldown: silent.
+    clock.t += DOWNSHIFT_SUSTAIN_S + 0.1
+    assert obs.observe(_tick(**bog)) == []
+
+    # Break the streak (throttle lifted), wait out the cooldown, then a fresh sustained
+    # bog cues again.
+    assert obs.observe(_tick(rpm=2500.0, gear=4, throttle=0.1, speed_kmh=90.0)) == []
+    clock.t += DOWNSHIFT_COOLDOWN_S + 1
+    assert obs.observe(_tick(**bog)) == []  # streak restarts, not yet sustained
+    clock.t += DOWNSHIFT_SUSTAIN_S + 0.1
+    out = obs.observe(_tick(**bog))
+    assert [a.kind for a in out] == ["downshift"]
+
+
+def test_downshift_not_cued_at_low_speed_or_low_gear() -> None:
+    obs, clock = _observer()
+    for frame in (
+        _tick(rpm=2500, gear=4, speed_kmh=10.0),  # pulling away
+        _tick(rpm=2500, gear=1, speed_kmh=90.0),  # first gear never bogs
+    ):
+        obs.observe(frame)
+        clock.t += DOWNSHIFT_SUSTAIN_S + 0.5
+        assert obs.observe(frame) == []
+        obs.reset()
+        clock.t += 1
+
+
+def test_reset_clears_armed_state() -> None:
+    obs, clock = _observer()
+    out = obs.observe(_tick(rpm=8500))
+    assert [a.kind for a in out] == ["upshift"]
+    obs.reset()
+    clock.t += UPSHIFT_COOLDOWN_S + 1
+    out = obs.observe(_tick(rpm=8500))
+    assert [a.kind for a in out] == ["upshift"]

--- a/tests/test_tablet_dash_endpoint.py
+++ b/tests/test_tablet_dash_endpoint.py
@@ -445,3 +445,34 @@ def test_identity_replay_topics_exclude_continuous_streams() -> None:
     for continuous in ("delta", "tire_temps", "coaching.snapshot", "lap"):
         assert continuous not in ep.IDENTITY_REPLAY_TOPICS
     assert ep.IDENTITY_REPLAY_TOPICS <= ep.KNOWN_TOPICS
+
+
+def test_validate_telemetry_tick_accepts_shift_rpm_and_rejects_bad() -> None:
+    """#531 Part E: the learned shift target rides the tick; same positivity contract as
+    rpm_max (0 = unknown -> the producer omits the key)."""
+    assert ep.validate_inbound(_tick_frame(shift_rpm=7400.0, shift_rpm_source="learned")) is None
+    assert ep.validate_inbound(_tick_frame()) is None  # optional
+    err = ep.validate_inbound(_tick_frame(shift_rpm=0))
+    assert err is not None and "shift_rpm" in err
+    err = ep.validate_inbound(_tick_frame(shift_rpm=-100))
+    assert err is not None and "shift_rpm" in err
+    err = ep.validate_inbound(_tick_frame(shift_rpm_source=42))
+    assert err is not None and "shift_rpm_source" in err
+
+
+def test_race_status_topic_is_sidecar_produced_and_subscribable() -> None:
+    """#531 Part D remainder: race.status joins the allow-list AND the sidecar-produced set
+    (a tablet without a Lua peer may still subscribe)."""
+    assert ep.TOPIC_RACE_STATUS in ep.KNOWN_TOPICS
+    assert ep.TOPIC_RACE_STATUS in ep.SIDECAR_PRODUCED_TOPICS
+    # Continuous-ish stream: deliberately NOT identity-replayed (a stale sample would
+    # masquerade as live fuel/predicted numbers).
+    assert ep.TOPIC_RACE_STATUS not in ep.IDENTITY_REPLAY_TOPICS
+
+
+def test_make_race_status_shape() -> None:
+    frame = ep.make_race_status({"fuel_l": 8.0, "laps_remaining": 4.0})
+    assert frame["type"] == ep.TYPE_STATE_SNAPSHOT
+    assert frame["topic"] == ep.TOPIC_RACE_STATUS
+    assert frame["source"] == "sidecar.race_status"
+    assert frame["payload"] == {"fuel_l": 8.0, "laps_remaining": 4.0}

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -729,7 +729,9 @@ def test_telemetry_tick_carries_learned_shift_rpm_from_profile():
             byGear = { [3] = 7400 },
             defaultRpm = 7600,
           }
-          M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws, shiftProfile = profile })
+          M.publishTelemetryTickIfDue({
+            dt = 0.06, car = car, wsBridge = ws, shiftProfile = profile,
+          })
           local p = ws._calls[1] and ws._calls[1].send.payload
           return { shift_rpm = p and p.shift_rpm, source = p and p.shift_rpm_source }
         end)()

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -795,3 +795,36 @@ def test_telemetry_tick_omits_shift_rpm_in_neutral_or_without_limiter():
     )
     assert out["neutral_has"] is False
     assert out["nolimiter_has"] is False
+
+
+def test_delta_carries_reference_lap_ms_when_known():
+    """#531 Part D remainder: the delta's own baseline rides with it so the sidecar's
+    predicted lap adds the gap to the RIGHT lap time; omitted when unknown or 0."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          M.publishDeltaIfDue({
+            dt = 0.15, deltaS = 0.42, spline = 0.5, wsBridge = ws, referenceLapMs = 90000,
+          })
+          M.reset()
+          local ws2 = make_ws()
+          M.publishDeltaIfDue({ dt = 0.15, deltaS = 0.42, spline = 0.5, wsBridge = ws2 })
+          M.reset()
+          local ws3 = make_ws()
+          M.publishDeltaIfDue({
+            dt = 0.15, deltaS = 0.42, spline = 0.5, wsBridge = ws3, referenceLapMs = 0,
+          })
+          return {
+            with_ref = ws._calls[1] and ws._calls[1].payload.reference_lap_ms,
+            without_has = ws2._calls[1].payload.reference_lap_ms ~= nil,
+            zero_has = ws3._calls[1].payload.reference_lap_ms ~= nil,
+          }
+        end)()
+        """
+    )
+    assert out["with_ref"] == 90000
+    assert out["without_has"] is False
+    assert out["zero_has"] is False

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -708,3 +708,88 @@ def test_entry_isolates_tire_stream_from_optional_delta_failures():
     assert "publishTireTempsIfDue" not in delta_block
     assert "pcall(function()" in tyre_block
     assert "publishTireTempsIfDue" in tyre_block
+
+
+# --------------------------------------------------------------------------- shift_rpm (#531 E)
+def test_telemetry_tick_carries_learned_shift_rpm_from_profile():
+    """#531 Part E: the resolved shift target rides the tick so the sidecar shift observer
+    cues from the SAME learned per-gear model the in-game HUD teaches (#442)."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.9, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2, rpmLimiter = 9000,
+          }
+          local profile = {
+            hasLearnedShift = true,
+            byGear = { [3] = 7400 },
+            defaultRpm = 7600,
+          }
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws, shiftProfile = profile })
+          local p = ws._calls[1] and ws._calls[1].send.payload
+          return { shift_rpm = p and p.shift_rpm, source = p and p.shift_rpm_source }
+        end)()
+        """
+    )
+    assert out["shift_rpm"] == 7400
+    assert out["source"] == "learned"
+
+
+def test_telemetry_tick_shift_rpm_heuristic_without_profile():
+    """No learned profile -> the shift_profile heuristic fraction of the real limiter."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.9, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2, rpmLimiter = 9000,
+          }
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
+          local p = ws._calls[1] and ws._calls[1].send.payload
+          return { shift_rpm = p and p.shift_rpm, source = p and p.shift_rpm_source }
+        end)()
+        """
+    )
+    assert out["shift_rpm"] == 9000 * 0.92
+    assert out["source"] == "heuristic"
+
+
+def test_telemetry_tick_omits_shift_rpm_in_neutral_or_without_limiter():
+    """Neutral has no shift point, and no-limiter+no-profile resolves nothing — both omit
+    the keys (unknown, never 0)."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local neutral = {
+            speedKmh = 0, rpm = 900, gas = 0.0, brake = 0.0, steer = 0.0,
+            gear = 0, splinePosition = 0.0, lapCount = 0, rpmLimiter = 9000,
+          }
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = neutral, wsBridge = ws })
+          M.reset()
+          local ws2 = make_ws()
+          local noLimiter = {
+            speedKmh = 120, rpm = 6000, gas = 0.9, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+          }
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = noLimiter, wsBridge = ws2 })
+          local p1 = ws._calls[1] and ws._calls[1].send.payload
+          local p2 = ws2._calls[1] and ws2._calls[1].send.payload
+          return {
+            neutral_has = p1.shift_rpm ~= nil,
+            nolimiter_has = p2.shift_rpm ~= nil,
+          }
+        end)()
+        """
+    )
+    assert out["neutral_has"] is False
+    assert out["nolimiter_has"] is False

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -199,6 +199,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
         <div class="trow"><span class="k">current</span><span class="t" id="tCur">&mdash;</span></div>
         <div class="trow"><span class="k">last</span><span class="t" id="tLast">&mdash;</span></div>
         <div class="trow"><span class="k">best</span><span class="t" id="tBest" style="color:var(--clear)">&mdash;</span></div>
+        <div class="trow"><span class="k">predicted</span><span class="t" id="tPred" style="color:var(--data)">&mdash;</span></div>
         <div class="stint"><div class="mh" style="margin-bottom:4px">Stint &middot; fuel to flag</div>
           <div style="display:flex;align-items:baseline;justify-content:space-between"><span class="m" id="stintM">&mdash;</span><span class="mono" style="font-size:12px;color:var(--dim)" id="stintSub"></span></div></div>
       </div>
@@ -300,6 +301,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   var $ = function (id) { return document.getElementById(id); };
   var RIBBON_CELLS = 20;
   var STALE_MS = 3000;
+  var RACE_STATUS_STALE_MS = 6000; // race.status is ~1 Hz + change-gated; allow a quiet gap
+  var CUE_MICRO_MS = 4000;         // tier-2 micro-cue dwell (§8: at most one, then blank)
   var RENDER_MIN_MS = 66; // <=15 Hz DOM writes (A133 budget)
 
   // ---- live state (written by WS handlers, read by the render loop) ----------------------
@@ -315,7 +318,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     sessionIdent: null,             // "car|track|session" key (re-request setup data on change)
     spinners: null,                 // setup.spinner.list.result .spinners
     fuelAtLap: null, burns: [],     // client-side fuel-per-lap (median of last 3 lap diffs)
-    lastCue: null,                  // latest coaching.cue text for the debrief page
+    lastCue: null, cueAt: 0,        // latest coaching.cue payload + receive time (tier-2 micro)
+    race: null, raceAt: 0,          // race.status payload (sidecar fuel/predicted, #531 Part D)
   };
 
   // ---- helpers ---------------------------------------------------------------------------
@@ -624,10 +628,30 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
         sub = tgt !== null ? "min " + Math.round(tgt) + " km/h" : String(snap.secondary_line || "");
         micro = snap.corner_label && snap.primary_line ? String(snap.primary_line) : "";
       }
+      // #531 Part E tier-2: a fresh actionable cue takes the single micro-cue slot (§8: at
+      // most ONE CommandVerb-lite), then blanks after its dwell. Corner cues stay with the
+      // snapshot line above; this slot carries the stint/shift verbs the snapshot never says.
+      var cueMicro = microCueLabel();
+      if (cueMicro) micro = cueMicro;
       setText("cNext", head);
       setText("cSub", sub);
       setText("cMicro", micro);
     }
+  }
+  // Kind → short lane verb for the tier-2 micro-cue slot. Deliberately NOT every cue kind:
+  // corner coaching already owns the snapshot line, and an unmapped kind renders nothing
+  // rather than a raw identifier.
+  var MICRO_CUE_LABELS = {
+    upshift: "UPSHIFT ▲", downshift: "DOWNSHIFT ▼", fuel_save: "FUEL SAVE",
+    fuel_status: "FUEL", tyre_manage: "TYRES", brake_manage: "BRAKES",
+    conditions_strategy: "CONDITIONS"
+  };
+  function microCueLabel() {
+    if (!S.lastCue || (Date.now() - S.cueAt) >= CUE_MICRO_MS) return "";
+    var label = MICRO_CUE_LABELS[String(S.lastCue.kind || "")];
+    if (!label) return "";
+    var corner = fin(S.lastCue.corner);
+    return corner !== null && corner >= 0 ? label + " · T" + (corner + 1) : label;
   }
 
   // ---- fuel-as-a-decision (client-side burn from lap boundaries) ----------------------------
@@ -712,16 +736,31 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     setText("tCur", live ? fmtLap(fin(t.lap_time_ms)) : "—");
     setText("tLast", S.lap ? fmtLap(fin(S.lap.last_lap_ms)) : "—");
     setText("tBest", S.lap ? fmtLap(fin(S.lap.best_lap_ms)) : "—");
+    // #531 Part D remainder: predicted lap (stint best + live delta) is computed SIDECAR-side
+    // on race.status; a stale/absent status renders the honest unknown, never a frozen value.
+    var race = S.race !== null && (Date.now() - S.raceAt) < RACE_STATUS_STALE_MS ? S.race : null;
+    setText("tPred", race ? fmtLap(fin(race.predicted_lap_ms)) : "—");
 
-    // fuel
+    // fuel — prefer the sidecar-computed race.status fields (#531 Part D remainder: observed
+    // whole-lap burn, target-aware); fall back to the client-side burn estimate when absent.
     var fuel = live ? fin(t.fuel_l) : null;
     var cap = live ? fin(t.fuel_capacity_l) : null;
     var burn = medianBurn();
-    if (fuel !== null && burn !== null) {
-      setText("fuelBig", (fuel / burn).toFixed(1));
+    var lapsLeft = null, burnShown = null, burnSrc = "";
+    if (race && fin(race.laps_remaining) !== null && fin(race.fuel_per_lap_l) !== null) {
+      lapsLeft = race.laps_remaining;
+      burnShown = race.fuel_per_lap_l;
+      if (fuel === null) fuel = fin(race.fuel_l);
+    } else if (fuel !== null && burn !== null) {
+      lapsLeft = fuel / burn;
+      burnShown = burn;
+      burnSrc = " est";
+    }
+    if (fuel !== null && lapsLeft !== null) {
+      setText("fuelBig", lapsLeft.toFixed(1));
       setText("fuelUnit", "laps left");
-      setText("fuelSub", fuel.toFixed(1) + " L · " + burn.toFixed(2) + " L/lap");
-      setText("stintM", "+" + (fuel / burn).toFixed(1));
+      setText("fuelSub", fuel.toFixed(1) + " L · " + burnShown.toFixed(2) + " L/lap" + burnSrc);
+      setText("stintM", "+" + lapsLeft.toFixed(1));
       setText("stintSub", "laps of fuel");
     } else {
       setText("fuelBig", fuel !== null ? fuel.toFixed(1) : "—");
@@ -731,7 +770,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       setText("stintSub", "burn unknown");
     }
     setText("stFuel", fuel !== null ? fuel.toFixed(1) : "—");
-    setText("stFuelSub", burn !== null ? "burn " + burn.toFixed(2) + " L/lap" : "burn — (complete a lap)");
+    setText("stFuelSub", burnShown !== null ? "burn " + burnShown.toFixed(2) + " L/lap" + burnSrc : "burn — (complete a lap)");
 
     // header weather/temps: render only when the producer actually sends them
     var wx = live && typeof t.weather_type === "string" && t.weather_type ? t.weather_type : null;
@@ -845,7 +884,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       ws.send(JSON.stringify({
         v: 1, type: "state.subscribe",
         topics: ["coaching.snapshot", "coaching.cue", "coaching.voice", "delta", "tire_temps",
-                 "setup.active", "session", "lap", "connection"],
+                 "setup.active", "session", "lap", "connection", "race.status"],
       }));
       requestSetupData(ws);
       // Re-request per-car ranges until they arrive (AC may connect after the tablet), then
@@ -876,7 +915,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
           case "tire_temps": S.tires = p; S.tiresAt = Date.now(); break;
           case "lap": onLapFrame(p); break;
           case "coaching.snapshot": S.coach = p; S.coachAt = Date.now(); break;
-          case "coaching.cue": S.lastCue = p; break;
+          case "coaching.cue": S.lastCue = p; S.cueAt = Date.now(); break;
+          case "race.status": S.race = p; S.raceAt = Date.now(); break;
           case "setup.active":
             S.setupName = p.name || null;
             renderHeader();
@@ -893,6 +933,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               S.lap = null; // prior identity's Last/Best are wrong now
               S.fuelAtLap = null;
               S.burns = []; // burn is per car AND per track length (Codex on PR #547)
+              S.race = null; S.raceAt = 0; // sidecar race.status is per identity too (#531)
               // A REAL identity switch invalidates the setup name (per-session fact; the
               // trainer's follow-up setup.active names the new one — Codex on PR #547).
               // The FIRST session frame after a page load must not: the identity-replay

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -251,10 +251,15 @@ TOPIC_COACHING_CUE = "coaching.cue"
 #: in-ear coach says without re-implementing the arbitration client-side.
 TOPIC_COACHING_VOICE = "coaching.voice"
 TOPIC_SESSION_REVIEW = "session.review"
+#: Topic the sidecar publishes fused race status on (#531 Part D remainder): clean
+#: fuel-per-lap / laps-remaining / predicted-lap fields, computed sidecar-side from the
+#: telemetry_tick fuel channel + the Lua ``delta``/``lap`` topics. Low-rate (~1 Hz),
+#: change-gated, honest — absent fields are unmeasured, never zero-filled.
+TOPIC_RACE_STATUS = "race.status"
 # Topics the sidecar produces directly (no loopback Lua relay). Voice/offline clients may
 # state.subscribe to these without a Lua peer connected.
 SIDECAR_PRODUCED_TOPICS: frozenset[str] = frozenset(
-    {TOPIC_COACHING_CUE, TOPIC_COACHING_VOICE, TOPIC_SESSION_REVIEW}
+    {TOPIC_COACHING_CUE, TOPIC_COACHING_VOICE, TOPIC_SESSION_REVIEW, TOPIC_RACE_STATUS}
 )
 KNOWN_TOPICS: frozenset[str] = frozenset(
     {
@@ -273,6 +278,8 @@ KNOWN_TOPICS: frozenset[str] = frozenset(
         TOPIC_COACHING_VOICE,
         # Sidecar-originated post-session debrief report (issue #404 Part A).
         TOPIC_SESSION_REVIEW,
+        # Sidecar-originated fused race status (#531 Part D remainder).
+        TOPIC_RACE_STATUS,
     }
 )
 
@@ -365,6 +372,22 @@ def make_coaching_voice(payload: dict[str, Any]) -> dict[str, Any]:
         "topic": TOPIC_COACHING_VOICE,
         "payload": payload,
         "source": "sidecar.voice",
+    }
+
+
+def make_race_status(payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a ``race.status`` topic frame (#531 Part D remainder).
+
+    Sidecar-originated ``state.snapshot`` envelope, same shape as every topic. ``payload``
+    carries the fused fields from :class:`tools.ai_sidecar.race_status.RaceStatusTracker`
+    (fuel-as-a-decision + stint best + live delta + predicted lap).
+    """
+    return {
+        ENVELOPE_KEY: ENVELOPE_VERSION,
+        TYPE_KEY: TYPE_STATE_SNAPSHOT,
+        "topic": TOPIC_RACE_STATUS,
+        "payload": payload,
+        "source": "sidecar.race_status",
     }
 
 
@@ -544,6 +567,10 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
         # treats 0 as "unknown -> omit the key", so a present rpm_max must be POSITIVE —
         # accepting 0 here would let a buggy producer render "N / 0" (Qodo on PR #547).
         "rpm_max": (1, None),
+        # #531 Part E: the Lua shift-profile model's resolved upshift target rides the tick so
+        # the sidecar shift observer cues from the LEARNED point, not just the limiter
+        # heuristic. Same positivity contract as rpm_max (0 = unknown -> producer omits).
+        "shift_rpm": (1, None),
         "fuel_l": (0, None),
         "fuel_capacity_l": (0, None),
         "fuel_per_lap_l": (0, None),
@@ -560,7 +587,7 @@ def _validate_telemetry_tick(frame: dict[str, Any]) -> str | None:
         err = _validate_optional_number(payload, key, min_value=min_value, max_value=max_value)
         if err is not None:
             return err
-    for key in ("weather_type", "tyre_compound"):
+    for key in ("weather_type", "tyre_compound", "shift_rpm_source"):
         if key in payload and not isinstance(payload[key], str):
             return f"{key} must be a string"
     # #531 Part D: `tc_active` joins the `abs_active` slot so the dashboard can flash BOTH

--- a/tools/ai_sidecar/race_management.py
+++ b/tools/ai_sidecar/race_management.py
@@ -188,27 +188,46 @@ class RaceManagementObserver:
         self._lap_start_fuel_l = fuel_l
         return True
 
-    def _fuel_advisory(
-        self, frame: dict[str, Any], lap: int | None, *, lap_advanced: bool
-    ) -> Advisory | None:
+    def fuel_status(self, frame: dict[str, Any], lap: int | None = None) -> dict[str, Any] | None:
+        """Clean fuel fields for the current frame, or ``None`` when fuel is unmeasurable.
+
+        #531 Part D remainder: the same numbers ``_fuel_advisory`` buries inside a cue ``detail``,
+        surfaced as first-class fields so the ``race.status`` topic (and any other consumer) can
+        read fuel-as-a-decision without parsing cues. Ungated — no dedup, no register ladder;
+        callers rate-limit. ``lap`` defaults to the frame's own lap counter.
+        """
+        if lap is None:
+            lap = _lap(frame)
         fuel_l = _num(_pick(frame, "fuel_l", "fuelLevel", "fuel"))
         direct_per_lap = _num(_pick(frame, "fuel_per_lap_l", "fuelPerLapL"))
         if fuel_l is None or (not self.fuel_samples and direct_per_lap is None):
             return None
         per_lap = _mean(list(self.fuel_samples)) if self.fuel_samples else direct_per_lap
-        if per_lap <= 0:
+        if per_lap is None or per_lap <= 0:
             return None
         laps_remaining = fuel_l / per_lap
-        target = _target_laps_remaining(frame, lap)
-        detail = {
+        status = {
             "fuel_l": round(fuel_l, 2),
             "fuel_per_lap_l": round(per_lap, 3),
             "laps_remaining": round(laps_remaining, 2),
             "samples": len(self.fuel_samples),
             "fuel_per_lap_source": "observed_laps" if self.fuel_samples else "frame",
         }
+        target = _target_laps_remaining(frame, lap)
         if target is not None:
-            detail["target_laps_remaining"] = round(target, 2)
+            status["target_laps_remaining"] = round(target, 2)
+        return status
+
+    def _fuel_advisory(
+        self, frame: dict[str, Any], lap: int | None, *, lap_advanced: bool
+    ) -> Advisory | None:
+        detail = self.fuel_status(frame, lap)
+        if detail is None:
+            return None
+        laps_remaining = float(detail["laps_remaining"])
+        per_lap = float(detail["fuel_per_lap_l"])
+        target = detail.get("target_laps_remaining")
+        if target is not None:
             deficit = target - laps_remaining
             if deficit > _FUEL_SHORT_MARGIN_LAPS:
                 register = "critical" if deficit >= _FUEL_CRITICAL_DEFICIT_LAPS else "urgent"

--- a/tools/ai_sidecar/race_management.py
+++ b/tools/ai_sidecar/race_management.py
@@ -188,6 +188,21 @@ class RaceManagementObserver:
         self._lap_start_fuel_l = fuel_l
         return True
 
+    def _fuel_numbers(
+        self, frame: dict[str, Any], lap: int | None
+    ) -> tuple[float, float, float, float | None] | None:
+        """Raw ``(fuel_l, per_lap, laps_remaining, target)`` for the current frame, or ``None``
+        when fuel is unmeasurable. Unrounded — cue thresholds compare against these so a value
+        rounded for the wire can never flip a near-threshold decision (Codex on PR #615)."""
+        fuel_l = _num(_pick(frame, "fuel_l", "fuelLevel", "fuel"))
+        direct_per_lap = _num(_pick(frame, "fuel_per_lap_l", "fuelPerLapL"))
+        if fuel_l is None or (not self.fuel_samples and direct_per_lap is None):
+            return None
+        per_lap = _mean(list(self.fuel_samples)) if self.fuel_samples else direct_per_lap
+        if per_lap is None or per_lap <= 0:
+            return None
+        return fuel_l, per_lap, fuel_l / per_lap, _target_laps_remaining(frame, lap)
+
     def fuel_status(self, frame: dict[str, Any], lap: int | None = None) -> dict[str, Any] | None:
         """Clean fuel fields for the current frame, or ``None`` when fuel is unmeasurable.
 
@@ -198,14 +213,10 @@ class RaceManagementObserver:
         """
         if lap is None:
             lap = _lap(frame)
-        fuel_l = _num(_pick(frame, "fuel_l", "fuelLevel", "fuel"))
-        direct_per_lap = _num(_pick(frame, "fuel_per_lap_l", "fuelPerLapL"))
-        if fuel_l is None or (not self.fuel_samples and direct_per_lap is None):
+        numbers = self._fuel_numbers(frame, lap)
+        if numbers is None:
             return None
-        per_lap = _mean(list(self.fuel_samples)) if self.fuel_samples else direct_per_lap
-        if per_lap is None or per_lap <= 0:
-            return None
-        laps_remaining = fuel_l / per_lap
+        fuel_l, per_lap, laps_remaining, target = numbers
         status = {
             "fuel_l": round(fuel_l, 2),
             "fuel_per_lap_l": round(per_lap, 3),
@@ -213,7 +224,6 @@ class RaceManagementObserver:
             "samples": len(self.fuel_samples),
             "fuel_per_lap_source": "observed_laps" if self.fuel_samples else "frame",
         }
-        target = _target_laps_remaining(frame, lap)
         if target is not None:
             status["target_laps_remaining"] = round(target, 2)
         return status
@@ -221,12 +231,11 @@ class RaceManagementObserver:
     def _fuel_advisory(
         self, frame: dict[str, Any], lap: int | None, *, lap_advanced: bool
     ) -> Advisory | None:
-        detail = self.fuel_status(frame, lap)
-        if detail is None:
+        numbers = self._fuel_numbers(frame, lap)
+        if numbers is None:
             return None
-        laps_remaining = float(detail["laps_remaining"])
-        per_lap = float(detail["fuel_per_lap_l"])
-        target = detail.get("target_laps_remaining")
+        _fuel_l, per_lap, laps_remaining, target = numbers
+        detail = self.fuel_status(frame, lap)
         if target is not None:
             deficit = target - laps_remaining
             if deficit > _FUEL_SHORT_MARGIN_LAPS:

--- a/tools/ai_sidecar/race_status.py
+++ b/tools/ai_sidecar/race_status.py
@@ -1,0 +1,122 @@
+"""Sidecar-computed race status for the ``race.status`` topic (#531 Part D remainder).
+
+The tablet dashboard's "fuel as a decision" and predicted-lap slots need clean first-class
+fields; before this module they lived only inside a race-management cue ``detail`` (fuel) or
+client-side (burn from lap boundaries). The tracker fuses the three streams the sidecar already
+sees — ``telemetry_tick`` (fuel level, via :meth:`RaceManagementObserver.fuel_status`), the Lua
+``delta`` topic (gap to reference), and the Lua ``lap`` topic (stint best) — into one low-rate
+payload:
+
+``{fuel_l, fuel_per_lap_l, laps_remaining, fuel_per_lap_source, samples,
+   target_laps_remaining?, lap?, best_lap_ms?, last_lap_ms?, delta_s?, predicted_lap_ms?}``
+
+Honesty rules (the #531 sentinel discipline): a field is present only when measured this
+session; ``predicted_lap_ms`` (= stint best + current delta) requires BOTH a stint best and a
+FRESH delta — a stale delta drops the prediction rather than freezing it. Pure stdlib.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+#: A delta older than this cannot anchor a predicted lap (the 10 Hz producer paused/stopped).
+DELTA_FRESH_S = 5.0
+
+
+def _num(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f and abs(f) != float("inf") else None
+
+
+@dataclass
+class RaceStatusTracker:
+    """Accumulates the latest fuel/lap/delta state and serializes ``race.status`` payloads."""
+
+    clock: Callable[[], float] = time.monotonic
+    _fuel: dict[str, Any] | None = None
+    _delta_s: float | None = None
+    _delta_at: float = field(default=float("-inf"))
+    _best_lap_ms: float | None = None
+    _last_lap_ms: float | None = None
+    _lap: int | None = None
+    _last_published: tuple[Any, ...] | None = None
+
+    def reset(self) -> None:
+        self._fuel = None
+        self._delta_s = None
+        self._delta_at = float("-inf")
+        self._best_lap_ms = None
+        self._last_lap_ms = None
+        self._lap = None
+        self._last_published = None
+
+    def note_fuel(self, status: dict[str, Any] | None) -> None:
+        """Latest clean fuel fields (from ``RaceManagementObserver.fuel_status``); ``None`` keeps
+        the previous measurement (a frame missing the fuel channel is unknown, not empty)."""
+        if isinstance(status, dict) and status:
+            self._fuel = dict(status)
+
+    def note_delta(self, payload: dict[str, Any] | None) -> None:
+        if not isinstance(payload, dict):
+            return
+        delta = _num(payload.get("delta_s"))
+        if delta is not None:
+            self._delta_s = delta
+            self._delta_at = self.clock()
+
+    def note_lap(self, payload: dict[str, Any] | None) -> None:
+        if not isinstance(payload, dict):
+            return
+        best = _num(payload.get("best_lap_ms"))
+        if best is not None and best > 0:
+            self._best_lap_ms = best
+        last = _num(payload.get("last_lap_ms"))
+        if last is not None and last > 0:
+            self._last_lap_ms = last
+        lap = _num(payload.get("lap"))
+        if lap is not None and lap >= 0:
+            self._lap = int(lap)
+
+    def snapshot(self, now: float | None = None) -> dict[str, Any] | None:
+        """The current ``race.status`` payload, or ``None`` when nothing is measured yet."""
+        if now is None:
+            now = self.clock()
+        out: dict[str, Any] = {}
+        if self._fuel:
+            out.update(self._fuel)
+        if self._lap is not None:
+            out["lap"] = self._lap
+        if self._best_lap_ms is not None:
+            out["best_lap_ms"] = self._best_lap_ms
+        if self._last_lap_ms is not None:
+            out["last_lap_ms"] = self._last_lap_ms
+        delta_fresh = self._delta_s is not None and (now - self._delta_at) <= DELTA_FRESH_S
+        if delta_fresh:
+            out["delta_s"] = self._delta_s
+            if self._best_lap_ms is not None:
+                # Stint best + live gap: the standard GT "predicted lap". Clamped at zero
+                # defensively; a huge negative delta means the reference is invalid, not a
+                # negative lap time.
+                predicted = self._best_lap_ms + self._delta_s * 1000.0
+                if predicted > 0:
+                    out["predicted_lap_ms"] = round(predicted)
+        return out or None
+
+    def snapshot_if_changed(self, now: float | None = None) -> dict[str, Any] | None:
+        """Like :meth:`snapshot`, but ``None`` when the payload is identical to the last one this
+        method returned — the publish path stays quiet while nothing moves (pit box, menu)."""
+        snap = self.snapshot(now)
+        if snap is None:
+            return None
+        key = tuple(sorted(snap.items()))
+        if key == self._last_published:
+            return None
+        self._last_published = key
+        return snap

--- a/tools/ai_sidecar/race_status.py
+++ b/tools/ai_sidecar/race_status.py
@@ -18,8 +18,9 @@ FRESH delta — a stale delta drops the prediction rather than freezing it. Pure
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 #: A delta older than this cannot anchor a predicted lap (the 10 Hz producer paused/stopped).
 DELTA_FRESH_S = 5.0

--- a/tools/ai_sidecar/race_status.py
+++ b/tools/ai_sidecar/race_status.py
@@ -44,25 +44,35 @@ class RaceStatusTracker:
     _fuel: dict[str, Any] | None = None
     _delta_s: float | None = None
     _delta_at: float = field(default=float("-inf"))
+    _reference_lap_ms: float | None = None
     _best_lap_ms: float | None = None
     _last_lap_ms: float | None = None
     _lap: int | None = None
+    _session_key: tuple[str, str, str] | None = None
     _last_published: tuple[Any, ...] | None = None
 
     def reset(self) -> None:
         self._fuel = None
         self._delta_s = None
         self._delta_at = float("-inf")
+        self._reference_lap_ms = None
         self._best_lap_ms = None
         self._last_lap_ms = None
         self._lap = None
         self._last_published = None
 
-    def note_fuel(self, status: dict[str, Any] | None) -> None:
-        """Latest clean fuel fields (from ``RaceManagementObserver.fuel_status``); ``None`` keeps
-        the previous measurement (a frame missing the fuel channel is unknown, not empty)."""
+    def note_fuel(self, status: dict[str, Any] | None, *, channel_live: bool = False) -> None:
+        """Latest clean fuel fields (from ``RaceManagementObserver.fuel_status``).
+
+        ``None`` with ``channel_live=False`` keeps the previous measurement (the frame simply
+        lacked the fuel channel — unknown, not empty). ``None`` with ``channel_live=True``
+        means the channel IS reporting but the burn state reset (lap rollback / refuel), so the
+        previous stint's numbers are stale and must be dropped, not frozen (Codex on PR #615).
+        """
         if isinstance(status, dict) and status:
             self._fuel = dict(status)
+        elif status is None and channel_live:
+            self._fuel = None
 
     def note_delta(self, payload: dict[str, Any] | None) -> None:
         if not isinstance(payload, dict):
@@ -71,6 +81,24 @@ class RaceStatusTracker:
         if delta is not None:
             self._delta_s = delta
             self._delta_at = self.clock()
+            # The delta's OWN baseline (the active reference trace's lap time), when the
+            # producer carries it. Stored with the delta — the two are meaningless apart.
+            self._reference_lap_ms = _num(payload.get("reference_lap_ms"))
+
+    def note_session(self, payload: dict[str, Any] | None) -> None:
+        """Reset the fusion only on a REAL identity change. The Lua bridge re-emits the
+        current ``session`` snapshot to late subscribers, so a frame alone is not a change
+        (Codex on PR #615) — compare car/track/session before dropping state."""
+        if not isinstance(payload, dict):
+            return
+        key = (
+            str(payload.get("car_id") or ""),
+            str(payload.get("track_id") or ""),
+            str(payload.get("session_index") if payload.get("session_index") is not None else ""),
+        )
+        if self._session_key is not None and key != self._session_key:
+            self.reset()
+        self._session_key = key
 
     def note_lap(self, payload: dict[str, Any] | None) -> None:
         if not isinstance(payload, dict):
@@ -101,11 +129,12 @@ class RaceStatusTracker:
         delta_fresh = self._delta_s is not None and (now - self._delta_at) <= DELTA_FRESH_S
         if delta_fresh:
             out["delta_s"] = self._delta_s
-            if self._best_lap_ms is not None:
-                # Stint best + live gap: the standard GT "predicted lap". Clamped at zero
-                # defensively; a huge negative delta means the reference is invalid, not a
-                # negative lap time.
-                predicted = self._best_lap_ms + self._delta_s * 1000.0
+            if self._reference_lap_ms is not None and self._reference_lap_ms > 0:
+                # Predicted lap = the delta's OWN reference lap time + the live gap. The stint
+                # best is the WRONG baseline when an imported/faster reference drives the delta
+                # (Codex on PR #615) — so the prediction exists only when the producer carries
+                # `reference_lap_ms` with the delta. Suppressed (never guessed) otherwise.
+                predicted = self._reference_lap_ms + self._delta_s * 1000.0
                 if predicted > 0:
                     out["predicted_lap_ms"] = round(predicted)
         return out or None

--- a/tools/ai_sidecar/registers.py
+++ b/tools/ai_sidecar/registers.py
@@ -44,3 +44,26 @@ REGISTER_RANK: dict[str, int] = {register: rank for rank, register in enumerate(
 def register_rank(register: object, default: int = 0) -> int:
     """Ordering helper for intensity comparisons, accepting legacy aliases."""
     return REGISTER_RANK.get(normalize_register(register), default)
+
+
+#: Audio-routing values carried on ``coaching.cue`` / ``coaching.voice`` payloads (#531 Part E).
+#: ``authoritative_pc`` = the PC WASAPI in-ear path owns the audible cue; ``tablet_native`` = the
+#: cue is glanceable/info-tier and a tablet endpoint may voice it natively. The field is a routing
+#: HINT for remote endpoints — the in-process PC coach's own scheduling is unchanged by it.
+AUDIO_ROUTING_AUTHORITATIVE_PC = "authoritative_pc"
+AUDIO_ROUTING_TABLET_NATIVE = "tablet_native"
+AUDIO_ROUTINGS: tuple[str, ...] = (AUDIO_ROUTING_AUTHORITATIVE_PC, AUDIO_ROUTING_TABLET_NATIVE)
+
+
+def audio_routing_for_register(register: object) -> str:
+    """Map an intensity register to its audio route (#531 Part E).
+
+    ``urgent``/``critical`` cues stay on the authoritative PC WASAPI path (measured sub-150 ms);
+    ``calm``/``alert`` cues may be voiced by the tablet. The boundary is policy, not physics:
+    #531 Part G re-derives it from the measured tablet native-audio dispatch→audible latency —
+    until that number is on record the PC keeps everything critical (the P7's WebAudio path
+    measured ~605 ms acoustic, over the 450 ms budget).
+    """
+    if register_rank(register) >= REGISTER_RANK["urgent"]:
+        return AUDIO_ROUTING_AUTHORITATIVE_PC
+    return AUDIO_ROUTING_TABLET_NATIVE

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -116,8 +116,6 @@ from tools.ai_sidecar.realtime_observer import (
     RealtimeObserver,
 )
 from tools.ai_sidecar.registers import audio_routing_for_register
-from tools.ai_sidecar.shift_observer import ShiftObserver
-from tools.ai_sidecar.voice.vocabulary import KINDS as VOICE_KINDS
 from tools.ai_sidecar.se_proxy import (
     DEFAULT_SETUP_EXCHANGE_ENDPOINT,
     ENV_SETUP_EXCHANGE_ENDPOINT,
@@ -144,6 +142,8 @@ from tools.ai_sidecar.setup_optimizer import (
     suggest_closed_loop,
     suggest_next_setup,
 )
+from tools.ai_sidecar.shift_observer import ShiftObserver
+from tools.ai_sidecar.voice.vocabulary import KINDS as VOICE_KINDS
 
 logger = logging.getLogger(__name__)
 

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -1344,6 +1344,12 @@ def _release_observer_feed(websocket: Any) -> None:
             _coach_runtime.reset()
         if _race_manager is not None:
             _race_manager.reset()
+        # #531 Parts D/E: the shift observer and race-status fusion are single-stream state
+        # too — a producer swap must not inherit the previous stream's armed gears or
+        # fuel/delta fusion (Codex on PR #615).
+        if _shift_observer is not None:
+            _shift_observer.reset()
+        _race_status.reset()
 
 
 def _drop_external_peer(peer: Any) -> None:
@@ -1566,7 +1572,14 @@ async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None
     # race-status state (fuel-as-a-decision); publish is change-gated + rate-limited.
     if race_manager is not None:
         try:
-            _race_status.note_fuel(race_manager.fuel_status(frame))
+            status = race_manager.fuel_status(frame)
+            # channel_live disambiguates the two None cases: a frame that DOES carry fuel
+            # but yields no status means the burn state reset (rollback/refuel) — the
+            # tracker must drop the prior stint's numbers, not freeze them (Codex #615).
+            tick_payload = frame.get("payload") if isinstance(frame.get("payload"), dict) else {}
+            fuel_raw = tick_payload.get("fuel_l", frame.get("fuel_l"))
+            channel_live = isinstance(fuel_raw, (int, float)) and not isinstance(fuel_raw, bool)
+            _race_status.note_fuel(status, channel_live=channel_live)
         except Exception:
             logger.exception("race-status fuel update failed on telemetry_tick")
     await _publish_race_status(exclude=exclude)
@@ -2324,10 +2337,11 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
         elif topic == "lap":
             _race_status.note_lap(tap_payload if isinstance(tap_payload, dict) else None)
         elif topic == "session":
-            # A session frame means a NEW car/track/session identity (the Lua publisher is
-            # change-detected): the prior identity's best/delta/fuel must not leak into the
-            # next one's predicted lap. The tracker refills within a lap.
-            _race_status.reset()
+            # The prior identity's best/delta/fuel must not leak into the next one's
+            # predicted lap — but the bridge also RE-EMITS the current session to late
+            # subscribers, so the tracker resets only on a real identity change (it
+            # compares car/track/session itself; Codex on PR #615).
+            _race_status.note_session(tap_payload if isinstance(tap_payload, dict) else None)
     if t == TYPE_STATE_SNAPSHOT and isinstance(topic, str) and topic in IDENTITY_REPLAY_TOPICS:
         # #531 Part B: remember the latest identity snapshot for late-subscriber replay,
         # tied to the producing peer — its disconnect invalidates the cached identity

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -96,6 +96,7 @@ from tools.ai_sidecar.external_protocol import (
     make_coaching_voice,
     make_error,
     make_hello_ack,
+    make_race_status,
     topics_are_sidecar_only,
     validate_inbound,
 )
@@ -110,9 +111,13 @@ from tools.ai_sidecar.protocol import (
     resolve_lap_archive,
 )
 from tools.ai_sidecar.race_management import RaceManagementObserver
+from tools.ai_sidecar.race_status import RaceStatusTracker
 from tools.ai_sidecar.realtime_observer import (
     RealtimeObserver,
 )
+from tools.ai_sidecar.registers import audio_routing_for_register
+from tools.ai_sidecar.shift_observer import ShiftObserver
+from tools.ai_sidecar.voice.vocabulary import KINDS as VOICE_KINDS
 from tools.ai_sidecar.se_proxy import (
     DEFAULT_SETUP_EXCHANGE_ENDPOINT,
     ENV_SETUP_EXCHANGE_ENDPOINT,
@@ -169,6 +174,13 @@ _observer: RealtimeObserver | None = None
 # producer in place of the legacy observer's apex_deficit/late_brake output.
 _coach_runtime: Any | None = None
 _race_manager: Any | None = RaceManagementObserver()
+# #531 Part E: live upshift/downshift cues from the tick (learned shift_rpm or limiter
+# heuristic). Rides the same single-producer telemetry feed as the race manager.
+_shift_observer: Any | None = ShiftObserver()
+# #531 Part D remainder: fused fuel/best/delta/predicted state behind the `race.status` topic.
+_race_status: RaceStatusTracker = RaceStatusTracker()
+#: Publish cadence cap for `race.status` (change-gated on top of this).
+RACE_STATUS_MAX_HZ = 1.0
 # The observer holds single-monotonic-stream state (last spline/lap, per-corner passes), so only ONE
 # producer may feed it. The first telemetry producer claims the feed; a second concurrent loopback
 # producer is still routed to peripherals but NOT into the observer (interleaving would corrupt wrap
@@ -238,6 +250,12 @@ def set_race_manager(manager: Any | None) -> None:
     """Install (or clear) the stint-level race-management observer."""
     global _race_manager
     _race_manager = manager
+
+
+def set_shift_observer(observer: Any | None) -> None:
+    """Install (or clear) the live shift-cue observer (#531 Part E)."""
+    global _shift_observer
+    _shift_observer = observer
 
 
 def set_voice_coach(coach: Any | None) -> None:
@@ -453,6 +471,9 @@ def _reset_external_state() -> None:
     _voice_echo_log.clear()
     if _race_manager is not None:
         _race_manager.reset()
+    if _shift_observer is not None:
+        _shift_observer.reset()
+    _race_status.reset()
     # The single-producer observer feed is external-peer state: a full reset (server (re)start or
     # teardown) leaves no producer owning the feed, so the next telemetry producer can claim it.
     # Without this, a stale owner persists and the next producer is silently rejected by the guard
@@ -1449,18 +1470,44 @@ def _advisory_to_payload(advisory: Any) -> dict[str, Any] | None:
     if not isinstance(kind, str) or not kind or not isinstance(urgency, str) or not urgency:
         logger.warning("voice: dropping advisory with missing kind/urgency: %r", advisory)
         return None
+    register = getattr(advisory, "register", "calm")
     return {
         "kind": kind,
         "corner": getattr(advisory, "corner", None),
         "urgency": urgency,
         # issue #368: the tone tier + severity travel on the cue so a WS voice client renders the
         # same intensity the in-process coach speaks (additive — older consumers ignore them).
-        "register": getattr(advisory, "register", "calm"),
+        "register": register,
         "intensity": getattr(advisory, "intensity", 0.0),
+        # #531 Part E: which endpoint owns the AUDIBLE cue — urgent/critical stay on the
+        # authoritative PC WASAPI path; calm/alert may be voiced by the tablet (Part G gates
+        # the native path on a measured latency). Routing hint only; additive.
+        "audio_routing": audio_routing_for_register(register),
         "message": getattr(advisory, "message", ""),
         "spline": getattr(advisory, "spline", None),
         "detail": getattr(advisory, "detail", {}),
     }
+
+
+async def _publish_race_status(*, exclude: Any) -> None:
+    """Broadcast the fused ``race.status`` payload when it changed (#531 Part D remainder).
+
+    Rate-capped at ``RACE_STATUS_MAX_HZ`` and change-gated by the tracker, so a parked car
+    (or a paused sim) goes quiet instead of re-broadcasting the same numbers. Never raises
+    into the telemetry loop.
+    """
+    try:
+        if not _peripheral_rate_limiter.allow(("race.status",), RACE_STATUS_MAX_HZ):
+            return
+        payload = _race_status.snapshot_if_changed()
+        if payload is None:
+            return
+        frame = make_race_status(payload)
+        task = asyncio.create_task(_broadcast_external(frame, exclude=exclude))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+    except Exception:
+        logger.exception("failed to publish race.status")
 
 
 async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None:
@@ -1482,7 +1529,8 @@ async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None
     # not reference-corner geometry.
     observer = _coach_runtime if _coach_runtime is not None else _observer
     race_manager = _race_manager
-    if observer is None and race_manager is None:
+    shift_observer = _shift_observer
+    if observer is None and race_manager is None and shift_observer is None:
         return
     if not _peripheral_rate_limiter.allow((TYPE_TELEMETRY_TICK, "observer"), TELEMETRY_TICK_MAX_HZ):
         return
@@ -1509,12 +1557,28 @@ async def _publish_coaching_cues(frame: dict[str, Any], *, exclude: Any) -> None
             advisories.extend(race_manager.observe(frame))
         except Exception:
             logger.exception("race-management observer failed on telemetry_tick")
+    if shift_observer is not None:
+        try:
+            advisories.extend(shift_observer.observe(frame))
+        except Exception:
+            logger.exception("shift observer failed on telemetry_tick")
+    # #531 Part D remainder: the same guarded single-producer tick also feeds the fused
+    # race-status state (fuel-as-a-decision); publish is change-gated + rate-limited.
+    if race_manager is not None:
+        try:
+            _race_status.note_fuel(race_manager.fuel_status(frame))
+        except Exception:
+            logger.exception("race-status fuel update failed on telemetry_tick")
+    await _publish_race_status(exclude=exclude)
     if not advisories:
         return
     ts_sim = frame.get("ts_sim")
     coach = _voice_coach
     for advisory in advisories:
-        if coach is not None:
+        # #531 Part E: only vocabulary-covered kinds reach the in-process voice coach. Shift
+        # cues (upshift/downshift) are tablet-tier by routing policy AND have no baked clips —
+        # submitting them would only warn-and-drop in the resolver on every straight.
+        if coach is not None and getattr(advisory, "kind", None) in VOICE_KINDS:
             try:
                 coach.subscribe(advisory)
             except Exception:
@@ -2250,6 +2314,20 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
     # responds with `config.value` / `config.ack` / `action.ack` /
     # `state.snapshot`, which are also forwarded back through this same path.
     topic = data.get("topic")
+    # #531 Part D remainder: the Lua `delta` / `lap` topics feed the fused race-status state
+    # (predicted lap = stint best + live gap) on their way through the relay. Read-only tap;
+    # the frames still broadcast unchanged below.
+    if t == TYPE_STATE_SNAPSHOT and isinstance(topic, str):
+        tap_payload = data.get("payload")
+        if topic == "delta":
+            _race_status.note_delta(tap_payload if isinstance(tap_payload, dict) else None)
+        elif topic == "lap":
+            _race_status.note_lap(tap_payload if isinstance(tap_payload, dict) else None)
+        elif topic == "session":
+            # A session frame means a NEW car/track/session identity (the Lua publisher is
+            # change-detected): the prior identity's best/delta/fuel must not leak into the
+            # next one's predicted lap. The tracker refills within a lap.
+            _race_status.reset()
     if t == TYPE_STATE_SNAPSHOT and isinstance(topic, str) and topic in IDENTITY_REPLAY_TOPICS:
         # #531 Part B: remember the latest identity snapshot for late-subscriber replay,
         # tied to the producing peer — its disconnect invalidates the cached identity

--- a/tools/ai_sidecar/shift_observer.py
+++ b/tools/ai_sidecar/shift_observer.py
@@ -1,0 +1,202 @@
+"""Live upshift/downshift cues from telemetry (#531 Part E).
+
+Mirrors the in-game shift model (``src/ac_copilot_trainer/modules/shift_profile.lua``): the Lua
+side resolves a per-gear upshift target from the learned reference-trace profile (falling back to
+a fixed fraction of the rev limiter) and — since #531 Part E — rides that resolved target on the
+``telemetry_tick`` as ``shift_rpm`` (+ ``shift_rpm_source``). This observer consumes it and emits
+``coaching.cue`` advisories for the tablet coach lane:
+
+- ``upshift`` — rpm reached the shift target under real throttle. Emitted once per gear
+  engagement (re-armed by a gear change), never while braking.
+- ``downshift`` — sustained bogging: real throttle but rpm far below the gear's shift target
+  (the lower gear would put the engine in its band). Heuristic by construction and labelled so
+  in ``detail``; conservatively gated (sustain window + cooldown + minimum speed) because a
+  wrong "shift down" is worse than silence.
+
+Both cues are ``register="calm"`` — glanceable tablet-tier per the #531 Part E audio-routing
+policy (``audio_routing="tablet_native"``); the PC in-ear coach never speaks them (they are not
+in the voice vocabulary, deliberately: the shift ribbon and HUD already own that surface).
+
+Pure stdlib; fed the same ``telemetry_tick`` frames as the other observers. Sentinel discipline:
+missing/non-finite channels disable the cue for that frame — ``0`` is a legitimate value
+(neutral gear, closed throttle), absence is unknown.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from tools.ai_sidecar.realtime_observer import Advisory
+
+#: Heuristic shift zone as a fraction of the rev limiter — mirrors
+#: ``shift_profile.lua``'s ``DEFAULT_SHIFT_ZONE_FRAC`` (the fallback when no learned
+#: ``shift_rpm`` rides the frame).
+DEFAULT_SHIFT_ZONE_FRAC = 0.92
+#: Only coach shifts under real throttle — mirrors ``realtime_coaching.lua``'s
+#: ``SHIFT_MIN_GAS``.
+MIN_SHIFT_GAS = 0.55
+#: Re-emit guard: even across gear changes, consecutive upshift cues are at least this far
+#: apart (a gearbox bounce must not machine-gun the lane).
+UPSHIFT_COOLDOWN_S = 2.0
+#: Bog detection: rpm at/below this fraction of the gear's shift target counts as lugging.
+DOWNSHIFT_BOG_FRAC = 0.40
+#: Bog must be sustained this long before a downshift cue fires (transient dips are normal).
+DOWNSHIFT_SUSTAIN_S = 0.6
+#: Downshift cues are rare by design.
+DOWNSHIFT_COOLDOWN_S = 8.0
+#: No bog coaching below this speed — pulling away from a stop legitimately lugs.
+DOWNSHIFT_MIN_SPEED_KMH = 30.0
+
+
+def _num(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f and abs(f) != float("inf") else None
+
+
+def _payload(frame: dict[str, Any]) -> dict[str, Any]:
+    return frame.get("payload") if isinstance(frame.get("payload"), dict) else {}
+
+
+def _pick(frame: dict[str, Any], *keys: str) -> Any:
+    payload = _payload(frame)
+    for src in (frame, payload):
+        for key in keys:
+            if key in src:
+                return src[key]
+    return None
+
+
+@dataclass
+class ShiftObserver:
+    """Stateful shift-cue observer; feed it live ``telemetry_tick`` frames."""
+
+    clock: Callable[[], float] = time.monotonic
+    _last_gear: int | None = None
+    _upshift_cued_gear: int | None = None
+    _last_upshift_at: float = field(default=float("-inf"))
+    _bog_since: float | None = None
+    _last_downshift_at: float = field(default=float("-inf"))
+
+    def reset(self) -> None:
+        self._last_gear = None
+        self._upshift_cued_gear = None
+        self._last_upshift_at = float("-inf")
+        self._bog_since = None
+        self._last_downshift_at = float("-inf")
+
+    def observe(self, frame: dict[str, Any]) -> list[Advisory]:
+        now = self.clock()
+        rpm = _num(_pick(frame, "rpm"))
+        gear_raw = _num(_pick(frame, "gear"))
+        throttle = _num(_pick(frame, "throttle", "gas"))
+        brake = _num(_pick(frame, "brake"))
+        gear = int(gear_raw) if gear_raw is not None and gear_raw >= 0 else None
+
+        if gear is None or rpm is None:
+            # Unknown gear/rpm: nothing to coach this frame; keep armed state (a dropped
+            # channel must not fabricate a fresh gear engagement).
+            return []
+
+        if gear != self._last_gear:
+            # New gear engagement re-arms both cues; a bog streak never spans gears.
+            self._last_gear = gear
+            self._upshift_cued_gear = None
+            self._bog_since = None
+
+        if gear < 1:
+            return []
+
+        target, source = self._shift_target(frame)
+        if target is None:
+            return []
+
+        out: list[Advisory] = []
+        throttled = throttle is not None and throttle >= MIN_SHIFT_GAS
+        braking = brake is not None and brake > 0.2
+
+        if (
+            throttled
+            and not braking
+            and rpm >= target
+            and self._upshift_cued_gear != gear
+            and (now - self._last_upshift_at) >= UPSHIFT_COOLDOWN_S
+        ):
+            self._upshift_cued_gear = gear
+            self._last_upshift_at = now
+            out.append(
+                Advisory(
+                    kind="upshift",
+                    corner=-1,
+                    spline=float(_num(_pick(frame, "spline")) or 0.0),
+                    urgency="act",
+                    message="Shift up.",
+                    detail={
+                        "gear": gear,
+                        "rpm": round(rpm),
+                        "shift_rpm": round(target),
+                        "shift_rpm_source": source,
+                    },
+                    intensity=0.2,
+                    register="calm",
+                )
+            )
+
+        speed = _num(_pick(frame, "speed_kmh", "speedKmh"))
+        bogging = (
+            throttled
+            and not braking
+            and gear >= 2
+            and speed is not None
+            and speed >= DOWNSHIFT_MIN_SPEED_KMH
+            and rpm > 0
+            and rpm <= target * DOWNSHIFT_BOG_FRAC
+        )
+        if not bogging:
+            self._bog_since = None
+        else:
+            if self._bog_since is None:
+                self._bog_since = now
+            if (
+                (now - self._bog_since) >= DOWNSHIFT_SUSTAIN_S
+                and (now - self._last_downshift_at) >= DOWNSHIFT_COOLDOWN_S
+            ):
+                self._last_downshift_at = now
+                self._bog_since = None
+                out.append(
+                    Advisory(
+                        kind="downshift",
+                        corner=-1,
+                        spline=float(_num(_pick(frame, "spline")) or 0.0),
+                        urgency="act",
+                        message="Shift down.",
+                        detail={
+                            "gear": gear,
+                            "rpm": round(rpm),
+                            "shift_rpm": round(target),
+                            "shift_rpm_source": source,
+                            "classification": "bog_heuristic",
+                        },
+                        intensity=0.2,
+                        register="calm",
+                    )
+                )
+        return out
+
+    def _shift_target(self, frame: dict[str, Any]) -> tuple[float | None, str]:
+        """The upshift rpm for the current frame: learned (from the Lua shift profile riding
+        the tick as ``shift_rpm``) when present, else the heuristic limiter fraction."""
+        direct = _num(_pick(frame, "shift_rpm"))
+        if direct is not None and direct > 0:
+            source = _pick(frame, "shift_rpm_source")
+            return direct, source if isinstance(source, str) and source else "learned"
+        rpm_max = _num(_pick(frame, "rpm_max", "rpmMax"))
+        if rpm_max is not None and rpm_max > 0:
+            return rpm_max * DEFAULT_SHIFT_ZONE_FRAC, "heuristic"
+        return None, "unavailable"

--- a/tools/ai_sidecar/shift_observer.py
+++ b/tools/ai_sidecar/shift_observer.py
@@ -25,8 +25,9 @@ missing/non-finite channels disable the cue for that frame — ``0`` is a legiti
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 from tools.ai_sidecar.realtime_observer import Advisory
 
@@ -163,10 +164,9 @@ class ShiftObserver:
         else:
             if self._bog_since is None:
                 self._bog_since = now
-            if (
-                (now - self._bog_since) >= DOWNSHIFT_SUSTAIN_S
-                and (now - self._last_downshift_at) >= DOWNSHIFT_COOLDOWN_S
-            ):
+            if (now - self._bog_since) >= DOWNSHIFT_SUSTAIN_S and (
+                now - self._last_downshift_at
+            ) >= DOWNSHIFT_COOLDOWN_S:
                 self._last_downshift_at = now
                 self._bog_since = None
                 out.append(

--- a/tools/ai_sidecar/voice/dispatch.py
+++ b/tools/ai_sidecar/voice/dispatch.py
@@ -24,6 +24,7 @@ import time
 from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass
 
+from tools.ai_sidecar.registers import audio_routing_for_register
 from tools.ai_sidecar.voice.playback import Playback
 from tools.ai_sidecar.voice.utterance import Utterance
 
@@ -54,7 +55,12 @@ class VoiceDispatch:
 
     def to_payload(self) -> dict[str, object]:
         """The ``coaching.voice`` wire payload (plain JSON-safe dict)."""
-        return asdict(self)
+        payload = asdict(self)
+        # #531 Part E: the routing hint travels with the dispatched clip too, so a tablet
+        # endpoint can tell "mirror only" (authoritative_pc — the PC already spoke it) from
+        # "you may own the audio" (tablet_native) without re-deriving the register policy.
+        payload["audio_routing"] = audio_routing_for_register(self.register)
+        return payload
 
 
 class DispatchTapPlayback:

--- a/tools/ai_sidecar/voice/dispatch.py
+++ b/tools/ai_sidecar/voice/dispatch.py
@@ -24,7 +24,7 @@ import time
 from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass
 
-from tools.ai_sidecar.registers import audio_routing_for_register
+from tools.ai_sidecar.registers import AUDIO_ROUTING_AUTHORITATIVE_PC
 from tools.ai_sidecar.voice.playback import Playback
 from tools.ai_sidecar.voice.utterance import Utterance
 
@@ -56,10 +56,12 @@ class VoiceDispatch:
     def to_payload(self) -> dict[str, object]:
         """The ``coaching.voice`` wire payload (plain JSON-safe dict)."""
         payload = asdict(self)
-        # #531 Part E: the routing hint travels with the dispatched clip too, so a tablet
-        # endpoint can tell "mirror only" (authoritative_pc — the PC already spoke it) from
-        # "you may own the audio" (tablet_native) without re-deriving the register policy.
-        payload["audio_routing"] = audio_routing_for_register(self.register)
+        # #531 Part E: every frame on this stream is a clip the in-process PC playback has
+        # ALREADY sounded (the tap fires post-play), so the audio owner is the PC by
+        # construction — regardless of register. A register-based hint here would invite a
+        # tablet endpoint to re-speak calm/alert clips the PC just played (Codex on PR #615).
+        # Part G revisits when tablet-native playback + PC-side suppression land together.
+        payload["audio_routing"] = AUDIO_ROUTING_AUTHORITATIVE_PC
         return payload
 
 


### PR DESCRIPTION
## Scope (#531 Phase 2, grouped parts)

### Part D remainder — clean fuel / predicted-lap fields (`race.status`)
- `RaceManagementObserver.fuel_status()` surfaces the fuel-per-lap / laps-remaining numbers that previously lived only inside a `fuel_save`/`fuel_status` cue `detail` — ungated, no dedup-key consumption (test-pinned).
- New `tools/ai_sidecar/race_status.py`: `RaceStatusTracker` fuses fuel (tick) + Lua `delta`/`lap` topics into `predicted_lap_ms = stint best + live delta`, with honesty gates: a stale (>5 s) delta **drops** the prediction (never frozen), sentinel-checked lap fields, per-identity reset on the Lua `session` topic.
- New **sidecar-produced topic `race.status`** (KNOWN_TOPICS + SIDECAR_PRODUCED_TOPICS; deliberately **not** identity-replayed — a stale sample would masquerade as live fuel numbers). Published from the guarded single-producer tick path, ≤1 Hz, change-gated.
- Dash: prefers the sidecar fields over its client-side burn estimate (which stays as fallback, labelled `est`), and fills the **`predicted` timing row that the frozen design already specifies** (mock line "predicted", spec §4 "cur/last/best/pred") but Phase 1 never implemented.

### Part E — shift cues + `audio_routing` + tier-2 lane wiring
- Lua: `telemetry_publisher` now rides the **resolved `shift_profile.lua` target** on the tick as `shift_rpm` + `shift_rpm_source` (learned per-gear model from #442, heuristic limiter fraction as fallback; omitted in neutral / when unresolvable — never 0).
- New `tools/ai_sidecar/shift_observer.py`: emits `upshift` (target reached under ≥0.55 throttle, once per gear engagement + 2 s cooldown, never while braking) and `downshift` (**conservative sustained-bog heuristic**, labelled `bog_heuristic` in detail: ≥0.6 s at ≤40 % of the gear's shift target, ≥30 km/h, gear ≥2, 8 s cooldown).
- **`audio_routing` field** on every `coaching.cue` and `coaching.voice` payload: `urgent`/`critical` → `authoritative_pc`, `calm`/`alert` → `tablet_native` (policy helper in `registers.py`; Part G re-derives the boundary from the measured tablet latency). Unknown registers fail toward the tablet tier, never claim the critical PC path.
- Shift cues are **vocabulary-gated out of the PC voice coach** at the subscribe seam — no baked clips exist for them, and submitting them would warn-and-drop in the resolver on every straight. Test-pinned both ways (shift cues broadcast but never voiced; vocabulary kinds still voiced).
- Dash coach lane: tier-2 micro-cue slot (§8 — at most ONE CommandVerb-lite) now renders fresh actionable cues (`UPSHIFT ▲`, `DOWNSHIFT ▼`, `FUEL SAVE`, …) with a 4 s dwell; corner coaching keeps the snapshot line; tier-3 braking takeover unchanged.

### Tests
107 focused tests pass (`test_shift_observer`, `test_race_status`, `test_audio_routing`, extended `test_race_management` / `test_server_observer_wiring` / `test_tablet_dash_endpoint` / `test_telemetry_publisher` incl. lupa producer coverage). `make ci-fast` OK locally.

### Pitfalls honoured
- `telemetry_tick` is a wire, not a dashboard feed — no existing consumer removed; `race_management` brake-temp path untouched.
- KNOWN_TOPICS allow-list extended for the new topic (drift-guard covered).
- Sentinel discipline throughout (`-1`/nil/absent = unknown, 0 legitimate).

Closes nothing by itself — part of #531 (Parts F/G/H/I remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)