### PR TITLE
feat(harness): add evidence-gated alien setup scientist (#654)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -173,6 +173,44 @@ provenance gates, and cache revalidation (a tampered refined profile fails the b
 and rebuilds); `--no-l3` artifacts are byte-identical to pre-#582 builds. Reality remains the
 judge: the #577 keep-last-valid oracle falsifies a refined profile the car cannot hold.
 
+### Evidence-gated setup scientist (#529 P4 / #654)
+
+The optional scientist composes the self-play and setup-intelligence paths; it does not give model
+text write access to setup files:
+
+```bash
+python -m tools.ac_harness.auto_alien \
+  --car ks_porsche_911_gt3_r_2016 --track magione \
+  --setup Copilot_Balanced_Fast --laps 2 --iterations 2 \
+  --scientist --scientist-trigger pace_plateau
+```
+
+- `--scientist` requires a resolved baseline setup, at least one self-play iteration, and at least
+  two timed laps per batch. It starts only from the newest batch that passes the normal auto-alien
+  validity oracle (timed, archived, AC-valid, zero recoveries).
+- A proposal is at most three physical hypotheses. The deterministic planner validates bounded
+  identifiers, a named mechanism, direction, current setup value, checked-in per-car spinner schema,
+  range, step, and read-only status. Each experiment changes exactly one `SECTION.VALUE`. Optional
+  `--scientist-proposals FILE` accepts a JSON array with `id`, `mechanism`, `parameter`, and
+  `direction` (`-1` or `1`); unsafe prose/data fails the stage and retains its traceback in
+  `alien_report.json`.
+- Candidates are immutable new `.ini` files beside the baseline under AC Documents; the baseline is
+  never overwritten. Each candidate goes through a nested normal auto-alien pipeline, including
+  identification, line/profile verification, and the same lap-validity oracle.
+- Promotion requires a single-parameter, unconfounded candidate batch that is faster with the
+  setup optimizer's measured uncertainty test. Invalid, confounded, or inconclusive batches keep
+  the previous setup. The report names the rejection and only a promoted result exposes
+  `recommended_setup`.
+- Completed plan, outcomes, and verdict persist under
+  `<AC user data>/journal/alien_scientist/runs/`; the append-only
+  `journal/alien_scientist/experiments.jsonl` ledger suppresses a falsified constraint for the same
+  mechanical platform, aero platform, tyre family, and track archetype. The four
+  `--scientist-*-platform` flags override conservative car/track-derived scope identities when the
+  operator has a better taxonomy.
+
+The existing `--setup` launch caveats still apply: a candidate that cannot reach a complete measured
+batch is an explicit scientist-stage failure, never a promotion or a plausible default.
+
 ## Composing downstream tasks (don't reinvent)
 
 - **Setup A/B**: run twice with different `--setup` names; compare the runs' lap archives with

--- a/tests/test_alien_scientist.py
+++ b/tests/test_alien_scientist.py
@@ -94,6 +94,14 @@ def test_falsified_constraint_is_suppressed_for_same_platform_scope() -> None:
                     "verdict": "falsified",
                 }
             ],
+            proposed_hypotheses=[
+                {
+                    "id": "renamed_same_adjustment",
+                    "mechanism": "different prose, identical physical adjustment",
+                    "parameter": "WING_2",
+                    "direction": -1,
+                }
+            ],
         )
 
 
@@ -136,7 +144,7 @@ def test_explicit_proposals_fail_closed_on_empty_unknown_or_duplicate() -> None:
         "direction": -1,
     }
     with pytest.raises(ScientistError, match="scientist_hypothesis_duplicate"):
-        build_plan(**common, proposed_hypotheses=[duplicate, duplicate])
+        build_plan(**common, proposed_hypotheses=[duplicate, {**duplicate, "id": "wing_renamed"}])
 
 
 @pytest.mark.parametrize(
@@ -332,3 +340,30 @@ def test_completed_run_rejects_unsafe_timestamp_and_empty_outcomes(tmp_path: Pat
             outcomes=[],
             created_utc="20260722T000001Z",
         )
+
+
+@pytest.mark.parametrize("redirect", ["scientist_root", "runs", "ledger"])
+def test_completed_run_rejects_state_symlink_redirection(tmp_path: Path, redirect: str) -> None:
+    user_dir = tmp_path / "Assetto Corsa"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    scientist_root = user_dir / "journal" / "alien_scientist"
+    if redirect == "scientist_root":
+        scientist_root.parent.mkdir(parents=True)
+        scientist_root.symlink_to(outside, target_is_directory=True)
+    else:
+        scientist_root.mkdir(parents=True)
+        target = scientist_root / ("runs" if redirect == "runs" else "experiments.jsonl")
+        external = outside if redirect == "runs" else outside / "experiments.jsonl"
+        if redirect == "ledger":
+            external.write_text("sentinel\n", encoding="utf-8")
+        target.symlink_to(external, target_is_directory=redirect == "runs")
+
+    with pytest.raises(ScientistError, match="scientist_state_path_unsafe"):
+        persist_completed_run(
+            user_dir,
+            plan=_plan(),
+            outcomes=[{"verdict": "rejected", "reason": "test"}],
+            created_utc="20260722T000002Z",
+        )
+    assert sorted(path.name for path in outside.iterdir()) in ([], ["experiments.jsonl"])

--- a/tests/test_alien_scientist.py
+++ b/tests/test_alien_scientist.py
@@ -1,0 +1,334 @@
+"""EPIC #529 P4: evidence-gated alien scientist setup experiments."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.ac_harness.alien_scientist import (
+    ScientistError,
+    append_ledger,
+    build_plan,
+    evaluate_experiment,
+    load_ledger,
+    persist_completed_run,
+    write_candidate_setup,
+)
+from tools.ai_sidecar.car_schema import CarSetupSchema
+
+
+def _schema() -> CarSetupSchema:
+    return CarSetupSchema.from_spinners_dump(
+        "car_a",
+        [
+            {"name": "WING_2", "min": 0, "max": 20, "step": 1, "value": 10},
+            {"name": "FRONT_BIAS", "min": 50, "max": 70, "step": 1, "value": 60},
+            {"name": "READ_ONLY", "min": 0, "max": 10, "step": 1, "readOnly": True},
+        ],
+    )
+
+
+def _lap(lap_uuid: str, lap_ms: int, *, wing: int = 10, bias: int = 60) -> dict:
+    return {
+        "schema_version": 1,
+        "lap_uuid": lap_uuid,
+        "session_uuid": "session-1",
+        "exported_at": f"2026-07-22T00:00:{lap_uuid[-1]}Z",
+        "car": {"id": "car_a"},
+        "track": {"id": "track_a", "layout": None},
+        "lap": {"lap_n": int(lap_uuid[-1]), "lap_ms": lap_ms, "is_valid": True},
+        "setup": {
+            "hash": f"setup-{wing}-{bias}",
+            "path": f"C:/setups/car_a/track_a/setup-{wing}-{bias}.ini",
+            "snapshot": {"WING_2.VALUE": wing, "FRONT_BIAS.VALUE": bias},
+        },
+    }
+
+
+_SCOPE = {
+    "mechanical_platform": "gt3",
+    "aero_platform": "gt",
+    "tyre_family": "slick",
+    "track_archetype": "short-technical",
+}
+_COMBO = {"car": "car_a", "track": "track_a", "layout": None}
+
+
+def test_plan_turns_prose_into_one_schema_valid_parameter() -> None:
+    plan = build_plan(
+        trigger="pace plateau after self-play",
+        combo=_COMBO,
+        scope=_SCOPE,
+        baseline_payloads=[_lap("lap-1", 100_000), _lap("lap-2", 100_100)],
+        schema=_schema(),
+    )
+
+    assert plan["trigger"] == "pace plateau after self-play"
+    assert len(plan["experiments"]) == 1
+    assert plan["experiments"][0]["changed_params"] == {"WING_2.VALUE": {"from": 10.0, "to": 9.0}}
+
+
+def test_falsified_constraint_is_suppressed_for_same_platform_scope() -> None:
+    first = build_plan(
+        trigger="pace plateau",
+        combo=_COMBO,
+        scope=_SCOPE,
+        baseline_payloads=[_lap("lap-1", 100_000)],
+        schema=_schema(),
+    )
+    constraint = first["experiments"][0]["constraint_key"]
+
+    with pytest.raises(ScientistError, match="scientist_constraints_suppressed"):
+        build_plan(
+            trigger="pace plateau again",
+            combo=_COMBO,
+            scope=_SCOPE,
+            baseline_payloads=[_lap("lap-1", 100_000)],
+            schema=_schema(),
+            ledger=[
+                {
+                    "scope_key": first["scope_key"],
+                    "constraint_key": constraint,
+                    "verdict": "falsified",
+                }
+            ],
+        )
+
+
+def test_rejected_batch_does_not_suppress_unmeasured_constraint() -> None:
+    first = _plan()
+    rebuilt = build_plan(
+        trigger="pace plateau retry",
+        combo=_COMBO,
+        scope=_SCOPE,
+        baseline_payloads=[_lap("lap-1", 100_000)],
+        schema=_schema(),
+        ledger=[
+            {
+                "scope_key": first["scope_key"],
+                "constraint_key": first["experiments"][0]["constraint_key"],
+                "verdict": "rejected",
+            }
+        ],
+    )
+    assert rebuilt["experiments"]
+
+
+def test_explicit_proposals_fail_closed_on_empty_unknown_or_duplicate() -> None:
+    common = {
+        "trigger": "pace plateau",
+        "combo": _COMBO,
+        "scope": _SCOPE,
+        "baseline_payloads": [_lap("lap-1", 100_000)],
+        "schema": _schema(),
+    }
+    with pytest.raises(ScientistError, match="scientist_hypothesis_count_out_of_range"):
+        build_plan(**common, proposed_hypotheses=[])
+    unknown = {"id": "unknown", "mechanism": "test", "parameter": "NOPE", "direction": 1}
+    with pytest.raises(ScientistError, match="scientist_hypothesis_outside_schema"):
+        build_plan(**common, proposed_hypotheses=[unknown])
+    duplicate = {
+        "id": "wing",
+        "mechanism": "test",
+        "parameter": "WING_2",
+        "direction": -1,
+    }
+    with pytest.raises(ScientistError, match="scientist_hypothesis_duplicate"):
+        build_plan(**common, proposed_hypotheses=[duplicate, duplicate])
+
+
+@pytest.mark.parametrize(
+    "proposal",
+    [
+        {"id": "x", "mechanism": "m", "parameter": "WING_2", "direction": float("nan")},
+        {"id": "x", "mechanism": "", "parameter": "WING_2", "direction": 1},
+        {"id": "x", "mechanism": "m", "parameter": "WING_2", "direction": 2},
+        {"id": "../escape", "mechanism": "m", "parameter": "WING_2", "direction": 1},
+    ],
+)
+def test_malformed_model_hypothesis_never_reaches_setup(proposal: dict) -> None:
+    with pytest.raises(ScientistError, match="scientist_hypothesis_malformed"):
+        build_plan(
+            trigger="plateau",
+            combo=_COMBO,
+            scope=_SCOPE,
+            baseline_payloads=[_lap("lap-1", 100_000)],
+            schema=_schema(),
+            proposed_hypotheses=[proposal],
+        )
+
+
+def test_candidate_writer_changes_exactly_one_parameter_under_ac_documents(tmp_path: Path) -> None:
+    user_dir = tmp_path / "Assetto Corsa"
+    baseline = user_dir / "setups" / "car_a" / "track_a" / "baseline.ini"
+    baseline.parent.mkdir(parents=True)
+    baseline.write_text("[WING_2]\nVALUE=10\n\n[FRONT_BIAS]\nVALUE=60\n", encoding="utf-8")
+    experiment = {
+        "hypothesis_id": "plateau_rear_wing",
+        "constraint_key": "0123456789abcdef",
+        "changed_params": {"WING_2.VALUE": {"from": 10, "to": 9}},
+    }
+
+    candidate = write_candidate_setup(
+        baseline, user_dir=user_dir, plan_id="0123456789abcdef", experiment=experiment
+    )
+
+    assert candidate.parent == baseline.parent
+    assert "VALUE=9" in candidate.read_text(encoding="utf-8")
+    assert "[FRONT_BIAS]\nVALUE=60" in candidate.read_text(encoding="utf-8")
+    assert baseline.read_text(encoding="utf-8").startswith("[WING_2]\nVALUE=10")
+    assert (
+        write_candidate_setup(
+            baseline, user_dir=user_dir, plan_id="0123456789abcdef", experiment=experiment
+        )
+        == candidate
+    )
+    candidate.write_text("[WING_2]\nVALUE=999\n", encoding="utf-8")
+    with pytest.raises(ScientistError, match="scientist_candidate_conflicts"):
+        write_candidate_setup(
+            baseline, user_dir=user_dir, plan_id="0123456789abcdef", experiment=experiment
+        )
+
+
+def test_candidate_writer_rejects_baseline_drift_since_measured_batch(tmp_path: Path) -> None:
+    user_dir = tmp_path / "Assetto Corsa"
+    baseline = user_dir / "setups" / "car_a" / "baseline.ini"
+    baseline.parent.mkdir(parents=True)
+    baseline.write_text("[WING_2]\nVALUE=11\n", encoding="utf-8")
+
+    with pytest.raises(ScientistError, match="scientist_baseline_setup_drifted"):
+        write_candidate_setup(
+            baseline,
+            user_dir=user_dir,
+            plan_id="0123456789abcdef",
+            experiment={
+                "constraint_key": "0123456789abcdef",
+                "changed_params": {"WING_2.VALUE": {"from": 10, "to": 9}},
+            },
+        )
+
+
+def test_candidate_writer_rejects_baseline_outside_ac_documents(tmp_path: Path) -> None:
+    user_dir = tmp_path / "Assetto Corsa"
+    (user_dir / "setups").mkdir(parents=True)
+    outside = tmp_path / "outside.ini"
+    outside.write_text("[WING_2]\nVALUE=10\n", encoding="utf-8")
+
+    with pytest.raises(ScientistError, match="scientist_baseline_outside_setups_root"):
+        write_candidate_setup(
+            outside,
+            user_dir=user_dir,
+            plan_id="0123456789abcdef",
+            experiment={
+                "hypothesis_id": "x",
+                "constraint_key": "0123456789abcdef",
+                "changed_params": {"WING_2.VALUE": {"from": 10, "to": 9}},
+            },
+        )
+
+
+def _plan() -> dict:
+    return build_plan(
+        trigger="pace plateau",
+        combo=_COMBO,
+        scope=_SCOPE,
+        baseline_payloads=[_lap("lap-1", 100_000), _lap("lap-2", 101_000)],
+        schema=_schema(),
+    )
+
+
+def test_measured_significant_single_parameter_gain_is_promoted() -> None:
+    plan = _plan()
+    outcome = evaluate_experiment(
+        plan=plan,
+        experiment=plan["experiments"][0],
+        baseline_payloads=[_lap("lap-1", 100_000), _lap("lap-2", 101_000)],
+        candidate_payloads=[_lap("lap-3", 90_000, wing=9), _lap("lap-4", 91_000, wing=9)],
+        candidate_valid=True,
+        candidate_reason="two valid laps",
+    )
+
+    assert outcome["verdict"] == "promoted"
+    assert outcome["promoted"] is True
+    assert outcome["comparison"]["significant"] is True
+
+
+def test_confounded_or_invalid_batch_keeps_last_valid_setup() -> None:
+    plan = _plan()
+    confounded = evaluate_experiment(
+        plan=plan,
+        experiment=plan["experiments"][0],
+        baseline_payloads=[_lap("lap-1", 100_000), _lap("lap-2", 101_000)],
+        candidate_payloads=[
+            _lap("lap-3", 90_000, wing=9, bias=61),
+            _lap("lap-4", 91_000, wing=9, bias=61),
+        ],
+        candidate_valid=True,
+        candidate_reason="two valid laps",
+    )
+    invalid = evaluate_experiment(
+        plan=plan,
+        experiment=plan["experiments"][0],
+        baseline_payloads=[_lap("lap-1", 100_000), _lap("lap-2", 101_000)],
+        candidate_payloads=[],
+        candidate_valid=False,
+        candidate_reason="spin recovery",
+    )
+
+    assert confounded["reason"] == "candidate_batch_confounded"
+    assert confounded["promoted"] is False
+    assert invalid["verdict"] == "rejected"
+    assert invalid["promoted"] is False
+
+
+def test_completed_run_persists_plan_outcomes_and_append_only_ledger(tmp_path: Path) -> None:
+    plan = _plan()
+    outcome = {
+        "constraint_key": plan["experiments"][0]["constraint_key"],
+        "verdict": "falsified",
+        "promoted": False,
+        "reason": "candidate_not_significantly_faster",
+    }
+
+    run_path = persist_completed_run(
+        tmp_path,
+        plan=plan,
+        outcomes=[outcome],
+        created_utc="20260722T000000Z",
+    )
+
+    payload = json.loads(run_path.read_text(encoding="utf-8"))
+    assert payload["plan"]["plan_id"] == plan["plan_id"]
+    assert payload["outcomes"] == [outcome]
+    ledger = load_ledger(tmp_path / "journal" / "alien_scientist" / "experiments.jsonl")
+    assert ledger[0]["verdict"] == "falsified"
+    with pytest.raises(ScientistError, match="scientist_experiment_already_recorded"):
+        append_ledger(tmp_path / "journal" / "alien_scientist" / "experiments.jsonl", ledger[0])
+
+    with pytest.raises(ScientistError, match="scientist_run_already_exists"):
+        persist_completed_run(
+            tmp_path,
+            plan=plan,
+            outcomes=[outcome],
+            created_utc="20260722T000000Z",
+        )
+
+
+def test_completed_run_rejects_unsafe_timestamp_and_empty_outcomes(tmp_path: Path) -> None:
+    plan = _plan()
+    with pytest.raises(ScientistError, match="scientist_created_utc_invalid"):
+        persist_completed_run(
+            tmp_path,
+            plan=plan,
+            outcomes=[{"verdict": "rejected"}],
+            created_utc="../../outside",
+        )
+    with pytest.raises(ScientistError, match="scientist_completed_outcomes_missing"):
+        persist_completed_run(
+            tmp_path,
+            plan=plan,
+            outcomes=[],
+            created_utc="20260722T000001Z",
+        )

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -835,7 +835,17 @@ def test_selfplay_late_persist_error_cannot_return_green(monkeypatch, tmp_path):
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "iter1"}'
 
 
-def test_scientist_executes_candidate_through_normal_pipeline_and_persists(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("baseline_laps", "candidate_laps", "expected_error"),
+    [
+        (((1, 100_000), (2, 101_000)), ((3, 90_000), (4, 91_000)), None),
+        (((1, 100_000), (2, 101_000)), ((3, 90_000),), "candidate_batch_incomplete"),
+        (((1, 100_000),), ((3, 90_000), (4, 91_000)), "baseline_batch_unverifiable"),
+    ],
+)
+def test_scientist_requires_requested_laps_before_persisting(
+    monkeypatch, tmp_path, baseline_laps, candidate_laps, expected_error
+):
     from tools.ai_sidecar import car_schema
     from tools.ai_sidecar.car_schema import CarSetupSchema
 
@@ -869,7 +879,7 @@ def test_scientist_executes_candidate_through_normal_pipeline_and_persists(monke
         }
 
     baseline_paths = []
-    for lap_n, lap_ms in ((1, 100_000), (2, 101_000)):
+    for lap_n, lap_ms in baseline_laps:
         path = tmp_path / f"baseline_lap_{lap_n}.json"
         path.write_text(
             _json.dumps(lap_payload(lap_n, lap_ms, wing=10, path=baseline_setup)),
@@ -877,7 +887,10 @@ def test_scientist_executes_candidate_through_normal_pipeline_and_persists(monke
         )
         baseline_paths.append(str(path))
     base_outcome = {
-        "report": {"lap_times_ms": [100_000, 101_000], "drive": {"recoveries": 0}},
+        "report": {
+            "lap_times_ms": [lap_ms for _, lap_ms in baseline_laps],
+            "drive": {"recoveries": 0},
+        },
         "lap_archives": baseline_paths,
     }
 
@@ -889,7 +902,7 @@ def test_scientist_executes_candidate_through_normal_pipeline_and_persists(monke
         drive_dir = Path(candidate_args.evidence_dir) / "drive"
         drive_dir.mkdir(parents=True)
         paths = []
-        for lap_n, lap_ms in ((3, 90_000), (4, 91_000)):
+        for lap_n, lap_ms in candidate_laps:
             path = drive_dir / f"lap_{lap_n}.json"
             path.write_text(
                 _json.dumps(lap_payload(lap_n, lap_ms, wing=9, path=Path(candidate_args.setup))),
@@ -900,7 +913,7 @@ def test_scientist_executes_candidate_through_normal_pipeline_and_persists(monke
             _json.dumps(
                 {
                     "report": {
-                        "lap_times_ms": [90_000, 91_000],
+                        "lap_times_ms": [lap_ms for _, lap_ms in candidate_laps],
                         "drive": {"recoveries": 0},
                     },
                     "lap_archives": paths,
@@ -934,9 +947,15 @@ def test_scientist_executes_candidate_through_normal_pipeline_and_persists(monke
         base_outcome=base_outcome,
     )
 
-    assert result["ok"] is True
-    assert result["outcomes"][0]["promoted"] is True
-    assert len(nested_calls) == 1
-    assert nested_calls[0].scientist is False
-    assert Path(result["run_path"]).is_file()
-    assert Path(result["ledger_path"]).is_file()
+    expected_nested_calls = 0 if expected_error == "baseline_batch_unverifiable" else 1
+    assert len(nested_calls) == expected_nested_calls
+    if nested_calls:
+        assert nested_calls[0].scientist is False
+    assert result["ok"] is (expected_error is None)
+    if expected_error is None:
+        assert result["outcomes"][0]["promoted"] is True
+        assert Path(result["run_path"]).is_file()
+        assert Path(result["ledger_path"]).is_file()
+    else:
+        assert expected_error in result["error"]
+        assert not (user_dir / "journal" / "alien_scientist" / "experiments.jsonl").exists()

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -18,6 +18,7 @@ from tools.ac_harness.auto_alien import (
     needs_identification,
     resolve_drive_seconds,
     run_pipeline,
+    run_scientist,
     stage_lap_archives,
     stage_lap_times_ms,
 )
@@ -432,6 +433,24 @@ def test_pipeline_rejects_bad_selfplay_flags(monkeypatch, tmp_path):
             _args(tmp_path, "--iterations", "1", "--laps", "1", "--max-scale", "0.8"),
             run_stage=_Runner([0]),
         )
+    with pytest.raises(ValueError, match="--scientist requires"):
+        run_pipeline(_args(tmp_path, "--scientist"), run_stage=_Runner([0]))
+    with pytest.raises(ValueError, match="--scientist requires"):
+        run_pipeline(
+            _args(
+                tmp_path,
+                "--scientist",
+                "--setup",
+                "baseline",
+                "--iterations",
+                "1",
+                "--laps",
+                "1",
+            ),
+            run_stage=_Runner([0]),
+        )
+    with pytest.raises(ValueError, match="--scientist-batch-size"):
+        run_pipeline(_args(tmp_path, "--scientist-batch-size", "4"), run_stage=_Runner([0]))
 
 
 class _SelfplayHarness:
@@ -814,3 +833,110 @@ def test_selfplay_late_persist_error_cannot_return_green(monkeypatch, tmp_path):
     assert "late candidate read failed" in report["error"]
     # The candidate may already be on disk, so returning success would expose an unverified plant.
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "iter1"}'
+
+
+def test_scientist_executes_candidate_through_normal_pipeline_and_persists(monkeypatch, tmp_path):
+    from tools.ai_sidecar import car_schema
+    from tools.ai_sidecar.car_schema import CarSetupSchema
+
+    user_dir = tmp_path / "Assetto Corsa"
+    baseline_setup = user_dir / "setups" / "car_a" / "trk" / "baseline.ini"
+    baseline_setup.parent.mkdir(parents=True)
+    baseline_setup.write_text("[WING_2]\nVALUE=10\n\n[FRONT_BIAS]\nVALUE=60\n", encoding="utf-8")
+    schema = CarSetupSchema.from_spinners_dump(
+        "car_a",
+        [
+            {"name": "WING_2", "min": 0, "max": 20, "step": 1},
+            {"name": "FRONT_BIAS", "min": 50, "max": 70, "step": 1},
+        ],
+    )
+    monkeypatch.setattr(car_schema, "load_latest_schema", lambda car: schema)
+
+    def lap_payload(lap_n: int, lap_ms: int, *, wing: int, path: Path) -> dict:
+        return {
+            "schema_version": 1,
+            "lap_uuid": f"lap-{wing}-{lap_n}",
+            "session_uuid": f"session-{wing}",
+            "exported_at": f"2026-07-22T00:00:0{lap_n}Z",
+            "car": {"id": "car_a"},
+            "track": {"id": "trk", "layout": None},
+            "lap": {"lap_n": lap_n, "lap_ms": lap_ms, "is_valid": True},
+            "setup": {
+                "hash": f"setup-{wing}",
+                "path": str(path),
+                "snapshot": {"WING_2.VALUE": wing, "FRONT_BIAS.VALUE": 60},
+            },
+        }
+
+    baseline_paths = []
+    for lap_n, lap_ms in ((1, 100_000), (2, 101_000)):
+        path = tmp_path / f"baseline_lap_{lap_n}.json"
+        path.write_text(
+            _json.dumps(lap_payload(lap_n, lap_ms, wing=10, path=baseline_setup)),
+            encoding="utf-8",
+        )
+        baseline_paths.append(str(path))
+    base_outcome = {
+        "report": {"lap_times_ms": [100_000, 101_000], "drive": {"recoveries": 0}},
+        "lap_archives": baseline_paths,
+    }
+
+    nested_calls = []
+
+    def fake_nested_pipeline(candidate_args, *, run_stage):
+        del run_stage
+        nested_calls.append(candidate_args)
+        drive_dir = Path(candidate_args.evidence_dir) / "drive"
+        drive_dir.mkdir(parents=True)
+        paths = []
+        for lap_n, lap_ms in ((3, 90_000), (4, 91_000)):
+            path = drive_dir / f"lap_{lap_n}.json"
+            path.write_text(
+                _json.dumps(lap_payload(lap_n, lap_ms, wing=9, path=Path(candidate_args.setup))),
+                encoding="utf-8",
+            )
+            paths.append(str(path))
+        (drive_dir / "report.json").write_text(
+            _json.dumps(
+                {
+                    "report": {
+                        "lap_times_ms": [90_000, 91_000],
+                        "drive": {"recoveries": 0},
+                    },
+                    "lap_archives": paths,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0, {
+            "stages": {"drive": {"evidence_dir": str(drive_dir)}},
+            "ok": True,
+        }
+
+    monkeypatch.setattr(auto_alien, "run_pipeline", fake_nested_pipeline)
+    args = _args(
+        user_dir,
+        "--setup",
+        str(baseline_setup),
+        "--laps",
+        "2",
+        "--iterations",
+        "1",
+        "--scientist",
+    )
+    result = run_scientist(
+        args,
+        run_stage=lambda argv: 0,
+        evidence_root=tmp_path / "evidence",
+        user_dir=user_dir,
+        setup_ini=baseline_setup,
+        selfplay={"base": {"valid": True}, "iterations": [], "stopped": "pace plateau"},
+        base_outcome=base_outcome,
+    )
+
+    assert result["ok"] is True
+    assert result["outcomes"][0]["promoted"] is True
+    assert len(nested_calls) == 1
+    assert nested_calls[0].scientist is False
+    assert Path(result["run_path"]).is_file()
+    assert Path(result["ledger_path"]).is_file()

--- a/tools/ac_harness/alien_scientist.py
+++ b/tools/ac_harness/alien_scientist.py
@@ -1,0 +1,523 @@
+"""Evidence-gated setup scientist for the alien self-play pipeline (#529 P4).
+
+The scientist proposes physical hypotheses; deterministic code validates the proposal, creates
+one-parameter setup candidates, and judges measured batches.  Model prose never writes a setup.
+Durable records live under Assetto Corsa Documents and suppress already-falsified constraints for
+the same platform/track scope.
+"""
+
+from __future__ import annotations
+
+import configparser
+import hashlib
+import json
+import math
+import os
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from tools.ai_sidecar.car_schema import CarSetupSchema
+from tools.ai_sidecar.setup_optimizer import (
+    SetupExperimentError,
+    compare_setups,
+    record_from_lap_archive,
+)
+
+SCHEMA_VERSION = 1
+MAX_HYPOTHESES = 3
+MAX_BATCH_SIZE = 3
+STATE_DIR = Path("journal") / "alien_scientist"
+LEDGER_NAME = "experiments.jsonl"
+_HYPOTHESIS_ID_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+_UTC_STAMP_RE = re.compile(r"^\d{8}T\d{6}Z$")
+
+
+class ScientistError(ValueError):
+    """A scientist plan or experiment is unsafe or unverifiable."""
+
+
+def _finite(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _digest(value: Any, *, length: int = 16) -> str:
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()[:length]
+
+
+def state_root(user_dir: str | Path) -> Path:
+    """Canonical scientist state root below the operator's AC Documents directory."""
+    return Path(user_dir) / STATE_DIR
+
+
+def scope_key(scope: Mapping[str, Any]) -> str:
+    required = ("mechanical_platform", "aero_platform", "tyre_family", "track_archetype")
+    normalized: dict[str, str] = {}
+    for key in required:
+        value = str(scope.get(key) or "").strip()
+        if not value or len(value) > 128:
+            raise ScientistError(f"scientist_scope_missing_{key}")
+        normalized[key] = value
+    return _digest(normalized)
+
+
+def load_ledger(path: str | Path) -> list[dict[str, Any]]:
+    ledger = Path(path)
+    if not ledger.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        with ledger.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, 1):
+                if not line.strip():
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ScientistError(f"scientist_ledger_invalid_json_line_{line_no}") from exc
+                if not isinstance(row, dict):
+                    raise ScientistError(f"scientist_ledger_invalid_record_line_{line_no}")
+                rows.append(row)
+    except (OSError, UnicodeError) as exc:
+        raise ScientistError("scientist_ledger_unreadable") from exc
+    return rows
+
+
+def _exclusive_write_text(path: Path, text: str) -> None:
+    """Publish a new immutable artifact without replacing an existing peer artifact."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp, path)
+        except FileExistsError:
+            raise ScientistError("scientist_run_already_exists") from None
+        tmp.unlink()
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def append_ledger(path: str | Path, row: Mapping[str, Any]) -> None:
+    """Append one completed experiment without rewriting peer/manual history."""
+    ledger = Path(path)
+    rows = load_ledger(ledger)
+    experiment_id = str(row.get("experiment_id") or "")
+    if not experiment_id:
+        raise ScientistError("scientist_experiment_id_missing")
+    if any(str(existing.get("experiment_id") or "") == experiment_id for existing in rows):
+        raise ScientistError("scientist_experiment_already_recorded")
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    data = (_stable_json(dict(row)) + "\n").encode("utf-8")
+    try:
+        fd = os.open(ledger, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+        with os.fdopen(fd, "ab") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError as exc:
+        raise ScientistError("scientist_ledger_append_failed") from exc
+
+
+def _normalized_params(payload: Mapping[str, Any]) -> dict[str, float]:
+    setup = payload.get("setup") if isinstance(payload.get("setup"), Mapping) else {}
+    snapshot = setup.get("snapshot") if isinstance(setup.get("snapshot"), Mapping) else {}
+    params: dict[str, float] = {}
+    for raw_key, raw_value in snapshot.items():
+        value = _finite(raw_value)
+        if value is not None:
+            key = str(raw_key).strip().upper()
+            params[key if key.endswith(".VALUE") else f"{key}.VALUE"] = value
+    return params
+
+
+def _default_hypotheses(trigger: str) -> list[dict[str, Any]]:
+    text = trigger.lower()
+    if "brak" in text or "entry" in text:
+        return [
+            {
+                "id": "braking_stability_front_bias",
+                "mechanism": "braking instability may respond to a one-click front-bias change",
+                "parameter": "FRONT_BIAS.VALUE",
+                "direction": 1,
+            }
+        ]
+    if "spin" in text or "oversteer" in text or "exit" in text:
+        return [
+            {
+                "id": "exit_stability_diff_power",
+                "mechanism": "power-exit instability may respond to one click of diff power",
+                "parameter": "DIFF_POWER.VALUE",
+                "direction": -1,
+            }
+        ]
+    if "understeer" in text:
+        return [
+            {
+                "id": "rotation_arb_front",
+                "mechanism": "persistent understeer may respond to one click less front ARB",
+                "parameter": "ARB_FRONT.VALUE",
+                "direction": -1,
+            }
+        ]
+    return [
+        {
+            "id": "plateau_rear_wing",
+            "mechanism": "a pace plateau may respond to one click less rear wing",
+            "parameter": "WING_2.VALUE",
+            "direction": -1,
+        }
+    ]
+
+
+def build_plan(
+    *,
+    trigger: str,
+    combo: Mapping[str, Any],
+    scope: Mapping[str, Any],
+    baseline_payloads: Sequence[Mapping[str, Any]],
+    schema: CarSetupSchema,
+    ledger: Sequence[Mapping[str, Any]] = (),
+    proposed_hypotheses: Sequence[Mapping[str, Any]] | None = None,
+    batch_size: int = 1,
+) -> dict[str, Any]:
+    """Validate scientist prose and produce bounded, schema-valid one-parameter experiments."""
+    named_trigger = str(trigger or "").strip()
+    if not named_trigger:
+        raise ScientistError("scientist_trigger_missing")
+    if not 1 <= batch_size <= MAX_BATCH_SIZE:
+        raise ScientistError("scientist_batch_size_out_of_range")
+    if not baseline_payloads:
+        raise ScientistError("scientist_baseline_missing")
+    baseline_params = _normalized_params(baseline_payloads[0])
+    if not baseline_params:
+        raise ScientistError("scientist_baseline_setup_missing")
+    for payload in baseline_payloads[1:]:
+        if _normalized_params(payload) != baseline_params:
+            raise ScientistError("scientist_baseline_setup_confounded")
+
+    explicit_proposals = proposed_hypotheses is not None
+    raw = list(proposed_hypotheses if explicit_proposals else _default_hypotheses(named_trigger))
+    if not raw or len(raw) > MAX_HYPOTHESES:
+        raise ScientistError("scientist_hypothesis_count_out_of_range")
+    scoped = scope_key(scope)
+    suppressed = {
+        str(row.get("constraint_key") or "")
+        for row in ledger
+        if row.get("scope_key") == scoped and row.get("verdict") == "falsified"
+    }
+    hypotheses: list[dict[str, Any]] = []
+    experiments: list[dict[str, Any]] = []
+    suppressed_rows: list[dict[str, str]] = []
+    seen_constraints: set[str] = set()
+    for proposal in raw:
+        hypothesis_id = str(proposal.get("id") or "").strip()
+        mechanism = str(proposal.get("mechanism") or "").strip()
+        parameter = str(proposal.get("parameter") or "").strip().upper()
+        if parameter and not parameter.endswith(".VALUE"):
+            parameter += ".VALUE"
+        direction = _finite(proposal.get("direction"))
+        if (
+            not _HYPOTHESIS_ID_RE.fullmatch(hypothesis_id)
+            or not mechanism
+            or len(mechanism) > 240
+            or not parameter
+            or len(parameter) > 80
+            or direction not in (-1.0, 1.0)
+        ):
+            raise ScientistError("scientist_hypothesis_malformed")
+        constraint_key = _digest(
+            {"hypothesis_id": hypothesis_id, "parameter": parameter, "direction": direction}
+        )
+        if constraint_key in seen_constraints:
+            raise ScientistError("scientist_hypothesis_duplicate")
+        seen_constraints.add(constraint_key)
+        hypothesis = {
+            "id": hypothesis_id,
+            "mechanism": mechanism,
+            "parameter": parameter,
+            "direction": int(direction),
+            "constraint_key": constraint_key,
+        }
+        hypotheses.append(hypothesis)
+        if constraint_key in suppressed:
+            suppressed_rows.append(
+                {"hypothesis_id": hypothesis_id, "constraint_key": constraint_key}
+            )
+            continue
+        current = baseline_params.get(parameter)
+        spinner = schema.get(parameter)
+        if current is None or spinner is None or spinner.read_only:
+            if explicit_proposals:
+                raise ScientistError("scientist_hypothesis_outside_schema")
+            continue
+        step = spinner.step if spinner.step is not None and spinner.step > 0 else 1.0
+        target = current + float(direction) * step
+        if not spinner.is_valid(target):
+            if explicit_proposals:
+                raise ScientistError("scientist_hypothesis_target_out_of_range")
+            continue
+        experiments.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "constraint_key": constraint_key,
+                "parameter": parameter,
+                "from": current,
+                "to": target,
+                "changed_params": {parameter: {"from": current, "to": target}},
+            }
+        )
+    if not experiments:
+        reason = (
+            "scientist_constraints_suppressed"
+            if suppressed_rows
+            else "scientist_no_safe_experiment"
+        )
+        raise ScientistError(reason)
+    experiments = experiments[:batch_size]
+
+    plan_core = {
+        "schema_version": SCHEMA_VERSION,
+        "trigger": named_trigger,
+        "combo": dict(combo),
+        "scope": dict(scope),
+        "scope_key": scoped,
+        "baseline_provenance": [
+            {
+                "lap_uuid": payload.get("lap_uuid"),
+                "session_uuid": payload.get("session_uuid"),
+                "lap_n": (
+                    payload.get("lap", {}).get("lap_n")
+                    if isinstance(payload.get("lap"), Mapping)
+                    else None
+                ),
+                "setup_hash": (
+                    payload.get("setup", {}).get("hash")
+                    if isinstance(payload.get("setup"), Mapping)
+                    else None
+                ),
+            }
+            for payload in baseline_payloads
+        ],
+        "hypotheses": hypotheses,
+        "suppressed": suppressed_rows,
+        "experiments": experiments,
+    }
+    return {**plan_core, "plan_id": _digest(plan_core)}
+
+
+def write_candidate_setup(
+    baseline_path: str | Path,
+    *,
+    user_dir: str | Path,
+    plan_id: str,
+    experiment: Mapping[str, Any],
+) -> Path:
+    """Create an immutable one-parameter candidate beside the baseline under AC Documents."""
+    baseline = Path(baseline_path).resolve(strict=True)
+    if not re.fullmatch(r"[0-9a-f]{16}", plan_id):
+        raise ScientistError("scientist_plan_id_invalid")
+    setups_root = (Path(user_dir) / "setups").resolve(strict=True)
+    try:
+        baseline.relative_to(setups_root)
+    except ValueError:
+        raise ScientistError("scientist_baseline_outside_setups_root") from None
+    changed = experiment.get("changed_params")
+    if not isinstance(changed, Mapping) or len(changed) != 1:
+        raise ScientistError("scientist_candidate_not_one_parameter")
+    parameter, delta = next(iter(changed.items()))
+    if not isinstance(delta, Mapping) or _finite(delta.get("to")) is None:
+        raise ScientistError("scientist_candidate_value_invalid")
+    section = str(parameter).upper().removesuffix(".VALUE")
+
+    parser = configparser.ConfigParser(strict=False, interpolation=None)
+    parser.optionxform = str
+    try:
+        with baseline.open("r", encoding="utf-8-sig") as handle:
+            parser.read_file(handle)
+    except (OSError, UnicodeError, configparser.Error) as exc:
+        raise ScientistError("scientist_baseline_setup_unreadable") from exc
+    if not parser.has_section(section) or not parser.has_option(section, "VALUE"):
+        raise ScientistError("scientist_parameter_missing_from_setup")
+    source_value = _finite(parser.get(section, "VALUE"))
+    expected_source = _finite(delta.get("from"))
+    if source_value is None or expected_source is None or source_value != expected_source:
+        raise ScientistError("scientist_baseline_setup_drifted")
+    target = float(delta["to"])
+    parser.set(section, "VALUE", str(int(target)) if target.is_integer() else f"{target:g}")
+
+    constraint_key = str(experiment.get("constraint_key") or "")
+    if not re.fullmatch(r"[0-9a-f]{16}", constraint_key):
+        constraint_key = _digest(experiment)
+    filename = f"Copilot_Scientist_{plan_id}_{constraint_key}.ini"
+    candidate = baseline.parent / filename
+    try:
+        candidate.resolve().relative_to(setups_root)
+    except ValueError:
+        raise ScientistError("scientist_candidate_outside_setups_root") from None
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{candidate.name}.", suffix=".tmp", dir=candidate.parent
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            parser.write(handle, space_around_delimiters=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp, candidate)
+        except FileExistsError:
+            if candidate.is_symlink() or not candidate.is_file():
+                raise ScientistError("scientist_candidate_conflicts") from None
+            try:
+                candidate.resolve(strict=True).relative_to(setups_root)
+            except (OSError, ValueError):
+                raise ScientistError("scientist_candidate_conflicts") from None
+            try:
+                identical = candidate.read_bytes() == tmp.read_bytes()
+            except OSError as exc:
+                raise ScientistError("scientist_candidate_existing_unreadable") from exc
+            if not identical:
+                raise ScientistError("scientist_candidate_conflicts") from None
+        tmp.unlink()
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    return candidate
+
+
+def evaluate_experiment(
+    *,
+    plan: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+    baseline_payloads: Sequence[Mapping[str, Any]],
+    candidate_payloads: Sequence[Mapping[str, Any]],
+    candidate_valid: bool,
+    candidate_reason: str,
+) -> dict[str, Any]:
+    """Measure a completed candidate batch and return its fail-closed promotion verdict."""
+    result: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "plan_id": plan.get("plan_id"),
+        "scope_key": plan.get("scope_key"),
+        "constraint_key": experiment.get("constraint_key"),
+        "experiment": dict(experiment),
+        "candidate_oracle": {"valid": candidate_valid, "reason": candidate_reason},
+        "verdict": "rejected",
+        "promoted": False,
+    }
+    if not candidate_valid:
+        result["reason"] = "candidate_batch_invalid"
+        return result
+    try:
+        baseline = [record_from_lap_archive(dict(payload)) for payload in baseline_payloads]
+        candidate = [record_from_lap_archive(dict(payload)) for payload in candidate_payloads]
+    except SetupExperimentError as exc:
+        result["reason"] = f"candidate_batch_unrecordable:{exc}"
+        return result
+    if not baseline or not candidate:
+        result["reason"] = "candidate_batch_missing_records"
+        return result
+    baseline_params = _normalized_params(baseline_payloads[0])
+    candidate_params = _normalized_params(candidate_payloads[0])
+    for payload in baseline_payloads:
+        if _normalized_params(payload) != baseline_params:
+            result["reason"] = "batch_setup_changed_within_window"
+            return result
+    for payload in candidate_payloads:
+        if _normalized_params(payload) != candidate_params:
+            result["reason"] = "batch_setup_changed_within_window"
+            return result
+    changed = sorted(
+        key
+        for key in set(baseline_params) | set(candidate_params)
+        if baseline_params.get(key) != candidate_params.get(key)
+    )
+    expected_parameter = str(experiment.get("parameter") or "")
+    if changed != [expected_parameter]:
+        result["reason"] = "candidate_batch_confounded"
+        result["changed_params"] = changed
+        return result
+
+    baseline_id = str(baseline[0]["setup"]["hash"])
+    candidate_id = str(candidate[0]["setup"]["hash"])
+    comparison = compare_setups(
+        [*baseline, *candidate],
+        baseline_setup=baseline_id,
+        candidate_setup=candidate_id,
+    )
+    result["comparison"] = comparison
+    result["baseline_records"] = len(baseline)
+    result["candidate_records"] = len(candidate)
+    if not comparison.get("ok"):
+        result["reason"] = "candidate_comparison_failed"
+        return result
+    if not comparison.get("significant"):
+        result["reason"] = "candidate_not_significantly_faster"
+        result["verdict"] = "falsified"
+        return result
+    result["reason"] = "candidate_significantly_faster"
+    result["verdict"] = "promoted"
+    result["promoted"] = True
+    return result
+
+
+def persist_completed_run(
+    user_dir: str | Path,
+    *,
+    plan: Mapping[str, Any],
+    outcomes: Sequence[Mapping[str, Any]],
+    created_utc: str,
+) -> Path:
+    """Persist plan, batch outcomes, and promotion verdict after the measured batch completes."""
+    if not _UTC_STAMP_RE.fullmatch(created_utc):
+        raise ScientistError("scientist_created_utc_invalid")
+    if not outcomes:
+        raise ScientistError("scientist_completed_outcomes_missing")
+    root = state_root(user_dir)
+    run = {
+        "schema_version": SCHEMA_VERSION,
+        "created_utc": created_utc,
+        "plan": dict(plan),
+        "outcomes": [dict(row) for row in outcomes],
+    }
+    run_id = _digest(run)
+    run["run_id"] = run_id
+    destination = root / "runs" / f"{created_utc}_{run_id}.json"
+    _exclusive_write_text(destination, json.dumps(run, indent=2, ensure_ascii=False) + "\n")
+    ledger_path = root / LEDGER_NAME
+    for index, outcome in enumerate(outcomes):
+        append_ledger(
+            ledger_path,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "experiment_id": f"{run_id}:{index}",
+                "created_utc": created_utc,
+                "run_path": str(destination),
+                "plan_id": plan.get("plan_id"),
+                "scope_key": plan.get("scope_key"),
+                "constraint_key": outcome.get("constraint_key"),
+                "verdict": outcome.get("verdict"),
+                "promoted": bool(outcome.get("promoted")),
+                "reason": outcome.get("reason"),
+            },
+        )
+    return destination

--- a/tools/ac_harness/alien_scientist.py
+++ b/tools/ac_harness/alien_scientist.py
@@ -62,6 +62,59 @@ def state_root(user_dir: str | Path) -> Path:
     return Path(user_dir) / STATE_DIR
 
 
+def ensure_state_root(user_dir: str | Path) -> Path:
+    """Create the state root while refusing symlinks/junctions below AC Documents."""
+    try:
+        base = Path(user_dir).resolve(strict=True)
+    except OSError as exc:
+        raise ScientistError("scientist_user_dir_unavailable") from exc
+    if not base.is_dir():
+        raise ScientistError("scientist_user_dir_unavailable")
+    current = base
+    for part in STATE_DIR.parts:
+        child = current / part
+        try:
+            child.mkdir()
+        except FileExistsError:
+            pass
+        except OSError as exc:
+            raise ScientistError("scientist_state_path_unavailable") from exc
+        try:
+            if child.is_symlink() or not child.is_dir() or child.resolve(strict=True) != child:
+                raise ScientistError("scientist_state_path_unsafe")
+        except OSError as exc:
+            raise ScientistError("scientist_state_path_unsafe") from exc
+        current = child
+    return current
+
+
+def _validate_state_destination(path: Path, allowed_root: Path | None = None) -> Path:
+    """Return an absolute state path only when no existing component redirects elsewhere."""
+    logical = Path(os.path.abspath(path))
+    boundary = Path(os.path.abspath(allowed_root or logical.parent))
+    try:
+        resolved_boundary = boundary.resolve(strict=True)
+        resolved_parent = logical.parent.resolve(strict=True)
+        resolved_parent.relative_to(resolved_boundary)
+    except (OSError, ValueError) as exc:
+        raise ScientistError("scientist_state_path_unsafe") from exc
+    if (
+        resolved_boundary != boundary
+        or resolved_parent != logical.parent
+        or not logical.parent.is_dir()
+    ):
+        raise ScientistError("scientist_state_path_unsafe")
+    if logical.is_symlink():
+        raise ScientistError("scientist_state_path_unsafe")
+    if logical.exists():
+        try:
+            if not logical.is_file() or logical.resolve(strict=True) != logical:
+                raise ScientistError("scientist_state_path_unsafe")
+        except OSError as exc:
+            raise ScientistError("scientist_state_path_unsafe") from exc
+    return logical
+
+
 def scope_key(scope: Mapping[str, Any]) -> str:
     required = ("mechanical_platform", "aero_platform", "tyre_family", "track_archetype")
     normalized: dict[str, str] = {}
@@ -73,10 +126,15 @@ def scope_key(scope: Mapping[str, Any]) -> str:
     return _digest(normalized)
 
 
-def load_ledger(path: str | Path) -> list[dict[str, Any]]:
+def load_ledger(
+    path: str | Path, *, allowed_root: str | Path | None = None
+) -> list[dict[str, Any]]:
     ledger = Path(path)
     if not ledger.exists():
         return []
+    ledger = _validate_state_destination(
+        ledger, Path(allowed_root) if allowed_root is not None else None
+    )
     rows: list[dict[str, Any]] = []
     try:
         with ledger.open("r", encoding="utf-8") as handle:
@@ -95,9 +153,9 @@ def load_ledger(path: str | Path) -> list[dict[str, Any]]:
     return rows
 
 
-def _exclusive_write_text(path: Path, text: str) -> None:
+def _exclusive_write_text(path: Path, text: str, *, allowed_root: Path) -> None:
     """Publish a new immutable artifact without replacing an existing peer artifact."""
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path = _validate_state_destination(path, allowed_root)
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
     tmp = Path(tmp_name)
     try:
@@ -115,16 +173,21 @@ def _exclusive_write_text(path: Path, text: str) -> None:
         raise
 
 
-def append_ledger(path: str | Path, row: Mapping[str, Any]) -> None:
+def append_ledger(
+    path: str | Path,
+    row: Mapping[str, Any],
+    *,
+    allowed_root: str | Path | None = None,
+) -> None:
     """Append one completed experiment without rewriting peer/manual history."""
-    ledger = Path(path)
-    rows = load_ledger(ledger)
+    boundary = Path(allowed_root) if allowed_root is not None else None
+    ledger = _validate_state_destination(Path(path), boundary)
+    rows = load_ledger(ledger, allowed_root=boundary)
     experiment_id = str(row.get("experiment_id") or "")
     if not experiment_id:
         raise ScientistError("scientist_experiment_id_missing")
     if any(str(existing.get("experiment_id") or "") == experiment_id for existing in rows):
         raise ScientistError("scientist_experiment_already_recorded")
-    ledger.parent.mkdir(parents=True, exist_ok=True)
     data = (_stable_json(dict(row)) + "\n").encode("utf-8")
     try:
         fd = os.open(ledger, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
@@ -243,9 +306,7 @@ def build_plan(
             or direction not in (-1.0, 1.0)
         ):
             raise ScientistError("scientist_hypothesis_malformed")
-        constraint_key = _digest(
-            {"hypothesis_id": hypothesis_id, "parameter": parameter, "direction": direction}
-        )
+        constraint_key = _digest({"parameter": parameter, "direction": direction})
         if constraint_key in seen_constraints:
             raise ScientistError("scientist_hypothesis_duplicate")
         seen_constraints.add(constraint_key)
@@ -492,7 +553,16 @@ def persist_completed_run(
         raise ScientistError("scientist_created_utc_invalid")
     if not outcomes:
         raise ScientistError("scientist_completed_outcomes_missing")
-    root = state_root(user_dir)
+    root = ensure_state_root(user_dir)
+    runs_dir = root / "runs"
+    try:
+        runs_dir.mkdir()
+    except FileExistsError:
+        pass
+    except OSError as exc:
+        raise ScientistError("scientist_state_path_unavailable") from exc
+    _validate_state_destination(runs_dir / ".boundary", root)
+    ledger_path = _validate_state_destination(root / LEDGER_NAME, root)
     run = {
         "schema_version": SCHEMA_VERSION,
         "created_utc": created_utc,
@@ -501,9 +571,12 @@ def persist_completed_run(
     }
     run_id = _digest(run)
     run["run_id"] = run_id
-    destination = root / "runs" / f"{created_utc}_{run_id}.json"
-    _exclusive_write_text(destination, json.dumps(run, indent=2, ensure_ascii=False) + "\n")
-    ledger_path = root / LEDGER_NAME
+    destination = runs_dir / f"{created_utc}_{run_id}.json"
+    _exclusive_write_text(
+        destination,
+        json.dumps(run, indent=2, ensure_ascii=False) + "\n",
+        allowed_root=root,
+    )
     for index, outcome in enumerate(outcomes):
         append_ledger(
             ledger_path,
@@ -519,5 +592,6 @@ def persist_completed_run(
                 "promoted": bool(outcome.get("promoted")),
                 "reason": outcome.get("reason"),
             },
+            allowed_root=root,
         )
     return destination

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import json
 import time
+import traceback
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -596,6 +597,199 @@ def run_selfplay(
     return selfplay
 
 
+def _scientist_baseline_outcome(selfplay: dict, base_outcome: dict | None) -> dict | None:
+    """Newest oracle-valid self-play outcome, falling back to the valid base batch."""
+    for entry in reversed(selfplay.get("iterations", [])):
+        if entry.get("valid") is True and entry.get("evidence_dir"):
+            outcome = load_stage_outcome(Path(entry["evidence_dir"]))
+            if outcome is not None:
+                return outcome
+    base = selfplay.get("base") if isinstance(selfplay.get("base"), dict) else {}
+    return base_outcome if base.get("valid") is True else None
+
+
+def _load_scientist_proposals(path: Path | None) -> list[dict] | None:
+    if path is None:
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"--scientist-proposals is unreadable: {exc}") from exc
+    if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+        raise ValueError("--scientist-proposals must contain a JSON array of objects")
+    return payload
+
+
+def run_scientist(
+    args: argparse.Namespace,
+    *,
+    run_stage: StageRunner,
+    evidence_root: Path,
+    user_dir: Path,
+    setup_ini: str | Path | None,
+    selfplay: dict,
+    base_outcome: dict | None,
+) -> dict:
+    """Plan and execute #529 P4 setup experiments through the normal auto-alien oracle."""
+    from tools.ac_harness.alien_scientist import (
+        LEDGER_NAME,
+        ScientistError,
+        build_plan,
+        evaluate_experiment,
+        load_ledger,
+        persist_completed_run,
+        state_root,
+        write_candidate_setup,
+    )
+    from tools.ai_sidecar.car_schema import load_latest_schema
+
+    result: dict = {"configured": True, "ok": False, "stage": "plan", "outcomes": []}
+    try:
+        if setup_ini is None:
+            raise ScientistError("scientist_requires_resolved_setup")
+        schema = load_latest_schema(args.car)
+        if schema is None:
+            raise ScientistError("scientist_car_schema_missing")
+        baseline_outcome = _scientist_baseline_outcome(selfplay, base_outcome)
+        if baseline_outcome is None:
+            raise ScientistError("scientist_valid_baseline_batch_missing")
+        baseline_payloads, load_errors = load_archive_payloads(stage_lap_archives(baseline_outcome))
+        baseline_payloads, foreign = combo_filter_payloads(
+            baseline_payloads,
+            car_id=args.car,
+            track_id=args.track,
+            layout=args.track_layout,
+        )
+        baseline_valid, baseline_reason = evaluate_selfplay_iteration(
+            0, baseline_outcome, baseline_payloads
+        )
+        if load_errors or foreign or not baseline_valid:
+            raise ScientistError(
+                "scientist_baseline_batch_unverifiable:"
+                f"{baseline_reason}:load_errors={len(load_errors)}:foreign={foreign}"
+            )
+        scope = {
+            "mechanical_platform": args.scientist_mechanical_platform or args.car,
+            "aero_platform": args.scientist_aero_platform or args.car,
+            "tyre_family": args.scientist_tyre_family or f"car:{args.car}",
+            "track_archetype": args.scientist_track_archetype or args.track,
+        }
+        stopped = str(selfplay.get("stopped") or "").strip()
+        trigger = args.scientist_trigger or (
+            "pace_plateau_after_selfplay" if stopped == "completed" else stopped or "pace_plateau"
+        )
+        ledger_path = state_root(user_dir) / LEDGER_NAME
+        plan = build_plan(
+            trigger=trigger,
+            combo={"car": args.car, "track": args.track, "layout": args.track_layout},
+            scope=scope,
+            baseline_payloads=baseline_payloads,
+            schema=schema,
+            ledger=load_ledger(ledger_path),
+            proposed_hypotheses=_load_scientist_proposals(args.scientist_proposals),
+            batch_size=args.scientist_batch_size,
+        )
+        result["plan"] = plan
+        result["stage"] = "execute"
+        for index, experiment in enumerate(plan["experiments"], 1):
+            candidate_path = write_candidate_setup(
+                setup_ini,
+                user_dir=user_dir,
+                plan_id=plan["plan_id"],
+                experiment=experiment,
+            )
+            candidate_root = evidence_root / "scientist" / f"candidate_{index:02d}"
+            candidate_args = argparse.Namespace(**vars(args))
+            candidate_args.setup = str(candidate_path)
+            candidate_args.force_identify = False
+            candidate_args.iterations = 0
+            candidate_args.scientist = False
+            candidate_args.scientist_proposals = None
+            candidate_args.evidence_dir = candidate_root
+            code, candidate_report = run_pipeline(candidate_args, run_stage=run_stage)
+            candidate_root.mkdir(parents=True, exist_ok=True)
+            (candidate_root / "alien_report.json").write_text(
+                json.dumps(candidate_report, indent=2), encoding="utf-8"
+            )
+            drive_stage = candidate_report.get("stages", {}).get("drive", {})
+            candidate_outcome = (
+                load_stage_outcome(Path(drive_stage["evidence_dir"]))
+                if drive_stage.get("evidence_dir")
+                else None
+            )
+            candidate_payloads, candidate_load_errors = load_archive_payloads(
+                stage_lap_archives(candidate_outcome)
+            )
+            candidate_payloads, candidate_foreign = combo_filter_payloads(
+                candidate_payloads,
+                car_id=args.car,
+                track_id=args.track,
+                layout=args.track_layout,
+            )
+            candidate_lap_times = stage_lap_times_ms(candidate_outcome)
+            if (
+                candidate_outcome is None
+                or not candidate_lap_times
+                or not candidate_payloads
+                or candidate_load_errors
+                or candidate_foreign
+            ):
+                raise ScientistError(
+                    "scientist_candidate_batch_incomplete:"
+                    f"exit={code}:timed_laps={len(candidate_lap_times)}:"
+                    f"archives={len(candidate_payloads)}:"
+                    f"load_errors={len(candidate_load_errors)}:foreign={candidate_foreign}"
+                )
+            candidate_valid, candidate_reason = evaluate_selfplay_iteration(
+                code, candidate_outcome, candidate_payloads
+            )
+            outcome = evaluate_experiment(
+                plan=plan,
+                experiment=experiment,
+                baseline_payloads=baseline_payloads,
+                candidate_payloads=candidate_payloads,
+                candidate_valid=candidate_valid,
+                candidate_reason=candidate_reason,
+            )
+            outcome["candidate_setup"] = str(candidate_path)
+            outcome["evidence_root"] = str(candidate_root)
+            if outcome.get("promoted"):
+                outcome["recommended_setup"] = str(candidate_path)
+            result["outcomes"].append(outcome)
+
+        result["stage"] = "persist"
+        run_path = persist_completed_run(
+            user_dir,
+            plan=plan,
+            outcomes=result["outcomes"],
+            created_utc=_utc_stamp(),
+        )
+        result["run_path"] = str(run_path)
+        result["ledger_path"] = str(ledger_path)
+        result["ok"] = True
+        result["stage"] = "completed"
+        return result
+    except Exception as exc:  # noqa: BLE001 - report must retain the complete failed-stage trace
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        result["traceback"] = traceback.format_exc()
+        # A later candidate failure must not erase earlier completed measurements. Persist only
+        # outcomes that reached evaluate_experiment; never record the incomplete candidate as a
+        # falsification (#654 state-consistency contract).
+        if result["outcomes"] and isinstance(result.get("plan"), dict):
+            try:
+                partial_path = persist_completed_run(
+                    user_dir,
+                    plan=result["plan"],
+                    outcomes=result["outcomes"],
+                    created_utc=_utc_stamp(),
+                )
+                result["partial_run_path"] = str(partial_path)
+                result["ledger_path"] = str(state_root(user_dir) / LEDGER_NAME)
+            except Exception as persist_exc:  # noqa: BLE001 - retain both failure traces
+                result["partial_persist_error"] = f"{type(persist_exc).__name__}: {persist_exc}"
+        return result
+
+
 def _passthrough_args(args: argparse.Namespace) -> list[str]:
     """CLI flags shared verbatim by both stages (combo identity + rig plumbing)."""
     out = ["--car", args.car, "--track", args.track]
@@ -778,6 +972,22 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="pipeline evidence root (default: .scratch/harness-evidence/<ts>_alien_...)",
     )
+    p.add_argument(
+        "--scientist",
+        action="store_true",
+        help="#529 P4: after self-play, run evidence-gated one-parameter setup experiments",
+    )
+    p.add_argument("--scientist-trigger", default=None, help="named failure or pace plateau")
+    p.add_argument(
+        "--scientist-proposals", type=Path, default=None, help="optional bounded JSON hypotheses"
+    )
+    p.add_argument(
+        "--scientist-batch-size", type=int, default=1, help="bounded candidate count (1-3)"
+    )
+    p.add_argument("--scientist-mechanical-platform", default=None)
+    p.add_argument("--scientist-aero-platform", default=None)
+    p.add_argument("--scientist-tyre-family", default=None)
+    p.add_argument("--scientist-track-archetype", default=None)
     return p
 
 
@@ -801,6 +1011,10 @@ def run_pipeline(
         raise ValueError(f"--laps must be >= 0 (got {args.laps})")
     if args.iterations < 0:
         raise ValueError(f"--iterations must be >= 0 (got {args.iterations})")
+    if args.scientist and (args.iterations < 1 or args.laps < 2 or not args.setup):
+        raise ValueError("--scientist requires --setup, --iterations >= 1, and --laps >= 2")
+    if not 1 <= args.scientist_batch_size <= 3:
+        raise ValueError("--scientist-batch-size must be between 1 and 3")
     # The BASE drive keeps the #572 one-shot gate: above-1 envelopes are reachable only through
     # the falsification-gated self-play ladder (per-iteration scale overrides), never by passing
     # a bare --ggv-scale > 1 (#579 Codex P1).
@@ -939,6 +1153,23 @@ def run_pipeline(
             f"auto-alien: selfplay done — {report['selfplay']['stopped']}"
             + (f"; best lap {best / 1000.0:.3f}s" if isinstance(best, int) else "")
         )
+        if args.scientist:
+            report["scientist"] = run_scientist(
+                args,
+                run_stage=run_stage,
+                evidence_root=evidence_root,
+                user_dir=user_dir,
+                setup_ini=setup_ini,
+                selfplay=report["selfplay"],
+                base_outcome=base_outcome,
+            )
+            if not report["scientist"].get("ok"):
+                report["error"] = (
+                    f"scientist stage {report['scientist'].get('stage')} failed: "
+                    f"{report['scientist'].get('error')}"
+                )
+                return 1, report
+            print(f"auto-alien: scientist done — {report['scientist']['run_path']}")
 
     report["ok"] = True
     return 0, report

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -635,6 +635,7 @@ def run_scientist(
         LEDGER_NAME,
         ScientistError,
         build_plan,
+        ensure_state_root,
         evaluate_experiment,
         load_ledger,
         persist_completed_run,
@@ -663,10 +664,19 @@ def run_scientist(
         baseline_valid, baseline_reason = evaluate_selfplay_iteration(
             0, baseline_outcome, baseline_payloads
         )
-        if load_errors or foreign or not baseline_valid:
+        baseline_lap_times = stage_lap_times_ms(baseline_outcome)
+        if (
+            load_errors
+            or foreign
+            or not baseline_valid
+            or len(baseline_lap_times) < args.laps
+            or len(baseline_payloads) < args.laps
+        ):
             raise ScientistError(
                 "scientist_baseline_batch_unverifiable:"
-                f"{baseline_reason}:load_errors={len(load_errors)}:foreign={foreign}"
+                f"{baseline_reason}:requested_laps={args.laps}:"
+                f"timed_laps={len(baseline_lap_times)}:archives={len(baseline_payloads)}:"
+                f"load_errors={len(load_errors)}:foreign={foreign}"
             )
         scope = {
             "mechanical_platform": args.scientist_mechanical_platform or args.car,
@@ -678,14 +688,15 @@ def run_scientist(
         trigger = args.scientist_trigger or (
             "pace_plateau_after_selfplay" if stopped == "completed" else stopped or "pace_plateau"
         )
-        ledger_path = state_root(user_dir) / LEDGER_NAME
+        scientist_root = ensure_state_root(user_dir)
+        ledger_path = scientist_root / LEDGER_NAME
         plan = build_plan(
             trigger=trigger,
             combo={"car": args.car, "track": args.track, "layout": args.track_layout},
             scope=scope,
             baseline_payloads=baseline_payloads,
             schema=schema,
-            ledger=load_ledger(ledger_path),
+            ledger=load_ledger(ledger_path, allowed_root=scientist_root),
             proposed_hypotheses=_load_scientist_proposals(args.scientist_proposals),
             batch_size=args.scientist_batch_size,
         )
@@ -729,14 +740,15 @@ def run_scientist(
             candidate_lap_times = stage_lap_times_ms(candidate_outcome)
             if (
                 candidate_outcome is None
-                or not candidate_lap_times
-                or not candidate_payloads
+                or len(candidate_lap_times) < args.laps
+                or len(candidate_payloads) < args.laps
                 or candidate_load_errors
                 or candidate_foreign
             ):
                 raise ScientistError(
                     "scientist_candidate_batch_incomplete:"
-                    f"exit={code}:timed_laps={len(candidate_lap_times)}:"
+                    f"exit={code}:requested_laps={args.laps}:"
+                    f"timed_laps={len(candidate_lap_times)}:"
                     f"archives={len(candidate_payloads)}:"
                     f"load_errors={len(candidate_load_errors)}:foreign={candidate_foreign}"
                 )


### PR DESCRIPTION
## Summary
- compose completed alien self-play evidence with bounded, schema-valid one-parameter setup hypotheses
- execute immutable setup candidates through the normal auto-alien pipeline and keep-last-valid oracle
- persist completed plans, uncertainty-aware outcomes, and durable falsification suppression under AC Documents
- document the operator CLI and failure semantics

## Verification
- `make ci-fast PYTHON=.venv/bin/python`
- 3286 passed, 89 skipped; policy, Bandit, CSP API, and UI safety checks green
- focused scientist/alien/setup suite: 192 passed

Closes #654
Parent: #529