### PR TITLE
docs(vault): post-merge handoff for PR #615

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -41,6 +41,16 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
+**Active (2026-07-16, autonomous run):** [#531](https://github.com/agorokh/ac-copilot-trainer/issues/531)
+Phase 2+ delivery. Parts **D-remainder + E** MERGED via PR
+[#615](https://github.com/agorokh/ac-copilot-trainer/pull/615)
+([`de04860`](https://github.com/agorokh/ac-copilot-trainer/commit/de0486066538ac1e59486ce2219524ff9c19e27d)):
+`race.status` topic (fuel-as-a-decision + reference-anchored predicted lap), `upshift`/`downshift`
+cues from the learned shift profile, `audio_routing` on every cue, dash predicted row + tier-2
+micro-cue slot. **Next in the same run:** P7 rig-verify from merged main (incl. the unobserved
+TC/ABS intervention flash via #595), then Part F (COACH/MAP/STINT depth), Part G (native-audio
+latency gate), H/I scope reconciliation. Detail: [[issue-531-parte-cues-fuel-2026-07-16]].
+
 **Delivered (2026-07-16):** [#602](https://github.com/agorokh/ac-copilot-trainer/issues/602) is
 **CLOSED** by PR [#606](https://github.com/agorokh/ac-copilot-trainer/pull/606), merge
 [`a153fda`](https://github.com/agorokh/ac-copilot-trainer/commit/a153fda063490f40963e59a8a40685e8c3d263a6).

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,8 +2,9 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-16T07:30:00Z
+last_updated: 2026-07-16T09:00:00Z
 relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-531-parte-cues-fuel-2026-07-16.md
   - AcCopilotTrainer/03_Investigations/rig-tablet-tunnel-keeper-armed-2026-07-16.md
   - AcCopilotTrainer/03_Investigations/rig-porsche-data-acd-restore-2026-07-16.md
   - AcCopilotTrainer/03_Investigations/issue-602-portaudio-fixed-layout-2026-07-15.md
@@ -99,6 +100,25 @@ relates_to:
 ---
 
 # Next session handoff
+
+## Delivered (2026-07-16) — #531 Part D remainder + Part E MERGED (PR #615)
+
+PR [#615](https://github.com/agorokh/ac-copilot-trainer/pull/615) squash-merged as
+[`de04860`](https://github.com/agorokh/ac-copilot-trainer/commit/de0486066538ac1e59486ce2219524ff9c19e27d).
+New `race.status` topic (clean fuel-per-lap / laps-remaining / **predicted lap anchored on the
+delta's own `reference_lap_ms` baseline**), `upshift`/`downshift` cues from the learned
+`shift_profile.lua` model riding the tick as `shift_rpm`, `audio_routing` on every cue
+(`coaching.voice` always `authoritative_pc` — the tap fires post-playback), dash `predicted`
+row + §8 tier-2 micro-cue slot. 6 Codex P2s fixed in one round; daemon review absent (vacuous).
+Detail: [[issue-531-parte-cues-fuel-2026-07-16]].
+
+**Resume here (same autonomous run, task queued):** rig-verify on the P7 from merged main —
+restart the :8765 sidecar, drive via harness, observe fuel/predicted/shift cues on glass +
+the still-unobserved TC/ABS intervention flash (#595 made it evidencable). Then Part F
+(COACH/MAP/STINT depth — reconcile spec-prose "boards never swept" vs the mock's full sweep;
+the mock is the issue-designated ground truth), Part G (native-audio latency gate), Parts H/I
+scope reconciliation. Note the installed AC app junction serves the **primary checkout — now
+on merged main `de04860`** (ff'd this session).
 
 ## Rig maintenance (2026-07-16) — Porsche `data.acd` restored, tablet dash was collateral
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-parte-cues-fuel-2026-07-16.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-531-parte-cues-fuel-2026-07-16.md
@@ -1,0 +1,62 @@
+---
+type: investigation
+status: active
+created: 2026-07-16
+updated: 2026-07-16
+memory_tier: canonical
+issue: https://github.com/agorokh/ac-copilot-trainer/issues/531
+relates_to:
+  - AcCopilotTrainer/03_Investigations/issue-531-partd-live-vitals-2026-07-14.md
+  - AcCopilotTrainer/03_Investigations/issue-531-phase1-tablet-dash-2026-07-13.md
+---
+
+# #531 Part D remainder + Part E — race.status, shift cues, audio_routing (PR #615)
+
+PR [#615](https://github.com/agorokh/ac-copilot-trainer/pull/615) squash-merged as `de04860`
+(2026-07-16). Parts delivered: **D remainder** (clean fuel/predicted-lap fields) + **E**
+(shift cues, `audio_routing`, tier-2 lane wiring).
+
+## What shipped
+
+- **`race.status` topic** (sidecar-produced, ≤1 Hz, change-gated): `RaceStatusTracker`
+  (`tools/ai_sidecar/race_status.py`) fuses `RaceManagementObserver.fuel_status()` (new
+  ungated read) + Lua `delta`/`lap` topics. **Predicted lap anchors on the delta's OWN
+  baseline** — the Lua delta now carries `reference_lap_ms` (= `state.activeReferenceLapMs`);
+  prediction is suppressed without it, never mixed with the stint best (Codex catch).
+- **Shift cues** (`tools/ai_sidecar/shift_observer.py`): `upshift` from the learned
+  `shift_profile.lua` target riding the tick as `shift_rpm`(+`shift_rpm_source`), heuristic
+  0.92×`rpm_max` fallback; `downshift` = conservative sustained-bog heuristic (labelled
+  `bog_heuristic`). Register `calm`, once-per-gear-engagement + cooldowns.
+- **`audio_routing`** on every cue: `urgent`/`critical` → `authoritative_pc`, `calm`/`alert`
+  → `tablet_native` (`registers.audio_routing_for_register`; Part G re-derives from measured
+  latency). **`coaching.voice` is ALWAYS `authoritative_pc`** — the tap fires post-playback,
+  so a register hint there would invite tablet double audio.
+- **Dash**: prefers sidecar fuel fields (client burn stays as `est` fallback), fills the
+  design's `predicted` timing row (was in the frozen mock, never implemented), renders the
+  §8 tier-2 micro-cue slot (`UPSHIFT ▲` … 4 s dwell, at most one).
+
+## Durable rules confirmed
+
+- **Shift cues never reach the PC voice** — vocabulary-gated at the subscribe seam; adding
+  kinds to the vocabulary would invalidate the baked bank (`vocabulary_hash`), so new
+  glanceable-only kinds stay out of `KINDS` deliberately.
+- **Single-stream state must reset on producer release** — any new observer/tracker fed from
+  the tick belongs in `_release_observer_feed()` too.
+- **`session` frames are replayed to late subscribers** — a consumer must compare identity
+  before dropping state (tracker `note_session`), never treat the frame itself as a change.
+- Fuel-state `None` is ambiguous: channel-missing (keep) vs burn-reset-while-live (drop) —
+  disambiguated with `channel_live` at the server tap.
+
+## Review
+
+6 Codex P2s, all real, all fixed in one batched round (`c6c7796`); threads replied with
+evidence + resolved. Self-hosted daemon posted no review on either SHA (two full cooldowns) —
+vacuous-absent path. resolve-gate: no substantive findings hanging.
+
+## Verification state
+
+- 131 focused tests + `make ci-fast` green; dash rendered against a live branch sidecar
+  (:8799) with zero console errors and the honest WAITING states intact.
+- **Live P7 pass rides the next rig session** (same session, task queued): restart the :8765
+  sidecar from merged main, drive, observe fuel/predicted/shift-cue fields on glass + the
+  still-unobserved TC/ABS intervention flash (PR #595 made it evidencable).


### PR DESCRIPTION
Vault-only handoff updates produced by `post-merge-steward` for PR #615.

This PR is auto-merged by `.github/workflows/vault-automerge.yml` after scope validation (only `docs/01_Vault/**` may change).