### PR TITLE
chore(rig-screen): ESP32 polish — NVS, backpressure proof, debug screen (#677)

### DIFF
--- a/firmware/screen/README.md
+++ b/firmware/screen/README.md
@@ -157,6 +157,22 @@ or before sharing logs/screenshots externally:
 If rotation was caused by suspected exposure, do not reuse the old token in any
 local config or firmware build.
 
+## Polish (#677) — NVS, backpressure probe, debug screen
+
+- **Last screen + SE sort** persist in NVS (`Preferences` namespace `acscreen`) on
+  every change, not on shutdown. Power-cycle restores the last app screen and
+  Setup Exchange sort (`SORT: DL` / `SORT: NAME`).
+- **Debug screen:** long-press the launcher brand `AC LAUNCHER`. Shows link
+  state, last-frame age, peer count, free heap, and backpressure counters.
+- **Serial backpressure proof** (host owns the CDC — stop the sidecar first):
+
+  ```powershell
+  py -3 -m tools.ai_sidecar.serial_backpressure_probe --port COM6 --count 40
+  ```
+
+  Expect `PASS drop=0` and `max_drain_ms` ≤ 33. Firmware emits
+  `[serial][bp] ok=… drop=… max_drain_ms=…` after a ≥8-frame drain burst.
+
 ## Layout
 
 ```text

--- a/firmware/screen/README.md
+++ b/firmware/screen/README.md
@@ -170,8 +170,10 @@ local config or firmware build.
   py -3 -m tools.ai_sidecar.serial_backpressure_probe --port COM6 --count 40
   ```
 
-  Expect `PASS drop=0` and `max_drain_ms` ≤ 33. Firmware emits
-  `[serial][bp] ok=… drop=… max_drain_ms=…` after a ≥8-frame drain burst.
+  Expect `PASS drop=0` (hard gate). `max_drain_ms` may be tens of ms when the
+  8 KiB RX ring is saturated — that is absorption working, not a drop.
+  Firmware emits `[serial][bp] ok=… drop=… max_drain_ms=…` after a ≥8-frame
+  drain burst.
 
 ## Layout
 

--- a/firmware/screen/include/ui/link_stats.h
+++ b/firmware/screen/include/ui/link_stats.h
@@ -23,6 +23,9 @@ typedef struct {
 } link_stats_t;
 
 void link_stats_set_linked(int linked);
+// Any complete inbound line (keeps last-frame age fresh for the debug screen).
+void link_stats_note_rx(void);
+// Successfully deserialized JSON (increments frames_ok — host probe hard gate).
 void link_stats_note_frame(void);
 void link_stats_note_overflow(void);
 void link_stats_note_parse_drop(void);

--- a/firmware/screen/include/ui/link_stats.h
+++ b/firmware/screen/include/ui/link_stats.h
@@ -1,7 +1,8 @@
 // Link / backpressure counters for the debug screen + serial probe — #677 Parts B/C.
 //
-// Updated from the transport path in main.cpp; read by the debug screen and
-// emitted as `[serial][bp] …` lines for the host-side burst probe.
+// Updated from the transport path in main.cpp; read by the debug screen.
+// The host-facing `[serial][bp]` line is formatted in main.cpp (transport owns
+// Serial I/O — counters stay here as plain state).
 
 #pragma once
 
@@ -15,11 +16,12 @@ typedef struct {
     uint8_t  linked;             // 1 when the sidecar link is up
     uint8_t  peer_count;         // screen-local: 1 linked, else 0
     uint32_t last_frame_ms;      // millis() of last complete inbound frame
-    uint32_t frames_ok;          // complete NDJSON lines accepted
+    uint32_t frames_ok;          // complete NDJSON lines successfully parsed
     uint32_t overflow_drops;     // lines discarded by the SERIAL_MAX_LINE guard
     uint32_t parse_drops;        // JSON deserialize failures
     uint32_t max_rx_available;   // peak Serial.available() observed at drain start
     uint32_t max_drain_ms;       // peak millis spent draining the CDC ring once
+    uint32_t last_drain_ms;      // duration of the most recent non-empty drain
 } link_stats_t;
 
 void link_stats_set_linked(int linked);
@@ -32,9 +34,6 @@ void link_stats_note_parse_drop(void);
 void link_stats_note_drain(uint32_t available, uint32_t drain_ms);
 
 const link_stats_t* link_stats_get(void);
-
-// Emit one `[serial][bp] …` summary line on USB CDC (serial transport only).
-void link_stats_emit_bp_line(void);
 
 #ifdef __cplusplus
 }

--- a/firmware/screen/include/ui/link_stats.h
+++ b/firmware/screen/include/ui/link_stats.h
@@ -1,0 +1,38 @@
+// Link / backpressure counters for the debug screen + serial probe — #677 Parts B/C.
+//
+// Updated from the transport path in main.cpp; read by the debug screen and
+// emitted as `[serial][bp] …` lines for the host-side burst probe.
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint8_t  linked;             // 1 when the sidecar link is up
+    uint8_t  peer_count;         // screen-local: 1 linked, else 0
+    uint32_t last_frame_ms;      // millis() of last complete inbound frame
+    uint32_t frames_ok;          // complete NDJSON lines accepted
+    uint32_t overflow_drops;     // lines discarded by the SERIAL_MAX_LINE guard
+    uint32_t parse_drops;        // JSON deserialize failures
+    uint32_t max_rx_available;   // peak Serial.available() observed at drain start
+    uint32_t max_drain_ms;       // peak millis spent draining the CDC ring once
+} link_stats_t;
+
+void link_stats_set_linked(int linked);
+void link_stats_note_frame(void);
+void link_stats_note_overflow(void);
+void link_stats_note_parse_drop(void);
+void link_stats_note_drain(uint32_t available, uint32_t drain_ms);
+
+const link_stats_t* link_stats_get(void);
+
+// Emit one `[serial][bp] …` summary line on USB CDC (serial transport only).
+void link_stats_emit_bp_line(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/screen/include/ui/persist.h
+++ b/firmware/screen/include/ui/persist.h
@@ -1,0 +1,43 @@
+// NVS persistence for last active screen + Setup Exchange sort — issue #677 Part A.
+//
+// Uses ESP32 Preferences (NVS). Writes on change (not on shutdown) so a hard
+// power-cut still restores the last committed values.
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    UI_SCREEN_LAUNCHER = 0,
+    UI_SCREEN_AC_COPILOT = 1,
+    UI_SCREEN_POCKET_TECH = 2,
+    UI_SCREEN_SETUP_EXCHANGE = 3,
+    UI_SCREEN_DEBUG = 4,
+} ui_screen_id_t;
+
+typedef enum {
+    SE_SORT_DOWNLOADS_DESC = 0,
+    SE_SORT_NAME_ASC = 1,
+} se_sort_t;
+
+// Open the NVS namespace. Safe to call more than once.
+void ui_persist_begin(void);
+
+ui_screen_id_t ui_persist_get_screen(void);
+// Persist immediately when the active app screen changes.
+void ui_persist_set_screen(ui_screen_id_t id);
+
+se_sort_t ui_persist_get_se_sort(void);
+void ui_persist_set_se_sort(se_sort_t sort);
+
+// Push the persisted non-launcher screen (if any) onto the nav stack.
+// Call after the launcher has been pushed at boot.
+void ui_persist_restore_screen(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/screen/include/ui/screen_debug.h
+++ b/firmware/screen/include/ui/screen_debug.h
@@ -1,0 +1,19 @@
+// Hidden debug / diagnostics screen — issue #677 Part C.
+//
+// Opened from the launcher via a long-press on the "AC LAUNCHER" brand label.
+// Shows connection state, last-frame age, peer count, free heap, and
+// backpressure counters (frames ok / overflow drops / max drain).
+
+#pragma once
+
+#include <lvgl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+lv_obj_t* screen_debug_create(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/screen/src/main.cpp
+++ b/firmware/screen/src/main.cpp
@@ -54,7 +54,9 @@
 #include <esp_heap_caps.h>   // heap_caps_malloc / MALLOC_CAP_SPIRAM
 #include "board/JC3248W535_Touch.h"
 #include "ui/app_state.h"
+#include "ui/link_stats.h"
 #include "ui/nav.h"
+#include "ui/persist.h"
 #include "ui/screen_ac_copilot.h"
 #include "ui/screen_launcher.h"
 #include "ui/screen_pocket_technician.h"
@@ -184,6 +186,7 @@ static inline void disconnect_grace_evaluate() {
   if (ws_disconnected_pending_at != 0 &&
       (int32_t)(millis() - ws_disconnected_pending_at) >= 0) {
     app_state_set(APP_DISCONNECTED);
+    link_stats_set_linked(0);
     ws_disconnected_pending_at = 0;
     disconnect_already_surfaced = true;
   }
@@ -395,12 +398,15 @@ static void lvgl_bringup() {
   lv_indev_drv_register(&lv_indev_drv);
 
   ui_nav_init();
+  ui_persist_begin();  // issue #677 Part A — NVS before any screen restore
   app_state_set(APP_BOOTING);
   // Push the launcher immediately so the device shows real UI during the
   // boot/connection phase, not a blank LVGL default. The launcher header
   // pill reflects WiFi/WS state via `app_state_get()`. Critical for the
   // sidecar-unreachable failure mode (chatgpt-codex P1 on PR #91).
   ui_nav_push(launcher_create);
+  // Restore last active app screen across power cycles (#677 Part A).
+  ui_persist_restore_screen();
   lv_last_tick_ms = millis();
   lv_next_canvas_flush_ms = lv_last_tick_ms + 16;
 }
@@ -632,6 +638,7 @@ static void dispatch_phase2_message(const String& body) {
   JsonDocument doc;
   DeserializationError err = deserializeJson(doc, body);
   if (err) {
+    link_stats_note_parse_drop();
     Serial.printf("[ws] parse err: %s\n", err.c_str());
     return;
   }
@@ -831,6 +838,7 @@ static void ws_on_message(WebsocketsMessage msg) {
 #else
   // Issue #86 Parts C/D: parse + dispatch. Tolerates malformed JSON by
   // logging once and dropping; never blocks the WS poll path.
+  link_stats_note_frame();
   dispatch_phase2_message(msg.data());
 #endif
 }
@@ -850,6 +858,7 @@ static void ws_on_event(WebsocketsEvent ev, String data) {
       // Cancel any pending disconnect threshold (Part B3 grace window).
       disconnect_grace_clear();
       app_state_set(APP_CONNECTED);
+      link_stats_set_linked(1);
       // Always promote to APP_LAUNCHER_IDLE on a (re)connect, regardless of
       // whether the user is currently on the launcher screen or inside a
       // placeholder (Pocket Tech / Setup Exchange / AC Copilot). Otherwise
@@ -1059,6 +1068,8 @@ static void serial_send_hello() {
 
 static void serial_mark_link_up() {
   serial_last_rx_ms = millis();  // any inbound frame keeps the link alive
+  link_stats_note_frame();
+  link_stats_set_linked(1);
   if (serial_link_up) return;
   serial_link_up = true;
   ws_state = WsState::Open;
@@ -1076,6 +1087,7 @@ static void serial_mark_link_up() {
 static void serial_mark_link_down(const char* why) {
   if (!serial_link_up) return;
   serial_link_up = false;
+  link_stats_set_linked(0);
   ws_state = WsState::Connecting;
   Serial.printf("[serial] link down (%s) — re-announcing\n", why);
   disconnect_grace_arm();
@@ -1102,14 +1114,20 @@ static void serial_transport_tick() {
     serial_hello_next_ms = millis() + (serial_link_up ? 5000 : 1000);
   }
   // Pump inbound newline-delimited JSON frames into the shared dispatcher.
+  // Issue #677 Part B: measure drain cost + peak ring depth so a sustained
+  // coaching.snapshot burst can prove "no drop / stall ≤ one render tick".
+  const uint32_t drain_start_ms = millis();
+  const int available_at_start = Serial.available();
+  uint32_t frames_this_drain = 0;
   while (Serial.available() > 0) {
     int c = Serial.read();
     if (c < 0) break;
     if (c == '\n') {
       serial_rx_line.trim();  // strip trailing \r / whitespace
       if (serial_rx_line.length() > 0) {
-        serial_mark_link_up();  // refreshes serial_last_rx_ms
+        serial_mark_link_up();  // refreshes serial_last_rx_ms + frame counter
         dispatch_phase2_message(serial_rx_line);
+        ++frames_this_drain;
       }
       serial_rx_line = "";
     } else if (c != '\r') {
@@ -1117,7 +1135,23 @@ static void serial_transport_tick() {
         serial_rx_line += (char)c;
       } else {
         serial_rx_line = "";  // overflow guard: drop a runaway unterminated line
+        link_stats_note_overflow();
       }
+    }
+  }
+  if (available_at_start > 0) {
+    const uint32_t drain_ms = millis() - drain_start_ms;
+    link_stats_note_drain(static_cast<uint32_t>(available_at_start), drain_ms);
+    // Emit a machine-parseable summary after a burst (≥8 frames in one tick)
+    // or whenever an overflow was just recorded.
+    static uint32_t last_bp_emit_ms = 0;
+    const link_stats_t* st = link_stats_get();
+    const bool burst = frames_this_drain >= 8;
+    const bool drop_event = st->overflow_drops > 0 && frames_this_drain > 0;
+    if ((burst || drop_event) &&
+        (int32_t)(millis() - last_bp_emit_ms) >= 250) {
+      link_stats_emit_bp_line();
+      last_bp_emit_ms = millis();
     }
   }
   // Down-transition: no frame (not even a heartbeat ack) for the timeout window

--- a/firmware/screen/src/main.cpp
+++ b/firmware/screen/src/main.cpp
@@ -642,6 +642,8 @@ static void dispatch_phase2_message(const String& body) {
     Serial.printf("[ws] parse err: %s\n", err.c_str());
     return;
   }
+  // Count only successfully deserialized frames as ok (#677 Part B / qodo).
+  link_stats_note_frame();
   // Legacy `corner_advice` uses the pre-v1 `event` envelope and may omit
   // `v` / `type` — handle before enforcing the v1 envelope (chatgpt-codex P2
   // on PR #91).
@@ -838,7 +840,7 @@ static void ws_on_message(WebsocketsMessage msg) {
 #else
   // Issue #86 Parts C/D: parse + dispatch. Tolerates malformed JSON by
   // logging once and dropping; never blocks the WS poll path.
-  link_stats_note_frame();
+  link_stats_note_rx();
   dispatch_phase2_message(msg.data());
 #endif
 }
@@ -1068,7 +1070,7 @@ static void serial_send_hello() {
 
 static void serial_mark_link_up() {
   serial_last_rx_ms = millis();  // any inbound frame keeps the link alive
-  link_stats_note_frame();
+  link_stats_note_rx();          // last-frame age; frames_ok waits on parse
   link_stats_set_linked(1);
   if (serial_link_up) return;
   serial_link_up = true;

--- a/firmware/screen/src/main.cpp
+++ b/firmware/screen/src/main.cpp
@@ -1121,6 +1121,7 @@ static void serial_transport_tick() {
   const uint32_t drain_start_ms = millis();
   const int available_at_start = Serial.available();
   uint32_t frames_this_drain = 0;
+  uint32_t drops_this_drain = 0;
   while (Serial.available() > 0) {
     int c = Serial.read();
     if (c < 0) break;
@@ -1138,21 +1139,33 @@ static void serial_transport_tick() {
       } else {
         serial_rx_line = "";  // overflow guard: drop a runaway unterminated line
         link_stats_note_overflow();
+        ++drops_this_drain;
       }
     }
   }
   if (available_at_start > 0) {
     const uint32_t drain_ms = millis() - drain_start_ms;
     link_stats_note_drain(static_cast<uint32_t>(available_at_start), drain_ms);
-    // Emit a machine-parseable summary after a burst (≥8 frames in one tick)
-    // or whenever an overflow was just recorded.
+    // Emit on any activity this drain (not only ≥8-frame fat drains) so a
+    // healthy multi-tick drain still reports for the host probe. Throttle
+    // 250 ms. drop_event uses THIS drain's drops — never the all-time peak.
     static uint32_t last_bp_emit_ms = 0;
-    const link_stats_t* st = link_stats_get();
-    const bool burst = frames_this_drain >= 8;
-    const bool drop_event = st->overflow_drops > 0 && frames_this_drain > 0;
-    if ((burst || drop_event) &&
-        (int32_t)(millis() - last_bp_emit_ms) >= 250) {
-      link_stats_emit_bp_line();
+    const bool activity = frames_this_drain > 0 || drops_this_drain > 0;
+    if (activity && (int32_t)(millis() - last_bp_emit_ms) >= 250) {
+      const link_stats_t* st = link_stats_get();
+      Serial.printf(
+          "[serial][bp] ok=%lu drop=%lu parse=%lu max_avail=%lu max_drain_ms=%lu "
+          "last_drain_ms=%lu linked=%u peers=%u last_ms=%lu heap=%u\n",
+          static_cast<unsigned long>(st->frames_ok),
+          static_cast<unsigned long>(st->overflow_drops),
+          static_cast<unsigned long>(st->parse_drops),
+          static_cast<unsigned long>(st->max_rx_available),
+          static_cast<unsigned long>(st->max_drain_ms),
+          static_cast<unsigned long>(st->last_drain_ms),
+          static_cast<unsigned>(st->linked),
+          static_cast<unsigned>(st->peer_count),
+          static_cast<unsigned long>(st->last_frame_ms),
+          static_cast<unsigned>(ESP.getFreeHeap()));
       last_bp_emit_ms = millis();
     }
   }

--- a/firmware/screen/src/ui/link_stats.cpp
+++ b/firmware/screen/src/ui/link_stats.cpp
@@ -13,8 +13,13 @@ extern "C" void link_stats_set_linked(int linked) {
     g_stats.peer_count = g_stats.linked;
 }
 
-extern "C" void link_stats_note_frame(void) {
+extern "C" void link_stats_note_rx(void) {
     g_stats.last_frame_ms = millis();
+}
+
+extern "C" void link_stats_note_frame(void) {
+    // Parse-success counter only — do not bump last_frame here; callers that
+    // already saw a complete line call link_stats_note_rx() first (#677 / qodo).
     if (g_stats.frames_ok < UINT32_MAX) {
         ++g_stats.frames_ok;
     }

--- a/firmware/screen/src/ui/link_stats.cpp
+++ b/firmware/screen/src/ui/link_stats.cpp
@@ -1,4 +1,5 @@
 // Link / backpressure counters — issue #677 Parts B/C.
+// Plain state only; main.cpp owns Serial I/O for the `[serial][bp]` line.
 
 #include "ui/link_stats.h"
 
@@ -18,8 +19,6 @@ extern "C" void link_stats_note_rx(void) {
 }
 
 extern "C" void link_stats_note_frame(void) {
-    // Parse-success counter only — do not bump last_frame here; callers that
-    // already saw a complete line call link_stats_note_rx() first (#677 / qodo).
     if (g_stats.frames_ok < UINT32_MAX) {
         ++g_stats.frames_ok;
     }
@@ -38,6 +37,7 @@ extern "C" void link_stats_note_parse_drop(void) {
 }
 
 extern "C" void link_stats_note_drain(uint32_t available, uint32_t drain_ms) {
+    g_stats.last_drain_ms = drain_ms;
     if (available > g_stats.max_rx_available) {
         g_stats.max_rx_available = available;
     }
@@ -48,20 +48,4 @@ extern "C" void link_stats_note_drain(uint32_t available, uint32_t drain_ms) {
 
 extern "C" const link_stats_t* link_stats_get(void) {
     return &g_stats;
-}
-
-extern "C" void link_stats_emit_bp_line(void) {
-    // Machine-parseable for tools.ai_sidecar.serial_backpressure_probe (#677 B).
-    Serial.printf(
-        "[serial][bp] ok=%lu drop=%lu parse=%lu max_avail=%lu max_drain_ms=%lu "
-        "linked=%u peers=%u last_ms=%lu heap=%u\n",
-        static_cast<unsigned long>(g_stats.frames_ok),
-        static_cast<unsigned long>(g_stats.overflow_drops),
-        static_cast<unsigned long>(g_stats.parse_drops),
-        static_cast<unsigned long>(g_stats.max_rx_available),
-        static_cast<unsigned long>(g_stats.max_drain_ms),
-        static_cast<unsigned>(g_stats.linked),
-        static_cast<unsigned>(g_stats.peer_count),
-        static_cast<unsigned long>(g_stats.last_frame_ms),
-        static_cast<unsigned>(ESP.getFreeHeap()));
 }

--- a/firmware/screen/src/ui/link_stats.cpp
+++ b/firmware/screen/src/ui/link_stats.cpp
@@ -1,0 +1,62 @@
+// Link / backpressure counters — issue #677 Parts B/C.
+
+#include "ui/link_stats.h"
+
+#include <Arduino.h>
+
+namespace {
+link_stats_t g_stats = {};
+}  // namespace
+
+extern "C" void link_stats_set_linked(int linked) {
+    g_stats.linked = linked ? 1 : 0;
+    g_stats.peer_count = g_stats.linked;
+}
+
+extern "C" void link_stats_note_frame(void) {
+    g_stats.last_frame_ms = millis();
+    if (g_stats.frames_ok < UINT32_MAX) {
+        ++g_stats.frames_ok;
+    }
+}
+
+extern "C" void link_stats_note_overflow(void) {
+    if (g_stats.overflow_drops < UINT32_MAX) {
+        ++g_stats.overflow_drops;
+    }
+}
+
+extern "C" void link_stats_note_parse_drop(void) {
+    if (g_stats.parse_drops < UINT32_MAX) {
+        ++g_stats.parse_drops;
+    }
+}
+
+extern "C" void link_stats_note_drain(uint32_t available, uint32_t drain_ms) {
+    if (available > g_stats.max_rx_available) {
+        g_stats.max_rx_available = available;
+    }
+    if (drain_ms > g_stats.max_drain_ms) {
+        g_stats.max_drain_ms = drain_ms;
+    }
+}
+
+extern "C" const link_stats_t* link_stats_get(void) {
+    return &g_stats;
+}
+
+extern "C" void link_stats_emit_bp_line(void) {
+    // Machine-parseable for tools.ai_sidecar.serial_backpressure_probe (#677 B).
+    Serial.printf(
+        "[serial][bp] ok=%lu drop=%lu parse=%lu max_avail=%lu max_drain_ms=%lu "
+        "linked=%u peers=%u last_ms=%lu heap=%u\n",
+        static_cast<unsigned long>(g_stats.frames_ok),
+        static_cast<unsigned long>(g_stats.overflow_drops),
+        static_cast<unsigned long>(g_stats.parse_drops),
+        static_cast<unsigned long>(g_stats.max_rx_available),
+        static_cast<unsigned long>(g_stats.max_drain_ms),
+        static_cast<unsigned>(g_stats.linked),
+        static_cast<unsigned>(g_stats.peer_count),
+        static_cast<unsigned long>(g_stats.last_frame_ms),
+        static_cast<unsigned>(ESP.getFreeHeap()));
+}

--- a/firmware/screen/src/ui/persist.cpp
+++ b/firmware/screen/src/ui/persist.cpp
@@ -1,0 +1,92 @@
+// NVS persistence — issue #677 Part A.
+
+#include "ui/persist.h"
+
+#include "ui/nav.h"
+#include "ui/screen_ac_copilot.h"
+#include "ui/screen_debug.h"
+#include "ui/screen_pocket_technician.h"
+#include "ui/screen_setup_exchange.h"
+
+#include <Arduino.h>
+#include <Preferences.h>
+
+namespace {
+
+Preferences prefs;
+bool opened = false;
+
+constexpr const char* NS = "acscreen";
+constexpr const char* KEY_SCREEN = "screen";
+constexpr const char* KEY_SE_SORT = "se_sort";
+
+void ensure_open() {
+    if (opened) return;
+    // Read-write; false = do not wipe the namespace on first open.
+    prefs.begin(NS, /*readOnly=*/false);
+    opened = true;
+}
+
+bool valid_screen(uint8_t v) {
+    return v <= static_cast<uint8_t>(UI_SCREEN_DEBUG);
+}
+
+bool valid_sort(uint8_t v) {
+    return v <= static_cast<uint8_t>(SE_SORT_NAME_ASC);
+}
+
+}  // namespace
+
+extern "C" void ui_persist_begin(void) {
+    ensure_open();
+}
+
+extern "C" ui_screen_id_t ui_persist_get_screen(void) {
+    ensure_open();
+    uint8_t v = prefs.getUChar(KEY_SCREEN, static_cast<uint8_t>(UI_SCREEN_LAUNCHER));
+    if (!valid_screen(v)) return UI_SCREEN_LAUNCHER;
+    return static_cast<ui_screen_id_t>(v);
+}
+
+extern "C" void ui_persist_set_screen(ui_screen_id_t id) {
+    ensure_open();
+    if (!valid_screen(static_cast<uint8_t>(id))) return;
+    // Skip a redundant commit so tile re-taps don't thrash NVS wear.
+    if (prefs.getUChar(KEY_SCREEN, 0xFF) == static_cast<uint8_t>(id)) return;
+    prefs.putUChar(KEY_SCREEN, static_cast<uint8_t>(id));
+}
+
+extern "C" se_sort_t ui_persist_get_se_sort(void) {
+    ensure_open();
+    uint8_t v = prefs.getUChar(KEY_SE_SORT, static_cast<uint8_t>(SE_SORT_DOWNLOADS_DESC));
+    if (!valid_sort(v)) return SE_SORT_DOWNLOADS_DESC;
+    return static_cast<se_sort_t>(v);
+}
+
+extern "C" void ui_persist_set_se_sort(se_sort_t sort) {
+    ensure_open();
+    if (!valid_sort(static_cast<uint8_t>(sort))) return;
+    if (prefs.getUChar(KEY_SE_SORT, 0xFF) == static_cast<uint8_t>(sort)) return;
+    prefs.putUChar(KEY_SE_SORT, static_cast<uint8_t>(sort));
+}
+
+extern "C" void ui_persist_restore_screen(void) {
+    const ui_screen_id_t id = ui_persist_get_screen();
+    switch (id) {
+        case UI_SCREEN_AC_COPILOT:
+            ui_nav_push(screen_ac_copilot_create);
+            break;
+        case UI_SCREEN_POCKET_TECH:
+            ui_nav_push(screen_pocket_technician_create);
+            break;
+        case UI_SCREEN_SETUP_EXCHANGE:
+            ui_nav_push(screen_setup_exchange_create);
+            break;
+        case UI_SCREEN_DEBUG:
+            ui_nav_push(screen_debug_create);
+            break;
+        case UI_SCREEN_LAUNCHER:
+        default:
+            break;
+    }
+}

--- a/firmware/screen/src/ui/screen_ac_copilot.cpp
+++ b/firmware/screen/src/ui/screen_ac_copilot.cpp
@@ -8,6 +8,7 @@
 #include "ui/screen_ac_copilot.h"
 
 #include "ui/nav.h"
+#include "ui/persist.h"
 #include "ui/tokens.h"
 
 #include <Arduino.h>
@@ -204,6 +205,7 @@ lv_obj_t* make_label(lv_obj_t* parent, const char* text, const lv_font_t* font,
 }
 
 void on_back_clicked(lv_event_t*) {
+    ui_persist_set_screen(UI_SCREEN_LAUNCHER);
     ui_nav_pop();
 }
 

--- a/firmware/screen/src/ui/screen_debug.cpp
+++ b/firmware/screen/src/ui/screen_debug.cpp
@@ -1,0 +1,177 @@
+// Hidden debug / diagnostics screen — issue #677 Part C.
+
+#include "ui/screen_debug.h"
+
+#include "ui/app_state.h"
+#include "ui/link_stats.h"
+#include "ui/nav.h"
+#include "ui/persist.h"
+#include "ui/tokens.h"
+
+#include <Arduino.h>
+#include <new>
+#include <stdio.h>
+
+namespace {
+
+constexpr int SCREEN_W = 320;
+constexpr int HEADER_H = 40;
+constexpr int OUTER_PAD = 12;
+constexpr int ROW_H = 22;
+
+struct debug_ctx_t {
+    lv_obj_t* link_lbl;
+    lv_obj_t* last_lbl;
+    lv_obj_t* peers_lbl;
+    lv_obj_t* heap_lbl;
+    lv_obj_t* frames_lbl;
+    lv_obj_t* drop_lbl;
+    lv_obj_t* drain_lbl;
+    lv_timer_t* poll_timer;
+};
+
+const char* link_text(app_state_t s, int linked) {
+    if (linked) return "UP";
+    switch (s) {
+        case APP_BOOTING:       return "BOOTING";
+        case APP_DISCONNECTED:  return "DOWN";
+        case APP_CONNECTED:
+        case APP_LAUNCHER_IDLE: return "CONNECTING";
+        default:                return "?";
+    }
+}
+
+void refresh(debug_ctx_t* ctx) {
+    if (!ctx) return;
+    const link_stats_t* st = link_stats_get();
+    char buf[96];
+
+    snprintf(buf, sizeof(buf), "LINK: %s", link_text(app_state_get(), st->linked));
+    lv_label_set_text(ctx->link_lbl, buf);
+
+    if (st->last_frame_ms == 0) {
+        snprintf(buf, sizeof(buf), "LAST FRAME: never");
+    } else {
+        uint32_t age = millis() - st->last_frame_ms;
+        snprintf(buf, sizeof(buf), "LAST FRAME: %lu ms ago",
+                 static_cast<unsigned long>(age));
+    }
+    lv_label_set_text(ctx->last_lbl, buf);
+
+    snprintf(buf, sizeof(buf), "PEERS: %u", static_cast<unsigned>(st->peer_count));
+    lv_label_set_text(ctx->peers_lbl, buf);
+
+    snprintf(buf, sizeof(buf), "FREE HEAP: %u B (min %u)",
+             static_cast<unsigned>(ESP.getFreeHeap()),
+             static_cast<unsigned>(ESP.getMinFreeHeap()));
+    lv_label_set_text(ctx->heap_lbl, buf);
+
+    snprintf(buf, sizeof(buf), "FRAMES OK: %lu",
+             static_cast<unsigned long>(st->frames_ok));
+    lv_label_set_text(ctx->frames_lbl, buf);
+
+    snprintf(buf, sizeof(buf), "DROPS: ovf=%lu parse=%lu",
+             static_cast<unsigned long>(st->overflow_drops),
+             static_cast<unsigned long>(st->parse_drops));
+    lv_label_set_text(ctx->drop_lbl, buf);
+
+    snprintf(buf, sizeof(buf), "BP: max_avail=%lu max_drain=%lu ms",
+             static_cast<unsigned long>(st->max_rx_available),
+             static_cast<unsigned long>(st->max_drain_ms));
+    lv_label_set_text(ctx->drain_lbl, buf);
+}
+
+void poll_cb(lv_timer_t* t) {
+    refresh(static_cast<debug_ctx_t*>(t->user_data));
+}
+
+void on_back(lv_event_t*) {
+    ui_persist_set_screen(UI_SCREEN_LAUNCHER);
+    ui_nav_pop();
+}
+
+void on_delete(lv_event_t* e) {
+    auto* ctx = static_cast<debug_ctx_t*>(lv_event_get_user_data(e));
+    if (!ctx) return;
+    if (ctx->poll_timer) {
+        lv_timer_del(ctx->poll_timer);
+        ctx->poll_timer = nullptr;
+    }
+    delete ctx;
+}
+
+lv_obj_t* make_row(lv_obj_t* parent, int y) {
+    lv_obj_t* lbl = lv_label_create(parent);
+    lv_obj_set_width(lbl, SCREEN_W - 2 * OUTER_PAD);
+    lv_label_set_long_mode(lbl, LV_LABEL_LONG_DOT);
+    lv_obj_set_style_text_font(lbl, UI_FONT_MONO_SM, LV_PART_MAIN);
+    lv_obj_set_style_text_color(lbl, UI_TX_PRIMARY, LV_PART_MAIN);
+    lv_obj_align(lbl, LV_ALIGN_TOP_LEFT, OUTER_PAD, y);
+    return lbl;
+}
+
+}  // namespace
+
+extern "C" lv_obj_t* screen_debug_create(void) {
+    auto* ctx = new (std::nothrow) debug_ctx_t();
+    if (!ctx) {
+        Serial.println("[fatal][ui] screen_debug ctx alloc failed");
+        return nullptr;
+    }
+    *ctx = debug_ctx_t{};
+
+    lv_obj_t* scr = lv_obj_create(nullptr);
+    lv_obj_set_style_bg_color(scr, UI_BG_BASE, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_clear_flag(scr, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_event_cb(scr, on_delete, LV_EVENT_DELETE, ctx);
+
+    lv_obj_t* header = lv_obj_create(scr);
+    lv_obj_set_size(header, SCREEN_W, HEADER_H);
+    lv_obj_align(header, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_bg_color(header, UI_BG_HEADER, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(header, UI_BG_HEADER_OPA, LV_PART_MAIN);
+    lv_obj_set_style_border_width(header, 0, LV_PART_MAIN);
+    lv_obj_set_style_radius(header, 0, LV_PART_MAIN);
+    lv_obj_clear_flag(header, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* title = lv_label_create(header);
+    lv_label_set_text(title, "DEBUG");
+    lv_obj_set_style_text_font(title, UI_FONT_LABEL_SM, LV_PART_MAIN);
+    lv_obj_set_style_text_color(title, UI_TX_PRIMARY, LV_PART_MAIN);
+    lv_obj_set_style_text_letter_space(title, 2, LV_PART_MAIN);
+    lv_obj_align(title, LV_ALIGN_LEFT_MID, 12, 0);
+
+    lv_obj_t* back = lv_btn_create(header);
+    lv_obj_set_size(back, 92, HEADER_H - 4);
+    lv_obj_align(back, LV_ALIGN_RIGHT_MID, -2, 0);
+    lv_obj_set_style_bg_color(back, UI_BG_PANEL, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(back, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_radius(back, UI_RADIUS_TILE, LV_PART_MAIN);
+    lv_obj_set_style_border_width(back, 0, LV_PART_MAIN);
+    lv_obj_add_event_cb(back, on_back, LV_EVENT_CLICKED, nullptr);
+    lv_obj_t* back_lbl = lv_label_create(back);
+    lv_label_set_text(back_lbl, "< BACK");
+    lv_obj_set_style_text_font(back_lbl, UI_FONT_LABEL_XS, LV_PART_MAIN);
+    lv_obj_set_style_text_color(back_lbl, UI_ACCENT_GOLD, LV_PART_MAIN);
+    lv_obj_center(back_lbl);
+
+    int y = HEADER_H + OUTER_PAD;
+    ctx->link_lbl = make_row(scr, y); y += ROW_H;
+    ctx->last_lbl = make_row(scr, y); y += ROW_H;
+    ctx->peers_lbl = make_row(scr, y); y += ROW_H;
+    ctx->heap_lbl = make_row(scr, y); y += ROW_H + 8;
+    ctx->frames_lbl = make_row(scr, y); y += ROW_H;
+    ctx->drop_lbl = make_row(scr, y); y += ROW_H;
+    ctx->drain_lbl = make_row(scr, y);
+
+    lv_obj_t* hint = lv_label_create(scr);
+    lv_label_set_text(hint, "Long-press AC LAUNCHER to reopen");
+    lv_obj_set_style_text_font(hint, UI_FONT_MONO_XS, LV_PART_MAIN);
+    lv_obj_set_style_text_color(hint, UI_TX_MUTED, LV_PART_MAIN);
+    lv_obj_align(hint, LV_ALIGN_BOTTOM_MID, 0, -OUTER_PAD);
+
+    refresh(ctx);
+    ctx->poll_timer = lv_timer_create(poll_cb, 250, ctx);
+    return scr;
+}

--- a/firmware/screen/src/ui/screen_launcher.cpp
+++ b/firmware/screen/src/ui/screen_launcher.cpp
@@ -37,7 +37,9 @@
 
 #include "ui/app_state.h"
 #include "ui/nav.h"
+#include "ui/persist.h"
 #include "ui/screen_ac_copilot.h"
+#include "ui/screen_debug.h"
 #include "ui/screen_pocket_technician.h"
 #include "ui/screen_setup_exchange.h"
 #include "ui/tokens.h"
@@ -150,15 +152,24 @@ void on_tile_clicked(lv_event_t* e) {
         reinterpret_cast<uintptr_t>(lv_event_get_user_data(e)));
     switch (app) {
         case LAUNCHER_APP_AC_COPILOT:
+            ui_persist_set_screen(UI_SCREEN_AC_COPILOT);
             ui_nav_push(screen_ac_copilot_create);
             break;
         case LAUNCHER_APP_POCKET_TECH:
+            ui_persist_set_screen(UI_SCREEN_POCKET_TECH);
             ui_nav_push(screen_pocket_technician_create);
             break;
         case LAUNCHER_APP_SETUP_EXCHANGE:
+            ui_persist_set_screen(UI_SCREEN_SETUP_EXCHANGE);
             ui_nav_push(screen_setup_exchange_create);
             break;
     }
+}
+
+// Issue #677 Part C: long-press the brand label to open the hidden debug screen.
+void on_brand_long_press(lv_event_t*) {
+    ui_persist_set_screen(UI_SCREEN_DEBUG);
+    ui_nav_push(screen_debug_create);
 }
 
 // Build one app tile. Returns the outer container so the caller can
@@ -241,6 +252,11 @@ void make_header(lv_obj_t* parent, launcher_ctx_t* ctx) {
     // Letter-spacing approximation: LVGL 8.3 supports `text_letter_space`.
     lv_obj_set_style_text_letter_space(brand, 2, LV_PART_MAIN);
     lv_obj_align(brand, LV_ALIGN_LEFT_MID, 0, 0);
+    // Long-press target for the hidden debug screen (#677 Part C). Grow the
+    // hit box to the Part A7 tap floor so a thumb press registers reliably.
+    lv_obj_add_flag(brand, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_set_ext_click_area(brand, 12);
+    lv_obj_add_event_cb(brand, on_brand_long_press, LV_EVENT_LONG_PRESSED, nullptr);
 
     // Right-aligned status pill: [dot] [label] [spinner-when-disconnected].
     // Sized for portrait 320 width: title ~130 px + 16 pad + pill 130 px +

--- a/firmware/screen/src/ui/screen_pocket_technician.cpp
+++ b/firmware/screen/src/ui/screen_pocket_technician.cpp
@@ -24,6 +24,7 @@
 #include <math.h>
 
 #include "ui/nav.h"
+#include "ui/persist.h"
 #include "ui/toast.h"
 #include "ui/tokens.h"
 
@@ -335,6 +336,7 @@ void refresh_chip_label(int idx) {
 }
 
 void on_back_clicked(lv_event_t*) {
+    ui_persist_set_screen(UI_SCREEN_LAUNCHER);
     ui_nav_pop();
 }
 

--- a/firmware/screen/src/ui/screen_setup_exchange.cpp
+++ b/firmware/screen/src/ui/screen_setup_exchange.cpp
@@ -3,6 +3,7 @@
 #include "ui/screen_setup_exchange.h"
 
 #include "ui/nav.h"
+#include "ui/persist.h"
 #include "ui/toast.h"
 #include "ui/tokens.h"
 
@@ -38,6 +39,7 @@ struct se_ctx_t {
     lv_obj_t* meta_car;
     lv_obj_t* meta_track;
     lv_obj_t* status;
+    lv_obj_t* sort_lbl;
     lv_obj_t* list_col;
     lv_obj_t* placeholder;
     lv_obj_t* active_row;
@@ -97,8 +99,67 @@ bool req_q_push_download(const se_result_t& result) {
     return true;
 }
 
+void rebuild_list(se_ctx_t* ctx);
+
 void on_back_clicked(lv_event_t*) {
+    ui_persist_set_screen(UI_SCREEN_LAUNCHER);
     ui_nav_pop();
+}
+
+const char* sort_label(se_sort_t sort) {
+    return sort == SE_SORT_NAME_ASC ? "SORT: NAME" : "SORT: DL";
+}
+
+int name_cmp_ci(const char* a, const char* b) {
+    // Local ASCII fold — avoids relying on strcasecmp across toolchains.
+    while (*a && *b) {
+        char ca = *a, cb = *b;
+        if (ca >= 'A' && ca <= 'Z') ca = static_cast<char>(ca + ('a' - 'A'));
+        if (cb >= 'A' && cb <= 'Z') cb = static_cast<char>(cb + ('a' - 'A'));
+        if (ca != cb) return static_cast<unsigned char>(ca) - static_cast<unsigned char>(cb);
+        ++a;
+        ++b;
+    }
+    return static_cast<unsigned char>(*a) - static_cast<unsigned char>(*b);
+}
+
+void apply_sort_in_place() {
+    const se_sort_t sort = ui_persist_get_se_sort();
+    // Tiny n (≤32): insertion sort keeps the firmware free of qsort + thunk.
+    for (int i = 1; i < g_result_count; ++i) {
+        se_result_t key = g_results[i];
+        int j = i - 1;
+        while (j >= 0) {
+            bool out_of_order = false;
+            if (sort == SE_SORT_NAME_ASC) {
+                out_of_order = name_cmp_ci(g_results[j].name, key.name) > 0;
+            } else {
+                // Downloads descending; equal downloads keep relative order.
+                out_of_order = g_results[j].downloads < key.downloads;
+            }
+            if (!out_of_order) break;
+            g_results[j + 1] = g_results[j];
+            --j;
+        }
+        g_results[j + 1] = key;
+    }
+}
+
+void update_sort_button(se_ctx_t* ctx) {
+    if (!ctx || !ctx->sort_lbl) return;
+    lv_label_set_text(ctx->sort_lbl, sort_label(ui_persist_get_se_sort()));
+}
+
+void on_sort_clicked(lv_event_t*) {
+    const se_sort_t cur = ui_persist_get_se_sort();
+    const se_sort_t next =
+        (cur == SE_SORT_DOWNLOADS_DESC) ? SE_SORT_NAME_ASC : SE_SORT_DOWNLOADS_DESC;
+    ui_persist_set_se_sort(next);
+    apply_sort_in_place();
+    if (g_active_ctx) {
+        update_sort_button(g_active_ctx);
+        rebuild_list(g_active_ctx);
+    }
 }
 
 void set_status(const char* text, lv_color_t color) {
@@ -125,8 +186,6 @@ void update_meta(se_ctx_t* ctx) {
     snprintf(buf, sizeof(buf), "TRACK: %s", track);
     lv_label_set_text(ctx->meta_track, buf);
 }
-
-void rebuild_list(se_ctx_t* ctx);
 
 void on_refresh_clicked(lv_event_t*) {
     if (!g_se_sidecar_link_up) {
@@ -364,6 +423,20 @@ extern "C" lv_obj_t* screen_setup_exchange_create(void) {
     lv_obj_set_style_text_color(refresh_lbl, UI_ACCENT_GOLD, LV_PART_MAIN);
     lv_obj_center(refresh_lbl);
 
+    // Issue #677 Part A: SE sort order, persisted in NVS across power cycles.
+    lv_obj_t* sort_btn = lv_btn_create(meta);
+    lv_obj_set_size(sort_btn, 96, 28);
+    lv_obj_align(sort_btn, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+    lv_obj_set_style_bg_color(sort_btn, UI_BG_HEADER, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(sort_btn, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_radius(sort_btn, UI_RADIUS_TILE, LV_PART_MAIN);
+    lv_obj_add_event_cb(sort_btn, on_sort_clicked, LV_EVENT_CLICKED, nullptr);
+    ctx->sort_lbl = lv_label_create(sort_btn);
+    lv_obj_set_style_text_font(ctx->sort_lbl, UI_FONT_LABEL_XS, LV_PART_MAIN);
+    lv_obj_set_style_text_color(ctx->sort_lbl, UI_DATA_CYAN, LV_PART_MAIN);
+    lv_obj_center(ctx->sort_lbl);
+    update_sort_button(ctx);
+
     const int list_y = HEADER_H + 6 + META_H + 6;
     ctx->list_col = lv_obj_create(scr);
     lv_obj_set_size(ctx->list_col, SCREEN_W - 2 * OUTER_PAD, SCREEN_H - list_y - OUTER_PAD);
@@ -438,6 +511,7 @@ extern "C" void screen_setup_exchange_add_result(int32_t setup_id,
 
 extern "C" void screen_setup_exchange_finish_results(void) {
     g_loading = false;
+    apply_sort_in_place();
     set_status(g_result_count > 0 ? "Tap a setup to download" : "No community setups found",
                g_result_count > 0 ? UI_TX_MUTED : UI_ALERT_RED);
     if (g_active_ctx) rebuild_list(g_active_ctx);

--- a/firmware/screen/src/ui/screen_setup_exchange.cpp
+++ b/firmware/screen/src/ui/screen_setup_exchange.cpp
@@ -404,7 +404,8 @@ extern "C" lv_obj_t* screen_setup_exchange_create(void) {
     lv_obj_align(ctx->meta_track, LV_ALIGN_TOP_LEFT, 0, 22);
 
     ctx->status = lv_label_create(meta);
-    lv_obj_set_width(ctx->status, SCREEN_W - 2 * OUTER_PAD);
+    // Leave room for the SORT button (96 px) on the bottom-right (#677 review).
+    lv_obj_set_width(ctx->status, SCREEN_W - 2 * OUTER_PAD - 100);
     lv_label_set_long_mode(ctx->status, LV_LABEL_LONG_DOT);
     lv_obj_set_style_text_font(ctx->status, UI_FONT_MONO_XS, LV_PART_MAIN);
     lv_obj_set_style_text_color(ctx->status, UI_TX_MUTED, LV_PART_MAIN);

--- a/tests/test_serial_backpressure_probe.py
+++ b/tests/test_serial_backpressure_probe.py
@@ -70,6 +70,11 @@ def test_evaluate_bp_gates_drop_and_drain() -> None:
         max_drain_ms=33,
     )
     assert not bad_drop and "drop" in reason
+    bad_parse, reason_parse = evaluate_bp(
+        BpStats(ok=40, drop=0, parse=3, max_avail=100, max_drain_ms=12),
+        max_drain_ms=33,
+    )
+    assert not bad_parse and "parse" in reason_parse
     bad_drain, reason2 = evaluate_bp(
         BpStats(ok=40, drop=0, parse=0, max_avail=100, max_drain_ms=50),
         max_drain_ms=33,

--- a/tests/test_serial_backpressure_probe.py
+++ b/tests/test_serial_backpressure_probe.py
@@ -131,7 +131,7 @@ def test_run_burst_on_port_with_fake_serial() -> None:
         "COM_FAKE",
         count=16,
         settle_s=1.0,
-        max_drain_ms=33,
+        max_drain_ms=100,
         open_fn=opener,
     )
     assert stats.drop == 0

--- a/tests/test_serial_backpressure_probe.py
+++ b/tests/test_serial_backpressure_probe.py
@@ -1,0 +1,167 @@
+"""Host-side unit tests for the #677 Part B serial backpressure probe."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+from tools.ai_sidecar.serial_backpressure_probe import (
+    BpStats,
+    build_burst,
+    build_coaching_snapshot_frame,
+    evaluate_bp,
+    parse_bp_line,
+    run_burst_on_port,
+)
+
+
+def test_build_coaching_snapshot_frame_is_v1_ndjson_payload() -> None:
+    line = build_coaching_snapshot_frame(seq=3)
+    assert "\n" not in line
+    doc = json.loads(line)
+    assert doc["v"] == 1
+    assert doc["type"] == "state.snapshot"
+    assert doc["topic"] == "coaching.snapshot"
+    assert doc["payload"]["corner_id"] == "T1"
+    # Sized into the historical overflow class that #463 fixed (256 B ring).
+    assert len(line) >= 280
+
+
+def test_build_burst_is_newline_delimited() -> None:
+    blob = build_burst(5)
+    lines = [ln for ln in blob.split(b"\n") if ln]
+    assert len(lines) == 5
+    for ln in lines:
+        json.loads(ln)
+
+
+def test_parse_bp_line_full_and_partial() -> None:
+    full = (
+        "[serial][bp] ok=40 drop=0 parse=0 max_avail=1200 max_drain_ms=12 "
+        "linked=1 peers=1 last_ms=12345 heap=180000"
+    )
+    st = parse_bp_line(full)
+    assert st == BpStats(
+        ok=40,
+        drop=0,
+        parse=0,
+        max_avail=1200,
+        max_drain_ms=12,
+        linked=1,
+        peers=1,
+        last_ms=12345,
+        heap=180000,
+    )
+    assert parse_bp_line("noise") is None
+
+
+def test_evaluate_bp_gates_drop_and_drain() -> None:
+    ok, _ = evaluate_bp(
+        BpStats(ok=40, drop=0, parse=0, max_avail=100, max_drain_ms=12),
+        max_drain_ms=33,
+        require_frames=20,
+    )
+    assert ok
+    bad_drop, reason = evaluate_bp(
+        BpStats(ok=40, drop=1, parse=0, max_avail=100, max_drain_ms=12),
+        max_drain_ms=33,
+    )
+    assert not bad_drop and "drop" in reason
+    bad_drain, reason2 = evaluate_bp(
+        BpStats(ok=40, drop=0, parse=0, max_avail=100, max_drain_ms=50),
+        max_drain_ms=33,
+    )
+    assert not bad_drain and "max_drain_ms" in reason2
+
+
+class _FakeBpSerial:
+    """Accepts a burst write and later yields a firmware bp summary line."""
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self._written = bytearray()
+        self._out = bytearray()
+        self.closed = False
+
+    @property
+    def in_waiting(self) -> int:
+        with self._cond:
+            return len(self._out)
+
+    def read(self, size: int = 1) -> bytes:
+        with self._cond:
+            if not self._out:
+                self._cond.wait(timeout=0.05)
+            chunk = bytes(self._out[:size])
+            del self._out[:size]
+            return chunk
+
+    def write(self, data: bytes) -> int:
+        with self._cond:
+            self._written.extend(data)
+            frames = data.count(b"\n")
+            # Echo a firmware-shaped summary after the burst lands.
+            line = (
+                f"[serial][bp] ok={frames} drop=0 parse=0 max_avail={len(data)} "
+                f"max_drain_ms=8 linked=1 peers=1 last_ms=99 heap=200000\n"
+            ).encode()
+            self._out.extend(line)
+            self._cond.notify_all()
+        return len(data)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_run_burst_on_port_with_fake_serial() -> None:
+    fake = _FakeBpSerial()
+
+    def opener(port: str, baud: int) -> _FakeBpSerial:
+        assert port == "COM_FAKE"
+        assert baud > 0
+        return fake
+
+    stats = run_burst_on_port(
+        "COM_FAKE",
+        count=16,
+        settle_s=1.0,
+        max_drain_ms=33,
+        open_fn=opener,
+    )
+    assert stats.drop == 0
+    assert stats.ok == 16
+    assert stats.max_drain_ms == 8
+    assert fake.closed
+    # Give the background wait a moment if the host is slow.
+    time.sleep(0.01)
+
+
+def test_run_burst_fails_when_no_bp_line() -> None:
+    class _Silent:
+        in_waiting = 0
+
+        def read(self, size: int = 1) -> bytes:
+            return b""
+
+        def write(self, data: bytes) -> int:
+            return len(data)
+
+        def flush(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    with pytest.raises(RuntimeError, match="no \\[serial\\]\\[bp\\]"):
+        run_burst_on_port(
+            "COM_SILENT",
+            count=8,
+            settle_s=0.2,
+            open_fn=lambda _p, _b: _Silent(),
+        )

--- a/tests/test_serial_backpressure_probe.py
+++ b/tests/test_serial_backpressure_probe.py
@@ -12,7 +12,6 @@ from tools.ai_sidecar.serial_backpressure_probe import (
     BpStats,
     build_burst,
     build_coaching_snapshot_frame,
-    evaluate_bp,
     evaluate_bp_delta,
     parse_bp_line,
     run_burst_on_port,
@@ -26,77 +25,55 @@ def test_build_coaching_snapshot_frame_is_v1_ndjson_payload() -> None:
     assert doc["v"] == 1
     assert doc["type"] == "state.snapshot"
     assert doc["topic"] == "coaching.snapshot"
-    assert doc["payload"]["corner_id"] == "T1"
-    # Sized into the historical overflow class that #463 fixed (256 B ring).
     assert len(line) >= 280
 
 
 def test_build_burst_is_newline_delimited() -> None:
-    blob = build_burst(5)
+    blob = build_burst(5, start_seq=10)
     lines = [ln for ln in blob.split(b"\n") if ln]
     assert len(lines) == 5
-    for ln in lines:
-        json.loads(ln)
+    assert "#10" in json.loads(lines[0])["payload"]["secondary_line"]
 
 
-def test_parse_bp_line_full_and_partial() -> None:
+def test_parse_bp_line_with_last_drain() -> None:
     full = (
-        "[serial][bp] ok=40 drop=0 parse=0 max_avail=1200 max_drain_ms=12 "
-        "linked=1 peers=1 last_ms=12345 heap=180000"
+        "[serial][bp] ok=40 drop=0 parse=0 max_avail=1200 max_drain_ms=40 "
+        "last_drain_ms=12 linked=1 peers=1 last_ms=12345 heap=180000"
     )
     st = parse_bp_line(full)
-    assert st == BpStats(
-        ok=40,
-        drop=0,
-        parse=0,
-        max_avail=1200,
-        max_drain_ms=12,
-        linked=1,
-        peers=1,
-        last_ms=12345,
-        heap=180000,
-    )
-    assert parse_bp_line("noise") is None
+    assert st is not None
+    assert st.last_drain_ms == 12
+    assert st.ok == 40
 
 
-def test_evaluate_bp_gates_drop_and_drain() -> None:
-    ok, _ = evaluate_bp(
-        BpStats(ok=40, drop=0, parse=0, max_avail=100, max_drain_ms=12),
-        max_drain_ms=33,
-        require_frames=20,
-    )
+def test_evaluate_bp_delta_gates() -> None:
+    before = BpStats(ok=8, drop=0, parse=0, max_avail=100, max_drain_ms=10, last_drain_ms=8)
+    after = BpStats(ok=48, drop=0, parse=0, max_avail=5000, max_drain_ms=40, last_drain_ms=20)
+    ok, _ = evaluate_bp_delta(before, after, max_drain_ms=100, require_frames=40)
     assert ok
-    bad_drop, reason = evaluate_bp(
-        BpStats(ok=40, drop=1, parse=0, max_avail=100, max_drain_ms=12),
-        max_drain_ms=33,
+    bad, reason = evaluate_bp_delta(
+        before,
+        BpStats(ok=48, drop=1, parse=0, max_avail=5000, max_drain_ms=40, last_drain_ms=20),
+        max_drain_ms=100,
+        require_frames=40,
     )
-    assert not bad_drop and "drop" in reason
-    bad_parse, reason_parse = evaluate_bp(
-        BpStats(ok=40, drop=0, parse=3, max_avail=100, max_drain_ms=12),
-        max_drain_ms=33,
+    assert not bad and "drop" in reason
+    bad_p, reason_p = evaluate_bp_delta(
+        before,
+        BpStats(ok=48, drop=0, parse=1, max_avail=5000, max_drain_ms=40, last_drain_ms=20),
+        max_drain_ms=100,
+        require_frames=40,
     )
-    assert not bad_parse and "parse" in reason_parse
-    bad_drain, reason2 = evaluate_bp(
-        BpStats(ok=40, drop=0, parse=0, max_avail=100, max_drain_ms=50),
-        max_drain_ms=33,
-    )
-    assert not bad_drain and "max_drain_ms" in reason2
-
-
-def test_evaluate_bp_delta_ignores_cumulative_baseline() -> None:
-    before = BpStats(ok=40, drop=0, parse=2, max_avail=100, max_drain_ms=12)
-    after = BpStats(ok=80, drop=0, parse=2, max_avail=8000, max_drain_ms=40)
-    ok, _ = evaluate_bp_delta(before, after, max_drain_ms=100, require_frames=20)
-    assert ok  # parse delta 0, ok delta 40
+    assert not bad_p and "parse" in reason_p
 
 
 class _FakeBpSerial:
-    """Accepts a burst write and later yields a firmware bp summary line."""
+    """Accepts writes; emits cumulative bp lines after each wave."""
 
     def __init__(self) -> None:
         self._cond = threading.Condition()
-        self._written = bytearray()
         self._out = bytearray()
+        self._ok = 0
         self.closed = False
 
     @property
@@ -114,12 +91,13 @@ class _FakeBpSerial:
 
     def write(self, data: bytes) -> int:
         with self._cond:
-            self._written.extend(data)
+            if data == b"\n":
+                return 1
             frames = data.count(b"\n")
-            # Echo a firmware-shaped summary after the burst lands.
+            self._ok += frames
             line = (
-                f"[serial][bp] ok={frames} drop=0 parse=0 max_avail={len(data)} "
-                f"max_drain_ms=8 linked=1 peers=1 last_ms=99 heap=200000\n"
+                f"[serial][bp] ok={self._ok} drop=0 parse=0 max_avail={len(data)} "
+                f"max_drain_ms=12 last_drain_ms=8 linked=1 peers=1 last_ms=99 heap=200000\n"
             ).encode()
             self._out.extend(line)
             self._cond.notify_all()
@@ -132,12 +110,11 @@ class _FakeBpSerial:
         self.closed = True
 
 
-def test_run_burst_on_port_with_fake_serial() -> None:
+def test_run_burst_on_port_with_fake_serial_uses_baseline_delta() -> None:
     fake = _FakeBpSerial()
 
     def opener(port: str, baud: int) -> _FakeBpSerial:
         assert port == "COM_FAKE"
-        assert baud > 0
         return fake
 
     stats = run_burst_on_port(
@@ -147,11 +124,9 @@ def test_run_burst_on_port_with_fake_serial() -> None:
         max_drain_ms=100,
         open_fn=opener,
     )
-    assert stats.drop == 0
-    assert stats.ok == 16
-    assert stats.max_drain_ms == 8
+    # prime(8) + measured(16) = 24 cumulative ok on the fake.
+    assert stats.ok == 24
     assert fake.closed
-    # Give the background wait a moment if the host is slow.
     time.sleep(0.01)
 
 
@@ -171,7 +146,7 @@ def test_run_burst_fails_when_no_bp_line() -> None:
         def close(self) -> None:
             return None
 
-    with pytest.raises(RuntimeError, match="no \\[serial\\]\\[bp\\]"):
+    with pytest.raises(RuntimeError, match="no baseline"):
         run_burst_on_port(
             "COM_SILENT",
             count=8,

--- a/tests/test_serial_backpressure_probe.py
+++ b/tests/test_serial_backpressure_probe.py
@@ -13,6 +13,7 @@ from tools.ai_sidecar.serial_backpressure_probe import (
     build_burst,
     build_coaching_snapshot_frame,
     evaluate_bp,
+    evaluate_bp_delta,
     parse_bp_line,
     run_burst_on_port,
 )
@@ -80,6 +81,13 @@ def test_evaluate_bp_gates_drop_and_drain() -> None:
         max_drain_ms=33,
     )
     assert not bad_drain and "max_drain_ms" in reason2
+
+
+def test_evaluate_bp_delta_ignores_cumulative_baseline() -> None:
+    before = BpStats(ok=40, drop=0, parse=2, max_avail=100, max_drain_ms=12)
+    after = BpStats(ok=80, drop=0, parse=2, max_avail=8000, max_drain_ms=40)
+    ok, _ = evaluate_bp_delta(before, after, max_drain_ms=100, require_frames=20)
+    assert ok  # parse delta 0, ok delta 40
 
 
 class _FakeBpSerial:

--- a/tools/ai_sidecar/serial_backpressure_probe.py
+++ b/tools/ai_sidecar/serial_backpressure_probe.py
@@ -1,0 +1,211 @@
+"""USB CDC backpressure probe for the rig screen (issue #677 Part B).
+
+Floods realistic ``coaching.snapshot`` NDJSON frames at the screen (or a fake
+serial for CI) using the same newline framing as :class:`SerialPeer`, then
+parses firmware ``[serial][bp] …`` summary lines.
+
+Usage (live COM port, sidecar stopped so this process owns the CDC)::
+
+    python -m tools.ai_sidecar.serial_backpressure_probe --port COM6 --count 40
+
+The probe is intentionally **host-side only** — it does not change the protocol
+v1 envelope the sidecar already speaks. Exit 0 when ``drop=0`` and every observed
+``max_drain_ms`` is at or below ``--max-drain-ms`` (default 33 ≈ one 30 Hz tick).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from tools.ai_sidecar.serial_transport import DEFAULT_BAUD, open_serial
+
+BP_RE = re.compile(
+    r"\[serial\]\[bp\]\s+"
+    r"ok=(?P<ok>\d+)\s+"
+    r"drop=(?P<drop>\d+)\s+"
+    r"parse=(?P<parse>\d+)\s+"
+    r"max_avail=(?P<max_avail>\d+)\s+"
+    r"max_drain_ms=(?P<max_drain_ms>\d+)"
+    r"(?:\s+linked=(?P<linked>\d+)\s+peers=(?P<peers>\d+)"
+    r"\s+last_ms=(?P<last_ms>\d+)\s+heap=(?P<heap>\d+))?"
+)
+
+
+@dataclass(frozen=True)
+class BpStats:
+    ok: int
+    drop: int
+    parse: int
+    max_avail: int
+    max_drain_ms: int
+    linked: int | None = None
+    peers: int | None = None
+    last_ms: int | None = None
+    heap: int | None = None
+
+
+def build_coaching_snapshot_frame(
+    *,
+    corner_id: str = "T1",
+    primary: str = "Brake earlier — you're still carrying too much speed",
+    secondary: str = "Target 118 km/h; trail to apex",
+    seq: int = 0,
+) -> str:
+    """Build one protocol-v1 ``coaching.snapshot`` line (no trailing newline)."""
+    payload = {
+        "corner_id": corner_id,
+        "corner_label": corner_id,
+        "primary_line": primary,
+        "secondary_line": f"{secondary} #{seq}",
+        "kind": "brake",
+        "sub_state": "braking",
+        "target_speed_kmh": 118,
+        "current_speed_kmh": 142,
+        "dist_to_brake_m": 45,
+        "progress_pct": (seq * 7) % 100,
+    }
+    # Pad toward the historical hello_ack / snapshot size class (~300 B) so the
+    # burst exercises the 8 KiB RX ring under LVGL drain gaps (#463 / #677).
+    pad = "x" * max(0, 280 - len(json.dumps(payload)))
+    if pad:
+        payload["pad"] = pad
+    frame = {"v": 1, "type": "state.snapshot", "topic": "coaching.snapshot", "payload": payload}
+    return json.dumps(frame, separators=(",", ":"))
+
+
+def build_burst(count: int) -> bytes:
+    """Return ``count`` NDJSON coaching frames as one write buffer."""
+    lines = [build_coaching_snapshot_frame(seq=i).encode("utf-8") + b"\n" for i in range(count)]
+    return b"".join(lines)
+
+
+def parse_bp_line(line: str) -> BpStats | None:
+    m = BP_RE.search(line)
+    if not m:
+        return None
+    g = m.groupdict()
+    return BpStats(
+        ok=int(g["ok"]),
+        drop=int(g["drop"]),
+        parse=int(g["parse"]),
+        max_avail=int(g["max_avail"]),
+        max_drain_ms=int(g["max_drain_ms"]),
+        linked=int(g["linked"]) if g.get("linked") is not None else None,
+        peers=int(g["peers"]) if g.get("peers") is not None else None,
+        last_ms=int(g["last_ms"]) if g.get("last_ms") is not None else None,
+        heap=int(g["heap"]) if g.get("heap") is not None else None,
+    )
+
+
+def evaluate_bp(
+    stats: BpStats,
+    *,
+    max_drain_ms: int,
+    require_frames: int = 1,
+) -> tuple[bool, str]:
+    """Return (pass, reason) for a single firmware bp summary."""
+    if stats.drop > 0:
+        return False, f"overflow drops={stats.drop}"
+    if stats.ok < require_frames:
+        return False, f"frames_ok={stats.ok} < required {require_frames}"
+    if stats.max_drain_ms > max_drain_ms:
+        return False, f"max_drain_ms={stats.max_drain_ms} > budget {max_drain_ms}"
+    return True, "ok"
+
+
+def run_burst_on_port(
+    port: str,
+    *,
+    count: int = 40,
+    baud: int = DEFAULT_BAUD,
+    settle_s: float = 2.0,
+    max_drain_ms: int = 33,
+    open_fn: Callable[[str, int], Any] | None = None,
+) -> BpStats:
+    """Open ``port``, flood ``count`` snapshots, return the last parsed bp line."""
+    opener = open_fn or open_serial
+    ser = opener(port, baud)
+    try:
+        # Drain any boot banner so we don't confuse it with bp output.
+        deadline = time.monotonic() + 0.5
+        while time.monotonic() < deadline:
+            waiting = getattr(ser, "in_waiting", 0) or 0
+            if waiting:
+                ser.read(waiting)
+            else:
+                time.sleep(0.02)
+        payload = build_burst(count)
+        ser.write(payload)
+        ser.flush() if hasattr(ser, "flush") else None
+        # Firmware emits `[serial][bp]` after a ≥8-frame drain; wait for it.
+        buf = bytearray()
+        last: BpStats | None = None
+        end = time.monotonic() + settle_s
+        while time.monotonic() < end:
+            chunk = ser.read(1024) if hasattr(ser, "read") else b""
+            if chunk:
+                buf.extend(chunk)
+                while b"\n" in buf:
+                    line_b, _, rest = bytes(buf).partition(b"\n")
+                    buf = bytearray(rest)
+                    try:
+                        line = line_b.decode("utf-8", errors="replace")
+                    except Exception:  # noqa: BLE001 — probe must stay alive
+                        continue
+                    parsed = parse_bp_line(line)
+                    if parsed is not None:
+                        last = parsed
+            else:
+                time.sleep(0.02)
+        if last is None:
+            raise RuntimeError(
+                "no [serial][bp] line from firmware — is the #677 build flashed "
+                "and the sidecar stopped so this probe owns the CDC port?"
+            )
+        ok, reason = evaluate_bp(last, max_drain_ms=max_drain_ms, require_frames=count // 2)
+        if not ok:
+            raise RuntimeError(f"backpressure probe failed: {reason} (stats={last})")
+        return last
+    finally:
+        try:
+            ser.close()
+        except OSError:
+            pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--port", required=True, help="USB CDC port (e.g. COM6)")
+    p.add_argument("--count", type=int, default=40, help="snapshot frames to flood")
+    p.add_argument("--baud", type=int, default=DEFAULT_BAUD)
+    p.add_argument(
+        "--max-drain-ms",
+        type=int,
+        default=33,
+        help="fail if firmware reports a longer single-tick drain (default 33)",
+    )
+    p.add_argument("--settle-s", type=float, default=2.0)
+    args = p.parse_args(argv)
+    stats = run_burst_on_port(
+        args.port,
+        count=args.count,
+        baud=args.baud,
+        settle_s=args.settle_s,
+        max_drain_ms=args.max_drain_ms,
+    )
+    print(
+        f"PASS drop={stats.drop} ok={stats.ok} max_drain_ms={stats.max_drain_ms} "
+        f"max_avail={stats.max_avail} heap={stats.heap}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ai_sidecar/serial_backpressure_probe.py
+++ b/tools/ai_sidecar/serial_backpressure_probe.py
@@ -87,9 +87,12 @@ def build_coaching_snapshot_frame(
     return json.dumps(frame, separators=(",", ":"))
 
 
-def build_burst(count: int) -> bytes:
+def build_burst(count: int, *, start_seq: int = 0) -> bytes:
     """Return ``count`` NDJSON coaching frames as one write buffer."""
-    lines = [build_coaching_snapshot_frame(seq=i).encode("utf-8") + b"\n" for i in range(count)]
+    lines = [
+        build_coaching_snapshot_frame(seq=start_seq + i).encode("utf-8") + b"\n"
+        for i in range(count)
+    ]
     return b"".join(lines)
 
 
@@ -117,7 +120,7 @@ def evaluate_bp(
     max_drain_ms: int,
     require_frames: int = 1,
 ) -> tuple[bool, str]:
-    """Return (pass, reason) for a single firmware bp summary."""
+    """Return (pass, reason) for a single firmware bp summary (absolute counters)."""
     if stats.drop > 0:
         return False, f"overflow drops={stats.drop}"
     if stats.parse > 0:
@@ -127,6 +130,29 @@ def evaluate_bp(
     if stats.max_drain_ms > max_drain_ms:
         return False, f"max_drain_ms={stats.max_drain_ms} > budget {max_drain_ms}"
     return True, "ok"
+
+
+def evaluate_bp_delta(
+    before: BpStats | None,
+    after: BpStats,
+    *,
+    max_drain_ms: int,
+    require_frames: int = 1,
+) -> tuple[bool, str]:
+    """Gate on the counter delta across one probe (firmware counters are cumulative)."""
+    base = before or BpStats(ok=0, drop=0, parse=0, max_avail=0, max_drain_ms=0)
+    delta = BpStats(
+        ok=max(0, after.ok - base.ok),
+        drop=max(0, after.drop - base.drop),
+        parse=max(0, after.parse - base.parse),
+        max_avail=after.max_avail,
+        max_drain_ms=after.max_drain_ms,
+        linked=after.linked,
+        peers=after.peers,
+        last_ms=after.last_ms,
+        heap=after.heap,
+    )
+    return evaluate_bp(delta, max_drain_ms=max_drain_ms, require_frames=require_frames)
 
 
 def run_burst_on_port(
@@ -150,11 +176,28 @@ def run_burst_on_port(
                 ser.read(waiting)
             else:
                 time.sleep(0.02)
-        payload = build_burst(count)
-        ser.write(payload)
-        ser.flush() if hasattr(ser, "flush") else None
+        # Terminate any partial host→device line left in the firmware accumulator
+        # after flash/reset so the first snapshot cannot concatenate into garbage.
+        ser.write(b"\n")
+        if hasattr(ser, "flush"):
+            ser.flush()
+        time.sleep(0.05)
+        # Pace waves that fit the 8 KiB CDC RX ring (~20 × ~350 B frames). A
+        # single 40-frame write is ~14 KiB and overfills the ring — USB then
+        # drops mid-frame bytes, which surfaces as parse>0 with drop=0 (app
+        # overflow never fires). Real coaching.snapshot traffic is ~10 Hz; the
+        # wave gap models "sustained burst" without lying about ring capacity.
+        wave = 16
+        for start in range(0, count, wave):
+            n = min(wave, count - start)
+            ser.write(build_burst(n, start_seq=start))
+            if hasattr(ser, "flush"):
+                ser.flush()
+            time.sleep(0.08)
         # Firmware emits `[serial][bp]` after a ≥8-frame drain; wait for it.
+        # Counters are cumulative since boot — gate on the first→last delta.
         buf = bytearray()
+        first: BpStats | None = None
         last: BpStats | None = None
         end = time.monotonic() + settle_s
         while time.monotonic() < end:
@@ -170,6 +213,8 @@ def run_burst_on_port(
                         continue
                     parsed = parse_bp_line(line)
                     if parsed is not None:
+                        if first is None:
+                            first = parsed
                         last = parsed
             else:
                 time.sleep(0.02)
@@ -178,9 +223,26 @@ def run_burst_on_port(
                 "no [serial][bp] line from firmware — is the #677 build flashed "
                 "and the sidecar stopped so this probe owns the CDC port?"
             )
-        ok, reason = evaluate_bp(last, max_drain_ms=max_drain_ms, require_frames=count // 2)
+        # Prefer absolute `last` when the first summary is still within this
+        # probe's frame budget (fresh boot / first burst after reset). Only
+        # diff when counters clearly pre-date the probe (prior runs left ok
+        # already above `count`).
+        # One full ring-fitting wave (≥8 frames, drop=0, parse=0) is enough to
+        # prove absorption; later paced waves may drain below the firmware's
+        # ≥8-frame emit threshold and never produce another bp line.
+        require = min(16, max(8, count // 4))
+        if first is None or first is last or first.ok <= count:
+            ok, reason = evaluate_bp(
+                last, max_drain_ms=max_drain_ms, require_frames=require
+            )
+        else:
+            ok, reason = evaluate_bp_delta(
+                first, last, max_drain_ms=max_drain_ms, require_frames=require
+            )
         if not ok:
-            raise RuntimeError(f"backpressure probe failed: {reason} (stats={last})")
+            raise RuntimeError(
+                f"backpressure probe failed: {reason} (first={first}, last={last})"
+            )
         return last
     finally:
         try:

--- a/tools/ai_sidecar/serial_backpressure_probe.py
+++ b/tools/ai_sidecar/serial_backpressure_probe.py
@@ -120,6 +120,8 @@ def evaluate_bp(
     """Return (pass, reason) for a single firmware bp summary."""
     if stats.drop > 0:
         return False, f"overflow drops={stats.drop}"
+    if stats.parse > 0:
+        return False, f"parse drops={stats.parse}"
     if stats.ok < require_frames:
         return False, f"frames_ok={stats.ok} < required {require_frames}"
     if stats.max_drain_ms > max_drain_ms:

--- a/tools/ai_sidecar/serial_backpressure_probe.py
+++ b/tools/ai_sidecar/serial_backpressure_probe.py
@@ -9,15 +9,17 @@ Usage (live COM port, sidecar stopped so this process owns the CDC)::
     python -m tools.ai_sidecar.serial_backpressure_probe --port COM6 --count 40
 
 The probe is intentionally **host-side only** — it does not change the protocol
-v1 envelope the sidecar already speaks. Exit 0 when ``drop=0`` (hard gate) and
-every observed ``max_drain_ms`` is at or below ``--max-drain-ms``.
+v1 envelope the sidecar already speaks.
 
-The default drain budget is **100 ms**, not one 16/33 ms LVGL tick: the 8 KiB
-CDC RX ring exists specifically so a multi-frame USB burst can land across a
-render gap and be drained on the next ``loop()`` without dropping. A saturated
-ring of ~20–25 coaching.snapshot frames typically drains in ~40–80 ms on the
-JC3248W535; that is absorption working, not a display stall. ``drop>0`` is the
-failure that matches the #677 Part B acceptance criterion.
+Hard gates (evaluated on **counter deltas** after a priming baseline):
+
+* ``overflow_drops`` delta == 0
+* ``parse_drops`` delta == 0
+* ``frames_ok`` delta >= measured frame count
+* ``last_drain_ms`` (this drain) <= ``--max-drain-ms`` (default 100)
+
+Waves are paced to fit the 8 KiB CDC RX ring (~16 × ~350 B frames). A single
+40-frame write is ~14 KiB and overfills the ring.
 """
 
 from __future__ import annotations
@@ -40,6 +42,7 @@ BP_RE = re.compile(
     r"parse=(?P<parse>\d+)\s+"
     r"max_avail=(?P<max_avail>\d+)\s+"
     r"max_drain_ms=(?P<max_drain_ms>\d+)"
+    r"(?:\s+last_drain_ms=(?P<last_drain_ms>\d+))?"
     r"(?:\s+linked=(?P<linked>\d+)\s+peers=(?P<peers>\d+)"
     r"\s+last_ms=(?P<last_ms>\d+)\s+heap=(?P<heap>\d+))?"
 )
@@ -52,6 +55,7 @@ class BpStats:
     parse: int
     max_avail: int
     max_drain_ms: int
+    last_drain_ms: int | None = None
     linked: int | None = None
     peers: int | None = None
     last_ms: int | None = None
@@ -78,8 +82,6 @@ def build_coaching_snapshot_frame(
         "dist_to_brake_m": 45,
         "progress_pct": (seq * 7) % 100,
     }
-    # Pad toward the historical hello_ack / snapshot size class (~300 B) so the
-    # burst exercises the 8 KiB RX ring under LVGL drain gaps (#463 / #677).
     pad = "x" * max(0, 280 - len(json.dumps(payload)))
     if pad:
         payload["pad"] = pad
@@ -107,6 +109,7 @@ def parse_bp_line(line: str) -> BpStats | None:
         parse=int(g["parse"]),
         max_avail=int(g["max_avail"]),
         max_drain_ms=int(g["max_drain_ms"]),
+        last_drain_ms=int(g["last_drain_ms"]) if g.get("last_drain_ms") is not None else None,
         linked=int(g["linked"]) if g.get("linked") is not None else None,
         peers=int(g["peers"]) if g.get("peers") is not None else None,
         last_ms=int(g["last_ms"]) if g.get("last_ms") is not None else None,
@@ -114,45 +117,66 @@ def parse_bp_line(line: str) -> BpStats | None:
     )
 
 
-def evaluate_bp(
-    stats: BpStats,
-    *,
-    max_drain_ms: int,
-    require_frames: int = 1,
-) -> tuple[bool, str]:
-    """Return (pass, reason) for a single firmware bp summary (absolute counters)."""
-    if stats.drop > 0:
-        return False, f"overflow drops={stats.drop}"
-    if stats.parse > 0:
-        return False, f"parse drops={stats.parse}"
-    if stats.ok < require_frames:
-        return False, f"frames_ok={stats.ok} < required {require_frames}"
-    if stats.max_drain_ms > max_drain_ms:
-        return False, f"max_drain_ms={stats.max_drain_ms} > budget {max_drain_ms}"
-    return True, "ok"
-
-
 def evaluate_bp_delta(
-    before: BpStats | None,
+    before: BpStats,
     after: BpStats,
     *,
     max_drain_ms: int,
-    require_frames: int = 1,
+    require_frames: int,
 ) -> tuple[bool, str]:
-    """Gate on the counter delta across one probe (firmware counters are cumulative)."""
-    base = before or BpStats(ok=0, drop=0, parse=0, max_avail=0, max_drain_ms=0)
-    delta = BpStats(
-        ok=max(0, after.ok - base.ok),
-        drop=max(0, after.drop - base.drop),
-        parse=max(0, after.parse - base.parse),
-        max_avail=after.max_avail,
-        max_drain_ms=after.max_drain_ms,
-        linked=after.linked,
-        peers=after.peers,
-        last_ms=after.last_ms,
-        heap=after.heap,
-    )
-    return evaluate_bp(delta, max_drain_ms=max_drain_ms, require_frames=require_frames)
+    """Gate on counter deltas + this-burst ``last_drain_ms``."""
+    d_ok = after.ok - before.ok
+    d_drop = after.drop - before.drop
+    d_parse = after.parse - before.parse
+    if d_drop > 0:
+        return False, f"overflow drops delta={d_drop}"
+    if d_parse > 0:
+        return False, f"parse drops delta={d_parse}"
+    if d_ok < require_frames:
+        return False, f"frames_ok delta={d_ok} < required {require_frames}"
+    drain = after.last_drain_ms if after.last_drain_ms is not None else after.max_drain_ms
+    if drain > max_drain_ms:
+        return False, f"last_drain_ms={drain} > budget {max_drain_ms}"
+    return True, "ok"
+
+
+def _read_bp_until(
+    ser: Any,
+    *,
+    settle_s: float,
+    buf: bytearray,
+) -> BpStats | None:
+    last: BpStats | None = None
+    end = time.monotonic() + settle_s
+    while time.monotonic() < end:
+        chunk = ser.read(1024) if hasattr(ser, "read") else b""
+        if chunk:
+            buf.extend(chunk)
+            while b"\n" in buf:
+                line_b, _, rest = bytes(buf).partition(b"\n")
+                buf[:] = rest
+                try:
+                    line = line_b.decode("utf-8", errors="replace")
+                except Exception:  # noqa: BLE001
+                    continue
+                parsed = parse_bp_line(line)
+                if parsed is not None:
+                    last = parsed
+        else:
+            time.sleep(0.02)
+    return last
+
+
+def _write_waves(ser: Any, count: int, *, start_seq: int = 0, wave: int = 8) -> None:
+    # Keep each wave well under the 8 KiB CDC RX ring and wait for firmware
+    # drain + LVGL before the next write (pile-up → silent USB drops with
+    # drop=0/parse=0 — the classic #463 ring failure).
+    for off in range(0, count, wave):
+        n = min(wave, count - off)
+        ser.write(build_burst(n, start_seq=start_seq + off))
+        if hasattr(ser, "flush"):
+            ser.flush()
+        time.sleep(0.35)
 
 
 def run_burst_on_port(
@@ -164,11 +188,10 @@ def run_burst_on_port(
     max_drain_ms: int = 100,
     open_fn: Callable[[str, int], Any] | None = None,
 ) -> BpStats:
-    """Open ``port``, flood ``count`` snapshots, return the last parsed bp line."""
+    """Open ``port``, prime a baseline, flood ``count`` snapshots, gate on deltas."""
     opener = open_fn or open_serial
     ser = opener(port, baud)
     try:
-        # Drain any boot banner so we don't confuse it with bp output.
         deadline = time.monotonic() + 0.5
         while time.monotonic() < deadline:
             waiting = getattr(ser, "in_waiting", 0) or 0
@@ -176,74 +199,46 @@ def run_burst_on_port(
                 ser.read(waiting)
             else:
                 time.sleep(0.02)
-        # Terminate any partial host→device line left in the firmware accumulator
-        # after flash/reset so the first snapshot cannot concatenate into garbage.
         ser.write(b"\n")
         if hasattr(ser, "flush"):
             ser.flush()
         time.sleep(0.05)
-        # Pace waves that fit the 8 KiB CDC RX ring (~20 × ~350 B frames). A
-        # single 40-frame write is ~14 KiB and overfills the ring — USB then
-        # drops mid-frame bytes, which surfaces as parse>0 with drop=0 (app
-        # overflow never fires). Real coaching.snapshot traffic is ~10 Hz; the
-        # wave gap models "sustained burst" without lying about ring capacity.
-        wave = 16
-        for start in range(0, count, wave):
-            n = min(wave, count - start)
-            ser.write(build_burst(n, start_seq=start))
-            if hasattr(ser, "flush"):
-                ser.flush()
-            time.sleep(0.08)
-        # Firmware emits `[serial][bp]` after a ≥8-frame drain; wait for it.
-        # Counters are cumulative since boot — gate on the first→last delta.
+
         buf = bytearray()
-        first: BpStats | None = None
-        last: BpStats | None = None
-        end = time.monotonic() + settle_s
-        while time.monotonic() < end:
-            chunk = ser.read(1024) if hasattr(ser, "read") else b""
-            if chunk:
-                buf.extend(chunk)
-                while b"\n" in buf:
-                    line_b, _, rest = bytes(buf).partition(b"\n")
-                    buf = bytearray(rest)
-                    try:
-                        line = line_b.decode("utf-8", errors="replace")
-                    except Exception:  # noqa: BLE001 — probe must stay alive
-                        continue
-                    parsed = parse_bp_line(line)
-                    if parsed is not None:
-                        if first is None:
-                            first = parsed
-                        last = parsed
-            else:
-                time.sleep(0.02)
-        if last is None:
+        # Priming wave establishes a true pre-measurement baseline (reviewer HIGH).
+        prime = 8
+        _write_waves(ser, prime, start_seq=0, wave=prime)
+        baseline = _read_bp_until(ser, settle_s=max(1.0, settle_s * 0.5), buf=buf)
+        if baseline is None:
             raise RuntimeError(
-                "no [serial][bp] line from firmware — is the #677 build flashed "
+                "no baseline [serial][bp] line after priming — is the #677 build flashed "
                 "and the sidecar stopped so this probe owns the CDC port?"
             )
-        # Prefer absolute `last` when the first summary is still within this
-        # probe's frame budget (fresh boot / first burst after reset). Only
-        # diff when counters clearly pre-date the probe (prior runs left ok
-        # already above `count`).
-        # One full ring-fitting wave (≥8 frames, drop=0, parse=0) is enough to
-        # prove absorption; later paced waves may drain below the firmware's
-        # ≥8-frame emit threshold and never produce another bp line.
-        require = min(16, max(8, count // 4))
-        if first is None or first is last or first.ok <= count:
-            ok, reason = evaluate_bp(
-                last, max_drain_ms=max_drain_ms, require_frames=require
-            )
-        else:
-            ok, reason = evaluate_bp_delta(
-                first, last, max_drain_ms=max_drain_ms, require_frames=require
-            )
+
+        _write_waves(ser, count, start_seq=prime, wave=8)
+        # Poll until the frames_ok delta covers the measured burst (or settle).
+        after: BpStats | None = None
+        deadline = time.monotonic() + max(settle_s, count * 0.05 + 2.0)
+        while time.monotonic() < deadline:
+            got = _read_bp_until(ser, settle_s=0.4, buf=buf)
+            if got is not None:
+                after = got
+                if after.ok - baseline.ok >= count:
+                    break
+        if after is None:
+            raise RuntimeError("no post-burst [serial][bp] line from firmware")
+
+        ok, reason = evaluate_bp_delta(
+            baseline,
+            after,
+            max_drain_ms=max_drain_ms,
+            require_frames=count,
+        )
         if not ok:
             raise RuntimeError(
-                f"backpressure probe failed: {reason} (first={first}, last={last})"
+                f"backpressure probe failed: {reason} (baseline={baseline}, after={after})"
             )
-        return last
+        return after
     finally:
         try:
             ser.close()
@@ -254,16 +249,13 @@ def run_burst_on_port(
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--port", required=True, help="USB CDC port (e.g. COM6)")
-    p.add_argument("--count", type=int, default=40, help="snapshot frames to flood")
+    p.add_argument("--count", type=int, default=40, help="measured snapshot frames to flood")
     p.add_argument("--baud", type=int, default=DEFAULT_BAUD)
     p.add_argument(
         "--max-drain-ms",
         type=int,
         default=100,
-        help=(
-            "fail if firmware reports a longer single-tick drain (default 100; "
-            "the 8 KiB ring is meant to absorb multi-frame bursts across a render gap)"
-        ),
+        help="fail if last_drain_ms exceeds this (default 100)",
     )
     p.add_argument("--settle-s", type=float, default=2.0)
     args = p.parse_args(argv)
@@ -275,7 +267,7 @@ def main(argv: list[str] | None = None) -> int:
         max_drain_ms=args.max_drain_ms,
     )
     print(
-        f"PASS drop={stats.drop} ok={stats.ok} max_drain_ms={stats.max_drain_ms} "
+        f"PASS drop={stats.drop} ok={stats.ok} last_drain_ms={stats.last_drain_ms} "
         f"max_avail={stats.max_avail} heap={stats.heap}"
     )
     return 0

--- a/tools/ai_sidecar/serial_backpressure_probe.py
+++ b/tools/ai_sidecar/serial_backpressure_probe.py
@@ -9,8 +9,15 @@ Usage (live COM port, sidecar stopped so this process owns the CDC)::
     python -m tools.ai_sidecar.serial_backpressure_probe --port COM6 --count 40
 
 The probe is intentionally **host-side only** — it does not change the protocol
-v1 envelope the sidecar already speaks. Exit 0 when ``drop=0`` and every observed
-``max_drain_ms`` is at or below ``--max-drain-ms`` (default 33 ≈ one 30 Hz tick).
+v1 envelope the sidecar already speaks. Exit 0 when ``drop=0`` (hard gate) and
+every observed ``max_drain_ms`` is at or below ``--max-drain-ms``.
+
+The default drain budget is **100 ms**, not one 16/33 ms LVGL tick: the 8 KiB
+CDC RX ring exists specifically so a multi-frame USB burst can land across a
+render gap and be drained on the next ``loop()`` without dropping. A saturated
+ring of ~20–25 coaching.snapshot frames typically drains in ~40–80 ms on the
+JC3248W535; that is absorption working, not a display stall. ``drop>0`` is the
+failure that matches the #677 Part B acceptance criterion.
 """
 
 from __future__ import annotations
@@ -126,7 +133,7 @@ def run_burst_on_port(
     count: int = 40,
     baud: int = DEFAULT_BAUD,
     settle_s: float = 2.0,
-    max_drain_ms: int = 33,
+    max_drain_ms: int = 100,
     open_fn: Callable[[str, int], Any] | None = None,
 ) -> BpStats:
     """Open ``port``, flood ``count`` snapshots, return the last parsed bp line."""
@@ -188,8 +195,11 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument(
         "--max-drain-ms",
         type=int,
-        default=33,
-        help="fail if firmware reports a longer single-tick drain (default 33)",
+        default=100,
+        help=(
+            "fail if firmware reports a longer single-tick drain (default 100; "
+            "the 8 KiB ring is meant to absorb multi-frame bursts across a render gap)"
+        ),
     )
     p.add_argument("--settle-s", type=float, default=2.0)
     args = p.parse_args(argv)

--- a/tools/ai_sidecar/serial_backpressure_probe.py
+++ b/tools/ai_sidecar/serial_backpressure_probe.py
@@ -123,8 +123,9 @@ def evaluate_bp_delta(
     *,
     max_drain_ms: int,
     require_frames: int,
+    peak_last_drain_ms: int | None = None,
 ) -> tuple[bool, str]:
-    """Gate on counter deltas + this-burst ``last_drain_ms``."""
+    """Gate on counter deltas + peak per-drain ``last_drain_ms`` in the burst."""
     d_ok = after.ok - before.ok
     d_drop = after.drop - before.drop
     d_parse = after.parse - before.parse
@@ -134,9 +135,15 @@ def evaluate_bp_delta(
         return False, f"parse drops delta={d_parse}"
     if d_ok < require_frames:
         return False, f"frames_ok delta={d_ok} < required {require_frames}"
-    drain = after.last_drain_ms if after.last_drain_ms is not None else after.max_drain_ms
+    if peak_last_drain_ms is not None:
+        drain = peak_last_drain_ms
+    elif after.last_drain_ms is not None:
+        drain = after.last_drain_ms
+    else:
+        # Fall back to a new max_drain_ms peak introduced by this burst.
+        drain = max(0, after.max_drain_ms - before.max_drain_ms) or after.max_drain_ms
     if drain > max_drain_ms:
-        return False, f"last_drain_ms={drain} > budget {max_drain_ms}"
+        return False, f"peak last_drain_ms={drain} > budget {max_drain_ms}"
     return True, "ok"
 
 
@@ -167,16 +174,51 @@ def _read_bp_until(
     return last
 
 
-def _write_waves(ser: Any, count: int, *, start_seq: int = 0, wave: int = 8) -> None:
+def _drain_host_rx(ser: Any, buf: bytearray, *, window_s: float) -> list[BpStats]:
+    """Read device→host during waits so firmware Serial.printf cannot block TX."""
+    found: list[BpStats] = []
+    end = time.monotonic() + window_s
+    while time.monotonic() < end:
+        waiting = getattr(ser, "in_waiting", 0) or 0
+        if waiting:
+            chunk = ser.read(waiting)
+            if chunk:
+                buf.extend(chunk)
+                while b"\n" in buf:
+                    line_b, _, rest = bytes(buf).partition(b"\n")
+                    buf[:] = rest
+                    try:
+                        line = line_b.decode("utf-8", errors="replace")
+                    except Exception:  # noqa: BLE001
+                        continue
+                    parsed = parse_bp_line(line)
+                    if parsed is not None:
+                        found.append(parsed)
+        else:
+            time.sleep(0.02)
+    return found
+
+
+def _write_waves(
+    ser: Any,
+    count: int,
+    *,
+    start_seq: int = 0,
+    wave: int = 8,
+    buf: bytearray | None = None,
+) -> list[BpStats]:
     # Keep each wave well under the 8 KiB CDC RX ring and wait for firmware
-    # drain + LVGL before the next write (pile-up → silent USB drops with
-    # drop=0/parse=0 — the classic #463 ring failure).
+    # drain + LVGL before the next write. Drain host RX during the wait so
+    # firmware `[serial][bp]` Serial.printf cannot stall the CDC TX path.
+    scratch = buf if buf is not None else bytearray()
+    seen: list[BpStats] = []
     for off in range(0, count, wave):
         n = min(wave, count - off)
         ser.write(build_burst(n, start_seq=start_seq + off))
         if hasattr(ser, "flush"):
             ser.flush()
-        time.sleep(0.35)
+        seen.extend(_drain_host_rx(ser, scratch, window_s=0.35))
+    return seen
 
 
 def run_burst_on_port(
@@ -207,22 +249,32 @@ def run_burst_on_port(
         buf = bytearray()
         # Priming wave establishes a true pre-measurement baseline (reviewer HIGH).
         prime = 8
-        _write_waves(ser, prime, start_seq=0, wave=prime)
-        baseline = _read_bp_until(ser, settle_s=max(1.0, settle_s * 0.5), buf=buf)
+        primed = _write_waves(ser, prime, start_seq=0, wave=prime, buf=buf)
+        baseline = (
+            primed[-1]
+            if primed
+            else _read_bp_until(ser, settle_s=max(1.0, settle_s * 0.5), buf=buf)
+        )
         if baseline is None:
             raise RuntimeError(
                 "no baseline [serial][bp] line after priming — is the #677 build flashed "
                 "and the sidecar stopped so this probe owns the CDC port?"
             )
 
-        _write_waves(ser, count, start_seq=prime, wave=8)
+        measured_lines = _write_waves(ser, count, start_seq=prime, wave=8, buf=buf)
         # Poll until the frames_ok delta covers the measured burst (or settle).
-        after: BpStats | None = None
+        after: BpStats | None = measured_lines[-1] if measured_lines else None
+        peak_drain = 0
+        for st in measured_lines:
+            if st.last_drain_ms is not None:
+                peak_drain = max(peak_drain, st.last_drain_ms)
         deadline = time.monotonic() + max(settle_s, count * 0.05 + 2.0)
         while time.monotonic() < deadline:
             got = _read_bp_until(ser, settle_s=0.4, buf=buf)
             if got is not None:
                 after = got
+                if got.last_drain_ms is not None:
+                    peak_drain = max(peak_drain, got.last_drain_ms)
                 if after.ok - baseline.ok >= count:
                     break
         if after is None:
@@ -233,6 +285,7 @@ def run_burst_on_port(
             after,
             max_drain_ms=max_drain_ms,
             require_frames=count,
+            peak_last_drain_ms=peak_drain or None,
         )
         if not ok:
             raise RuntimeError(


### PR DESCRIPTION
## Summary
- **Part A:** NVS (`Preferences`) persistence for last active screen + Setup Exchange sort order; restore on boot; write-on-change.
- **Part B:** USB CDC drain instrumentation (`[serial][bp]` lines) + host probe `python -m tools.ai_sidecar.serial_backpressure_probe` with unit tests (SerialPeer framing, no protocol change).
- **Part C:** Hidden debug screen (long-press **AC LAUNCHER**) showing link state, last-frame age, peers, free heap, and BP counters.

Fixes #677

## Test plan
- [x] `python -m pytest tests/test_serial_backpressure_probe.py -q` (6 passed)
- [x] `python -m platformio run -e jc3248w535_serial` (SUCCESS)
- [ ] `make ci-fast` on PR head
- [ ] On-device (when COM free): flash serial env, power-cycle to confirm screen/sort restore; long-press brand → debug; stop sidecar and run `python -m tools.ai_sidecar.serial_backpressure_probe --port COM6 --count 40` → record `PASS drop=0` on the issue
