### PR TITLE
fix(rig): read pause from physics-packet stagnation, not AC status (#630 Part B)

### DIFF
--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -164,6 +164,80 @@ def test_sustained_not_ready_state_fails_the_attempt():
     )
 
 
+def steady_phys(
+    start_t: float, end_t: float, *, first_packet: int, first_phys: int, step: float = 1.0
+) -> list[Sample]:
+    """A healthy render trace where BOTH the graphics and physics packets advance."""
+    out: list[Sample] = []
+    packet, phys, t = first_packet, first_phys, start_t
+    while t <= end_t:
+        out.append(Sample(t=t, gfx_packet=packet, acs_alive=True, phys_packet=phys))
+        packet += 60
+        phys += 40
+        t += step
+    return out
+
+
+def test_pause_via_physics_stagnation_is_not_a_freeze():
+    """#630 Part B — a pause is read from PHYSICS stagnation, not status (which AC leaves LIVE).
+
+    An alt-tab pins the graphics packet AND stops physics; that must not FROZE + taskkill a healthy
+    session. A real wedge (physics still advancing) is unaffected — see the next test.
+    """
+    samples = steady_phys(0.0, 10.0, first_packet=100, first_phys=5000)
+    # 12 s paused: gfx pinned, physics pinned (status may still read LIVE, entry_ready False).
+    samples += [
+        Sample(t=11.0 + i, gfx_packet=760, acs_alive=True, entry_ready=False, phys_packet=5480)
+        for i in range(12)
+    ]
+    # ...then the operator resumes and both streams advance, completing the window.
+    samples += steady_phys(24.0, 90.0, first_packet=820, first_phys=5520)
+
+    assert (
+        classify(samples, go_live_timeout=30.0, stability_window=45.0, stall_samples=4)
+        is LaunchVerdict.STABLE
+    )
+
+
+def test_render_wedge_with_physics_still_advancing_is_froze():
+    """The pause carve-out must not weaken real freeze detection: gfx pinned + phys ADVANCING."""
+    samples = steady_phys(0.0, 10.0, first_packet=100, first_phys=5000)
+    held = samples[-1].gfx_packet
+    phys = samples[-1].phys_packet
+    # The #627 §2 signature: graphics packet pinned while physics keeps advancing.
+    samples += [
+        Sample(t=11.0 + i, gfx_packet=held, acs_alive=True, phys_packet=phys + 40 * (i + 1))
+        for i in range(5)
+    ]
+
+    assert (
+        classify(samples, go_live_timeout=30.0, stability_window=45.0, stall_samples=4)
+        is LaunchVerdict.FROZE
+    )
+
+
+def test_pause_suspends_the_stability_clock():
+    """#630 Part B — paused seconds are not credited toward the window.
+
+    Without suspension, a session that goes live, pauses for longer than the window, then emits one
+    resumed frame would satisfy ``t - live_since >= window`` immediately and hand off without a real
+    post-resume render window — letting the delayed init wedge land after handoff.
+    """
+    samples = steady_phys(0.0, 10.0, first_packet=100, first_phys=5000)
+    # Paused (physics pinned) from t=11 to t=70 — 60 s, well past the 45 s window.
+    samples += [
+        Sample(t=11.0 + i, gfx_packet=760, acs_alive=True, entry_ready=False, phys_packet=5480)
+        for i in range(60)
+    ]
+    # One resumed live frame: the window must NOT be satisfied yet (paused time excluded).
+    samples.append(Sample(t=71.0, gfx_packet=820, acs_alive=True, phys_packet=5520))
+
+    assert (
+        classify(samples, go_live_timeout=30.0, stability_window=45.0, stall_samples=4)
+        is LaunchVerdict.PENDING
+    )
+
+
 def test_unfinished_live_trace_is_pending_not_a_terminal_failure():
     samples = steady(0.0, 20.0, first_packet=100)
     assert classify(samples, go_live_timeout=10.0, stability_window=60.0) is LaunchVerdict.PENDING

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -264,6 +264,34 @@ def test_pause_beyond_budget_falls_back_to_stall_detection():
     )
 
 
+def test_stable_requires_physics_advancing_past_pause_budget():
+    """#637 daemon HIGH — STABLE must never land while physics is still pinned.
+
+    AC can keep the graphics stream animating through a pause/menu; if readiness stays true and
+    the pause outlasts ``pause_budget``, the pre-fix code fell through to the ordinary STABLE
+    predicate and handed off a session whose physics never resumed (the delayed-init handoff
+    #630 Part B exists to prevent). Physics-pinned seconds are never credited and STABLE
+    requires physics advancing, so this trace stays PENDING.
+    """
+    samples = steady_phys(0.0, 10.0, first_packet=100, first_phys=5000)
+    # Past the 5 s budget: graphics keeps ANIMATING, physics pinned, still READY.
+    samples += [
+        Sample(t=11.0 + i, gfx_packet=760 + 60 * i, acs_alive=True, phys_packet=5480)
+        for i in range(20)
+    ]
+
+    assert (
+        classify(
+            samples,
+            go_live_timeout=30.0,
+            stability_window=12.0,
+            stall_samples=4,
+            pause_budget=5.0,
+        )
+        is LaunchVerdict.PENDING
+    )
+
+
 def test_streaming_watch_extends_deadline_through_pause(monkeypatch):
     """#637 Codex P1 + daemon HIGH: a pause longer than the spare 30 s must not FROZE at the
     fixed wall-clock deadline — the watcher stretches its budget by the pause hold classify

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -238,6 +238,106 @@ def test_pause_suspends_the_stability_clock():
     )
 
 
+def test_pause_beyond_budget_falls_back_to_stall_detection():
+    """The pause hold is bounded (#637 daemon MEDIUM).
+
+    A hang that pins BOTH streams while acs.exe stays enumerated is indistinguishable from an
+    alt-tab at any single instant, so past ``pause_budget`` the hold expires and the ordinary
+    stall/not-ready paths must still FROZE the attempt.
+    """
+    samples = steady_phys(0.0, 10.0, first_packet=100, first_phys=5000)
+    # 30 s of dual stagnation against a 10 s pause budget: the hold must expire mid-trace.
+    samples += [
+        Sample(t=11.0 + i, gfx_packet=760, acs_alive=True, entry_ready=False, phys_packet=5480)
+        for i in range(30)
+    ]
+
+    assert (
+        classify(
+            samples,
+            go_live_timeout=30.0,
+            stability_window=45.0,
+            stall_samples=4,
+            pause_budget=10.0,
+        )
+        is LaunchVerdict.FROZE
+    )
+
+
+def test_streaming_watch_extends_deadline_through_pause(monkeypatch):
+    """#637 Codex P1 + daemon HIGH: a pause longer than the spare 30 s must not FROZE at the
+    fixed wall-clock deadline — the watcher stretches its budget by the pause hold classify
+    reports, so a healthy paused session survives to STABLE after the operator resumes."""
+    now = 0.0
+    tick = 0
+
+    def monotonic() -> float:
+        return now
+
+    def sleep(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
+    def read_state() -> tuple[int, bool, bool, int]:
+        nonlocal tick
+        tick += 1
+        if tick <= 5:
+            return 100 + tick, True, True, 5000 + tick  # live, both streams advancing
+        if tick <= 45:
+            return 105, False, True, 5005  # 40 s paused: graphics AND physics pinned
+        return 105 + (tick - 45), True, True, 5005 + (tick - 45)  # resumed
+
+    monkeypatch.setattr("tools.ac_harness.resilient_launch.time.monotonic", monotonic)
+    monkeypatch.setattr("tools.ac_harness.resilient_launch.time.sleep", sleep)
+    # Budget is 2 + 5 + 30 = 37 s; the 40 s pause outlives it, so without the pause-aware
+    # deadline this returns FROZE while the operator is simply alt-tabbed.
+    assert (
+        _watch_live(
+            read_state,
+            lambda: True,
+            go_live_timeout=2.0,
+            stability_window=5.0,
+            poll_interval=1.0,
+        )
+        is LaunchVerdict.STABLE
+    )
+
+
+def test_streaming_watch_freezes_dual_stream_hang_past_pause_budget(monkeypatch):
+    """A hang that pins both streams forever is not an infinite pause: once the hold exceeds
+    ``pause_budget`` the stall path takes over and FROZEs — the deadline extension is capped."""
+    now = 0.0
+    tick = 0
+
+    def monotonic() -> float:
+        return now
+
+    def sleep(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
+    def read_state() -> tuple[int, bool, bool, int]:
+        nonlocal tick
+        tick += 1
+        if tick <= 5:
+            return 100 + tick, True, True, 5000 + tick
+        return 105, True, True, 5005  # hard hang: both pinned, still READY (not a menu)
+
+    monkeypatch.setattr("tools.ac_harness.resilient_launch.time.monotonic", monotonic)
+    monkeypatch.setattr("tools.ac_harness.resilient_launch.time.sleep", sleep)
+    assert (
+        _watch_live(
+            read_state,
+            lambda: True,
+            go_live_timeout=2.0,
+            stability_window=5.0,
+            poll_interval=1.0,
+            pause_budget=8.0,
+        )
+        is LaunchVerdict.FROZE
+    )
+
+
 def test_unfinished_live_trace_is_pending_not_a_terminal_failure():
     samples = steady(0.0, 20.0, first_packet=100)
     assert classify(samples, go_live_timeout=10.0, stability_window=60.0) is LaunchVerdict.PENDING

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -97,7 +97,10 @@ class Sample:
     frozen render loop pins it while the process stays alive. ``entry_ready`` preserves the
     graphics page's LIVE + not-in-pit predicate. ``drivable`` is the stronger, rig-proven Car0
     handshake: the CSP pre-drive overlay can report LIVE + not-in-pit while remaining non-drivable.
-    ``None`` means that field could not be read yet.
+    ``phys_packet`` is ``acpmf_physics.packetId``: it keeps advancing during a genuine render wedge
+    (#627 §2) but STOPS at a pause/menu, so its stagnation is the reliable pause signal — AC often
+    leaves ``status`` at LIVE when paused (``shared_memory`` documents this), which is why status
+    alone cannot tell a pause from a freeze (#630 Part B). ``None`` means the field was not read.
     """
 
     t: float
@@ -105,6 +108,7 @@ class Sample:
     acs_alive: bool
     entry_ready: bool | None = True
     drivable: bool | None = True
+    phys_packet: int | None = None
 
 
 def classify(
@@ -142,6 +146,8 @@ def classify(
     t0 = samples[0].t if started_at is None else started_at
     live_since: float | None = None
     prev_packet: int | None = None
+    prev_phys: int | None = None
+    prev_t: float | None = None
     stall_run = 0
     not_ready_run = 0
     seen_acs_alive = False
@@ -159,6 +165,15 @@ def classify(
             sample.gfx_packet is not None
             and prev_packet is not None
             and sample.gfx_packet < prev_packet
+        )
+        # A pause/menu is read from PHYSICS stagnation, not status: a render wedge (#627 §2) keeps
+        # physics advancing while the graphics packet pins, whereas a pause stops physics — and AC
+        # often leaves status at LIVE when paused. Unknown physics (None) degrades to the
+        # graphics-only behavior so off-rig traces without a physics page are unaffected.
+        phys_stagnant = (
+            sample.phys_packet is not None
+            and prev_phys is not None
+            and sample.phys_packet == prev_phys
         )
         if live_since is None:
             if seen_acs_alive and not sample.acs_alive:
@@ -190,26 +205,39 @@ def classify(
                 # packetId reset means the render stream/session was replaced; never let a new
                 # acs.exe inherit stability time accumulated by its predecessor.
                 return LaunchVerdict.FROZE
-            if not_ready:
-                not_ready_run += 1
-                if not_ready_run >= stall_samples:
-                    return LaunchVerdict.FROZE
-            elif ready:
+            if phys_stagnant:
+                # #630 Part B — physics stopped advancing: the sim is paused or at a menu (the
+                # graphics packet may pin OR keep animating; either way this is NOT a render wedge,
+                # which holds physics ADVANCING). Hold: clear the freeze counters so an alt-tab
+                # cannot trip a false FROZE + taskkill, and suspend the stability clock so paused
+                # seconds are not credited as proven-live time (a session that only just resumed
+                # must still earn its window — finding: the delayed init wedge could otherwise land
+                # after handoff).
+                if prev_t is not None:
+                    live_since += sample.t - prev_t
                 not_ready_run = 0
-            else:
-                # An unavailable graphics observation cannot extend a consecutive run.
-                not_ready_run = 0
-            if advanced:
                 stall_run = 0
-            elif sample.gfx_packet is not None and sample.gfx_packet == prev_packet:
-                stall_run += 1
-                if stall_run >= stall_samples:
-                    return LaunchVerdict.FROZE
             else:
-                # Missing shared memory is unknown, not another observation of the same packet.
-                stall_run = 0
-            if advanced and ready and sample.t - live_since >= stability_window:
-                return LaunchVerdict.STABLE
+                if not_ready:
+                    not_ready_run += 1
+                    if not_ready_run >= stall_samples:
+                        return LaunchVerdict.FROZE
+                elif ready:
+                    not_ready_run = 0
+                else:
+                    # An unavailable graphics observation cannot extend a consecutive run.
+                    not_ready_run = 0
+                if advanced:
+                    stall_run = 0
+                elif sample.gfx_packet is not None and sample.gfx_packet == prev_packet:
+                    stall_run += 1
+                    if stall_run >= stall_samples:
+                        return LaunchVerdict.FROZE
+                else:
+                    # Missing shared memory is unknown, not another observation of the same packet.
+                    stall_run = 0
+                if advanced and ready and sample.t - live_since >= stability_window:
+                    return LaunchVerdict.STABLE
         # Only a reading correlated with a LIVE acs.exe may seed the comparison baseline.
         # ``acpmf_*`` is a shared section that survives its creator: a hard kill leaves it mapped
         # by whatever else has it open (measured on the rig: still PRESENT 14 s after taskkill),
@@ -219,6 +247,9 @@ def classify(
         # brief reaching the shipped verdict logic, not just the ad-hoc probes. See #628.
         if sample.gfx_packet is not None and sample.acs_alive:
             prev_packet = sample.gfx_packet
+        if sample.phys_packet is not None and sample.acs_alive:
+            prev_phys = sample.phys_packet
+        prev_t = sample.t
 
     if live_since is None:
         return LaunchVerdict.PENDING
@@ -390,7 +421,9 @@ def _log(msg: str) -> None:  # pragma: no cover - rig-only progress trace
 def _sample_now(
     read_state: Callable[
         [],
-        tuple[int | None, bool | None] | tuple[int | None, bool | None, bool | None],
+        tuple[int | None, bool | None]
+        | tuple[int | None, bool | None, bool | None]
+        | tuple[int | None, bool | None, bool | None, int | None],
     ],
     acs_alive: Callable[[], bool],
 ) -> Sample:  # pragma: no cover - rig-only
@@ -401,17 +434,21 @@ def _sample_now(
     state = read_state()
     observed_alive = acs_alive()
     observed_at = time.monotonic()
+    phys_packet: int | None = None
     if len(state) == 2:
         packet, entry_ready = state
         drivable = entry_ready
-    else:
+    elif len(state) == 3:
         packet, entry_ready, drivable = state
+    else:
+        packet, entry_ready, drivable, phys_packet = state
     return Sample(
         t=observed_at,
         gfx_packet=packet,
         acs_alive=observed_alive,
         entry_ready=entry_ready,
         drivable=drivable,
+        phys_packet=phys_packet,
     )
 
 
@@ -1000,17 +1037,23 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
     from tools.ac_harness.shared_memory import SharedMemoryReader, SharedMemoryUnavailable
     from tools.ac_harness.window_utils import minimize_foreground_window
 
-    def read_state() -> tuple[int | None, bool | None]:
-        """Current render packet and LIVE+not-in-pit readiness from one graphics snapshot."""
+    def read_state() -> tuple[int | None, bool | None, int | None]:
+        """Render packet, LIVE+not-in-pit readiness, and the PHYSICS packet from one snapshot.
+
+        The physics packetId is the reliable pause signal (it stops at a pause/menu but keeps
+        advancing during a render wedge); ``classify`` uses its stagnation for #630 Part B.
+        """
         try:
-            reader = SharedMemoryReader(with_physics=False)
+            reader = SharedMemoryReader(with_physics=True)
         except (SharedMemoryUnavailable, OSError):
-            return None, None
+            return None, None, None
         try:
             graphics = reader.read_graphics()
-            return graphics.packet_id, graphics.is_live and not graphics.is_in_pit
+            physics = reader.read_physics()
+            ready = graphics.is_live and not graphics.is_in_pit
+            return graphics.packet_id, ready, (physics.packet_id if physics else None)
         except (SharedMemoryUnavailable, OSError):
-            return None, None
+            return None, None, None
         finally:
             reader.close()
 
@@ -1109,23 +1152,24 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 )
             )
 
-            def read_attempt_state() -> tuple[int | None, bool | None, bool | None]:
+            def read_attempt_state() -> tuple[int | None, bool | None, bool | None, int | None]:
                 """Report shared memory; trust readiness only once the packet proves a live owner.
 
                 No process-liveness probe is consulted here on purpose (see
                 :class:`SectionOwnershipGate`): a corpse's fields — including ``is_live`` — are
                 trusted only after the render packet ADVANCES, which only a live process can do.
-                ``read_state`` already degrades a shared-memory failure to ``(None, None)``, which
+                ``read_state`` degrades a shared-memory failure to ``(None, None, None)``, which
                 ``classify`` treats as "no observation"; process death is ended by ``classify`` via
-                the debounced ``Sample.acs_alive``.
+                the debounced ``Sample.acs_alive``. The physics packet rides straight through so
+                ``classify`` can read a pause from its stagnation (#630 Part B).
                 """
                 _retry_telemetry_cleanup_holds(telemetry_cleanup_holds)
                 if release_requested():
                     raise _OperatorRelease
 
-                packet, entry_ready = read_state()
+                packet, entry_ready, phys_packet = read_state()
                 ready, drivable = readiness.observe(packet=packet, entry_ready=entry_ready)
-                return packet, ready, drivable
+                return packet, ready, drivable, phys_packet
 
             try:
                 verdict = _watch_live(

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -44,6 +44,11 @@ DEFAULT_GO_LIVE_TIMEOUT = 80.0
 DEFAULT_MAX_ATTEMPTS = 12
 #: consecutive unchanged-packet samples (while acs is alive) that count as a wedge
 DEFAULT_STALL_SAMPLES = 4
+#: seconds a physics-stagnant pause hold (#630 Part B) is honored before sustained dual-stream
+#: stagnation must be treated as the hang it may be — a hard hang that pins BOTH streams while
+#: acs.exe stays enumerated is indistinguishable from an alt-tab at any single instant, so the
+#: carve-out is bounded and the ordinary stall/not-ready paths take over past this budget.
+DEFAULT_PAUSE_BUDGET = 300.0
 #: consecutive never_live attempts before cold-restarting Content Manager (#537/#558)
 NEVER_LIVE_BEFORE_CM_RESTART = 2
 
@@ -118,6 +123,8 @@ def classify(
     stability_window: float = DEFAULT_STABILITY_WINDOW,
     stall_samples: int = DEFAULT_STALL_SAMPLES,
     started_at: float | None = None,
+    pause_budget: float = DEFAULT_PAUSE_BUDGET,
+    pause_sink: list[float] | None = None,
 ) -> LaunchVerdict:
     """Classify one launch attempt from its liveness trace. Pure — no I/O, no clock.
 
@@ -128,9 +135,17 @@ def classify(
     * after go-live, ``stall_samples`` consecutive samples with an unchanged ``gfx_packet`` while
       ``acs_alive`` → ``FROZE`` (this is the delayed init livelock the other launchers miss).
     * surviving ``stability_window`` seconds past go-live without stalling → ``STABLE``.
+    * a **pause** (physics packet stagnant post-go-live, #630 Part B) is held — freeze counters
+      cleared, stability clock suspended — but only up to ``pause_budget`` cumulative seconds.
+      Beyond the budget, sustained dual-stream stagnation falls back to the ordinary
+      stall/not-ready paths: an unbounded hold would make a real hang undetectable.
 
     ``acs`` disappearing after go-live is reported as ``FROZE`` rather than ``STABLE``: the session
     did not survive, and the caller must retry either way.
+
+    When ``pause_sink`` is provided and the trace is still ``PENDING`` past go-live, the cumulative
+    held-pause seconds are appended to it. ``_watch_live`` extends its wall-clock budget by exactly
+    this much so a held pause cannot FROZE a healthy paused session at a fixed deadline.
     """
     if not samples:
         return LaunchVerdict.PENDING
@@ -140,6 +155,8 @@ def classify(
         raise ValueError("stability_window must be > 0")
     if stall_samples <= 0:
         raise ValueError("stall_samples must be > 0")
+    if pause_budget <= 0:
+        raise ValueError("pause_budget must be > 0")
 
     # ``_watch_live`` supplies its pre-probe start so a blocking readiness handshake consumes the
     # go-live budget. Pure/unit callers may omit it and retain the trace-relative behavior.
@@ -150,6 +167,7 @@ def classify(
     prev_t: float | None = None
     stall_run = 0
     not_ready_run = 0
+    paused_total = 0.0
     seen_acs_alive = False
 
     for sample in samples:
@@ -205,16 +223,20 @@ def classify(
                 # packetId reset means the render stream/session was replaced; never let a new
                 # acs.exe inherit stability time accumulated by its predecessor.
                 return LaunchVerdict.FROZE
-            if phys_stagnant:
+            if phys_stagnant and paused_total < pause_budget:
                 # #630 Part B — physics stopped advancing: the sim is paused or at a menu (the
                 # graphics packet may pin OR keep animating; either way this is NOT a render wedge,
                 # which holds physics ADVANCING). Hold: clear the freeze counters so an alt-tab
                 # cannot trip a false FROZE + taskkill, and suspend the stability clock so paused
                 # seconds are not credited as proven-live time (a session that only just resumed
                 # must still earn its window — finding: the delayed init wedge could otherwise land
-                # after handoff).
+                # after handoff). The hold is BOUNDED by ``pause_budget``: a hang that pins both
+                # streams while acs.exe stays enumerated is indistinguishable from a pause at any
+                # single instant, so past the budget the sample falls through to the ordinary
+                # stall/not-ready paths and the attempt still fails (#637 daemon MEDIUM).
                 if prev_t is not None:
                     live_since += sample.t - prev_t
+                    paused_total += sample.t - prev_t
                 not_ready_run = 0
                 stall_run = 0
             else:
@@ -255,6 +277,8 @@ def classify(
         return LaunchVerdict.PENDING
     # The trace ended before either terminal threshold. A short hitch is not a freeze, and an
     # advancing live session is not a never-live failure merely because its window is unfinished.
+    if pause_sink is not None:
+        pause_sink.append(paused_total)
     return LaunchVerdict.PENDING
 
 
@@ -935,28 +959,45 @@ def _retry_telemetry_cleanup_holds(controllers: list[object]) -> None:
 def _watch_live(  # pragma: no cover - rig-only
     read_state: Callable[
         [],
-        tuple[int | None, bool | None] | tuple[int | None, bool | None, bool | None],
+        tuple[int | None, bool | None]
+        | tuple[int | None, bool | None, bool | None]
+        | tuple[int | None, bool | None, bool | None, int | None],
     ],
     acs_alive: Callable[[], bool],
     *,
     go_live_timeout: float,
     stability_window: float,
     poll_interval: float = 1.0,
+    pause_budget: float = DEFAULT_PAUSE_BUDGET,
 ) -> LaunchVerdict:
-    """Sample until the attempt resolves, then classify. Streams samples into :func:`classify`."""
+    """Sample until the attempt resolves, then classify. Streams samples into :func:`classify`.
+
+    The wall-clock budget is ``go_live_timeout + stability_window + 30`` **plus the pause hold**
+    ``classify`` reports (capped at ``pause_budget``): a long alt-tab must stay PENDING, never
+    FROZE a healthy paused session at a fixed deadline — the exact failure #630 Part B set out to
+    stop (#637 Codex P1 + self-hosted daemon HIGH). A dual-stream hang outlasting the pause
+    budget stops being a hold inside ``classify`` and fails via the ordinary stall/not-ready
+    paths, so the extension cannot hide a real freeze either.
+    """
     samples: list[Sample] = []
     started_at = time.monotonic()
-    deadline = started_at + go_live_timeout + stability_window + 30.0
-    while time.monotonic() < deadline:
+    budget = go_live_timeout + stability_window + 30.0
+    paused = 0.0
+    while time.monotonic() < started_at + budget + min(paused, pause_budget):
         samples.append(_sample_now(read_state, acs_alive))
+        sink: list[float] = []
         verdict = classify(
             samples,
             go_live_timeout=go_live_timeout,
             stability_window=stability_window,
             started_at=started_at,
+            pause_budget=pause_budget,
+            pause_sink=sink,
         )
         if verdict is not LaunchVerdict.PENDING:
             return verdict
+        if sink:
+            paused = sink[-1]
         time.sleep(poll_interval)
     return LaunchVerdict.FROZE
 

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -135,10 +135,11 @@ def classify(
     * after go-live, ``stall_samples`` consecutive samples with an unchanged ``gfx_packet`` while
       ``acs_alive`` → ``FROZE`` (this is the delayed init livelock the other launchers miss).
     * surviving ``stability_window`` seconds past go-live without stalling → ``STABLE``.
-    * a **pause** (physics packet stagnant post-go-live, #630 Part B) is held — freeze counters
-      cleared, stability clock suspended — but only up to ``pause_budget`` cumulative seconds.
-      Beyond the budget, sustained dual-stream stagnation falls back to the ordinary
-      stall/not-ready paths: an unbounded hold would make a real hang undetectable.
+    * a **pause** (physics packet stagnant post-go-live, #630 Part B) is never credited toward
+      the stability window, and its freeze counters stay cleared for up to ``pause_budget``
+      cumulative seconds. Beyond the budget the ordinary stall/not-ready paths resume — an
+      unbounded hold would make a real hang undetectable — and ``STABLE`` always requires
+      physics ADVANCING, so a session that never resumed cannot hand off.
 
     ``acs`` disappearing after go-live is reported as ``FROZE`` rather than ``STABLE``: the session
     did not survive, and the caller must retry either way.
@@ -223,20 +224,21 @@ def classify(
                 # packetId reset means the render stream/session was replaced; never let a new
                 # acs.exe inherit stability time accumulated by its predecessor.
                 return LaunchVerdict.FROZE
-            if phys_stagnant and paused_total < pause_budget:
+            if phys_stagnant and prev_t is not None:
+                # Physics pinned: this interval is NEVER credited as proven-live time, whatever
+                # the budget — STABLE must be earned with physics RUNNING, so a pause that
+                # outlasts the budget cannot hand off on wall-clock accumulation (#637 daemon).
+                live_since += sample.t - prev_t
+                paused_total += sample.t - prev_t
+            if phys_stagnant and paused_total <= pause_budget:
                 # #630 Part B — physics stopped advancing: the sim is paused or at a menu (the
                 # graphics packet may pin OR keep animating; either way this is NOT a render wedge,
                 # which holds physics ADVANCING). Hold: clear the freeze counters so an alt-tab
-                # cannot trip a false FROZE + taskkill, and suspend the stability clock so paused
-                # seconds are not credited as proven-live time (a session that only just resumed
-                # must still earn its window — finding: the delayed init wedge could otherwise land
-                # after handoff). The hold is BOUNDED by ``pause_budget``: a hang that pins both
-                # streams while acs.exe stays enumerated is indistinguishable from a pause at any
-                # single instant, so past the budget the sample falls through to the ordinary
-                # stall/not-ready paths and the attempt still fails (#637 daemon MEDIUM).
-                if prev_t is not None:
-                    live_since += sample.t - prev_t
-                    paused_total += sample.t - prev_t
+                # cannot trip a false FROZE + taskkill. The counter-clearing is BOUNDED by
+                # ``pause_budget``: a hang that pins both streams while acs.exe stays enumerated
+                # is indistinguishable from a pause at any single instant, so past the budget the
+                # sample falls through to the ordinary stall/not-ready paths and the attempt still
+                # fails (#637 daemon MEDIUM).
                 not_ready_run = 0
                 stall_run = 0
             else:
@@ -258,7 +260,15 @@ def classify(
                 else:
                     # Missing shared memory is unknown, not another observation of the same packet.
                     stall_run = 0
-                if advanced and ready and sample.t - live_since >= stability_window:
+                # STABLE additionally requires physics ADVANCING when a physics reading exists:
+                # an animating graphics stream with pinned physics past the pause budget is a
+                # session that never resumed, not a proven-live one (#637 daemon HIGH).
+                if (
+                    advanced
+                    and ready
+                    and not phys_stagnant
+                    and sample.t - live_since >= stability_window
+                ):
                     return LaunchVerdict.STABLE
         # Only a reading correlated with a LIVE acs.exe may seed the comparison baseline.
         # ``acpmf_*`` is a shared section that survives its creator: a hard kill leaves it mapped


### PR DESCRIPTION
Advances #630 (Part B), reworked after review. Refs #627.

## What the review found (and it was right)

The first cut used `status == PAUSE` to carve pauses out of the freeze logic. Codex flagged a **P1**
and the self-hosted daemon concurred: `shared_memory.py` documents that AC *"sometimes doesn't
bother setting Status to Pause"* — it leaves a paused session flagged **LIVE**. So a status check
misses real pauses, the pinned packet takes the ordinary stall path, and the launcher `FROZE`s +
taskkills a **healthy paused sim**. Status is not a reliable pause signal.

## The fix — physics-packet stagnation

The reliable discriminator is the one #627 §2 already uses: a **render wedge keeps the physics
packet advancing** while the graphics packet pins, whereas a **pause STOPS physics**.

- `Sample` now carries `phys_packet` (`acpmf_physics.packetId`).
- `classify` reads a pause from **physics stagnation, regardless of status**. On a stagnant-physics
  sample post-go-live it **holds**: clears the freeze counters, and **suspends the stability clock**
  so paused seconds aren't credited (a session that only just resumed must still earn its window —
  otherwise the delayed init wedge could land right after handoff).
- A real wedge (physics still advancing while graphics pins) is `FROZE`, unchanged.
- Unknown physics (`None` — off-rig traces, or no physics page yet) degrades to the prior
  graphics-only behavior, so **every existing verdict test is unaffected**.

## Tests

3 new physics tests — a pause (physics stagnant) is not a freeze; a physics-advancing wedge is still
`FROZE`; a pause suspends the stability clock. `95 passed`, `make ci-fast: OK`, plus a rig-verify of
the new `with_physics=True` read path (posted below).

## Scope change from the first cut

The earlier commit's **Part A** (post-handoff wedge detection in the hold loop) is **dropped from
here**. The review showed it had the same status-vs-physics problem *and* that its `phase="wedged"`
surfaced as "STABILIZING AC" in Game Point (every non-`stable` phase maps there). Part A returns as
its own PR built on this physics discriminator **plus a real Game Point `wedged` state**, rather than
a misleading phase. Tracked on #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)