### PR TITLE
feat(hud): finish Racing Atelier Part-A remainder (#673)

### DIFF
--- a/src/ac_copilot_trainer/modules/coaching_overlay.lua
+++ b/src/ac_copilot_trainer/modules/coaching_overlay.lua
@@ -607,21 +607,28 @@ function M.drawApproachPanel(approachData)
   return true
 end
 
+local COLOR_DATA = T.color("data") -- neutral telemetry accent (replaces retired cyan)
+
 local function accentForKind(kind)
   local k = type(kind) == "string" and kind or "general"
   if k == "brake" then
-    return rgbm(0.95, 0.30, 0.25, 1)
+    return COLOR_RED
   end
   if k == "throttle" then
-    return rgbm(0.25, 0.85, 0.35, 1)
+    return COLOR_GREEN
   end
   if k == "line" then
-    return rgbm(0.30, 0.70, 0.95, 1)
+    return COLOR_DATA
   end
   if k == "positive" then
-    return rgbm(0.40, 0.90, 0.70, 1)
+    return COLOR_GREEN
   end
-  return rgbm(0.85, 0.85, 0.40, 1)
+  return COLOR_AMBER
+end
+
+--- Alpha-scale an already-tokenized rgbm (not a palette literal).
+local function withAlpha(c, a)
+  return rgbm(c.r, c.g, c.b, (c.mult or 1) * a)
 end
 
 local function hintText(entry)
@@ -677,156 +684,13 @@ local function computeAlpha(timeRemaining, holdSeconds)
   return math.max(0, rem / fadeWindow)
 end
 
---- Shared panel chrome for Coaching window idle / fallback states (PR #50 review).
-local function drawStandardCoachingPanel(defaultW, defaultH, minH)
-  local w, h = defaultW or 400, defaultH or 140
-  local minHeight = minH or 100
-  if ui.windowSize then
-    local sz = ui.windowSize()
-    if sz and sz.x and sz.y then
-      w, h = sz.x, math.max(minHeight, sz.y)
-    end
-  end
-  if ui.drawRectFilled and vec2 then
-    ui.drawRectFilled(vec2(0, 0), vec2(w, h), rgbm(0.04, 0.04, 0.07, 0.78), 12)
-  end
-  if ui.drawRect and vec2 then
-    ui.drawRect(vec2(0, 0), vec2(w, h), rgbm(0.4, 0.43, 0.5, 0.45), 12, nil, 1)
-  end
-end
+-- Legacy ImGui coaching panels (M.draw / drawFallback / drawBetweenLapsIdle /
+-- drawHoldNoHints) carried the retired cyan accent and had zero call sites outside
+-- this module after the #72 / #432 approach-panel rebuild. Deleted in issue #673
+-- so no code path can resurrect those palette literals. drawMainWindowStrip is
+-- retained (design-conformance RC-03) and re-tokenized onto the Atelier map.
 
----@param coachingLines table[]|string[]|nil
----@param timeRemaining number
----@param holdSeconds number
----@param maxVisibleHints integer|nil
-function M.draw(coachingLines, timeRemaining, holdSeconds, maxVisibleHints)
-  if not coachingLines or #coachingLines == 0 or timeRemaining <= 0 then
-    return
-  end
-  if not ui or ui.textColored == nil then
-    return
-  end
-
-  local alpha = computeAlpha(timeRemaining, holdSeconds)
-  local hold = holdSeconds or 30
-
-  local w, h = 400, 300
-  if ui.windowSize then
-    local sz = ui.windowSize()
-    if sz and sz.x and sz.y then
-      w, h = sz.x, sz.y
-    end
-  end
-  if ui.drawRectFilled and vec2 then
-    ui.drawRectFilled(vec2(0, 0), vec2(w, h), rgbm(0.05, 0.05, 0.08, 0.82 * alpha), 12)
-  end
-  if ui.drawRect and vec2 then
-    ui.drawRect(vec2(0, 0), vec2(w, h), rgbm(0.45, 0.48, 0.55, 0.55 * alpha), 12, nil, 1)
-  end
-
-  local fk = fontMod.push()
-  local titleColor = rgbm(0.35, 0.82, 0.95, alpha)
-  ui.textColored("COACHING", titleColor)
-  if ui.separator then
-    ui.separator()
-  end
-
-  local cap = M.normalizedCoachingMaxVisibleHints(maxVisibleHints)
-  local showN = math.min(cap, #coachingLines)
-  for i = 1, showN do
-    local body = hintText(coachingLines[i])
-    if body ~= "" then
-      local a = accentForKind(hintKind(coachingLines[i]))
-      local col = rgbm(a.r, a.g, a.b, a.mult * alpha * 0.98)
-      if ui.textWrapped and ui.StyleColor and ui.pushStyleColor and ui.popStyleColor then
-        ui.pushStyleColor(ui.StyleColor.Text, col)
-        ui.textWrapped(body)
-        ui.popStyleColor()
-      else
-        ui.textColored(body, col)
-      end
-    end
-  end
-
-  fontMod.pop(fk)
-
-  if timeRemaining < hold * 0.5 then
-    ui.textColored(string.format("(%.0fs)", timeRemaining), rgbm(0.55, 0.58, 0.62, alpha * 0.65))
-  end
-end
-
-function M.drawFallback()
-  if not ui or ui.textColored == nil then
-    return
-  end
-  drawStandardCoachingPanel(400, 120, 100)
-  local fk = fontMod.push()
-  ui.textColored("Complete a lap for coaching hints", rgbm(0.92, 0.93, 0.95, 0.95))
-  fontMod.pop(fk)
-  local sub = "Open the Coaching window (second app icon) for the full overlay after your first lap."
-  if ui.textWrapped and ui.StyleColor and ui.pushStyleColor and ui.popStyleColor then
-    ui.pushStyleColor(ui.StyleColor.Text, rgbm(0.65, 0.68, 0.74, 0.85))
-    ui.textWrapped(sub)
-    ui.popStyleColor()
-  else
-    ui.textColored(sub, rgbm(0.65, 0.68, 0.74, 0.85))
-  end
-end
-
---- Coaching window when session has started but no tip is active (timer expired or empty hints).
-function M.drawBetweenLapsIdle(holdSeconds)
-  if not ui or ui.textColored == nil then
-    return
-  end
-  drawStandardCoachingPanel(400, 140, 120)
-  local fk = fontMod.push()
-  ui.textColored("COACHING", rgbm(0.35, 0.82, 0.95, 0.95))
-  if ui.separator then
-    ui.separator()
-  end
-  local hs = holdSeconds or 30
-  local body = string.format(
-    "No active tip right now. After each completed lap, hints show here for ~%ds. "
-      .. "Complete another lap for fresh coaching, or check the main app window for telemetry.",
-    math.floor(hs + 0.5)
-  )
-  if ui.textWrapped and ui.StyleColor and ui.pushStyleColor and ui.popStyleColor then
-    ui.pushStyleColor(ui.StyleColor.Text, rgbm(0.72, 0.74, 0.78, 0.9))
-    ui.textWrapped(body)
-    ui.popStyleColor()
-  else
-    ui.textColored(body, rgbm(0.72, 0.74, 0.78, 0.9))
-  end
-  fontMod.pop(fk)
-end
-
---- Lap completed and hold timer running, but `buildAfterLap` produced no lines (trace quality / first lap).
-function M.drawHoldNoHints(remainingSec)
-  if not ui or ui.textColored == nil then
-    return
-  end
-  drawStandardCoachingPanel(400, 120, 100)
-  local fk = fontMod.push()
-  ui.textColored("COACHING", rgbm(0.35, 0.82, 0.95, 0.95))
-  if ui.separator then
-    ui.separator()
-  end
-  local r = math.max(0, remainingSec or 0)
-  local body = string.format(
-    "No hints for the last lap (needs a cleaner full lap or more data). Timer ~%.0fs — complete another lap to try again.",
-    r
-  )
-  if ui.textWrapped and ui.StyleColor and ui.pushStyleColor and ui.popStyleColor then
-    ui.pushStyleColor(ui.StyleColor.Text, rgbm(0.78, 0.72, 0.55, 0.92))
-    ui.textWrapped(body)
-    ui.popStyleColor()
-  else
-    ui.textColored(body, rgbm(0.78, 0.72, 0.55, 0.92))
-  end
-  fontMod.pop(fk)
-end
-
---- Main telemetry window: primer or primary coaching line (issue #41).
+--- Main telemetry window: primer or primary coaching line (issue #41; #673 tokens).
 ---@class CoachingHudStrip
 ---@field coachingLines (string|{ kind: string, text: string })[]|nil
 ---@field coachingRemaining number|nil
@@ -875,7 +739,7 @@ function M.drawMainWindowStrip(vm)
     title = "COACHING"
     body = "Complete a lap for coaching hints"
     detail = "Full hints appear here and in the Coaching window."
-    accent = rgbm(0.88, 0.9, 0.94, 1)
+    accent = COLOR_WHITE
   end
 
   local pad = vec2(10, 8)
@@ -895,10 +759,10 @@ function M.drawMainWindowStrip(vm)
   local p0 = vec2(region.x, region.y)
   local p1 = vec2(region.x + rw, region.y + boxH)
   if ui.drawRectFilled then
-    ui.drawRectFilled(p0, p1, rgbm(0.04, 0.04, 0.07, 0.78 * alpha), 8)
+    ui.drawRectFilled(p0, p1, withAlpha(COLOR_BG, alpha), PANEL_ROUNDING)
   end
   if ui.drawRect then
-    ui.drawRect(p0, p1, rgbm(0.42, 0.45, 0.52, 0.5 * alpha), 8, nil, 1)
+    ui.drawRect(p0, p1, withAlpha(COLOR_BG_BORDER, alpha), PANEL_ROUNDING, nil, 1)
   end
 
   if ui.setCursor then
@@ -906,11 +770,11 @@ function M.drawMainWindowStrip(vm)
   end
 
   local fk = fontMod.push()
-  ui.textColored(title, rgbm(0.35, 0.82, 0.95, alpha))
+  ui.textColored(title, withAlpha(COLOR_TITLE, alpha))
   if ui.spacing then
     ui.spacing()
   end
-  local colBody = rgbm(accent.r, accent.g, accent.b, accent.mult * alpha * 0.98)
+  local colBody = withAlpha(accent, alpha * 0.98)
   if ui.textWrapped and ui.StyleColor and ui.pushStyleColor and ui.popStyleColor then
     ui.pushStyleColor(ui.StyleColor.Text, colBody)
     ui.textWrapped(body)
@@ -922,7 +786,7 @@ function M.drawMainWindowStrip(vm)
     if ui.spacing then
       ui.spacing()
     end
-    local colDet = rgbm(0.62, 0.65, 0.7, alpha * 0.85)
+    local colDet = withAlpha(COLOR_BRAND_GREY, alpha * 0.85)
     if ui.textWrapped and ui.StyleColor and ui.pushStyleColor and ui.popStyleColor then
       ui.pushStyleColor(ui.StyleColor.Text, colDet)
       ui.textWrapped(detail)

--- a/src/ac_copilot_trainer/modules/design_tokens.lua
+++ b/src/ac_copilot_trainer/modules/design_tokens.lua
@@ -6,8 +6,9 @@
 -- redundant-code-drift — do not hand-copy tokens into N runtimes without a conformance check).
 --
 -- HEX is kept as plain strings so the conformance test needs no Lua runtime. M.color()
--- builds a CSP rgbm on demand; hud.lua and coaching_overlay.lua call it at require
--- time to define module-level COLOR_* constants (rgbm is available when AC loads Lua apps).
+-- builds a CSP rgbm on demand; hud.lua, hud_settings.lua, coaching_overlay.lua, and
+-- racing_line.lua call it at require time to define module-level COLOR_* constants
+-- (rgbm is available when AC loads Lua apps).
 
 local M = {}
 

--- a/src/ac_copilot_trainer/modules/hud_settings.lua
+++ b/src/ac_copilot_trainer/modules/hud_settings.lua
@@ -1,6 +1,16 @@
 -- Settings / admin window (issue #57 Part B): `ac.storage` controls + telemetry stats moved from main HUD.
+-- Racing Atelier palette (epic #432 Part A remainder — issue #673) — sourced from design_tokens.lua.
+
+local T = require("design_tokens")
 
 local M = {}
+
+local COLOR_TITLE = T.color("brass") -- house accent on the settings chrome
+local COLOR_SECTION = T.color("chalk") -- primary section headers
+local COLOR_LABEL = T.color("mute") -- stats / field labels
+local COLOR_META = T.color("dim") -- demoted / unavailable CSP controls
+local COLOR_OK = T.color("clear") -- sidecar connected
+local COLOR_WAIT = T.color("lift") -- waiting / not running caution
 
 ---@class HudSettingsStats
 ---@field telemetrySamples integer|nil
@@ -56,23 +66,23 @@ end
 
 local function drawStats(st)
   if st.throttleLapHint and st.throttleLapHint ~= "" then
-    ui.textColored("Throttle (last lap)", rgbm(0.75, 0.78, 0.85, 1))
+    ui.textColored("Throttle (last lap)", COLOR_LABEL)
     textWrappedMaybe(st.throttleLapHint)
   end
   if st.consistencyHud and st.consistencyHud ~= "" then
-    ui.textColored("Consistency", rgbm(0.75, 0.78, 0.85, 1))
+    ui.textColored("Consistency", COLOR_LABEL)
     textWrappedMaybe(st.consistencyHud)
   end
   if st.styleHud and st.styleHud ~= "" then
-    ui.textColored("Style vs reference", rgbm(0.75, 0.78, 0.85, 1))
+    ui.textColored("Style vs reference", COLOR_LABEL)
     textWrappedMaybe(st.styleHud)
   end
   if st.tireHud and st.tireHud ~= "" then
-    ui.textColored("Tires (last lap)", rgbm(0.75, 0.78, 0.85, 1))
+    ui.textColored("Tires (last lap)", COLOR_LABEL)
     textWrappedMaybe(st.tireHud)
   end
   if st.shiftProfile and st.shiftProfile ~= "" then
-    ui.textColored("Shift coaching", rgbm(0.75, 0.78, 0.85, 1))
+    ui.textColored("Shift coaching", COLOR_LABEL)
     textWrappedMaybe(st.shiftProfile)
   end
   if st.refAiDistanceM ~= nil and st.refAiDistanceM == st.refAiDistanceM then
@@ -99,16 +109,16 @@ function M.draw(vm)
     return
   end
 
-  ui.textColored("AC Copilot Trainer — Settings", rgbm(0.55, 0.6, 0.68, 1))
+  ui.textColored("AC Copilot Trainer — Settings", COLOR_TITLE)
   ui.separator()
 
-  ui.textColored("Display", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("Display", COLOR_SECTION)
   checkbox(cfg, "hudEnabled", "Show HUD/coaching windows", "strictTrue")
   checkbox(cfg, "racingLineEnabled", "Show racing line (3D)", "notFalse")
   checkbox(cfg, "brakeMarkersEnabled", "Show brake markers (3D)", "notFalse")
 
   ui.separator()
-  ui.textColored("Coaching", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("Coaching", COLOR_SECTION)
   if type(ui.slider) == "function" then
     pcall(function()
       local curA = math.max(50, math.min(500, tonumber(cfg.approachMeters) or 200))
@@ -133,7 +143,7 @@ function M.draw(vm)
     local curH = math.max(5, math.min(120, tonumber(cfg.coachingHoldSeconds) or 30))
     ui.text(string.format("Approach distance (m): %.0f", curA))
     ui.text(string.format("Post-lap coaching hold (s): %.0f", curH))
-    ui.textColored("Sliders not available in this CSP build.", rgbm(0.65, 0.65, 0.7, 1))
+    ui.textColored("Sliders not available in this CSP build.", COLOR_META)
   end
 
   local mode = tostring(cfg.racingLineMode or "best")
@@ -154,7 +164,7 @@ function M.draw(vm)
     end)
   else
     ui.text("Racing line source: " .. modePreview)
-    ui.textColored("Combo not available — edit racingLineMode in storage if needed.", rgbm(0.65, 0.65, 0.7, 1))
+    ui.textColored("Combo not available — edit racingLineMode in storage if needed.", COLOR_META)
   end
 
   local style = tostring(cfg.lineStyle or "tilt")
@@ -175,7 +185,7 @@ function M.draw(vm)
   end
 
   ui.separator()
-  ui.textColored("Focus practice (#44)", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("Focus practice (#44)", COLOR_SECTION)
   local stf = vm.focusPracticeUi
   if stf and type(stf) == "table" then
     local cur = stf.focusPracticeActive == true
@@ -193,7 +203,7 @@ function M.draw(vm)
   end
 
   ui.separator()
-  ui.textColored("AI sidecar", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("AI sidecar", COLOR_SECTION)
   do
     -- Issue #77 Part A: sidecar is now AUTO-LAUNCHED via os.runConsoleProcess
     -- from ws_bridge.lua. The URL is fixed at ws://127.0.0.1:8765 and managed
@@ -211,16 +221,16 @@ function M.draw(vm)
       if ok then connected = c end
     end
     if connected then
-      ui.textColored("Status: connected (LLM coaching active)", rgbm(0.55, 0.85, 0.55, 1))
+      ui.textColored("Status: connected (LLM coaching active)", COLOR_OK)
     elseif spawned then
-      ui.textColored("Status: process launched, waiting for handshake...", rgbm(0.85, 0.85, 0.45, 1))
+      ui.textColored("Status: process launched, waiting for handshake...", COLOR_WAIT)
     else
-      ui.textColored("Status: not running (will retry every 5s)", rgbm(0.85, 0.65, 0.45, 1))
+      ui.textColored("Status: not running (will retry every 5s)", COLOR_WAIT)
     end
   end
 
   ui.separator()
-  ui.textColored("Lap archive (issue #77)", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("Lap archive (issue #77)", COLOR_SECTION)
   do
     -- Append-only per-lap JSON archive (full trace + setup + corners + coaching).
     -- Builds the dataset for future analysis / RAG / training.
@@ -275,7 +285,7 @@ function M.draw(vm)
   end
 
   ui.separator()
-  ui.textColored("Reference lap", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("Reference lap", COLOR_SECTION)
   do
     ui.text(tostring(vm.referenceStatus or "Active reference: none"))
     local cur = cfg.useImportedReference == true
@@ -309,12 +319,12 @@ function M.draw(vm)
   end
 
   ui.separator()
-  ui.textColored("Diagnostics", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("Diagnostics", COLOR_SECTION)
   checkbox(cfg, "enableRenderDiagnostics", "Render diagnostics ([DIAG] UI + 3D probes)", "strictTrue")
   checkbox(cfg, "enableDraw3DDiagnostics", "Verbose Draw3D logging (~2s interval)", "strictTrue")
 
   ui.separator()
-  ui.textColored("Telemetry & stats", rgbm(0.78, 0.8, 0.88, 1))
+  ui.textColored("Telemetry & stats", COLOR_SECTION)
   if vm.stats and type(vm.stats) == "table" then
     drawStats(vm.stats)
   end

--- a/src/ac_copilot_trainer/modules/racing_line.lua
+++ b/src/ac_copilot_trainer/modules/racing_line.lua
@@ -1,7 +1,10 @@
 -- Racing line: filled quads on track via CSP render.shaderedQuad (issue #39).
 -- Replaces render.quad / GL immediate mode (not in production CSP Lua).
+-- Racing Atelier palette (epic #432 Part A remainder — issue #673) — speed gradient
+-- endpoints derive from design_tokens.lua signal triad (clear / lift / brake).
 
 local ch = require("csp_helpers")
+local T = require("design_tokens")
 
 local M = {}
 
@@ -37,7 +40,7 @@ local function ensureQuadArgs()
     p2 = vec3(),
     p3 = vec3(),
     p4 = vec3(),
-    values = { gColor = rgbm(1, 1, 1, 0.8) },
+    values = { gColor = T.color("chalk", 0.8) },
     shader = RACING_LINE_SHADER,
   }
   if render.BlendMode and render.BlendMode.AlphaBlend then
@@ -57,18 +60,49 @@ local function distSq(ax, ay, az, bx, by, bz)
   return dx * dx + dy * dy + dz * dz
 end
 
+--- Token signal endpoints (built once from design_tokens HEX — never re-typed literals).
+local function _hexRgb(name)
+  local hex = T.HEX[name]
+  if type(hex) ~= "string" then
+    error("[COPILOT][racing_line] missing design token: " .. tostring(name), 2)
+  end
+  return tonumber(hex:sub(2, 3), 16) / 255,
+    tonumber(hex:sub(4, 5), 16) / 255,
+    tonumber(hex:sub(6, 7), 16) / 255
+end
+
+local CLEAR_R, CLEAR_G, CLEAR_B = _hexRgb("clear")
+local LIFT_R, LIFT_G, LIFT_B = _hexRgb("lift")
+local BRAKE_R, BRAKE_G, BRAKE_B = _hexRgb("brake")
+
+local function _lerp(a, b, t)
+  return a + (b - a) * t
+end
+
+--- Speed → color: slow=brake → mid=lift → fast=clear (Atelier signal triad).
 local function speedColor(speed)
   if speed > 150 then
-    return rgbm(0.1, 0.95, 0.2, 0.8)
+    return rgbm(CLEAR_R, CLEAR_G, CLEAR_B, 0.8)
   end
   if speed >= 80 then
     local t = (speed - 80) / 70
-    return rgbm(1.0 - t * 0.9, 0.75 + t * 0.2, 0.05 + t * 0.15, 0.8)
+    return rgbm(
+      _lerp(LIFT_R, CLEAR_R, t),
+      _lerp(LIFT_G, CLEAR_G, t),
+      _lerp(LIFT_B, CLEAR_B, t),
+      0.8
+    )
   end
   local t = math.max(0, speed / 80)
-  return rgbm(1.0, 0.15 + t * 0.6, 0.05, 0.8 + (1 - t) * 0.05)
+  return rgbm(
+    _lerp(BRAKE_R, LIFT_R, t),
+    _lerp(BRAKE_G, LIFT_G, t),
+    _lerp(BRAKE_B, LIFT_B, t),
+    0.8 + (1 - t) * 0.05
+  )
 end
 
+-- Cache built from token-derived speedColor (not hand-typed palette literals).
 local speedColorCache = {}
 for s = 0, 200, 5 do
   speedColorCache[s] = speedColor(s)

--- a/tests/test_coaching_max_visible_contract.py
+++ b/tests/test_coaching_max_visible_contract.py
@@ -41,7 +41,10 @@ def test_normalization_bounds_match_lua_contract() -> None:
 def test_lua_single_normalizer_and_wiring() -> None:
     overlay = OVERLAY.read_text(encoding="utf-8")
     assert "function M.normalizedCoachingMaxVisibleHints" in overlay
-    assert "math.min(cap, #coachingLines)" in overlay
+    # Live consumer after #673: drawMainWindowStrip (legacy M.draw deleted).
+    assert "function M.drawMainWindowStrip" in overlay
+    assert "M.normalizedCoachingMaxVisibleHints(maxVis)" in overlay
+    assert "math.min(#lines, cap)" in overlay
     main = MAIN.read_text(encoding="utf-8")
     assert (
         "coachingOverlay.normalizedCoachingMaxVisibleHints(config.coachingMaxVisibleHints)" in main

--- a/tests/test_design_conformance.py
+++ b/tests/test_design_conformance.py
@@ -207,11 +207,18 @@ class TestTransparency:
             r"if\s+rem\s*>=\s*fadeWindow\s+then\s*\n\s*return\s+1\.0",
             src,
         ), "computeAlpha should return 1.0 before fade window"
-        # Background: drawRectFilled with alpha 0.82 (M.draw) or 0.78 (strip).
+        # Live chrome uses tokenized carbon with a translucent alpha (#432 / #673).
+        carbon = re.search(
+            r'T\.color\(\s*["\']carbon["\']\s*,\s*(0\.\d+)\s*\)',
+            src,
+        )
+        assert carbon, 'COLOR_BG must use T.color("carbon", <alpha<1>)'
+        assert float(carbon.group(1)) < 1.0, (
+            f"Background carbon alpha should be < 1, got {carbon.group(1)}"
+        )
+        # Any remaining inline rgbm fills (alpha-scaled token copies) must also stay translucent.
         bg_matches = re.findall(r"drawRectFilled\(.*?rgbm\([^)]+\)", src)
-        assert bg_matches, "No drawRectFilled calls found"
         for m in bg_matches:
-            # Last number in rgbm(...) is alpha; extract it.
             nums = re.findall(r"[\d.]+", m.split("rgbm")[-1])
             if len(nums) >= 4:
                 alpha = float(nums[3])

--- a/tests/test_hud_design_tokens.py
+++ b/tests/test_hud_design_tokens.py
@@ -2,10 +2,13 @@
 
 Drift guard (fleet pitfall *redundant-code-drift*): the CSP-Lua HUD adapter
 ``src/ac_copilot_trainer/modules/design_tokens.lua`` mirrors the Racing Atelier palette that the
-in-game HUD (`hud.lua`, `coaching_overlay.lua`) renders. This test parses both that adapter and
-the canonical ``colors.css`` and asserts every hex matches, so the HUD palette cannot silently
-diverge from the design of record — the same single-source-of-truth check the launcher's
-``theme.py`` gets in ``test_rig_launcher_theme.py``.
+in-game HUD (`hud.lua`, `coaching_overlay.lua`, `hud_settings.lua`, `racing_line.lua`) renders.
+This test parses both that adapter and the canonical ``colors.css`` and asserts every hex
+matches, so the HUD palette cannot silently diverge from the design of record — the same
+single-source-of-truth check the launcher's ``theme.py`` gets in ``test_rig_launcher_theme.py``.
+
+Issue #673 extends the lock to the Part-A remainder surfaces so inline ``rgbm`` palette
+literals cannot reappear without failing CI.
 """
 
 from __future__ import annotations
@@ -16,11 +19,22 @@ from pathlib import Path
 from tests.lua_text_helpers import strip_lua_comments
 
 _ROOT = Path(__file__).resolve().parents[1]
+_MODULES = _ROOT / "src/ac_copilot_trainer/modules"
 _COLORS_CSS = _ROOT / "docs/10_Development/design/racing-atelier/project/tokens/colors.css"
-_DESIGN_TOKENS_LUA = _ROOT / "src/ac_copilot_trainer/modules/design_tokens.lua"
+_DESIGN_TOKENS_LUA = _MODULES / "design_tokens.lua"
 
 _CSS_HEX = re.compile(r"--([a-zA-Z0-9-]+)\s*:\s*(#[0-9A-Fa-f]{6})\b")
 _LUA_HEX = re.compile(r'(\w+)\s*=\s*["\'](#[0-9A-Fa-f]{6})["\']')
+# Numeric component palette literals (rgbm(0.12, ...)). Reconstruction from token
+# fields (rgbm(c.r, c.g, c.b, ...)) and availability checks (``if not rgbm``) are OK.
+_NUMERIC_RGBM = re.compile(r"\brgbm\s*\(\s*\d")
+
+_ATELIER_SURFACES = (
+    "hud.lua",
+    "hud_settings.lua",
+    "coaching_overlay.lua",
+    "racing_line.lua",
+)
 
 
 def _css_tokens() -> dict[str, str]:
@@ -33,6 +47,10 @@ def _lua_tokens() -> dict[str, str]:
     if not hex_block:
         return {}
     return {n: v.upper() for n, v in _LUA_HEX.findall(hex_block.group(1))}
+
+
+def _surface(name: str) -> str:
+    return strip_lua_comments((_MODULES / name).read_text(encoding="utf-8"))
 
 
 def test_hud_design_tokens_match_colors_css() -> None:
@@ -49,3 +67,33 @@ def test_hud_design_tokens_cover_the_signal_palette() -> None:
     lua = _lua_tokens()
     for required in ("carbon", "edge", "chalk", "mute", "brass", "brake", "lift", "clear"):
         assert required in lua, f"HUD palette missing required token {required!r}"
+
+
+def test_atelier_surfaces_require_design_tokens() -> None:
+    """#673: every in-sim Atelier surface derives color from the shared token map."""
+    for name in _ATELIER_SURFACES:
+        src = _surface(name)
+        assert re.search(
+            r'^\s*local\s+T\s*=\s*require\(["\']design_tokens["\']\)',
+            src,
+            re.M,
+        ), f"{name} must require design_tokens"
+
+
+def test_atelier_surfaces_ban_numeric_rgbm_palette_literals() -> None:
+    """#673: no surface may reintroduce hand-typed rgbm(0.x, ...) palette literals."""
+    for name in _ATELIER_SURFACES:
+        src = _surface(name)
+        hits = _NUMERIC_RGBM.findall(src)
+        assert not hits, f"{name} still has numeric rgbm palette literals: {hits[:5]!r}"
+
+
+def test_racing_line_speed_gradient_uses_signal_triad() -> None:
+    """#673 Part B: racing-line gradient endpoints come from clear/lift/brake tokens."""
+    src = _surface("racing_line.lua")
+    for token in ("clear", "lift", "brake"):
+        assert re.search(
+            rf'_hexRgb\(\s*["\']{token}["\']\s*\)',
+            src,
+        ), f"racing_line speedColor must derive endpoint from token {token!r}"
+    assert "speedColorCache" in src, "speedColorCache must remain (built from token refs)"


### PR DESCRIPTION
﻿## Summary
- **Part A:** `hud_settings.lua` derives every color from `design_tokens.lua` (brass title, chalk sections, mute labels, clear/lift status signals) — zero inline `rgbm()` palette literals.
- **Part B:** `racing_line.lua` `speedColor` / `speedColorCache` endpoints come from the token signal triad (`clear` / `lift` / `brake`) with load-time cache built from those refs.
- **Part C:** Deleted unwired legacy coaching panels (`M.draw`, `drawFallback`, `drawBetweenLapsIdle`, `drawHoldNoHints`) that carried the retired cyan accent; re-tokenized retained `drawMainWindowStrip` (RC-03).
- **Conformance:** Extended `tests/test_hud_design_tokens.py` to require `design_tokens` on all Atelier surfaces and ban numeric `rgbm(0.…)` palette literals; updated TR-01 and max-visible wiring for the retained strip.

Fixes #673

## Test plan
- [x] `pytest tests/test_hud_design_tokens.py tests/test_design_conformance.py tests/test_coaching_max_visible_contract.py -q`
- [ ] `make ci-fast`
- [ ] In-sim: open Settings (`WINDOW_2`) — Atelier chrome, all controls still present
- [ ] In-sim: racing-line speed gradient reads clear→lift→brake triad
- [ ] Grep surfaces: no `rgbm(\d` palette literals remain
