### PR TITLE
feat(rig): promote the freeze-forensics instrument out of .scratch (#630 Part F)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-21T06:10:00Z
+last_updated: 2026-07-21T08:16:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/pr-637-pause-semantics-review-2026-07-20.md
   - AcCopilotTrainer/03_Investigations/mcp-preflight-guard-2026-07-20.md
@@ -108,14 +108,14 @@ relates_to:
 
 ## In flight (2026-07-21) — #630 Part F: freeze-forensics instrument promoted; PR #644 green & converged, awaiting merge
 
-**PR [#644](https://github.com/agorokh/ac-copilot-trainer/pull/644) OPEN**, head `2544c9c`, CI
-green (build / canonical-docs / conformance), all review threads resolved — **ready to merge**.
-Promotes `.scratch/freeze_forensics.py` into `tools/ac_harness/freeze_forensics.py` (S1
+**PR [#644](https://github.com/agorokh/ac-copilot-trainer/pull/644) OPEN**, head `e1a7c5b`, CI
+green (build / canonical-docs / conformance), GraphQL 0 unresolved, resolve-gate clean, daemon
+absent after cooldown (vacuous) — **ready to merge**. Promotes
+`.scratch/freeze_forensics.py` into `tools/ac_harness/freeze_forensics.py` (S1
 `QueryThreadCycleTime` spin-vs-block, S2 noninvasive cdb RIP sampling, the S3 contract inside
-`classify_forensics`; 14 unit tests).
+`classify_forensics`; 19 unit tests).
 
-**Five review rounds, every finding real** (codex 4×P1, daemon cursor HIGH, daemon antigravity
-HIGH-advisory):
+**Review rounds, every finding real** (codex P1s, daemon cursor HIGH, qodo advisory):
 
 1. `int(match.group(1), 16)` crashed on WinDbg's backtick address form → extracted `parse_rip`
    (regex + strip + ValueError-safe) as the single source of truth; the old test re-implemented
@@ -133,20 +133,26 @@ HIGH-advisory):
    unconfirmed transcripts return `rip=None` so the verdict stays INCONCLUSIVE.
 5. The substring marker check accepted hex-prefix tids (`AC_TID=1a2b` vs requested `0x1a`) →
    exact regex capture + integer compare; the prefix case is pinned in tests.
+6. Daemon HIGH on `a3fb7b1`: cdb timeout kills `-pv` before `qd` → `best_effort_thaw` re-attaches
+   with `qd` only; nonzero exit is `thaw=failed` not `thaw=ok` (`b3c9c9d` + `e1a7c5b`).
+7. Codex P1: S1/S2 sample the *hottest* thread, not a render-identified one — under the #627 §2
+   signature a busy physics worker can look like a livelock. LIVELOCK reading now names that
+   residual; `sample_cycles` docstring marks the hottest row as a candidate (`e1a7c5b`).
 
 **Out of scope, tracked:** codex "no runnable capture path" (the module has no `main()`) → filed
 as **Part G** on #630 ([comment](https://github.com/agorokh/ac-copilot-trainer/issues/630#issuecomment-5030577466)):
-S1→S2→S3 driver + machine-readable record (overlaps Part E).
+S1→S2→S3 driver + machine-readable record (overlaps Part E). Part G should also prefer a
+render-stack TID over pure hottest-thread selection.
 
 **Two ops notes for next session:**
-- The ws-ops daemon reviewed only 3 of 6 head SHAs this session (465 s lag once, then silent for
-  the last three pushes despite full cooldowns). Absence-after-cooldown is vacuous per the
-  resolve-pr anti-hang rule, but the trigger health is worth a glance.
+- The ws-ops daemon reviewed several early head SHAs then went silent for later pushes despite
+  full cooldowns (including `e1a7c5b`). Absence-after-cooldown is vacuous per the resolve-pr
+  anti-hang rule, but the trigger health is worth a glance.
 - This host's git identity is unset: the session's commits carry
-  `arseny_gorokh@Arsenys-Mac-Studio.local` instead of the branch's `Arseny <agorokh@example.com>`.
-  Amend before merge if attribution matters, or set `git config` on this host.
+  `arseny_gorokh@Arsenys-Mac-Studio.local` instead of the branch's expected author. Amend before
+  merge if attribution matters, or set `git config` on this host.
 
-**Resume here:** merge PR #644 (squash). Remaining on #630: Parts C, D, E, G. Local `main` is 13
+**Resume here:** merge PR #644 (squash). Remaining on #630: Parts C, D, E, G. Local `main` may be
 behind origin — sync on the post-merge pass.
 
 ## Delivered (2026-07-20) — #630 Parts A+B: the launcher no longer lies about a frozen session

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-20T18:40:00Z
+last_updated: 2026-07-21T06:10:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/pr-637-pause-semantics-review-2026-07-20.md
   - AcCopilotTrainer/03_Investigations/mcp-preflight-guard-2026-07-20.md
@@ -105,6 +105,49 @@ relates_to:
 ---
 
 # Next session handoff
+
+## In flight (2026-07-21) — #630 Part F: freeze-forensics instrument promoted; PR #644 green & converged, awaiting merge
+
+**PR [#644](https://github.com/agorokh/ac-copilot-trainer/pull/644) OPEN**, head `2544c9c`, CI
+green (build / canonical-docs / conformance), all review threads resolved — **ready to merge**.
+Promotes `.scratch/freeze_forensics.py` into `tools/ac_harness/freeze_forensics.py` (S1
+`QueryThreadCycleTime` spin-vs-block, S2 noninvasive cdb RIP sampling, the S3 contract inside
+`classify_forensics`; 14 unit tests).
+
+**Five review rounds, every finding real** (codex 4×P1, daemon cursor HIGH, daemon antigravity
+HIGH-advisory):
+
+1. `int(match.group(1), 16)` crashed on WinDbg's backtick address form → extracted `parse_rip`
+   (regex + strip + ValueError-safe) as the single source of truth; the old test re-implemented
+   the sanitization and masked the gap (the antigravity test-production-drift point) — it now
+   calls the production parser directly.
+2. `LIVELOCK_CONFIRMED` overclaimed non-convergence → the verdict text now names the residual
+   class (a finite tight loop longer than the sampling interval) and points at the independent
+   progress check already in the design (the render packet → `NOT_WEDGED` on re-run). Verdict and
+   gate order unchanged.
+3. `tid=None` default selected thread index 0 (parked in ntdll) → `tid` is now a required keyword
+   argument sourced from `sample_cycles`' hottest row; the `~0s` fallback is deleted, so the
+   documented misdiagnosis is unrepresentable.
+4. Daemon HIGH: a failed `~~[0xTID]s` does NOT abort cdb's `-c` script — registers still print
+   from the default (parked) context → a `.printf "AC_TID=%x"` marker right after the switch;
+   unconfirmed transcripts return `rip=None` so the verdict stays INCONCLUSIVE.
+5. The substring marker check accepted hex-prefix tids (`AC_TID=1a2b` vs requested `0x1a`) →
+   exact regex capture + integer compare; the prefix case is pinned in tests.
+
+**Out of scope, tracked:** codex "no runnable capture path" (the module has no `main()`) → filed
+as **Part G** on #630 ([comment](https://github.com/agorokh/ac-copilot-trainer/issues/630#issuecomment-5030577466)):
+S1→S2→S3 driver + machine-readable record (overlaps Part E).
+
+**Two ops notes for next session:**
+- The ws-ops daemon reviewed only 3 of 6 head SHAs this session (465 s lag once, then silent for
+  the last three pushes despite full cooldowns). Absence-after-cooldown is vacuous per the
+  resolve-pr anti-hang rule, but the trigger health is worth a glance.
+- This host's git identity is unset: the session's commits carry
+  `arseny_gorokh@Arsenys-Mac-Studio.local` instead of the branch's `Arseny <agorokh@example.com>`.
+  Amend before merge if attribution matters, or set `git config` on this host.
+
+**Resume here:** merge PR #644 (squash). Remaining on #630: Parts C, D, E, G. Local `main` is 13
+behind origin — sync on the post-merge pass.
 
 ## Delivered (2026-07-20) — #630 Parts A+B: the launcher no longer lies about a frozen session
 

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -1,0 +1,106 @@
+"""Off-rig tests for the freeze-forensics verdict logic (#630 Part F / #627 §6.1).
+
+The instrument's whole value is that its PASS is honest: it decides whether a wedged ``acs.exe`` is
+spinning, blocked, or still computing, and #627 gates the upstream CSP bug report on that answer.
+So the decision is a pure function and every branch is pinned here — including the two verdicts that
+exist because both mistakes were made for real during the 2026-07-19 session.
+"""
+
+from __future__ import annotations
+
+from tools.ac_harness.freeze_forensics import (
+    DEFAULT_TIGHT_LOOP_BYTES,
+    ForensicVerdict,
+    classify_forensics,
+    rip_span,
+)
+
+
+def _classify(**overrides):
+    """A confirmed-livelock observation set, with individual signals overridden per test."""
+    args = {
+        "burning_cpu": True,
+        "gfx_static": True,
+        "phys_advancing": True,
+        "rip_samples_observed": 3,
+        "rip_span_bytes": 64,
+    }
+    args.update(overrides)
+    return classify_forensics(**args)
+
+
+def test_livelock_is_confirmed_when_all_three_signals_agree() -> None:
+    verdict, reading = _classify()
+    assert verdict is ForensicVerdict.LIVELOCK_CONFIRMED
+    assert "tight loop" in reading
+
+
+def test_a_recovered_session_is_not_a_wedge() -> None:
+    """The mistake made for real: a trial whose graphics packet advanced had RECOVERED.
+
+    It was a transient init stall reported as a freeze, and calling it a confirmed spin was wrong.
+    An advancing render packet must short-circuit before any livelock claim.
+    """
+    verdict, reading = _classify(gfx_static=False)
+    assert verdict is ForensicVerdict.NOT_WEDGED
+    assert "recovered" in reading
+
+
+def test_a_recovered_session_wins_over_every_other_signal() -> None:
+    """Even with CPU burning and a pinned RIP, an advancing render packet means no wedge."""
+    verdict, _ = _classify(gfx_static=False, burning_cpu=True, rip_span_bytes=8)
+    assert verdict is ForensicVerdict.NOT_WEDGED
+
+
+def test_both_streams_stopped_is_not_a_render_wedge() -> None:
+    """#627 §2: a render wedge keeps PHYSICS advancing. Both stopped is a pause or a dead sim."""
+    verdict, reading = _classify(phys_advancing=False)
+    assert verdict is ForensicVerdict.NOT_RENDER_WEDGE
+    assert "physics" in reading
+
+
+def test_idle_thread_is_a_block_not_a_spin() -> None:
+    verdict, reading = _classify(burning_cpu=False)
+    assert verdict is ForensicVerdict.BLOCKED_NOT_SPIN
+    assert "WAITING" in reading
+
+
+def test_one_rip_sample_is_inconclusive_not_a_long_computation() -> None:
+    """The audit's catch: a single sample carries no information about wandering.
+
+    Falling through to LONG_COMPUTATION would print "RIP wanders" from one point — and that is the
+    one verdict that would wrongly kill the livelock hypothesis the upstream report rests on.
+    """
+    verdict, reading = _classify(rip_samples_observed=1, rip_span_bytes=None)
+    assert verdict is ForensicVerdict.INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES
+    assert "cannot be decided" in reading
+
+
+def test_zero_rip_samples_is_inconclusive() -> None:
+    verdict, _ = _classify(rip_samples_observed=0, rip_span_bytes=None)
+    assert verdict is ForensicVerdict.INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES
+
+
+def test_wandering_rip_is_a_long_computation() -> None:
+    verdict, reading = _classify(rip_span_bytes=DEFAULT_TIGHT_LOOP_BYTES * 4)
+    assert verdict is ForensicVerdict.LONG_COMPUTATION
+    assert "wanders" in reading
+
+
+def test_the_tight_loop_boundary_is_exclusive() -> None:
+    assert _classify(rip_span_bytes=DEFAULT_TIGHT_LOOP_BYTES - 1)[0] is (
+        ForensicVerdict.LIVELOCK_CONFIRMED
+    )
+    assert _classify(rip_span_bytes=DEFAULT_TIGHT_LOOP_BYTES)[0] is (
+        ForensicVerdict.LONG_COMPUTATION
+    )
+
+
+def test_rip_span_needs_two_samples() -> None:
+    assert rip_span([]) is None
+    assert rip_span([0x7FF000001000]) is None
+    assert rip_span([0x7FF000001000, 0x7FF000001040]) == 0x40
+
+
+def test_rip_span_is_the_full_spread_not_the_last_step() -> None:
+    assert rip_span([0x1000, 0x1010, 0x1004]) == 0x10

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -8,6 +8,8 @@ exist because both mistakes were made for real during the 2026-07-19 session.
 
 from __future__ import annotations
 
+import subprocess
+
 from tools.ac_harness.freeze_forensics import (
     DEFAULT_TIGHT_LOOP_BYTES,
     ForensicVerdict,
@@ -135,3 +137,78 @@ def test_selected_tid_confirmed_only_for_the_requested_thread() -> None:
     # The requested tid as a hex PREFIX of the actual thread must not confirm (substring trap).
     assert not selected_tid_confirmed("AC_TID=1a2b\nrip=00007ff600001234", 0x1A)
     assert not selected_tid_confirmed("no marker at all", 0x1A2B)
+
+
+def test_thaw_cdb_command_is_noninvasive_and_detaches() -> None:
+    """The thaw must stay ``-pv`` (never become the process debugger) and end with ``qd``."""
+    from pathlib import Path
+
+    from tools.ac_harness.freeze_forensics import thaw_cdb_command
+
+    cmd = thaw_cdb_command(Path("/fake/cdb.exe"), 4242)
+    assert cmd[0].endswith("cdb.exe")
+    assert "-pv" in cmd
+    assert cmd[cmd.index("-p") + 1] == "4242"
+    assert cmd[-2:] == ["-c", "qd"]
+
+
+def test_best_effort_thaw_never_raises_on_timeout(monkeypatch) -> None:
+    """A stuck thaw must not promote a capture failure into a second exception."""
+    from pathlib import Path
+
+    from tools.ac_harness.freeze_forensics import best_effort_thaw
+
+    def _timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=["cdb"], timeout=15)
+
+    monkeypatch.setattr(
+        "tools.ac_harness.freeze_forensics.subprocess.run",
+        _timeout,
+    )
+    assert best_effort_thaw(Path("/fake/cdb.exe"), 99) == "thaw=timeout"
+
+
+def test_best_effort_thaw_never_raises_on_oserror(monkeypatch) -> None:
+    from pathlib import Path
+
+    from tools.ac_harness.freeze_forensics import best_effort_thaw
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("CreateProcess failed")
+
+    monkeypatch.setattr(
+        "tools.ac_harness.freeze_forensics.subprocess.run",
+        _boom,
+    )
+    assert best_effort_thaw(Path("/fake/cdb.exe"), 99).startswith("thaw=failed:")
+
+
+def test_cdb_snapshot_thaws_target_after_timeout(monkeypatch) -> None:
+    """A hard-killed ``-pv`` attach leaves suspend counts on the target unless ``qd`` re-runs.
+
+    This is the daemon HIGH: ``subprocess.run`` kills ``cdb`` on timeout *before* the primary
+    script's trailing ``qd``, so without a follow-up thaw the wedged process is permanently
+    suspended — destroying the evidence the tool exists to capture.
+    """
+    from pathlib import Path
+
+    import tools.ac_harness.freeze_forensics as ff
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if len(calls) == 1:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 90))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(ff, "find_cdb", lambda: Path("/fake/cdb.exe"))
+    monkeypatch.setattr(ff.subprocess, "run", fake_run)
+
+    sample = ff.cdb_snapshot(1234, tid=0x1A2B, timeout=1.0)
+    assert sample.rip is None
+    assert "cdb timed out" in sample.raw
+    assert "thaw=ok" in sample.raw
+    assert len(calls) == 2
+    # Second call is the thaw: noninvasive attach + immediate detach.
+    assert calls[1] == ["/fake/cdb.exe", "-pv", "-p", "1234", "-c", "qd"]

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -22,8 +22,7 @@ def _classify(**overrides):
         "burning_cpu": True,
         "gfx_static": True,
         "phys_advancing": True,
-        "rip_samples_observed": 3,
-        "rip_span_bytes": 64,
+        "rips": [0x7FF000001000, 0x7FF000001020, 0x7FF000001040],
     }
     args.update(overrides)
     return classify_forensics(**args)
@@ -48,7 +47,7 @@ def test_a_recovered_session_is_not_a_wedge() -> None:
 
 def test_a_recovered_session_wins_over_every_other_signal() -> None:
     """Even with CPU burning and a pinned RIP, an advancing render packet means no wedge."""
-    verdict, _ = _classify(gfx_static=False, burning_cpu=True, rip_span_bytes=8)
+    verdict, _ = _classify(gfx_static=False, burning_cpu=True, rips=[0x1000, 0x1008])
     assert verdict is ForensicVerdict.NOT_WEDGED
 
 
@@ -71,27 +70,27 @@ def test_one_rip_sample_is_inconclusive_not_a_long_computation() -> None:
     Falling through to LONG_COMPUTATION would print "RIP wanders" from one point — and that is the
     one verdict that would wrongly kill the livelock hypothesis the upstream report rests on.
     """
-    verdict, reading = _classify(rip_samples_observed=1, rip_span_bytes=None)
+    verdict, reading = _classify(rips=[0x1000])
     assert verdict is ForensicVerdict.INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES
     assert "cannot be decided" in reading
 
 
 def test_zero_rip_samples_is_inconclusive() -> None:
-    verdict, _ = _classify(rip_samples_observed=0, rip_span_bytes=None)
+    verdict, _ = _classify(rips=[])
     assert verdict is ForensicVerdict.INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES
 
 
 def test_wandering_rip_is_a_long_computation() -> None:
-    verdict, reading = _classify(rip_span_bytes=DEFAULT_TIGHT_LOOP_BYTES * 4)
+    verdict, reading = _classify(rips=[0x1000, 0x1000 + DEFAULT_TIGHT_LOOP_BYTES * 4])
     assert verdict is ForensicVerdict.LONG_COMPUTATION
     assert "wanders" in reading
 
 
 def test_the_tight_loop_boundary_is_exclusive() -> None:
-    assert _classify(rip_span_bytes=DEFAULT_TIGHT_LOOP_BYTES - 1)[0] is (
+    assert _classify(rips=[0x1000, 0x1000 + DEFAULT_TIGHT_LOOP_BYTES - 1])[0] is (
         ForensicVerdict.LIVELOCK_CONFIRMED
     )
-    assert _classify(rip_span_bytes=DEFAULT_TIGHT_LOOP_BYTES)[0] is (
+    assert _classify(rips=[0x1000, 0x1000 + DEFAULT_TIGHT_LOOP_BYTES])[0] is (
         ForensicVerdict.LONG_COMPUTATION
     )
 
@@ -104,3 +103,24 @@ def test_rip_span_needs_two_samples() -> None:
 
 def test_rip_span_is_the_full_spread_not_the_last_step() -> None:
     assert rip_span([0x1000, 0x1010, 0x1004]) == 0x10
+
+
+def test_two_identical_rips_are_a_zero_span_tight_loop() -> None:
+    """A perfectly pinned RIP is span 0 — the strongest livelock evidence, not a missing span."""
+    verdict, _ = _classify(rips=[0x7FF000001000, 0x7FF000001000])
+    assert verdict is ForensicVerdict.LIVELOCK_CONFIRMED
+
+
+def test_rip_regex_parses_both_windbg_address_forms() -> None:
+    """WinDbg prints 64-bit addresses flat OR backtick-separated (``00007ff6`00001234``).
+
+    Missing the backtick form yields zero parsed RIPs, silently degrading every diagnosis to
+    INCONCLUSIVE — the instrument would look like it works while proving nothing.
+    """
+    from tools.ac_harness.freeze_forensics import _RIP_RE
+
+    flat = _RIP_RE.search("rax=0000000000000001 rip=00007ff600001234 rsp=...")
+    ticked = _RIP_RE.search("rax=0000000000000001 rip=00007ff6`00001234 rsp=...")
+
+    assert flat is not None and int(flat.group(1).replace("`", ""), 16) == 0x00007FF600001234
+    assert ticked is not None and int(ticked.group(1).replace("`", ""), 16) == 0x00007FF600001234

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -34,6 +34,9 @@ def test_livelock_is_confirmed_when_all_three_signals_agree() -> None:
     verdict, reading = _classify()
     assert verdict is ForensicVerdict.LIVELOCK_CONFIRMED
     assert "tight loop" in reading
+    # Hottest-thread residual must stay visible in the reading — S1/S2 do not identify render.
+    assert "hottest sampled thread" in reading
+    assert "physics worker" in reading
 
 
 def test_a_recovered_session_is_not_a_wedge() -> None:
@@ -183,6 +186,27 @@ def test_best_effort_thaw_never_raises_on_oserror(monkeypatch) -> None:
     assert best_effort_thaw(Path("/fake/cdb.exe"), 99).startswith("thaw=failed:")
 
 
+def test_best_effort_thaw_requires_zero_exit(monkeypatch) -> None:
+    """A nonzero cdb exit is a failed thaw — subprocess.run still returns normally."""
+    from pathlib import Path
+
+    from tools.ac_harness.freeze_forensics import best_effort_thaw
+
+    def _nonzero(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["cdb"], returncode=1, stdout="", stderr="Could not attach"
+        )
+
+    monkeypatch.setattr(
+        "tools.ac_harness.freeze_forensics.subprocess.run",
+        _nonzero,
+    )
+    status = best_effort_thaw(Path("/fake/cdb.exe"), 99)
+    assert status.startswith("thaw=failed:")
+    assert "rc=1" in status
+    assert "Could not attach" in status
+
+
 def test_cdb_snapshot_thaws_target_after_timeout(monkeypatch) -> None:
     """A hard-killed ``-pv`` attach leaves suspend counts on the target unless ``qd`` re-runs.
 
@@ -195,6 +219,7 @@ def test_cdb_snapshot_thaws_target_after_timeout(monkeypatch) -> None:
     import tools.ac_harness.freeze_forensics as ff
 
     calls: list[list[str]] = []
+    cdb = Path("/fake/cdb.exe")
 
     def fake_run(cmd, **kwargs):
         calls.append(list(cmd))
@@ -202,7 +227,7 @@ def test_cdb_snapshot_thaws_target_after_timeout(monkeypatch) -> None:
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 90))
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-    monkeypatch.setattr(ff, "find_cdb", lambda: Path("/fake/cdb.exe"))
+    monkeypatch.setattr(ff, "find_cdb", lambda: cdb)
     monkeypatch.setattr(ff.subprocess, "run", fake_run)
 
     sample = ff.cdb_snapshot(1234, tid=0x1A2B, timeout=1.0)
@@ -211,4 +236,5 @@ def test_cdb_snapshot_thaws_target_after_timeout(monkeypatch) -> None:
     assert "thaw=ok" in sample.raw
     assert len(calls) == 2
     # Second call is the thaw: noninvasive attach + immediate detach.
-    assert calls[1] == ["/fake/cdb.exe", "-pv", "-p", "1234", "-c", "qd"]
+    # Use str(Path) so the expected path matches production on Windows and POSIX.
+    assert calls[1] == [str(cdb), "-pv", "-p", "1234", "-c", "qd"]

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -132,4 +132,6 @@ def test_selected_tid_confirmed_only_for_the_requested_thread() -> None:
 
     assert selected_tid_confirmed("AC_TID=1a2b\nrip=00007ff600001234", 0x1A2B)
     assert not selected_tid_confirmed("AC_TID=3c4d\nrip=00007ff600001234", 0x1A2B)
+    # The requested tid as a hex PREFIX of the actual thread must not confirm (substring trap).
+    assert not selected_tid_confirmed("AC_TID=1a2b\nrip=00007ff600001234", 0x1A)
     assert not selected_tid_confirmed("no marker at all", 0x1A2B)

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -123,3 +123,13 @@ def test_parse_rip_handles_both_windbg_address_forms() -> None:
     assert parse_rip("rax=0000000000000001 rip=00007ff600001234 rsp=...") == 0x00007FF600001234
     assert parse_rip("rax=0000000000000001 rip=00007ff6`00001234 rsp=...") == 0x00007FF600001234
     assert parse_rip("no registers captured") is None
+
+
+def test_selected_tid_confirmed_only_for_the_requested_thread() -> None:
+    """A failed ``~~[tid]s`` leaves cdb in the default (parked) context but still prints
+    registers — only the post-switch marker separates real evidence from a wrong-thread RIP."""
+    from tools.ac_harness.freeze_forensics import selected_tid_confirmed
+
+    assert selected_tid_confirmed("AC_TID=1a2b\nrip=00007ff600001234", 0x1A2B)
+    assert not selected_tid_confirmed("AC_TID=3c4d\nrip=00007ff600001234", 0x1A2B)
+    assert not selected_tid_confirmed("no marker at all", 0x1A2B)

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -111,16 +111,15 @@ def test_two_identical_rips_are_a_zero_span_tight_loop() -> None:
     assert verdict is ForensicVerdict.LIVELOCK_CONFIRMED
 
 
-def test_rip_regex_parses_both_windbg_address_forms() -> None:
+def test_parse_rip_handles_both_windbg_address_forms() -> None:
     """WinDbg prints 64-bit addresses flat OR backtick-separated (``00007ff6`00001234``).
 
     Missing the backtick form yields zero parsed RIPs, silently degrading every diagnosis to
-    INCONCLUSIVE — the instrument would look like it works while proving nothing.
+    INCONCLUSIVE — the instrument would look like it works while proving nothing. The test
+    must exercise the production parser itself so the sanitization cannot drift away from it.
     """
-    from tools.ac_harness.freeze_forensics import _RIP_RE
+    from tools.ac_harness.freeze_forensics import parse_rip
 
-    flat = _RIP_RE.search("rax=0000000000000001 rip=00007ff600001234 rsp=...")
-    ticked = _RIP_RE.search("rax=0000000000000001 rip=00007ff6`00001234 rsp=...")
-
-    assert flat is not None and int(flat.group(1).replace("`", ""), 16) == 0x00007FF600001234
-    assert ticked is not None and int(ticked.group(1).replace("`", ""), 16) == 0x00007FF600001234
+    assert parse_rip("rax=0000000000000001 rip=00007ff600001234 rsp=...") == 0x00007FF600001234
+    assert parse_rip("rax=0000000000000001 rip=00007ff6`00001234 rsp=...") == 0x00007FF600001234
+    assert parse_rip("no registers captured") is None

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -297,6 +297,44 @@ class RipSample:
     raw: str = field(repr=False, default="")
 
 
+#: How long the best-effort thaw attach may run. Short on purpose — a stuck thaw must not
+#: re-block the operator for the full sampling budget.
+_THAW_TIMEOUT_S = 15.0
+
+
+def thaw_cdb_command(cdb: Path, pid: int) -> list[str]:
+    """Command that attaches noninvasively and immediately detaches (``qd``).
+
+    Used after a timed-out primary attach: ``subprocess.run`` kills ``cdb`` before the trailing
+    ``qd`` of the sampling script can run, and a killed ``-pv`` session does not reliably clear the
+    suspend counts it applied. A follow-up ``qd`` is the cheapest way to thaw without becoming the
+    process's debugger (which would risk terminating the evidence on detach).
+    """
+    return [str(cdb), "-pv", "-p", str(pid), "-c", "qd"]
+
+
+def best_effort_thaw(cdb: Path, pid: int, *, timeout: float = _THAW_TIMEOUT_S) -> str:
+    """Best-effort thaw of ``pid`` after a failed noninvasive attach. Never raises.
+
+    Returns a short status token for the sample's ``raw`` field so a log can show whether the
+    thaw was attempted and whether it completed. Failures are swallowed: the capture already
+    failed, and a second exception here would only hide that fact.
+    """
+    try:
+        subprocess.run(
+            thaw_cdb_command(cdb, pid),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            errors="replace",
+        )
+        return "thaw=ok"
+    except subprocess.TimeoutExpired:
+        return "thaw=timeout"
+    except OSError as exc:
+        return f"thaw=failed:{exc}"
+
+
 def cdb_snapshot(
     pid: int, *, tid: int, timeout: float = 90.0
 ) -> RipSample:  # pragma: no cover - rig-only
@@ -311,6 +349,9 @@ def cdb_snapshot(
     :data:`_TID_MARKER` line is checked before any parsing, because a failed thread switch does
     not abort the ``-c`` script — an unconfirmed transcript yields ``rip=None`` so the verdict
     stays at INCONCLUSIVE rather than convicting a parked thread.
+
+    On ``TimeoutExpired``, :func:`best_effort_thaw` runs before returning: the primary ``-c`` script
+    ends with ``qd``, but a hard-killed ``cdb`` never reaches it, and suspend counts can stick.
     """
     cdb = find_cdb()
     if cdb is None:
@@ -330,7 +371,8 @@ def cdb_snapshot(
         )
         raw = proc.stdout + proc.stderr
     except subprocess.TimeoutExpired:
-        return RipSample(time.time(), None, "", "cdb timed out")
+        thaw_status = best_effort_thaw(cdb, pid)
+        return RipSample(time.time(), None, "", f"cdb timed out; {thaw_status}")
     except OSError as exc:
         # The binary can vanish or refuse CreateProcess (WindowsApps ACLs) between the glob and
         # exec — degrade to INCONCLUSIVE like every other capture failure, never crash the run.

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -38,6 +38,7 @@ import glob
 import re
 import subprocess
 import time
+from collections.abc import Sequence
 from ctypes import wintypes
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -69,15 +70,21 @@ def classify_forensics(
     burning_cpu: bool,
     gfx_static: bool,
     phys_advancing: bool,
-    rip_samples_observed: int,
-    rip_span_bytes: int | None,
+    rips: Sequence[int],
     tight_loop_bytes: int = DEFAULT_TIGHT_LOOP_BYTES,
 ) -> tuple[ForensicVerdict, str]:
     """Decide the verdict from the three signals. Pure — no I/O, no clock.
 
     The order of these checks is the whole design: each one rules out a cheaper explanation before
     the more expensive claim is allowed.
+
+    ``rips`` is the observed instruction pointers themselves, not a pre-computed count and span.
+    Passing those two separately made an inconsistent state representable — a caller could report
+    "2 samples" with a ``None`` span, which fell through to ``LONG_COMPUTATION``, the single verdict
+    that must never be reached without evidence. Deriving both here makes that unrepresentable.
     """
+    observed = list(rips)
+    span = rip_span(observed)
     if not gfx_static:
         return (
             ForensicVerdict.NOT_WEDGED,
@@ -97,23 +104,23 @@ def classify_forensics(
             "the hottest thread is not consuming CPU, so the main thread is WAITING, not "
             "spinning. That is a block/deadlock — a different bug from the livelock hypothesis.",
         )
-    if rip_samples_observed < MIN_RIP_SAMPLES:
+    if span is None:
         return (
             ForensicVerdict.INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES,
-            f"only {rip_samples_observed} RIP sample(s) were read (need >={MIN_RIP_SAMPLES}). CPU "
+            f"only {len(observed)} RIP sample(s) were read (need >={MIN_RIP_SAMPLES}). CPU "
             "is burning, but spin-vs-long-computation cannot be decided: one sample carries no "
             "information about wandering. Re-run the capture against the still-live process.",
         )
-    if rip_span_bytes is not None and rip_span_bytes < tight_loop_bytes:
+    if span < tight_loop_bytes:
         return (
             ForensicVerdict.LIVELOCK_CONFIRMED,
             f"the main thread burns CPU while the render packet never advances, and RIP stays "
-            f"inside a {rip_span_bytes}-byte window across the sampling interval. A thread cannot "
+            f"inside a {span}-byte window across the sampling interval. A thread cannot "
             "be waiting with RIP on moving code: this is a tight loop that is not converging.",
         )
     return (
         ForensicVerdict.LONG_COMPUTATION,
-        f"CPU is burning but RIP wanders across {rip_span_bytes} bytes — the thread is walking "
+        f"CPU is burning but RIP wanders across {span} bytes — the thread is walking "
         "through code, so this is a long finite computation rather than a tight loop.",
     )
 
@@ -133,7 +140,10 @@ TH32CS_SNAPTHREAD = 0x00000004
 THREAD_QUERY_LIMITED_INFORMATION = 0x0800
 INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
 
-_RIP_RE = re.compile(r"rip=([0-9a-f]{16})", re.IGNORECASE)
+#: WinDbg/cdb print 64-bit addresses either flat or with a backtick separator
+#: (``rip=00007ff6`00001234``). Missing the backtick form would yield zero parsed RIPs and
+#: silently degrade every diagnosis to INCONCLUSIVE.
+_RIP_RE = re.compile(r"rip=([0-9a-f`]{16,17})", re.IGNORECASE)
 
 
 def find_cdb() -> Path | None:  # pragma: no cover - rig-only

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -1,0 +1,282 @@
+"""Decide what a wedged ``acs.exe`` is actually doing: spinning, blocked, or still working.
+
+#627 §6.1 blocks the upstream CSP bug report on one question — is the wedge a **livelock** (a
+data-dependent loop that never converges) or something else? A single memory dump cannot answer it:
+a thread moving very fast in a circle and a thread grinding through a long computation look
+identical at one instant. The council's answer was "take two 4.8 GB dumps 10 s apart and diff
+thread 0" — expensive, and it still only gives two points.
+
+This module answers it from three cheap, independent signals:
+
+``S1`` ``QueryThreadCycleTime`` per thread → **burning CPU vs blocked**. A blocked thread accrues
+    ~0 cycles; a spinning one accrues ~a full core. This alone kills the deadlock explanation.
+``S2`` RIP sampled from repeated NONINVASIVE ``cdb`` attaches → **tight loop vs long computation**.
+    A long computation walks through code (RIP wanders); a tight loop pins RIP inside a few dozen
+    bytes indefinitely.
+``S3`` ``acpmf_graphics`` vs ``acpmf_physics`` packet ids, with an ``acs.exe`` liveness check →
+    the #627 §2 discriminator, and the guard against trap §7.1 (shared-memory sections outlive
+    ``acs.exe``, so a dead sim reads identical to a wedged one without the process check).
+
+The decision over those signals is :func:`classify_forensics` — pure, so every branch is unit
+tested off-rig. Collection is Windows/rig-only.
+
+Two lessons from the 2026-07-19 session are encoded as explicit verdicts, because both were
+mistakes made in practice:
+
+* A session whose graphics packet ADVANCED during the diagnosis had recovered — it was a transient
+  init stall, not a terminal wedge. Reported as ``NOT_WEDGED`` rather than quietly analysed. (I
+  called such a trial a confirmed spin before reading the artifact; it was not.)
+* Fewer than two successful RIP reads carries no information about wandering, so it must not fall
+  through to ``LONG_COMPUTATION`` — the one verdict that would wrongly kill the livelock
+  hypothesis. Reported as ``INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import glob
+import re
+import subprocess
+import time
+from ctypes import wintypes
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+#: cycles/second above which a thread counts as burning CPU. A modern core retires on the order of
+#: 1e9 cycles/s, so a spin pins ~one core; an idle/blocked thread accrues essentially none.
+DEFAULT_BURNING_CYCLES_PER_S = 2e8
+#: RIP spread (bytes) within which the sampled instruction pointer counts as a tight loop rather
+#: than a computation walking through code.
+DEFAULT_TIGHT_LOOP_BYTES = 4096
+#: RIP reads needed before "wandering" can be claimed at all.
+MIN_RIP_SAMPLES = 2
+
+
+class ForensicVerdict(StrEnum):
+    """What the three signals together prove about a wedged process."""
+
+    LIVELOCK_CONFIRMED = "livelock_confirmed"
+    LONG_COMPUTATION = "long_computation"
+    BLOCKED_NOT_SPIN = "blocked_not_spin"
+    NOT_WEDGED = "not_wedged"
+    NOT_RENDER_WEDGE = "not_render_wedge"
+    INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES = "inconclusive_insufficient_rip_samples"
+
+
+def classify_forensics(
+    *,
+    burning_cpu: bool,
+    gfx_static: bool,
+    phys_advancing: bool,
+    rip_samples_observed: int,
+    rip_span_bytes: int | None,
+    tight_loop_bytes: int = DEFAULT_TIGHT_LOOP_BYTES,
+) -> tuple[ForensicVerdict, str]:
+    """Decide the verdict from the three signals. Pure — no I/O, no clock.
+
+    The order of these checks is the whole design: each one rules out a cheaper explanation before
+    the more expensive claim is allowed.
+    """
+    if not gfx_static:
+        return (
+            ForensicVerdict.NOT_WEDGED,
+            "the render packet ADVANCED during the diagnosis, so the session recovered — this was "
+            "a transient stall, not a terminal wedge. Nothing here supports a livelock claim.",
+        )
+    if not phys_advancing:
+        return (
+            ForensicVerdict.NOT_RENDER_WEDGE,
+            "graphics and physics are BOTH stopped. A #627 §2 render wedge keeps physics "
+            "advancing, so this is a pause, a fully stopped sim, or a dead process — not a "
+            "render-thread wedge.",
+        )
+    if not burning_cpu:
+        return (
+            ForensicVerdict.BLOCKED_NOT_SPIN,
+            "the hottest thread is not consuming CPU, so the main thread is WAITING, not "
+            "spinning. That is a block/deadlock — a different bug from the livelock hypothesis.",
+        )
+    if rip_samples_observed < MIN_RIP_SAMPLES:
+        return (
+            ForensicVerdict.INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES,
+            f"only {rip_samples_observed} RIP sample(s) were read (need >={MIN_RIP_SAMPLES}). CPU "
+            "is burning, but spin-vs-long-computation cannot be decided: one sample carries no "
+            "information about wandering. Re-run the capture against the still-live process.",
+        )
+    if rip_span_bytes is not None and rip_span_bytes < tight_loop_bytes:
+        return (
+            ForensicVerdict.LIVELOCK_CONFIRMED,
+            f"the main thread burns CPU while the render packet never advances, and RIP stays "
+            f"inside a {rip_span_bytes}-byte window across the sampling interval. A thread cannot "
+            "be waiting with RIP on moving code: this is a tight loop that is not converging.",
+        )
+    return (
+        ForensicVerdict.LONG_COMPUTATION,
+        f"CPU is burning but RIP wanders across {rip_span_bytes} bytes — the thread is walking "
+        "through code, so this is a long finite computation rather than a tight loop.",
+    )
+
+
+def rip_span(rips: list[int]) -> int | None:
+    """Spread of the observed instruction pointers, or ``None`` below the evidence threshold."""
+    if len(rips) < MIN_RIP_SAMPLES:
+        return None
+    return max(rips) - min(rips)
+
+
+# --------------------------------------------------------------------------------------
+# Collection (Windows/rig-only).
+# --------------------------------------------------------------------------------------
+
+TH32CS_SNAPTHREAD = 0x00000004
+THREAD_QUERY_LIMITED_INFORMATION = 0x0800
+INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+
+_RIP_RE = re.compile(r"rip=([0-9a-f]{16})", re.IGNORECASE)
+
+
+def find_cdb() -> Path | None:  # pragma: no cover - rig-only
+    """Locate ``cdb.exe`` without pinning a WinDbg version (a store update breaks a pinned path)."""
+    for pattern in (
+        r"C:\Program Files\WindowsApps\Microsoft.WinDbg_*\amd64\cdb.exe",
+        r"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe",
+    ):
+        hits = sorted(glob.glob(pattern))
+        if hits:
+            return Path(hits[-1])
+    return None
+
+
+class _THREADENTRY32(ctypes.Structure):  # pragma: no cover - rig-only
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ThreadID", wintypes.DWORD),
+        ("th32OwnerProcessID", wintypes.DWORD),
+        ("tpBasePri", ctypes.c_long),
+        ("tpDeltaPri", ctypes.c_long),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+
+def _kernel32():  # pragma: no cover - rig-only
+    k = ctypes.WinDLL("kernel32", use_last_error=True)
+    k.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    k.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    k.Thread32First.argtypes = [wintypes.HANDLE, ctypes.POINTER(_THREADENTRY32)]
+    k.Thread32Next.argtypes = [wintypes.HANDLE, ctypes.POINTER(_THREADENTRY32)]
+    k.OpenThread.restype = wintypes.HANDLE
+    k.OpenThread.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    k.QueryThreadCycleTime.restype = wintypes.BOOL
+    k.QueryThreadCycleTime.argtypes = [wintypes.HANDLE, ctypes.POINTER(ctypes.c_ulonglong)]
+    k.CloseHandle.argtypes = [wintypes.HANDLE]
+    return k
+
+
+def thread_ids(pid: int) -> list[int]:  # pragma: no cover - rig-only
+    """Every thread id owned by ``pid``, in enumeration order."""
+    k = _kernel32()
+    snap = k.CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0)
+    if snap == INVALID_HANDLE_VALUE:
+        raise OSError(ctypes.get_last_error(), "CreateToolhelp32Snapshot failed")
+    try:
+        entry = _THREADENTRY32()
+        entry.dwSize = ctypes.sizeof(_THREADENTRY32)
+        out: list[int] = []
+        if not k.Thread32First(snap, ctypes.byref(entry)):
+            return out
+        while True:
+            if entry.th32OwnerProcessID == pid:
+                out.append(entry.th32ThreadID)
+            if not k.Thread32Next(snap, ctypes.byref(entry)):
+                break
+        return out
+    finally:
+        k.CloseHandle(snap)
+
+
+def sample_cycles(pid: int, window_s: float = 5.0) -> list[dict]:  # pragma: no cover - rig-only
+    """Cycles/second per thread over ``window_s``, hottest first. The spin shows as one hot thread.
+
+    NOTE for anyone validating this against a fixture: a Python venv launcher (``.venv\\Scripts\\
+    python.exe``) re-spawns the real interpreter as a CHILD, so sampling the pid ``Popen`` returns
+    measures a parked shim and reads 0 cycles/s. Resolve to the worker pid first. ``acs.exe`` has
+    no such shim.
+    """
+    k = _kernel32()
+
+    def cycles(tid: int) -> int | None:
+        handle = k.OpenThread(THREAD_QUERY_LIMITED_INFORMATION, False, tid)
+        if not handle:
+            return None
+        try:
+            value = ctypes.c_ulonglong(0)
+            if not k.QueryThreadCycleTime(handle, ctypes.byref(value)):
+                return None
+            return value.value
+        finally:
+            k.CloseHandle(handle)
+
+    tids = thread_ids(pid)
+    first = {t: cycles(t) for t in tids}
+    started = time.monotonic()
+    time.sleep(window_s)
+    elapsed = time.monotonic() - started
+
+    rows: list[dict] = []
+    for tid in tids:
+        before, after = first.get(tid), cycles(tid)
+        if before is None or after is None:
+            continue
+        rows.append({"tid": tid, "cycles_per_s": (after - before) / elapsed})
+    rows.sort(key=lambda row: row["cycles_per_s"], reverse=True)
+    return rows
+
+
+@dataclass
+class RipSample:
+    """One noninvasive register/stack snapshot."""
+
+    at: float
+    rip: int | None
+    stack: str
+    raw: str = field(repr=False, default="")
+
+
+def cdb_snapshot(
+    pid: int, *, tid: int | None = None, timeout: float = 90.0
+) -> RipSample:  # pragma: no cover - rig-only
+    """One NONINVASIVE register+stack snapshot of ``tid``.
+
+    ``-pv`` attaches without becoming the process's debugger, so detaching cannot terminate it —
+    the wedged process is irreplaceable evidence. ``tid`` selects by OS thread id
+    (``~~[0xTID]s``): ``~0s`` selects thread *index* 0, which in ``acs.exe`` is parked in an ntdll
+    wait while the hot thread is elsewhere, making RIP appear to wander across gigabytes and
+    misreporting a real livelock as a long computation.
+    """
+    cdb = find_cdb()
+    if cdb is None:
+        return RipSample(time.time(), None, "", "cdb.exe not found")
+    select = f"~~[0x{tid:x}]s" if tid is not None else "~0s"
+    command = [str(cdb), "-pv", "-p", str(pid), "-c", f"{select}; r; k; lm; qd"]
+    try:
+        proc = subprocess.run(
+            command, capture_output=True, text=True, timeout=timeout, errors="replace"
+        )
+        raw = proc.stdout + proc.stderr
+    except subprocess.TimeoutExpired:
+        return RipSample(time.time(), None, "", "cdb timed out")
+    match = _RIP_RE.search(raw)
+    stack_lines: list[str] = []
+    grabbing = False
+    for line in raw.splitlines():
+        if line.strip().startswith("#") or "Child-SP" in line:
+            grabbing = True
+        if grabbing and line.strip():
+            stack_lines.append(line.rstrip())
+        if grabbing and len(stack_lines) > 30:
+            break
+    return RipSample(
+        time.time(), int(match.group(1), 16) if match else None, "\n".join(stack_lines), raw
+    )

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -11,8 +11,9 @@ This module answers it from three cheap, independent signals:
 ``S1`` ``QueryThreadCycleTime`` per thread → **burning CPU vs blocked**. A blocked thread accrues
     ~0 cycles; a spinning one accrues ~a full core. This alone kills the deadlock explanation.
 ``S2`` RIP sampled from repeated NONINVASIVE ``cdb`` attaches → **tight loop vs long computation**.
-    A long computation walks through code (RIP wanders); a tight loop pins RIP inside a few dozen
-    bytes indefinitely.
+    A long computation walks through code (RIP wanders); a tight loop pins RIP inside a small
+    window across the whole sampling interval (the render packet is the independent progress
+    check: a converging loop would let it advance).
 ``S3`` ``acpmf_graphics`` vs ``acpmf_physics`` packet ids, with an ``acs.exe`` liveness check →
     the #627 §2 discriminator, and the guard against trap §7.1 (shared-memory sections outlive
     ``acs.exe``, so a dead sim reads identical to a wedged one without the process check).
@@ -115,8 +116,10 @@ def classify_forensics(
         return (
             ForensicVerdict.LIVELOCK_CONFIRMED,
             f"the main thread burns CPU while the render packet never advances, and RIP stays "
-            f"inside a {span}-byte window across the sampling interval. A thread cannot "
-            "be waiting with RIP on moving code: this is a tight loop that is not converging.",
+            f"inside a {span}-byte window across the sampling interval. RIP locality alone cannot "
+            "rule out a finite loop longer than that interval — the independent progress check is "
+            "the render packet itself, which a converging loop would let advance. No sample shows "
+            "progress: a tight loop with no observed convergence (re-run to confirm).",
         )
     return (
         ForensicVerdict.LONG_COMPUTATION,

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -102,7 +102,8 @@ def classify_forensics(
     if not burning_cpu:
         return (
             ForensicVerdict.BLOCKED_NOT_SPIN,
-            "the hottest thread is not consuming CPU, so the main thread is WAITING, not "
+            "the hottest sampled thread is not consuming CPU, so nothing in the process is "
+            "spinning hard enough to explain a wedge — the stalled path is WAITING, not "
             "spinning. That is a block/deadlock — a different bug from the livelock hypothesis.",
         )
     if span is None:
@@ -115,16 +116,22 @@ def classify_forensics(
     if span < tight_loop_bytes:
         return (
             ForensicVerdict.LIVELOCK_CONFIRMED,
-            f"the main thread burns CPU while the render packet never advances, and RIP stays "
-            f"inside a {span}-byte window across the sampling interval. RIP locality alone cannot "
-            "rule out a finite loop longer than that interval — the independent progress check is "
-            "the render packet itself, which a converging loop would let advance. No sample shows "
-            "progress: a tight loop with no observed convergence (re-run to confirm).",
+            f"the hottest sampled thread burns CPU while the render packet never advances, and "
+            f"its RIP stays inside a {span}-byte window across the sampling interval. Two "
+            "residuals remain: (1) RIP locality alone cannot rule out a finite loop longer than "
+            "that interval — the independent progress check is the render packet itself, which a "
+            "converging loop would let advance; (2) S1/S2 sample the *hottest* thread, not a "
+            "render-identified one, so a busy physics worker (physics keeps advancing under the "
+            "#627 §2 signature) can supply both signals while the renderer is merely blocked — "
+            "confirm the sampled thread's stack is render-side before treating this as the #627 "
+            "livelock, or re-run against a render-stack TID. No sample shows progress: a tight "
+            "loop with no observed convergence (re-run to confirm).",
         )
     return (
         ForensicVerdict.LONG_COMPUTATION,
-        f"CPU is burning but RIP wanders across {span} bytes — the thread is walking "
-        "through code, so this is a long finite computation rather than a tight loop.",
+        f"the hottest sampled thread burns CPU but RIP wanders across {span} bytes — that "
+        "thread is walking through code, so this is a long finite computation rather than a "
+        "tight loop (same hottest-thread residual as LIVELOCK_CONFIRMED).",
     )
 
 
@@ -250,7 +257,12 @@ def thread_ids(pid: int) -> list[int]:  # pragma: no cover - rig-only
 
 
 def sample_cycles(pid: int, window_s: float = 5.0) -> list[dict]:  # pragma: no cover - rig-only
-    """Cycles/second per thread over ``window_s``, hottest first. The spin shows as one hot thread.
+    """Cycles/second per thread over ``window_s``, hottest first.
+
+    The hottest row is a *candidate* for S2, not a proof of render-thread identity. Under the
+    #627 §2 wedge signature physics keeps advancing, so a legitimate physics worker can outrank a
+    blocked renderer; the stack from :func:`cdb_snapshot` is what ties the candidate to (or rules
+    it out of) the render path before :func:`classify_forensics` is trusted as a #627 livelock.
 
     NOTE for anyone validating this against a fixture: a Python venv launcher (``.venv\\Scripts\\
     python.exe``) re-spawns the real interpreter as a CHILD, so sampling the pid ``Popen`` returns
@@ -317,22 +329,32 @@ def best_effort_thaw(cdb: Path, pid: int, *, timeout: float = _THAW_TIMEOUT_S) -
     """Best-effort thaw of ``pid`` after a failed noninvasive attach. Never raises.
 
     Returns a short status token for the sample's ``raw`` field so a log can show whether the
-    thaw was attempted and whether it completed. Failures are swallowed: the capture already
-    failed, and a second exception here would only hide that fact.
+    thaw was attempted and whether it completed. A zero exit is required for ``thaw=ok`` —
+    ``subprocess.run`` returns normally on a nonzero exit, and treating that as success would
+    claim the process was resumed when ``qd`` may never have run. Failures are otherwise
+    swallowed: the capture already failed, and a second exception here would only hide that fact.
     """
     try:
-        subprocess.run(
+        proc = subprocess.run(
             thaw_cdb_command(cdb, pid),
             capture_output=True,
             text=True,
             timeout=timeout,
             errors="replace",
         )
-        return "thaw=ok"
     except subprocess.TimeoutExpired:
         return "thaw=timeout"
     except OSError as exc:
         return f"thaw=failed:{exc}"
+    if proc.returncode != 0:
+        # Keep the token short (it rides in RipSample.raw) but include enough of stderr that a
+        # log shows *why* the thaw did not complete.
+        err = (proc.stderr or proc.stdout or "").strip().replace("\n", " ")
+        if len(err) > 160:
+            err = err[:157] + "..."
+        detail = f" rc={proc.returncode}" + (f" err={err}" if err else "")
+        return f"thaw=failed:{detail.strip()}"
+    return "thaw=ok"
 
 
 def cdb_snapshot(

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -185,10 +185,15 @@ def selected_tid_confirmed(raw: str, tid: int) -> bool:
 
 
 def find_cdb() -> Path | None:  # pragma: no cover - rig-only
-    """Locate ``cdb.exe`` without pinning a WinDbg version (a store update breaks a pinned path)."""
+    """Locate ``cdb.exe`` without pinning a WinDbg version (a store update breaks a pinned path).
+
+    The Windows Kits debugger is preferred: the Store-packaged cdb under ``WindowsApps`` commonly
+    fails ``CreateProcess`` for a normal operator (package ACLs), so preferring it would leave RIP
+    sampling broken on machines that also have a working Kits install.
+    """
     for pattern in (
-        r"C:\Program Files\WindowsApps\Microsoft.WinDbg_*\amd64\cdb.exe",
         r"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe",
+        r"C:\Program Files\WindowsApps\Microsoft.WinDbg_*\amd64\cdb.exe",
     ):
         hits = sorted(glob.glob(pattern))
         if hits:
@@ -326,6 +331,10 @@ def cdb_snapshot(
         raw = proc.stdout + proc.stderr
     except subprocess.TimeoutExpired:
         return RipSample(time.time(), None, "", "cdb timed out")
+    except OSError as exc:
+        # The binary can vanish or refuse CreateProcess (WindowsApps ACLs) between the glob and
+        # exec — degrade to INCONCLUSIVE like every other capture failure, never crash the run.
+        return RipSample(time.time(), None, "", f"cdb failed to start: {exc}")
     if not selected_tid_confirmed(raw, tid):
         return RipSample(time.time(), None, "", raw)
     stack_lines: list[str] = []

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -172,10 +172,16 @@ def parse_rip(raw: str) -> int | None:
 #: marker a wrong-thread RIP parses as real evidence and recreates the parked-thread misdiagnosis.
 _TID_MARKER = "AC_TID"
 
+#: Exact marker-value capture. A substring test would accept a requested tid that is a hex prefix
+#: of the actual thread (``AC_TID=1a2b`` contains ``ac_tid=1a``), re-admitting the wrong-thread
+#: transcript the marker exists to reject.
+_TID_RE = re.compile(rf"{_TID_MARKER}=([0-9a-f]+)", re.IGNORECASE)
+
 
 def selected_tid_confirmed(raw: str, tid: int) -> bool:
     """True only when the cdb transcript's post-switch marker names the requested OS thread."""
-    return f"{_TID_MARKER}={tid:x}".lower() in raw.lower()
+    match = _TID_RE.search(raw)
+    return match is not None and int(match.group(1), 16) == tid
 
 
 def find_cdb() -> Path | None:  # pragma: no cover - rig-only

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -165,6 +165,19 @@ def parse_rip(raw: str) -> int | None:
         return None
 
 
+#: Token ``cdb_snapshot`` prints (via ``.printf``) immediately after the thread switch, carrying
+#: the *actual* current OS thread id — the only proof the register/stack dump ran on the requested
+#: thread. A failed ``~~[0xTID]s`` does not abort the ``-c`` script: cdb continues in the default
+#: context (thread index 0, parked in an ntdll wait) and still prints registers, so without this
+#: marker a wrong-thread RIP parses as real evidence and recreates the parked-thread misdiagnosis.
+_TID_MARKER = "AC_TID"
+
+
+def selected_tid_confirmed(raw: str, tid: int) -> bool:
+    """True only when the cdb transcript's post-switch marker names the requested OS thread."""
+    return f"{_TID_MARKER}={tid:x}".lower() in raw.lower()
+
+
 def find_cdb() -> Path | None:  # pragma: no cover - rig-only
     """Locate ``cdb.exe`` without pinning a WinDbg version (a store update breaks a pinned path)."""
     for pattern in (
@@ -283,13 +296,23 @@ def cdb_snapshot(
     of the *hot* thread — the first row of :func:`sample_cycles`. There is no safe default:
     ``~0s`` selects thread *index* 0, which in ``acs.exe`` is parked in an ntdll wait while the hot
     thread is elsewhere, so a default would combine a parked thread's RIPs with the hot thread's
-    CPU reading and fabricate both false livelocks and false long computations.
+    CPU reading and fabricate both false livelocks and false long computations. The post-switch
+    :data:`_TID_MARKER` line is checked before any parsing, because a failed thread switch does
+    not abort the ``-c`` script — an unconfirmed transcript yields ``rip=None`` so the verdict
+    stays at INCONCLUSIVE rather than convicting a parked thread.
     """
     cdb = find_cdb()
     if cdb is None:
         return RipSample(time.time(), None, "", "cdb.exe not found")
     select = f"~~[0x{tid:x}]s"
-    command = [str(cdb), "-pv", "-p", str(pid), "-c", f"{select}; r; k; lm; qd"]
+    command = [
+        str(cdb),
+        "-pv",
+        "-p",
+        str(pid),
+        "-c",
+        f'{select}; .printf "{_TID_MARKER}=%x\\n", @$tid; r; k; lm; qd',
+    ]
     try:
         proc = subprocess.run(
             command, capture_output=True, text=True, timeout=timeout, errors="replace"
@@ -297,6 +320,8 @@ def cdb_snapshot(
         raw = proc.stdout + proc.stderr
     except subprocess.TimeoutExpired:
         return RipSample(time.time(), None, "", "cdb timed out")
+    if not selected_tid_confirmed(raw, tid):
+        return RipSample(time.time(), None, "", raw)
     stack_lines: list[str] = []
     grabbing = False
     for line in raw.splitlines():

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -146,6 +146,22 @@ INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
 _RIP_RE = re.compile(r"rip=([0-9a-f`]{16,17})", re.IGNORECASE)
 
 
+def parse_rip(raw: str) -> int | None:
+    """First RIP register value in cdb output, or ``None`` when absent or unparseable.
+
+    Single source of truth for the regex match, backtick strip, and hex conversion — the
+    backtick form must be normalized *before* ``int(..., 16)`` or a matched address raises
+    ``ValueError`` and aborts the whole capture.
+    """
+    match = _RIP_RE.search(raw)
+    if match is None:
+        return None
+    try:
+        return int(match.group(1).replace("`", ""), 16)
+    except ValueError:
+        return None
+
+
 def find_cdb() -> Path | None:  # pragma: no cover - rig-only
     """Locate ``cdb.exe`` without pinning a WinDbg version (a store update breaks a pinned path)."""
     for pattern in (
@@ -277,7 +293,6 @@ def cdb_snapshot(
         raw = proc.stdout + proc.stderr
     except subprocess.TimeoutExpired:
         return RipSample(time.time(), None, "", "cdb timed out")
-    match = _RIP_RE.search(raw)
     stack_lines: list[str] = []
     grabbing = False
     for line in raw.splitlines():
@@ -287,6 +302,4 @@ def cdb_snapshot(
             stack_lines.append(line.rstrip())
         if grabbing and len(stack_lines) > 30:
             break
-    return RipSample(
-        time.time(), int(match.group(1), 16) if match else None, "\n".join(stack_lines), raw
-    )
+    return RipSample(time.time(), parse_rip(raw), "\n".join(stack_lines), raw)

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -274,20 +274,21 @@ class RipSample:
 
 
 def cdb_snapshot(
-    pid: int, *, tid: int | None = None, timeout: float = 90.0
+    pid: int, *, tid: int, timeout: float = 90.0
 ) -> RipSample:  # pragma: no cover - rig-only
     """One NONINVASIVE register+stack snapshot of ``tid``.
 
     ``-pv`` attaches without becoming the process's debugger, so detaching cannot terminate it —
-    the wedged process is irreplaceable evidence. ``tid`` selects by OS thread id
-    (``~~[0xTID]s``): ``~0s`` selects thread *index* 0, which in ``acs.exe`` is parked in an ntdll
-    wait while the hot thread is elsewhere, making RIP appear to wander across gigabytes and
-    misreporting a real livelock as a long computation.
+    the wedged process is irreplaceable evidence. ``tid`` is required and must be the OS thread id
+    of the *hot* thread — the first row of :func:`sample_cycles`. There is no safe default:
+    ``~0s`` selects thread *index* 0, which in ``acs.exe`` is parked in an ntdll wait while the hot
+    thread is elsewhere, so a default would combine a parked thread's RIPs with the hot thread's
+    CPU reading and fabricate both false livelocks and false long computations.
     """
     cdb = find_cdb()
     if cdb is None:
         return RipSample(time.time(), None, "", "cdb.exe not found")
-    select = f"~~[0x{tid:x}]s" if tid is not None else "~0s"
+    select = f"~~[0x{tid:x}]s"
     command = [str(cdb), "-pv", "-p", str(pid), "-c", f"{select}; r; k; lm; qd"]
     try:
         proc = subprocess.run(


### PR DESCRIPTION
Advances #630 (**Part F**). Refs #627 §6.1.

## Why

#627 §6.1 gates the upstream CSP bug report on one question — is the wedge a **livelock**, a
**block**, or a **long computation**? The instrument that answers it was built and validated during
the 2026-07-19 session, but it lives in **gitignored `.scratch/`**: invisible to every future
session and one cleanup away from being lost. The repo already carries that pitfall on record (the
offline `model_id.py` was lost exactly this way).

## What it does

Three independent signals, cheaper and stronger than the two-4.8 GB-dump plan:

| | signal | answers |
|---|---|---|
| S1 | `QueryThreadCycleTime` per thread | burning CPU **vs** blocked |
| S2 | RIP from repeated **noninvasive** `cdb` attaches | tight loop **vs** wandering |
| S3 | graphics vs physics packet ids + `acs.exe` liveness | the #627 §2 discriminator, and the §7.1 corpse guard |

The **decision** is extracted as a pure `classify_forensics()` so all 11 branches are unit tested
off-rig; collection stays Windows/rig-only.

## Two verdicts exist because I made both mistakes

- **`NOT_WEDGED`** — a session whose graphics packet *advanced during the diagnosis* had
  **recovered**: a transient init stall, not a terminal wedge. I called such a trial a "confirmed
  spin" before reading the artifact, and it wasn't. This now short-circuits before any livelock
  claim can be made.
- **`INCONCLUSIVE_INSUFFICIENT_RIP_SAMPLES`** — fewer than two RIP reads carry *no* information
  about wandering, so they must not fall through to `LONG_COMPUTATION` — the one verdict that would
  wrongly kill the livelock hypothesis the upstream report rests on.

Also carried over: `NOT_RENDER_WEDGE` when both streams are stopped; version-independent `cdb`
discovery (a store update breaks a pinned path); and **hot-TID** RIP selection — `~0s` selects
thread *index* 0, which in `acs.exe` is parked in an ntdll wait, making RIP appear to wander across
gigabytes and misreporting a genuine livelock.

## Validated against ground truth

Before shipping, re-ran the self-check on the rig:

```
cdb resolved: ...Microsoft.WinDbg_1.2606.22001.0_x64.../cdb.exe
[PASS] SPIN  hottest=2.840 Gcycles/s burning=True  (expected True)
[PASS] SLEEP hottest=0.000 Gcycles/s burning=False (expected False)
```

This is the same check that caught the instrument reading **0 cycles/s on a known spinner** the
first time — it was sampling a venv launcher shim instead of the worker process. That trap is now
documented in `sample_cycles`' docstring so the next person doesn't lose an hour to it.

`11 passed`, `make ci-fast: OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)