### PR TITLE
feat(rig): persist the cdb lm module map in freeze-forensics capture records (#662)

### DIFF
--- a/tests/test_freeze_forensics.py
+++ b/tests/test_freeze_forensics.py
@@ -365,7 +365,7 @@ def test_capture_record_is_json_serializable_and_auditable() -> None:
         elapsed_s=42.5,
     )
     payload = json.loads(json.dumps(record))
-    assert payload["schema"] == "freeze-forensics-capture/v1"
+    assert payload["schema"] == "freeze-forensics-capture/v1.1"
     assert payload["selected_tid"] == 222
     assert payload["rips_hex"] == ["0x7ff000001000", "0x7ff000001020"]
     assert payload["rip_span_bytes"] == 0x20
@@ -612,3 +612,126 @@ def test_s3_new_session_publishing_during_capture_reads_as_recovered() -> None:
     result = evaluate_s3([(16_983, 9_999, True), (121, 50, True), (180, 90, True)])
     assert result.sufficient is True
     assert result.gfx_static is False  # gfx moved -> classify() returns NOT_WEDGED
+
+
+# --------------------------------------------------------------------------------------
+# #662 — lm module map in capture records.
+# --------------------------------------------------------------------------------------
+
+_LM_FIXTURE = (
+    "AC_TID=1a2b\n"
+    "rip=00007ff8`f16f0464 rsp=...\n"
+    " # Child-SP          RetAddr               Call Site\n"
+    "00 000000bf`676ff070 00007ff8`f1a6d084     DWrite!DWriteCreateFactory+0xacee73\n"
+    "start             end                 module name\n"
+    "00007ff7`10530000 00007ff7`17f00000   acs        (deferred)\n"
+    "00007ff8`f0210000 00007ff8`f7590000   DWrite     (deferred)\n"
+    "00007ff9`10000000 00007ff9`11000000   nvgpucomp64   (deferred)\n"
+    "00007ff9`88670000 00007ff9`88880000   ntdll      (pdb symbols)\n"
+)
+
+
+def test_parse_lm_reads_module_rows_after_the_header() -> None:
+    from tools.ac_harness.freeze_forensics import parse_lm
+
+    rows = parse_lm(_LM_FIXTURE)
+    assert [r["module"] for r in rows] == ["acs", "DWrite", "nvgpucomp64", "ntdll"]
+    assert rows[1]["base"] == 0x7FF8F0210000
+    assert rows[1]["end"] == 0x7FF8F7590000
+
+
+def test_parse_lm_without_header_reads_nothing() -> None:
+    """The k frame table's address columns must not be misread as module rows."""
+    from tools.ac_harness.freeze_forensics import parse_lm
+
+    no_lm = (
+        " # Child-SP          RetAddr               Call Site\n"
+        "00 000000bf`676ff070 00007ff8`f1a6d084     DWrite!x+0x1\n"
+    )
+    assert parse_lm(no_lm) == []
+
+
+def test_parse_lm_rejects_degenerate_ranges_and_dedups() -> None:
+    from tools.ac_harness.freeze_forensics import parse_lm
+
+    raw = (
+        "start             end                 module name\n"
+        "00007ff7`10530000 00007ff7`10530000   zero_len\n"
+        "00007ff7`20000000 00007ff7`10000000   inverted\n"
+        "00007ff8`f0210000 00007ff8`f7590000   DWrite\n"
+        "00007ff8`f0210000 00007ff8`f7590000   DWrite\n"
+    )
+    rows = parse_lm(raw)
+    assert [r["module"] for r in rows] == ["DWrite"]
+
+
+def test_rebase_rip_names_the_containing_module() -> None:
+    """The exact case from the 2026-07-22 wedge captures: RIPs needed hand arithmetic to
+    rebase into accRenderingAdv, and the 0x7ff910… module went unnamed."""
+    from tools.ac_harness.freeze_forensics import parse_lm, rebase_rip
+
+    modules = parse_lm(_LM_FIXTURE)
+    assert rebase_rip(0x7FF8F16F0464, modules) == "DWrite+0x14e0464"
+    assert rebase_rip(0x7FF9103A73B1, modules) == "nvgpucomp64+0x3a73b1"
+    # End is exclusive; base is inclusive.
+    assert rebase_rip(0x7FF8F0210000, modules) == "DWrite+0x0"
+    assert rebase_rip(0x7FF8F7590000, modules) != "DWrite+0x7380000"
+    # Outside every module: raw hex, never a wrong name.
+    assert rebase_rip(0x1234, modules) == "0x1234"
+
+
+def test_capture_record_v11_carries_modules_and_rebased_rips() -> None:
+    import json
+
+    from tools.ac_harness.freeze_forensics import (
+        build_capture_record,
+        evaluate_s3,
+        parse_lm,
+    )
+
+    record = build_capture_record(
+        pid=1,
+        tid=2,
+        tid_reason="hottest",
+        cycles_rows=[],
+        candidate_stacks=[],
+        rips=[0x7FF8F16F0464, 0x7FF9103A73B1],
+        s3=evaluate_s3([(1, 1, True), (1, 2, True)]),
+        verdict="not_wedged",
+        rationale="r",
+        started_at_utc="2026-07-22T00:00:00Z",
+        elapsed_s=1.0,
+        modules=parse_lm(_LM_FIXTURE),
+    )
+    payload = json.loads(json.dumps(record))
+    assert payload["schema"] == "freeze-forensics-capture/v1.1"
+    assert payload["rips_rebased"] == ["DWrite+0x14e0464", "nvgpucomp64+0x3a73b1"]
+    assert payload["modules"][1] == {
+        "module": "DWrite",
+        "base": "0x7ff8f0210000",
+        "end": "0x7ff8f7590000",
+    }
+
+
+def test_capture_record_without_modules_still_serializes() -> None:
+    """A capture whose transcripts never yielded an lm listing degrades additively."""
+    import json
+
+    from tools.ac_harness.freeze_forensics import build_capture_record, evaluate_s3
+
+    record = build_capture_record(
+        pid=1,
+        tid=2,
+        tid_reason="hottest",
+        cycles_rows=[],
+        candidate_stacks=[],
+        rips=[0x1000],
+        s3=evaluate_s3([]),
+        verdict="capture_failed_insufficient_s3",
+        rationale="r",
+        started_at_utc="2026-07-22T00:00:00Z",
+        elapsed_s=1.0,
+    )
+    payload = json.loads(json.dumps(record))
+    assert payload["modules"] == []
+    assert payload["rips_rebased"] == ["0x1000"]

--- a/tools/ac_harness/freeze_forensics.py
+++ b/tools/ac_harness/freeze_forensics.py
@@ -211,6 +211,56 @@ def selected_tid_confirmed(raw: str, tid: int) -> bool:
 _LM_HEADER_RE = re.compile(r"^\s*start\s+end\s+module name\s*$", re.IGNORECASE)
 
 
+#: ``lm`` listing row: `start end module name` with backtick-separated 64-bit addresses, e.g.
+#: ``00007ff8`f0210000 00007ff8`f7590000   DWrite     (deferred)``. The trailing load state is
+#: ignored; the module name may contain no spaces (cdb prints the image name token).
+_LM_ROW_RE = re.compile(
+    r"^\s*([0-9a-f`]{8,17})\s+([0-9a-f`]{8,17})\s+(\S+)", re.IGNORECASE | re.MULTILINE
+)
+
+#: whole-transcript form of :data:`_LM_HEADER_RE` — that one is anchored for per-line ``match``
+#: in :func:`extract_stack`; searching a multi-line transcript needs MULTILINE anchors.
+_LM_HEADER_ML_RE = re.compile(r"^\s*start\s+end\s+module name\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def parse_lm(raw: str) -> list[dict]:
+    """Module rows from a cdb transcript's ``lm`` listing. Pure — no I/O (#662).
+
+    The snapshot script already runs ``lm`` on every attach; this parses what
+    :func:`extract_stack` deliberately excludes from the stack text. Returns
+    ``{"module", "base", "end"}`` rows (ints), sorted by base, deduplicated. A transcript
+    without an ``lm`` header yields ``[]`` — the header check prevents reading the ``k``
+    frame table (whose Child-SP/RetAddr columns would otherwise match the row regex).
+    """
+    header = _LM_HEADER_ML_RE.search(raw)
+    if header is None:
+        return []
+    rows: dict[int, dict] = {}
+    for match in _LM_ROW_RE.finditer(raw[header.end() :]):
+        try:
+            base = int(match.group(1).replace("`", ""), 16)
+            end = int(match.group(2).replace("`", ""), 16)
+        except ValueError:
+            continue
+        if end <= base:
+            continue
+        rows.setdefault(base, {"module": match.group(3), "base": base, "end": end})
+    return [rows[base] for base in sorted(rows)]
+
+
+def rebase_rip(rip: int, modules: Sequence[dict]) -> str:
+    """``module+0xRVA`` for a RIP inside a known module, else the raw hex address. Pure (#662).
+
+    This is what turns a capture record's opaque ``rips_hex`` into upstream-actionable
+    evidence — the 2026-07-22 wedge captures needed hand arithmetic against stack frames to
+    rebase RIPs into ``accRenderingAdv.dll``, and the second hot module went unnamed entirely.
+    """
+    for row in modules:
+        if row["base"] <= rip < row["end"]:
+            return f"{row['module']}+{hex(rip - row['base'])}"
+    return hex(rip)
+
+
 def extract_stack(raw: str) -> str:
     """The ``k`` call-stack frames from a cdb transcript — and ONLY those.
 
@@ -601,6 +651,7 @@ def build_capture_record(
     started_at_utc: str,
     elapsed_s: float,
     selected_cycles: dict[str, float | None] | None = None,
+    modules: Sequence[dict] = (),
 ) -> dict:
     """Assemble the machine-readable capture record (#627 §9.2 sibling for forensics runs).
 
@@ -609,7 +660,9 @@ def build_capture_record(
     against a disassembly without re-parsing decimal).
     """
     return {
-        "schema": "freeze-forensics-capture/v1",
+        # v1.1 (#662): adds `modules` (cdb lm map) + `rips_rebased` (module+RVA per RIP).
+        # Additive only — v1 consumers reading rips_hex/s3/verdict are unaffected.
+        "schema": "freeze-forensics-capture/v1.1",
         "started_at_utc": started_at_utc,
         "elapsed_s": round(elapsed_s, 3),
         "pid": pid,
@@ -629,6 +682,11 @@ def build_capture_record(
             for candidate_tid, stack in candidate_stacks
         ],
         "rips_hex": [hex(rip) for rip in rips],
+        "rips_rebased": [rebase_rip(rip, modules) for rip in rips],
+        "modules": [
+            {"module": row["module"], "base": hex(row["base"]), "end": hex(row["end"])}
+            for row in modules
+        ],
         "rip_span_bytes": rip_span(list(rips)),
         "s3": {
             "gfx_static": s3.gfx_static,
@@ -992,10 +1050,22 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         return 2
     s3_samples.append(_read_s3_once(pid))
 
+    # Module map accumulates from EVERY transcript (#662): each cdb attach already prints `lm`,
+    # and a module loading mid-capture appears in later listings — merging keeps them all.
+    lm_modules: dict[int, dict] = {}
+
+    def merge_lm(raw: str) -> None:
+        for module_row in parse_lm(raw):
+            lm_modules.setdefault(module_row["base"], module_row)
+
+    def sorted_modules() -> list[dict]:
+        return [lm_modules[base] for base in sorted(lm_modules)]
+
     candidate_stacks: list[tuple[int, str]] = []
     candidate_rips: dict[int, list[int]] = {}
     for row in rows[: args.candidates]:
         snapshot = cdb_snapshot(pid, tid=row["tid"])
+        merge_lm(snapshot.raw)
         candidate_stacks.append((row["tid"], snapshot.stack))
         if snapshot.rip is not None:
             candidate_rips.setdefault(row["tid"], []).append(snapshot.rip)
@@ -1025,6 +1095,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         if index or rips:
             time.sleep(args.rip_interval)
         snapshot = cdb_snapshot(pid, tid=tid)
+        merge_lm(snapshot.raw)
         if snapshot.rip is not None:
             rips.append(snapshot.rip)
         else:
@@ -1081,6 +1152,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             started_at_utc=started_utc,
             elapsed_s=time.monotonic() - started,
             selected_cycles=selected_cycles,
+            modules=sorted_modules(),
         )
         print(json.dumps(record, indent=2))
         if args.json_path is not None:
@@ -1108,6 +1180,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         started_at_utc=started_utc,
         elapsed_s=time.monotonic() - started,
         selected_cycles=selected_cycles,
+        modules=sorted_modules(),
     )
     print(json.dumps(record, indent=2))
     record_written = True


### PR DESCRIPTION
## Summary

Closes #662. Capture records now name the modules RIPs land in — the gap that left the second hot module (`~0x7ff910…`) unnamed in the 2026-07-22 wedge captures and forced hand arithmetic to rebase RIPs into `accRenderingAdv.dll` for the upstream report ([acc-extension-config#622](https://github.com/ac-custom-shaders-patch/acc-extension-config/issues/622)).

- **`parse_lm()`** (pure): module rows from the transcript's `lm` section only — a MULTILINE header anchor (the per-line `extract_stack` regex can't search a whole transcript), zero-length/inverted ranges rejected, dedup by base. No header → `[]` (the `k` frame table's address columns can never be misread as modules).
- **`rebase_rip()`** (pure): `module+0xRVA` when contained (base inclusive, end exclusive), raw hex otherwise — never a wrong name.
- **`main()`** merges `lm` rows from **every** transcript (candidate + S2 attaches), so a module loading mid-capture is still named. No new cdb invocations — the data was already in `RipSample.raw`.
- **Schema → `freeze-forensics-capture/v1.1`**, additive only: `modules` + `rips_rebased`; v1 consumers of `rips_hex`/`s3`/`verdict` unaffected.

## Verification

- 54 tests (7 new), including the exact 2026-07-22 case: `0x7FF8F16F0464` → `DWrite+0x14e0464` against a real-shaped fixture transcript, and the no-`lm` additive degradation.
- `make ci-fast` OK; `--self-test` re-verified on the rig (exit 0).
- The next live wedge capture (queued for the ≥9h-uptime window tonight) exercises the field end-to-end.

Refs #627 · acc-extension-config#622

🤖 Generated with [Claude Code](https://claude.com/claude-code)