### PR TITLE
feat(dash): #531 Part F — COACH/MAP/STINT page depth + durable dev feeder

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -64,21 +64,26 @@ local function readSessionLapsTotal()
   if idx == nil then
     return nil
   end
-  if sessionLapsCacheIndex ~= idx or (sessionLapsCacheValue == nil and sessionLapsRetryCountdown <= 0) then
-    -- A FAILED read must not negative-cache for the whole session (daemon on PR #618 R9):
-    -- retry, but only every ~120 calls (~2 s at 60 Hz) so a broken CSP build never pays
-    -- the pcall at frame rate. A successful read (or a timed session's honest nil-laps
-    -- payload with ok==true) caches until the session index changes.
+  if sessionLapsCacheIndex ~= idx then
+    -- The previous session's total must NEVER leak across an index change — cleared
+    -- unconditionally BEFORE any read attempt (daemon HIGH on PR #618 R10).
     sessionLapsCacheIndex = idx
+    sessionLapsCacheValue = nil
+    sessionLapsRetryCountdown = 0
+  end
+  if sessionLapsCacheValue == nil and sessionLapsRetryCountdown <= 0 then
+    -- A FAILED read must not negative-cache for the whole session either (R9): retry
+    -- every ~120 calls (~2 s at 60 Hz) so a broken CSP build never pays the pcall at
+    -- frame rate. A successful read — including a timed session's honest no-laps
+    -- answer — settles until the session index changes.
     sessionLapsRetryCountdown = 120
     local ok, sess = pcall(ac.getSession, idx)
     if ok then
-      sessionLapsCacheValue = nil
       local laps = sess and tonumber(sess.laps)
       if laps and laps > 0 then
         sessionLapsCacheValue = laps
       end
-      sessionLapsRetryCountdown = math.huge -- settled for this session index
+      sessionLapsRetryCountdown = math.huge
     end
   elseif sessionLapsCacheValue == nil and sessionLapsRetryCountdown ~= math.huge then
     sessionLapsRetryCountdown = sessionLapsRetryCountdown - 1

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -58,21 +58,30 @@ local sim ---@type ac.StateSim
 -- yields nil and the key is omitted.
 local sessionLapsCacheIndex = nil
 local sessionLapsCacheValue = nil
+local sessionLapsRetryCountdown = 0
 local function readSessionLapsTotal()
   local idx = sim and sim.currentSessionIndex or nil
   if idx == nil then
     return nil
   end
-  if sessionLapsCacheIndex ~= idx then
+  if sessionLapsCacheIndex ~= idx or (sessionLapsCacheValue == nil and sessionLapsRetryCountdown <= 0) then
+    -- A FAILED read must not negative-cache for the whole session (daemon on PR #618 R9):
+    -- retry, but only every ~120 calls (~2 s at 60 Hz) so a broken CSP build never pays
+    -- the pcall at frame rate. A successful read (or a timed session's honest nil-laps
+    -- payload with ok==true) caches until the session index changes.
     sessionLapsCacheIndex = idx
-    sessionLapsCacheValue = nil
+    sessionLapsRetryCountdown = 120
     local ok, sess = pcall(ac.getSession, idx)
-    if ok and sess then
-      local laps = tonumber(sess.laps)
+    if ok then
+      sessionLapsCacheValue = nil
+      local laps = sess and tonumber(sess.laps)
       if laps and laps > 0 then
         sessionLapsCacheValue = laps
       end
+      sessionLapsRetryCountdown = math.huge -- settled for this session index
     end
+  elseif sessionLapsCacheValue == nil and sessionLapsRetryCountdown ~= math.huge then
+    sessionLapsRetryCountdown = sessionLapsRetryCountdown - 1
   end
   return sessionLapsCacheValue
 end

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2543,6 +2543,17 @@ function script.update(dt)
     -- Was hardcoded 0/0; chassis_read pcall-guards the read and degrades to nil (→ 0 in the
     -- publisher) off-rig, so the live coaching path now sees true lateral/longitudinal load.
     local liveChassis = chassisRead.read(car)
+    -- #531 Part F: a lap-count race's total rides the tick as `session_laps_total` so the
+    -- sidecar's fuel plan (margin-to-flag / pit window) has a real target. pcall-guarded:
+    -- an older CSP build without the session API, or a timed session (laps==0), omits it.
+    local sessionLapsTotal = nil
+    pcall(function()
+      local sess = ac.getSession(sim.currentSessionIndex)
+      local laps = sess and tonumber(sess.laps)
+      if laps and laps > 0 then
+        sessionLapsTotal = laps
+      end
+    end)
     telemetryPublisher.publishTelemetryTickIfDue({
       dt = dt,
       car = car,
@@ -2553,6 +2564,7 @@ function script.update(dt)
       -- #531 Part E: the learned shift profile (#442) rides the tick as `shift_rpm` so the
       -- sidecar's shift observer cues from the same model the in-game HUD teaches.
       shiftProfile = state.shiftProfile,
+      sessionLapsTotal = sessionLapsTotal,
     })
   end)
   -- Round 10: drain any corner_advice replies into state.cornerAdvisories.

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -50,6 +50,32 @@ local MANIFEST_WINDOW_SIZES = {
 }
 
 local sim ---@type ac.StateSim
+
+-- #531 Part F: lap-count race total for the sidecar fuel plan (`session_laps_total` on the
+-- tick). Cached per session index — static session metadata must not be re-read, nor a pcall
+-- closure allocated, at 60 Hz in the update loop (self-hosted reviewer on PR #618).
+-- pcall-guarded: an older CSP build without the session API, or a timed session (laps == 0),
+-- yields nil and the key is omitted.
+local sessionLapsCacheIndex = nil
+local sessionLapsCacheValue = nil
+local function readSessionLapsTotal()
+  local idx = sim and sim.currentSessionIndex or nil
+  if idx == nil then
+    return nil
+  end
+  if sessionLapsCacheIndex ~= idx then
+    sessionLapsCacheIndex = idx
+    sessionLapsCacheValue = nil
+    local ok, sess = pcall(ac.getSession, idx)
+    if ok and sess then
+      local laps = tonumber(sess.laps)
+      if laps and laps > 0 then
+        sessionLapsCacheValue = laps
+      end
+    end
+  end
+  return sessionLapsCacheValue
+end
 local car ---@type ac.StateCar
 
 --- Defaults for `ac.storage` (issue #57 Part A). Keys must stay stable across versions.
@@ -2543,17 +2569,6 @@ function script.update(dt)
     -- Was hardcoded 0/0; chassis_read pcall-guards the read and degrades to nil (→ 0 in the
     -- publisher) off-rig, so the live coaching path now sees true lateral/longitudinal load.
     local liveChassis = chassisRead.read(car)
-    -- #531 Part F: a lap-count race's total rides the tick as `session_laps_total` so the
-    -- sidecar's fuel plan (margin-to-flag / pit window) has a real target. pcall-guarded:
-    -- an older CSP build without the session API, or a timed session (laps==0), omits it.
-    local sessionLapsTotal = nil
-    pcall(function()
-      local sess = ac.getSession(sim.currentSessionIndex)
-      local laps = sess and tonumber(sess.laps)
-      if laps and laps > 0 then
-        sessionLapsTotal = laps
-      end
-    end)
     telemetryPublisher.publishTelemetryTickIfDue({
       dt = dt,
       car = car,
@@ -2564,7 +2579,7 @@ function script.update(dt)
       -- #531 Part E: the learned shift profile (#442) rides the tick as `shift_rpm` so the
       -- sidecar's shift observer cues from the same model the in-game HUD teaches.
       shiftProfile = state.shiftProfile,
-      sessionLapsTotal = sessionLapsTotal,
+      sessionLapsTotal = readSessionLapsTotal(),
     })
   end)
   -- Round 10: drain any corner_advice replies into state.cornerAdvisories.

--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2536,6 +2536,8 @@ function script.update(dt)
       dt = dt,
       temps = currentTireTemps,
       wsBridge = wsBridge,
+      -- #531 Part F: sources the inner/mid/outer cross-tread maps for the STINT page.
+      car = car,
     })
     -- Real measured g-forces (issue #478): CSP `car.acceleration` is in G (.x lateral, .z long).
     -- Was hardcoded 0/0; chassis_read pcall-guards the read and degrades to nil (→ 0 in the

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -187,27 +187,43 @@ function M.publishTireTempsIfDue(opts)
   local fr = _finite(temps.fr)
   local rl = _finite(temps.rl)
   local rr = _finite(temps.rr)
-  if fl == nil and fr == nil and rl == nil and rr == nil then
-    -- No wheel temp resolvable on this CSP build/car: treat the sample as UNAVAILABLE rather
-    -- than publishing an empty {} every interval (Lua drops nil-valued keys), which would
-    -- mask the data-source failure as apparently-live-but-empty samples (codex on #185).
-    return false
+  local anyCore = fl ~= nil or fr ~= nil or rl ~= nil or rr ~= nil
+  local innerMap, middleMap, outerMap
+  if not anyCore then
+    -- Core read failed on this CSP build/car: the tread channels decide publishability —
+    -- the STINT board must not lose measured I/M/O to a core-only gate (Codex on PR #618).
+    -- Only a sample with NO wheel temp at all is treated as unavailable rather than
+    -- publishing an empty {} every interval, which would mask the data-source failure as
+    -- apparently-live-but-empty samples (codex on #185).
+    local inner, middle, outer = _treadMaps(opts.car)
+    innerMap = _cornerMap(inner)
+    middleMap = _cornerMap(middle)
+    outerMap = _cornerMap(outer)
+    if innerMap == nil and middleMap == nil and outerMap == nil then
+      return false
+    end
   end
   local due, accum = _due(_tireAccum, tonumber(opts.dt) or 0, TIRE_INTERVAL_SEC)
   _tireAccum = accum
   if not due then
     return false
   end
+  if anyCore then
+    -- Deferred past the 5 Hz gate so the per-wheel tread reads never run at frame rate.
+    local inner, middle, outer = _treadMaps(opts.car)
+    innerMap = _cornerMap(inner)
+    middleMap = _cornerMap(middle)
+    outerMap = _cornerMap(outer)
+  end
   local payload = {
     fl = fl,
     fr = fr,
     rl = rl,
     rr = rr,
+    inner = innerMap,
+    middle = middleMap,
+    outer = outerMap,
   }
-  local inner, middle, outer = _treadMaps(opts.car)
-  payload.inner = _cornerMap(inner)
-  payload.middle = _cornerMap(middle)
-  payload.outer = _cornerMap(outer)
   return wsBridge.publishTopic(TOPIC_TIRE_TEMPS, payload) == true
 end
 

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -188,32 +188,23 @@ function M.publishTireTempsIfDue(opts)
   local rl = _finite(temps.rl)
   local rr = _finite(temps.rr)
   local anyCore = fl ~= nil or fr ~= nil or rl ~= nil or rr ~= nil
-  local innerMap, middleMap, outerMap
-  if not anyCore then
-    -- Core read failed on this CSP build/car: the tread channels decide publishability —
-    -- the STINT board must not lose measured I/M/O to a core-only gate (Codex on PR #618).
-    -- Only a sample with NO wheel temp at all is treated as unavailable rather than
-    -- publishing an empty {} every interval, which would mask the data-source failure as
-    -- apparently-live-but-empty samples (codex on #185).
-    local inner, middle, outer = _treadMaps(opts.car)
-    innerMap = _cornerMap(inner)
-    middleMap = _cornerMap(middle)
-    outerMap = _cornerMap(outer)
-    if innerMap == nil and middleMap == nil and outerMap == nil then
-      return false
-    end
-  end
+  -- The 5 Hz gate runs BEFORE any per-wheel tread read on BOTH branches (daemon MEDIUM on
+  -- PR #618: the tread-only path was reading four wheels at frame rate). On a car with no
+  -- wheel temps at all this consumes at most one publish slot per interval and sends
+  -- nothing — still never an empty {} frame masking the data-source failure (#185).
   local due, accum = _due(_tireAccum, tonumber(opts.dt) or 0, TIRE_INTERVAL_SEC)
   _tireAccum = accum
   if not due then
     return false
   end
-  if anyCore then
-    -- Deferred past the 5 Hz gate so the per-wheel tread reads never run at frame rate.
-    local inner, middle, outer = _treadMaps(opts.car)
-    innerMap = _cornerMap(inner)
-    middleMap = _cornerMap(middle)
-    outerMap = _cornerMap(outer)
+  local inner, middle, outer = _treadMaps(opts.car)
+  local innerMap = _cornerMap(inner)
+  local middleMap = _cornerMap(middle)
+  local outerMap = _cornerMap(outer)
+  if not anyCore and innerMap == nil and middleMap == nil and outerMap == nil then
+    -- No wheel temp resolvable AT ALL (core or tread) on this CSP build/car: unavailable,
+    -- not empty — the STINT board keeps its explicit unknowns (Codex on PR #618 + #185).
+    return false
   end
   local payload = {
     fl = fl,

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -109,60 +109,6 @@ function M.publishDeltaIfDue(opts)
 end
 
 
---- Publish `tire_temps` at ~5 Hz. `opts.temps` is {fl, fr, rl, rr} (numbers or nil), e.g. from
---- `tire_monitor`'s :currentTemps(car).
----@param opts table  {dt:number, temps:table, wsBridge}
----@return boolean  true if a frame was actually published this call
-function M.publishTireTempsIfDue(opts)
-  if type(opts) ~= "table" then
-    return false
-  end
-  local wsBridge = _wsReady(opts)
-  if not wsBridge then
-    return false
-  end
-  local temps = opts.temps
-  if type(temps) ~= "table" then
-    return false
-  end
-  local fl = _finite(temps.fl)
-  local fr = _finite(temps.fr)
-  local rl = _finite(temps.rl)
-  local rr = _finite(temps.rr)
-  if fl == nil and fr == nil and rl == nil and rr == nil then
-    -- No wheel temp resolvable on this CSP build/car: treat the sample as UNAVAILABLE rather
-    -- than publishing an empty {} every interval (Lua drops nil-valued keys), which would
-    -- mask the data-source failure as apparently-live-but-empty samples (codex on #185).
-    return false
-  end
-  local due, accum = _due(_tireAccum, tonumber(opts.dt) or 0, TIRE_INTERVAL_SEC)
-  _tireAccum = accum
-  if not due then
-    return false
-  end
-  return wsBridge.publishTopic(TOPIC_TIRE_TEMPS, {
-    fl = fl,
-    fr = fr,
-    rl = rl,
-    rr = rr,
-  }) == true
-end
-
-
-local function _clamp(v, lo, hi)
-  v = tonumber(v)
-  if v == nil or v ~= v or v == math.huge or v == -math.huge then
-    return lo
-  end
-  if v < lo then
-    return lo
-  end
-  if v > hi then
-    return hi
-  end
-  return v
-end
-
 local function _field(obj, key)
   if obj == nil then
     return nil
@@ -196,6 +142,89 @@ local function _cornerMap(values)
   return nil
 end
 
+
+-- #531 Part F: cross-tread temps (inner/mid/outer) for the STINT page, from the #490 Tier-1
+-- wheel channels. Per-wheel pcall-free (wheel_read guards its own field reads); a wheel or
+-- channel that does not resolve is simply absent from its map, and an entirely-empty map is
+-- omitted from the payload (unknown, never zero-filled).
+local function _treadMaps(car)
+  local inner, middle, outer = {}, {}, {}
+  local wheels = car and _field(car, "wheels")
+  if wheels == nil then
+    return nil, nil, nil
+  end
+  for i = 0, 3 do
+    local key = wheelRead.WHEEL_KEYS[i]
+    local one = _field(wheels, i)
+    if one ~= nil then
+      inner[key] = wheelRead.tyreTempInner(one)
+      middle[key] = wheelRead.tyreTempMid(one)
+      outer[key] = wheelRead.tyreTempOuter(one)
+    end
+  end
+  return inner, middle, outer
+end
+
+
+--- Publish `tire_temps` at ~5 Hz. `opts.temps` is {fl, fr, rl, rr} (numbers or nil), e.g. from
+--- `tire_monitor`'s :currentTemps(car). `opts.car` (optional) additionally sources the
+--- inner/mid/outer cross-tread maps for the STINT page (#531 Part F).
+---@param opts table  {dt:number, temps:table, wsBridge, car?:any}
+---@return boolean  true if a frame was actually published this call
+function M.publishTireTempsIfDue(opts)
+  if type(opts) ~= "table" then
+    return false
+  end
+  local wsBridge = _wsReady(opts)
+  if not wsBridge then
+    return false
+  end
+  local temps = opts.temps
+  if type(temps) ~= "table" then
+    return false
+  end
+  local fl = _finite(temps.fl)
+  local fr = _finite(temps.fr)
+  local rl = _finite(temps.rl)
+  local rr = _finite(temps.rr)
+  if fl == nil and fr == nil and rl == nil and rr == nil then
+    -- No wheel temp resolvable on this CSP build/car: treat the sample as UNAVAILABLE rather
+    -- than publishing an empty {} every interval (Lua drops nil-valued keys), which would
+    -- mask the data-source failure as apparently-live-but-empty samples (codex on #185).
+    return false
+  end
+  local due, accum = _due(_tireAccum, tonumber(opts.dt) or 0, TIRE_INTERVAL_SEC)
+  _tireAccum = accum
+  if not due then
+    return false
+  end
+  local payload = {
+    fl = fl,
+    fr = fr,
+    rl = rl,
+    rr = rr,
+  }
+  local inner, middle, outer = _treadMaps(opts.car)
+  payload.inner = _cornerMap(inner)
+  payload.middle = _cornerMap(middle)
+  payload.outer = _cornerMap(outer)
+  return wsBridge.publishTopic(TOPIC_TIRE_TEMPS, payload) == true
+end
+
+
+local function _clamp(v, lo, hi)
+  v = tonumber(v)
+  if v == nil or v ~= v or v == math.huge or v == -math.huge then
+    return lo
+  end
+  if v < lo then
+    return lo
+  end
+  if v > hi then
+    return hi
+  end
+  return v
+end
 
 -- #531 Part D: CSP `ac.StateWheel.tyreWear` is 0..1 wear CONSUMED — 0.0 is a NEW tyre and the
 -- value grows with use. Matches the wire field `tyre_wear_pct` (0 = new, 100 = gone), which the

--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -365,6 +365,13 @@ function M.publishTelemetryTickIfDue(opts)
   if lapTimeMs ~= nil and lapTimeMs >= 0 then
     payload.lap_time_ms = lapTimeMs
   end
+  -- #531 Part F: lap-count race total for the sidecar fuel plan (race_management's
+  -- `_target_laps_remaining` reads `session_laps_total` - lap). Omitted for timed
+  -- sessions / practice (caller passes nil) — the plan then renders its honest fallback.
+  local sessionLaps = _finite(opts.sessionLapsTotal)
+  if sessionLaps ~= nil and sessionLaps > 0 then
+    payload.session_laps_total = sessionLaps
+  end
   local fuel = _finite(_field(car, "fuel"))
   if fuel ~= nil then
     payload.fuel_l = math.max(0, fuel)

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -712,3 +712,18 @@ def test_release_observer_feed_resets_shift_and_race_status(monkeypatch):
     server._release_observer_feed("ws-owner")
     assert shift.resets == 1
     assert server._race_status.snapshot() is None
+
+
+def test_wire_voice_builds_track_map_frame(tmp_path, monkeypatch):
+    """#531 Part F: wiring a corner-bearing reference also builds the track.map frame the
+    subscribe replay path serves to late subscribers."""
+    monkeypatch.setattr(server, "_observer", None)
+    monkeypatch.setattr(server, "_track_map_frame", None)
+    ref = tmp_path / "ref.json"
+    ref.write_text(json.dumps(_corner_archive()), encoding="utf-8")
+    server._wire_voice(server.VoiceRuntimeConfig(reference_path=str(ref), bank_dir=None))
+    frame = server._track_map_frame
+    assert frame is not None
+    assert frame["topic"] == "track.map"
+    assert len(frame["payload"]["outline"]) >= 8
+    assert frame["payload"]["corners"][0]["label"] == "T1"

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -727,3 +727,14 @@ def test_wire_voice_builds_track_map_frame(tmp_path, monkeypatch):
     assert frame["topic"] == "track.map"
     assert len(frame["payload"]["outline"]) >= 8
     assert frame["payload"]["corners"][0]["label"] == "T1"
+
+
+def test_rewire_without_geometry_clears_stale_track_map(tmp_path, monkeypatch):
+    """A re-wire whose reference cannot supply geometry must not leave the previous
+    track's map for late subscribers (Codex on PR #618)."""
+    monkeypatch.setattr(server, "_observer", None)
+    monkeypatch.setattr(server, "_track_map_frame", {"topic": "track.map", "payload": {}})
+    ref = tmp_path / "no_geometry.json"
+    ref.write_text(json.dumps({}), encoding="utf-8")
+    server._wire_voice(server.VoiceRuntimeConfig(reference_path=str(ref), bank_dir=None))
+    assert server._track_map_frame is None

--- a/tests/test_tablet_dash_endpoint.py
+++ b/tests/test_tablet_dash_endpoint.py
@@ -476,3 +476,17 @@ def test_make_race_status_shape() -> None:
     assert frame["topic"] == ep.TOPIC_RACE_STATUS
     assert frame["source"] == "sidecar.race_status"
     assert frame["payload"] == {"fuel_l": 8.0, "laps_remaining": 4.0}
+
+
+def test_track_map_topic_is_sidecar_produced_and_subscribable() -> None:
+    """#531 Part F: track.map joins the allow-list + sidecar-produced set (event-driven,
+    built at reference wire time)."""
+    assert ep.TOPIC_TRACK_MAP in ep.KNOWN_TOPICS
+    assert ep.TOPIC_TRACK_MAP in ep.SIDECAR_PRODUCED_TOPICS
+
+
+def test_make_track_map_shape() -> None:
+    frame = ep.make_track_map({"outline": [[0, 0]], "spline": [0.0], "corners": []})
+    assert frame["type"] == ep.TYPE_STATE_SNAPSHOT
+    assert frame["topic"] == ep.TOPIC_TRACK_MAP
+    assert frame["source"] == "sidecar.track_map"

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -874,3 +874,42 @@ def test_tire_temps_carries_tread_imo_when_wheels_expose_it():
     assert out["outer_fr"] == 80
     assert out["core_fl"] == 82
     assert out["no_car_has_inner"] is False
+
+
+def test_tire_temps_publishes_tread_even_without_core_temps():
+    """A car whose core read fails but whose tread channels resolve still publishes —
+    the I/M/O board must not be lost to a core-only gate (Codex on PR #618)."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local wheels = {}
+          for i = 0, 3 do
+            wheels[i] = {
+              tyreInsideTemperature = 84, tyreMiddleTemperature = 82, tyreOutsideTemperature = 79,
+            }
+          end
+          M.publishTireTempsIfDue({
+            dt = 0.25, temps = {}, wsBridge = ws, car = { wheels = wheels },
+          })
+          M.reset()
+          local ws2 = make_ws()
+          M.publishTireTempsIfDue({
+            dt = 0.25, temps = {}, wsBridge = ws2, car = { wheels = nil },
+          })
+          local p = ws._calls[1] and ws._calls[1].payload
+          return {
+            published = ws._calls[1] ~= nil,
+            inner_fl = p and p.inner and p.inner.fl,
+            has_core = p and p.fl ~= nil,
+            nothing_published = #ws2._calls == 0,
+          }
+        end)()
+        """
+    )
+    assert out["published"] is True
+    assert out["inner_fl"] == 84
+    assert out["has_core"] is False
+    assert out["nothing_published"] is True

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -828,3 +828,49 @@ def test_delta_carries_reference_lap_ms_when_known():
     assert out["with_ref"] == 90000
     assert out["without_has"] is False
     assert out["zero_has"] is False
+
+
+def test_tire_temps_carries_tread_imo_when_wheels_expose_it():
+    """#531 Part F: inner/mid/outer cross-tread maps ride the tire_temps topic when the
+    #490 Tier-1 wheel channels resolve; omitted entirely when the car lacks them."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local wheels = {}
+          for i = 0, 3 do
+            wheels[i] = {
+              tyreInsideTemperature = 84 + i,
+              tyreMiddleTemperature = 82 + i,
+              tyreOutsideTemperature = 79 + i,
+            }
+          end
+          local car = { wheels = wheels }
+          M.publishTireTempsIfDue({
+            dt = 0.25, temps = { fl = 82, fr = 84, rl = 86, rr = 88 }, wsBridge = ws, car = car,
+          })
+          M.reset()
+          local ws2 = make_ws()
+          M.publishTireTempsIfDue({
+            dt = 0.25, temps = { fl = 82, fr = 84, rl = 86, rr = 88 }, wsBridge = ws2,
+            car = { wheels = nil },
+          })
+          local p = ws._calls[1] and ws._calls[1].payload
+          local p2 = ws2._calls[1] and ws2._calls[1].payload
+          return {
+            inner_fl = p and p.inner and p.inner.fl,
+            middle_rr = p and p.middle and p.middle.rr,
+            outer_fr = p and p.outer and p.outer.fr,
+            core_fl = p and p.fl,
+            no_car_has_inner = p2.inner ~= nil,
+          }
+        end)()
+        """
+    )
+    assert out["inner_fl"] == 84
+    assert out["middle_rr"] == 85
+    assert out["outer_fr"] == 80
+    assert out["core_fl"] == 82
+    assert out["no_car_has_inner"] is False

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -913,3 +913,33 @@ def test_tire_temps_publishes_tread_even_without_core_temps():
     assert out["inner_fl"] == 84
     assert out["has_core"] is False
     assert out["nothing_published"] is True
+
+
+def test_telemetry_tick_carries_session_laps_total_when_positive():
+    """#531 Part F: a lap-count race total rides the tick for the sidecar fuel plan;
+    timed sessions (nil/0) omit the key."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws()
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+          }
+          M.publishTelemetryTickIfDue({
+            dt = 0.06, car = car, wsBridge = ws, sessionLapsTotal = 28,
+          })
+          M.reset()
+          local ws2 = make_ws()
+          M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws2 })
+          return {
+            laps = ws._calls[1].send.payload.session_laps_total,
+            omitted = ws2._calls[1].send.payload.session_laps_total == nil,
+          }
+        end)()
+        """
+    )
+    assert out["laps"] == 28
+    assert out["omitted"] is True

--- a/tests/test_track_map.py
+++ b/tests/test_track_map.py
@@ -68,3 +68,15 @@ def test_build_track_map_honest_none_on_malformed() -> None:
         for row in archive["trace"]["samples"]
     ]
     assert build_track_map(archive) is None
+
+
+def test_build_track_map_rejects_degenerate_zero_positions() -> None:
+    """Zero-filled px/pz columns (present-but-unreadable) must yield None — a collapsed
+    single-point 'outline' would hide the honest no-reference state (Codex on PR #618)."""
+    archive = _corner_archive()
+    fields = archive["trace"]["fields"]
+    px_i, pz_i = fields.index("px"), fields.index("pz")
+    for row in archive["trace"]["samples"]:
+        row[px_i] = 0.0
+        row[pz_i] = 0.0
+    assert build_track_map(archive) is None

--- a/tests/test_track_map.py
+++ b/tests/test_track_map.py
@@ -80,3 +80,23 @@ def test_build_track_map_rejects_degenerate_zero_positions() -> None:
         row[px_i] = 0.0
         row[pz_i] = 0.0
     assert build_track_map(archive) is None
+
+
+def test_build_track_map_always_keeps_the_final_sample() -> None:
+    """Downsampling must include the last sample — dropping the S/F tail makes the client's
+    closing segment a false chord (daemon MEDIUM on PR #618)."""
+    archive = _corner_archive()
+    trace = archive["trace"]
+    base = trace["samples"]
+    n = len(base) * 20 + 7  # deliberately NOT divisible by the step
+    big = []
+    for i in range(n):
+        row = list(base[i % len(base)])
+        row[0] = i / n
+        big.append(row)
+    trace["samples"] = big
+    trace["samples_count"] = len(big)
+
+    payload = build_track_map(archive)
+    assert payload is not None
+    assert payload["spline"][-1] == round(big[-1][0], 4)

--- a/tests/test_track_map.py
+++ b/tests/test_track_map.py
@@ -1,0 +1,70 @@
+"""#531 Part F: track.map geometry built from the reference archive."""
+
+from __future__ import annotations
+
+from tests.test_realtime_observer import _corner_archive
+from tools.ai_sidecar.track_map import MAX_OUTLINE_POINTS, build_track_map
+
+
+def test_build_track_map_from_corner_archive() -> None:
+    payload = build_track_map(_corner_archive())
+    assert payload is not None
+    assert payload["source"] == "reference_archive"
+    assert payload["track_id"] == "magione"
+    assert payload["car_id"] == "ks_porsche_911_gt3_r_2016"
+
+    outline = payload["outline"]
+    spline = payload["spline"]
+    assert len(outline) == len(spline)
+    assert 8 <= len(outline) <= MAX_OUTLINE_POINTS
+    assert all(len(p) == 2 for p in outline)
+    # spline-ordered: monotonically nondecreasing
+    assert all(spline[i] <= spline[i + 1] for i in range(len(spline) - 1))
+
+    corners = payload["corners"]
+    assert len(corners) == 1  # the fixture is a single braking corner
+    corner = corners[0]
+    assert corner["label"] == "T1"
+    assert 0.0 < corner["spline"] < 1.0
+    assert corner["entry_spline"] <= corner["spline"]
+    # apex minimum in the fixture is 25 m/s = 90 km/h
+    assert 80 <= corner["min_speed_kmh"] <= 100
+    assert corner.get("gear") == 4
+
+
+def test_build_track_map_downsamples_long_traces() -> None:
+    archive = _corner_archive()
+    trace = archive["trace"]
+    # inflate the trace ~20x by repeating samples with advancing spline
+    base = trace["samples"]
+    big = []
+    n = len(base) * 20
+    for i in range(n):
+        row = list(base[i % len(base)])
+        row[0] = i / n  # spline strictly increasing
+        big.append(row)
+    trace["samples"] = big
+    trace["samples_count"] = len(big)
+
+    payload = build_track_map(archive)
+    assert payload is not None
+    assert len(payload["outline"]) <= MAX_OUTLINE_POINTS
+
+
+def test_build_track_map_honest_none_on_malformed() -> None:
+    assert build_track_map({}) is None
+    assert build_track_map({"trace": {"fields": ["spline"], "samples": []}}) is None
+    # position channels missing -> None, never invented geometry
+    archive = _corner_archive()
+    fields = archive["trace"]["fields"]
+    px_i = fields.index("px")
+    pz_i = fields.index("pz")
+    for row in archive["trace"]["samples"]:
+        row[px_i] = None
+        row[pz_i] = None
+    archive["trace"]["fields"] = [f for f in fields if f not in ("px", "pz")]
+    archive["trace"]["samples"] = [
+        [v for i, v in enumerate(row) if i not in (px_i, pz_i)]
+        for row in archive["trace"]["samples"]
+    ]
+    assert build_track_map(archive) is None

--- a/tools/ai_sidecar/dash/dev_feeder.py
+++ b/tools/ai_sidecar/dash/dev_feeder.py
@@ -1,0 +1,242 @@
+"""Synthetic producer for tablet-dash page work (#531 Part F).
+
+Phase 1 proved the dash against a throwaway ``.scratch/dash_feeder.py`` that was lost with the
+scratch dir (the Phase-1 vault node flagged the loss); this is its durable replacement. It
+connects to a running sidecar as the loopback Lua producer would — ``hello`` then a stream of
+``telemetry_tick`` frames plus the ``delta`` / ``lap`` / ``tire_temps`` / ``session`` /
+``coaching.snapshot`` topics — so every dash page renders live data with **no sim and no rig**:
+
+    python -m tools.ai_sidecar.dash.dev_feeder --port 8765 [--laps 3] [--rate 20]
+
+Deliberately simple and self-contained (stdlib + websockets, which the sidecar already
+requires). The synthetic lap is a closed analytic circuit (two straights + four corners), so
+spline/speed/gear/delta stay mutually consistent and the MAP page's dot tracks the outline the
+sidecar derives from a reference — pass ``--reference <archive.json>`` to have the feeder drive
+the REAL geometry instead (spline-faithful replay of the archive trace).
+
+Not a test fixture: tests use in-process fakes. This is an operator/dev tool for eyeballing
+the page on a desktop browser or the P7 without launching AC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    from websockets.asyncio.client import connect as ws_connect
+except ImportError as exc:  # pragma: no cover - dep ships with the sidecar
+    raise SystemExit("dev_feeder requires the 'websockets' package (sidecar dependency)") from exc
+
+LAP_S = 90.0
+RPM_MAX = 8500.0
+SHIFT_RPM = 7800.0
+FUEL_START_L = 42.0
+BURN_L_PER_LAP = 2.4
+
+
+def _speed_profile(s: float) -> float:
+    """Synthetic speed (km/h) over spline: straights ~230, four braking zones down to ~80."""
+    v = 200.0 + 40.0 * math.sin(2 * math.pi * s)
+    for corner_s in (0.15, 0.4, 0.65, 0.85):
+        d = min(abs(s - corner_s), 1 - abs(s - corner_s))
+        v -= 130.0 * math.exp(-((d / 0.035) ** 2))
+    return max(75.0, v)
+
+
+def _gear_for(v_kmh: float) -> int:
+    return max(1, min(6, int(v_kmh // 45) + 1))
+
+
+def _tick_payload(s: float, lap: int, lap_time_ms: float, fuel_l: float) -> dict[str, Any]:
+    v = _speed_profile(s)
+    gear = _gear_for(v)
+    accel = _speed_profile((s + 0.004) % 1.0) - v
+    throttle = 0.95 if accel >= 0 else 0.1
+    brake = 0.0 if accel >= 0 else min(1.0, -accel / 8.0)
+    rpm = 3000 + (v % 45) / 45 * (RPM_MAX - 3400)
+    return {
+        "speed_kmh": round(v, 1),
+        "rpm": round(rpm),
+        "throttle": throttle,
+        "brake": round(brake, 2),
+        "steer": round(0.4 * math.sin(6 * math.pi * s), 3),
+        "gear": gear,
+        "lat_g": round(1.4 * abs(math.sin(6 * math.pi * s)), 2),
+        "long_g": round(-brake * 1.2 + throttle * 0.4, 2),
+        "spline": round(s, 5),
+        "lap": lap,
+        "rpm_max": RPM_MAX,
+        "shift_rpm": SHIFT_RPM,
+        "shift_rpm_source": "learned",
+        "lap_time_ms": round(lap_time_ms),
+        "fuel_l": round(fuel_l, 2),
+        "fuel_capacity_l": 120.0,
+        "tyre_temps_c": {"fl": 82, "fr": 84, "rl": 86, "rr": 88},
+        "tyre_pressures_psi": {"fl": 27.6, "fr": 27.7, "rl": 27.9, "rr": 28.1},
+        "tyre_wear_pct": {"fl": 1.2, "fr": 1.4, "rl": 2.1, "rr": 2.3},
+        "tc_active": (0.13 < (s % 0.25) < 0.145),
+        "abs_active": False,
+        "race_laps_remaining": 12.0,
+    }
+
+
+def _load_reference_spline(path: str) -> list[float] | None:
+    archive = json.loads(Path(path).read_text(encoding="utf-8"))
+    trace = archive.get("trace") or {}
+    fields, samples = trace.get("fields") or [], trace.get("samples") or []
+    if "spline" in fields and samples:
+        i_sp = fields.index("spline")
+        return [float(row[i_sp]) for row in samples]
+    return None
+
+
+async def _run(args: argparse.Namespace) -> None:
+    uri = f"ws://127.0.0.1:{args.port}/"
+    reference_spline: list[float] | None = None
+    if args.reference:
+        # One-shot startup read of a small file — fine to do before the socket opens.
+        reference_spline = await asyncio.to_thread(_load_reference_spline, args.reference)
+
+    async with ws_connect(uri, max_size=2**22) as ws:
+
+        async def send(obj: dict[str, Any]) -> None:
+            await ws.send(json.dumps(obj))
+
+        await send({"v": 1, "type": "hello", "client": "dev-feeder", "client_class": "external"})
+        await asyncio.sleep(0.3)
+        if args.review_lap_dir:
+            # Loopback peers may ask the sidecar to generate the post-session review — this
+            # exercises the COACH page against REAL lap archives without a sim.
+            await send(
+                {
+                    "v": 1,
+                    "type": "session.review.generate",
+                    "lap_dir": args.review_lap_dir,
+                }
+            )
+        await send(
+            {
+                "v": 1,
+                "type": "state.snapshot",
+                "topic": "session",
+                "payload": {
+                    "car_id": "dev_feeder_gt3",
+                    "track_id": "synthetic",
+                    "session_index": 0,
+                },
+            }
+        )
+        dt = 1.0 / args.rate
+        seq = 0
+        fuel = FUEL_START_L
+        best_ms: float | None = None
+        for lap in range(args.laps):
+            lap_start = time.monotonic()
+            while (elapsed := time.monotonic() - lap_start) < LAP_S / args.speedup:
+                s = (elapsed * args.speedup) / LAP_S
+                if reference_spline:
+                    idx = min(len(reference_spline) - 1, int(s * (len(reference_spline) - 1)))
+                    s = reference_spline[idx]
+                seq += 1
+                lap_ms = elapsed * args.speedup * 1000.0
+                await send(
+                    {
+                        "v": 1,
+                        "type": "telemetry_tick",
+                        "seq": seq,
+                        "payload": _tick_payload(s, lap, lap_ms, fuel),
+                    }
+                )
+                if seq % max(1, args.rate // 10) == 0:
+                    await send(
+                        {
+                            "v": 1,
+                            "type": "state.snapshot",
+                            "topic": "delta",
+                            "payload": {
+                                "delta_s": round(0.8 * math.sin(2 * math.pi * s), 3),
+                                "spline": round(s, 5),
+                                "reference_lap_ms": LAP_S * 1000.0,
+                            },
+                        }
+                    )
+                if seq % args.rate == 0:
+                    await send(
+                        {
+                            "v": 1,
+                            "type": "state.snapshot",
+                            "topic": "tire_temps",
+                            "payload": {
+                                "fl": 82,
+                                "fr": 84,
+                                "rl": 86,
+                                "rr": 88,
+                                "inner": {"fl": 84, "fr": 86, "rl": 88, "rr": 92},
+                                "middle": {"fl": 82, "fr": 84, "rl": 86, "rr": 89},
+                                "outer": {"fl": 79, "fr": 81, "rl": 83, "rr": 86},
+                            },
+                        }
+                    )
+                await asyncio.sleep(dt)
+            fuel -= BURN_L_PER_LAP
+            lap_ms = LAP_S * 1000.0 + (lap % 3) * 400.0
+            best_ms = lap_ms if best_ms is None or lap_ms < best_ms else best_ms
+            await send(
+                {
+                    "v": 1,
+                    "type": "state.snapshot",
+                    "topic": "lap",
+                    "payload": {
+                        "lap": lap + 1,
+                        "last_lap_ms": lap_ms,
+                        "best_lap_ms": best_ms,
+                        "laps_completed": lap + 1,
+                        "valid": True,
+                    },
+                }
+            )
+            print(f"feeder: lap {lap + 1}/{args.laps} complete ({lap_ms / 1000:.3f}s)")
+        print("feeder: done")
+
+
+async def _run_resilient(args: argparse.Namespace) -> None:
+    """Reconnect-and-continue wrapper: a busy dev box (or a sidecar restart) drops the WS
+    with a keepalive timeout; a feeder that dies with it makes page work miserable."""
+    attempt = 0
+    while True:
+        try:
+            await _run(args)
+            return
+        except (OSError, Exception) as exc:  # noqa: BLE001 — dev tool: log and retry
+            attempt += 1
+            if attempt > 20:
+                raise
+            print(f"feeder: connection lost ({type(exc).__name__}: {exc}); reconnecting…")
+            await asyncio.sleep(1.0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--laps", type=int, default=3)
+    parser.add_argument("--rate", type=int, default=20, help="telemetry_tick Hz")
+    parser.add_argument("--speedup", type=float, default=1.0, help="time compression factor")
+    parser.add_argument("--reference", help="optional lap archive to replay spline from")
+    parser.add_argument(
+        "--review-lap-dir",
+        help="optional journal/laps dir — ask the sidecar to generate a session review "
+        "(exercises the COACH page with real archives)",
+    )
+    args = parser.parse_args()
+    asyncio.run(_run_resilient(args))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ai_sidecar/dash/dev_feeder.py
+++ b/tools/ai_sidecar/dash/dev_feeder.py
@@ -86,22 +86,36 @@ def _tick_payload(s: float, lap: int, lap_time_ms: float, fuel_l: float) -> dict
     }
 
 
-def _load_reference_spline(path: str) -> list[float] | None:
+def _load_reference(path: str) -> tuple[list[float] | None, str | None, str | None]:
+    """(spline series, car_id, track_id) from a lap archive.
+
+    The archive's own identity matters (#618 R7): the feeder's session snapshot must match
+    the sidecar's reference-derived ``track.map``/``session.review`` payloads, or the
+    tablet's identity gate correctly rejects them and the pages under test stay empty.
+    """
     archive = json.loads(Path(path).read_text(encoding="utf-8"))
     trace = archive.get("trace") or {}
     fields, samples = trace.get("fields") or [], trace.get("samples") or []
+    spline = None
     if "spline" in fields and samples:
         i_sp = fields.index("spline")
-        return [float(row[i_sp]) for row in samples]
-    return None
+        spline = [float(row[i_sp]) for row in samples]
+    car = (archive.get("car") or {}).get("id")
+    track = (archive.get("track") or {}).get("id")
+    return spline, car, track
 
 
 async def _run(args: argparse.Namespace) -> None:
     uri = f"ws://127.0.0.1:{args.port}/"
     reference_spline: list[float] | None = None
+    session_car, session_track = "dev_feeder_gt3", "synthetic"
     if args.reference:
         # One-shot startup read of a small file — fine to do before the socket opens.
-        reference_spline = await asyncio.to_thread(_load_reference_spline, args.reference)
+        reference_spline, ref_car, ref_track = await asyncio.to_thread(
+            _load_reference, args.reference
+        )
+        session_car = ref_car or session_car
+        session_track = ref_track or session_track
 
     async with ws_connect(uri, max_size=2**22) as ws:
 
@@ -126,8 +140,8 @@ async def _run(args: argparse.Namespace) -> None:
                 "type": "state.snapshot",
                 "topic": "session",
                 "payload": {
-                    "car_id": "dev_feeder_gt3",
-                    "track_id": "synthetic",
+                    "car_id": session_car,
+                    "track_id": session_track,
                     "session_index": 0,
                 },
             }

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -769,12 +769,17 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     q._key = null;
   }
   function buildMapGeometry() {
+    var m = S.map;
+    var outline = m && Array.isArray(m.outline) ? m.outline : null;
+    if (!outline || outline.length < 8) {
+      // A map that fails to build must leave NO residue — including the pace-note queue
+      // (daemon on PR #618 R8); resetMapDom also invalidates the queue cache key.
+      resetMapDom();
+      return;
+    }
     // A new map invalidates the pace-note cache even when the next three labels match the
     // previous track's (T1|T2|T3 is the common case) — the notes behind them changed (#618 R3).
     $("mapQueue")._key = null;
-    var m = S.map;
-    var outline = m && Array.isArray(m.outline) ? m.outline : null;
-    if (!outline || outline.length < 8) { mapGeom = null; $("mapSvg").style.display = "none"; $("mapEmpty").style.display = ""; return; }
     var minX = 1 / 0, maxX = -1 / 0, minZ = 1 / 0, maxZ = -1 / 0;
     outline.forEach(function (p) {
       if (p[0] < minX) minX = p[0]; if (p[0] > maxX) maxX = p[0];

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -839,10 +839,16 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     } else {
       dot.style.display = "none"; ring.style.display = "none";
     }
-    // Pace-note queue: the next up-to-3 coach-aligned corners ahead of the live spline.
+    // Pace-note queue: the next up-to-3 coach-aligned corners ahead of the LIVE spline.
+    // Without a live position the "ahead" ordering would be fabricated from spline 0 —
+    // blank the queue instead, matching the hidden dot (#618 R11).
     var corners = g.corners;
-    if (!corners.length) { $("mapQueue").innerHTML = ""; return; }
-    var s = spline !== null ? spline : 0;
+    if (!corners.length || !liveTick || spline === null) {
+      var q = $("mapQueue");
+      if (q._key) { q.innerHTML = ""; q._key = null; } // change-gated: populated keys are non-empty
+      return;
+    }
+    var s = spline;
     var ahead = corners.slice().sort(function (a, b) {
       var da = (a.spline - s + 1) % 1, db = (b.spline - s + 1) % 1;
       return da - db;

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -747,7 +747,11 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   // render the replayed map/review, and single-identity rigs are the common case).
   function identCompatible(carId, trackId) {
     if (carId && S.sessionCarId && String(carId) !== String(S.sessionCarId)) return false;
-    if (trackId && S.sessionTrackId && String(trackId) !== String(S.sessionTrackId)) return false;
+    // Venue-level track gate (#618 R4): session producers use full "track/layout" ids while
+    // reference archives may carry the bare track id — comparing the base segment tolerates
+    // that mismatch while still rejecting a genuinely different circuit.
+    if (trackId && S.sessionTrackId
+        && String(trackId).split("/")[0] !== String(S.sessionTrackId).split("/")[0]) return false;
     return true;
   }
   function resetMapDom() {
@@ -1194,12 +1198,15 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               S.fuelAtLap = null;
               S.burns = []; // burn is per car AND per track length (Codex on PR #547)
               S.race = null; S.raceAt = 0; // sidecar race.status is per identity too (#531)
-              // The debrief and the live-cue fallback gate on S.review — a new identity's
-              // COACH page must not stay pinned to the previous session's report (Codex #618).
-              S.review = null; reviewDirty = true;
-              // Same for the MAP geometry: the previous track's outline must drop to the
-              // explicit empty state until the new identity's track.map arrives (#618 R2).
-              S.map = null; resetMapDom();
+              if (hadIdentity) {
+                // A REAL identity switch drops the debrief and map — the new identity must
+                // not render the previous one's report/outline (Codex #618 R2). The FIRST
+                // session frame must NOT (#618 R4): the subscribe replay delivers
+                // track.map/session.review BEFORE session and never re-sends them; the
+                // compatibility check above already rejected any known mismatch.
+                S.review = null; reviewDirty = true;
+                S.map = null; resetMapDom();
+              }
               // A REAL identity switch invalidates the setup name (per-session fact; the
               // trainer's follow-up setup.active names the new one — Codex on PR #547).
               // The FIRST session frame after a page load must not: the identity-replay
@@ -1225,6 +1232,10 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               // a reset, and must not wipe live state.
               S.lap = null;
               S.fuelAtLap = null;
+              // A stint reset stales the debrief too — the fresh stint must fall back to
+              // live cues, not stay pinned to the previous stint's review (#618 R4). The
+              // MAP geometry survives: it is reference-tied, not stint-tied.
+              S.review = null; reviewDirty = true;
               requestSetupData(ws); // pit work may have changed the setup during the reset
             }
             break;

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -1168,8 +1168,13 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
             reviewDirty = true;
             break;
           case "track.map":
-            S.map = identCompatible(p.car_id, p.track_id) ? p : null;
-            mapDirty = true;
+            if (identCompatible(p.car_id, p.track_id)) {
+              S.map = p; mapDirty = true;
+            } else {
+              // Full DOM reset on rejection (#618 R5): a dirty-flag alone leaves the
+              // previous track's pace notes under the no-reference state.
+              S.map = null; resetMapDom();
+            }
             break;
           case "setup.active":
             S.setupName = p.name || null;
@@ -1181,6 +1186,12 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
             // re-request setup data (Codex P2 on PR #547), not just a car swap.
             var ident = String(p.car_id || "") + "|" + String(p.track_id || "")
               + "|" + String(p.session_index === undefined ? "" : p.session_index);
+            // Car/track delta computed BEFORE the identity parts update: a session_index-only
+            // transition (practice→quali) must not drop the map (#618 R5 — track.map is only
+            // replayed on subscribe and would stay blank for the rest of the connection).
+            var carTrackChanged = S.sessionIdent !== null && (
+              String(S.sessionCarId || "") !== String(p.car_id || "")
+              || String(S.sessionTrackId || "").split("/")[0] !== String(p.track_id || "").split("/")[0]);
             S.sessionCarId = p.car_id || null;
             S.sessionTrackId = p.track_id || null;
             // Replayed cached frames may have arrived BEFORE this session snapshot — drop
@@ -1199,13 +1210,16 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               S.burns = []; // burn is per car AND per track length (Codex on PR #547)
               S.race = null; S.raceAt = 0; // sidecar race.status is per identity too (#531)
               if (hadIdentity) {
-                // A REAL identity switch drops the debrief and map — the new identity must
-                // not render the previous one's report/outline (Codex #618 R2). The FIRST
-                // session frame must NOT (#618 R4): the subscribe replay delivers
+                // A REAL identity switch drops the debrief — the new session must not
+                // render the previous one's report (Codex #618 R2). The FIRST session
+                // frame must NOT (#618 R4): the subscribe replay delivers
                 // track.map/session.review BEFORE session and never re-sends them; the
                 // compatibility check above already rejected any known mismatch.
                 S.review = null; reviewDirty = true;
-                S.map = null; resetMapDom();
+                // The MAP drops only when car/track actually changed (#618 R5): a
+                // session_index-only transition keeps the same geometry, and track.map
+                // would never be re-sent on this connection.
+                if (carTrackChanged) { S.map = null; resetMapDom(); }
               }
               // A REAL identity switch invalidates the setup name (per-session fact; the
               // trainer's follow-up setup.active names the new one — Codex on PR #547).

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -1192,9 +1192,12 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
             // Car/track delta computed BEFORE the identity parts update: a session_index-only
             // transition (practice→quali) must not drop the map (#618 R5 — track.map is only
             // replayed on subscribe and would stay blank for the rest of the connection).
+            // FULL track-id comparison (layout-sensitive, #618 R7): a layout switch must
+            // drop the map even when a bare-id archive slipped the compat gate, while a
+            // session_index-only transition (same full track id) still keeps it.
             var carTrackChanged = S.sessionIdent !== null && (
               String(S.sessionCarId || "") !== String(p.car_id || "")
-              || String(S.sessionTrackId || "").split("/")[0] !== String(p.track_id || "").split("/")[0]);
+              || String(S.sessionTrackId || "") !== String(p.track_id || ""));
             S.sessionCarId = p.car_id || null;
             S.sessionTrackId = p.track_id || null;
             // Replayed cached frames may have arrived BEFORE this session snapshot — drop

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -673,8 +673,19 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     var r = S.review;
     var problems = r && Array.isArray(r.problems) ? r.problems : [];
     if (!r || r.error) {
+      // Full reset to the empty state — an identity change nulls S.review, and leaving the
+      // prior session's causes/priorities in the DOM would show a stale debrief for the new
+      // car/track (daemon HIGH on PR #618).
       setText("dbTitle", "Debrief");
-      if (r && r.error) { setText("dbHead", "REVIEW FAILED"); setText("dbBody", String(r.error)); }
+      if (r && r.error) {
+        setText("dbHead", "REVIEW FAILED");
+        setText("dbBody", String(r.error));
+      } else {
+        setText("dbHead", "—");
+        setText("dbBody", "Live coaching lines appear here as they arrive; the full debrief lands with the post-session review.");
+      }
+      $("dbCauses").innerHTML = "";
+      $("dbPriorities").innerHTML = '<div class="mono" style="font-size:12px;color:var(--dim);margin-top:4px">review pending — complete a session</div>';
       return;
     }
     var best = fin(r.best_lap_ms);
@@ -730,6 +741,17 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   // ---- MAP page (#531 Part F): real geometry from the sidecar track.map topic -------------
   var mapDirty = false;
   var mapGeom = null; // {pts:[[svgx,svgy]...], spline:[...], corners:[...]} in viewBox space
+  function resetMapDom() {
+    mapGeom = null;
+    mapDirty = false;
+    $("mapSvg").style.display = "none";
+    $("mapEmpty").style.display = "";
+    $("mapDot").style.display = "none";
+    $("mapDotRing").style.display = "none";
+    var q = $("mapQueue");
+    q.innerHTML = "";
+    q._key = null;
+  }
   function buildMapGeometry() {
     var m = S.map;
     var outline = m && Array.isArray(m.outline) ? m.outline : null;
@@ -1145,6 +1167,9 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               // The debrief and the live-cue fallback gate on S.review — a new identity's
               // COACH page must not stay pinned to the previous session's report (Codex #618).
               S.review = null; reviewDirty = true;
+              // Same for the MAP geometry: the previous track's outline must drop to the
+              // explicit empty state until the new identity's track.map arrives (#618 R2).
+              S.map = null; resetMapDom();
               // A REAL identity switch invalidates the setup name (per-session fact; the
               // trainer's follow-up setup.active names the new one — Codex on PR #547).
               // The FIRST session frame after a page load must not: the identity-replay

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -160,6 +160,13 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
 .crow{display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--line)}
 .cnm{font-family:var(--fd);font-weight:600;font-size:14px;letter-spacing:.04em;text-transform:uppercase;color:var(--mute)}
 .cg{font-family:var(--fm);font-size:11px;color:var(--dim)}
+/* #531 Part F — mock-faithful COACH cause bars + MAP corner badges (reference_mock.html). */
+.cbadge{font-family:var(--fd);font-weight:700;font-size:12px;color:var(--brass);border:1px solid var(--edge);padding:1px 6px}
+.phase{display:flex;align-items:center;gap:10px;padding:9px 0}
+.phase .pl{font-family:var(--fd);font-weight:600;font-size:12px;letter-spacing:.06em;text-transform:uppercase;color:var(--mute);width:64px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.pbar{flex:1;height:16px;background:var(--raise);position:relative}
+.pbf{position:absolute;top:0;bottom:0;left:50%}
+.pv{font-family:var(--fr);font-weight:700;font-size:16px;font-variant-numeric:tabular-nums;width:70px;text-align:right}
 .nodata{font-family:var(--fd);font-weight:600;font-size:13px;letter-spacing:.08em;text-transform:uppercase;color:var(--faint);text-align:center;line-height:1.8}
 .tcell{border:1px solid var(--edge);padding:10px}
 </style>
@@ -237,37 +244,45 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     </div>
   </div>
 
-  <!-- COACH (post-lap debrief; full reference-vs-you split lands with #531 Part F) -->
+  <!-- COACH (post-lap debrief, #531 Part F — bound to the sidecar session.review topic) -->
   <div class="page" id="p-coach">
     <div class="sketch">
-      <div class="panel pad" style="flex:1;display:flex;flex-direction:column"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
-        <div class="mh">Debrief</div>
-        <div style="font-family:var(--fd);font-weight:800;font-size:26px;text-transform:uppercase;color:var(--chalk);margin:6px 0 4px" id="dbHead">&mdash;</div>
-        <div class="mono" style="font-size:13px;color:var(--mute);line-height:1.6;margin-bottom:12px" id="dbBody">Live coaching lines appear here as they arrive.</div>
-        <div class="nodata" style="margin:auto">PER-PHASE DELTA SPLIT &mdash; PHASE 2 (#531 PART F)</div>
+      <div class="panel pad" style="flex:1;display:flex;flex-direction:column;overflow:hidden"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
+        <div class="mh" id="dbTitle">Debrief</div>
+        <div style="font-family:var(--fd);font-weight:800;font-size:26px;text-transform:uppercase;color:var(--chalk);margin:6px 0 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis" id="dbHead">&mdash;</div>
+        <div class="mono" style="font-size:13px;color:var(--mute);line-height:1.6;margin-bottom:12px" id="dbBody">Live coaching lines appear here as they arrive; the full debrief lands with the post-session review.</div>
+        <div id="dbCauses"></div>
       </div>
-      <div class="panel pad" style="width:320px;display:flex;flex-direction:column"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
-        <div class="mh">Laps</div>
+      <div class="panel pad" style="width:320px;display:flex;flex-direction:column;overflow:hidden"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
+        <div class="mh">Priorities &middot; time lost</div>
+        <div id="dbPriorities"><div class="mono" style="font-size:12px;color:var(--dim);margin-top:4px" id="dbPrioEmpty">review pending &mdash; complete a session</div></div>
+        <div class="mh" style="margin-top:12px">Laps</div>
         <div class="crow"><span class="cnm">Last</span><span class="cg" id="dbLast" style="font-size:14px;color:var(--chalk)">&mdash;</span></div>
         <div class="crow"><span class="cnm">Best</span><span class="cg" id="dbBest" style="font-size:14px;color:var(--clear)">&mdash;</span></div>
         <div class="crow" style="border-bottom:0"><span class="cnm">Laps done</span><span class="cg" id="dbLaps" style="font-size:14px;color:var(--chalk)">&mdash;</span></div>
-        <div class="nodata" style="margin:auto">PRIORITIES BY TIME LOST &mdash; PHASE 2</div>
       </div>
     </div>
   </div>
 
-  <!-- MAP (track map + pace notes land with #531 Part F) -->
+  <!-- MAP (real geometry from the sidecar track.map topic — #531 Part F) -->
   <div class="page" id="p-map">
     <div class="sketch">
       <div class="panel mapmain"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
-        <div class="nodata">TRACK MAP &mdash; PHASE 2 (#531 PART F)<br><span class="mono" style="font-size:12px;color:var(--faint);text-transform:none">spline position <span id="mapSpline">&mdash;</span></span></div>
+        <svg id="mapSvg" viewBox="0 0 620 380" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" style="display:none">
+          <path id="mapTrough" d="" fill="none" stroke="#20242A" stroke-width="15" stroke-linejoin="round"></path>
+          <path id="mapLine" d="" fill="none" stroke="#49B6C9" stroke-width="3" stroke-linejoin="round"></path>
+          <rect id="mapStart" x="0" y="0" width="9" height="26" fill="#EEF1F3" style="display:none"></rect>
+          <circle id="mapDot" cx="0" cy="0" r="10" fill="#F23B2C" style="display:none"></circle>
+          <circle id="mapDotRing" cx="0" cy="0" r="10" fill="none" stroke="#0B0C0D" stroke-width="2" style="display:none"></circle>
+        </svg>
+        <div class="nodata" id="mapEmpty">TRACK MAP &mdash; NO REFERENCE LOADED<br><span class="mono" style="font-size:12px;color:var(--faint);text-transform:none">spline position <span id="mapSpline">&mdash;</span></span></div>
       </div>
       <div class="panel mside"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
         <div style="display:flex;justify-content:space-between;align-items:baseline"><span class="lbl" style="font-size:11px" id="mapLap">lap &mdash;</span><span style="font-family:var(--fr);font-weight:700;font-size:24px;color:var(--chalk)" id="mapCur">&mdash;</span></div>
         <div style="display:flex;justify-content:space-between;align-items:baseline;margin-top:6px;border-bottom:1px solid var(--line);padding-bottom:12px"><span class="lbl" style="font-size:11px">delta</span><span style="font-family:var(--fr);font-weight:700;font-size:24px;color:var(--dim)" id="mapDelta">&mdash;</span></div>
         <div class="mh" style="margin-top:12px">Ahead</div>
         <div class="crow" style="border-bottom:0"><span class="cnm" id="mapNext">&mdash;</span><span class="cg" id="mapNextSub"></span></div>
-        <div class="nodata" style="margin:auto">PACE-NOTE QUEUE &mdash; PHASE 2</div>
+        <div id="mapQueue"></div>
       </div>
     </div>
   </div>
@@ -276,7 +291,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   <div class="page" id="p-stint">
     <div class="sketch">
       <div class="panel pad" style="flex:1"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
-        <div class="mh">Tyres &middot; core temp (inner/mid/outer &mdash; Phase 2)</div>
+        <div class="mh">Tyres &middot; tread inner / mid / outer + wear</div>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:6px">
           <div class="tcell"><div class="lbl" style="font-size:10px">FL</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-fl">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)" id="stp-fl">&mdash; psi &middot; &mdash; wear</div></div>
           <div class="tcell"><div class="lbl" style="font-size:10px">FR</div><div class="mono" style="font-size:16px;color:var(--chalk);margin-top:4px" id="st-fr">&mdash;</div><div class="mono" style="font-size:12px;color:var(--dim)" id="stp-fr">&mdash; psi &middot; &mdash; wear</div></div>
@@ -285,10 +300,11 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
         </div>
       </div>
       <div class="panel pad" style="width:320px;display:flex;flex-direction:column"><span class="bk tl"></span><span class="bk tr"></span><span class="bk bl"></span><span class="bk br"></span>
-        <div class="mh">Fuel</div>
-        <div style="display:flex;align-items:baseline;gap:8px;margin-top:4px"><span style="font-family:var(--fr);font-weight:700;font-size:34px;color:var(--chalk)" id="stFuel">&mdash;</span><span class="lbl" style="font-size:11px">litres onboard</span></div>
-        <div class="mono" style="font-size:13px;color:var(--mute);line-height:1.8;margin-top:10px" id="stFuelSub">burn &mdash;</div>
-        <div class="nodata" style="margin:auto">PIT WINDOW &mdash; PHASE 2</div>
+        <div class="mh" id="stPlanTitle">Fuel</div>
+        <div style="display:flex;align-items:baseline;gap:8px;margin-top:4px"><span style="font-family:var(--fr);font-weight:700;font-size:34px;color:var(--chalk)" id="stFuel">&mdash;</span><span class="lbl" style="font-size:11px" id="stFuelUnit">litres onboard</span></div>
+        <div class="mono" style="font-size:13px;color:var(--mute);line-height:1.8;margin-top:10px;white-space:pre-line" id="stFuelSub">burn &mdash;</div>
+        <div class="mh" style="margin-top:14px">Pit window</div>
+        <div class="mono" style="font-size:13px;color:var(--chalk);margin-top:4px" id="stPit">&mdash; (no race target set)</div>
       </div>
     </div>
   </div>
@@ -320,6 +336,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     fuelAtLap: null, burns: [],     // client-side fuel-per-lap (median of last 3 lap diffs)
     lastCue: null, cueAt: 0,        // latest coaching.cue payload + receive time (tier-2 micro)
     race: null, raceAt: 0,          // race.status payload (sidecar fuel/predicted, #531 Part D)
+    review: null,                   // session.review payload (COACH debrief, #531 Part F)
+    map: null,                      // track.map payload (MAP geometry, #531 Part F)
   };
 
   // ---- helpers ---------------------------------------------------------------------------
@@ -570,7 +588,16 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       setEl(pe, p !== null ? p.toFixed(1) : "—");
       var pfg = p !== null ? "" : "var(--dim)";
       if (pe._fg !== pfg) { pe.style.color = pfg; pe._fg = pfg; }
-      setText("st-" + c, t !== null ? Math.round(t) + "° core" : "—");
+      // #531 Part F: cross-tread I/M/O when the producer streams it; the core temp remains
+      // the honest fallback (an absent tread channel never fabricates a spread).
+      var imo = null;
+      if (fresh && S.tires.inner && S.tires.middle && S.tires.outer) {
+        var ti = fin(S.tires.inner[c]), tm = fin(S.tires.middle[c]), to = fin(S.tires.outer[c]);
+        if (ti !== null && tm !== null && to !== null) {
+          imo = Math.round(ti) + " · " + Math.round(tm) + " · " + Math.round(to) + "°";
+        }
+      }
+      setText("st-" + c, imo !== null ? imo : (t !== null ? Math.round(t) + "° core" : "—"));
       setText("stp-" + c, (p !== null ? p.toFixed(1) + " psi" : "— psi")
         + " · " + (w !== null ? Math.round(w) + "% wear" : "— wear"));
     }
@@ -638,6 +665,144 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       setText("cMicro", micro);
     }
   }
+  // ---- COACH page (#531 Part F): bound to the sidecar session.review topic ---------------
+  var reviewDirty = false;
+  function renderCoachPage() {
+    if (!reviewDirty) return;
+    reviewDirty = false;
+    var r = S.review;
+    var problems = r && Array.isArray(r.problems) ? r.problems : [];
+    if (!r || r.error) {
+      setText("dbTitle", "Debrief");
+      if (r && r.error) { setText("dbHead", "REVIEW FAILED"); setText("dbBody", String(r.error)); }
+      return;
+    }
+    var best = fin(r.best_lap_ms);
+    setText("dbTitle", "Debrief" + (best !== null ? " · vs best (" + fmtLap(best) + ")" : ""));
+    var summary = typeof r.screen_summary === "string" && r.screen_summary ? r.screen_summary : "";
+    if (problems.length) {
+      var top = problems[0];
+      setText("dbHead", "Biggest gain · " + String(top.label || top.corner || "—"));
+      var line = String(top.headline || "");
+      if (top.recommended_fix) line += (line ? " — " : "") + String(top.recommended_fix);
+      setText("dbBody", line || summary || "—");
+      // Cause split for the top problem: measured attribution counts, weighted into the
+      // mock's bar rows. Bars render only for causes that were actually observed.
+      var causes = Array.isArray(top.causes) ? top.causes.slice(0, 4) : [];
+      var totalC = 0;
+      causes.forEach(function (c) { totalC += (fin(c.count) || 0); });
+      var html = "";
+      causes.forEach(function (c) {
+        var w = totalC > 0 ? Math.round(((fin(c.count) || 0) / totalC) * 46) : 0;
+        html += '<div class="phase"><span class="pl">' + esc(String(c.cause || "")) + '</span>'
+          + '<div class="pbar"><span class="pbf" style="width:' + w + '%;background:var(--brake)"></span></div>'
+          + '<span class="pv" style="color:var(--brake)">' + (fin(c.count) || 0) + '×</span></div>';
+      });
+      $("dbCauses").innerHTML = html;
+    } else {
+      setText("dbHead", summary ? "SESSION REVIEW" : "—");
+      setText("dbBody", summary || "Review generated with no corner problems above threshold.");
+      $("dbCauses").innerHTML = "";
+    }
+    var pr = "";
+    problems.slice(0, 4).forEach(function (p, i) {
+      var loss = fin(p.total_time_loss_s);
+      var col = i === 0 ? "var(--brake)" : (i === 1 ? "var(--brake)" : "var(--lift)");
+      pr += '<div class="crow"' + (i === 3 ? ' style="border-bottom:0"' : "") + '><span class="cnm"'
+        + (i === 0 ? ' style="color:var(--chalk)"' : "") + ">" + esc(String(p.label || "T?"))
+        + " · " + esc(shortFix(p)) + '</span><span class="cg" style="color:' + col + ';font-size:13px">'
+        + (loss !== null ? loss.toFixed(2) : "—") + "</span></div>";
+    });
+    $("dbPriorities").innerHTML = pr
+      || '<div class="mono" style="font-size:12px;color:var(--dim);margin-top:4px">no corner problems above threshold</div>';
+  }
+  function shortFix(p) {
+    var fix = String(p.recommended_fix || p.primary_cause || "").toLowerCase();
+    return fix.length > 22 ? fix.slice(0, 22) + "…" : fix;
+  }
+  function esc(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  // ---- MAP page (#531 Part F): real geometry from the sidecar track.map topic -------------
+  var mapDirty = false;
+  var mapGeom = null; // {pts:[[svgx,svgy]...], spline:[...], corners:[...]} in viewBox space
+  function buildMapGeometry() {
+    var m = S.map;
+    var outline = m && Array.isArray(m.outline) ? m.outline : null;
+    if (!outline || outline.length < 8) { mapGeom = null; return; }
+    var minX = 1 / 0, maxX = -1 / 0, minZ = 1 / 0, maxZ = -1 / 0;
+    outline.forEach(function (p) {
+      if (p[0] < minX) minX = p[0]; if (p[0] > maxX) maxX = p[0];
+      if (p[1] < minZ) minZ = p[1]; if (p[1] > maxZ) maxZ = p[1];
+    });
+    var pad = 30, W = 620, H = 380;
+    var sx = (W - 2 * pad) / Math.max(1, maxX - minX);
+    var sy = (H - 2 * pad) / Math.max(1, maxZ - minZ);
+    var sc = Math.min(sx, sy);
+    var ox = (W - (maxX - minX) * sc) / 2, oy = (H - (maxZ - minZ) * sc) / 2;
+    var pts = outline.map(function (p) {
+      return [ox + (p[0] - minX) * sc, oy + (p[1] - minZ) * sc];
+    });
+    mapGeom = { pts: pts, spline: m.spline || [], corners: Array.isArray(m.corners) ? m.corners : [] };
+    var d = "M" + pts.map(function (p) { return p[0].toFixed(1) + "," + p[1].toFixed(1); }).join(" L") + " Z";
+    $("mapTrough").setAttribute("d", d);
+    $("mapLine").setAttribute("d", d);
+    var s0 = pts[0];
+    var st = $("mapStart");
+    st.setAttribute("x", (s0[0] - 4.5).toFixed(1));
+    st.setAttribute("y", (s0[1] - 13).toFixed(1));
+    st.style.display = "";
+    $("mapSvg").style.display = "";
+    $("mapEmpty").style.display = "none";
+  }
+  function mapPointAt(spline) {
+    // The outline is spline-ordered and near-uniform; index by fraction, exact enough for a dot.
+    var g = mapGeom;
+    if (!g || !g.pts.length) return null;
+    var i = Math.max(0, Math.min(g.pts.length - 1, Math.round(spline * (g.pts.length - 1))));
+    return g.pts[i];
+  }
+  function renderMapPage(liveTick, spline) {
+    if (mapDirty) { mapDirty = false; buildMapGeometry(); }
+    var g = mapGeom;
+    if (!g) return; // honest empty state stays
+    var dot = $("mapDot"), ring = $("mapDotRing");
+    if (liveTick && spline !== null) {
+      var p = mapPointAt(spline);
+      if (p) {
+        dot.setAttribute("cx", p[0].toFixed(1)); dot.setAttribute("cy", p[1].toFixed(1));
+        ring.setAttribute("cx", p[0].toFixed(1)); ring.setAttribute("cy", p[1].toFixed(1));
+        dot.style.display = ""; ring.style.display = "";
+      }
+    } else {
+      dot.style.display = "none"; ring.style.display = "none";
+    }
+    // Pace-note queue: the next up-to-3 coach-aligned corners ahead of the live spline.
+    var corners = g.corners;
+    if (!corners.length) { $("mapQueue").innerHTML = ""; return; }
+    var s = spline !== null ? spline : 0;
+    var ahead = corners.slice().sort(function (a, b) {
+      var da = (a.spline - s + 1) % 1, db = (b.spline - s + 1) % 1;
+      return da - db;
+    }).slice(0, 3);
+    var key = ahead.map(function (c) { return c.label; }).join("|");
+    if ($("mapQueue")._key === key) return; // change-gated DOM write
+    $("mapQueue")._key = key;
+    var html = "";
+    ahead.forEach(function (c, i) {
+      var note = (fin(c.gear) !== null ? ordinalGear(c.gear) : "")
+        + (fin(c.min_speed_kmh) !== null ? (fin(c.gear) !== null ? " · " : "") + Math.round(c.min_speed_kmh) : "");
+      html += '<div class="crow"' + (i === 2 ? ' style="border-bottom:0"' : "")
+        + '><span style="display:flex;gap:9px;align-items:center"><span class="cbadge">' + esc(String(c.label || "")) + "</span></span>"
+        + '<span class="cg">' + esc(note || "—") + "</span></div>";
+    });
+    $("mapQueue").innerHTML = html;
+  }
+  function ordinalGear(g) {
+    return g === 1 ? "1st" : g === 2 ? "2nd" : g === 3 ? "3rd" : g + "th";
+  }
+
   // Kind → short lane verb for the tier-2 micro-cue slot. Deliberately NOT every cue kind:
   // corner coaching already owns the snapshot line, and an unmapped kind renders nothing
   // rather than a raw identifier.
@@ -769,8 +934,29 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       setText("stintM", "—");
       setText("stintSub", "burn unknown");
     }
-    setText("stFuel", fuel !== null ? fuel.toFixed(1) : "—");
-    setText("stFuelSub", burnShown !== null ? "burn " + burnShown.toFixed(2) + " L/lap" + burnSrc : "burn — (complete a lap)");
+    // STINT fuel plan (#531 Part F): margin-to-flag + pit window when the sidecar knows the
+    // race target (race.status target_laps_remaining); plain onboard litres otherwise.
+    var target = race ? fin(race.target_laps_remaining) : null;
+    if (target !== null && lapsLeft !== null && burnShown !== null) {
+      var margin = lapsLeft - target;
+      var need = target * burnShown;
+      setText("stPlanTitle", "Fuel plan · " + Math.ceil(target) + " laps to flag");
+      setText("stFuel", (margin >= 0 ? "+" : "−") + Math.abs(margin).toFixed(1));
+      setText("stFuelUnit", "lap margin to flag");
+      $("stFuel").style.color = margin >= 0 ? "var(--clear)" : "var(--brake)";
+      setText("stFuelSub", "onboard " + (fuel !== null ? fuel.toFixed(1) : "—") + " L\nburn "
+        + burnShown.toFixed(2) + " L/lap" + burnSrc + "\nto flag need " + need.toFixed(1) + " L");
+      setText("stPit", margin >= 0 ? "no stop needed" : "pit within " + Math.max(0, Math.floor(lapsLeft)) + " laps");
+      $("stPit").style.color = margin >= 0 ? "var(--chalk)" : "var(--brake)";
+    } else {
+      setText("stPlanTitle", "Fuel");
+      setText("stFuel", fuel !== null ? fuel.toFixed(1) : "—");
+      setText("stFuelUnit", "litres onboard");
+      $("stFuel").style.color = "var(--chalk)";
+      setText("stFuelSub", burnShown !== null ? "burn " + burnShown.toFixed(2) + " L/lap" + burnSrc : "burn — (complete a lap)");
+      setText("stPit", "— (no race target set)");
+      $("stPit").style.color = "var(--chalk)";
+    }
 
     // header weather/temps: render only when the producer actually sends them
     var wx = live && typeof t.weather_type === "string" && t.weather_type ? t.weather_type : null;
@@ -798,6 +984,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     $("mapDelta").style.color = d === null ? "var(--dim)" : (d <= 0 ? "var(--clear)" : "var(--brake)");
     var spl = live ? fin(t.spline) : null;
     setText("mapSpline", spl !== null ? (spl * 100).toFixed(1) + "%" : "—");
+    renderMapPage(live, spl);
+    renderCoachPage();
     // Same freshness gate as the RACE lane: MAP must not keep advertising a corner whose
     // producer stopped (Codex on PR #547).
     var snap = S.coach !== null && (Date.now() - S.coachAt) < STALE_MS ? S.coach : null;
@@ -806,7 +994,9 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     setText("dbLast", S.lap ? fmtLap(fin(S.lap.last_lap_ms)) : "—");
     setText("dbBest", S.lap ? fmtLap(fin(S.lap.best_lap_ms)) : "—");
     setText("dbLaps", S.lap && fin(S.lap.laps_completed) !== null ? String(S.lap.laps_completed) : "—");
-    if (S.lastCue) {
+    if (S.lastCue && !S.review) {
+      // Pre-review fallback only (#531 Part F): once a session.review lands, the debrief
+      // owns dbHead/dbBody (renderCoachPage) and the live-cue line must not clobber it.
       // coaching.cue contract: `message` is the human-readable line (kind/corner/urgency/
       // message/spline/detail per make_coaching_cue); `detail` is a structured object —
       // never stringify it at the UI (Qodo on PR #547).
@@ -884,7 +1074,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       ws.send(JSON.stringify({
         v: 1, type: "state.subscribe",
         topics: ["coaching.snapshot", "coaching.cue", "coaching.voice", "delta", "tire_temps",
-                 "setup.active", "session", "lap", "connection", "race.status"],
+                 "setup.active", "session", "lap", "connection", "race.status",
+                 "session.review", "track.map"],
       }));
       requestSetupData(ws);
       // Re-request per-car ranges until they arrive (AC may connect after the tablet), then
@@ -917,6 +1108,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
           case "coaching.snapshot": S.coach = p; S.coachAt = Date.now(); break;
           case "coaching.cue": S.lastCue = p; S.cueAt = Date.now(); break;
           case "race.status": S.race = p; S.raceAt = Date.now(); break;
+          case "session.review": S.review = p; reviewDirty = true; break;
+          case "track.map": S.map = p; mapDirty = true; break;
           case "setup.active":
             S.setupName = p.name || null;
             renderHeader();

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -332,6 +332,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     setupName: null,                // setup.active .name
     carName: null, trackName: null, // setup.list.result identity
     sessionIdent: null,             // "car|track|session" key (re-request setup data on change)
+    sessionCarId: null, sessionTrackId: null, // identity parts for replay-frame gating (#618 R3)
     spinners: null,                 // setup.spinner.list.result .spinners
     fuelAtLap: null, burns: [],     // client-side fuel-per-lap (median of last 3 lap diffs)
     lastCue: null, cueAt: 0,        // latest coaching.cue payload + receive time (tier-2 micro)
@@ -741,6 +742,14 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   // ---- MAP page (#531 Part F): real geometry from the sidecar track.map topic -------------
   var mapDirty = false;
   var mapGeom = null; // {pts:[[svgx,svgy]...], spline:[...], corners:[...]} in viewBox space
+  // Identity gate for replayed sidecar frames (#618 R3): reject only a KNOWN mismatch —
+  // when either side lacks an id, accept (a fresh tablet with no session yet must still
+  // render the replayed map/review, and single-identity rigs are the common case).
+  function identCompatible(carId, trackId) {
+    if (carId && S.sessionCarId && String(carId) !== String(S.sessionCarId)) return false;
+    if (trackId && S.sessionTrackId && String(trackId) !== String(S.sessionTrackId)) return false;
+    return true;
+  }
   function resetMapDom() {
     mapGeom = null;
     mapDirty = false;
@@ -753,9 +762,12 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     q._key = null;
   }
   function buildMapGeometry() {
+    // A new map invalidates the pace-note cache even when the next three labels match the
+    // previous track's (T1|T2|T3 is the common case) — the notes behind them changed (#618 R3).
+    $("mapQueue")._key = null;
     var m = S.map;
     var outline = m && Array.isArray(m.outline) ? m.outline : null;
-    if (!outline || outline.length < 8) { mapGeom = null; return; }
+    if (!outline || outline.length < 8) { mapGeom = null; $("mapSvg").style.display = "none"; $("mapEmpty").style.display = ""; return; }
     var minX = 1 / 0, maxX = -1 / 0, minZ = 1 / 0, maxZ = -1 / 0;
     outline.forEach(function (p) {
       if (p[0] < minX) minX = p[0]; if (p[0] > maxX) maxX = p[0];
@@ -1145,8 +1157,16 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
           case "coaching.snapshot": S.coach = p; S.coachAt = Date.now(); break;
           case "coaching.cue": S.lastCue = p; S.cueAt = Date.now(); break;
           case "race.status": S.race = p; S.raceAt = Date.now(); break;
-          case "session.review": S.review = p; reviewDirty = true; break;
-          case "track.map": S.map = p; mapDirty = true; break;
+          case "session.review":
+            // Late-subscriber replay can deliver a PREVIOUS identity's cached review after
+            // the session snapshot (#618 R3) — accept only when identity-compatible.
+            S.review = identCompatible(p.car_id, p.track_id) ? p : null;
+            reviewDirty = true;
+            break;
+          case "track.map":
+            S.map = identCompatible(p.car_id, p.track_id) ? p : null;
+            mapDirty = true;
+            break;
           case "setup.active":
             S.setupName = p.name || null;
             renderHeader();
@@ -1157,6 +1177,16 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
             // re-request setup data (Codex P2 on PR #547), not just a car swap.
             var ident = String(p.car_id || "") + "|" + String(p.track_id || "")
               + "|" + String(p.session_index === undefined ? "" : p.session_index);
+            S.sessionCarId = p.car_id || null;
+            S.sessionTrackId = p.track_id || null;
+            // Replayed cached frames may have arrived BEFORE this session snapshot — drop
+            // any that a known identity now contradicts (#618 R3).
+            if (S.review && !identCompatible(S.review.car_id, S.review.track_id)) {
+              S.review = null; reviewDirty = true;
+            }
+            if (S.map && !identCompatible(S.map.car_id, S.map.track_id)) {
+              S.map = null; resetMapDom();
+            }
             if (ident !== S.sessionIdent) {
               var hadIdentity = S.sessionIdent !== null;
               S.sessionIdent = ident;

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -679,7 +679,10 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     }
     var best = fin(r.best_lap_ms);
     setText("dbTitle", "Debrief" + (best !== null ? " · vs best (" + fmtLap(best) + ")" : ""));
-    var summary = typeof r.screen_summary === "string" && r.screen_summary ? r.screen_summary : "";
+    // screen_summary is list[str] from the producer (session_review.report._screen_summary);
+    // a plain string is tolerated for forward-compat (Codex on PR #618).
+    var summary = Array.isArray(r.screen_summary) ? r.screen_summary.join(" · ")
+      : (typeof r.screen_summary === "string" ? r.screen_summary : "");
     if (problems.length) {
       var top = problems[0];
       setText("dbHead", "Biggest gain · " + String(top.label || top.corner || "—"));
@@ -757,11 +760,23 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     $("mapEmpty").style.display = "none";
   }
   function mapPointAt(spline) {
-    // The outline is spline-ordered and near-uniform; index by fraction, exact enough for a dot.
+    // Look up by the STORED per-point spline (binary search): real traces sample by update
+    // index, so points are denser in slow corners — uniform indexing would drift the dot on
+    // straights (Codex on PR #618). Falls back to uniform only if the spline array is absent.
     var g = mapGeom;
     if (!g || !g.pts.length) return null;
-    var i = Math.max(0, Math.min(g.pts.length - 1, Math.round(spline * (g.pts.length - 1))));
-    return g.pts[i];
+    var sp = g.spline;
+    if (!sp || sp.length !== g.pts.length) {
+      return g.pts[Math.max(0, Math.min(g.pts.length - 1, Math.round(spline * (g.pts.length - 1))))];
+    }
+    var lo = 0, hi = sp.length - 1;
+    while (lo < hi) {
+      var mid = (lo + hi) >> 1;
+      if (sp[mid] < spline) lo = mid + 1; else hi = mid;
+    }
+    // pick the nearer neighbour of the insertion point
+    if (lo > 0 && Math.abs(sp[lo - 1] - spline) < Math.abs(sp[lo] - spline)) lo -= 1;
+    return g.pts[lo];
   }
   function renderMapPage(liveTick, spline) {
     if (mapDirty) { mapDirty = false; buildMapGeometry(); }
@@ -1127,6 +1142,9 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               S.fuelAtLap = null;
               S.burns = []; // burn is per car AND per track length (Codex on PR #547)
               S.race = null; S.raceAt = 0; // sidecar race.status is per identity too (#531)
+              // The debrief and the live-cue fallback gate on S.review — a new identity's
+              // COACH page must not stay pinned to the previous session's report (Codex #618).
+              S.review = null; reviewDirty = true;
               // A REAL identity switch invalidates the setup name (per-session fact; the
               // trainer's follow-up setup.active names the new one — Codex on PR #547).
               // The FIRST session frame after a page load must not: the identity-replay

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -747,11 +747,14 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   // render the replayed map/review, and single-identity rigs are the common case).
   function identCompatible(carId, trackId) {
     if (carId && S.sessionCarId && String(carId) !== String(S.sessionCarId)) return false;
-    // Venue-level track gate (#618 R4): session producers use full "track/layout" ids while
-    // reference archives may carry the bare track id — comparing the base segment tolerates
-    // that mismatch while still rejecting a genuinely different circuit.
-    if (trackId && S.sessionTrackId
-        && String(trackId).split("/")[0] !== String(S.sessionTrackId).split("/")[0]) return false;
+    // Track gate (#618 R4+R6): when BOTH ids are layout-qualified, compare in full — two
+    // layouts of one venue have different geometry. Base-segment comparison applies only
+    // when one side is bare (reference archives may omit the layout).
+    if (trackId && S.sessionTrackId) {
+      var a = String(trackId), b = String(S.sessionTrackId);
+      var qualified = a.indexOf("/") >= 0 && b.indexOf("/") >= 0;
+      if (qualified ? a !== b : a.split("/")[0] !== b.split("/")[0]) return false;
+    }
     return true;
   }
   function resetMapDom() {
@@ -1216,6 +1219,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
                 // track.map/session.review BEFORE session and never re-sends them; the
                 // compatibility check above already rejected any known mismatch.
                 S.review = null; reviewDirty = true;
+                // The stale live-cue must not repopulate the freshly reset debrief (#618 R6).
+                S.lastCue = null; S.cueAt = 0;
                 // The MAP drops only when car/track actually changed (#618 R5): a
                 // session_index-only transition keeps the same geometry, and track.map
                 // would never be re-sent on this connection.
@@ -1250,6 +1255,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               // live cues, not stay pinned to the previous stint's review (#618 R4). The
               // MAP geometry survives: it is reference-tied, not stint-tied.
               S.review = null; reviewDirty = true;
+              S.lastCue = null; S.cueAt = 0; // and the stale cue must not refill it (R6)
               requestSetupData(ws); // pit work may have changed the setup during the reset
             }
             break;

--- a/tools/ai_sidecar/external_protocol.py
+++ b/tools/ai_sidecar/external_protocol.py
@@ -256,10 +256,21 @@ TOPIC_SESSION_REVIEW = "session.review"
 #: telemetry_tick fuel channel + the Lua ``delta``/``lap`` topics. Low-rate (~1 Hz),
 #: change-gated, honest — absent fields are unmeasured, never zero-filled.
 TOPIC_RACE_STATUS = "race.status"
+#: Topic the sidecar publishes the reference-derived track geometry on (#531 Part F): a
+#: downsampled spline-ordered outline (real px/pz from the loaded reference archive) plus the
+#: coach-aligned corner list. Event-driven (built once at reference wire time), cached, and
+#: replayed to late subscribers like the other sidecar-produced snapshots.
+TOPIC_TRACK_MAP = "track.map"
 # Topics the sidecar produces directly (no loopback Lua relay). Voice/offline clients may
 # state.subscribe to these without a Lua peer connected.
 SIDECAR_PRODUCED_TOPICS: frozenset[str] = frozenset(
-    {TOPIC_COACHING_CUE, TOPIC_COACHING_VOICE, TOPIC_SESSION_REVIEW, TOPIC_RACE_STATUS}
+    {
+        TOPIC_COACHING_CUE,
+        TOPIC_COACHING_VOICE,
+        TOPIC_SESSION_REVIEW,
+        TOPIC_RACE_STATUS,
+        TOPIC_TRACK_MAP,
+    }
 )
 KNOWN_TOPICS: frozenset[str] = frozenset(
     {
@@ -280,6 +291,8 @@ KNOWN_TOPICS: frozenset[str] = frozenset(
         TOPIC_SESSION_REVIEW,
         # Sidecar-originated fused race status (#531 Part D remainder).
         TOPIC_RACE_STATUS,
+        # Sidecar-originated reference-derived track geometry (#531 Part F).
+        TOPIC_TRACK_MAP,
     }
 )
 
@@ -388,6 +401,18 @@ def make_race_status(payload: dict[str, Any]) -> dict[str, Any]:
         "topic": TOPIC_RACE_STATUS,
         "payload": payload,
         "source": "sidecar.race_status",
+    }
+
+
+def make_track_map(payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a ``track.map`` topic frame (#531 Part F) — see
+    :func:`tools.ai_sidecar.track_map.build_track_map` for the payload contract."""
+    return {
+        ENVELOPE_KEY: ENVELOPE_VERSION,
+        TYPE_KEY: TYPE_STATE_SNAPSHOT,
+        "topic": TOPIC_TRACK_MAP,
+        "payload": payload,
+        "source": "sidecar.track_map",
     }
 
 

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -2712,6 +2712,11 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
     # voice-disabled (or different-bank) configuration can never keep serving stale clips;
     # the enabled path below re-arms via _set_voice_web_bank (PR #519 review).
     _disarm_voice_web_bank()
+    # Same authority for the reference-derived track map (#531 Part F): a re-wire whose
+    # reference cannot supply geometry — or that has no reference at all — must not leave
+    # the previous track's map for late subscribers (Codex on PR #618).
+    global _track_map_frame
+    _track_map_frame = None
     reference_path = voice_settings.reference_path
     bank_dir = voice_settings.bank_dir
     bank_backend = (
@@ -2756,7 +2761,7 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                 archive = json.load(fh)
             # #531 Part F: the same archive carries real px/pz — build the MAP page's
             # geometry once, best-effort (a map failure must never disable the observer).
-            global _track_map_frame
+            # The stale frame was already cleared at the top of _wire_voice.
             try:
                 from tools.ai_sidecar.track_map import build_track_map
 

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -97,6 +97,7 @@ from tools.ai_sidecar.external_protocol import (
     make_error,
     make_hello_ack,
     make_race_status,
+    make_track_map,
     topics_are_sidecar_only,
     validate_inbound,
 )
@@ -181,6 +182,11 @@ _shift_observer: Any | None = ShiftObserver()
 _race_status: RaceStatusTracker = RaceStatusTracker()
 #: Publish cadence cap for `race.status` (change-gated on top of this).
 RACE_STATUS_MAX_HZ = 1.0
+# #531 Part F: the reference-derived `track.map` frame, built once at voice/observer wire
+# time. Held OUTSIDE `_sidecar_state_cache` because that cache is cleared by
+# `_reset_external_state()` at serve start (after wiring); the subscribe replay path
+# consults this global as the fallback.
+_track_map_frame: dict[str, Any] | None = None
 # The observer holds single-monotonic-stream state (last spline/lap, per-corner passes), so only ONE
 # producer may feed it. The first telemetry producer claims the feed; a second concurrent loopback
 # producer is still routed to peripherals but NOT into the observer (interleaving would corrupt wrap
@@ -2303,6 +2309,10 @@ async def _handle_external_frame(websocket: Any, data: dict[str, Any]) -> None:
         # sidecar-only fast path below and the relayed mixed-topic subscribe.
         for topic in data.get("topics") or []:
             cached = _sidecar_state_cache.get(str(topic))
+            # #531 Part F: track.map is built at wire time (before the serve-start cache
+            # reset), so its frame lives in a global rather than the peer-scoped cache.
+            if cached is None and str(topic) == "track.map":
+                cached = _track_map_frame
             if cached is not None:
                 await _safe_send(websocket, cached)
     if t in (TYPE_STATE_SUBSCRIBE, TYPE_STATE_UNSUBSCRIBE) and topics_are_sidecar_only(
@@ -2744,6 +2754,24 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
 
             with open(reference_path, encoding="utf-8") as fh:
                 archive = json.load(fh)
+            # #531 Part F: the same archive carries real px/pz — build the MAP page's
+            # geometry once, best-effort (a map failure must never disable the observer).
+            global _track_map_frame
+            try:
+                from tools.ai_sidecar.track_map import build_track_map
+
+                map_payload = build_track_map(archive)
+                if map_payload is not None:
+                    _track_map_frame = make_track_map(map_payload)
+                    logger.info(
+                        "track.map built from reference: %d outline points, %d corners",
+                        len(map_payload.get("outline") or []),
+                        len(map_payload.get("corners") or []),
+                    )
+                else:
+                    logger.info("track.map not built: reference lacks usable geometry")
+            except Exception:
+                logger.exception("track.map build failed (non-fatal)")
             # Issue #522: the anticipatory lead is the full audibility budget (clip + audio
             # latency + human reaction). Tunable per rig; clamped to a sane coaching range.
             observer = build_observer_from_reference(

--- a/tools/ai_sidecar/track_map.py
+++ b/tools/ai_sidecar/track_map.py
@@ -33,9 +33,12 @@ MIN_OUTLINE_SPAN_M = 50.0
 
 def _round_gear(value: float) -> int | None:
     try:
-        g = int(round(float(value)))
+        f = float(value)
     except (TypeError, ValueError):
         return None
+    if not math.isfinite(f):  # Infinity would raise OverflowError at int() (#618 R11)
+        return None
+    g = int(round(f))
     return g if g >= 1 else None
 
 
@@ -76,6 +79,10 @@ def build_track_map(archive: dict[str, Any]) -> dict[str, Any] | None:
         # Always keep the final sample: dropping up to step-1 points at S/F would make the
         # client's closing segment a false chord tens of metres off (daemon on PR #618).
         idx.append(finite_idx[-1])
+    if len(idx) > MAX_OUTLINE_POINTS:
+        # The forced tail can overshoot the cap by one (daemon R11) — drop the point before
+        # it, keeping the first and last samples exact.
+        del idx[-2]
     outline = [[round(lap.x[i], 1), round(lap.z[i], 1)] for i in idx]
     spline = [round(lap.spline[i], 4) for i in idx]
 

--- a/tools/ai_sidecar/track_map.py
+++ b/tools/ai_sidecar/track_map.py
@@ -81,11 +81,21 @@ def build_track_map(archive: dict[str, Any]) -> dict[str, Any] | None:
 
     corners: list[dict[str, Any]] = []
     for turn, (entry_i, apex_i, _exit_i) in enumerate(segment_corners(lap), start=1):
+        # Same finiteness contract as the outline (daemon on PR #618 R8): one non-finite
+        # corner metric would serialize as a bare NaN/Infinity token and kill the whole
+        # frame at the tablet's JSON.parse. Skip the corner, keep the map.
+        spline_apex = lap.spline[apex_i]
+        spline_entry = lap.spline[entry_i]
+        v_apex = lap.v_ms[apex_i]
+        if not (
+            math.isfinite(spline_apex) and math.isfinite(spline_entry) and math.isfinite(v_apex)
+        ):
+            continue
         corner: dict[str, Any] = {
             "label": f"T{turn}",
-            "spline": round(lap.spline[apex_i], 4),
-            "entry_spline": round(lap.spline[entry_i], 4),
-            "min_speed_kmh": round(lap.v_ms[apex_i] * 3.6),
+            "spline": round(spline_apex, 4),
+            "entry_spline": round(spline_entry, 4),
+            "min_speed_kmh": round(v_apex * 3.6),
         }
         gear = _round_gear(lap.gear[apex_i])
         if gear is not None:

--- a/tools/ai_sidecar/track_map.py
+++ b/tools/ai_sidecar/track_map.py
@@ -19,6 +19,7 @@ from the voice (the cue/track-misalignment pitfall).
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from tools.ai_sidecar.lap_dynamics import LapTrace, lap_trace_from_archive, segment_corners
@@ -48,23 +49,33 @@ def build_track_map(archive: dict[str, Any]) -> dict[str, Any] | None:
         lap = lap_trace_from_archive(archive)
     except (ValueError, TypeError):
         return None
-    n = len(lap.spline)
+    # Non-finite coordinates would serialize as bare `NaN` tokens that the tablet's
+    # JSON.parse rejects, dropping the only replayed map frame (Codex on PR #618 R6) —
+    # keep only fully finite samples, then re-check viability.
+    finite_idx = [
+        i
+        for i in range(len(lap.spline))
+        if math.isfinite(lap.x[i]) and math.isfinite(lap.z[i]) and math.isfinite(lap.spline[i])
+    ]
+    n = len(finite_idx)
     if n < 8:
         return None
+    xs = [lap.x[i] for i in finite_idx]
+    zs = [lap.z[i] for i in finite_idx]
     # Degenerate-geometry gate (Codex on PR #618): a trace whose px/pz columns were present
     # but unreadable defaults to 0.0 rows — the "outline" would be a collapsed point that
     # HIDES the honest no-reference state. Require a real spatial span on both axes' union.
-    span_x = max(lap.x) - min(lap.x)
-    span_z = max(lap.z) - min(lap.z)
+    span_x = max(xs) - min(xs)
+    span_z = max(zs) - min(zs)
     if max(span_x, span_z) < MIN_OUTLINE_SPAN_M:
         return None
 
     step = max(1, -(-n // MAX_OUTLINE_POINTS))  # ceil-div: the cap is a cap, not a target
-    idx = list(range(0, n, step))
-    if idx[-1] != n - 1:
+    idx = [finite_idx[i] for i in range(0, n, step)]
+    if idx[-1] != finite_idx[-1]:
         # Always keep the final sample: dropping up to step-1 points at S/F would make the
         # client's closing segment a false chord tens of metres off (daemon on PR #618).
-        idx.append(n - 1)
+        idx.append(finite_idx[-1])
     outline = [[round(lap.x[i], 1), round(lap.z[i], 1)] for i in idx]
     spline = [round(lap.spline[i], 4) for i in idx]
 

--- a/tools/ai_sidecar/track_map.py
+++ b/tools/ai_sidecar/track_map.py
@@ -25,6 +25,9 @@ from tools.ai_sidecar.lap_dynamics import LapTrace, lap_trace_from_archive, segm
 
 #: Outline resolution cap — ~2 m spacing on a 5 km lap, well under the A133's SVG budget.
 MAX_OUTLINE_POINTS = 256
+#: A real circuit spans hundreds of metres; anything under this is a zero-filled/degenerate
+#: position column, not geometry (Codex on PR #618).
+MIN_OUTLINE_SPAN_M = 50.0
 
 
 def _round_gear(value: float) -> int | None:
@@ -47,6 +50,13 @@ def build_track_map(archive: dict[str, Any]) -> dict[str, Any] | None:
         return None
     n = len(lap.spline)
     if n < 8:
+        return None
+    # Degenerate-geometry gate (Codex on PR #618): a trace whose px/pz columns were present
+    # but unreadable defaults to 0.0 rows — the "outline" would be a collapsed point that
+    # HIDES the honest no-reference state. Require a real spatial span on both axes' union.
+    span_x = max(lap.x) - min(lap.x)
+    span_z = max(lap.z) - min(lap.z)
+    if max(span_x, span_z) < MIN_OUTLINE_SPAN_M:
         return None
 
     step = max(1, -(-n // MAX_OUTLINE_POINTS))  # ceil-div: the cap is a cap, not a target

--- a/tools/ai_sidecar/track_map.py
+++ b/tools/ai_sidecar/track_map.py
@@ -1,0 +1,85 @@
+"""Track-map payload for the tablet MAP page (#531 Part F).
+
+Built once from the loaded reference archive — the same artifact that arms the realtime
+observer — because its trace carries real world coordinates (``px``/``pz``, in the archive
+since the Tier-B channel work) ordered by spline. No track-install parsing, no invented
+geometry: **no reference archive → no map** (the page renders its explicit unknown).
+
+Payload shape (the ``track.map`` topic):
+
+``{track_id?, car_id?, source: "reference_archive", lap_ms?,
+   outline: [[x, z], ...],       # downsampled to <= MAX_OUTLINE_POINTS, spline-ordered
+   spline:  [s, ...],            # per outline point — the client maps live spline -> dot
+   corners: [{label, spline, entry_spline, min_speed_kmh, gear?}, ...]}``
+
+Corners come from :func:`tools.ai_sidecar.lap_dynamics.segment_corners` — the SAME
+segmentation the coach's spoken turn numbers use, so the map's T-labels can never drift
+from the voice (the cue/track-misalignment pitfall).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.ai_sidecar.lap_dynamics import LapTrace, lap_trace_from_archive, segment_corners
+
+#: Outline resolution cap — ~2 m spacing on a 5 km lap, well under the A133's SVG budget.
+MAX_OUTLINE_POINTS = 256
+
+
+def _round_gear(value: float) -> int | None:
+    try:
+        g = int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+    return g if g >= 1 else None
+
+
+def build_track_map(archive: dict[str, Any]) -> dict[str, Any] | None:
+    """The ``track.map`` payload for ``archive``, or ``None`` when it cannot be built honestly.
+
+    Never raises: a malformed archive (no trace, no position channels, too few samples)
+    returns ``None`` — the caller logs and the MAP page keeps its explicit unknown.
+    """
+    try:
+        lap = lap_trace_from_archive(archive)
+    except (ValueError, TypeError):
+        return None
+    n = len(lap.spline)
+    if n < 8:
+        return None
+
+    step = max(1, -(-n // MAX_OUTLINE_POINTS))  # ceil-div: the cap is a cap, not a target
+    idx = list(range(0, n, step))
+    outline = [[round(lap.x[i], 1), round(lap.z[i], 1)] for i in idx]
+    spline = [round(lap.spline[i], 4) for i in idx]
+
+    corners: list[dict[str, Any]] = []
+    for turn, (entry_i, apex_i, _exit_i) in enumerate(segment_corners(lap), start=1):
+        corner: dict[str, Any] = {
+            "label": f"T{turn}",
+            "spline": round(lap.spline[apex_i], 4),
+            "entry_spline": round(lap.spline[entry_i], 4),
+            "min_speed_kmh": round(lap.v_ms[apex_i] * 3.6),
+        }
+        gear = _round_gear(lap.gear[apex_i])
+        if gear is not None:
+            corner["gear"] = gear
+        corners.append(corner)
+
+    payload: dict[str, Any] = {
+        "source": "reference_archive",
+        "outline": outline,
+        "spline": spline,
+        "corners": corners,
+    }
+    if lap.track_id:
+        payload["track_id"] = lap.track_id
+    if lap.car_id:
+        payload["car_id"] = lap.car_id
+    if lap.lap_ms is not None and lap.lap_ms > 0:
+        payload["lap_ms"] = lap.lap_ms
+    return payload
+
+
+__all__ = ["MAX_OUTLINE_POINTS", "build_track_map", "LapTrace"]

--- a/tools/ai_sidecar/track_map.py
+++ b/tools/ai_sidecar/track_map.py
@@ -61,6 +61,10 @@ def build_track_map(archive: dict[str, Any]) -> dict[str, Any] | None:
 
     step = max(1, -(-n // MAX_OUTLINE_POINTS))  # ceil-div: the cap is a cap, not a target
     idx = list(range(0, n, step))
+    if idx[-1] != n - 1:
+        # Always keep the final sample: dropping up to step-1 points at S/F would make the
+        # client's closing segment a false chord tens of metres off (daemon on PR #618).
+        idx.append(n - 1)
     outline = [[round(lap.x[i], 1), round(lap.z[i], 1)] for i in idx]
     spline = [round(lap.spline[i], 4) for i in idx]
 


### PR DESCRIPTION
## Scope (#531 Part F)

### COACH — post-lap debrief (bound to `session.review`)
- Renders the sidecar's existing review payload: **Biggest gain** headline from the top problem, narrative from `headline` + `recommended_fix`, **measured cause-split bars** (attribution counts — never fabricated phase numbers), **Priorities · time lost** from `problems[0..3]` (`total_time_loss_s`).
- The Phase-1 live-cue line is demoted to a **pre-review fallback** — once a review lands it owns the panel (the live line was clobbering it every frame; caught in-browser).
- Generation stays **loopback-only** (disk safety); the dash consumes the broadcast + cached replay.

### MAP — real geometry (`track.map`, new sidecar-produced topic)
- `tools/ai_sidecar/track_map.py` builds a ≤256-point spline-ordered outline from the loaded reference archive's **real `px`/`pz`** plus the corner list from the **same `segment_corners` the voice coach uses** (labels can never drift from spoken turn numbers). No reference → no map → explicit unknown (never invented geometry).
- Built once at reference wire time; held in a module global (the topic cache resets at serve start) and replayed to late subscribers via the subscribe path.
- Page renders outline (mock-faithful trough+line strokes), live car dot by spline, start line, and a **spline-rotated pace-note queue** (badge + gear + min-speed from the reference).

### STINT — real I/M/O + fuel plan
- `tire_temps` topic now carries optional `inner`/`middle`/`outer` corner maps from the **#490 Tier-1 `wheel_read` channels** (omitted entirely when the car/CSP lacks them; cells fall back to core temp — never a fabricated spread). Includes the Lua scoping relocation of `_field`/`_cornerMap` (they were declared below the new consumer — upvalue trap).
- Fuel plan from `race.status`: **margin-to-flag** (green/red), need-litres, pit window ("no stop needed" / "pit within N laps") — rendered **only when a race target exists**; plain onboard litres otherwise.

### Dev feeder (durable, replaces the lost Phase-1 scratch tool)
`python -m tools.ai_sidecar.dash.dev_feeder --port 8765 [--reference <archive>] [--review-lap-dir <journal/laps>]` — synthetic or reference-replayed laps across all dash topics, auto-reconnect (a busy box drops WS keepalives), optional real session-review trigger. The Phase-1 node explicitly flagged the scratch feeder's loss.

### Design authority note
`DESIGN_SPEC.md` line 15 prose ("hero/boards never swept") contradicts `reference_mock.html`'s full-region sweep; the issue designates the mock as ground truth and Phase 1 shipped the mock behavior — kept.

### Verified live (in-browser, branch sidecar armed with a real Magione reference)
- `track.map built from reference: 250 outline points, 5 corners` (T1@57 → T5@53 km/h apex, real trace data)
- MAP: moving dot on the real outline, queue rotating with spline (T4→T5→T1)
- STINT: `84 · 82 · 79°` I/M/O cells, fuel plan arithmetic exact (39.6 L ÷ 2.40 = 16.5 vs target 12 → **+4.5 margin**, "no stop needed")
- COACH: review title with real best, priorities/threshold behavior honest
- Zero console errors; 121+ focused tests; `make ci-fast` OK.

Part of #531 (Parts G/H/I remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)