### PR TITLE
feat(rig): surface a post-handoff render wedge as a distinct Game Point state (#630 Part A)

### DIFF
--- a/tests/test_process_miner/test_workflow_pr_scope.py
+++ b/tests/test_process_miner/test_workflow_pr_scope.py
@@ -8,16 +8,39 @@ alone (glob add-only + the fail-closed scope guard this file proves).
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOW = _REPO_ROOT / ".github/workflows/process-miner.yml"
 _SCOPE_GUARD = _REPO_ROOT / "scripts/process_miner_pr_scope.sh"
 
 
+def _bash_executable() -> str | None:
+    """Locate a bash interpreter, or ``None`` when the host has none.
+
+    ``bash`` is not guaranteed on ``PATH`` in a native Windows shell: Git for Windows commonly
+    exposes ``git.exe`` through its ``cmd`` directory while leaving ``bash.exe`` off ``PATH``. So
+    fall back to deriving it from git's own install root rather than assuming the bare name
+    resolves.
+    """
+    found = shutil.which("bash")
+    if found:
+        return found
+    git = shutil.which("git")
+    if git:
+        root = Path(git).resolve().parent.parent
+        for candidate in (root / "bin" / "bash.exe", root / "usr" / "bin" / "bash.exe"):
+            if candidate.is_file():
+                return str(candidate)
+    return None
+
+
 def _run_scope_guard(repo: Path) -> subprocess.CompletedProcess[str]:
-    """Run the shell scope guard through ``bash`` rather than exec'ing the ``.sh`` directly.
+    """Run the shell scope guard through bash rather than exec'ing the ``.sh`` directly.
 
     Windows cannot execute a shell script as a process image — a direct
     ``subprocess.run([str(_SCOPE_GUARD)])`` raises ``OSError: [WinError 193] %1 is not a valid
@@ -25,8 +48,11 @@ def _run_scope_guard(repo: Path) -> subprocess.CompletedProcess[str]:
     Windows rig, where they blocked ``make ci-fast``. Naming the interpreter explicitly is correct
     on every platform (it is a bash script either way) and keeps the guard's behavior identical.
     """
+    bash = _bash_executable()
+    if bash is None:
+        pytest.skip("no bash interpreter available to run the shell scope guard")
     return subprocess.run(
-        ["bash", str(_SCOPE_GUARD)],
+        [bash, str(_SCOPE_GUARD)],
         cwd=repo,
         capture_output=True,
         text=True,

--- a/tests/test_process_miner/test_workflow_pr_scope.py
+++ b/tests/test_process_miner/test_workflow_pr_scope.py
@@ -16,6 +16,23 @@ _WORKFLOW = _REPO_ROOT / ".github/workflows/process-miner.yml"
 _SCOPE_GUARD = _REPO_ROOT / "scripts/process_miner_pr_scope.sh"
 
 
+def _run_scope_guard(repo: Path) -> subprocess.CompletedProcess[str]:
+    """Run the shell scope guard through ``bash`` rather than exec'ing the ``.sh`` directly.
+
+    Windows cannot execute a shell script as a process image — a direct
+    ``subprocess.run([str(_SCOPE_GUARD)])`` raises ``OSError: [WinError 193] %1 is not a valid
+    Win32 application`` — so these tests passed in Linux CI but failed deterministically on the
+    Windows rig, where they blocked ``make ci-fast``. Naming the interpreter explicitly is correct
+    on every platform (it is a bash script either way) and keeps the guard's behavior identical.
+    """
+    return subprocess.run(
+        ["bash", str(_SCOPE_GUARD)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
 def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -76,7 +93,7 @@ def test_runtime_scope_guard_accepts_only_added_rule_pairs(tmp_path: Path) -> No
         ":(glob).claude/rules/learned/**/*.md",
         ":(glob).cursor/rules/learned/**/*.mdc",
     )
-    result = subprocess.run([str(_SCOPE_GUARD)], cwd=tmp_path, capture_output=True, text=True)
+    result = _run_scope_guard(tmp_path)
 
     assert result.returncode == 0
     assert _git(tmp_path, "diff", "--cached", "--name-status").stdout.splitlines() == [
@@ -95,13 +112,13 @@ def test_runtime_scope_guard_accepts_modified_rule_and_rejects_non_rule(tmp_path
 
     existing.write_text("modified rule\n", encoding="utf-8")
     _git(tmp_path, "add", str(existing.relative_to(tmp_path)))
-    modified = subprocess.run([str(_SCOPE_GUARD)], cwd=tmp_path, capture_output=True, text=True)
+    modified = _run_scope_guard(tmp_path)
     assert modified.returncode == 0
 
     _git(tmp_path, "reset", "--hard", "HEAD")
     (tmp_path / "AGENTS.md").write_text("unsafe index update\n", encoding="utf-8")
     _git(tmp_path, "add", "AGENTS.md")
-    non_rule = subprocess.run([str(_SCOPE_GUARD)], cwd=tmp_path, capture_output=True, text=True)
+    non_rule = _run_scope_guard(tmp_path)
     assert non_rule.returncode == 1
     assert "AGENTS.md" in non_rule.stderr
 

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -1680,3 +1680,26 @@ def test_hold_publishes_the_wedged_phase_exactly_once_on_success() -> None:
     )
 
     assert calls == ["wedged"]
+
+
+def test_a_blip_before_the_first_confirm_does_not_move_the_wedge_anchor() -> None:
+    """#630 Part A — the reviewer's deferral scenario, pinned.
+
+    Establish the pin at t=0, blip at t=10, first confirming read at t=15. The anchor must remain
+    t=0 (when the packet was last SEEN at that value), so the 20 s window latches at t=20 — not at
+    t=30, which is what an anchor moved forward by the blip would produce.
+    """
+    watch = StableSessionWatch(wedge_seconds=20.0)
+    watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+    watch.observe(gfx_packet=None, phys_packet=None, now=10.0)  # blip must not move the anchor
+    assert watch.observe(gfx_packet=5000, phys_packet=9030, now=15.0) is False
+    assert watch.observe(gfx_packet=5000, phys_packet=9060, now=20.0) is True
+
+
+def test_an_armed_clock_expires_even_on_a_neutral_sample() -> None:
+    """A shared-memory blackout after the wedge was confirmed must not postpone reporting it."""
+    watch = StableSessionWatch(wedge_seconds=20.0)
+    watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+    watch.observe(gfx_packet=5000, phys_packet=9030, now=5.0)  # clock armed, anchored at t=0
+    # Section goes unreadable and never comes back; the armed clock still expires.
+    assert watch.observe(gfx_packet=None, phys_packet=None, now=25.0) is True

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -1593,3 +1593,90 @@ class TestStableSessionWatch:
         assert watch.observe(gfx_packet=5000, phys_packet=9060, now=25.0) is True
         # A later advance does not un-wedge it (terminal per #627 §3.2).
         assert watch.observe(gfx_packet=6000, phys_packet=9090, now=26.0) is True
+
+
+def test_unreadable_sample_does_not_restart_the_wedge_clock() -> None:
+    """#630 Part A — an unreadable blip must not defer (or defeat) detection of a real wedge.
+
+    Resetting the clock on ``None`` would let a periodically-unreadable section keep restarting the
+    window while the render thread stays dead.
+    """
+    watch = StableSessionWatch(wedge_seconds=20.0)
+    watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+    watch.observe(gfx_packet=5000, phys_packet=9030, now=5.0)  # wedge clock running from t=0
+    watch.observe(gfx_packet=None, phys_packet=None, now=10.0)  # blip: neutral, clock keeps running
+    assert watch.observe(gfx_packet=5000, phys_packet=9060, now=20.0) is True
+
+
+def test_a_resumed_render_after_a_blip_still_clears_the_clock() -> None:
+    """The neutral-blip rule must not make the clock un-clearable: real progress still resets it."""
+    watch = StableSessionWatch(wedge_seconds=20.0)
+    watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+    watch.observe(gfx_packet=None, phys_packet=None, now=5.0)
+    watch.observe(gfx_packet=5100, phys_packet=9030, now=10.0)  # render advanced -> clock cleared
+    assert watch.observe(gfx_packet=5100, phys_packet=9060, now=25.0) is False
+
+
+def test_hold_retries_a_failed_wedged_phase_publish() -> None:
+    """#630 Part A — a swallowed publish failure would leave Game Point showing a healthy hold.
+
+    That is the exact failure this detection exists to end, so the durable write is retried until
+    it lands rather than attempted once inside the latch transition.
+    """
+    polls = {"n": 0}
+
+    def acs_alive() -> bool:
+        polls["n"] += 1
+        return polls["n"] <= 10
+
+    phys = {"p": 1000}
+
+    def read_state() -> tuple[int | None, bool | None, int | None]:
+        phys["p"] += 10  # physics advancing while graphics stays pinned -> a wedge
+        return 500, True, phys["p"]
+
+    published = {"attempts": 0}
+
+    def set_phase(name: str) -> None:
+        assert name == "wedged"
+        published["attempts"] += 1
+        if published["attempts"] == 1:
+            raise OSError("durable phase write failed")
+
+    _hold_stable_session(
+        acs_alive,
+        lambda: False,
+        poll=0.0,
+        read_state=read_state,
+        set_phase=set_phase,
+        wedge_seconds=1e-6,
+    )
+
+    # First attempt raised; the loop must have retried and landed it.
+    assert published["attempts"] >= 2
+
+
+def test_hold_publishes_the_wedged_phase_exactly_once_on_success() -> None:
+    polls = {"n": 0}
+
+    def acs_alive() -> bool:
+        polls["n"] += 1
+        return polls["n"] <= 10
+
+    phys = {"p": 1000}
+
+    def read_state() -> tuple[int | None, bool | None, int | None]:
+        phys["p"] += 10
+        return 500, True, phys["p"]
+
+    calls: list[str] = []
+    _hold_stable_session(
+        acs_alive,
+        lambda: False,
+        poll=0.0,
+        read_state=read_state,
+        set_phase=calls.append,
+        wedge_seconds=1e-6,
+    )
+
+    assert calls == ["wedged"]

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -18,6 +18,7 @@ from tools.ac_harness.resilient_launch import (
     LaunchVerdict,
     Sample,
     SectionOwnershipGate,
+    StableSessionWatch,
     _Car0NotDrivable,
     _Car0ProbeCleanupError,
     _ensure_acs_gone,
@@ -1522,3 +1523,73 @@ def test_ensure_acs_gone_honors_release_before_process_probe() -> None:
             lambda: pytest.fail("release must be checked before probing or killing acs.exe"),
             release_requested=lambda: True,
         )
+
+
+class TestStableSessionWatch:
+    """#630 Part A — a render freeze AFTER the stable handoff must be surfaced, not held as healthy.
+
+    The wedge test is the Part B discriminator: graphics pinned while PHYSICS keeps advancing. That
+    is what makes it safe — an alt-tab pins graphics too, but it also stops physics, so a pause can
+    never latch a false wedge here.
+    """
+
+    @staticmethod
+    def _watch() -> StableSessionWatch:
+        return StableSessionWatch(wedge_seconds=20.0)
+
+    def test_healthy_session_never_wedges(self) -> None:
+        watch = self._watch()
+        for i in range(60):  # both streams advancing for 60 s
+            assert (
+                watch.observe(gfx_packet=1000 + i * 5, phys_packet=9000 + i * 30, now=float(i))
+                is False
+            )
+        assert watch.wedged is False
+
+    def test_gfx_pinned_while_physics_advances_is_a_wedge(self) -> None:
+        """The #627 §2 signature: render thread dead, physics thread alive."""
+        watch = self._watch()
+        watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+        # gfx pinned at 5000 from t=0; physics keeps advancing.
+        assert watch.observe(gfx_packet=5000, phys_packet=9030, now=10.0) is False
+        assert watch.observe(gfx_packet=5000, phys_packet=9060, now=19.0) is False
+        assert watch.observe(gfx_packet=5000, phys_packet=9090, now=20.0) is True
+        assert watch.wedged is True
+
+    def test_a_pause_never_wedges_even_though_graphics_pins(self) -> None:
+        """An alt-tab pins graphics AND stops physics — the false wedge this avoids."""
+        watch = self._watch()
+        watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+        for t in range(1, 90):  # 90 s paused: both streams pinned
+            assert watch.observe(gfx_packet=5000, phys_packet=9000, now=float(t)) is False
+        assert watch.wedged is False
+
+    def test_a_brief_hitch_under_the_window_is_not_a_wedge(self) -> None:
+        watch = self._watch()
+        watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+        for t in (5.0, 10.0, 15.0):  # 15 s pinned, physics advancing — under the window
+            assert watch.observe(gfx_packet=5000, phys_packet=9000 + int(t) * 3, now=t) is False
+        # ...then rendering resumes.
+        assert watch.observe(gfx_packet=5100, phys_packet=9100, now=17.0) is False
+        assert watch.wedged is False
+
+    def test_resumed_render_clears_the_wedge_clock(self) -> None:
+        watch = self._watch()
+        watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+        watch.observe(gfx_packet=5000, phys_packet=9030, now=15.0)  # 15 s pinned
+        watch.observe(gfx_packet=5100, phys_packet=9060, now=16.0)  # advances -> clock resets
+        assert watch.observe(gfx_packet=5100, phys_packet=9090, now=30.0) is False  # 14 s
+        assert watch.observe(gfx_packet=5100, phys_packet=9120, now=36.0) is True  # 20 s since 16
+
+    def test_unreadable_sample_neither_advances_nor_confirms(self) -> None:
+        watch = self._watch()
+        watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+        assert watch.observe(gfx_packet=None, phys_packet=None, now=10.0) is False
+        assert watch.wedged is False
+
+    def test_wedged_latches(self) -> None:
+        watch = self._watch()
+        watch.observe(gfx_packet=5000, phys_packet=9000, now=0.0)
+        assert watch.observe(gfx_packet=5000, phys_packet=9060, now=25.0) is True
+        # A later advance does not un-wedge it (terminal per #627 §3.2).
+        assert watch.observe(gfx_packet=6000, phys_packet=9090, now=26.0) is True

--- a/tests/test_rig_launcher_theme.py
+++ b/tests/test_rig_launcher_theme.py
@@ -309,3 +309,25 @@ def test_display_ladder_prefers_bundled_semicondensed_family() -> None:
     # the Windows fallbacks.
     assert theme.FONT_DISPLAY[:2] == ("Saira SemiCondensed", "Saira Semi Condensed")
     assert "Bahnschrift" in theme.FONT_DISPLAY
+
+
+def test_post_handoff_wedge_renders_as_a_distinct_state() -> None:
+    """#630 Part A — a frozen handed-off session must not read as an in-progress start.
+
+    Every non-``stable`` phase used to collapse into "STABILIZING AC", so a post-handoff render
+    freeze told the driver a startup was still running while the picture sat frozen.
+    """
+    status = _status(
+        resilient=ProbeResult(
+            "ac_session",
+            False,
+            "wedged",
+            "resilient session WEDGED after handoff (render frozen); relaunch to recover",
+        )
+    )
+
+    assert theme.summary_for(status) == (
+        "AC WEDGED",
+        "brake",
+        "resilient session WEDGED after handoff (render frozen); relaunch to recover",
+    )

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -376,6 +376,73 @@ class AttemptReadiness:
         return entry_ready, (self.car0_ready if entry_ready is True else None)
 
 
+#: seconds a held session's render packet may stay pinned — while physics keeps advancing —
+#: before the hold reports a post-handoff wedge. Well past any frame-time hitch, and #627 §3.2
+#: records a wedge as terminal once it lands, so a conservative window rules out false alarms.
+DEFAULT_HOLD_WEDGE_SECONDS = 20.0
+
+
+class StableSessionWatch:
+    """Detect a render freeze that lands AFTER the stable session was handed to the operator.
+
+    The hold loop polls only process liveness and the release sentinel, so a render-thread wedge
+    that pins the graphics packet while ``acs.exe`` stays alive — the #627 §2 signature, and the
+    operator's literal "the video freezes but the tool says everything's fine" report — is
+    invisible: the launcher holds a dead session as healthy indefinitely (#630 Part A).
+
+    The wedge test is the same discriminator ``classify`` uses (#630 Part B): **graphics pinned
+    while PHYSICS keeps advancing**. Watching the graphics packet alone would latch a false wedge
+    on an ordinary alt-tab, because a pause pins graphics too — it just stops physics as well. So a
+    pause can never trip this, and only a genuine render-thread stall can.
+    """
+
+    def __init__(self, wedge_seconds: float = DEFAULT_HOLD_WEDGE_SECONDS) -> None:
+        if wedge_seconds <= 0:
+            raise ValueError("wedge_seconds must be > 0")
+        self._wedge_seconds = wedge_seconds
+        self._prev_gfx: int | None = None
+        self._prev_phys: int | None = None
+        self._prev_t: float | None = None
+        self._wedged_since: float | None = None
+        self._wedged = False
+
+    @property
+    def wedged(self) -> bool:
+        return self._wedged
+
+    def observe(self, *, gfx_packet: int | None, phys_packet: int | None, now: float) -> bool:
+        """Record one held-session sample; return True once a sustained render wedge is proven.
+
+        Latches, so the caller surfaces the wedge exactly once. An unreadable packet neither
+        advances nor confirms; a pause (physics stagnant) clears the wedge clock.
+        """
+        if self._wedged:
+            return True
+        gfx_pinned = (
+            gfx_packet is not None and self._prev_gfx is not None and gfx_packet == self._prev_gfx
+        )
+        phys_advancing = (
+            phys_packet is not None
+            and self._prev_phys is not None
+            and phys_packet > self._prev_phys
+        )
+        if gfx_pinned and phys_advancing:
+            # Anchor at the previous sample: the packet was already pinned at that value then, so
+            # the stall is measured from when it stopped moving, not from the first repeat we saw.
+            if self._wedged_since is None:
+                self._wedged_since = self._prev_t if self._prev_t is not None else now
+            if now - self._wedged_since >= self._wedge_seconds:
+                self._wedged = True
+        else:
+            self._wedged_since = None
+        if gfx_packet is not None:
+            self._prev_gfx = gfx_packet
+        if phys_packet is not None:
+            self._prev_phys = phys_packet
+        self._prev_t = now
+        return self._wedged
+
+
 @dataclass(frozen=True)
 class LaunchReport:
     """Summary of a full retry run."""
@@ -794,12 +861,39 @@ def _hold_stable_session(  # pragma: no cover - rig-only
     *,
     poll: float = 1.0,
     maintenance: Callable[[], None] | None = None,
+    read_state: Callable[[], tuple[int | None, bool | None, int | None]] | None = None,
+    set_phase: Callable[[str], None] | None = None,
+    wedge_seconds: float = DEFAULT_HOLD_WEDGE_SECONDS,
 ) -> bool:
-    """Hold rig ownership for a stable session and report whether release was intentional."""
+    """Hold rig ownership for a stable session and report whether release was intentional.
+
+    While holding, watch for a post-handoff render wedge (#630 Part A): graphics pinned while
+    physics keeps advancing. On one, say so loudly and republish the rig phase as ``wedged`` so
+    Game Point renders a distinct recovery state instead of continuing to present a frozen session
+    as a healthy hold. Ownership is deliberately retained either way — a wedged ``acs.exe`` must
+    not be inherited by a peer harness — so recovery stays the operator's/supervisor's call.
+    """
+    watch = StableSessionWatch(wedge_seconds) if read_state is not None else None
     try:
         while acs_alive() and not release_requested():
             if maintenance is not None:
                 maintenance()
+            if watch is not None and not watch.wedged and read_state is not None:
+                gfx_packet, _ready, phys_packet = read_state()
+                if watch.observe(
+                    gfx_packet=gfx_packet, phys_packet=phys_packet, now=time.monotonic()
+                ):
+                    _log(
+                        "WARNING: the handed-off session has WEDGED — the render packet has been "
+                        f"pinned for >={wedge_seconds:.0f}s while PHYSICS keeps advancing and "
+                        "acs.exe is alive (#627 §2 render freeze, not a pause). Holding rig "
+                        "ownership; the session needs a relaunch to recover."
+                    )
+                    if set_phase is not None:
+                        try:
+                            set_phase("wedged")
+                        except OSError as exc:
+                            _log(f"WARNING: could not publish the wedged rig phase: {exc}")
             time.sleep(poll)
     except KeyboardInterrupt:
         _log("operator released rig ownership; AC left LIVE")
@@ -1304,6 +1398,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 acs_alive,
                 release_requested,
                 maintenance=lambda: _retry_telemetry_cleanup_holds(telemetry_cleanup_holds),
+                read_state=read_state,
+                set_phase=rig_lock.set_phase,
             )
         except _Car0ProbeCleanupError as exc:
             _log(f"stable-session cleanup aborted: {exc}")

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -418,14 +418,12 @@ class StableSessionWatch:
         """
         if self._wedged:
             return True
-        gfx_pinned = (
-            gfx_packet is not None and self._prev_gfx is not None and gfx_packet == self._prev_gfx
-        )
-        phys_advancing = (
-            phys_packet is not None
-            and self._prev_phys is not None
-            and phys_packet > self._prev_phys
-        )
+        gfx_known = gfx_packet is not None and self._prev_gfx is not None
+        phys_known = phys_packet is not None and self._prev_phys is not None
+        gfx_pinned = gfx_known and gfx_packet == self._prev_gfx
+        gfx_moved = gfx_known and gfx_packet != self._prev_gfx
+        phys_advancing = phys_known and phys_packet > self._prev_phys
+        phys_stagnant = phys_known and phys_packet == self._prev_phys
         if gfx_pinned and phys_advancing:
             # Anchor at the previous sample: the packet was already pinned at that value then, so
             # the stall is measured from when it stopped moving, not from the first repeat we saw.
@@ -433,7 +431,12 @@ class StableSessionWatch:
                 self._wedged_since = self._prev_t if self._prev_t is not None else now
             if now - self._wedged_since >= self._wedge_seconds:
                 self._wedged = True
-        else:
+        elif gfx_moved or phys_stagnant:
+            # Positive evidence that no wedge is in progress: the render advanced, or physics
+            # stopped (a pause). Only these clear the clock — an UNREADABLE sample must not, or a
+            # momentary shared-memory blip would restart the window and could defer, or with
+            # periodic blips entirely defeat, detection of a real wedge. This is the "neither
+            # advances nor confirms" contract in the docstring.
             self._wedged_since = None
         if gfx_packet is not None:
             self._prev_gfx = gfx_packet
@@ -874,26 +877,33 @@ def _hold_stable_session(  # pragma: no cover - rig-only
     not be inherited by a peer harness — so recovery stays the operator's/supervisor's call.
     """
     watch = StableSessionWatch(wedge_seconds) if read_state is not None else None
+    wedge_phase_published = False
     try:
         while acs_alive() and not release_requested():
             if maintenance is not None:
                 maintenance()
-            if watch is not None and not watch.wedged and read_state is not None:
-                gfx_packet, _ready, phys_packet = read_state()
-                if watch.observe(
-                    gfx_packet=gfx_packet, phys_packet=phys_packet, now=time.monotonic()
-                ):
-                    _log(
-                        "WARNING: the handed-off session has WEDGED — the render packet has been "
-                        f"pinned for >={wedge_seconds:.0f}s while PHYSICS keeps advancing and "
-                        "acs.exe is alive (#627 §2 render freeze, not a pause). Holding rig "
-                        "ownership; the session needs a relaunch to recover."
-                    )
-                    if set_phase is not None:
-                        try:
-                            set_phase("wedged")
-                        except OSError as exc:
-                            _log(f"WARNING: could not publish the wedged rig phase: {exc}")
+            if watch is not None and read_state is not None:
+                if not watch.wedged:
+                    gfx_packet, _ready, phys_packet = read_state()
+                    if watch.observe(
+                        gfx_packet=gfx_packet, phys_packet=phys_packet, now=time.monotonic()
+                    ):
+                        _log(
+                            "WARNING: the handed-off session has WEDGED — the render packet has "
+                            f"been pinned for >={wedge_seconds:.0f}s while PHYSICS keeps advancing "
+                            "and acs.exe is alive (#627 §2 render freeze, not a pause). Holding "
+                            "rig ownership; the session needs a relaunch to recover."
+                        )
+                # Keep retrying the durable phase write until it lands. A single swallowed OSError
+                # would leave the lock metadata reading "stable" while the session is frozen — Game
+                # Point would keep presenting a healthy handoff, which is precisely the #630 failure
+                # this detection exists to end. The latch is never cleared by a retry.
+                if watch.wedged and not wedge_phase_published and set_phase is not None:
+                    try:
+                        set_phase("wedged")
+                        wedge_phase_published = True
+                    except OSError as exc:
+                        _log(f"WARNING: could not publish the wedged rig phase; retrying: {exc}")
             time.sleep(poll)
     except KeyboardInterrupt:
         _log("operator released rig ownership; AC left LIVE")

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -429,8 +429,6 @@ class StableSessionWatch:
             # the stall is measured from when it stopped moving, not from the first repeat we saw.
             if self._wedged_since is None:
                 self._wedged_since = self._prev_t if self._prev_t is not None else now
-            if now - self._wedged_since >= self._wedge_seconds:
-                self._wedged = True
         elif gfx_moved or phys_stagnant:
             # Positive evidence that no wedge is in progress: the render advanced, or physics
             # stopped (a pause). Only these clear the clock — an UNREADABLE sample must not, or a
@@ -438,11 +436,21 @@ class StableSessionWatch:
             # periodic blips entirely defeat, detection of a real wedge. This is the "neither
             # advances nor confirms" contract in the docstring.
             self._wedged_since = None
+        # An armed clock expires on ANY sample, including a neutral one. Once the wedge has been
+        # confirmed at least once, a shared-memory blackout must not postpone reporting it: the
+        # surfacing is non-destructive (a log plus a phase), so erring toward reporting is right.
+        if self._wedged_since is not None and now - self._wedged_since >= self._wedge_seconds:
+            self._wedged = True
         if gfx_packet is not None:
             self._prev_gfx = gfx_packet
         if phys_packet is not None:
             self._prev_phys = phys_packet
-        self._prev_t = now
+        if gfx_packet is not None:
+            # Only a readable graphics sample may move the anchor. The anchor means "when the
+            # render packet was last seen at this value"; letting an unreadable blip carry it
+            # forward would measure the stall from the blip instead of the last observed pin and
+            # defer detection by the whole blip gap.
+            self._prev_t = now
         return self._wedged
 
 

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -709,6 +709,18 @@ class GamePointSupervisor:
             for key in ("pid", "car", "track", "started_at", "phase")
             if owner.get(key) not in (None, "")
         )
+        if phase == "wedged":
+            # #630 Part A — the launcher proved a stable session, handed it over, and then watched
+            # its render packet pin while physics kept advancing (#627 §2). That is a frozen
+            # session needing a relaunch, NOT a startup still in progress, so it must not fall
+            # through to "stabilizing" and be presented as an in-progress start.
+            return ProbeResult(
+                "ac_session",
+                False,
+                "wedged",
+                "resilient session WEDGED after handoff (render frozen); relaunch to recover"
+                + (f": {detail}" if detail else ""),
+            )
         if phase != "stable":
             return ProbeResult(
                 "ac_session",

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -718,8 +718,9 @@ class GamePointSupervisor:
                 "ac_session",
                 False,
                 "wedged",
-                "resilient session WEDGED after handoff (render frozen); press RELEASE AC "
-                "then STABLE AC to recover" + (f": {detail}" if detail else ""),
+                "resilient session WEDGED after handoff (render frozen); press RELEASE AC, "
+                "wait for the rig to report idle, then STABLE AC"
+                + (f": {detail}" if detail else ""),
             )
         if phase != "stable":
             return ProbeResult(

--- a/tools/rig_launcher/supervisor.py
+++ b/tools/rig_launcher/supervisor.py
@@ -718,8 +718,8 @@ class GamePointSupervisor:
                 "ac_session",
                 False,
                 "wedged",
-                "resilient session WEDGED after handoff (render frozen); relaunch to recover"
-                + (f": {detail}" if detail else ""),
+                "resilient session WEDGED after handoff (render frozen); press RELEASE AC "
+                "then STABLE AC to recover" + (f": {detail}" if detail else ""),
             )
         if phase != "stable":
             return ProbeResult(

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -183,7 +183,7 @@ def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, st
                 "AC WEDGED",
                 "brake",
                 status.resilient.detail
-                or "session froze after handoff; press RELEASE AC then STABLE AC",
+                or "session froze after handoff; RELEASE AC, wait for idle, then STABLE AC",
             )
         if resilient_state in {"starting", "stabilizing"}:
             return (

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -182,7 +182,8 @@ def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, st
             return (
                 "AC WEDGED",
                 "brake",
-                status.resilient.detail or "session froze after handoff; relaunch to recover",
+                status.resilient.detail
+                or "session froze after handoff; press RELEASE AC then STABLE AC",
             )
         if resilient_state in {"starting", "stabilizing"}:
             return (

--- a/tools/rig_launcher/theme.py
+++ b/tools/rig_launcher/theme.py
@@ -175,6 +175,15 @@ def summary_for(status: GamePointStatus, port: int = 8765) -> tuple[str, str, st
                 "brake",
                 status.resilient.detail or "another rig session owns Assetto Corsa",
             )
+        if resilient_state == "wedged":
+            # #630 Part A — a post-handoff render freeze is a distinct, actionable state: the
+            # session is dead and needs a relaunch. Rendering it as "STABILIZING AC" would tell
+            # the driver a start is still in progress while the picture is frozen.
+            return (
+                "AC WEDGED",
+                "brake",
+                status.resilient.detail or "session froze after handoff; relaunch to recover",
+            )
         if resilient_state in {"starting", "stabilizing"}:
             return (
                 "STABILIZING AC",


### PR DESCRIPTION
Advances #630 (**Part A** — the issue's "highest operator impact"). Refs #627.

## The gap

The launcher proves a stable session, hands it to the operator, and then **goes blind**:
`_hold_stable_session` polls only `acs_alive()` + the release sentinel. A render-thread wedge landing
*after* the handoff — graphics packet pinned while `acs.exe` stays alive (#627 §2) — was invisible,
so the tool kept reporting a **frozen session as a healthy hold**. That is the operator's original
report: *"the video freezes but the tool says everything's fine."*

## The fix

`StableSessionWatch` samples the held session and proves a wedge with the same discriminator #630
Part B established: **graphics pinned while PHYSICS keeps advancing**.

That choice is the safety property. An alt-tab pins graphics too — but it also stops physics — so an
ordinary pause can **never** latch a false wedge. (The first cut of this change watched graphics
alone and would have false-wedged on any alt-tab; review caught it.) Window is a conservative 20 s.

## Surfacing it required a real state

`_rig_owner_status` mapped **every** non-`stable` phase to `stabilizing`, which the UI renders as
"STABILIZING AC" — so a post-handoff freeze would have been shown as a startup still in progress.
Game Point now carries a distinct `wedged` state rendered as **"AC WEDGED"** with a
relaunch-to-recover detail. Ownership is deliberately retained on a wedge so a peer harness cannot
inherit a wedged `acs.exe`; recovery stays the operator's/supervisor's call.

## Tests

- 7 `StableSessionWatch` tests: healthy never wedges; gfx-pinned-while-physics-advances **is** a
  wedge; **a 90 s pause never wedges**; brief hitch doesn't; resumed render clears the clock;
  unreadable sample is neutral; latches.
- 1 Game Point test pinning "AC WEDGED" as distinct from "STABILIZING AC".
- `106 passed` (launcher), `make ci-fast: OK`.

## Disclosed extra file

`tests/test_process_miner/test_workflow_pr_scope.py` exec'd `scripts/process_miner_pr_scope.sh`
**directly**, which Windows cannot run as a process image (`OSError: [WinError 193] %1 is not a valid
Win32 application`). It passes in Linux CI and fails deterministically on the Windows rig, where it
**red the `make ci-fast` gate** this PR must pass. Now invoked through `bash` — correct on both
platforms. Verified failing on clean `main` before my changes, so it is not a regression from this
work; included because it blocks the gate, disclosed rather than folded in silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)