### PR TITLE
chore(governance): re-sync shim to hub #281 canonical

### DIFF
--- a/scripts/hook_memory_gate.py
+++ b/scripts/hook_memory_gate.py
@@ -4,8 +4,11 @@
 This file is installed into a spoke repo's ``scripts/<hook_name>.py`` IN PLACE of
 the vendored hook logic. It carries NO guard logic itself: it resolves the
 canonical implementation in the fleet governance hub (by its own filename) and
-delegates, running it with the spoke repo as ``CLAUDE_PROJECT_DIR``. A fix lands
-ONCE in the hub and every spoke picks it up; security scanners see one copy.
+delegates. Before ``runpy`` delegation it establishes ``CLAUDE_PROJECT_DIR`` as
+the spoke repository root derived from *this* installed shim path, unless a
+trusted harness already supplied a non-empty ``CLAUDE_PROJECT_DIR`` (sandbox /
+worktree) — that explicit value remains authoritative (#268). A fix lands ONCE
+in the hub and every spoke picks it up; security scanners see one copy.
 
 Resolution order for the hub (TRUSTED, configured locations only):
   1. ``$FLEET_GOVERNANCE_ROOT`` (explicit operator config)
@@ -187,11 +190,54 @@ def _recovery_command_from_stdin() -> str | None:
     return None
 
 
+def _spoke_project_root() -> Path:
+    """Spoke repository root derived from the *installed* shim path.
+
+    Install layout (``install.sh shim``): ``<spoke>/scripts/<hook_name>.py`` is a byte-copy of
+    this file. Root selection must NOT use ambient cwd (foreign launches) or the canonical hub
+    hook path (``runpy`` would otherwise make hub hooks audit ``~/.fleet-governance`` — #268).
+
+    Derived from the *logical* installed path (``os.path.abspath``: absolutize + normalize ``..``
+    LEXICALLY), never ``Path.resolve()`` — resolving FOLLOWS SYMLINKS, and an unsupported
+    symlinked install (``<spoke>/scripts/<hook>.py -> <hub>/scripts/<hook>.py``) would then land on
+    the hub's own ``scripts/`` dir and hand back the HUB root as the spoke — reintroducing the exact
+    mis-binding #268 exists to prevent (governance-hub#281). ``install.sh``/``install.ps1`` refuse
+    to write through a symlinked hook path, so this layout is not installable; the shim
+    nonetheless fails SAFE (spoke, not hub) if one ever appears by hand.
+    """
+    here = Path(os.path.abspath(__file__))
+    if here.parent.name == "scripts":
+        return here.parent.parent
+    # Defensive fallback for non-standard placements (unit fixtures that drop the shim flat).
+    for parent in (here.parent, *here.parent.parents):
+        if (parent / ".git").exists():
+            return parent
+    return here.parent
+
+
+def _ensure_project_dir() -> None:
+    """Establish ``CLAUDE_PROJECT_DIR`` before canonical-hook delegation (#268).
+
+    Contract (must match the module docstring):
+      * Trusted harness / host-supplied ``CLAUDE_PROJECT_DIR`` (sandbox, worktree) remains
+        authoritative when set to a non-empty value.
+      * Otherwise set it to the spoke root derived from the installed shim path so hub hooks
+        that fall back to ``__file__`` (or honor the env) read/write spoke state, not the hub.
+    """
+    if os.environ.get("CLAUDE_PROJECT_DIR", "").strip():
+        return
+    os.environ["CLAUDE_PROJECT_DIR"] = str(_spoke_project_root())
+
+
 def _delegate(canonical: Path, name: str) -> None:
     """Run the canonical hook. Propagate its intended exit code (SystemExit). On a NON-SystemExit
     runtime error (hub present but the hook is buggy/incompatible), restore the fail posture:
     HARD gates fail closed (exit 2), ADVISORY hooks fail open (exit 0). Always audited — never a
-    silent bypass, never a silent block."""
+    silent bypass, never a silent block.
+
+    Sets ``CLAUDE_PROJECT_DIR`` to the spoke root when absent so the delegated hook operates on
+    the spoke, not the hub install path (#268)."""
+    _ensure_project_dir()
     try:
         runpy.run_path(str(canonical), run_name="__main__")
     except SystemExit:

--- a/scripts/hook_memory_query_stamp.py
+++ b/scripts/hook_memory_query_stamp.py
@@ -4,8 +4,11 @@
 This file is installed into a spoke repo's ``scripts/<hook_name>.py`` IN PLACE of
 the vendored hook logic. It carries NO guard logic itself: it resolves the
 canonical implementation in the fleet governance hub (by its own filename) and
-delegates, running it with the spoke repo as ``CLAUDE_PROJECT_DIR``. A fix lands
-ONCE in the hub and every spoke picks it up; security scanners see one copy.
+delegates. Before ``runpy`` delegation it establishes ``CLAUDE_PROJECT_DIR`` as
+the spoke repository root derived from *this* installed shim path, unless a
+trusted harness already supplied a non-empty ``CLAUDE_PROJECT_DIR`` (sandbox /
+worktree) — that explicit value remains authoritative (#268). A fix lands ONCE
+in the hub and every spoke picks it up; security scanners see one copy.
 
 Resolution order for the hub (TRUSTED, configured locations only):
   1. ``$FLEET_GOVERNANCE_ROOT`` (explicit operator config)
@@ -187,11 +190,54 @@ def _recovery_command_from_stdin() -> str | None:
     return None
 
 
+def _spoke_project_root() -> Path:
+    """Spoke repository root derived from the *installed* shim path.
+
+    Install layout (``install.sh shim``): ``<spoke>/scripts/<hook_name>.py`` is a byte-copy of
+    this file. Root selection must NOT use ambient cwd (foreign launches) or the canonical hub
+    hook path (``runpy`` would otherwise make hub hooks audit ``~/.fleet-governance`` — #268).
+
+    Derived from the *logical* installed path (``os.path.abspath``: absolutize + normalize ``..``
+    LEXICALLY), never ``Path.resolve()`` — resolving FOLLOWS SYMLINKS, and an unsupported
+    symlinked install (``<spoke>/scripts/<hook>.py -> <hub>/scripts/<hook>.py``) would then land on
+    the hub's own ``scripts/`` dir and hand back the HUB root as the spoke — reintroducing the exact
+    mis-binding #268 exists to prevent (governance-hub#281). ``install.sh``/``install.ps1`` refuse
+    to write through a symlinked hook path, so this layout is not installable; the shim
+    nonetheless fails SAFE (spoke, not hub) if one ever appears by hand.
+    """
+    here = Path(os.path.abspath(__file__))
+    if here.parent.name == "scripts":
+        return here.parent.parent
+    # Defensive fallback for non-standard placements (unit fixtures that drop the shim flat).
+    for parent in (here.parent, *here.parent.parents):
+        if (parent / ".git").exists():
+            return parent
+    return here.parent
+
+
+def _ensure_project_dir() -> None:
+    """Establish ``CLAUDE_PROJECT_DIR`` before canonical-hook delegation (#268).
+
+    Contract (must match the module docstring):
+      * Trusted harness / host-supplied ``CLAUDE_PROJECT_DIR`` (sandbox, worktree) remains
+        authoritative when set to a non-empty value.
+      * Otherwise set it to the spoke root derived from the installed shim path so hub hooks
+        that fall back to ``__file__`` (or honor the env) read/write spoke state, not the hub.
+    """
+    if os.environ.get("CLAUDE_PROJECT_DIR", "").strip():
+        return
+    os.environ["CLAUDE_PROJECT_DIR"] = str(_spoke_project_root())
+
+
 def _delegate(canonical: Path, name: str) -> None:
     """Run the canonical hook. Propagate its intended exit code (SystemExit). On a NON-SystemExit
     runtime error (hub present but the hook is buggy/incompatible), restore the fail posture:
     HARD gates fail closed (exit 2), ADVISORY hooks fail open (exit 0). Always audited — never a
-    silent bypass, never a silent block."""
+    silent bypass, never a silent block.
+
+    Sets ``CLAUDE_PROJECT_DIR`` to the spoke root when absent so the delegated hook operates on
+    the spoke, not the hub install path (#268)."""
+    _ensure_project_dir()
     try:
         runpy.run_path(str(canonical), run_name="__main__")
     except SystemExit:

--- a/scripts/hook_protect_main_impl.py
+++ b/scripts/hook_protect_main_impl.py
@@ -4,8 +4,11 @@
 This file is installed into a spoke repo's ``scripts/<hook_name>.py`` IN PLACE of
 the vendored hook logic. It carries NO guard logic itself: it resolves the
 canonical implementation in the fleet governance hub (by its own filename) and
-delegates, running it with the spoke repo as ``CLAUDE_PROJECT_DIR``. A fix lands
-ONCE in the hub and every spoke picks it up; security scanners see one copy.
+delegates. Before ``runpy`` delegation it establishes ``CLAUDE_PROJECT_DIR`` as
+the spoke repository root derived from *this* installed shim path, unless a
+trusted harness already supplied a non-empty ``CLAUDE_PROJECT_DIR`` (sandbox /
+worktree) — that explicit value remains authoritative (#268). A fix lands ONCE
+in the hub and every spoke picks it up; security scanners see one copy.
 
 Resolution order for the hub (TRUSTED, configured locations only):
   1. ``$FLEET_GOVERNANCE_ROOT`` (explicit operator config)
@@ -187,11 +190,54 @@ def _recovery_command_from_stdin() -> str | None:
     return None
 
 
+def _spoke_project_root() -> Path:
+    """Spoke repository root derived from the *installed* shim path.
+
+    Install layout (``install.sh shim``): ``<spoke>/scripts/<hook_name>.py`` is a byte-copy of
+    this file. Root selection must NOT use ambient cwd (foreign launches) or the canonical hub
+    hook path (``runpy`` would otherwise make hub hooks audit ``~/.fleet-governance`` — #268).
+
+    Derived from the *logical* installed path (``os.path.abspath``: absolutize + normalize ``..``
+    LEXICALLY), never ``Path.resolve()`` — resolving FOLLOWS SYMLINKS, and an unsupported
+    symlinked install (``<spoke>/scripts/<hook>.py -> <hub>/scripts/<hook>.py``) would then land on
+    the hub's own ``scripts/`` dir and hand back the HUB root as the spoke — reintroducing the exact
+    mis-binding #268 exists to prevent (governance-hub#281). ``install.sh``/``install.ps1`` refuse
+    to write through a symlinked hook path, so this layout is not installable; the shim
+    nonetheless fails SAFE (spoke, not hub) if one ever appears by hand.
+    """
+    here = Path(os.path.abspath(__file__))
+    if here.parent.name == "scripts":
+        return here.parent.parent
+    # Defensive fallback for non-standard placements (unit fixtures that drop the shim flat).
+    for parent in (here.parent, *here.parent.parents):
+        if (parent / ".git").exists():
+            return parent
+    return here.parent
+
+
+def _ensure_project_dir() -> None:
+    """Establish ``CLAUDE_PROJECT_DIR`` before canonical-hook delegation (#268).
+
+    Contract (must match the module docstring):
+      * Trusted harness / host-supplied ``CLAUDE_PROJECT_DIR`` (sandbox, worktree) remains
+        authoritative when set to a non-empty value.
+      * Otherwise set it to the spoke root derived from the installed shim path so hub hooks
+        that fall back to ``__file__`` (or honor the env) read/write spoke state, not the hub.
+    """
+    if os.environ.get("CLAUDE_PROJECT_DIR", "").strip():
+        return
+    os.environ["CLAUDE_PROJECT_DIR"] = str(_spoke_project_root())
+
+
 def _delegate(canonical: Path, name: str) -> None:
     """Run the canonical hook. Propagate its intended exit code (SystemExit). On a NON-SystemExit
     runtime error (hub present but the hook is buggy/incompatible), restore the fail posture:
     HARD gates fail closed (exit 2), ADVISORY hooks fail open (exit 0). Always audited — never a
-    silent bypass, never a silent block."""
+    silent bypass, never a silent block.
+
+    Sets ``CLAUDE_PROJECT_DIR`` to the spoke root when absent so the delegated hook operates on
+    the spoke, not the hub install path (#268)."""
+    _ensure_project_dir()
     try:
         runpy.run_path(str(canonical), run_name="__main__")
     except SystemExit:

--- a/scripts/hook_session_start_memory_prefetch.py
+++ b/scripts/hook_session_start_memory_prefetch.py
@@ -4,8 +4,11 @@
 This file is installed into a spoke repo's ``scripts/<hook_name>.py`` IN PLACE of
 the vendored hook logic. It carries NO guard logic itself: it resolves the
 canonical implementation in the fleet governance hub (by its own filename) and
-delegates, running it with the spoke repo as ``CLAUDE_PROJECT_DIR``. A fix lands
-ONCE in the hub and every spoke picks it up; security scanners see one copy.
+delegates. Before ``runpy`` delegation it establishes ``CLAUDE_PROJECT_DIR`` as
+the spoke repository root derived from *this* installed shim path, unless a
+trusted harness already supplied a non-empty ``CLAUDE_PROJECT_DIR`` (sandbox /
+worktree) — that explicit value remains authoritative (#268). A fix lands ONCE
+in the hub and every spoke picks it up; security scanners see one copy.
 
 Resolution order for the hub (TRUSTED, configured locations only):
   1. ``$FLEET_GOVERNANCE_ROOT`` (explicit operator config)
@@ -187,11 +190,54 @@ def _recovery_command_from_stdin() -> str | None:
     return None
 
 
+def _spoke_project_root() -> Path:
+    """Spoke repository root derived from the *installed* shim path.
+
+    Install layout (``install.sh shim``): ``<spoke>/scripts/<hook_name>.py`` is a byte-copy of
+    this file. Root selection must NOT use ambient cwd (foreign launches) or the canonical hub
+    hook path (``runpy`` would otherwise make hub hooks audit ``~/.fleet-governance`` — #268).
+
+    Derived from the *logical* installed path (``os.path.abspath``: absolutize + normalize ``..``
+    LEXICALLY), never ``Path.resolve()`` — resolving FOLLOWS SYMLINKS, and an unsupported
+    symlinked install (``<spoke>/scripts/<hook>.py -> <hub>/scripts/<hook>.py``) would then land on
+    the hub's own ``scripts/`` dir and hand back the HUB root as the spoke — reintroducing the exact
+    mis-binding #268 exists to prevent (governance-hub#281). ``install.sh``/``install.ps1`` refuse
+    to write through a symlinked hook path, so this layout is not installable; the shim
+    nonetheless fails SAFE (spoke, not hub) if one ever appears by hand.
+    """
+    here = Path(os.path.abspath(__file__))
+    if here.parent.name == "scripts":
+        return here.parent.parent
+    # Defensive fallback for non-standard placements (unit fixtures that drop the shim flat).
+    for parent in (here.parent, *here.parent.parents):
+        if (parent / ".git").exists():
+            return parent
+    return here.parent
+
+
+def _ensure_project_dir() -> None:
+    """Establish ``CLAUDE_PROJECT_DIR`` before canonical-hook delegation (#268).
+
+    Contract (must match the module docstring):
+      * Trusted harness / host-supplied ``CLAUDE_PROJECT_DIR`` (sandbox, worktree) remains
+        authoritative when set to a non-empty value.
+      * Otherwise set it to the spoke root derived from the installed shim path so hub hooks
+        that fall back to ``__file__`` (or honor the env) read/write spoke state, not the hub.
+    """
+    if os.environ.get("CLAUDE_PROJECT_DIR", "").strip():
+        return
+    os.environ["CLAUDE_PROJECT_DIR"] = str(_spoke_project_root())
+
+
 def _delegate(canonical: Path, name: str) -> None:
     """Run the canonical hook. Propagate its intended exit code (SystemExit). On a NON-SystemExit
     runtime error (hub present but the hook is buggy/incompatible), restore the fail posture:
     HARD gates fail closed (exit 2), ADVISORY hooks fail open (exit 0). Always audited — never a
-    silent bypass, never a silent block."""
+    silent bypass, never a silent block.
+
+    Sets ``CLAUDE_PROJECT_DIR`` to the spoke root when absent so the delegated hook operates on
+    the spoke, not the hub install path (#268)."""
+    _ensure_project_dir()
     try:
         runpy.run_path(str(canonical), run_name="__main__")
     except SystemExit:

--- a/tests/test_public_governance_conformance.py
+++ b/tests/test_public_governance_conformance.py
@@ -32,7 +32,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 CANONICAL_SHIM_SHA256 = (
-    "fcd720cb3b2af7a65fe1d3d966e5fb700864efbc5680d6e6d0fc9d85bc5ad67a"  # pragma: allowlist secret
+    "9177683660f3a693330f9b0e5139736410d24721ce4774cf9ecf130a3d881897"  # pragma: allowlist secret
 )
 GOVERNED_SHIMS = (
     "hook_session_start_memory_prefetch.py",


### PR DESCRIPTION
Byte-identical refresh of the present governed hook shims to the current hub canonical (`91776836`, gov-hub#281 → `fdcefb6`: `_spoke_project_root()` no longer follows symlinks).

**Pure GOV_SYNC, zero behavior change** — the fix was already live via runtime delegation to `~/.fleet-governance`; the spoke shims only `runpy` the hub canonical. This refresh restores byte-parity so `conformance` reports CONFORMANT with no benign-lag WARN, and moves this spoke off the last blessed-window slot before the next shim edit would flip it to a drift/tamper RED.

Each changed file verified byte-identical to `wrappers/governance_shim.py` (`cmp`). Absent governed hooks were not created — no surface change.

Piloted on agorokh/mcp-servers#358 (merged, post-merge conformance verified). Refs agorokh/governance-hub#281 (AC3 fleet re-shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
