### PR TITLE
fix(vault): retire Context7 instruction in the actively-imported Library Map (governance-hub#274)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Library Map.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Library Map.md
@@ -14,4 +14,4 @@ relates_to:
 |------------|------|-------|
 | _Add rows as the project grows_ | | |
 
-Use Context7 MCP for upstream API details; record **project-specific** integration choices here.
+Use official docs and targeted web search for upstream API details (the context7 MCP server is retired fleet-wide; governance-hub#274 <!-- mcp-retirement-ok -->); record **project-specific** integration choices here.


### PR DESCRIPTION
Micro follow-up: CLAUDE.md @-imports this vault note into every session, making its Context7 line an active instruction (same class fixed fleet-wide; canonical: agorokh/template-repo@3a56f41). One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)