### PR TITLE
feat(rig): runnable freeze-forensics capture driver with render-TID preference (#630 Part G)

### DIFF
--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -497,11 +497,25 @@ def test_record_path_from_an_unapproved_cwd_is_rejected(tmp_path, monkeypatch) -
         _resolve_record_path(Path("capture.json"), approved_roots=(tmp_path / "approved",))
 
 
-def test_repo_checkout_root_is_the_module_checkout() -> None:
-    from tools.ac_harness.freeze_forensics import _repo_checkout_root
+def test_scratch_root_is_the_module_checkouts_scratch_dir() -> None:
+    """The checkout-side root is .scratch ONLY — a checkout-wide root would validate a --json
+    destination that overwrites source files (#647 review round 3)."""
+    from tools.ac_harness.freeze_forensics import _scratch_root
 
-    root = _repo_checkout_root()
-    assert (root / "tools" / "ac_harness" / "freeze_forensics.py").is_file()
+    root = _scratch_root()
+    assert root.name == ".scratch"
+    assert (root.parent / "tools" / "ac_harness" / "freeze_forensics.py").is_file()
+
+
+def test_source_files_are_outside_the_scratch_root() -> None:
+    """--json <checkout>/tools/.../freeze_forensics.py must NOT validate."""
+    import pytest
+
+    from tools.ac_harness.freeze_forensics import _resolve_record_path, _scratch_root
+
+    source = _scratch_root().parent / "tools" / "ac_harness" / "freeze_forensics.py"
+    with pytest.raises(ValueError, match="approved output root"):
+        _resolve_record_path(source, approved_roots=(_scratch_root(),))
 
 
 def test_s3_physics_regression_is_not_advancing() -> None:

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -480,3 +480,25 @@ def test_cli_validators_reject_degenerate_windows() -> None:
     assert _positive_float("2.5") == 2.5
     assert _non_negative_float("0") == 0.0
     assert _non_negative_int("0") == 0
+
+
+def test_record_path_from_an_unapproved_cwd_is_rejected(tmp_path, monkeypatch) -> None:
+    """The caller's CWD is not a root — same boundary as PR #646's launcher fix."""
+    from pathlib import Path
+
+    import pytest
+
+    from tools.ac_harness.freeze_forensics import _resolve_record_path
+
+    downloads = tmp_path / "Downloads"
+    downloads.mkdir()
+    monkeypatch.chdir(downloads)
+    with pytest.raises(ValueError, match="approved output root"):
+        _resolve_record_path(Path("capture.json"), approved_roots=(tmp_path / "approved",))
+
+
+def test_repo_checkout_root_is_the_module_checkout() -> None:
+    from tools.ac_harness.freeze_forensics import _repo_checkout_root
+
+    root = _repo_checkout_root()
+    assert (root / "tools" / "ac_harness" / "freeze_forensics.py").is_file()

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -502,3 +502,27 @@ def test_repo_checkout_root_is_the_module_checkout() -> None:
 
     root = _repo_checkout_root()
     assert (root / "tools" / "ac_harness" / "freeze_forensics.py").is_file()
+
+
+def test_s3_physics_regression_is_not_advancing() -> None:
+    """#647 review round 2 — an endpoint-only comparison read 100, 5, 200 as advancing; a
+    mid-stream regression is a section/session reset and must not feed the wedge signature."""
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3([(23, 100, True), (23, 5, True), (23, 200, True)])
+    assert result.phys_advancing is False
+
+
+def test_acs_pid_picks_deterministically_from_the_process_set(monkeypatch) -> None:
+    """#647 review round 2 — running_process_ids returns a frozenset; pids[0] was a TypeError
+    on the default no---pid path whenever acs.exe was actually running."""
+    import tools.ac_harness.entry_launcher as entry_launcher
+    from tools.ac_harness.freeze_forensics import _acs_pid
+
+    monkeypatch.setattr(
+        entry_launcher, "running_process_ids", lambda name, strict: frozenset({31337, 20001})
+    )
+    assert _acs_pid() == 20001
+
+    monkeypatch.setattr(entry_launcher, "running_process_ids", lambda name, strict: frozenset())
+    assert _acs_pid() is None

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -540,3 +540,40 @@ def test_acs_pid_picks_deterministically_from_the_process_set(monkeypatch) -> No
 
     monkeypatch.setattr(entry_launcher, "running_process_ids", lambda name, strict: frozenset())
     assert _acs_pid() is None
+
+
+def test_cli_duration_validators_reject_sleep_breaking_values() -> None:
+    """#647 review round 4 — a finite-but-huge duration (1e308) raises OverflowError from
+    time.sleep, bypassing the OSError handling; bound at the validator."""
+    import pytest
+
+    from tools.ac_harness.freeze_forensics import _non_negative_float, _positive_float
+
+    with pytest.raises(Exception, match="<="):
+        _positive_float("1e308")
+    with pytest.raises(Exception, match="<="):
+        _non_negative_float("1e308")
+    assert _positive_float("600") == 600.0
+
+
+def test_capture_record_carries_s1_and_final_selected_rates() -> None:
+    import json
+
+    from tools.ac_harness.freeze_forensics import build_capture_record, evaluate_s3
+
+    record = build_capture_record(
+        pid=1,
+        tid=2,
+        tid_reason="hottest",
+        cycles_rows=[],
+        candidate_stacks=[],
+        rips=[],
+        s3=evaluate_s3([(1, 1, True), (1, 2, True)]),
+        verdict="not_wedged",
+        rationale="r",
+        started_at_utc="2026-07-22T00:00:00Z",
+        elapsed_s=1.0,
+        selected_cycles={"s1": 2.9e9, "final": 1000.0},
+    )
+    payload = json.loads(json.dumps(record))
+    assert payload["selected_cycles_per_s"] == {"s1": 2.9e9, "final": 1000.0}

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -373,3 +373,110 @@ def test_capture_record_is_json_serializable_and_auditable() -> None:
     assert payload["s3"]["sufficient"] is True
     # Stack heads are capped so the record stays a record, not a transcript dump.
     assert len(payload["candidate_stack_heads"][0]["stack_head"]) == 6
+
+
+def test_extract_stack_excludes_the_lm_module_listing() -> None:
+    """#647 review P1 — d3d11/dxgi are loaded in EVERY AC process; letting the ``lm`` listing
+    into the stack text would make the render hints match every candidate and neuter the
+    render-TID preference."""
+    from tools.ac_harness.freeze_forensics import extract_stack, select_capture_tid
+
+    raw = (
+        "AC_TID=1a2b\n"
+        " # Child-SP          RetAddr               Call Site\n"
+        "00 0000005e`f16df620 00007ff9`1d2080c4     acs!physicsWorker+0x40\n"
+        "01 0000005e`f16df8e0 00007ff9`1d207f7a     ntdll!RtlUserThreadStart+0x21\n"
+        "start             end                 module name\n"
+        "00007ff9`1d000000 00007ff9`1e000000   d3d11      (deferred)\n"
+        "00007ff9`1f000000 00007ff9`20000000   nvwgf2umx  (deferred)\n"
+    )
+    stack = extract_stack(raw)
+    assert "physicsWorker" in stack
+    assert "d3d11" not in stack
+    assert "nvwgf2umx" not in stack
+    # The physics thread must NOT be selected as render-side off module-listing pollution.
+    tid, reason = select_capture_tid([(0x1A2B, stack)])
+    assert "hottest thread" in reason
+
+
+def test_s3_gate_refuses_a_liveness_gap() -> None:
+    """#647 review P1 — acs_alive_throughout must gate: mixed process generations can fabricate
+    the wedge signature from two healthy sessions."""
+    from tools.ac_harness.freeze_forensics import evaluate_s3, s3_gate
+
+    # Enough live readings on either side of a death to look like a wedge...
+    s3 = evaluate_s3([(23, 100, True), (16_983, 9_999, False), (23, 400, True)])
+    assert s3.sufficient is True
+    refusal = s3_gate(s3)
+    assert refusal is not None
+    token, rationale = refusal
+    assert token == "capture_failed_liveness_gap"
+    assert "generations" in rationale
+
+
+def test_s3_gate_refuses_insufficiency_first() -> None:
+    from tools.ac_harness.freeze_forensics import evaluate_s3, s3_gate
+
+    refusal = s3_gate(evaluate_s3([(23, 100, True)]))
+    assert refusal is not None
+    assert refusal[0] == "capture_failed_insufficient_s3"
+
+
+def test_s3_gate_passes_a_continuously_live_capture() -> None:
+    from tools.ac_harness.freeze_forensics import evaluate_s3, s3_gate
+
+    assert s3_gate(evaluate_s3([(23, 100, True), (23, 400, True)])) is None
+
+
+class TestResolveRecordPath:
+    """#647 review P2 — the --json destination must stay inside an approved output root."""
+
+    def test_inside_root_accepted(self, tmp_path) -> None:
+        from tools.ac_harness.freeze_forensics import _resolve_record_path
+
+        target = tmp_path / "captures" / "wedge.json"
+        assert _resolve_record_path(target, approved_roots=(tmp_path,)) == target.resolve()
+
+    def test_absolute_outside_rejected(self, tmp_path) -> None:
+        import pytest
+
+        from tools.ac_harness.freeze_forensics import _resolve_record_path
+
+        with pytest.raises(ValueError, match="approved output root"):
+            _resolve_record_path(tmp_path / "out.json", approved_roots=(tmp_path / "approved",))
+
+    def test_dotdot_traversal_rejected(self, tmp_path) -> None:
+        import pytest
+
+        from tools.ac_harness.freeze_forensics import _resolve_record_path
+
+        approved = tmp_path / "approved"
+        with pytest.raises(ValueError, match="approved output root"):
+            _resolve_record_path(approved / ".." / "escape.json", approved_roots=(approved,))
+
+
+def test_cli_validators_reject_degenerate_windows() -> None:
+    """#647 review P2 — --cycles-window 0 would turn incidental cycle increments into an
+    arbitrary burning-CPU rate; negatives raise from time.sleep mid-capture."""
+    import pytest
+
+    from tools.ac_harness.freeze_forensics import (
+        _non_negative_float,
+        _non_negative_int,
+        _positive_float,
+        _positive_int,
+    )
+
+    with pytest.raises(Exception, match="> 0"):
+        _positive_float("0")
+    with pytest.raises(Exception, match="finite"):
+        _positive_float("nan")
+    with pytest.raises(Exception, match=">= 0"):
+        _non_negative_float("-1")
+    with pytest.raises(Exception, match="> 0"):
+        _positive_int("0")
+    with pytest.raises(Exception, match=">= 0"):
+        _non_negative_int("-1")
+    assert _positive_float("2.5") == 2.5
+    assert _non_negative_float("0") == 0.0
+    assert _non_negative_int("0") == 0

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -238,3 +238,138 @@ def test_cdb_snapshot_thaws_target_after_timeout(monkeypatch) -> None:
     # Second call is the thaw: noninvasive attach + immediate detach.
     # Use str(Path) so the expected path matches production on Windows and POSIX.
     assert calls[1] == [str(cdb), "-pv", "-p", "1234", "-c", "qd"]
+
+
+# --------------------------------------------------------------------------------------
+# Part G — capture-driver decision helpers (pure; the assembly in main() is rig-only).
+# --------------------------------------------------------------------------------------
+
+
+def test_render_stack_candidate_beats_a_hotter_physics_thread() -> None:
+    """#630 Part G — a busy physics worker outranking a wedged renderer on cycles must lose."""
+    from tools.ac_harness.freeze_forensics import select_capture_tid
+
+    physics_stack = "00 ntdll!NtWaitForSingleObject\n01 acs!physicsWorker"
+    render_stack = "00 dwrite!hashLoop\n01 accRenderingAdv+0x1391c02"
+    tid, reason = select_capture_tid([(111, physics_stack), (222, render_stack)])
+    assert tid == 222
+    assert "render-stack hint" in reason
+
+
+def test_hottest_thread_is_the_fallback_when_no_stack_matches() -> None:
+    from tools.ac_harness.freeze_forensics import select_capture_tid
+
+    tid, reason = select_capture_tid([(111, "00 acs!physics"), (222, "00 ntdll!wait")])
+    assert tid == 111
+    assert "hottest thread" in reason
+
+
+def test_unconfirmed_candidate_stacks_never_match() -> None:
+    """An unconfirmed cdb transcript yields an empty stack — it must simply not match."""
+    from tools.ac_harness.freeze_forensics import select_capture_tid
+
+    tid, reason = select_capture_tid([(111, ""), (222, "")])
+    assert tid == 111
+    assert "hottest" in reason
+
+
+def test_select_capture_tid_rejects_empty_candidates() -> None:
+    import pytest
+
+    from tools.ac_harness.freeze_forensics import select_capture_tid
+
+    with pytest.raises(ValueError, match="candidates"):
+        select_capture_tid([])
+
+
+def test_s3_corpse_readings_are_discarded_not_compared() -> None:
+    """Trap §7.1 — a dead sim's pinned packet must not manufacture the wedge signature."""
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    # Every reading taken while acs is dead: the corpse holds gfx pinned and phys pinned.
+    result = evaluate_s3([(16_983, 121, False), (16_983, 121, False), (16_983, 121, False)])
+    assert result.gfx_readings == ()
+    assert result.phys_readings == ()
+    assert result.sufficient is False
+    assert result.gfx_static is False
+    assert result.acs_alive_throughout is False
+
+
+def test_s3_wedge_signature_from_live_readings() -> None:
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3([(23, 100, True), (23, 400, True), (23, 800, True)])
+    assert result.gfx_static is True
+    assert result.phys_advancing is True
+    assert result.acs_alive_throughout is True
+    assert result.sufficient is True
+
+
+def test_s3_recovered_session_is_not_static() -> None:
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3([(23, 100, True), (23, 400, True), (4233, 800, True)])
+    assert result.gfx_static is False  # the packet ADVANCED — the session recovered
+
+
+def test_s3_mixed_dead_and_live_readings_keep_only_live_ones() -> None:
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3(
+        [
+            (16_983, 9_999, False),  # corpse — discarded
+            (17, 100, True),
+            (17, 400, True),
+        ]
+    )
+    assert result.gfx_readings == (17, 17)
+    assert result.phys_readings == (100, 400)
+    assert result.gfx_static is True
+    assert result.phys_advancing is True
+    assert result.acs_alive_throughout is False  # honesty: the process was not alive throughout
+
+
+def test_s3_single_live_reading_is_insufficient() -> None:
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3([(23, 100, True)])
+    assert result.sufficient is False
+    assert result.gfx_static is False
+    assert result.phys_advancing is False
+
+
+def test_s3_unreadable_streams_are_not_observations() -> None:
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3([(None, None, True), (None, None, True)])
+    assert result.sufficient is False
+
+
+def test_capture_record_is_json_serializable_and_auditable() -> None:
+    import json
+
+    from tools.ac_harness.freeze_forensics import build_capture_record, evaluate_s3
+
+    s3 = evaluate_s3([(23, 100, True), (23, 400, True)])
+    record = build_capture_record(
+        pid=1234,
+        tid=222,
+        tid_reason="render-stack hint(s) ['dwrite'] in sampled stack",
+        cycles_rows=[{"tid": 222, "cycles_per_s": 2.85e9}, {"tid": 111, "cycles_per_s": 1.0e9}],
+        candidate_stacks=[(222, "00 dwrite!loop\n01 acs!frame\nline3\nline4\nline5\nline6\nline7")],
+        rips=[0x7FF000001000, 0x7FF000001020],
+        s3=s3,
+        verdict="livelock_confirmed",
+        rationale="test rationale",
+        started_at_utc="2026-07-21T00:00:00Z",
+        elapsed_s=42.5,
+    )
+    payload = json.loads(json.dumps(record))
+    assert payload["schema"] == "freeze-forensics-capture/v1"
+    assert payload["selected_tid"] == 222
+    assert payload["rips_hex"] == ["0x7ff000001000", "0x7ff000001020"]
+    assert payload["rip_span_bytes"] == 0x20
+    assert payload["s3"]["gfx_static"] is True
+    assert payload["s3"]["sufficient"] is True
+    # Stack heads are capped so the record stays a record, not a transcript dump.
+    assert len(payload["candidate_stack_heads"][0]["stack_head"]) == 6

--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -577,3 +577,38 @@ def test_capture_record_carries_s1_and_final_selected_rates() -> None:
     )
     payload = json.loads(json.dumps(record))
     assert payload["selected_cycles_per_s"] == {"s1": 2.9e9, "final": 1000.0}
+
+
+def test_s3_alive_correlated_corpse_without_any_advance_is_discarded() -> None:
+    """#647 review round 6 — the ~6 s handover: a NEW acs is alive-and-sole while acpmf still
+    exposes the previous session's frozen corpse. Without an observed advance there is no proof
+    a live writer owns the sections, so nothing may be retained (refusal, not NOT_RENDER_WEDGE
+    from corpse data)."""
+    from tools.ac_harness.freeze_forensics import evaluate_s3, s3_gate
+
+    result = evaluate_s3([(16_983, 9_999, True), (16_983, 9_999, True), (16_983, 9_999, True)])
+    assert result.gfx_readings == ()
+    assert result.phys_readings == ()
+    assert result.sufficient is False
+    refusal = s3_gate(result)
+    assert refusal is not None and refusal[0] == "capture_failed_insufficient_s3"
+
+
+def test_s3_wedge_ownership_is_proven_by_advancing_physics() -> None:
+    """A render wedge still earns ownership through its ADVANCING physics stream."""
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3([(23, 100, True), (23, 400, True), (23, 800, True)])
+    assert result.gfx_static is True
+    assert result.phys_advancing is True
+    assert result.sufficient is True
+
+
+def test_s3_new_session_publishing_during_capture_reads_as_recovered() -> None:
+    """Handover that completes mid-capture: the new stream advances, so ownership is earned and
+    the verdict path honestly reads NOT_WEDGED (the session is rendering)."""
+    from tools.ac_harness.freeze_forensics import evaluate_s3
+
+    result = evaluate_s3([(16_983, 9_999, True), (121, 50, True), (180, 90, True)])
+    assert result.sufficient is True
+    assert result.gfx_static is False  # gfx moved -> classify() returns NOT_WEDGED

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -1083,11 +1083,20 @@ class TestResolveReportPath:
         with pytest.raises(ValueError, match="approved output root"):
             _resolve_report_path(Path("report.json"), approved_roots=(tmp_path / "approved",))
 
-    def test_repo_checkout_root_is_the_module_checkout(self) -> None:
-        from tools.ac_harness.resilient_launch import _repo_checkout_root
+    def test_scratch_root_is_the_module_checkouts_scratch_dir(self) -> None:
+        from tools.ac_harness.resilient_launch import _scratch_root
 
-        root = _repo_checkout_root()
-        assert (root / "tools" / "ac_harness" / "resilient_launch.py").is_file()
+        root = _scratch_root()
+        assert root.name == ".scratch"
+        assert (root.parent / "tools" / "ac_harness" / "resilient_launch.py").is_file()
+
+    def test_source_files_are_outside_the_scratch_root(self) -> None:
+        """--json <checkout>/tools/.../resilient_launch.py must NOT validate (#647 round 3)."""
+        from tools.ac_harness.resilient_launch import _resolve_report_path, _scratch_root
+
+        source = _scratch_root().parent / "tools" / "ac_harness" / "resilient_launch.py"
+        with pytest.raises(ValueError, match="approved output root"):
+            _resolve_report_path(source, approved_roots=(_scratch_root(),))
 
 
 @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -38,6 +38,7 @@ import argparse
 import ctypes
 import glob
 import json
+import math
 import os
 import re
 import subprocess
@@ -193,6 +194,34 @@ def selected_tid_confirmed(raw: str, tid: int) -> bool:
     """True only when the cdb transcript's post-switch marker names the requested OS thread."""
     match = _TID_RE.search(raw)
     return match is not None and int(match.group(1), 16) == tid
+
+
+#: ``lm`` module-list header. The snapshot script runs ``r; k; lm; qd`` and the stack collector
+#: must STOP here: the module listing names every loaded module — ``d3d11``, ``dxgi``,
+#: ``nvwgf2um`` are loaded in ANY AC process — so letting it ride in the "stack" text would make
+#: the render-hint match true for every candidate thread and neuter the render-TID preference
+#: entirely (#647 review P1).
+_LM_HEADER_RE = re.compile(r"^\s*start\s+end\s+module name\s*$", re.IGNORECASE)
+
+
+def extract_stack(raw: str) -> str:
+    """The ``k`` call-stack frames from a cdb transcript — and ONLY those.
+
+    Collection starts at the ``k`` header (``#`` / ``Child-SP``), stops at the ``lm`` module-list
+    header, and caps at ~30 frames so the sample stays a stack, not a transcript.
+    """
+    stack_lines: list[str] = []
+    grabbing = False
+    for line in raw.splitlines():
+        if _LM_HEADER_RE.match(line):
+            break
+        if line.strip().startswith("#") or "Child-SP" in line:
+            grabbing = True
+        if grabbing and line.strip():
+            stack_lines.append(line.rstrip())
+        if grabbing and len(stack_lines) > 30:
+            break
+    return "\n".join(stack_lines)
 
 
 def find_cdb() -> Path | None:  # pragma: no cover - rig-only
@@ -416,16 +445,7 @@ def cdb_snapshot(
         return RipSample(time.time(), None, "", f"cdb failed to start: {exc}")
     if not selected_tid_confirmed(raw, tid):
         return RipSample(time.time(), None, "", raw)
-    stack_lines: list[str] = []
-    grabbing = False
-    for line in raw.splitlines():
-        if line.strip().startswith("#") or "Child-SP" in line:
-            grabbing = True
-        if grabbing and line.strip():
-            stack_lines.append(line.rstrip())
-        if grabbing and len(stack_lines) > 30:
-            break
-    return RipSample(time.time(), parse_rip(raw), "\n".join(stack_lines), raw)
+    return RipSample(time.time(), parse_rip(raw), extract_stack(raw), raw)
 
 
 # --------------------------------------------------------------------------------------
@@ -481,6 +501,36 @@ class S3Result:
     def sufficient(self) -> bool:
         """Whether the discriminator can be claimed at all (two comparable readings per stream)."""
         return len(self.gfx_readings) >= 2 and len(self.phys_readings) >= 2
+
+
+def s3_gate(s3: S3Result) -> tuple[str, str] | None:
+    """Why S3 forbids classification, as ``(verdict_token, rationale)`` — or ``None`` when it may.
+
+    Two distinct refusals (#647 review P1 — ``acs_alive_throughout`` must actually gate):
+
+    * **insufficient** — fewer than two live-correlated readings per stream: nothing to compare.
+    * **liveness gap** — enough readings, but the target pid was NOT alive across the whole
+      capture. The retained readings then straddle a process exit/restart, and ``gfx_static`` +
+      ``phys_advancing`` computed across two different process generations (or a corpse gap) can
+      fabricate the exact wedge signature this instrument exists to prove. Mixed-generation
+      evidence is corrupted evidence — no verdict.
+    """
+    if not s3.sufficient:
+        return (
+            "capture_failed_insufficient_s3",
+            "fewer than two live-correlated readings per shared-memory stream — the §2 "
+            "discriminator cannot be claimed (dead process, unreadable sections, or the "
+            "§7.1 corpse guard discarded every sample). No verdict.",
+        )
+    if not s3.acs_alive_throughout:
+        return (
+            "capture_failed_liveness_gap",
+            "the target pid was not alive at every observation — the retained readings straddle "
+            "a process exit/restart, so the packet comparison may mix process generations and "
+            "fabricate (or mask) the wedge signature. Re-run against a continuously-live pid. "
+            "No verdict.",
+        )
+    return None
 
 
 def evaluate_s3(samples: Sequence[tuple[int | None, int | None, bool]]) -> S3Result:
@@ -562,19 +612,45 @@ def build_capture_record(
     }
 
 
-def _read_s3_once() -> tuple[int | None, int | None, bool]:  # pragma: no cover - rig-only
-    """One correlated ``(gfx_packet, phys_packet, acs_alive)`` observation.
+#: ``GetExitCodeProcess`` sentinel for a process that has not exited.
+_STILL_ACTIVE = 259
+PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
 
-    Liveness is read immediately before the shared-memory read so the §7.1 corpse guard in
-    :func:`evaluate_s3` can discard readings that were not correlated with a live ``acs.exe``.
+
+def _pid_alive(pid: int) -> bool:  # pragma: no cover - rig-only
+    """Whether the SPECIFIC target process is alive.
+
+    An image-name check cannot bind evidence to one process generation (#647 review P1):
+    ``acs.exe`` restarting mid-capture yields a same-named process whose readings must not be
+    mixed with the wedged generation's. Open the pid itself and ask.
     """
-    from tools.ac_harness.entry_launcher import running_process_ids
+    k = ctypes.WinDLL("kernel32", use_last_error=True)
+    k.OpenProcess.restype = wintypes.HANDLE
+    k.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    k.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    k.CloseHandle.argtypes = [wintypes.HANDLE]
+    handle = k.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        return False
+    try:
+        exit_code = wintypes.DWORD(0)
+        if not k.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == _STILL_ACTIVE
+    finally:
+        k.CloseHandle(handle)
+
+
+def _read_s3_once(pid: int) -> tuple[int | None, int | None, bool]:  # pragma: no cover - rig-only
+    """One correlated ``(gfx_packet, phys_packet, target_alive)`` observation.
+
+    Liveness of the TARGET PID (not the image name — #647 review P1) is read immediately before
+    the shared-memory read so the §7.1 corpse guard in :func:`evaluate_s3` can discard readings
+    that were not correlated with the live target generation.
+    """
     from tools.ac_harness.shared_memory import SharedMemoryReader, SharedMemoryUnavailable
 
-    try:
-        alive = bool(running_process_ids("acs.exe", strict=True))
-    except OSError:
-        alive = False
+    alive = _pid_alive(pid)
     try:
         reader = SharedMemoryReader(with_physics=True)
     except (SharedMemoryUnavailable, OSError):
@@ -648,6 +724,56 @@ def _self_test() -> int:  # pragma: no cover - rig-only
         proc.kill()
 
 
+def _resolve_record_path(raw: Path, approved_roots: Sequence[Path]) -> Path:
+    """Resolve the ``--json`` destination and require it inside an approved output root.
+
+    #647 review: an absolute path or ``..`` traversal would let this rig tool create parent
+    directories and overwrite arbitrary writable locations. Approved roots are the per-user
+    Harness root (rig lock / presets) and the current working directory (the checkout's
+    gitignored ``.scratch`` capture artifacts).
+    """
+    resolved = raw.expanduser()
+    if not resolved.is_absolute():
+        resolved = Path.cwd() / resolved
+    resolved = resolved.resolve(strict=False)
+    for root in approved_roots:
+        anchored = root.resolve(strict=False)
+        if resolved == anchored or anchored in resolved.parents:
+            return resolved
+    raise ValueError(
+        f"--json destination {resolved} is outside every approved output root "
+        f"({', '.join(str(root) for root in approved_roots)})"
+    )
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be finite and > 0")
+    return parsed
+
+
+def _non_negative_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("must be finite and >= 0")
+    return parsed
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be > 0")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
+
+
 def _write_record(record: dict, path: Path) -> None:  # pragma: no cover - rig-only
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -665,25 +791,31 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             "S3 packet discriminator with the §7.1 corpse guard."
         )
     )
-    parser.add_argument("--pid", type=int, default=None, help="target pid (default: find acs.exe)")
     parser.add_argument(
-        "--cycles-window", type=float, default=5.0, help="S1 sampling window seconds (default 5)"
+        "--pid", type=_positive_int, default=None, help="target pid (default: find acs.exe)"
+    )
+    parser.add_argument(
+        "--cycles-window",
+        type=_positive_float,
+        default=5.0,
+        help="S1 sampling window seconds (default 5; must be > 0 — a near-zero window turns "
+        "incidental cycle increments into an arbitrary burning-CPU rate)",
     )
     parser.add_argument(
         "--rip-samples",
-        type=int,
+        type=_non_negative_int,
         default=3,
         help="S2 snapshots of the selected thread (default 3)",
     )
     parser.add_argument(
         "--rip-interval",
-        type=float,
+        type=_non_negative_float,
         default=10.0,
         help="seconds between S2 snapshots (default 10; wandering needs time to show)",
     )
     parser.add_argument(
         "--candidates",
-        type=int,
+        type=_positive_int,
         default=3,
         help="hot threads whose stacks are inspected for render-path hints (default 3)",
     )
@@ -704,6 +836,18 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
     if args.self_test:
         return _self_test()
 
+    if args.json_path is not None:
+        from tools.ac_harness.rig_lock import default_rig_session_lock_path
+
+        try:
+            args.json_path = _resolve_record_path(
+                args.json_path,
+                approved_roots=(default_rig_session_lock_path().parent, Path.cwd()),
+            )
+        except ValueError as exc:
+            print(f"CAPTURE ABORTED: {exc}")
+            return 2
+
     started_wall = time.time()
     started = time.monotonic()
     started_utc = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(started_wall))
@@ -713,40 +857,42 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         print("CAPTURE FAILED: no acs.exe process found (pass --pid to target another process)")
         return 2
 
-    s3_samples: list[tuple[int | None, int | None, bool]] = [_read_s3_once()]
+    s3_samples: list[tuple[int | None, int | None, bool]] = [_read_s3_once(pid)]
     print(f"capture: pid {pid}; S1 cycle sampling over {args.cycles_window:.1f}s ...")
     rows = sample_cycles(pid, args.cycles_window)
     if not rows:
         print("CAPTURE FAILED: no thread cycle data (process gone or access denied)")
         return 2
-    s3_samples.append(_read_s3_once())
+    s3_samples.append(_read_s3_once(pid))
 
     candidate_stacks: list[tuple[int, str]] = []
     candidate_rips: dict[int, list[int]] = {}
-    for row in rows[: max(1, args.candidates)]:
+    for row in rows[: args.candidates]:
         snapshot = cdb_snapshot(pid, tid=row["tid"])
         candidate_stacks.append((row["tid"], snapshot.stack))
         if snapshot.rip is not None:
             candidate_rips.setdefault(row["tid"], []).append(snapshot.rip)
-        s3_samples.append(_read_s3_once())
+        s3_samples.append(_read_s3_once(pid))
     tid, tid_reason = select_capture_tid(candidate_stacks)
     hot_cycles = next(row["cycles_per_s"] for row in rows if row["tid"] == tid)
     print(f"capture: selected tid {tid} ({tid_reason}); {hot_cycles:.3g} cycles/s")
 
     rips: list[int] = list(candidate_rips.get(tid, []))
-    for index in range(max(0, args.rip_samples)):
+    for index in range(args.rip_samples):
         if index or rips:
-            time.sleep(max(0.0, args.rip_interval))
+            time.sleep(args.rip_interval)
         snapshot = cdb_snapshot(pid, tid=tid)
         if snapshot.rip is not None:
             rips.append(snapshot.rip)
         else:
             note = snapshot.raw if len(snapshot.raw) < 120 else snapshot.raw[:117] + "..."
             print(f"capture: S2 snapshot {index + 1} unconfirmed/unreadable ({note})")
-        s3_samples.append(_read_s3_once())
+        s3_samples.append(_read_s3_once(pid))
 
     s3 = evaluate_s3(s3_samples)
-    if not s3.sufficient:
+    refusal = s3_gate(s3)
+    if refusal is not None:
+        verdict_token, refusal_rationale = refusal
         record = build_capture_record(
             pid=pid,
             tid=tid,
@@ -755,12 +901,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             candidate_stacks=candidate_stacks,
             rips=rips,
             s3=s3,
-            verdict="capture_failed_insufficient_s3",
-            rationale=(
-                "fewer than two live-correlated readings per shared-memory stream — the §2 "
-                "discriminator cannot be claimed (dead process, unreadable sections, or the "
-                "§7.1 corpse guard discarded every sample). No verdict."
-            ),
+            verdict=verdict_token,
+            rationale=refusal_rationale,
             started_at_utc=started_utc,
             elapsed_s=time.monotonic() - started,
         )

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -587,6 +587,7 @@ def build_capture_record(
     rationale: str,
     started_at_utc: str,
     elapsed_s: float,
+    selected_cycles: dict[str, float | None] | None = None,
 ) -> dict:
     """Assemble the machine-readable capture record (#627 §9.2 sibling for forensics runs).
 
@@ -601,6 +602,11 @@ def build_capture_record(
         "pid": pid,
         "selected_tid": tid,
         "tid_selection_reason": tid_reason,
+        # S1 vs end-of-capture rates for the selected thread: the burning-CPU input to the
+        # verdict is the FRESH rate (#647 review round 4 — a thread can burn during S1 then
+        # park in a wait while the RIP samples sit in a tiny wait-site window; observed live
+        # on the 2026-07-22 wedge #2 capture).
+        "selected_cycles_per_s": selected_cycles or {},
         "cycles_top": [
             {"tid": row["tid"], "cycles_per_s": round(row["cycles_per_s"], 1)}
             for row in list(cycles_rows)[:10]
@@ -786,17 +792,23 @@ def _resolve_record_path(raw: Path, approved_roots: Sequence[Path]) -> Path:
     )
 
 
+#: upper bound for CLI durations — far above any useful capture, far below what breaks
+#: ``time.sleep`` (a finite-but-huge value like 1e308 raises OverflowError, not the OSError the
+#: capture path handles — #647 review round 4).
+_MAX_CLI_SECONDS = 86_400.0
+
+
 def _positive_float(value: str) -> float:
     parsed = float(value)
-    if not math.isfinite(parsed) or parsed <= 0:
-        raise argparse.ArgumentTypeError("must be finite and > 0")
+    if not math.isfinite(parsed) or parsed <= 0 or parsed > _MAX_CLI_SECONDS:
+        raise argparse.ArgumentTypeError(f"must be finite, > 0 and <= {_MAX_CLI_SECONDS:.0f}")
     return parsed
 
 
 def _non_negative_float(value: str) -> float:
     parsed = float(value)
-    if not math.isfinite(parsed) or parsed < 0:
-        raise argparse.ArgumentTypeError("must be finite and >= 0")
+    if not math.isfinite(parsed) or parsed < 0 or parsed > _MAX_CLI_SECONDS:
+        raise argparse.ArgumentTypeError(f"must be finite, >= 0 and <= {_MAX_CLI_SECONDS:.0f}")
     return parsed
 
 
@@ -872,6 +884,15 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         help="hot threads whose stacks are inspected for render-path hints (default 3)",
     )
     parser.add_argument(
+        "--tid",
+        type=_positive_int,
+        default=None,
+        help="sample THIS OS thread id for S2 instead of the render-preferred selection — the "
+        "second pass of a two-thread diagnosis (e.g. the hottest thread after the render "
+        "thread read as parked; 2026-07-22 capture: renderer at one wait RIP while an "
+        "unidentified hottest thread burned a full core)",
+    )
+    parser.add_argument(
         "--json",
         type=Path,
         default=None,
@@ -904,12 +925,24 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
     started = time.monotonic()
     started_utc = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(started_wall))
 
+    acs_present = _acs_pids()
+    if len(acs_present) > 1:
+        # The acpmf_* sections are global singletons with ONE writer — with two acs.exe present
+        # there is no guarantee the selected process is that writer, so S1/S2 could describe one
+        # process while S3 describes the other: a plausible but invalid verdict (#647 review
+        # round 4). Refuse rather than guess; --pid does not disambiguate the sections.
+        print(
+            f"CAPTURE ABORTED: {len(acs_present)} acs.exe processes present "
+            f"({sorted(acs_present)}) — the global acpmf sections cannot be attributed to one "
+            "of them; close the extras and re-run"
+        )
+        return 2
     if args.pid is not None:
         # S3 always reads AC's GLOBAL acpmf sections, so all three signals must describe the
         # same process (#647 review round 2): sampling an unrelated busy pid's S1/S2 next to a
         # wedged AC's S3 would fabricate an "ACS livelock" out of two different processes.
         # Instrument validation against a non-AC process is --self-test's job.
-        if args.pid not in _acs_pids():
+        if args.pid not in acs_present:
             print(
                 f"CAPTURE ABORTED: --pid {args.pid} is not a running acs.exe process — S3 reads "
                 "AC's global acpmf sections, so S1/S2/S3 must describe the same process "
@@ -918,7 +951,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             return 2
         pid = args.pid
     else:
-        pid = _acs_pid()
+        pid = min(acs_present) if acs_present else None
     if pid is None:
         print("CAPTURE FAILED: no acs.exe process found")
         return 2
@@ -945,13 +978,22 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         if snapshot.rip is not None:
             candidate_rips.setdefault(row["tid"], []).append(snapshot.rip)
         s3_samples.append(_read_s3_once(pid))
-    tid, tid_reason = select_capture_tid(candidate_stacks)
+    if args.tid is not None:
+        known = {row["tid"] for row in rows}
+        if args.tid not in known:
+            print(f"CAPTURE FAILED: --tid {args.tid} is not a thread of pid {pid}")
+            return 2
+        tid, tid_reason = args.tid, "operator-selected via --tid"
+    else:
+        tid, tid_reason = select_capture_tid(candidate_stacks)
     hot_cycles = next(row["cycles_per_s"] for row in rows if row["tid"] == tid)
     print(f"capture: selected tid {tid} ({tid_reason}); {hot_cycles:.3g} cycles/s")
     # The rationale must name the thread the signals actually describe: when a render-stack
     # candidate outranked a hotter physics worker, "the hottest sampled thread" would be false
     # evidence in the record (#647 review round 3).
-    if "render-stack" in tid_reason:
+    if "operator-selected" in tid_reason:
+        thread_desc = f"the operator-selected thread (tid {tid}, --tid)"
+    elif "render-stack" in tid_reason:
         thread_desc = f"the selected render-stack thread (tid {tid}, not necessarily the hottest)"
     else:
         thread_desc = f"the hottest sampled thread (tid {tid})"
@@ -967,6 +1009,22 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             note = snapshot.raw if len(snapshot.raw) < 120 else snapshot.raw[:117] + "..."
             print(f"capture: S2 snapshot {index + 1} unconfirmed/unreadable ({note})")
         s3_samples.append(_read_s3_once(pid))
+
+    # Re-measure the selected thread at the END of the capture: the S1 rate is minutes stale by
+    # now, and a thread that burned during S1 then parked in a wait would otherwise be convicted
+    # as a livelock off wait-site RIPs (#647 review round 4; observed live on wedge #2).
+    final_cycles: float | None = None
+    try:
+        final_rows = sample_cycles(pid, min(2.0, args.cycles_window))
+        final_cycles = next((row["cycles_per_s"] for row in final_rows if row["tid"] == tid), None)
+    except OSError as exc:
+        print(f"capture: final cycle resample failed ({exc}); falling back to the S1 rate")
+    effective_cycles = final_cycles if final_cycles is not None else hot_cycles
+    selected_cycles = {
+        "s1": round(hot_cycles, 1),
+        "final": None if final_cycles is None else round(final_cycles, 1),
+    }
+    s3_samples.append(_read_s3_once(pid))
 
     s3 = evaluate_s3(s3_samples)
     refusal = s3_gate(s3)
@@ -984,6 +1042,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             rationale=refusal_rationale,
             started_at_utc=started_utc,
             elapsed_s=time.monotonic() - started,
+            selected_cycles=selected_cycles,
         )
         print(json.dumps(record, indent=2))
         if args.json_path is not None:
@@ -992,7 +1051,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         return 2
 
     verdict, rationale = classify_forensics(
-        burning_cpu=hot_cycles >= DEFAULT_BURNING_CYCLES_PER_S,
+        burning_cpu=effective_cycles >= DEFAULT_BURNING_CYCLES_PER_S,
         gfx_static=s3.gfx_static,
         phys_advancing=s3.phys_advancing,
         rips=rips,
@@ -1010,6 +1069,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         rationale=rationale,
         started_at_utc=started_utc,
         elapsed_s=time.monotonic() - started,
+        selected_cycles=selected_cycles,
     )
     print(json.dumps(record, indent=2))
     record_written = True

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -34,10 +34,14 @@ mistakes made in practice:
 
 from __future__ import annotations
 
+import argparse
 import ctypes
 import glob
+import json
+import os
 import re
 import subprocess
+import sys
 import time
 from collections.abc import Sequence
 from ctypes import wintypes
@@ -194,14 +198,25 @@ def selected_tid_confirmed(raw: str, tid: int) -> bool:
 def find_cdb() -> Path | None:  # pragma: no cover - rig-only
     """Locate ``cdb.exe`` without pinning a WinDbg version (a store update breaks a pinned path).
 
-    The Windows Kits debugger is preferred: the Store-packaged cdb under ``WindowsApps`` commonly
-    fails ``CreateProcess`` for a normal operator (package ACLs), so preferring it would leave RIP
-    sampling broken on machines that also have a working Kits install.
+    Preference order (#630 Part G — the middle rung is what the rig actually has):
+
+    1. The Windows Kits debugger — a plain executable with no package ACLs.
+    2. The Store WinDbg's **app-execution alias** (``%LOCALAPPDATA%\\Microsoft\\WindowsApps\\
+       cdbX64.exe``) — Windows creates it precisely so normal processes can launch the packaged
+       binary. On this rig the SDK is installed WITHOUT the Debuggers feature and the package
+       directory is ACL-opaque, so the alias is the only working entry point; the Part G
+       self-test read 0 confirmed RIPs before this rung existed.
+    3. The raw ``WindowsApps`` package glob — last because ``CreateProcess`` on it commonly fails
+       package ACLs for a normal operator.
     """
-    for pattern in (
+    local_appdata = os.environ.get("LOCALAPPDATA")
+    candidates: list[str] = [
         r"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe",
-        r"C:\Program Files\WindowsApps\Microsoft.WinDbg_*\amd64\cdb.exe",
-    ):
+    ]
+    if local_appdata:
+        candidates.append(str(Path(local_appdata) / "Microsoft" / "WindowsApps" / "cdbX64.exe"))
+    candidates.append(r"C:\Program Files\WindowsApps\Microsoft.WinDbg_*\amd64\cdb.exe")
+    for pattern in candidates:
         hits = sorted(glob.glob(pattern))
         if hits:
             return Path(hits[-1])
@@ -411,3 +426,374 @@ def cdb_snapshot(
         if grabbing and len(stack_lines) > 30:
             break
     return RipSample(time.time(), parse_rip(raw), "\n".join(stack_lines), raw)
+
+
+# --------------------------------------------------------------------------------------
+# Part G (#630) — the runnable capture driver: S1 → TID selection → S2 → S3 → verdict.
+# The evidence path used to live only in a bespoke .scratch harness, so during a real
+# freeze the operator had to rebuild it from the module docstring. The decision helpers
+# below are pure and unit-tested off-rig; ``main`` is the rig-only assembly.
+# --------------------------------------------------------------------------------------
+
+#: substrings that identify a RENDER-side stack. The #627 §2 signature keeps physics ADVANCING,
+#: so a legitimately busy physics worker can outrank a wedged (or blocked) renderer on cycles
+#: alone — S2 must target a render-stack thread when one is visible among the hot candidates.
+RENDER_STACK_HINTS: tuple[str, ...] = (
+    "accrenderingadv",  # CSP's renderer (OriginalFilename accRenderingAdv.dll)
+    "dwrite",  # the same module's on-disk alias in the game folder (#627 §3.5 caveat)
+    "d3d11",
+    "dxgi",
+    "nvwgf2um",  # NVIDIA D3D UMD
+)
+
+
+def select_capture_tid(candidates: Sequence[tuple[int, str]]) -> tuple[int, str]:
+    """Pick the S2 target from ``(tid, stack_text)`` candidates ordered hottest-first.
+
+    Prefers the hottest thread whose sampled stack shows the render path
+    (:data:`RENDER_STACK_HINTS`) over the merely hottest thread — the residual explicitly
+    flagged in :func:`classify_forensics`'s LIVELOCK reading. Falls back to the hottest
+    candidate when no stack matches (an unconfirmed cdb transcript has an empty stack and
+    simply never matches). Returns the tid plus a human-readable selection reason that the
+    capture record carries, so a later reader can audit *why* this thread was diagnosed.
+    """
+    if not candidates:
+        raise ValueError("candidates must not be empty")
+    for tid, stack in candidates:
+        lowered = stack.lower()
+        matched = [hint for hint in RENDER_STACK_HINTS if hint in lowered]
+        if matched:
+            return tid, f"render-stack hint(s) {matched} in sampled stack"
+    return candidates[0][0], "hottest thread (no render-stack hint in any sampled candidate stack)"
+
+
+@dataclass(frozen=True)
+class S3Result:
+    """The #627 §2 discriminator evaluated over a capture's shared-memory observations."""
+
+    gfx_static: bool
+    phys_advancing: bool
+    acs_alive_throughout: bool
+    gfx_readings: tuple[int, ...]
+    phys_readings: tuple[int, ...]
+
+    @property
+    def sufficient(self) -> bool:
+        """Whether the discriminator can be claimed at all (two comparable readings per stream)."""
+        return len(self.gfx_readings) >= 2 and len(self.phys_readings) >= 2
+
+
+def evaluate_s3(samples: Sequence[tuple[int | None, int | None, bool]]) -> S3Result:
+    """Evaluate ``(gfx_packet, phys_packet, acs_alive)`` observations. Pure — no I/O.
+
+    Trap §7.1 corpse guard: a reading taken while ``acs.exe`` is NOT alive is **discarded**, not
+    compared — ``acpmf_*`` sections outlive their creator, so a dead sim's pinned packet would
+    read exactly like a wedge. ``gfx_static`` requires every retained graphics reading identical;
+    any advance (or a regression = replaced session) means the session moved and the wedge claim
+    dies. ``phys_advancing`` is strictly monotonic growth from first to last retained reading.
+    """
+    gfx: list[int] = []
+    phys: list[int] = []
+    alive_flags: list[bool] = []
+    for gfx_packet, phys_packet, acs_alive in samples:
+        alive_flags.append(acs_alive)
+        if not acs_alive:
+            continue
+        if gfx_packet is not None:
+            gfx.append(gfx_packet)
+        if phys_packet is not None:
+            phys.append(phys_packet)
+    return S3Result(
+        gfx_static=len(gfx) >= 2 and len(set(gfx)) == 1,
+        phys_advancing=len(phys) >= 2 and phys[-1] > phys[0],
+        acs_alive_throughout=bool(alive_flags) and all(alive_flags),
+        gfx_readings=tuple(gfx),
+        phys_readings=tuple(phys),
+    )
+
+
+def build_capture_record(
+    *,
+    pid: int,
+    tid: int | None,
+    tid_reason: str,
+    cycles_rows: Sequence[dict],
+    candidate_stacks: Sequence[tuple[int, str]],
+    rips: Sequence[int],
+    s3: S3Result,
+    verdict: str,
+    rationale: str,
+    started_at_utc: str,
+    elapsed_s: float,
+) -> dict:
+    """Assemble the machine-readable capture record (#627 §9.2 sibling for forensics runs).
+
+    Everything a later reader needs to re-derive — or dispute — the verdict rides in the record:
+    the raw signals, the thread-selection reason, and the RIP set itself (hex, so it can be diffed
+    against a disassembly without re-parsing decimal).
+    """
+    return {
+        "schema": "freeze-forensics-capture/v1",
+        "started_at_utc": started_at_utc,
+        "elapsed_s": round(elapsed_s, 3),
+        "pid": pid,
+        "selected_tid": tid,
+        "tid_selection_reason": tid_reason,
+        "cycles_top": [
+            {"tid": row["tid"], "cycles_per_s": round(row["cycles_per_s"], 1)}
+            for row in list(cycles_rows)[:10]
+        ],
+        "candidate_stack_heads": [
+            {"tid": candidate_tid, "stack_head": stack.splitlines()[:6]}
+            for candidate_tid, stack in candidate_stacks
+        ],
+        "rips_hex": [hex(rip) for rip in rips],
+        "rip_span_bytes": rip_span(list(rips)),
+        "s3": {
+            "gfx_static": s3.gfx_static,
+            "phys_advancing": s3.phys_advancing,
+            "acs_alive_throughout": s3.acs_alive_throughout,
+            "gfx_readings": list(s3.gfx_readings),
+            "phys_readings": list(s3.phys_readings),
+            "sufficient": s3.sufficient,
+        },
+        "verdict": verdict,
+        "rationale": rationale,
+    }
+
+
+def _read_s3_once() -> tuple[int | None, int | None, bool]:  # pragma: no cover - rig-only
+    """One correlated ``(gfx_packet, phys_packet, acs_alive)`` observation.
+
+    Liveness is read immediately before the shared-memory read so the §7.1 corpse guard in
+    :func:`evaluate_s3` can discard readings that were not correlated with a live ``acs.exe``.
+    """
+    from tools.ac_harness.entry_launcher import running_process_ids
+    from tools.ac_harness.shared_memory import SharedMemoryReader, SharedMemoryUnavailable
+
+    try:
+        alive = bool(running_process_ids("acs.exe", strict=True))
+    except OSError:
+        alive = False
+    try:
+        reader = SharedMemoryReader(with_physics=True)
+    except (SharedMemoryUnavailable, OSError):
+        return None, None, alive
+    try:
+        graphics = reader.read_graphics()
+        physics = reader.read_physics()
+        return graphics.packet_id, (physics.packet_id if physics else None), alive
+    except (SharedMemoryUnavailable, OSError):
+        return None, None, alive
+    finally:
+        reader.close()
+
+
+def _acs_pid() -> int | None:  # pragma: no cover - rig-only
+    from tools.ac_harness.entry_launcher import running_process_ids
+
+    try:
+        pids = running_process_ids("acs.exe", strict=True)
+    except OSError:
+        return None
+    return int(pids[0]) if pids else None
+
+
+def _self_test() -> int:  # pragma: no cover - rig-only
+    """Validate the instrument against a known ground-truth spinner before trusting it.
+
+    This is the check that caught the instrument reading **0 cycles/s on a deliberate spinner**
+    (the venv ``python.exe`` shim re-spawns the real interpreter as a child, so sampling the
+    ``Popen`` pid measured a parked launcher). The worker prints its OWN pid, which resolves the
+    shim trap by construction. S1 must see the spin; S2 passes when >=2 confirmed RIP reads land
+    (a Python bytecode loop does not guarantee a <4 KiB C-level window, so span is reported, not
+    asserted).
+    """
+    spinner = "import os\nprint(os.getpid(), flush=True)\nwhile True:\n    pass\n"
+    proc = subprocess.Popen([sys.executable, "-c", spinner], stdout=subprocess.PIPE, text=True)
+    try:
+        assert proc.stdout is not None
+        worker_pid = int(proc.stdout.readline().strip())
+        print(f"self-test: spinner worker pid {worker_pid} (Popen pid {proc.pid})")
+        rows = sample_cycles(worker_pid, 2.0)
+        if not rows or rows[0]["cycles_per_s"] < DEFAULT_BURNING_CYCLES_PER_S:
+            observed = rows[0]["cycles_per_s"] if rows else 0.0
+            print(
+                "SELF-TEST FAIL (S1): a deliberate spinner read "
+                f"{observed:.3g} cycles/s — the instrument would call a spin a block. "
+                "Do not trust a capture from this machine state."
+            )
+            return 1
+        hot = rows[0]
+        print(f"self-test: S1 OK — hottest tid {hot['tid']} at {hot['cycles_per_s']:.3g} cycles/s")
+        rips: list[int] = []
+        for _ in range(2):
+            snapshot = cdb_snapshot(worker_pid, tid=hot["tid"], timeout=60.0)
+            if snapshot.rip is not None:
+                rips.append(snapshot.rip)
+        span = rip_span(rips)
+        if span is None:
+            print(
+                "SELF-TEST FAIL (S2): fewer than 2 confirmed RIP reads "
+                f"({len(rips)}) — cdb missing or the thread-switch marker never confirmed. "
+                "S1 is validated; RIP sampling is NOT."
+            )
+            return 1
+        print(
+            f"self-test: S2 OK — {len(rips)} confirmed RIP reads, span {span} bytes (informational)"
+        )
+        print("SELF-TEST OK: S1 spin detection and S2 RIP plumbing validated against ground truth")
+        return 0
+    finally:
+        proc.kill()
+
+
+def _write_record(record: dict, path: Path) -> None:  # pragma: no cover - rig-only
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+        print(f"record -> {path}")
+    except OSError as exc:
+        print(f"WARNING: could not write capture record {path}: {exc}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-only entrypoint
+    parser = argparse.ArgumentParser(
+        description=(
+            "Freeze forensics capture (#627 §6.1): decide whether a wedged acs.exe is spinning, "
+            "blocked, or still computing — S1 cycle sampling, S2 noninvasive RIP snapshots, "
+            "S3 packet discriminator with the §7.1 corpse guard."
+        )
+    )
+    parser.add_argument("--pid", type=int, default=None, help="target pid (default: find acs.exe)")
+    parser.add_argument(
+        "--cycles-window", type=float, default=5.0, help="S1 sampling window seconds (default 5)"
+    )
+    parser.add_argument(
+        "--rip-samples",
+        type=int,
+        default=3,
+        help="S2 snapshots of the selected thread (default 3)",
+    )
+    parser.add_argument(
+        "--rip-interval",
+        type=float,
+        default=10.0,
+        help="seconds between S2 snapshots (default 10; wandering needs time to show)",
+    )
+    parser.add_argument(
+        "--candidates",
+        type=int,
+        default=3,
+        help="hot threads whose stacks are inspected for render-path hints (default 3)",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        default=None,
+        dest="json_path",
+        help="also write the machine-readable capture record to this path",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="validate S1/S2 against a deliberate spinner and exit (no acs.exe involved)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    started_wall = time.time()
+    started = time.monotonic()
+    started_utc = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(started_wall))
+
+    pid = args.pid if args.pid is not None else _acs_pid()
+    if pid is None:
+        print("CAPTURE FAILED: no acs.exe process found (pass --pid to target another process)")
+        return 2
+
+    s3_samples: list[tuple[int | None, int | None, bool]] = [_read_s3_once()]
+    print(f"capture: pid {pid}; S1 cycle sampling over {args.cycles_window:.1f}s ...")
+    rows = sample_cycles(pid, args.cycles_window)
+    if not rows:
+        print("CAPTURE FAILED: no thread cycle data (process gone or access denied)")
+        return 2
+    s3_samples.append(_read_s3_once())
+
+    candidate_stacks: list[tuple[int, str]] = []
+    candidate_rips: dict[int, list[int]] = {}
+    for row in rows[: max(1, args.candidates)]:
+        snapshot = cdb_snapshot(pid, tid=row["tid"])
+        candidate_stacks.append((row["tid"], snapshot.stack))
+        if snapshot.rip is not None:
+            candidate_rips.setdefault(row["tid"], []).append(snapshot.rip)
+        s3_samples.append(_read_s3_once())
+    tid, tid_reason = select_capture_tid(candidate_stacks)
+    hot_cycles = next(row["cycles_per_s"] for row in rows if row["tid"] == tid)
+    print(f"capture: selected tid {tid} ({tid_reason}); {hot_cycles:.3g} cycles/s")
+
+    rips: list[int] = list(candidate_rips.get(tid, []))
+    for index in range(max(0, args.rip_samples)):
+        if index or rips:
+            time.sleep(max(0.0, args.rip_interval))
+        snapshot = cdb_snapshot(pid, tid=tid)
+        if snapshot.rip is not None:
+            rips.append(snapshot.rip)
+        else:
+            note = snapshot.raw if len(snapshot.raw) < 120 else snapshot.raw[:117] + "..."
+            print(f"capture: S2 snapshot {index + 1} unconfirmed/unreadable ({note})")
+        s3_samples.append(_read_s3_once())
+
+    s3 = evaluate_s3(s3_samples)
+    if not s3.sufficient:
+        record = build_capture_record(
+            pid=pid,
+            tid=tid,
+            tid_reason=tid_reason,
+            cycles_rows=rows,
+            candidate_stacks=candidate_stacks,
+            rips=rips,
+            s3=s3,
+            verdict="capture_failed_insufficient_s3",
+            rationale=(
+                "fewer than two live-correlated readings per shared-memory stream — the §2 "
+                "discriminator cannot be claimed (dead process, unreadable sections, or the "
+                "§7.1 corpse guard discarded every sample). No verdict."
+            ),
+            started_at_utc=started_utc,
+            elapsed_s=time.monotonic() - started,
+        )
+        print(json.dumps(record, indent=2))
+        if args.json_path is not None:
+            _write_record(record, args.json_path)
+        return 2
+
+    verdict, rationale = classify_forensics(
+        burning_cpu=hot_cycles >= DEFAULT_BURNING_CYCLES_PER_S,
+        gfx_static=s3.gfx_static,
+        phys_advancing=s3.phys_advancing,
+        rips=rips,
+    )
+    record = build_capture_record(
+        pid=pid,
+        tid=tid,
+        tid_reason=tid_reason,
+        cycles_rows=rows,
+        candidate_stacks=candidate_stacks,
+        rips=rips,
+        s3=s3,
+        verdict=str(verdict),
+        rationale=rationale,
+        started_at_utc=started_utc,
+        elapsed_s=time.monotonic() - started,
+    )
+    print(json.dumps(record, indent=2))
+    if args.json_path is not None:
+        _write_record(record, args.json_path)
+    print(f"VERDICT: {verdict} — {rationale}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -540,7 +540,8 @@ def evaluate_s3(samples: Sequence[tuple[int | None, int | None, bool]]) -> S3Res
     compared — ``acpmf_*`` sections outlive their creator, so a dead sim's pinned packet would
     read exactly like a wedge. ``gfx_static`` requires every retained graphics reading identical;
     any advance (or a regression = replaced session) means the session moved and the wedge claim
-    dies. ``phys_advancing`` is strictly monotonic growth from first to last retained reading.
+    dies. ``phys_advancing`` requires every ADJACENT retained pair to strictly increase — a
+    regression mid-stream is a section/session reset, not advancement.
     """
     gfx: list[int] = []
     phys: list[int] = []
@@ -555,7 +556,11 @@ def evaluate_s3(samples: Sequence[tuple[int | None, int | None, bool]]) -> S3Res
             phys.append(phys_packet)
     return S3Result(
         gfx_static=len(gfx) >= 2 and len(set(gfx)) == 1,
-        phys_advancing=len(phys) >= 2 and phys[-1] > phys[0],
+        # STRICTLY monotonic across every adjacent retained pair — an endpoint-only comparison
+        # would read a regression like 100, 5, 200 (a section/session reset) as "advancing" and
+        # let a discontinuous stream contribute the wedge signature (#647 review round 2).
+        phys_advancing=len(phys) >= 2
+        and all(later > earlier for earlier, later in zip(phys, phys[1:], strict=False)),
         acs_alive_throughout=bool(alive_flags) and all(alive_flags),
         gfx_readings=tuple(gfx),
         phys_readings=tuple(phys),
@@ -644,35 +649,49 @@ def _pid_alive(pid: int) -> bool:  # pragma: no cover - rig-only
 def _read_s3_once(pid: int) -> tuple[int | None, int | None, bool]:  # pragma: no cover - rig-only
     """One correlated ``(gfx_packet, phys_packet, target_alive)`` observation.
 
-    Liveness of the TARGET PID (not the image name — #647 review P1) is read immediately before
-    the shared-memory read so the §7.1 corpse guard in :func:`evaluate_s3` can discard readings
-    that were not correlated with the live target generation.
+    Liveness of the TARGET PID (not the image name — #647 review P1) is read immediately BEFORE
+    **and re-checked AFTER** the shared-memory reads (#647 review round 2): the target can exit
+    between the pre-check and the reads, in which case the persistent ``acpmf_*`` corpse would be
+    returned as a live-correlated observation. A reading only counts as alive when the target was
+    alive on both sides of it, so the §7.1 corpse guard in :func:`evaluate_s3` can trust the flag.
     """
     from tools.ac_harness.shared_memory import SharedMemoryReader, SharedMemoryUnavailable
 
-    alive = _pid_alive(pid)
+    alive_before = _pid_alive(pid)
+    gfx: int | None = None
+    phys: int | None = None
     try:
         reader = SharedMemoryReader(with_physics=True)
     except (SharedMemoryUnavailable, OSError):
-        return None, None, alive
+        return None, None, alive_before and _pid_alive(pid)
     try:
         graphics = reader.read_graphics()
         physics = reader.read_physics()
-        return graphics.packet_id, (physics.packet_id if physics else None), alive
+        gfx = graphics.packet_id
+        phys = physics.packet_id if physics else None
     except (SharedMemoryUnavailable, OSError):
-        return None, None, alive
+        pass
     finally:
         reader.close()
+    return gfx, phys, alive_before and _pid_alive(pid)
 
 
-def _acs_pid() -> int | None:  # pragma: no cover - rig-only
+def _acs_pids() -> frozenset[int]:  # pragma: no cover - rig-only
+    """Every running ``acs.exe`` pid (empty on enumeration failure)."""
     from tools.ac_harness.entry_launcher import running_process_ids
 
     try:
-        pids = running_process_ids("acs.exe", strict=True)
+        return frozenset(running_process_ids("acs.exe", strict=True))
     except OSError:
-        return None
-    return int(pids[0]) if pids else None
+        return frozenset()
+
+
+def _acs_pid() -> int | None:  # pragma: no cover - rig-only
+    # ``running_process_ids`` returns an unordered frozenset — it is not subscriptable, and
+    # ``min`` keeps the pick deterministic if more than one acs.exe is somehow present
+    # (#647 review round 2: ``pids[0]`` crashed the default no---pid path with a TypeError).
+    pids = _acs_pids()
+    return min(pids) if pids else None
 
 
 def _self_test() -> int:  # pragma: no cover - rig-only
@@ -804,7 +823,11 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         )
     )
     parser.add_argument(
-        "--pid", type=_positive_int, default=None, help="target pid (default: find acs.exe)"
+        "--pid",
+        type=_positive_int,
+        default=None,
+        help="target acs.exe pid (default: discover; a non-acs pid is rejected because S3 reads "
+        "AC's global shared memory)",
     )
     parser.add_argument(
         "--cycles-window",
@@ -864,9 +887,23 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
     started = time.monotonic()
     started_utc = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(started_wall))
 
-    pid = args.pid if args.pid is not None else _acs_pid()
+    if args.pid is not None:
+        # S3 always reads AC's GLOBAL acpmf sections, so all three signals must describe the
+        # same process (#647 review round 2): sampling an unrelated busy pid's S1/S2 next to a
+        # wedged AC's S3 would fabricate an "ACS livelock" out of two different processes.
+        # Instrument validation against a non-AC process is --self-test's job.
+        if args.pid not in _acs_pids():
+            print(
+                f"CAPTURE ABORTED: --pid {args.pid} is not a running acs.exe process — S3 reads "
+                "AC's global acpmf sections, so S1/S2/S3 must describe the same process "
+                "(use --self-test to validate the instrument against a synthetic spinner)"
+            )
+            return 2
+        pid = args.pid
+    else:
+        pid = _acs_pid()
     if pid is None:
-        print("CAPTURE FAILED: no acs.exe process found (pass --pid to target another process)")
+        print("CAPTURE FAILED: no acs.exe process found")
         return 2
 
     s3_samples: list[tuple[int | None, int | None, bool]] = [_read_s3_once(pid)]

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -724,13 +724,25 @@ def _self_test() -> int:  # pragma: no cover - rig-only
         proc.kill()
 
 
+def _repo_checkout_root() -> Path:
+    """The checkout this module runs from — a FIXED approved output root, unlike the CWD.
+
+    Anchoring on the module's own location (``tools/ac_harness/`` → two parents up) keeps the
+    ``.scratch`` capture-artifact workflow working from any invocation directory, while an
+    arbitrary caller CWD is never trusted as a write root (same boundary as PR #646's launcher
+    fix — a CWD root is caller-controlled and therefore no boundary at all).
+    """
+    return Path(__file__).resolve().parents[2]
+
+
 def _resolve_record_path(raw: Path, approved_roots: Sequence[Path]) -> Path:
     """Resolve the ``--json`` destination and require it inside an approved output root.
 
     #647 review: an absolute path or ``..`` traversal would let this rig tool create parent
     directories and overwrite arbitrary writable locations. Approved roots are the per-user
-    Harness root (rig lock / presets) and the current working directory (the checkout's
-    gitignored ``.scratch`` capture artifacts).
+    Harness root (rig lock / presets) and the repo checkout root (gitignored ``.scratch``
+    capture artifacts). A relative path still resolves against the caller's CWD — but it only
+    passes when that resolution lands inside a fixed root.
     """
     resolved = raw.expanduser()
     if not resolved.is_absolute():
@@ -842,7 +854,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         try:
             args.json_path = _resolve_record_path(
                 args.json_path,
-                approved_roots=(default_rig_session_lock_path().parent, Path.cwd()),
+                approved_roots=(default_rig_session_lock_path().parent, _repo_checkout_root()),
             )
         except ValueError as exc:
             print(f"CAPTURE ABORTED: {exc}")

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -532,10 +532,10 @@ def s3_gate(s3: S3Result) -> tuple[str, str] | None:
     if not s3.acs_alive_throughout:
         return (
             "capture_failed_liveness_gap",
-            "the target pid was not alive at every observation — the retained readings straddle "
-            "a process exit/restart, so the packet comparison may mix process generations and "
-            "fabricate (or mask) the wedge signature. Re-run against a continuously-live pid. "
-            "No verdict.",
+            "the target pid was not alive-and-sole-acs at every observation — the retained "
+            "readings straddle a process exit/restart or a second acs.exe appearing, so the "
+            "packet comparison may mix process generations (or writers) and fabricate (or mask) "
+            "the wedge signature. Re-run against a continuously-live, sole acs.exe. No verdict.",
         )
     return None
 
@@ -660,23 +660,32 @@ def _pid_alive(pid: int) -> bool:  # pragma: no cover - rig-only
 
 
 def _read_s3_once(pid: int) -> tuple[int | None, int | None, bool]:  # pragma: no cover - rig-only
-    """One correlated ``(gfx_packet, phys_packet, target_alive)`` observation.
+    """One correlated ``(gfx_packet, phys_packet, target_attributable)`` observation.
 
-    Liveness of the TARGET PID (not the image name — #647 review P1) is read immediately BEFORE
-    **and re-checked AFTER** the shared-memory reads (#647 review round 2): the target can exit
-    between the pre-check and the reads, in which case the persistent ``acpmf_*`` corpse would be
-    returned as a live-correlated observation. A reading only counts as alive when the target was
-    alive on both sides of it, so the §7.1 corpse guard in :func:`evaluate_s3` can trust the flag.
+    The flag is True only when the reading can be ATTRIBUTED to the target generation:
+
+    * target-pid liveness (not the image name — #647 review P1) read immediately BEFORE **and
+      re-checked AFTER** the shared-memory reads (round 2): the target can exit between the
+      pre-check and the reads, in which case the persistent ``acpmf_*`` corpse would be returned
+      as a live-correlated observation;
+    * the target is the SOLE ``acs.exe`` at both checks (round 5): the preflight uniqueness
+      guard runs once, but a second acs.exe starting mid-capture would take over the global
+      sections while the original pid stays alive — S3 would then describe the newcomer while
+      S1/S2 describe the target. A non-sole sample is discarded by the §7.1 guard in
+      :func:`evaluate_s3` exactly like a dead-correlated one.
     """
     from tools.ac_harness.shared_memory import SharedMemoryReader, SharedMemoryUnavailable
 
-    alive_before = _pid_alive(pid)
+    def attributable() -> bool:
+        return _pid_alive(pid) and _acs_pids() == frozenset({pid})
+
+    ok_before = attributable()
     gfx: int | None = None
     phys: int | None = None
     try:
         reader = SharedMemoryReader(with_physics=True)
     except (SharedMemoryUnavailable, OSError):
-        return None, None, alive_before and _pid_alive(pid)
+        return None, None, ok_before and attributable()
     try:
         graphics = reader.read_graphics()
         physics = reader.read_physics()
@@ -686,7 +695,7 @@ def _read_s3_once(pid: int) -> tuple[int | None, int | None, bool]:  # pragma: n
         pass
     finally:
         reader.close()
-    return gfx, phys, alive_before and _pid_alive(pid)
+    return gfx, phys, ok_before and attributable()
 
 
 def _acs_pids() -> frozenset[int]:  # pragma: no cover - rig-only

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -561,6 +561,19 @@ def evaluate_s3(samples: Sequence[tuple[int | None, int | None, bool]]) -> S3Res
             gfx.append(gfx_packet)
         if phys_packet is not None:
             phys.append(phys_packet)
+    # Section-ownership proof (#647 review round 6): ``acpmf_*`` outlives its creator and stays
+    # mapped ~6 s INTO a new acs.exe's lifetime, so alive-and-sole checks can all pass while the
+    # readings are the previous session's frozen corpse — which would produce a "normal"
+    # NOT_RENDER_WEDGE from corpse data. Only an observed ADVANCE (either stream, between
+    # retained readings) proves a live writer owns the sections; without one, every reading is
+    # discarded and the capture refuses as insufficient. A wedge still proves ownership through
+    # its ADVANCING physics stream, so this cannot mask the #627 signature.
+    ownership_proven = any(
+        later > earlier for earlier, later in zip(gfx, gfx[1:], strict=False)
+    ) or any(later > earlier for earlier, later in zip(phys, phys[1:], strict=False))
+    if not ownership_proven:
+        gfx = []
+        phys = []
     return S3Result(
         gfx_static=len(gfx) >= 2 and len(set(gfx)) == 1,
         # STRICTLY monotonic across every adjacent retained pair — an endpoint-only comparison
@@ -1023,11 +1036,27 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
     # now, and a thread that burned during S1 then parked in a wait would otherwise be convicted
     # as a livelock off wait-site RIPs (#647 review round 4; observed live on wedge #2).
     final_cycles: float | None = None
+    resample_failed = False
     try:
         final_rows = sample_cycles(pid, min(2.0, args.cycles_window))
-        final_cycles = next((row["cycles_per_s"] for row in final_rows if row["tid"] == tid), None)
     except OSError as exc:
+        # A transient measurement failure is ambiguous — fall back to the S1 rate with the gap
+        # recorded (selected_cycles.final stays null). A MISSING ROW below is not ambiguous.
         print(f"capture: final cycle resample failed ({exc}); falling back to the S1 rate")
+        resample_failed = True
+        final_rows = []
+    if not resample_failed:
+        final_cycles = next((row["cycles_per_s"] for row in final_rows if row["tid"] == tid), None)
+        if final_cycles is None:
+            # The selected thread no longer exists (#647 review round 6): emitting a verdict
+            # about a vanished thread from stale S1 cycles + earlier RIPs could report a
+            # livelock after the suspect already completed. Refuse instead.
+            print(
+                f"CAPTURE FAILED: selected tid {tid} is no longer a thread of pid {pid} — "
+                "the sampled thread exited during the capture; its S1 rate and RIPs describe "
+                "a thread that no longer exists. No verdict."
+            )
+            return 2
     effective_cycles = final_cycles if final_cycles is not None else hot_cycles
     selected_cycles = {
         "s1": round(hot_cycles, 1),

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -78,6 +78,7 @@ def classify_forensics(
     phys_advancing: bool,
     rips: Sequence[int],
     tight_loop_bytes: int = DEFAULT_TIGHT_LOOP_BYTES,
+    thread_desc: str = "the hottest sampled thread",
 ) -> tuple[ForensicVerdict, str]:
     """Decide the verdict from the three signals. Pure — no I/O, no clock.
 
@@ -88,6 +89,11 @@ def classify_forensics(
     Passing those two separately made an inconsistent state representable — a caller could report
     "2 samples" with a ``None`` span, which fell through to ``LONG_COMPUTATION``, the single verdict
     that must never be reached without evidence. Deriving both here makes that unrepresentable.
+
+    ``thread_desc`` names the thread the S1/S2 signals describe. The Part G driver may select a
+    render-stack candidate that is NOT the hottest thread — a rationale hard-coded to "the hottest
+    sampled thread" would then state false evidence in the capture record and mislead the
+    follow-up diagnosis (#647 review round 3).
     """
     observed = list(rips)
     span = rip_span(observed)
@@ -107,9 +113,10 @@ def classify_forensics(
     if not burning_cpu:
         return (
             ForensicVerdict.BLOCKED_NOT_SPIN,
-            "the hottest sampled thread is not consuming CPU, so nothing in the process is "
-            "spinning hard enough to explain a wedge — the stalled path is WAITING, not "
-            "spinning. That is a block/deadlock — a different bug from the livelock hypothesis.",
+            f"{thread_desc} is not consuming CPU — the stalled path is WAITING, not "
+            "spinning. That is a block/deadlock — a different bug from the livelock hypothesis. "
+            "(The claim is about the sampled thread only; when it was render-preferred rather "
+            "than hottest, other threads may still be busy by design.)",
         )
     if span is None:
         return (
@@ -121,22 +128,22 @@ def classify_forensics(
     if span < tight_loop_bytes:
         return (
             ForensicVerdict.LIVELOCK_CONFIRMED,
-            f"the hottest sampled thread burns CPU while the render packet never advances, and "
+            f"{thread_desc} burns CPU while the render packet never advances, and "
             f"its RIP stays inside a {span}-byte window across the sampling interval. Two "
             "residuals remain: (1) RIP locality alone cannot rule out a finite loop longer than "
             "that interval — the independent progress check is the render packet itself, which a "
-            "converging loop would let advance; (2) S1/S2 sample the *hottest* thread, not a "
-            "render-identified one, so a busy physics worker (physics keeps advancing under the "
-            "#627 §2 signature) can supply both signals while the renderer is merely blocked — "
-            "confirm the sampled thread's stack is render-side before treating this as the #627 "
-            "livelock, or re-run against a render-stack TID. No sample shows progress: a tight "
-            "loop with no observed convergence (re-run to confirm).",
+            "converging loop would let advance; (2) unless the sampled thread was selected off a "
+            "render-side stack, a busy physics worker (physics keeps advancing under the #627 §2 "
+            "signature) can supply both signals while the renderer is merely blocked — confirm "
+            "the sampled thread's stack is render-side before treating this as the #627 "
+            "livelock. No sample shows progress: a tight loop with no observed convergence "
+            "(re-run to confirm).",
         )
     return (
         ForensicVerdict.LONG_COMPUTATION,
-        f"the hottest sampled thread burns CPU but RIP wanders across {span} bytes — that "
+        f"{thread_desc} burns CPU but RIP wanders across {span} bytes — that "
         "thread is walking through code, so this is a long finite computation rather than a "
-        "tight loop (same hottest-thread residual as LIVELOCK_CONFIRMED).",
+        "tight loop (same sampled-thread residual as LIVELOCK_CONFIRMED).",
     )
 
 
@@ -743,15 +750,16 @@ def _self_test() -> int:  # pragma: no cover - rig-only
         proc.kill()
 
 
-def _repo_checkout_root() -> Path:
-    """The checkout this module runs from — a FIXED approved output root, unlike the CWD.
+def _scratch_root() -> Path:
+    """The checkout's gitignored ``.scratch`` directory — the ONLY checkout-side approved root.
 
-    Anchoring on the module's own location (``tools/ac_harness/`` → two parents up) keeps the
-    ``.scratch`` capture-artifact workflow working from any invocation directory, while an
-    arbitrary caller CWD is never trusted as a write root (same boundary as PR #646's launcher
-    fix — a CWD root is caller-controlled and therefore no boundary at all).
+    Anchored on the module's own location (``tools/ac_harness/`` → two parents up), never the
+    caller's CWD (a CWD root is caller-controlled and therefore no boundary at all). Scoped to
+    ``.scratch`` rather than the whole checkout because a checkout-wide root would validate
+    ``--json <checkout>/tools/ac_harness/freeze_forensics.py`` and let a capture record overwrite
+    source (#647 review round 3).
     """
-    return Path(__file__).resolve().parents[2]
+    return Path(__file__).resolve().parents[2] / ".scratch"
 
 
 def _resolve_record_path(raw: Path, approved_roots: Sequence[Path]) -> Path:
@@ -759,9 +767,10 @@ def _resolve_record_path(raw: Path, approved_roots: Sequence[Path]) -> Path:
 
     #647 review: an absolute path or ``..`` traversal would let this rig tool create parent
     directories and overwrite arbitrary writable locations. Approved roots are the per-user
-    Harness root (rig lock / presets) and the repo checkout root (gitignored ``.scratch``
-    capture artifacts). A relative path still resolves against the caller's CWD — but it only
-    passes when that resolution lands inside a fixed root.
+    Harness root (rig lock / presets) and the checkout's gitignored ``.scratch`` directory
+    (capture artifacts) — never the whole checkout, which would allow overwriting source. A
+    relative path still resolves against the caller's CWD — but it only passes when that
+    resolution lands inside a fixed root.
     """
     resolved = raw.expanduser()
     if not resolved.is_absolute():
@@ -805,13 +814,21 @@ def _non_negative_int(value: str) -> int:
     return parsed
 
 
-def _write_record(record: dict, path: Path) -> None:  # pragma: no cover - rig-only
+def _write_record(record: dict, path: Path) -> bool:  # pragma: no cover - rig-only
+    """Persist the record; report success so a requested-but-absent artifact fails the run.
+
+    When ``--json`` was supplied, the persisted record is part of the deliverable — automation
+    reading exit 0 while the artifact is absent would treat a failed capture as archived
+    (#647 review round 3). The record is always printed to stdout first as salvage.
+    """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
         print(f"record -> {path}")
+        return True
     except OSError as exc:
         print(f"WARNING: could not write capture record {path}: {exc}")
+        return False
 
 
 def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-only entrypoint
@@ -877,7 +894,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         try:
             args.json_path = _resolve_record_path(
                 args.json_path,
-                approved_roots=(default_rig_session_lock_path().parent, _repo_checkout_root()),
+                approved_roots=(default_rig_session_lock_path().parent, _scratch_root()),
             )
         except ValueError as exc:
             print(f"CAPTURE ABORTED: {exc}")
@@ -908,7 +925,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
 
     s3_samples: list[tuple[int | None, int | None, bool]] = [_read_s3_once(pid)]
     print(f"capture: pid {pid}; S1 cycle sampling over {args.cycles_window:.1f}s ...")
-    rows = sample_cycles(pid, args.cycles_window)
+    try:
+        rows = sample_cycles(pid, args.cycles_window)
+    except OSError as exc:
+        # Thread enumeration can fail outright (CreateToolhelp32Snapshot) — degrade to the same
+        # controlled exit-2 as every other capture failure instead of a traceback.
+        print(f"CAPTURE FAILED: thread cycle sampling failed: {exc}")
+        return 2
     if not rows:
         print("CAPTURE FAILED: no thread cycle data (process gone or access denied)")
         return 2
@@ -925,6 +948,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
     tid, tid_reason = select_capture_tid(candidate_stacks)
     hot_cycles = next(row["cycles_per_s"] for row in rows if row["tid"] == tid)
     print(f"capture: selected tid {tid} ({tid_reason}); {hot_cycles:.3g} cycles/s")
+    # The rationale must name the thread the signals actually describe: when a render-stack
+    # candidate outranked a hotter physics worker, "the hottest sampled thread" would be false
+    # evidence in the record (#647 review round 3).
+    if "render-stack" in tid_reason:
+        thread_desc = f"the selected render-stack thread (tid {tid}, not necessarily the hottest)"
+    else:
+        thread_desc = f"the hottest sampled thread (tid {tid})"
 
     rips: list[int] = list(candidate_rips.get(tid, []))
     for index in range(args.rip_samples):
@@ -957,6 +987,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         )
         print(json.dumps(record, indent=2))
         if args.json_path is not None:
+            # Best-effort persistence of the refusal record; the exit is already the stronger 2.
             _write_record(record, args.json_path)
         return 2
 
@@ -965,6 +996,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         gfx_static=s3.gfx_static,
         phys_advancing=s3.phys_advancing,
         rips=rips,
+        thread_desc=thread_desc,
     )
     record = build_capture_record(
         pid=pid,
@@ -980,9 +1012,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         elapsed_s=time.monotonic() - started,
     )
     print(json.dumps(record, indent=2))
+    record_written = True
     if args.json_path is not None:
-        _write_record(record, args.json_path)
+        record_written = _write_record(record, args.json_path)
     print(f"VERDICT: {verdict} — {rationale}")
+    if not record_written:
+        print("CAPTURE INCOMPLETE: the requested record JSON could not be written (see WARNING)")
+        return 1
     return 0
 
 

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -720,15 +720,18 @@ def _machine_uptime_hours() -> float | None:  # pragma: no cover - rig-only
         return None
 
 
-def _repo_checkout_root() -> Path:
-    """The checkout this module runs from — a FIXED approved output root, unlike the CWD.
+def _scratch_root() -> Path:
+    """The checkout's gitignored ``.scratch`` directory — the ONLY checkout-side approved root.
 
     Anchoring on the module's own location (``tools/ac_harness/`` → two parents up) keeps the
     established ``.scratch`` measurement-artifact workflow working from any invocation directory,
     while an arbitrary caller CWD (e.g. a Downloads directory) is never trusted as a write root
-    (#646 review — the CWD root was caller-controlled and therefore no boundary at all).
+    (#646 review — the CWD root was caller-controlled and therefore no boundary at all). Scoped
+    to ``.scratch`` rather than the whole checkout because a checkout-wide root would validate a
+    ``--json`` destination that overwrites source files (#647 review round 3, applied here for
+    parity — same boundary, same reason).
     """
-    return Path(__file__).resolve().parents[2]
+    return Path(__file__).resolve().parents[2] / ".scratch"
 
 
 def _resolve_report_path(raw: Path, approved_roots: Sequence[Path]) -> Path:
@@ -736,9 +739,10 @@ def _resolve_report_path(raw: Path, approved_roots: Sequence[Path]) -> Path:
 
     #646 review: an absolute path or a ``..`` traversal would let this rig tool create parent
     directories and overwrite files at arbitrary writable locations. The approved roots are the
-    per-user Harness root (where the rig lock and generated presets already live) and the repo
-    checkout root (gitignored ``.scratch`` measurement artifacts). A relative path still resolves
-    against the caller's CWD — but it only passes when that resolution lands inside a fixed root.
+    per-user Harness root (where the rig lock and generated presets already live) and the
+    checkout's gitignored ``.scratch`` directory (measurement artifacts) — never the whole
+    checkout, which would allow overwriting source. A relative path still resolves against the
+    caller's CWD — but it only passes when that resolution lands inside a fixed root.
     """
     resolved = raw.expanduser()
     if not resolved.is_absolute():
@@ -1499,7 +1503,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
     if args.json_path is not None:
         try:
             args.json_path = _resolve_report_path(
-                args.json_path, approved_roots=(lock_path.parent, _repo_checkout_root())
+                args.json_path, approved_roots=(lock_path.parent, _scratch_root())
             )
         except ValueError as exc:
             _log(f"launch aborted: {exc}")


### PR DESCRIPTION
## Summary

PR #644 (Part F) promoted the freeze-forensics instrument functions but left **no shipped call
site** — `python -m tools.ac_harness.freeze_forensics` imported and exited, so during a real freeze
the operator would have had to rebuild the bespoke `.scratch` harness the promotion was meant to
replace (chatgpt-codex finding on #644, filed as Part G on #630).

### What ships

- **`main()` runs the full evidence path end-to-end:** S1 `sample_cycles` → hot candidates → one
  noninvasive cdb stack per candidate → **`select_capture_tid` prefers a render-stack thread**
  (`accRenderingAdv`/`dwrite`/`d3d11`/`dxgi`/`nvwgf2um` hints) over the merely hottest one — the
  exact hottest-thread residual `classify_forensics` flags (under the #627 §2 signature physics
  keeps advancing, so a busy physics worker can outrank a blocked renderer on cycles alone) → S2
  repeated snapshots of the selected TID → S3 packet + liveness reads evaluated by the pure
  `evaluate_s3` with the **trap-§7.1 corpse guard** (readings not correlated with a live `acs.exe`
  are *discarded*, never compared) → `classify_forensics` → verdict + rationale as a
  machine-readable record (`freeze-forensics-capture/v1`; `--json` persists it).
- **`--self-test`** validates the instrument against a ground-truth spinner before any capture is
  trusted — the check that caught the instrument reading 0 cycles/s on a known spinner. The worker
  prints its own pid, defeating the venv-shim trap by construction.
- **`find_cdb()` gains the Store WinDbg app-execution alias rung**
  (`%LOCALAPPDATA%\Microsoft\WindowsApps\cdbX64.exe`). On the rig the SDK lacks the Debuggers
  feature and the package dir is ACL-opaque — the alias is the only working entry point; the
  self-test read 0 confirmed RIPs before this rung existed.
- Insufficient S3 evidence → `capture_failed_insufficient_s3`, exit 2 — the driver refuses to
  synthesize a verdict it cannot support (the #627 §7.5 "measure or say nothing" rule).

### Rig verification (2026-07-21, AG_PC — observed, not inferred)

| Check | Result |
|---|---|
| `--self-test` | **exit 0** — S1 OK (spinner 2.81e9 cycles/s), S2 OK (2 confirmed RIP reads via the alias) |
| Full capture vs spinner pid, no AC running | **exit 2**, `capture_failed_insufficient_s3` — §7.1 guard discarded all readings; candidate stack heads show real `python313!PyEval_EvalFrameDefault` frames (cdb attach + TID marker + stack parse proven live) |

A capture against a **real wedge** remains the payoff run (#627 §6.1) — the rig currently launches
stable (21/21 soak), so that evidence arrives when the wedge next fires; the negative paths above
prove the driver runs end-to-end and reports honestly.

### Off-rig

- 40 tests in `tests/test_freeze_forensics.py` (20 new across the driver + review-hardening rounds: render-TID preference incl. fallback +
  empty-candidate rejection, §7.1 discard semantics, wedge signature, recovered session,
  mixed dead/live, insufficiency, record serialization/audit caps; lm-listing exclusion, liveness-gap gate, record-path boundary incl. unapproved-CWD, CLI validators, checkout-root anchor).
- `make ci-fast` OK.

Refs #630 (Part G) · #627 §6.1 (the question this instrument answers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
