### PR TITLE
feat(rig): graceful-first teardown for verdict-proven healthy sessions (#668)

### DIFF
--- a/tests/test_ac_harness_entry_launcher.py
+++ b/tests/test_ac_harness_entry_launcher.py
@@ -685,3 +685,106 @@ def test_cli_cm_mode_requires_preset():
 def test_launcher_config_validates_retry_budget(kwargs: dict, match: str):
     with pytest.raises(ValueError, match=match):
         EntryLauncherConfig(**kwargs)
+
+
+def test_terminate_graceful_grace_soft_close_succeeds_without_forced_kill(monkeypatch):
+    """#668 — a healthy process honoring WM_CLOSE is never force-killed."""
+    clock = FakeClock()
+    observations = iter([True, True, False, False])
+    calls: list[list[str]] = []
+
+    def runner(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+
+    assert (
+        terminate_process_tree_confirmed_absent(
+            "acs.exe",
+            is_running=lambda: next(observations),
+            timeout=30.0,
+            poll=0.1,
+            runner=runner,
+            clock=clock,
+            sleep=clock.sleep,
+            graceful_grace=20.0,
+        )
+        is True
+    )
+    # Only the soft close ran — no /F anywhere.
+    assert calls == [["taskkill", "/IM", "acs.exe"]]
+
+
+def test_terminate_graceful_grace_escalates_to_forced_after_grace(monkeypatch):
+    """A wedged pump cannot process WM_CLOSE — past the grace the old forced boundary returns."""
+    clock = FakeClock()
+    calls: list[list[str]] = []
+    messages: list[str] = []
+    state = {"dead": False}
+
+    def runner(command, **_kwargs):
+        calls.append(command)
+        if "/F" in command:
+            state["dead"] = True
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+
+    assert (
+        terminate_process_tree_confirmed_absent(
+            "acs.exe",
+            is_running=lambda: not state["dead"],
+            timeout=10.0,
+            poll=0.5,
+            runner=runner,
+            clock=clock,
+            sleep=clock.sleep,
+            log=messages.append,
+            graceful_grace=2.0,
+        )
+        is True
+    )
+    assert calls[0] == ["taskkill", "/IM", "acs.exe"]
+    assert calls[1] == ["taskkill", "/IM", "acs.exe", "/F", "/T"]
+    assert len(calls) == 2
+    assert any("escalating to forced kill" in message for message in messages)
+
+
+def test_terminate_graceful_grace_zero_is_the_old_behavior(monkeypatch):
+    clock = FakeClock()
+    observations = iter([True, False, False])
+    calls: list[list[str]] = []
+
+    def runner(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+
+    assert (
+        terminate_process_tree_confirmed_absent(
+            "acs.exe",
+            is_running=lambda: next(observations),
+            timeout=2.0,
+            poll=0.1,
+            runner=runner,
+            clock=clock,
+            sleep=clock.sleep,
+            graceful_grace=0.0,
+        )
+        is True
+    )
+    assert calls == [["taskkill", "/IM", "acs.exe", "/F", "/T"]]
+
+
+def test_terminate_graceful_grace_validation(monkeypatch):
+    monkeypatch.setattr(entry_launcher.sys, "platform", "win32")
+    with pytest.raises(ValueError, match="graceful_grace"):
+        terminate_process_tree_confirmed_absent(
+            "acs.exe", is_running=lambda: False, graceful_grace=-1.0
+        )
+    with pytest.raises(ValueError, match="forced phase"):
+        terminate_process_tree_confirmed_absent(
+            "acs.exe", is_running=lambda: False, timeout=10.0, graceful_grace=10.0
+        )

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -1472,7 +1472,7 @@ def test_make_rig_safe_attempts_cleanup_before_honoring_release(monkeypatch):
     def release_requested() -> bool:
         return True
 
-    def cleanup(_acs_alive, *, release_requested=None):
+    def cleanup(_acs_alive, *, release_requested=None, graceful_grace=0.0):
         callbacks.append(release_requested)
         return False
 

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -225,6 +225,34 @@ def _taskkill(
     return f"taskkill {process_name} exited {result.returncode}{suffix}"
 
 
+def _taskkill_soft(
+    process_name: str,
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> str:
+    """Graceful ``taskkill`` (WM_CLOSE, no ``/F``); returns a human-readable detail string.
+
+    The #668 batteries measured why this exists: the #627 freeze accumulator arms with
+    launch/kill cycles, and hard-kill teardown moved onset from launch ~14 to launch ~8 —
+    graceful exits roughly double a boot's clean-launch budget. A wedged render pump cannot
+    process WM_CLOSE (observed: one WM_CLOSE hang immediately after a freeze burst), so this
+    is only ever a FIRST phase — the forced kill remains the fallback boundary.
+    """
+
+    if sys.platform != "win32":
+        return f"{process_name} graceful close skipped on {sys.platform}"
+    result = runner(
+        ["taskkill", "/IM", process_name],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return f"requested graceful close of {process_name}"
+    detail = (result.stderr or result.stdout or "").strip()
+    suffix = f": {detail}" if detail else ""
+    return f"graceful taskkill {process_name} exited {result.returncode}{suffix}"
+
+
 def running_process_ids(
     process_name: str,
     runner: Callable[..., subprocess.CompletedProcess] | None = None,
@@ -297,12 +325,20 @@ def terminate_process_tree_confirmed_absent(
     clock: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
     log: Callable[[str], None] | None = None,
+    graceful_grace: float = 0.0,
 ) -> bool:
     """Kill one process tree and require consecutive strict absence observations.
 
     This is the shared rig-safety boundary for both human and autonomous launchers. Enumeration
     failure is unknown—not absence—and triggers the same best-effort taskkill as positive presence.
     A process already absent is not killed, but still needs ``absent_confirmations`` observations.
+
+    ``graceful_grace`` > 0 prepends a WM_CLOSE phase (#668): the first presence observation sends
+    a graceful ``taskkill`` (no ``/F``) and the forced kill is deferred until ``graceful_grace``
+    seconds have elapsed without absence. The confirmed-absent contract is unchanged — the forced
+    fallback and the overall ``timeout`` still bound the wait, so a wedged process (which cannot
+    pump WM_CLOSE) degrades to exactly the old behavior, ``graceful_grace`` later. Callers must
+    size ``timeout`` to leave room for the forced phase (``timeout > graceful_grace``).
     """
     if timeout <= 0:
         raise ValueError("process termination timeout must be > 0")
@@ -310,6 +346,10 @@ def terminate_process_tree_confirmed_absent(
         raise ValueError("process termination poll must be > 0")
     if absent_confirmations < 1:
         raise ValueError("absent_confirmations must be >= 1")
+    if graceful_grace < 0:
+        raise ValueError("graceful_grace must be >= 0")
+    if graceful_grace >= timeout:
+        raise ValueError("graceful_grace must leave room for the forced phase (< timeout)")
     emit = log or (lambda _message: None)
     if sys.platform != "win32":
         emit(f"cannot confirm {process_name} termination on unsupported platform {sys.platform}")
@@ -321,8 +361,11 @@ def terminate_process_tree_confirmed_absent(
             return bool(running_process_ids(process_name, strict=True))
 
     run = runner or subprocess.run
-    deadline = clock() + timeout
+    started = clock()
+    deadline = started + timeout
+    forced_after = started + graceful_grace
     absent_run = 0
+    soft_attempted = False
     kill_attempted = False
     while True:
         try:
@@ -336,7 +379,18 @@ def terminate_process_tree_confirmed_absent(
                 return True
         else:
             absent_run = 0
-            if not kill_attempted:
+            if graceful_grace > 0 and not soft_attempted:
+                try:
+                    emit(_taskkill_soft(process_name, run))
+                except OSError as exc:
+                    emit(f"failed to invoke graceful taskkill for {process_name}: {exc}")
+                soft_attempted = True
+            elif not kill_attempted and (graceful_grace <= 0 or clock() >= forced_after):
+                if soft_attempted:
+                    emit(
+                        f"{process_name} survived the {graceful_grace:.0f}s graceful grace — "
+                        "escalating to forced kill (wedged pumps cannot process WM_CLOSE)"
+                    )
                 try:
                     emit(_taskkill(process_name, run))
                 except OSError as exc:

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -53,6 +53,12 @@ DEFAULT_STALL_SAMPLES = 4
 DEFAULT_PAUSE_BUDGET = 300.0
 #: consecutive never_live attempts before cold-restarting Content Manager (#537/#558)
 NEVER_LIVE_BEFORE_CM_RESTART = 2
+#: seconds a HEALTHY session gets to honor WM_CLOSE before the forced kill (#668): the freeze
+#: accumulator arms with launch/kill cycles, and hard-kill teardown moved onset from launch ~14
+#: to ~8 — graceful exits roughly double a boot's clean-launch budget. Grace applies ONLY after
+#: a STABLE verdict: a wedged pump cannot process WM_CLOSE (measured), so wedge cleanup stays
+#: immediate-forced and loses nothing.
+DEFAULT_GRACEFUL_EXIT_GRACE = 20.0
 #: seconds a cached Car0 drivability verdict stays valid before the handshake re-runs (#630
 #: Part D) — a one-shot latch would hold a session that LOSES drivability after go-live as
 #: STABLE for the rest of the window. Long enough that a 140 s window costs ~3 extra probes.
@@ -1097,6 +1103,7 @@ def _ensure_acs_gone(  # pragma: no cover - rig-only
     timeout: float = 15.0,
     poll: float = 1.0,
     release_requested: Callable[[], bool] | None = None,
+    graceful_grace: float = 0.0,
 ) -> bool:
     """Kill any surviving ``acs.exe`` and wait until it has really left the process table.
 
@@ -1104,6 +1111,11 @@ def _ensure_acs_gone(  # pragma: no cover - rig-only
     Content Manager's next start fail to reach LIVE. ``taskkill`` returning is not sufficient —
     the process can linger — so poll (bounded) until it is actually gone. The caller must abort
     rather than relaunch when this returns ``False``.
+
+    ``graceful_grace`` > 0 lets a HEALTHY session honor WM_CLOSE before the forced kill (#668 —
+    pass it only when the previous verdict proved the session could pump messages; a wedge gets
+    the immediate forced path). The overall timeout is extended by the grace so the forced
+    phase keeps its full window either way.
     """
     from tools.ac_harness.entry_launcher import terminate_process_tree_confirmed_absent
 
@@ -1118,9 +1130,10 @@ def _ensure_acs_gone(  # pragma: no cover - rig-only
     safe = terminate_process_tree_confirmed_absent(
         "acs.exe",
         is_running=observe,
-        timeout=timeout,
+        timeout=timeout + graceful_grace,
         poll=poll,
         absent_confirmations=2,
+        graceful_grace=graceful_grace,
         clock=time.monotonic,
         sleep=time.sleep,
         log=lambda message: _log(f"acs.exe cleanup: {message}"),
@@ -1266,8 +1279,14 @@ def _make_rig_safe(  # pragma: no cover - rig-only
     release_requested: Callable[[], bool] | None = None,
     allow_operator_release: bool = True,
     hold_timeout: float | None = None,
+    graceful_grace: float = 0.0,
 ) -> bool:
-    """Attempt cleanup before allowing a release to drop machine-wide ownership."""
+    """Attempt cleanup before allowing a release to drop machine-wide ownership.
+
+    ``graceful_grace`` flows to the first :func:`_ensure_acs_gone` attempt (#668) — pass it only
+    when the session being torn down is verdict-proven healthy. The unsafe-hold retry loop below
+    stays forced-only: by the time it runs, the graceful phase has already been given its chance.
+    """
     # A pre-stability release reaches this path with its durable sentinel still present. Do not
     # pass that callback into the first cleanup: _ensure_acs_gone would raise before taskkill and
     # let a live/wedged acs.exe outlast the rig lock. Only the subsequent unsafe-hold loop treats
@@ -1279,7 +1298,7 @@ def _make_rig_safe(  # pragma: no cover - rig-only
     if not initially_alive:
         return True
     try:
-        safe = _ensure_acs_gone(acs_alive)
+        safe = _ensure_acs_gone(acs_alive, graceful_grace=graceful_grace)
     except (KeyboardInterrupt, _OperatorRelease):
         if allow_operator_release:
             raise
@@ -1653,12 +1672,27 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             _log(f"launch aborted: Content Manager executable not found: {actuator.cm_exe}")
             return 1
 
+        # The previous attempt's verdict gates the #668 graceful-teardown grace: only a session
+        # that PROVED it could pump messages (STABLE) is asked to honor WM_CLOSE. One-element
+        # list so the closure can rebind it.
+        last_attempt_verdict: list[LaunchVerdict | None] = [None]
+
         def watch_attempt(attempt: int) -> LaunchVerdict:
             if release_requested():
                 raise _OperatorRelease
             _log(f"attempt {attempt}/{args.max_attempts}: launching via Content Manager")
-            # A wedged acs from the previous attempt must be GONE before relaunching.
-            if not _ensure_acs_gone(acs_present, release_requested=release_requested):
+            # A wedged acs from the previous attempt must be GONE before relaunching. A HEALTHY
+            # previous session (STABLE verdict — trials mode continues past those) gets the #668
+            # WM_CLOSE grace first: hard kills accelerate the freeze-accumulator's onset, and a
+            # wedge cannot pump WM_CLOSE anyway, so grace is verdict-gated rather than blanket.
+            grace = (
+                DEFAULT_GRACEFUL_EXIT_GRACE
+                if last_attempt_verdict[0] is LaunchVerdict.STABLE
+                else 0.0
+            )
+            if not _ensure_acs_gone(
+                acs_present, release_requested=release_requested, graceful_grace=grace
+            ):
                 raise _AcsCleanupTimeout("acs.exe remained alive after the bounded cleanup wait")
             # The previous attempt's real process sighting must not leak into the next attempt's
             # pre-spawn absence. Reset only AFTER cleanup has used that history to confirm the old
@@ -1721,6 +1755,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 # rendered attempt so it cannot advance the stale-CM/never-live restart streak.
                 verdict = LaunchVerdict.FROZE
             _log(f"attempt {attempt}: {verdict}")
+            last_attempt_verdict[0] = verdict
             return verdict
 
         def cold_restart_cm() -> None:
@@ -1808,7 +1843,15 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 f"trials complete: stable {report.stable}/{report.attempts} "
                 f"({report._counts()}); hard kills between trials — see #627 §6.5"
             )
-            rig_safe = _make_rig_safe(acs_present, release_requested=release_requested)
+            rig_safe = _make_rig_safe(
+                acs_present,
+                release_requested=release_requested,
+                # A stable FINAL trial left a healthy session — it gets the WM_CLOSE grace
+                # (#668); any other final verdict left a corpse/wedge and stays forced-only.
+                graceful_grace=(
+                    DEFAULT_GRACEFUL_EXIT_GRACE if report.verdict is LaunchVerdict.STABLE else 0.0
+                ),
+            )
             if not rig_safe:
                 # The advertised end-of-run teardown failed: a live (possibly wedged) acs.exe is
                 # about to outlast the released rig lock. A measurement run must not read as


### PR DESCRIPTION
## Summary

Closes #668 — the operational mitigation its batteries earned tonight.

**Measured basis** ([#668 results](https://github.com/agorokh/ac-copilot-trainer/issues/668#issuecomment-5065689952)): the #627 freeze accumulator arms with launch/kill cycles; hard-kill teardown moved onset from launch ~14 (graceful) to ~8 (forced) at matched uptime/build — graceful exits roughly **double the clean-launch budget per boot**. A wedged pump can't process WM_CLOSE (observed live), so grace is strictly a bounded first phase.

- `terminate_process_tree_confirmed_absent(..., graceful_grace=)` — soft `taskkill` (no `/F`) on first presence; forced kill deferred until the grace elapses; confirmed-absent contract, enumeration fail-closed behavior, and overall timeout semantics unchanged. `grace >= timeout` rejected.
- `resilient_launch`: `DEFAULT_GRACEFUL_EXIT_GRACE = 20.0`, **verdict-gated** — grace flows only when the torn-down session proved `STABLE` (trials continuation + stable end-of-run via `_make_rig_safe`); wedge/never-live cleanup stays immediate-forced.

## Verification

- 4 new teardown tests: healthy-close-without-`/F`, escalation-after-grace (with the wedge rationale in the log), `grace=0` identity with the old behavior, validation bounds. 47 entry-launcher + 138 resilient tests green; `make ci-fast` OK.
- The WM_CLOSE mechanics themselves were rig-proven tonight: 14 graceful session exits in the #668 battery (plus 1 measured fallback where a post-burst session hung WM_CLOSE — the exact case the forced boundary covers).

Refs #627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)