### PR TITLE
fix(ws): gate telemetry_tick on externalHelloAcked (#671)

### DIFF
--- a/src/ac_copilot_trainer/modules/telemetry_publisher.lua
+++ b/src/ac_copilot_trainer/modules/telemetry_publisher.lua
@@ -4,8 +4,11 @@
 --   * `delta`       — live time delta vs the reference lap (reuses delta.deltaSecondsAtSpline).
 --   * `tire_temps`  — current per-wheel core temps {fl, fr, rl, rr}.
 --
--- M0 (#341): also emits client→server `telemetry_tick` frames (20 Hz) via `wsBridge.sendJson`
--- so the sidecar observer receives spline + lap from the in-game Lua producer.
+-- M0 (#341): also emits client→server `telemetry_tick` frames (20 Hz) via
+-- `wsBridge.sendClientFrame` (falls back to `sendJson` for test doubles) so the
+-- sidecar observer receives spline + lap from the in-game Lua producer. The tick
+-- path must share the v1 hello gate with `publishTopic` (#671) — ungated
+-- `sendJson` during reconnect storms reaches the sidecar before peer registration.
 -- Unlike the lifecycle topics (`lifecycle_publisher.lua`) these carry NO ordering contract and
 -- need no reconnect machinery — they are continuous streams like `coaching.snapshot`, so a
 -- (re)connected consumer simply gets the next sample within the publish interval. Both are
@@ -298,7 +301,9 @@ local function _physicsFlag(car, key)
 end
 
 
---- Publish client→server ``telemetry_tick`` at ~20 Hz (M0 #341). Requires ``wsBridge.sendJson``.
+--- Publish client→server ``telemetry_tick`` at ~20 Hz (M0 #341).
+--- Prefers ``wsBridge.sendClientFrame`` (hello-gated); falls back to ``sendJson``
+--- when the bridge exposes only that (lupa test doubles).
 ---@param opts table  {dt:number, car:any, wsBridge, lat_g?:number, long_g?:number, temps?:table, shiftProfile?:table}
 ---@return boolean
 function M.publishTelemetryTickIfDue(opts)
@@ -306,7 +311,16 @@ function M.publishTelemetryTickIfDue(opts)
     return false
   end
   local wsBridge = _wsReady(opts)
-  if not wsBridge or type(wsBridge.sendJson) ~= "function" then
+  if not wsBridge then
+    return false
+  end
+  -- Prefer the hello-gated client-frame path (#671); fall back to sendJson for
+  -- lupa doubles that only stub the raw sender.
+  local sendFn = wsBridge.sendClientFrame
+  if type(sendFn) ~= "function" then
+    sendFn = wsBridge.sendJson
+  end
+  if type(sendFn) ~= "function" then
     return false
   end
   local car = opts.car
@@ -318,6 +332,12 @@ function M.publishTelemetryTickIfDue(opts)
   local due, accum = _due(_tickAccum, tonumber(opts.dt) or 0, TICK_INTERVAL_SEC)
   _tickAccum = accum
   if not due then
+    return false
+  end
+  -- Gate before advancing seq / building payload so a reconnect-storm skip is an
+  -- explicit not-ready `false`, not a burned sequence or a sendJson failure (#671).
+  -- Real `ws_bridge` always exposes `isExternalReady`; test doubles without it stay open.
+  if type(wsBridge.isExternalReady) == "function" and not wsBridge.isExternalReady() then
     return false
   end
   _tickSeq = _tickSeq + 1
@@ -416,7 +436,7 @@ function M.publishTelemetryTickIfDue(opts)
   if absActive ~= nil then
     payload.abs_active = absActive
   end
-  return wsBridge.sendJson({
+  return sendFn({
     v = 1,
     type = "telemetry_tick",
     seq = _tickSeq,

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -1097,11 +1097,25 @@ function M.tick(simTime)
   tryOpen()
 end
 
+--- True when the external WS peer is registered for non-hello client frames.
+---
+--- Socket presence alone is not enough: the sidecar rejects every frame type
+--- other than `hello` until the peer is in `_external_peers` ("peer must send
+--- hello before other frame types"). Shared by `publishTopic`, `sendClientFrame`,
+--- and the setup/session helpers so those gates cannot drift apart (#671 / PR #171).
+---@return boolean
+function M.isExternalReady()
+  return sock ~= nil and externalHelloAcked == true
+end
+
 --- Send a JSON payload over the WebSocket.
 ---
 --- CSP's web.Socket is a polymorphic {close: fun()}|fun(data: binary) -- call
 --- it AS A FUNCTION to send data. We try the callable form first, then fall
 --- back to :send() / :write() for any non-CSP socket implementation.
+---
+--- Does NOT gate on `externalHelloAcked` — the hello retry path must keep
+--- using this entry point. Non-hello client→server frames use `sendClientFrame`.
 ---@param payload table|nil
 ---@return boolean  true if bytes were handed to the socket layer
 function M.sendJson(payload)
@@ -1146,6 +1160,21 @@ function M.sendJson(payload)
   return true
 end
 
+--- Send a non-hello client→server frame once the v1 external peer is registered.
+---
+--- Returns `false` (not-ready) without touching the socket when
+--- `isExternalReady()` is false — distinct from `sendJson`'s send-failure path
+--- so a permanently-unacked hello stays visible in WS-DIAG as missing sends
+--- rather than a broken socket (#671). Hello itself must keep using `sendJson`.
+---@param payload table|nil
+---@return boolean
+function M.sendClientFrame(payload)
+  if not M.isExternalReady() then
+    return false
+  end
+  return M.sendJson(payload)
+end
+
 --- Issue #86 Part C/D: external-client `state.snapshot` push.
 --- Wraps `M.sendJson` with the v1 envelope expected by the rig screen
 --- (`{v=1, type="state.snapshot", topic=<t>, payload=<p>}`). Returns
@@ -1157,13 +1186,15 @@ end
 function M.publishTopic(topic, payload)
   if type(topic) ~= "string" or topic == "" then return false end
   -- Only publish after the v1 hello handshake completes (a non-error v1 frame
-  -- seen, so we are in the sidecar's v1 `_external_peers`). Gate on the
-  -- v1-specific `externalHelloAcked`, NOT `sidecarConnected()`/`sidecarProtocolReady`
-  -- — the latter is also set by the legacy `protocol=1` flow, and a legacy reply
-  -- arriving before hello_ack would otherwise unblock this v1 publish path while
-  -- we are still unregistered, so the sidecar would reject the snapshot
-  -- ("peer must send hello before other frame types") (chatgpt-codex P1, PR #171).
-  if not (sock and externalHelloAcked) then return false end
+  -- seen, so we are in the sidecar's v1 `_external_peers`). Gate via
+  -- `isExternalReady()` (v1-specific `externalHelloAcked`), NOT
+  -- `sidecarConnected()`/`sidecarProtocolReady` — the latter is also set by the
+  -- legacy `protocol=1` flow, and a legacy reply arriving before hello_ack would
+  -- otherwise unblock this v1 publish path while we are still unregistered, so
+  -- the sidecar would reject the snapshot ("peer must send hello before other
+  -- frame types") (chatgpt-codex P1, PR #171). Shared with `sendClientFrame`
+  -- so topic and tick gates cannot drift (#671).
+  if not M.isExternalReady() then return false end
   return M.sendJson({
     v = PROTOCOL_VERSION,
     type = "state.snapshot",
@@ -1180,7 +1211,7 @@ function M.setSetupExperimentStorePath(storePath)
   setupExperimentStorePath = storePath
   setupExperimentStoreSent = false
   setupExperimentStoreRetryFrames = SETUP_EXPERIMENT_STORE_RETRY_FRAMES
-  if sock and externalHelloAcked then
+  if M.isExternalReady() then
     return M.sendSetupExperimentStorePath()
   end
   return true
@@ -1202,7 +1233,7 @@ end
 function M.sendSetupExperimentStorePath()
   if type(setupExperimentStorePath) ~= "string" or setupExperimentStorePath == "" then return false end
   if setupExperimentStoreSent then return true end
-  if not (sock and externalHelloAcked) then return false end
+  if not M.isExternalReady() then return false end
   if not localPathFramesAllowed() then return false end
   if setupExperimentStoreRetryFrames < SETUP_EXPERIMENT_STORE_RETRY_FRAMES then
     setupExperimentStoreRetryFrames = setupExperimentStoreRetryFrames + 1
@@ -1227,7 +1258,7 @@ end
 ---@return boolean
 function M.sendSetupExperimentRecord(archivePath)
   if type(archivePath) ~= "string" or archivePath == "" then return false end
-  if not (sock and externalHelloAcked) then return false end
+  if not M.isExternalReady() then return false end
   if not localPathFramesAllowed() then return false end
   return M.sendJson({
     v = PROTOCOL_VERSION,
@@ -1244,7 +1275,7 @@ end
 ---@return boolean
 function M.sendSessionReviewGenerate(lapDir, sessionUuid, referenceSource, referenceFile)
   if type(lapDir) ~= "string" or lapDir == "" then return false end
-  if not (sock and externalHelloAcked) then return false end
+  if not M.isExternalReady() then return false end
   if not localPathFramesAllowed() then return false end
   local payload = {
     v = PROTOCOL_VERSION,

--- a/src/ac_copilot_trainer/modules/ws_bridge.lua
+++ b/src/ac_copilot_trainer/modules/ws_bridge.lua
@@ -1193,9 +1193,11 @@ function M.publishTopic(topic, payload)
   -- otherwise unblock this v1 publish path while we are still unregistered, so
   -- the sidecar would reject the snapshot ("peer must send hello before other
   -- frame types") (chatgpt-codex P1, PR #171). Shared with `sendClientFrame`
-  -- so topic and tick gates cannot drift (#671).
+  -- so topic and tick gates cannot drift (#671). Early readiness probe avoids
+  -- allocating the envelope when gated; the actual send still goes through
+  -- `sendClientFrame` so every non-hello client frame shares one transport.
   if not M.isExternalReady() then return false end
-  return M.sendJson({
+  return M.sendClientFrame({
     v = PROTOCOL_VERSION,
     type = "state.snapshot",
     topic = topic,
@@ -1239,7 +1241,7 @@ function M.sendSetupExperimentStorePath()
     setupExperimentStoreRetryFrames = setupExperimentStoreRetryFrames + 1
     return false
   end
-  local ok = M.sendJson({
+  local ok = M.sendClientFrame({
     v = PROTOCOL_VERSION,
     type = "setup.experiment.store",
     store_path = setupExperimentStorePath,
@@ -1260,7 +1262,7 @@ function M.sendSetupExperimentRecord(archivePath)
   if type(archivePath) ~= "string" or archivePath == "" then return false end
   if not M.isExternalReady() then return false end
   if not localPathFramesAllowed() then return false end
-  return M.sendJson({
+  return M.sendClientFrame({
     v = PROTOCOL_VERSION,
     type = "setup.experiment.record",
     archive_path = archivePath,
@@ -1292,7 +1294,7 @@ function M.sendSessionReviewGenerate(lapDir, sessionUuid, referenceSource, refer
   if type(referenceFile) == "string" and referenceFile ~= "" then
     payload.reference_file = referenceFile
   end
-  return M.sendJson(payload)
+  return M.sendClientFrame(payload)
 end
 
 --- Issue #86 Part D: register a handler for an external `request` event

--- a/tests/test_telemetry_publisher.py
+++ b/tests/test_telemetry_publisher.py
@@ -22,28 +22,58 @@ MODULES_DIR = REPO / "src" / "ac_copilot_trainer" / "modules"
 _STUB = r"""
 function make_ws()
   local calls = {}
+  local function sendJson(payload)
+    calls[#calls + 1] = { send = payload }
+    return true
+  end
   return {
     _calls = calls,
+    isExternalReady = function() return true end,
     publishTopic = function(topic, payload)
       calls[#calls + 1] = { topic = topic, payload = payload }
       return true
     end,
-    sendJson = function(payload)
-      calls[#calls + 1] = { send = payload }
-      return true
+    sendJson = sendJson,
+    sendClientFrame = function(payload)
+      return sendJson(payload)
     end,
   }
 end
 function make_ws_closed()
   local calls = {}
+  local function sendJson(payload)
+    calls[#calls + 1] = { send = payload }
+    return false
+  end
   return {
     _calls = calls,
+    isExternalReady = function() return false end,
     publishTopic = function(topic, payload)
       calls[#calls + 1] = { topic = topic, payload = payload }
       return false
     end,
-    sendJson = function(payload)
-      calls[#calls + 1] = { send = payload }
+    sendJson = sendJson,
+    sendClientFrame = function(payload)
+      return false
+    end,
+  }
+end
+function make_ws_unacked()
+  -- Connected socket, hello not acked (#671): sendJson would succeed, but the
+  -- publisher must not hand a telemetry_tick to the socket.
+  local calls = {}
+  local function sendJson(payload)
+    calls[#calls + 1] = { send = payload }
+    return true
+  end
+  return {
+    _calls = calls,
+    isExternalReady = function() return false end,
+    publishTopic = function(topic, payload)
+      return false
+    end,
+    sendJson = sendJson,
+    sendClientFrame = function(payload)
       return false
     end,
   }
@@ -352,6 +382,28 @@ def test_telemetry_tick_rate_limited_to_20hz():
     assert out["typ"] == "telemetry_tick"
     assert out["spline"] == 0.42
     assert out["lap"] == 2
+
+
+def test_telemetry_tick_suppressed_until_external_hello_acked():
+    # #671: due ticks must return false and leave the socket untouched while
+    # isExternalReady is false — even when raw sendJson would succeed.
+    rt = _runtime()
+    out = rt.eval(
+        r"""
+        (function()
+          local M = require("telemetry_publisher"); M.reset()
+          local ws = make_ws_unacked()
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+          }
+          local r = M.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = ws })
+          return { r = r, n = #ws._calls }
+        end)()
+        """
+    )
+    assert out["r"] is False
+    assert out["n"] == 0
 
 
 def test_telemetry_tick_carries_fuel_and_tyre_temps_when_available():

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -399,8 +399,7 @@ def test_send_client_frame_gated_until_hello_ack():
     sent_before = int(rt.eval("_ws_sent"))
     assert (
         rt.eval(
-            'require("ws_bridge").sendClientFrame('
-            '{v=1, type="telemetry_tick", seq=1, payload={}})'
+            'require("ws_bridge").sendClientFrame({v=1, type="telemetry_tick", seq=1, payload={}})'
         )
         is False
     )
@@ -414,8 +413,7 @@ def test_send_client_frame_gated_until_hello_ack():
     sent_ready = int(rt.eval("_ws_sent"))
     assert (
         rt.eval(
-            'require("ws_bridge").sendClientFrame('
-            '{v=1, type="telemetry_tick", seq=1, payload={}})'
+            'require("ws_bridge").sendClientFrame({v=1, type="telemetry_tick", seq=1, payload={}})'
         )
         is True
     )

--- a/tests/test_ws_bridge_hello_handshake.py
+++ b/tests/test_ws_bridge_hello_handshake.py
@@ -387,3 +387,129 @@ def test_state_subscribe_without_session_does_not_request_replay():
     _inject(rt, {"v": 1, "type": "state.unsubscribe", "topics": ["session"]})
 
     assert rt.eval('require("ws_bridge").consumeSessionReplayRequest()') is False
+
+
+def test_send_client_frame_gated_until_hello_ack():
+    # #671: non-hello client frames (telemetry_tick) must share publishTopic's
+    # externalHelloAcked gate. Gate lives on sendClientFrame / isExternalReady —
+    # never inside sendJson, which the hello retry still uses.
+    rt = _runtime()
+    _open(rt)
+    assert rt.eval('require("ws_bridge").isExternalReady()') is False
+    sent_before = int(rt.eval("_ws_sent"))
+    assert (
+        rt.eval(
+            'require("ws_bridge").sendClientFrame('
+            '{v=1, type="telemetry_tick", seq=1, payload={}})'
+        )
+        is False
+    )
+    assert int(rt.eval("_ws_sent")) == sent_before
+    # Hello retry still uses sendJson and must keep firing while gated.
+    rt.execute('local wb = require("ws_bridge"); for _ = 1, 30 do wb.tick(0) end')
+    assert int(rt.eval("_ws_sent")) > sent_before
+
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    assert rt.eval('require("ws_bridge").isExternalReady()') is True
+    sent_ready = int(rt.eval("_ws_sent"))
+    assert (
+        rt.eval(
+            'require("ws_bridge").sendClientFrame('
+            '{v=1, type="telemetry_tick", seq=1, payload={}})'
+        )
+        is True
+    )
+    assert int(rt.eval("_ws_sent")) == sent_ready + 1
+
+
+def test_telemetry_tick_publisher_respects_hello_gate_across_reconnect():
+    # #671 acceptance: due ticks stay silent until hello_ack; resume after ack;
+    # reconnect re-suppresses until the new hello is acked — same observable
+    # shape as publishTopic.
+    rt = _runtime()
+    _open(rt)
+    out = rt.eval(
+        r"""
+        (function()
+          local pub = require("telemetry_publisher"); pub.reset()
+          local wb = require("ws_bridge")
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+          }
+          local sent0 = _ws_sent
+          local r1 = pub.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = wb })
+          local sent1 = _ws_sent
+          return { r1 = r1, delta = sent1 - sent0, ready = wb.isExternalReady() }
+        end)()
+        """
+    )
+    assert out["ready"] is False
+    assert out["r1"] is False
+    assert out["delta"] == 0
+
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    out2 = rt.eval(
+        r"""
+        (function()
+          local pub = require("telemetry_publisher")
+          local wb = require("ws_bridge")
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+          }
+          local sent0 = _ws_sent
+          local r = pub.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = wb })
+          return { r = r, delta = _ws_sent - sent0, ready = wb.isExternalReady() }
+        end)()
+        """
+    )
+    assert out2["ready"] is True
+    assert out2["r"] is True
+    assert out2["delta"] == 1
+
+    rt.execute("_ws_on_open()")
+    out3 = rt.eval(
+        r"""
+        (function()
+          local pub = require("telemetry_publisher")
+          local wb = require("ws_bridge")
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+          }
+          local sent0 = _ws_sent
+          local r = pub.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = wb })
+          return {
+            r = r,
+            delta = _ws_sent - sent0,
+            ready = wb.isExternalReady(),
+            topic = wb.publishTopic("coaching.snapshot", {}),
+          }
+        end)()
+        """
+    )
+    assert out3["ready"] is False
+    assert out3["r"] is False
+    assert out3["topic"] is False
+    # sent0 is sampled after onOpen's hello re-announce; a due tick must add nothing.
+    assert out3["delta"] == 0
+
+    _inject(rt, {"v": 1, "type": "hello_ack", "server_version": "1.0.0"})
+    out4 = rt.eval(
+        r"""
+        (function()
+          local pub = require("telemetry_publisher")
+          local wb = require("ws_bridge")
+          local car = {
+            speedKmh = 120, rpm = 6000, gas = 0.5, brake = 0.0, steer = 0.1,
+            gear = 3, splinePosition = 0.42, lapCount = 2,
+          }
+          local sent0 = _ws_sent
+          local r = pub.publishTelemetryTickIfDue({ dt = 0.06, car = car, wsBridge = wb })
+          return { r = r, delta = _ws_sent - sent0 }
+        end)()
+        """
+    )
+    assert out4["r"] is True
+    assert out4["delta"] == 1


### PR DESCRIPTION
## Summary
- Extract shared `isExternalReady()` / `sendClientFrame()` on `ws_bridge` so non-hello client frames reuse the same v1 hello gate as `publishTopic` (PR #171 contract).
- Route `publishTelemetryTickIfDue` through the gated path so reconnect-storm ticks cannot reach the sidecar before peer registration.
- Add lupa coverage for gated ticks, hello-retry still using `sendJson`, and reconnect re-suppression.

Fixes #671

## Test plan
- [x] `pytest tests/test_ws_bridge_hello_handshake.py tests/test_telemetry_publisher.py -q` (51 passed)
- [ ] `make ci-fast`
- [ ] Confirm hello frames still send while `externalHelloAcked` is false
- [ ] Confirm `telemetry_tick` resumes after `hello_ack` and re-gates on reconnect `onOpen`