### PR TITLE
fix(protocol): scope session review replay by UUID (#622)

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -2503,7 +2503,12 @@ function script.update(dt)
       wsBridge = wsBridge,
       appVersion = APP_VERSION_UI,
     })
-    if lifecyclePublisher.publishSessionIfChanged({ car = car, sim = sim, wsBridge = wsBridge }) then
+    if lifecyclePublisher.publishSessionIfChanged({
+      car = car,
+      sim = sim,
+      sessionUuid = SESSION_UUID,
+      wsBridge = wsBridge,
+    }) then
       -- A re-emitted `session` means the car/track/session identity changed: follow with a
       -- fresh setup.active so the dashboard header never carries the previous session's
       -- setup name into the new identity (Codex on PR #547). Unresolved here publishes a

--- a/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
+++ b/src/ac_copilot_trainer/modules/lifecycle_publisher.lua
@@ -25,7 +25,7 @@ local TOPIC_SESSION = "session"
 local TOPIC_LAP = "lap"
 
 -- Module-level rate-limiter / change-detector state.
--- `session` is a pure CHANGE event: published when track/car/session-index changes, and
+-- `session` is a pure CHANGE event: published when track/car/session-index/session UUID changes, and
 -- re-armed by M.rearmSession() (WS reconnect) / M.reset() (stint reset). It is deliberately
 -- NOT coupled to the connection heartbeat — doing so spawned reconnect edge cases (duplicate
 -- on reset; ~1s re-emit delay). Reconnect re-arm is driven per-frame by the entry script via
@@ -135,7 +135,7 @@ end
 
 
 --- Publish `session` only when track/car/session-index changes since the last call.
----@param opts table  {car?, sim?, wsBridge}
+---@param opts table  {car?, sim?, sessionUuid?, wsBridge}
 ---@return boolean  true if a frame was actually published this call
 function M.publishSessionIfChanged(opts)
   if type(opts) ~= "table" then
@@ -148,7 +148,9 @@ function M.publishSessionIfChanged(opts)
   local trackId = _trackId()
   local carId = _carId(opts.car)
   local sessIdx = _sessionIndex(opts.sim)
+  local sessionUuid = opts.sessionUuid
   local key = tostring(trackId) .. "|" .. tostring(carId) .. "|" .. tostring(sessIdx)
+      .. "|" .. tostring(sessionUuid)
   if key == _lastSessionKey then
     return false
   end
@@ -160,6 +162,7 @@ function M.publishSessionIfChanged(opts)
     track_id = trackId,
     car_id = carId,
     session_index = sessIdx,
+    session_uuid = sessionUuid,
   }) == true
   if ok then
     _lastSessionKey = key

--- a/tests/test_lifecycle_publisher.py
+++ b/tests/test_lifecycle_publisher.py
@@ -110,6 +110,44 @@ def test_session_published_once_then_suppressed_until_change():
     assert out["sess"] == 0
 
 
+def test_session_uuid_is_published_and_part_of_change_identity():
+    """#622: a rolling same-car/track/index stint gets a new journal UUID and must emit a
+    distinguishable lifecycle frame even if reset/rearm ordering changes later."""
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("lifecycle_publisher"); M.reset()
+          local ws = make_ws()
+          local base = { sim = { currentSessionIndex = 0 }, sessionUuid = "stint-a", wsBridge = ws }
+          local r1 = M.publishSessionIfChanged(base)
+          local r2 = M.publishSessionIfChanged(base)
+          local r3 = M.publishSessionIfChanged({
+            sim = { currentSessionIndex = 0 }, sessionUuid = "stint-b", wsBridge = ws,
+          })
+          return { r1 = r1, r2 = r2, r3 = r3, n = #ws._calls,
+                   uuid1 = ws._calls[1].payload.session_uuid,
+                   uuid2 = ws._calls[2].payload.session_uuid }
+        end)()
+        """
+    )
+    assert out["r1"] is True
+    assert out["r2"] is False
+    assert out["r3"] is True
+    assert out["n"] == 2
+    assert out["uuid1"] == "stint-a"
+    assert out["uuid2"] == "stint-b"
+
+
+def test_entry_script_passes_active_session_uuid_to_lifecycle_frame():
+    source = (REPO / "src" / "ac_copilot_trainer" / "ac_copilot_trainer.lua").read_text(
+        encoding="utf-8"
+    )
+    call = source[source.index("lifecyclePublisher.publishSessionIfChanged") :]
+    call = call[: call.index("})") + 2]
+    assert "sessionUuid = SESSION_UUID" in call
+
+
 def test_session_retries_after_ws_recovers():
     # Regression: a session change while the WS is down must NOT mark the key as
     # sent, so the initial `session` frame is re-published once the WS comes up.

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -729,6 +729,32 @@ def test_wire_voice_builds_track_map_frame(tmp_path, monkeypatch):
     assert frame["payload"]["corners"][0]["label"] == "T1"
 
 
+def test_runtime_rewire_broadcasts_fresh_track_map(tmp_path, monkeypatch):
+    """#622 advisory: if voice/reference wiring moves in-process at runtime, connected
+    subscribers receive the rebuilt map instead of waiting for another subscribe."""
+    sent = _capture_broadcast(monkeypatch)
+    monkeypatch.setattr(server, "_observer", None)
+    monkeypatch.setattr(server, "_track_map_frame", None)
+    server._background_tasks.clear()
+    ref = tmp_path / "ref.json"
+    ref.write_text(json.dumps(_corner_archive()), encoding="utf-8")
+
+    async def _rewire():
+        monkeypatch.setattr(server, "_event_loop", asyncio.get_running_loop())
+        server._wire_voice(server.VoiceRuntimeConfig(reference_path=str(ref), bank_dir=None))
+        await asyncio.sleep(0)
+        pending = list(server._background_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+
+    asyncio.run(_rewire())
+    assert len(sent) == 1
+    frame, exclude = sent[0]
+    assert exclude is None
+    assert frame["topic"] == "track.map"
+    assert frame == server._track_map_frame
+
+
 def test_rewire_without_geometry_clears_stale_track_map(tmp_path, monkeypatch):
     """A re-wire whose reference cannot supply geometry must not leave the previous
     track's map for late subscribers (Codex on PR #618)."""

--- a/tests/test_tablet_dash_endpoint.py
+++ b/tests/test_tablet_dash_endpoint.py
@@ -119,6 +119,18 @@ def test_dash_page_is_offline_kiosk_and_a133_safe() -> None:
         assert (_TABLET_DASH_FONTS_DIR / name).is_file(), f"vendored font missing: {name}"
 
 
+def test_session_review_replay_is_scoped_by_shared_session_uuid() -> None:
+    """#622: the actual shipped page must compare a replayed review's UUID with the live
+    lifecycle UUID, while retaining the additive "both known" compatibility rule."""
+    body = _TABLET_DASH_PAGE_PATH.read_text(encoding="utf-8")
+    assert "function identCompatible(carId, trackId, sessionUuid)" in body
+    assert "sessionUuid && S.sessionUuid" in body
+    assert "String(sessionUuid) !== String(S.sessionUuid)" in body
+    assert "identCompatible(p.car_id, p.track_id, p.session_uuid)" in body
+    assert "S.sessionUuid = p.session_uuid || null" in body
+    assert '+ "|" + String(p.session_uuid || "")' in body
+
+
 def test_dash_part_d_vitals_are_bound_end_to_end() -> None:
     """#531 Part D anti-dead-wiring guard.
 

--- a/tools/ai_sidecar/dash/web/tablet_dash.html
+++ b/tools/ai_sidecar/dash/web/tablet_dash.html
@@ -331,8 +331,9 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
     coach: null, coachAt: 0,        // coaching.snapshot payload
     setupName: null,                // setup.active .name
     carName: null, trackName: null, // setup.list.result identity
-    sessionIdent: null,             // "car|track|session" key (re-request setup data on change)
-    sessionCarId: null, sessionTrackId: null, // identity parts for replay-frame gating (#618 R3)
+    sessionIdent: null,             // "car|track|session|uuid" key (re-request setup data on change)
+    sessionCarId: null, sessionTrackId: null, sessionUuid: null,
+                                      // identity parts for replay-frame gating (#618 R3, #622)
     spinners: null,                 // setup.spinner.list.result .spinners
     fuelAtLap: null, burns: [],     // client-side fuel-per-lap (median of last 3 lap diffs)
     lastCue: null, cueAt: 0,        // latest coaching.cue payload + receive time (tier-2 micro)
@@ -745,7 +746,7 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
   // Identity gate for replayed sidecar frames (#618 R3): reject only a KNOWN mismatch —
   // when either side lacks an id, accept (a fresh tablet with no session yet must still
   // render the replayed map/review, and single-identity rigs are the common case).
-  function identCompatible(carId, trackId) {
+  function identCompatible(carId, trackId, sessionUuid) {
     if (carId && S.sessionCarId && String(carId) !== String(S.sessionCarId)) return false;
     // Track gate (#618 R4+R6): when BOTH ids are layout-qualified, compare in full — two
     // layouts of one venue have different geometry. Base-segment comparison applies only
@@ -755,6 +756,10 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
       var qualified = a.indexOf("/") >= 0 && b.indexOf("/") >= 0;
       if (qualified ? a !== b : a.split("/")[0] !== b.split("/")[0]) return false;
     }
+    // UUID is additive/backward-compatible: only reject when BOTH producers carry one.
+    // This closes a reconnect replay from the prior same-car/track/session-index stint (#622).
+    if (sessionUuid && S.sessionUuid
+        && String(sessionUuid) !== String(S.sessionUuid)) return false;
     return true;
   }
   function resetMapDom() {
@@ -1178,11 +1183,11 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
           case "session.review":
             // Late-subscriber replay can deliver a PREVIOUS identity's cached review after
             // the session snapshot (#618 R3) — accept only when identity-compatible.
-            S.review = identCompatible(p.car_id, p.track_id) ? p : null;
+            S.review = identCompatible(p.car_id, p.track_id, p.session_uuid) ? p : null;
             reviewDirty = true;
             break;
           case "track.map":
-            if (identCompatible(p.car_id, p.track_id)) {
+            if (identCompatible(p.car_id, p.track_id, p.session_uuid)) {
               S.map = p; mapDirty = true;
             } else {
               // Full DOM reset on rejection (#618 R5): a dirty-flag alone leaves the
@@ -1199,7 +1204,8 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
             // Full identity key: a new track or session with the SAME car must also
             // re-request setup data (Codex P2 on PR #547), not just a car swap.
             var ident = String(p.car_id || "") + "|" + String(p.track_id || "")
-              + "|" + String(p.session_index === undefined ? "" : p.session_index);
+              + "|" + String(p.session_index === undefined ? "" : p.session_index)
+              + "|" + String(p.session_uuid || "");
             // Car/track delta computed BEFORE the identity parts update: a session_index-only
             // transition (practice→quali) must not drop the map (#618 R5 — track.map is only
             // replayed on subscribe and would stay blank for the rest of the connection).
@@ -1211,12 +1217,14 @@ body{font-family:var(--fr);-webkit-user-select:none;user-select:none}
               || String(S.sessionTrackId || "") !== String(p.track_id || ""));
             S.sessionCarId = p.car_id || null;
             S.sessionTrackId = p.track_id || null;
+            S.sessionUuid = p.session_uuid || null;
             // Replayed cached frames may have arrived BEFORE this session snapshot — drop
             // any that a known identity now contradicts (#618 R3).
-            if (S.review && !identCompatible(S.review.car_id, S.review.track_id)) {
+            if (S.review && !identCompatible(
+                S.review.car_id, S.review.track_id, S.review.session_uuid)) {
               S.review = null; reviewDirty = true;
             }
-            if (S.map && !identCompatible(S.map.car_id, S.map.track_id)) {
+            if (S.map && !identCompatible(S.map.car_id, S.map.track_id, S.map.session_uuid)) {
               S.map = null; resetMapDom();
             }
             if (ident !== S.sessionIdent) {

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -1334,6 +1334,29 @@ async def _broadcast_external(frame: dict[str, Any], *, exclude: Any) -> None:
     await _broadcast_targets(frame, targets=targets)
 
 
+def _schedule_external_broadcast(frame: dict[str, Any], *, label: str) -> bool:
+    """Schedule a sync producer's frame on the active server loop, if one exists.
+
+    ``_wire_voice`` normally runs before ``_run`` creates the loop, but keeping this bridge
+    makes a future runtime re-wire immediately visible to already-connected subscribers.
+    """
+    loop = _event_loop
+    if loop is None or loop.is_closed():
+        return False
+
+    def _schedule() -> None:
+        task = asyncio.ensure_future(_broadcast_external(frame, exclude=None))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+    try:
+        loop.call_soon_threadsafe(_schedule)
+    except RuntimeError:
+        logger.debug("%s broadcast skipped (event loop closed)", label)
+        return False
+    return True
+
+
 def _release_observer_feed(websocket: Any) -> None:
     """Release the observer feed + reset stream state when the owning producer disconnects.
 
@@ -2768,6 +2791,7 @@ def _wire_voice(voice_settings: VoiceRuntimeConfig) -> None:
                 map_payload = build_track_map(archive)
                 if map_payload is not None:
                     _track_map_frame = make_track_map(map_payload)
+                    _schedule_external_broadcast(_track_map_frame, label="track.map re-wire")
                     logger.info(
                         "track.map built from reference: %d outline points, %d corners",
                         len(map_payload.get("outline") or []),


### PR DESCRIPTION
Closes #622

## Summary
- publish the active journal session UUID on lifecycle session frames and include it in change detection
- reject stale same-car/track review replays when both review and live session UUIDs are known
- broadcast a rebuilt track map to connected peers during any future runtime reference rewire

## Verification
- focused matrix: 68 passed across lifecycle Lua, tablet endpoint, and observer wiring tests
- make ci-fast PYTHON=.venv/bin/python: 3,248 passed, 89 optional/platform skips, 83.52% coverage, ci-fast OK
- live endpoint at http://127.0.0.1:8876/tablet/dash: an old same-car/track/index review with session_uuid=stint-old visibly rendered STALE REVIEW MUST DISAPPEAR; a lifecycle session with session_uuid=stint-new cleared it to the review-pending state
- screenshots: .scratch/issue-622-old-review.png and .scratch/issue-622-new-session-cleared.png (local verification evidence, intentionally gitignored)