### PR TITLE
fix(rig): launcher discarded healthy sessions — acpmf corpse hands over into the new acs lifetime (#628)

### DIFF
--- a/tests/test_ac_harness_rig_lock.py
+++ b/tests/test_ac_harness_rig_lock.py
@@ -236,13 +236,55 @@ def test_status_probe_reports_unknown_when_lock_file_cannot_be_opened(
 def test_status_probe_reports_unknown_on_non_contention_os_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """POSIX branch: a non-contention lock error is reported as an unknown owner.
+
+    The platform must be pinned. ``read_rig_session_owner`` only calls ``_lock_byte`` on POSIX —
+    on win32 it uses a contend-only byte read instead — so without this the patched ``_lock_byte``
+    is never reached on a Windows host, the read succeeds, and the probe returns ``None``. That
+    made this test pass in CI and fail permanently on the Windows rig, where it blocked
+    ``make ci-fast``. Pinned the same way as
+    ``test_windows_status_probe_never_acquires_the_exclusive_byte`` pins win32.
+    """
     path = tmp_path / "rig-session.lock"
     path.write_bytes(b"\0")
 
     def fail_lock(_lock_file) -> None:
         raise OSError(errno.EIO, "device failure")
 
+    monkeypatch.setattr(rig_lock_module.sys, "platform", "linux")
     monkeypatch.setattr(RigSessionLock, "_lock_byte", fail_lock)
+
+    assert read_rig_session_owner(path) == {"cwd": "unknown"}
+
+
+def test_windows_status_probe_reports_unknown_on_non_contention_read_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """win32 branch of the same contract: a non-contention read error is an unknown owner.
+
+    The POSIX test above cannot cover this path because win32 never calls ``_lock_byte``.
+    """
+    path = tmp_path / "rig-session.lock"
+    path.write_bytes(b"\0")
+
+    monkeypatch.setattr(rig_lock_module.sys, "platform", "win32")
+    monkeypatch.setattr(RigSessionLock, "_is_lock_contention", staticmethod(lambda _exc: False))
+
+    real_open = Path.open
+
+    def open_with_failing_read(self: Path, *args: object, **kwargs: object) -> object:
+        handle = real_open(self, *args, **kwargs)
+
+        class _FailingRead:
+            def __getattr__(self, name: str) -> object:
+                return getattr(handle, name)
+
+            def read(self, *_a: object, **_k: object) -> bytes:
+                raise OSError(errno.EIO, "device failure")
+
+        return _FailingRead()
+
+    monkeypatch.setattr(Path, "open", open_with_failing_read)
 
     assert read_rig_session_owner(path) == {"cwd": "unknown"}
 

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -14,9 +14,11 @@ import subprocess
 import pytest
 
 from tools.ac_harness.resilient_launch import (
+    AttemptReadiness,
     LaunchVerdict,
     Sample,
     SectionOwnershipGate,
+    _Car0NotDrivable,
     _Car0ProbeCleanupError,
     _ensure_acs_gone,
     _ensure_cm_running,
@@ -320,6 +322,60 @@ class TestSectionOwnershipGate:
         gate.observe(acs_alive=True, packet=100)
         assert gate.observe(acs_alive=True, packet=200) is True
         assert gate.observe(acs_alive=True, packet=None) is True
+
+
+class TestAttemptReadiness:
+    """#628 — the Car0 cache must be revoked with section ownership, not outlive it."""
+
+    @staticmethod
+    def _earn_ownership(readiness: AttemptReadiness) -> None:
+        readiness.observe(acs_alive=True, packet=100, entry_ready=False)
+        readiness.observe(acs_alive=True, packet=200, entry_ready=False)
+        assert readiness.publishing is True
+
+    def test_car0_probe_runs_once_per_attempt(self) -> None:
+        calls = []
+        readiness = AttemptReadiness(lambda: (calls.append(1), True)[1])
+        self._earn_ownership(readiness)
+
+        for packet in (300, 400, 500):
+            ready, drivable = readiness.observe(acs_alive=True, packet=packet, entry_ready=True)
+            assert (ready, drivable) == (True, True)
+        assert len(calls) == 1
+
+    def test_probe_is_not_run_before_ownership_is_earned(self) -> None:
+        calls = []
+        readiness = AttemptReadiness(lambda: (calls.append(1), True)[1])
+
+        # The corpse reports READY before acs even exists — this is the 6/6 froze case.
+        assert readiness.observe(acs_alive=False, packet=16_983, entry_ready=True) == (None, None)
+        assert readiness.observe(acs_alive=True, packet=16_983, entry_ready=True) == (None, None)
+        assert calls == []
+
+    def test_process_death_revokes_the_car0_cache(self) -> None:
+        """A fast crash/restart inside one attempt must not inherit the old drivability verdict."""
+        calls = []
+        readiness = AttemptReadiness(lambda: (calls.append(1), True)[1])
+        self._earn_ownership(readiness)
+        readiness.observe(acs_alive=True, packet=300, entry_ready=True)
+        assert readiness.car0_ready is True
+        assert len(calls) == 1
+
+        # acs dies -> ownership and the Car0 verdict are both revoked.
+        assert readiness.observe(acs_alive=False, packet=None, entry_ready=True) == (None, None)
+        assert readiness.car0_ready is None
+
+        # A new generation must re-earn ownership AND re-run the handshake.
+        readiness.observe(acs_alive=True, packet=5, entry_ready=True)
+        readiness.observe(acs_alive=True, packet=9, entry_ready=True)
+        assert len(calls) == 2
+
+    def test_not_drivable_raises(self) -> None:
+        readiness = AttemptReadiness(lambda: False)
+        self._earn_ownership(readiness)
+
+        with pytest.raises(_Car0NotDrivable):
+            readiness.observe(acs_alive=True, packet=300, entry_ready=True)
 
 
 def test_empty_trace_is_pending():

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -214,6 +214,45 @@ def test_packet_reset_during_stability_cannot_inherit_prior_session_progress() -
     assert classify(samples, go_live_timeout=30.0, stability_window=45.0) is LaunchVerdict.FROZE
 
 
+def test_surviving_shared_memory_corpse_does_not_fail_a_healthy_launch() -> None:
+    """#628 — a dead session's ``acpmf_*`` section outlives it and must not poison the next verdict.
+
+    Measured on the rig: after ``taskkill /IM acs.exe /F`` the graphics section is still PRESENT
+    14 s later, holding the previous session's high packet id. The next launch renders its own
+    stream from ~0. Before the fix that read as a regression and a perfectly healthy session was
+    discarded as ``never_live`` — burning every retry after the first.
+    """
+    corpse = trace([(0.0, 23_000, False), (2.0, 23_000, False), (4.0, 23_000, False)])
+    fresh = steady(6.0, 60.0, first_packet=5)
+
+    assert classify(corpse + fresh, go_live_timeout=30.0, stability_window=45.0) is (
+        LaunchVerdict.STABLE
+    )
+
+
+def test_corpse_reading_does_not_mask_a_genuinely_dead_launch() -> None:
+    """The corpse must not manufacture liveness either: no live acs means NEVER_LIVE."""
+    corpse = trace([(float(t), 23_000, False) for t in range(0, 40, 2)])
+
+    assert classify(corpse, go_live_timeout=30.0, stability_window=45.0) is (
+        LaunchVerdict.NEVER_LIVE
+    )
+
+
+def test_pre_go_live_regression_with_acs_alive_is_still_never_live() -> None:
+    """The #628 fix must not weaken the real guard, only ignore corpse readings.
+
+    A regression observed while ``acs.exe`` IS alive still means the render stream was replaced.
+    (The post-go-live half of this guard is pinned by
+    ``test_packet_reset_during_stability_cannot_inherit_prior_session_progress``.)
+    """
+    samples = trace([(0.0, 1_000, True), (2.0, 5, True)])
+
+    assert classify(samples, go_live_timeout=30.0, stability_window=45.0) is (
+        LaunchVerdict.NEVER_LIVE
+    )
+
+
 def test_empty_trace_is_pending():
     assert classify([]) is LaunchVerdict.PENDING
 

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -16,6 +16,7 @@ import pytest
 from tools.ac_harness.resilient_launch import (
     LaunchVerdict,
     Sample,
+    SectionOwnershipGate,
     _Car0ProbeCleanupError,
     _ensure_acs_gone,
     _ensure_cm_running,
@@ -276,6 +277,49 @@ def test_pre_go_live_regression_does_not_bypass_the_go_live_timeout() -> None:
     assert classify(samples, go_live_timeout=30.0, stability_window=45.0) is (
         LaunchVerdict.NEVER_LIVE
     )
+
+
+class TestSectionOwnershipGate:
+    """#628 — readings must be suppressed until the live acs.exe is proven to own the section.
+
+    The shipped launcher failed 6/6 attempts in ~7 s each because the corpse's ``is_live`` flag
+    fired the Car0 drivability handshake before AC existed.
+    """
+
+    def test_dead_process_is_never_trusted(self) -> None:
+        gate = SectionOwnershipGate()
+        for packet in (23_000, 23_000, 23_000):
+            assert gate.observe(acs_alive=False, packet=packet) is False
+
+    def test_alive_but_still_reading_the_corpse_is_not_trusted(self) -> None:
+        """The measured case: acs is ALIVE and loading, section still pinned at the dead value."""
+        gate = SectionOwnershipGate()
+        assert gate.observe(acs_alive=False, packet=16_983) is False
+        for _ in range(3):
+            assert gate.observe(acs_alive=True, packet=16_983) is False
+
+    def test_trusted_once_the_new_stream_advances(self) -> None:
+        gate = SectionOwnershipGate()
+        gate.observe(acs_alive=False, packet=16_983)
+        gate.observe(acs_alive=True, packet=16_983)
+        # The new session publishes its own stream, starting low.
+        assert gate.observe(acs_alive=True, packet=121) is False
+        assert gate.observe(acs_alive=True, packet=140) is True
+        assert gate.publishing is True
+
+    def test_process_death_revokes_trust(self) -> None:
+        gate = SectionOwnershipGate()
+        gate.observe(acs_alive=True, packet=100)
+        assert gate.observe(acs_alive=True, packet=200) is True
+        assert gate.observe(acs_alive=False, packet=200) is False
+        # ...and the dead generation's value cannot seed the next one.
+        assert gate.observe(acs_alive=True, packet=5) is False
+
+    def test_unreadable_section_neither_grants_nor_revokes_trust(self) -> None:
+        gate = SectionOwnershipGate()
+        gate.observe(acs_alive=True, packet=100)
+        assert gate.observe(acs_alive=True, packet=200) is True
+        assert gate.observe(acs_alive=True, packet=None) is True
 
 
 def test_empty_trace_is_pending():

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -239,14 +239,39 @@ def test_corpse_reading_does_not_mask_a_genuinely_dead_launch() -> None:
     )
 
 
-def test_pre_go_live_regression_with_acs_alive_is_still_never_live() -> None:
-    """The #628 fix must not weaken the real guard, only ignore corpse readings.
+def test_corpse_persisting_into_the_new_acs_lifetime_does_not_fail_the_launch() -> None:
+    """#628 — the exact trace measured on the rig, which the ``acs_alive`` guard alone misses.
 
-    A regression observed while ``acs.exe`` IS alive still means the render stream was replaced.
-    (The post-go-live half of this guard is pinned by
-    ``test_packet_reset_during_stability_cannot_inherit_prior_session_progress``.)
+    The dead session's section stays mapped for ~6 s AFTER the new acs.exe starts: the process is
+    alive and loading but has not published its own stream yet, so readings in that window are
+    live-correlated *and* stale. Verbatim from ``.scratch/trial_verbose.py``::
+
+        t=0.0  acs=None   gfx=16983   <- corpse
+        t=2.0  acs=14020  gfx=16983   <- new acs ALIVE, section still the corpse
+        t=4.0  acs=14020  gfx=16983
+        t=6.0  acs=14020  gfx=16983
+        t=8.0  acs=14020  gfx=121     <- new session finally publishes
+
+    Before the fix this was ``never_live`` at t=8.0 s — a normal, healthy load discarded.
     """
-    samples = trace([(0.0, 1_000, True), (2.0, 5, True)])
+    samples = [Sample(t=0.0, gfx_packet=16_983, acs_alive=False, entry_ready=True, drivable=True)]
+    samples += [
+        Sample(t=t, gfx_packet=16_983, acs_alive=True, entry_ready=True, drivable=True)
+        for t in (2.0, 4.0, 6.0)
+    ]
+    samples += [Sample(t=8.0, gfx_packet=121, acs_alive=True, entry_ready=True, drivable=True)]
+    samples += steady(10.0, 70.0, first_packet=200)
+
+    assert classify(samples, go_live_timeout=80.0, stability_window=45.0) is LaunchVerdict.STABLE
+
+
+def test_pre_go_live_regression_does_not_bypass_the_go_live_timeout() -> None:
+    """Rebasing before go-live must not become an infinite grace period."""
+    # A stream that keeps resetting and never advances-while-ready must still time out.
+    samples = [
+        Sample(t=float(t), gfx_packet=1_000 - t, acs_alive=True, entry_ready=False, drivable=False)
+        for t in range(0, 40, 2)
+    ]
 
     assert classify(samples, go_live_timeout=30.0, stability_window=45.0) is (
         LaunchVerdict.NEVER_LIVE

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -317,6 +317,18 @@ class TestSectionOwnershipGate:
         # ...and the dead generation's value cannot seed the next one.
         assert gate.observe(acs_alive=True, packet=5) is False
 
+    def test_packet_regression_while_alive_revokes_trust(self) -> None:
+        """A restart fast enough that absence was never observed must still re-earn trust."""
+        gate = SectionOwnershipGate()
+        gate.observe(acs_alive=True, packet=100)
+        assert gate.observe(acs_alive=True, packet=200) is True
+
+        # Session replaced; the new stream restarts low while acs.exe never appeared absent.
+        assert gate.observe(acs_alive=True, packet=5) is False
+        assert gate.publishing is False
+        # ...and the new generation re-earns trust on its own strictly-increasing stream.
+        assert gate.observe(acs_alive=True, packet=9) is True
+
     def test_unreadable_section_neither_grants_nor_revokes_trust(self) -> None:
         gate = SectionOwnershipGate()
         gate.observe(acs_alive=True, packet=100)
@@ -367,6 +379,21 @@ class TestAttemptReadiness:
 
         # A new generation must re-earn ownership AND re-run the handshake.
         readiness.observe(acs_alive=True, packet=5, entry_ready=True)
+        readiness.observe(acs_alive=True, packet=9, entry_ready=True)
+        assert len(calls) == 2
+
+    def test_packet_regression_revokes_the_car0_cache(self) -> None:
+        """The revocation must propagate: a replacement session re-runs the handshake."""
+        calls = []
+        readiness = AttemptReadiness(lambda: (calls.append(1), True)[1])
+        self._earn_ownership(readiness)
+        readiness.observe(acs_alive=True, packet=300, entry_ready=True)
+        assert len(calls) == 1
+
+        # Session replaced without an observed absence.
+        assert readiness.observe(acs_alive=True, packet=5, entry_ready=True) == (None, None)
+        assert readiness.car0_ready is None
+
         readiness.observe(acs_alive=True, packet=9, entry_ready=True)
         assert len(calls) == 2
 

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -282,58 +282,45 @@ def test_pre_go_live_regression_does_not_bypass_the_go_live_timeout() -> None:
 
 
 class TestSectionOwnershipGate:
-    """#628 — readings must be suppressed until the live acs.exe is proven to own the section.
+    """#628 — readings are trusted only once the packet proves a LIVE writer.
 
     The shipped launcher failed 6/6 attempts in ~7 s each because the corpse's ``is_live`` flag
-    fired the Car0 drivability handshake before AC existed.
+    fired the Car0 drivability handshake before AC existed. A corpse packet never advances, so the
+    gate needs nothing but the packet stream to tell a corpse from a live owner.
     """
 
-    def test_dead_process_is_never_trusted(self) -> None:
+    def test_pinned_corpse_is_never_trusted(self) -> None:
+        """A corpse holds one value forever — no advance, no trust."""
         gate = SectionOwnershipGate()
-        for packet in (23_000, 23_000, 23_000):
-            assert gate.observe(acs_alive=False, packet=packet) is False
-
-    def test_alive_but_still_reading_the_corpse_is_not_trusted(self) -> None:
-        """The measured case: acs is ALIVE and loading, section still pinned at the dead value."""
-        gate = SectionOwnershipGate()
-        assert gate.observe(acs_alive=False, packet=16_983) is False
-        for _ in range(3):
-            assert gate.observe(acs_alive=True, packet=16_983) is False
+        for _ in range(4):
+            assert gate.observe(16_983) is False
+        assert gate.publishing is False
 
     def test_trusted_once_the_new_stream_advances(self) -> None:
         gate = SectionOwnershipGate()
-        gate.observe(acs_alive=False, packet=16_983)
-        gate.observe(acs_alive=True, packet=16_983)
-        # The new session publishes its own stream, starting low.
-        assert gate.observe(acs_alive=True, packet=121) is False
-        assert gate.observe(acs_alive=True, packet=140) is True
+        # Corpse pinned, then the new session publishes its own low, ADVANCING stream.
+        gate.observe(16_983)
+        gate.observe(16_983)
+        assert gate.observe(121) is False  # regression off the corpse
+        assert gate.observe(140) is True  # first advance = proven live writer
         assert gate.publishing is True
 
-    def test_process_death_revokes_trust(self) -> None:
+    def test_packet_regression_revokes_trust(self) -> None:
+        """A restart fast enough that no absence was observed must still re-earn trust."""
         gate = SectionOwnershipGate()
-        gate.observe(acs_alive=True, packet=100)
-        assert gate.observe(acs_alive=True, packet=200) is True
-        assert gate.observe(acs_alive=False, packet=200) is False
-        # ...and the dead generation's value cannot seed the next one.
-        assert gate.observe(acs_alive=True, packet=5) is False
-
-    def test_packet_regression_while_alive_revokes_trust(self) -> None:
-        """A restart fast enough that absence was never observed must still re-earn trust."""
-        gate = SectionOwnershipGate()
-        gate.observe(acs_alive=True, packet=100)
-        assert gate.observe(acs_alive=True, packet=200) is True
-
-        # Session replaced; the new stream restarts low while acs.exe never appeared absent.
-        assert gate.observe(acs_alive=True, packet=5) is False
+        gate.observe(100)
+        assert gate.observe(200) is True
+        # Session replaced: the new stream restarts low.
+        assert gate.observe(5) is False
         assert gate.publishing is False
         # ...and the new generation re-earns trust on its own strictly-increasing stream.
-        assert gate.observe(acs_alive=True, packet=9) is True
+        assert gate.observe(9) is True
 
-    def test_unreadable_section_neither_grants_nor_revokes_trust(self) -> None:
+    def test_unreadable_sample_neither_grants_nor_revokes_trust(self) -> None:
         gate = SectionOwnershipGate()
-        gate.observe(acs_alive=True, packet=100)
-        assert gate.observe(acs_alive=True, packet=200) is True
-        assert gate.observe(acs_alive=True, packet=None) is True
+        gate.observe(100)
+        assert gate.observe(200) is True
+        assert gate.observe(None) is True  # a momentary unreadable section does not revoke
 
 
 class TestAttemptReadiness:
@@ -341,8 +328,8 @@ class TestAttemptReadiness:
 
     @staticmethod
     def _earn_ownership(readiness: AttemptReadiness) -> None:
-        readiness.observe(acs_alive=True, packet=100, entry_ready=False)
-        readiness.observe(acs_alive=True, packet=200, entry_ready=False)
+        readiness.observe(packet=100, entry_ready=False)
+        readiness.observe(packet=200, entry_ready=False)
         assert readiness.publishing is True
 
     def test_car0_probe_runs_once_per_attempt(self) -> None:
@@ -351,7 +338,7 @@ class TestAttemptReadiness:
         self._earn_ownership(readiness)
 
         for packet in (300, 400, 500):
-            ready, drivable = readiness.observe(acs_alive=True, packet=packet, entry_ready=True)
+            ready, drivable = readiness.observe(packet=packet, entry_ready=True)
             assert (ready, drivable) == (True, True)
         assert len(calls) == 1
 
@@ -359,42 +346,25 @@ class TestAttemptReadiness:
         calls = []
         readiness = AttemptReadiness(lambda: (calls.append(1), True)[1])
 
-        # The corpse reports READY before acs even exists — this is the 6/6 froze case.
-        assert readiness.observe(acs_alive=False, packet=16_983, entry_ready=True) == (None, None)
-        assert readiness.observe(acs_alive=True, packet=16_983, entry_ready=True) == (None, None)
+        # The corpse reports READY on a pinned packet before AC publishes — the 6/6 froze case.
+        assert readiness.observe(packet=16_983, entry_ready=True) == (None, None)
+        assert readiness.observe(packet=16_983, entry_ready=True) == (None, None)
         assert calls == []
 
-    def test_process_death_revokes_the_car0_cache(self) -> None:
-        """A fast crash/restart inside one attempt must not inherit the old drivability verdict."""
+    def test_packet_regression_revokes_the_car0_cache(self) -> None:
+        """A fast restart (packet regression) must re-run the handshake, not inherit the verdict."""
         calls = []
         readiness = AttemptReadiness(lambda: (calls.append(1), True)[1])
         self._earn_ownership(readiness)
-        readiness.observe(acs_alive=True, packet=300, entry_ready=True)
+        readiness.observe(packet=300, entry_ready=True)
         assert readiness.car0_ready is True
         assert len(calls) == 1
 
-        # acs dies -> ownership and the Car0 verdict are both revoked.
-        assert readiness.observe(acs_alive=False, packet=None, entry_ready=True) == (None, None)
+        # Session replaced: the new low stream revokes trust and the cached verdict.
+        assert readiness.observe(packet=5, entry_ready=True) == (None, None)
         assert readiness.car0_ready is None
 
-        # A new generation must re-earn ownership AND re-run the handshake.
-        readiness.observe(acs_alive=True, packet=5, entry_ready=True)
-        readiness.observe(acs_alive=True, packet=9, entry_ready=True)
-        assert len(calls) == 2
-
-    def test_packet_regression_revokes_the_car0_cache(self) -> None:
-        """The revocation must propagate: a replacement session re-runs the handshake."""
-        calls = []
-        readiness = AttemptReadiness(lambda: (calls.append(1), True)[1])
-        self._earn_ownership(readiness)
-        readiness.observe(acs_alive=True, packet=300, entry_ready=True)
-        assert len(calls) == 1
-
-        # Session replaced without an observed absence.
-        assert readiness.observe(acs_alive=True, packet=5, entry_ready=True) == (None, None)
-        assert readiness.car0_ready is None
-
-        readiness.observe(acs_alive=True, packet=9, entry_ready=True)
+        readiness.observe(packet=9, entry_ready=True)
         assert len(calls) == 2
 
     def test_not_drivable_raises(self) -> None:
@@ -402,7 +372,7 @@ class TestAttemptReadiness:
         self._earn_ownership(readiness)
 
         with pytest.raises(_Car0NotDrivable):
-            readiness.observe(acs_alive=True, packet=300, entry_ready=True)
+            readiness.observe(packet=300, entry_ready=True)
 
 
 def test_empty_trace_is_pending():

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -1070,7 +1070,17 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 if release_requested():
                     raise _OperatorRelease
 
-                alive = acs_present()
+                try:
+                    alive = acs_present()
+                except OSError as exc:
+                    # A transient process-enumeration failure is UNKNOWN liveness, not death.
+                    # Report the sample as unobserved and leave the ownership gate untouched:
+                    # feeding it acs_alive=False would REVOKE proven ownership over a hiccup and
+                    # re-arm the Car0 handshake mid-session. ``classify`` already treats a
+                    # None packet / None readiness as "no observation" rather than as evidence.
+                    _log(f"WARNING: acs.exe enumeration failed; sample unobserved: {exc}")
+                    return None, None, None
+
                 packet, entry_ready = read_state() if alive else (None, None)
                 if not ownership.observe(acs_alive=alive, packet=packet):
                     return packet, None, None

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -1126,17 +1126,27 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 try:
                     alive = acs_present()
                 except OSError as exc:
-                    # A transient process-enumeration failure is UNKNOWN liveness, not death.
-                    # Report the sample as unobserved and leave the readiness state untouched:
-                    # feeding it acs_alive=False would REVOKE proven ownership over a hiccup and
-                    # re-arm the Car0 handshake mid-session. ``classify`` already treats a
-                    # None packet / None readiness as "no observation" rather than as evidence.
                     _log(f"WARNING: acs.exe enumeration failed; sample unobserved: {exc}")
+                    alive = False
+
+                if not alive:
+                    # ``acs_present`` is an UNDEBOUNCED strict probe, so this may be a single
+                    # false-negative snapshot, not a real exit. Two things follow:
+                    #  - Do NOT read shared memory. If the process really is gone, its section is a
+                    #    corpse; suppressing the read is what keeps a corpse from being trusted.
+                    #  - Do NOT revoke ownership on this one miss. Revoking here would clear the
+                    #    Car0 verdict and re-arm the blocking handshake on a healthy session over a
+                    #    momentary enumeration blip. A REAL exit is still caught: ``_sample_now``
+                    #    stamps ``Sample.acs_alive`` from the DEBOUNCED probe, so ``classify`` ends
+                    #    the attempt after its absence confirmations. A fast restart that never
+                    #    trips the debounce is caught instead by packet regression in
+                    #    ``SectionOwnershipGate`` (the new low stream revokes trust). So ownership
+                    #    is revoked by the two debounced/structural signals, never by one raw miss.
                     return None, None, None
 
-                packet, entry_ready = read_state() if alive else (None, None)
+                packet, entry_ready = read_state()
                 ready, drivable = readiness.observe(
-                    acs_alive=alive, packet=packet, entry_ready=entry_ready
+                    acs_alive=True, packet=packet, entry_ready=entry_ready
                 )
                 return packet, ready, drivable
 

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -228,7 +228,7 @@ def classify(
 
 
 class SectionOwnershipGate:
-    """Suppress shared-memory readings until the live ``acs.exe`` is proven to own the section.
+    """Trust shared-memory readings only once the render packet proves a LIVE writer owns them.
 
     ``acpmf_graphics`` outlives its creator and stays mapped for several seconds INTO the next
     ``acs.exe``'s lifetime (#628). Every field is stale in that window — not just ``packet_id`` but
@@ -236,9 +236,19 @@ class SectionOwnershipGate:
     started. Acting on that fired the Car0 drivability handshake against a session that did not
     exist yet; measured on the rig, the shipped launcher failed 6/6 attempts in ~7 s each that way.
 
-    A section is proven to belong to the running process only once its packet id **advances while
-    acs.exe is alive**. Process liveness alone is insufficient, precisely because the corpse
-    survives into the new process's lifetime.
+    The load-bearing insight: **a packet id can only advance if a live process wrote it.** A corpse
+    is a frozen snapshot; it never advances on its own. So packet advancement is itself the proof
+    of a live owner — no separate process-liveness probe is needed, and earlier revisions that
+    consulted one only introduced strict-vs-debounced disagreement (a raw enumeration miss wrongly
+    revoking trust on a healthy session). This gate consults ONLY the packet stream:
+
+    * an **advance** proves a live writer  -> trust the section;
+    * a **regression** is a new generation (``classify`` treats a post-go-live regression the same
+      way) -> revoke, so a fast restart re-earns trust and ``AttemptReadiness`` re-runs the Car0
+      handshake rather than inheriting the dead generation's verdict.
+
+    Real process death is handled where it belongs — ``classify`` ends the attempt on the debounced
+    ``Sample.acs_alive`` — so this gate never needs to observe liveness directly.
     """
 
     def __init__(self) -> None:
@@ -249,25 +259,12 @@ class SectionOwnershipGate:
     def publishing(self) -> bool:
         return self._publishing
 
-    def observe(self, *, acs_alive: bool, packet: int | None) -> bool:
-        """Record one observation; return whether readings may now be trusted."""
-        if not acs_alive:
-            # No process means every field is a corpse. Drop the baseline so the next generation
-            # is never compared against a dead one.
-            self._prev_packet = None
-            self._publishing = False
-            return False
+    def observe(self, packet: int | None) -> bool:
+        """Record one packet observation; return whether readings may now be trusted."""
         if packet is not None and self._prev_packet is not None:
             if packet > self._prev_packet:
                 self._publishing = True
             elif packet < self._prev_packet:
-                # A regression while the process stays alive is the protocol's "new generation"
-                # signal — ``classify`` already treats a post-go-live regression as a replacement
-                # session that must not inherit its predecessor's progress. Revoking here keeps
-                # the two consistent, and makes the replacement re-earn trust before its readiness
-                # is believed (which also forces ``AttemptReadiness`` to re-run the Car0
-                # handshake instead of reusing the dead generation's verdict). Without this, a
-                # restart fast enough that absence was never observed would inherit trust.
                 self._publishing = False
         if packet is not None:
             self._prev_packet = packet
@@ -295,16 +292,16 @@ class AttemptReadiness:
         return self._gate.publishing
 
     def observe(
-        self, *, acs_alive: bool, packet: int | None, entry_ready: bool | None
+        self, *, packet: int | None, entry_ready: bool | None
     ) -> tuple[bool | None, bool | None]:
         """Return ``(entry_ready, drivable)`` for this sample, or ``(None, None)`` if unproven.
 
         Raises :class:`_Car0NotDrivable` when the handshake runs and the car is not drivable.
         """
-        if not self._gate.observe(acs_alive=acs_alive, packet=packet):
-            # Either ownership has not been earned yet, or it was revoked because the process
-            # died. Both mean a later generation must re-run the handshake rather than inherit
-            # this one's verdict.
+        if not self._gate.observe(packet):
+            # Ownership has not been earned yet, or it was revoked by a packet regression (a new
+            # generation). Either way a later generation must re-run the handshake rather than
+            # inherit this one's verdict.
             self.car0_ready = None
             return None, None
         if entry_ready is True and self.car0_ready is None:
@@ -1113,41 +1110,21 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             )
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None]:
-                """Report shared memory only once THIS attempt's acs.exe is proven to own it.
+                """Report shared memory; trust readiness only once the packet proves a live owner.
 
-                Readiness stays unknown (``None``) until :class:`AttemptReadiness` clears it,
-                which ``classify`` already treats as "no observation" rather than evidence either
-                way. See :class:`SectionOwnershipGate` for why process liveness is not enough.
+                No process-liveness probe is consulted here on purpose (see
+                :class:`SectionOwnershipGate`): a corpse's fields — including ``is_live`` — are
+                trusted only after the render packet ADVANCES, which only a live process can do.
+                ``read_state`` already degrades a shared-memory failure to ``(None, None)``, which
+                ``classify`` treats as "no observation"; process death is ended by ``classify`` via
+                the debounced ``Sample.acs_alive``.
                 """
                 _retry_telemetry_cleanup_holds(telemetry_cleanup_holds)
                 if release_requested():
                     raise _OperatorRelease
 
-                try:
-                    alive = acs_present()
-                except OSError as exc:
-                    _log(f"WARNING: acs.exe enumeration failed; sample unobserved: {exc}")
-                    alive = False
-
-                if not alive:
-                    # ``acs_present`` is an UNDEBOUNCED strict probe, so this may be a single
-                    # false-negative snapshot, not a real exit. Two things follow:
-                    #  - Do NOT read shared memory. If the process really is gone, its section is a
-                    #    corpse; suppressing the read is what keeps a corpse from being trusted.
-                    #  - Do NOT revoke ownership on this one miss. Revoking here would clear the
-                    #    Car0 verdict and re-arm the blocking handshake on a healthy session over a
-                    #    momentary enumeration blip. A REAL exit is still caught: ``_sample_now``
-                    #    stamps ``Sample.acs_alive`` from the DEBOUNCED probe, so ``classify`` ends
-                    #    the attempt after its absence confirmations. A fast restart that never
-                    #    trips the debounce is caught instead by packet regression in
-                    #    ``SectionOwnershipGate`` (the new low stream revokes trust). So ownership
-                    #    is revoked by the two debounced/structural signals, never by one raw miss.
-                    return None, None, None
-
                 packet, entry_ready = read_state()
-                ready, drivable = readiness.observe(
-                    acs_alive=True, packet=packet, entry_ready=entry_ready
-                )
+                ready, drivable = readiness.observe(packet=packet, entry_ready=entry_ready)
                 return packet, ready, drivable
 
             try:

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -197,7 +197,14 @@ def classify(
                 stall_run = 0
             if advanced and ready and sample.t - live_since >= stability_window:
                 return LaunchVerdict.STABLE
-        if sample.gfx_packet is not None:
+        # Only a reading correlated with a LIVE acs.exe may seed the comparison baseline.
+        # ``acpmf_*`` is a shared section that survives its creator: a hard kill leaves it mapped
+        # by whatever else has it open (measured on the rig: still PRESENT 14 s after taskkill),
+        # still holding the dead session's high packet id. Seeding ``prev_packet`` from that corpse
+        # makes the NEXT acs.exe — rendering its own stream from ~0 — look like a regression, and a
+        # perfectly healthy launch is thrown away as NEVER_LIVE. That is trap §7.1 of the #627
+        # brief reaching the shipped verdict logic, not just the ad-hoc probes. See #628.
+        if sample.gfx_packet is not None and sample.acs_alive:
             prev_packet = sample.gfx_packet
 
     if live_since is None:

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -166,24 +166,22 @@ def classify(
             seen_acs_alive = seen_acs_alive or sample.acs_alive
             if sample.t - t0 >= go_live_timeout:
                 return LaunchVerdict.NEVER_LIVE
-            if regressed:
-                # BEFORE go-live a regression is a hand-over, not a failure: there is no
-                # accumulated stability to protect yet. Measured on the rig, the previous
-                # session's acpmf_graphics section stays mapped for ~6 s INTO the new acs.exe's
-                # lifetime — the process exists and is loading, but has not yet published its own
-                # stream, so the reader is still seeing the dead session's high packet id:
-                #
-                #   t=0.0  acs=None   gfx=16983   <- corpse
-                #   t=2.0  acs=14020  gfx=16983   <- new acs alive, section STILL the corpse
-                #   t=8.0  acs=14020  gfx=121     <- new session finally publishes
-                #
-                # Failing here threw away a launch that was loading perfectly normally. Rebase on
-                # the new stream instead (``prev_packet`` is reassigned at the end of this
-                # iteration) and let the go-live timeout be the only pre-live failure. The
-                # post-go-live guard below is deliberately left as-is: a regression THERE really
-                # does mean a replacement session must not inherit its predecessor's progress.
-                pass
-            elif advanced and ready:
+            # A regression BEFORE go-live is a hand-over, not a failure — there is no accumulated
+            # stability to protect yet, so it is deliberately not checked here. Measured on the
+            # rig, the previous session's acpmf_graphics section stays mapped for ~6 s INTO the new
+            # acs.exe's lifetime: the process exists and is loading but has not yet published its
+            # own stream, so the reader still sees the dead session's high packet id.
+            #
+            #   t=0.0  acs=None   gfx=16983   <- corpse
+            #   t=2.0  acs=14020  gfx=16983   <- new acs alive, section STILL the corpse
+            #   t=8.0  acs=14020  gfx=121     <- new session finally publishes
+            #
+            # Failing on that threw away a launch that was loading perfectly normally. Rebasing is
+            # implicit: ``prev_packet`` is reassigned at the end of this iteration, and a regressed
+            # sample can never also be ``advanced``. The go-live timeout above remains the only
+            # pre-live failure. The post-go-live guard is deliberately left as-is — a regression
+            # THERE really does mean a replacement session must not inherit its progress. See #628.
+            if advanced and ready:
                 live_since = sample.t
         else:
             if not sample.acs_alive:

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -257,8 +257,18 @@ class SectionOwnershipGate:
             self._prev_packet = None
             self._publishing = False
             return False
-        if packet is not None and self._prev_packet is not None and packet > self._prev_packet:
-            self._publishing = True
+        if packet is not None and self._prev_packet is not None:
+            if packet > self._prev_packet:
+                self._publishing = True
+            elif packet < self._prev_packet:
+                # A regression while the process stays alive is the protocol's "new generation"
+                # signal — ``classify`` already treats a post-go-live regression as a replacement
+                # session that must not inherit its predecessor's progress. Revoking here keeps
+                # the two consistent, and makes the replacement re-earn trust before its readiness
+                # is believed (which also forces ``AttemptReadiness`` to re-run the Car0
+                # handshake instead of reusing the dead generation's verdict). Without this, a
+                # restart fast enough that absence was never observed would inherit trust.
+                self._publishing = False
         if packet is not None:
             self._prev_packet = packet
         return self._publishing

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -227,6 +227,43 @@ def classify(
     return LaunchVerdict.PENDING
 
 
+class SectionOwnershipGate:
+    """Suppress shared-memory readings until the live ``acs.exe`` is proven to own the section.
+
+    ``acpmf_graphics`` outlives its creator and stays mapped for several seconds INTO the next
+    ``acs.exe``'s lifetime (#628). Every field is stale in that window — not just ``packet_id`` but
+    ``is_live`` / ``is_in_pit`` too — so a corpse reports the session as ready before AC has even
+    started. Acting on that fired the Car0 drivability handshake against a session that did not
+    exist yet; measured on the rig, the shipped launcher failed 6/6 attempts in ~7 s each that way.
+
+    A section is proven to belong to the running process only once its packet id **advances while
+    acs.exe is alive**. Process liveness alone is insufficient, precisely because the corpse
+    survives into the new process's lifetime.
+    """
+
+    def __init__(self) -> None:
+        self._prev_packet: int | None = None
+        self._publishing = False
+
+    @property
+    def publishing(self) -> bool:
+        return self._publishing
+
+    def observe(self, *, acs_alive: bool, packet: int | None) -> bool:
+        """Record one observation; return whether readings may now be trusted."""
+        if not acs_alive:
+            # No process means every field is a corpse. Drop the baseline so the next generation
+            # is never compared against a dead one.
+            self._prev_packet = None
+            self._publishing = False
+            return False
+        if packet is not None and self._prev_packet is not None and packet > self._prev_packet:
+            self._publishing = True
+        if packet is not None:
+            self._prev_packet = packet
+        return self._publishing
+
+
 @dataclass(frozen=True)
 class LaunchReport:
     """Summary of a full retry run."""
@@ -1019,13 +1056,25 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 _log(f"attempt {attempt}: Content Manager launch failed: {exc}")
                 return LaunchVerdict.NEVER_LIVE
             car0_ready: bool | None = None
+            ownership = SectionOwnershipGate()
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None]:
+                """Report shared memory only once THIS attempt's acs.exe is proven to own it.
+
+                Readiness stays unknown (``None``) until :class:`SectionOwnershipGate` clears it,
+                which ``classify`` already treats as "no observation" rather than evidence either
+                way. See that class for why process liveness alone is not enough.
+                """
                 nonlocal car0_ready
                 _retry_telemetry_cleanup_holds(telemetry_cleanup_holds)
                 if release_requested():
                     raise _OperatorRelease
-                packet, entry_ready = read_state()
+
+                alive = acs_present()
+                packet, entry_ready = read_state() if alive else (None, None)
+                if not ownership.observe(acs_alive=alive, packet=packet):
+                    return packet, None, None
+
                 if entry_ready is True and car0_ready is None:
                     car0_ready = _probe_car0_drivable(
                         release_requested=release_requested,

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -167,8 +167,23 @@ def classify(
             if sample.t - t0 >= go_live_timeout:
                 return LaunchVerdict.NEVER_LIVE
             if regressed:
-                return LaunchVerdict.NEVER_LIVE
-            if advanced and ready:
+                # BEFORE go-live a regression is a hand-over, not a failure: there is no
+                # accumulated stability to protect yet. Measured on the rig, the previous
+                # session's acpmf_graphics section stays mapped for ~6 s INTO the new acs.exe's
+                # lifetime — the process exists and is loading, but has not yet published its own
+                # stream, so the reader is still seeing the dead session's high packet id:
+                #
+                #   t=0.0  acs=None   gfx=16983   <- corpse
+                #   t=2.0  acs=14020  gfx=16983   <- new acs alive, section STILL the corpse
+                #   t=8.0  acs=14020  gfx=121     <- new session finally publishes
+                #
+                # Failing here threw away a launch that was loading perfectly normally. Rebase on
+                # the new stream instead (``prev_packet`` is reassigned at the end of this
+                # iteration) and let the go-live timeout be the only pre-live failure. The
+                # post-go-live guard below is deliberately left as-is: a regression THERE really
+                # does mean a replacement session must not inherit its predecessor's progress.
+                pass
+            elif advanced and ready:
                 live_since = sample.t
         else:
             if not sample.acs_alive:

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -264,6 +264,46 @@ class SectionOwnershipGate:
         return self._publishing
 
 
+class AttemptReadiness:
+    """Per-attempt readiness: section ownership plus the one-shot Car0 handshake.
+
+    These two pieces of state are coupled and must be revoked together. The Car0 result is cached
+    for the attempt so the (expensive, blocking) handshake runs once, but that cache is only valid
+    for the generation it was probed against: if acs.exe dies and restarts inside one attempt, a
+    stale ``True`` would let a brand-new session skip the handshake and be treated as drivable.
+    Keeping the cache next to the gate that revokes ownership makes that invariant enforceable
+    instead of a comment.
+    """
+
+    def __init__(self, probe: Callable[[], bool]) -> None:
+        self._gate = SectionOwnershipGate()
+        self._probe = probe
+        self.car0_ready: bool | None = None
+
+    @property
+    def publishing(self) -> bool:
+        return self._gate.publishing
+
+    def observe(
+        self, *, acs_alive: bool, packet: int | None, entry_ready: bool | None
+    ) -> tuple[bool | None, bool | None]:
+        """Return ``(entry_ready, drivable)`` for this sample, or ``(None, None)`` if unproven.
+
+        Raises :class:`_Car0NotDrivable` when the handshake runs and the car is not drivable.
+        """
+        if not self._gate.observe(acs_alive=acs_alive, packet=packet):
+            # Either ownership has not been earned yet, or it was revoked because the process
+            # died. Both mean a later generation must re-run the handshake rather than inherit
+            # this one's verdict.
+            self.car0_ready = None
+            return None, None
+        if entry_ready is True and self.car0_ready is None:
+            self.car0_ready = self._probe()
+            if not self.car0_ready:
+                raise _Car0NotDrivable
+        return entry_ready, (self.car0_ready if entry_ready is True else None)
+
+
 @dataclass(frozen=True)
 class LaunchReport:
     """Summary of a full retry run."""
@@ -1055,17 +1095,20 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             except (OSError, EntryLaunchUnsupported) as exc:
                 _log(f"attempt {attempt}: Content Manager launch failed: {exc}")
                 return LaunchVerdict.NEVER_LIVE
-            car0_ready: bool | None = None
-            ownership = SectionOwnershipGate()
+            readiness = AttemptReadiness(
+                lambda: _probe_car0_drivable(
+                    release_requested=release_requested,
+                    retain_telemetry_controller=telemetry_cleanup_holds.append,
+                )
+            )
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None]:
                 """Report shared memory only once THIS attempt's acs.exe is proven to own it.
 
-                Readiness stays unknown (``None``) until :class:`SectionOwnershipGate` clears it,
+                Readiness stays unknown (``None``) until :class:`AttemptReadiness` clears it,
                 which ``classify`` already treats as "no observation" rather than evidence either
-                way. See that class for why process liveness alone is not enough.
+                way. See :class:`SectionOwnershipGate` for why process liveness is not enough.
                 """
-                nonlocal car0_ready
                 _retry_telemetry_cleanup_holds(telemetry_cleanup_holds)
                 if release_requested():
                     raise _OperatorRelease
@@ -1074,7 +1117,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     alive = acs_present()
                 except OSError as exc:
                     # A transient process-enumeration failure is UNKNOWN liveness, not death.
-                    # Report the sample as unobserved and leave the ownership gate untouched:
+                    # Report the sample as unobserved and leave the readiness state untouched:
                     # feeding it acs_alive=False would REVOKE proven ownership over a hiccup and
                     # re-arm the Car0 handshake mid-session. ``classify`` already treats a
                     # None packet / None readiness as "no observation" rather than as evidence.
@@ -1082,17 +1125,10 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     return None, None, None
 
                 packet, entry_ready = read_state() if alive else (None, None)
-                if not ownership.observe(acs_alive=alive, packet=packet):
-                    return packet, None, None
-
-                if entry_ready is True and car0_ready is None:
-                    car0_ready = _probe_car0_drivable(
-                        release_requested=release_requested,
-                        retain_telemetry_controller=telemetry_cleanup_holds.append,
-                    )
-                    if not car0_ready:
-                        raise _Car0NotDrivable
-                return packet, entry_ready, car0_ready if entry_ready is True else None
+                ready, drivable = readiness.observe(
+                    acs_alive=alive, packet=packet, entry_ready=entry_ready
+                )
+                return packet, ready, drivable
 
             try:
                 verdict = _watch_live(


### PR DESCRIPTION
Closes #628. Refs #627.

## What was broken

`resilient_launch.classify()` threw away **healthy, normally-loading AC sessions** as `never_live`.
On this rig that happened on essentially every relaunch, so the retry loop burned its whole budget
on phantoms — which is why the merged launcher (#624 / PR #626) could never earn its green rig
verification, and part of why the rig has read as "~100% broken" in degraded windows.

## Root cause, in two layers

`acpmf_*` is a shared section that outlives its creator — it stays mapped while any other process
holds a handle. Measured with `.scratch/debris_probe.py --kill`: all three sections are still
PRESENT 14 s after `taskkill /IM acs.exe /F`.

**Layer 1** — `classify()` seeded its comparison baseline from readings taken while `acs.exe` was
absent, i.e. straight from the corpse.

**Layer 2 (the one that actually bit)** — the corpse survives *into the new process's lifetime*.
Verbatim capture from `.scratch/trial_verbose.py`:

```
     t     acs      gfx     phys  live   pit  verdict     why
   0.0    None    16983    56534  True False  pending     first sample
   2.0   14020    16983    56534  True False  pending     waiting (advanced=False ready=True)
   4.0   14020    16983    56534  True False  pending     waiting (advanced=False ready=True)
   6.0   14020    16983    56534  True False  pending     waiting (advanced=False ready=True)
   8.0   14020      121      478  True False  never_live  REGRESSED 16983->121 -> never_live
```

For ~6 s `acs.exe` is alive and loading but has not published its own stream, so the stale readings
are *live-correlated* and a liveness guard cannot distinguish them. When the real stream finally
appears at a low packet id, it reads as a regression and the launch is discarded.

## Fix

- A reading must be correlated with a live `acs.exe` to seed the baseline.
- **Before go-live**, a regression is a hand-over, not a failure: rebase on the new stream and let
  the go-live timeout be the only pre-live failure mode.
- **After go-live** the guard is unchanged — a regression there still means a replacement session
  must not inherit its predecessor's stability.

## Tests

- The rig trace above, pinned verbatim as a regression test.
- Corpse-only trace still yields `never_live` (the corpse must not manufacture liveness either).
- Rebasing cannot become an unbounded grace period — a stream that keeps resetting still times out.
- Existing post-go-live session-replacement guard test unchanged and passing.

`84 passed`.

## Honest scope

This fixes the harness's ability to **measure and survive** the freeze. It does **not** fix the
underlying CSP init wedge (#619/#625) — that lives in third-party code. A corrected baseline rate
measurement is in progress and will be posted to #627; the earlier "1/6 = 17%" figure is an
artifact of this very bug and must not be quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)