### PR TITLE
fix(evolution): steward resolution for the public spoke + pin e9e5f35 + rules-only emission (gov-hub#289)

### DIFF
--- a/.github/workflows/process-miner.yml
+++ b/.github/workflows/process-miner.yml
@@ -65,6 +65,9 @@ jobs:
 
       - name: Upload process-miner audit sidecar
         if: always()
+        # Audit telemetry must never gate rules delivery: a transient upload-artifact
+        # failure (quota, network) would otherwise skip commit/push/PR (review, gov-hub#289).
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: process-miner-audit-${{ github.run_id }}

--- a/.github/workflows/process-miner.yml
+++ b/.github/workflows/process-miner.yml
@@ -63,6 +63,15 @@ jobs:
         run: |
           echo "::warning::Process miner wrote 0 new learned artifact files this run (stricter clustering or sparse review data)."
 
+      - name: Upload process-miner audit sidecar
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: process-miner-audit-${{ github.run_id }}
+          path: reports/process_miner
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Configure git
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -79,11 +88,17 @@ jobs:
           fi
           BRANCH="chore/miner-weekly-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
           git checkout -b "$BRANCH"
-          git add .claude/rules/learned .cursor/rules/learned reports/process_miner AGENTS.md || true
+          # Rules-only, add-only staging (epic gov-hub#197: scope_pure_for_pr). The miner may
+          # still touch AGENTS.md / reports/process_miner in the runner workspace: reports are
+          # preserved as a workflow artifact above; AGENTS.md deltas are intentionally not
+          # emitted (the learned-rules mirrors are the sole rules channel).
+          git add -- ':(glob).claude/rules/learned/**/*.md' || true
+          git add -- ':(glob).cursor/rules/learned/**/*.mdc' || true
           if git diff --cached --quiet; then
             echo "No changes to commit."
             exit 0
           fi
+          scripts/process_miner_pr_scope.sh
           git commit -m "chore: weekly process miner — learned rules"
           git push --set-upstream origin "$BRANCH"
           if gh pr create \

--- a/.github/workflows/steward-miner-rules.yml
+++ b/.github/workflows/steward-miner-rules.yml
@@ -1,11 +1,14 @@
 # Rules-miner Steward consumer — wires this repo's `chore: weekly miner rules` PRs into the
-# hub-canonical deterministic gate (agorokh/governance-hub#216, epic #197). Mirror of the
-# vault-automerge cross-repo pattern: calls the PRIVATE hub's composite action with THIS repo's
-# OWN GITHUB_TOKEN (no central fleet super-token). Actuates this repo's own PR only.
+# hub-canonical deterministic gate (agorokh/governance-hub#216, epic #197). Actuates this repo's
+# own PR only, with this repo's OWN GITHUB_TOKEN.
 #
-# Ships REPORT-ONLY: comments the verdict + digest and files a council issue for escalations, but
-# closes/labels NOTHING until the STEWARD_MINER_MODE repo variable is set to `enforce` after
-# observing one live report cycle. Pinned to the hub SHA that carries the full Steward stack.
+# PUBLIC-SPOKE RESOLUTION (gov-hub#197 loop break 3): a public repo can NEVER resolve a private
+# repo's action via cross-repo `uses:` ("Unable to resolve action `agorokh/governance-hub`, not
+# found" — failed identically 2026-07-13 and 2026-07-20; private-action sharing only extends to
+# private repos). Mirror this repo's own proven vault-automerge pattern (issue #329): mint the
+# fleet-bot App token, check the hub out at its pinned SHA, run the composite via a local path.
+# Reference-not-vendor is preserved — the logic lives ONCE in the hub at this SHA; only the fetch
+# mechanism differs from private spokes.
 name: steward-miner-rules
 
 on:
@@ -42,8 +45,23 @@ jobs:
   steward:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint fleet-bot token (read governance-hub)
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FLEET_BOT_APP_ID }}
+          private-key: ${{ secrets.FLEET_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: governance-hub
+      - name: Check out the pinned governance-hub steward action
+        uses: actions/checkout@v7
+        with:
+          repository: agorokh/governance-hub
+          ref: e9e5f352d44bd802b3da1150b9ab6da517b3df1d  # pragma: allowlist secret (git SHA, not a secret)
+          token: ${{ steps.app-token.outputs.token }}
+          path: .governance-hub
       - name: Adjudicate the miner-rules PR
-        uses: agorokh/governance-hub/.github/actions/steward-miner-rules@6d94f29a8bf8b66138a46d0dab328f452fd0c176
+        uses: ./.governance-hub/.github/actions/steward-miner-rules
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.repository }}

--- a/scripts/process_miner_pr_scope.sh
+++ b/scripts/process_miner_pr_scope.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# OWNER: @agorokh
+# Fail closed unless the staged weekly-miner diff contains only added or repaired learned rules.
+set -euo pipefail
+
+if git diff --cached --quiet; then
+  exit 0
+fi
+
+INVALID_STAGED="$(
+  git diff --cached --name-status |
+    awk '
+      $1 !~ /^(A|M)$/ ||
+      ($2 !~ /^\.claude\/rules\/learned\/.*\.md$/ &&
+       $2 !~ /^\.cursor\/rules\/learned\/.*\.mdc$/) { print }
+    '
+)"
+if [[ -n "$INVALID_STAGED" ]]; then
+  echo "Weekly miner PR must contain only added or repaired learned-rule files." >&2
+  printf '%s\n' "$INVALID_STAGED" >&2
+  exit 1
+fi

--- a/tests/test_process_miner/test_workflow_pr_scope.py
+++ b/tests/test_process_miner/test_workflow_pr_scope.py
@@ -1,0 +1,114 @@
+"""Weekly process-miner PRs stay inside the zero-human merge contract.
+
+Spoke-adapted from template-repo tests/test_process_miner/test_workflow_pr_scope.py
+(gov-hub#289): the `--no-agents-md` assert is intentionally absent — this spoke's
+vendored miner CLI predates the flag, and purity is delivered by staging control
+alone (glob add-only + the fail-closed scope guard this file proves).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/process-miner.yml"
+_SCOPE_GUARD = _REPO_ROOT / "scripts/process_miner_pr_scope.sh"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "miner-test@example.invalid")
+    _git(repo, "config", "user.name", "Miner Test")
+    (repo / "AGENTS.md").write_text("baseline\n", encoding="utf-8")
+    _git(repo, "add", "AGENTS.md")
+    _git(repo, "commit", "-m", "baseline")
+
+
+def test_weekly_miner_workflow_invokes_runtime_scope_guard() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+
+    assert "':(glob).claude/rules/learned/**/*.md'" in text
+    assert "':(glob).cursor/rules/learned/**/*.mdc'" in text
+    assert "scripts/process_miner_pr_scope.sh" in text
+    assert "git add -- ':(glob).claude/rules/learned/**/*.md' || true" in text
+    assert "git add -- ':(glob).cursor/rules/learned/**/*.mdc' || true" in text
+    assert (
+        "git add .claude/rules/learned .cursor/rules/learned reports/process_miner AGENTS.md"
+        not in text
+    )
+
+
+def test_weekly_miner_stages_missing_rule_sides_independently() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    claude_stage = "git add -- ':(glob).claude/rules/learned/**/*.md' || true"
+    cursor_stage = "git add -- ':(glob).cursor/rules/learned/**/*.mdc' || true"
+
+    assert text.count(claude_stage) == 1
+    assert text.count(cursor_stage) == 1
+    assert text.index(claude_stage) < text.index(cursor_stage)
+
+
+def test_runtime_scope_guard_accepts_only_added_rule_pairs(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    claude_rule = tmp_path / ".claude/rules/learned/local/rule.md"
+    cursor_rule = tmp_path / ".cursor/rules/learned/local/rule.mdc"
+    report = tmp_path / "reports/process_miner/latest.md"
+    for path in (claude_rule, cursor_rule, report):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("generated\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("dirty but deliberately unstaged\n", encoding="utf-8")
+
+    _git(
+        tmp_path,
+        "add",
+        "--",
+        ":(glob).claude/rules/learned/**/*.md",
+        ":(glob).cursor/rules/learned/**/*.mdc",
+    )
+    result = subprocess.run([str(_SCOPE_GUARD)], cwd=tmp_path, capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert _git(tmp_path, "diff", "--cached", "--name-status").stdout.splitlines() == [
+        "A\t.claude/rules/learned/local/rule.md",
+        "A\t.cursor/rules/learned/local/rule.mdc",
+    ]
+
+
+def test_runtime_scope_guard_accepts_modified_rule_and_rejects_non_rule(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    existing = tmp_path / ".claude/rules/learned/local/existing.md"
+    existing.parent.mkdir(parents=True, exist_ok=True)
+    existing.write_text("baseline rule\n", encoding="utf-8")
+    _git(tmp_path, "add", str(existing.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "-m", "existing rule")
+
+    existing.write_text("modified rule\n", encoding="utf-8")
+    _git(tmp_path, "add", str(existing.relative_to(tmp_path)))
+    modified = subprocess.run([str(_SCOPE_GUARD)], cwd=tmp_path, capture_output=True, text=True)
+    assert modified.returncode == 0
+
+    _git(tmp_path, "reset", "--hard", "HEAD")
+    (tmp_path / "AGENTS.md").write_text("unsafe index update\n", encoding="utf-8")
+    _git(tmp_path, "add", "AGENTS.md")
+    non_rule = subprocess.run([str(_SCOPE_GUARD)], cwd=tmp_path, capture_output=True, text=True)
+    assert non_rule.returncode == 1
+    assert "AGENTS.md" in non_rule.stderr
+
+
+def test_weekly_miner_report_is_an_audit_artifact_not_pr_content() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+
+    assert "name: Upload process-miner audit sidecar" in text
+    assert "uses: actions/upload-artifact@v7" in text
+    assert "path: reports/process_miner" in text


### PR DESCRIPTION
Replica of the Council-ratified fleet fan-out **governance-hub#289** (epic gov-hub#197, 2026-07-20 cycle audit). Pilot: hermescraft#366 (PR-branch CI green incl. the anti-orphan proof test; substantive content identical).

1. **Steward pin `6d94f29` → `e9e5f35`** — human-guard via REST `.user.type` (the fleet reviewer bot no longer trips "human interaction — Steward yields"; that single reason false-escalated 15/15 rules in hermescraft run 29734025964), escalation-sink live guard, `.cursor` mirror gate coverage.
2. **Rules-only, add-only weekly emission** — replaces the impure `git add … reports/process_miner AGENTS.md` staging that failed the steward's `scope_pure_for_pr` by construction: glob add-only staging of the two learned mirrors, reports as a 30-day workflow artifact, fail-closed `scripts/process_miner_pr_scope.sh` + spoke-adapted proof test (anti-orphan triad).
3. **Public-spoke action resolution (gov-hub#197 loop break 3)** — this repo's steward has NEVER run: a public repo cannot resolve a private hub action cross-repo ('Unable to resolve action', failed identically 07-13 + 07-20). Rewritten to this repo's own proven vault-automerge pattern (#329): mint fleet-bot App token → checkout hub at the pin into `.governance-hub` → local-path `uses:`. Verification after merge: `workflow_dispatch` in report mode against a real PR.
Rollback: single-commit revert; nothing here is consumed cross-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)