### PR TITLE
feat(alien): L4 stint optimizer, L0 env observer, META prior transfer (#674)

### DIFF
--- a/tests/test_alien_scientist.py
+++ b/tests/test_alien_scientist.py
@@ -13,7 +13,9 @@ from tools.ac_harness.alien_scientist import (
     build_plan,
     evaluate_experiment,
     load_ledger,
+    meta_priors,
     persist_completed_run,
+    scope_key,
     write_candidate_setup,
 )
 from tools.ai_sidecar.car_schema import CarSetupSchema
@@ -98,6 +100,125 @@ def test_falsified_constraint_is_suppressed_for_same_platform_scope() -> None:
                 {
                     "id": "renamed_same_adjustment",
                     "mechanism": "different prose, identical physical adjustment",
+                    "parameter": "WING_2",
+                    "direction": -1,
+                }
+            ],
+        )
+
+
+def test_meta_prior_transfers_across_combos_sharing_scope_key() -> None:
+    """#674: falsified constraint for combo A suppresses the same META key on combo B."""
+    first = build_plan(
+        trigger="pace plateau",
+        combo=_COMBO,
+        scope=_SCOPE,
+        baseline_payloads=[_lap("lap-1", 100_000)],
+        schema=_schema(),
+    )
+    constraint = first["experiments"][0]["constraint_key"]
+    other_combo = {"car": "car_b", "track": "track_b", "layout": "gp"}
+    assert scope_key(_SCOPE) == first["scope_key"]
+
+    ledger = [
+        {
+            "scope_key": first["scope_key"],
+            "scope": dict(_SCOPE),
+            "combo": dict(_COMBO),
+            "constraint_key": constraint,
+            "verdict": "falsified",
+            "experiment_id": "run:0",
+            "reason": "candidate_not_significantly_faster",
+        }
+    ]
+    priors = meta_priors(ledger, scope=_SCOPE)
+    assert len(priors) == 1
+    assert priors[0]["source_combo"] == _COMBO
+
+    # Wing is suppressed via cross-combo transfer; front bias remains a safe experiment.
+    transferred = build_plan(
+        trigger="pace plateau other combo",
+        combo=other_combo,
+        scope=_SCOPE,
+        baseline_payloads=[
+            {
+                **_lap("lap-9", 100_000),
+                "car": {"id": "car_b"},
+                "track": {"id": "track_b", "layout": "gp"},
+            }
+        ],
+        schema=_schema(),
+        ledger=ledger,
+        proposed_hypotheses=[
+            {
+                "id": "plateau_rear_wing",
+                "mechanism": "transferred prior must suppress this",
+                "parameter": "WING_2",
+                "direction": -1,
+            },
+            {
+                "id": "braking_stability_front_bias",
+                "mechanism": "unrelated constraint remains available",
+                "parameter": "FRONT_BIAS",
+                "direction": 1,
+            },
+        ],
+    )
+    assert transferred["combo"] == other_combo
+    assert transferred["experiments"][0]["parameter"] == "FRONT_BIAS.VALUE"
+    assert transferred["suppressed"][0]["transfer"]["mode"] == "cross_combo"
+    assert transferred["suppressed"][0]["transfer"]["source_combo"] == _COMBO
+    assert transferred["meta_priors"][0]["constraint_key"] == constraint
+
+
+def test_meta_prior_does_not_transfer_across_different_scope_dimensions() -> None:
+    first = build_plan(
+        trigger="pace plateau",
+        combo=_COMBO,
+        scope=_SCOPE,
+        baseline_payloads=[_lap("lap-1", 100_000)],
+        schema=_schema(),
+    )
+    other_scope = {**_SCOPE, "track_archetype": "long-fast"}
+    assert scope_key(other_scope) != first["scope_key"]
+    rebuilt = build_plan(
+        trigger="pace plateau",
+        combo=_COMBO,
+        scope=other_scope,
+        baseline_payloads=[_lap("lap-1", 100_000)],
+        schema=_schema(),
+        ledger=[
+            {
+                "scope_key": first["scope_key"],
+                "constraint_key": first["experiments"][0]["constraint_key"],
+                "verdict": "falsified",
+            }
+        ],
+    )
+    assert rebuilt["experiments"]
+    assert rebuilt["suppressed"] == []
+
+
+def test_legacy_ledger_row_without_combo_still_suppresses() -> None:
+    first = _plan()
+    with pytest.raises(ScientistError, match="scientist_constraints_suppressed"):
+        build_plan(
+            trigger="pace plateau",
+            combo={"car": "car_z", "track": "track_z", "layout": None},
+            scope=_SCOPE,
+            baseline_payloads=[_lap("lap-1", 100_000)],
+            schema=_schema(),
+            ledger=[
+                {
+                    "scope_key": first["scope_key"],
+                    "constraint_key": first["experiments"][0]["constraint_key"],
+                    "verdict": "falsified",
+                }
+            ],
+            proposed_hypotheses=[
+                {
+                    "id": "plateau_rear_wing",
+                    "mechanism": "legacy row transfer",
                     "parameter": "WING_2",
                     "direction": -1,
                 }
@@ -312,6 +433,9 @@ def test_completed_run_persists_plan_outcomes_and_append_only_ledger(tmp_path: P
     assert payload["outcomes"] == [outcome]
     ledger = load_ledger(tmp_path / "journal" / "alien_scientist" / "experiments.jsonl")
     assert ledger[0]["verdict"] == "falsified"
+    assert ledger[0]["scope"] == _SCOPE
+    assert ledger[0]["combo"] == _COMBO
+    assert ledger[0]["scope_key"] == plan["scope_key"]
     with pytest.raises(ScientistError, match="scientist_experiment_already_recorded"):
         append_ledger(tmp_path / "journal" / "alien_scientist" / "experiments.jsonl", ledger[0])
 

--- a/tests/test_auto_alien_stint_layers.py
+++ b/tests/test_auto_alien_stint_layers.py
@@ -1,0 +1,126 @@
+"""#674 auto_alien Layer-0 / Layer-4 composition helpers (offline)."""
+
+from __future__ import annotations
+
+from tools.ac_harness.auto_alien import compose_stint_layers
+from tools.ac_harness.auto_drive import generic_gt3_ggv
+from tools.ac_harness.ggv_profile import with_binned_uncertainty
+from tools.ac_harness.reference_lap import TRACE_FIELDS
+
+
+def _plant() -> dict:
+    prior = generic_gt3_ggv()
+    rows = [
+        {"speed_kmh": float(speed), "accg_lat": 1.2, "accg_lon": -1.2, "source": "brake_probe"}
+        for speed in range(50, 151, 10)
+        for _ in range(40)
+    ]
+    model = with_binned_uncertainty(prior, rows, prior)
+    return {
+        "schema_version": 3,
+        "ok": True,
+        "car_id": "car_a",
+        "track_id": "track_a",
+        "layout": None,
+        "setup": "race",
+        "constants": {
+            "ff_sign": 1.0,
+            "ff_c1": 0.5,
+            "ff_c2": 0.0,
+            "rpm_up": 7000.0,
+            "rpm_dn": 5000.0,
+            "r_eff_m": 0.32,
+        },
+        "ggv": {
+            "ok": True,
+            "model": model.to_dict(),
+            "thermal_cohort": {
+                "core_temp_c": 90.0,
+                "pressure_psi": 27.0,
+                "core_tolerance_c": 5.0,
+                "pressure_tolerance_psi": 2.0,
+                "compound": 1,
+                "setup_hash": "setup-a",
+                "thermal_tag": "optimal",
+            },
+        },
+    }
+
+
+def _archive(lap_uuid: str, *, lap_n: int, core_c: float) -> dict:
+    fields = list(TRACE_FIELDS)
+    samples = []
+    for i in range(120):
+        values = dict.fromkeys(fields, 0.0)
+        values.update({"spline": i / 120.0, "speed": 70.0, "eMs": i * 10.0, "fuel": 18.0})
+        for wheel in ("fl", "fr", "rl", "rr"):
+            values[f"tyreCoreTemp_{wheel}"] = core_c
+            values[f"tyreTempInner_{wheel}"] = core_c
+            values[f"tyreTempMid_{wheel}"] = core_c
+            values[f"tyreTempOuter_{wheel}"] = core_c
+            values[f"wheelsPressure_{wheel}"] = 27.0
+            values[f"dy_{wheel}"] = 1.4
+        samples.append([values[field] for field in fields])
+    return {
+        "schema_version": 1,
+        "lap_uuid": lap_uuid,
+        "lap": {"lap_n": lap_n, "lap_ms": 91_000, "is_valid": True},
+        "setup": {"hash": "setup-a"},
+        "tyres": {"compoundIndex": 1, "name": "M", "optimalTempC": 90.0},
+        "trace": {"fields": fields, "samples": samples, "samples_count": len(samples)},
+    }
+
+
+def test_compose_stint_layers_ok_without_archives() -> None:
+    block = compose_stint_layers(
+        plant_artifact=_plant(),
+        archive_payloads=[],
+        laps_remaining=5,
+        fuel_start_l=30.0,
+        fuel_burn_l_per_lap=2.0,
+        tyre_temp_target_c=90.0,
+        tyre_temp_tolerance_c=5.0,
+        wear_budget_fraction=0.35,
+        v_top_kmh=250.0,
+    )
+    assert block["ok"] is True
+    assert block["stint"]["pace_scale"] == 1.0
+    assert block["inner_loop"]["ggv_scale"] == 1.0
+    assert block["environment"] is None
+
+
+def test_compose_stint_layers_flags_environment_drift() -> None:
+    block = compose_stint_layers(
+        plant_artifact=_plant(),
+        archive_payloads=[
+            _archive("lap-1", lap_n=1, core_c=70.0),
+            _archive("lap-2", lap_n=2, core_c=115.0),
+        ],
+        laps_remaining=4,
+        fuel_start_l=20.0,
+        fuel_burn_l_per_lap=2.0,
+        tyre_temp_target_c=90.0,
+        tyre_temp_tolerance_c=5.0,
+        wear_budget_fraction=0.35,
+        v_top_kmh=240.0,
+    )
+    assert block["ok"] is True
+    assert block["environment"]["nonstationary"] is True
+    assert block["stint"]["degraded"] is True
+    assert block["inner_loop"]["ggv_scale"] < 1.0
+
+
+def test_compose_stint_layers_names_missing_plant() -> None:
+    block = compose_stint_layers(
+        plant_artifact=None,
+        archive_payloads=[],
+        laps_remaining=1,
+        fuel_start_l=30.0,
+        fuel_burn_l_per_lap=2.0,
+        tyre_temp_target_c=90.0,
+        tyre_temp_tolerance_c=5.0,
+        wear_budget_fraction=0.35,
+        v_top_kmh=250.0,
+    )
+    assert block["ok"] is False
+    assert "stint_plant_missing" in block["error"]

--- a/tests/test_env_observer.py
+++ b/tests/test_env_observer.py
@@ -1,0 +1,117 @@
+"""EPIC #529 / #674 Layer-0 environment observer — offline, no rig."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.ac_harness.env_observer import (
+    EnvironmentObserverError,
+    environment_for_plan,
+    environment_from_archives,
+    observation_from_lap_archive,
+    update_environment,
+)
+from tools.ac_harness.reference_lap import TRACE_FIELDS
+
+
+def _archive(
+    lap_uuid: str,
+    *,
+    lap_n: int,
+    core_c: float,
+    pressure_psi: float = 27.0,
+    grip_dy: float = 1.5,
+    fuel: float = 20.0,
+    wear: float = 0.1,
+    valid: bool = True,
+) -> dict:
+    fields = list(TRACE_FIELDS)
+    samples = []
+    for i in range(200):
+        values = dict.fromkeys(fields, 0.0)
+        values.update(
+            {
+                "spline": i / 200.0,
+                "speed": 80.0,
+                "eMs": i * 10.0,
+                "fuel": fuel,
+                "accG_lat": 1.1,
+                "accG_long": -0.2,
+            }
+        )
+        for wheel in ("fl", "fr", "rl", "rr"):
+            values[f"tyreCoreTemp_{wheel}"] = core_c
+            values[f"tyreTempInner_{wheel}"] = core_c + 1.0
+            values[f"tyreTempMid_{wheel}"] = core_c
+            values[f"tyreTempOuter_{wheel}"] = core_c - 1.0
+            values[f"wheelsPressure_{wheel}"] = pressure_psi
+            values[f"tyreWear_{wheel}"] = wear
+            values[f"dy_{wheel}"] = grip_dy
+        samples.append([values[field] for field in fields])
+    return {
+        "schema_version": 1,
+        "lap_uuid": lap_uuid,
+        "lap": {"lap_n": lap_n, "lap_ms": 90_000, "is_valid": valid},
+        "setup": {"hash": "setup-a"},
+        "tyres": {"compoundIndex": 1, "name": "M", "optimalTempC": 90.0},
+        "trace": {"fields": fields, "samples": samples, "samples_count": len(samples)},
+    }
+
+
+def test_observation_validates_finite_ranges() -> None:
+    obs = observation_from_lap_archive(_archive("lap-1", lap_n=1, core_c=90.0))
+    assert obs.core_temp_c == pytest.approx(90.0)
+    assert obs.pressure_psi == pytest.approx(27.0)
+    assert obs.grip_multiplier is not None
+    assert obs.fuel_end_l == pytest.approx(20.0)
+    assert obs.fit_eligible is True
+
+    bad = _archive("lap-bad", lap_n=1, core_c=90.0, valid=False)
+    with pytest.raises(EnvironmentObserverError, match="environment_lap_invalid"):
+        observation_from_lap_archive(bad)
+
+    nan_arch = _archive("lap-nan", lap_n=1, core_c=90.0)
+    nan_arch["lap"]["lap_ms"] = float("nan")
+    with pytest.raises(EnvironmentObserverError, match="environment_lap_ms_non_finite"):
+        observation_from_lap_archive(nan_arch)
+
+
+def test_stationary_sequence_keeps_low_uncertainty() -> None:
+    state = None
+    for n in range(1, 4):
+        state = update_environment(
+            state, observation_from_lap_archive(_archive(f"lap-{n}", lap_n=n, core_c=90.0))
+        )
+    assert state is not None
+    assert state.n_laps == 3
+    assert state.nonstationary is False
+    assert state.reidentify_recommended is False
+    assert state.track_grip_std is not None
+    assert state.track_grip_std < 0.05
+    plan_view = environment_for_plan(state)
+    assert plan_view["nonstationary"] is False
+    assert plan_view["evidence_lap_uuids"] == ["lap-1", "lap-2", "lap-3"]
+
+
+def test_thermal_and_grip_drift_flags_nonstationarity() -> None:
+    cold = observation_from_lap_archive(
+        _archive("lap-1", lap_n=1, core_c=70.0, pressure_psi=25.0, grip_dy=1.6)
+    )
+    hot = observation_from_lap_archive(
+        _archive("lap-2", lap_n=2, core_c=110.0, pressure_psi=29.0, grip_dy=0.9)
+    )
+    state = update_environment(None, cold)
+    state = update_environment(state, hot)
+    assert state.nonstationary is True
+    assert state.reidentify_recommended is True
+    assert state.thermal_delta_c is not None and state.thermal_delta_c >= 8.0
+    assert "thermal_delta" in (state.reason or "")
+
+
+def test_duplicate_lap_and_empty_archives_fail_loud() -> None:
+    first = observation_from_lap_archive(_archive("lap-1", lap_n=1, core_c=90.0))
+    state = update_environment(None, first)
+    with pytest.raises(EnvironmentObserverError, match="environment_lap_duplicate"):
+        update_environment(state, first)
+    with pytest.raises(EnvironmentObserverError, match="environment_archives_empty"):
+        environment_from_archives([])

--- a/tests/test_stint_optimizer.py
+++ b/tests/test_stint_optimizer.py
@@ -1,0 +1,161 @@
+"""EPIC #529 / #674 Layer-4 stint optimizer — offline, no rig."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tools.ac_harness.auto_drive import generic_gt3_ggv
+from tools.ac_harness.corner_refine import L3Params, refine_profile
+from tools.ac_harness.env_observer import EnvironmentState
+from tools.ac_harness.ggv_profile import with_binned_uncertainty
+from tools.ac_harness.stint_optimizer import (
+    StintInputs,
+    StintOptimizerError,
+    inner_loop_inputs,
+    plan_stint,
+)
+
+
+def _uncertain_model():
+    prior = generic_gt3_ggv()
+    rows = []
+    for speed in range(50, 151, 10):
+        for _ in range(40):
+            rows.append(
+                {
+                    "speed_kmh": float(speed),
+                    "accg_lat": 1.2,
+                    "accg_lon": -1.2,
+                    "source": "brake_probe",
+                }
+            )
+    return with_binned_uncertainty(prior, rows, prior)
+
+
+def _plant(*, core_temp_c: float = 90.0, with_cohort: bool = True) -> dict:
+    model = _uncertain_model()
+    ggv: dict = {"ok": True, "model": model.to_dict()}
+    if with_cohort:
+        ggv["thermal_cohort"] = {
+            "core_temp_c": core_temp_c,
+            "pressure_psi": 27.0,
+            "core_tolerance_c": 5.0,
+            "pressure_tolerance_psi": 2.0,
+            "compound": 1,
+            "setup_hash": "setup-a",
+            "thermal_tag": "optimal",
+        }
+    return {
+        "schema_version": 3,
+        "ok": True,
+        "car_id": "car_a",
+        "track_id": "track_a",
+        "layout": None,
+        "setup": "race",
+        "constants": {
+            "ff_sign": 1.0,
+            "ff_c1": 0.5,
+            "ff_c2": 0.0,
+            "rpm_up": 7000.0,
+            "rpm_dn": 5000.0,
+            "gear_ratios": {"2": 3.0, "3": 2.0, "4": 1.5},
+            "r_eff_m": 0.32,
+        },
+        "ggv": ggv,
+    }
+
+
+def test_plan_emits_deterministic_thermal_fuel_wear_targets() -> None:
+    plan = plan_stint(
+        StintInputs(
+            plant_artifact=_plant(core_temp_c=90.0),
+            environment=None,
+            laps_remaining=8,
+            fuel_start_l=30.0,
+            fuel_burn_l_per_lap=2.0,
+            wear_budget_fraction=0.35,
+        )
+    )
+    assert plan.schema_version == 1
+    assert plan.pace_scale == 1.0
+    assert plan.degraded is False
+    assert plan.target_thermal_window_c == (85.0, 95.0)
+    assert plan.projected_fuel_end_l == pytest.approx(14.0)
+    assert plan.fuel_target_l == pytest.approx(14.0)
+    knobs = inner_loop_inputs(plan)
+    assert knobs["ggv_scale"] == 1.0
+    assert isinstance(knobs["l3_params"], L3Params)
+
+
+def test_nonstationary_environment_and_missing_cohort_degrade() -> None:
+    env = EnvironmentState(
+        n_laps=3,
+        track_grip_mean=0.8,
+        track_grip_std=0.12,
+        nonstationary=True,
+        reason="grip_std=0.120>=0.080",
+        reidentify_recommended=True,
+        evidence_lap_uuids=("a", "b", "c"),
+    )
+    degraded = plan_stint(
+        StintInputs(
+            plant_artifact=_plant(with_cohort=False),
+            environment=env,
+            laps_remaining=5,
+            fuel_start_l=8.0,
+            fuel_burn_l_per_lap=2.5,
+            wear_budget_fraction=0.1,
+        )
+    )
+    assert degraded.degraded is True
+    assert degraded.pace_scale < 1.0
+    assert degraded.pace_scale >= 0.85
+    assert "missing_thermal_cohort" in degraded.reasons
+    assert any("grip_std" in reason for reason in degraded.reasons)
+    assert degraded.l3_params is not None
+    assert degraded.l3_params["z_ladder"] == [1.0]
+
+
+def test_unusable_plant_fails_loud() -> None:
+    with pytest.raises(StintOptimizerError, match="stint_plant_unusable"):
+        plan_stint(
+            StintInputs(
+                plant_artifact={"ok": True, "ggv": {"ok": False}},
+                environment=None,
+                laps_remaining=1,
+            )
+        )
+    with pytest.raises(StintOptimizerError, match="stint_laps_remaining_invalid"):
+        plan_stint(
+            StintInputs(plant_artifact=_plant(), environment=None, laps_remaining=0)
+        )
+
+
+def test_inner_loop_knobs_feed_refine_profile() -> None:
+    plan = plan_stint(
+        StintInputs(
+            plant_artifact=_plant(),
+            environment=EnvironmentState(
+                n_laps=2,
+                nonstationary=True,
+                reason="thermal_delta_c=10.00>=8.00",
+                reidentify_recommended=True,
+            ),
+            laps_remaining=3,
+        )
+    )
+    knobs = inner_loop_inputs(plan)
+    ggv = _uncertain_model()
+    # Tiny cyclic track: straight + corner + straight.
+    n = 12
+    seg = [10.0] * n
+    kappa = [0.0] * 3 + [0.02] * 6 + [0.0] * 3
+    v_qss = [40.0] * n
+    params = knobs["l3_params"]
+    assert params is not None
+    refined, report = refine_profile(seg, kappa, v_qss, ggv, params, v_top_ms=60.0)
+    assert len(refined) == n
+    assert report["schema_version"] == 1
+    assert all(math.isfinite(v) and v > 0 for v in refined)

--- a/tests/test_stint_optimizer.py
+++ b/tests/test_stint_optimizer.py
@@ -128,9 +128,7 @@ def test_unusable_plant_fails_loud() -> None:
             )
         )
     with pytest.raises(StintOptimizerError, match="stint_laps_remaining_invalid"):
-        plan_stint(
-            StintInputs(plant_artifact=_plant(), environment=None, laps_remaining=0)
-        )
+        plan_stint(StintInputs(plant_artifact=_plant(), environment=None, laps_remaining=0))
 
 
 def test_inner_loop_knobs_feed_refine_profile() -> None:

--- a/tools/ac_harness/alien_scientist.py
+++ b/tools/ac_harness/alien_scientist.py
@@ -1,9 +1,10 @@
-"""Evidence-gated setup scientist for the alien self-play pipeline (#529 P4).
+"""Evidence-gated setup scientist for the alien self-play pipeline (#529 P4 / #674 META).
 
 The scientist proposes physical hypotheses; deterministic code validates the proposal, creates
 one-parameter setup candidates, and judges measured batches.  Model prose never writes a setup.
 Durable records live under Assetto Corsa Documents and suppress already-falsified constraints for
-the same platform/track scope.
+the same META scope (mechanical × aero × tyre family × track archetype). Cross-combo transfer
+reuses that single ``scope_key`` ledger — never a second prior store (#674).
 """
 
 from __future__ import annotations
@@ -115,7 +116,8 @@ def _validate_state_destination(path: Path, allowed_root: Path | None = None) ->
     return logical
 
 
-def scope_key(scope: Mapping[str, Any]) -> str:
+def normalized_scope(scope: Mapping[str, Any]) -> dict[str, str]:
+    """Validate and normalize the four META dimensions used for prior transfer."""
     required = ("mechanical_platform", "aero_platform", "tyre_family", "track_archetype")
     normalized: dict[str, str] = {}
     for key in required:
@@ -123,7 +125,72 @@ def scope_key(scope: Mapping[str, Any]) -> str:
         if not value or len(value) > 128:
             raise ScientistError(f"scientist_scope_missing_{key}")
         normalized[key] = value
-    return _digest(normalized)
+    return normalized
+
+
+def scope_key(scope: Mapping[str, Any]) -> str:
+    """Digest of the four META dimensions — the single key for same-scope and cross-combo priors."""
+    return _digest(normalized_scope(scope))
+
+
+def _combo_identity(combo: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(combo, Mapping):
+        return None
+    car = str(combo.get("car") or "").strip()
+    track = str(combo.get("track") or "").strip()
+    if not car or not track:
+        return None
+    layout = combo.get("layout")
+    if layout is not None:
+        layout = str(layout).strip() or None
+    return {"car": car, "track": track, "layout": layout}
+
+
+def meta_priors(
+    ledger: Sequence[Mapping[str, Any]],
+    *,
+    scope: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Falsified qualitative constraints transferable to any combo sharing ``scope``'s META key.
+
+    Legacy ledger rows that only carry ``scope_key`` remain usable; newer rows may also carry
+    ``scope`` / ``combo`` for provenance. One bookkeeping store — the experiments ledger.
+    """
+    scoped = scope_key(scope)
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in ledger:
+        if row.get("scope_key") != scoped or row.get("verdict") != "falsified":
+            continue
+        constraint = str(row.get("constraint_key") or "")
+        if not constraint or constraint in seen:
+            continue
+        seen.add(constraint)
+        source_combo = _combo_identity(row.get("combo") if isinstance(row.get("combo"), Mapping) else None)
+        out.append(
+            {
+                "constraint_key": constraint,
+                "scope_key": scoped,
+                "source_experiment_id": row.get("experiment_id"),
+                "source_combo": source_combo,
+                "reason": row.get("reason"),
+            }
+        )
+    return out
+
+
+def _transfer_mode(
+    *,
+    plan_combo: Mapping[str, Any] | None,
+    source_combo: Mapping[str, Any] | None,
+) -> str:
+    plan_id = _combo_identity(plan_combo)
+    source_id = _combo_identity(source_combo)
+    if plan_id is None or source_id is None:
+        return "same_scope"
+    if plan_id == source_id:
+        return "same_scope"
+    return "cross_combo"
 
 
 def load_ledger(
@@ -280,15 +347,14 @@ def build_plan(
     raw = list(proposed_hypotheses if explicit_proposals else _default_hypotheses(named_trigger))
     if not raw or len(raw) > MAX_HYPOTHESES:
         raise ScientistError("scientist_hypothesis_count_out_of_range")
-    scoped = scope_key(scope)
-    suppressed = {
-        str(row.get("constraint_key") or "")
-        for row in ledger
-        if row.get("scope_key") == scoped and row.get("verdict") == "falsified"
-    }
+    scope_norm = normalized_scope(scope)
+    scoped = scope_key(scope_norm)
+    plan_combo = _combo_identity(combo) or dict(combo)
+    priors = meta_priors(ledger, scope=scope_norm)
+    prior_by_constraint = {str(row["constraint_key"]): row for row in priors}
     hypotheses: list[dict[str, Any]] = []
     experiments: list[dict[str, Any]] = []
-    suppressed_rows: list[dict[str, str]] = []
+    suppressed_rows: list[dict[str, Any]] = []
     seen_constraints: set[str] = set()
     for proposal in raw:
         hypothesis_id = str(proposal.get("id") or "").strip()
@@ -318,9 +384,20 @@ def build_plan(
             "constraint_key": constraint_key,
         }
         hypotheses.append(hypothesis)
-        if constraint_key in suppressed:
+        prior = prior_by_constraint.get(constraint_key)
+        if prior is not None:
+            mode = _transfer_mode(plan_combo=plan_combo, source_combo=prior.get("source_combo"))
             suppressed_rows.append(
-                {"hypothesis_id": hypothesis_id, "constraint_key": constraint_key}
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "constraint_key": constraint_key,
+                    "transfer": {
+                        "scope_key": scoped,
+                        "mode": mode,
+                        "source_experiment_id": prior.get("source_experiment_id"),
+                        "source_combo": prior.get("source_combo"),
+                    },
+                }
             )
             continue
         current = baseline_params.get(parameter)
@@ -357,9 +434,10 @@ def build_plan(
     plan_core = {
         "schema_version": SCHEMA_VERSION,
         "trigger": named_trigger,
-        "combo": dict(combo),
-        "scope": dict(scope),
+        "combo": plan_combo,
+        "scope": scope_norm,
         "scope_key": scoped,
+        "meta_priors": priors,
         "baseline_provenance": [
             {
                 "lap_uuid": payload.get("lap_uuid"),
@@ -577,21 +655,32 @@ def persist_completed_run(
         json.dumps(run, indent=2, ensure_ascii=False) + "\n",
         allowed_root=root,
     )
+    scope_payload = (
+        normalized_scope(plan["scope"])
+        if isinstance(plan.get("scope"), Mapping)
+        else None
+    )
+    combo_payload = _combo_identity(plan.get("combo") if isinstance(plan.get("combo"), Mapping) else None)
     for index, outcome in enumerate(outcomes):
+        row: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "experiment_id": f"{run_id}:{index}",
+            "created_utc": created_utc,
+            "run_path": str(destination),
+            "plan_id": plan.get("plan_id"),
+            "scope_key": plan.get("scope_key"),
+            "constraint_key": outcome.get("constraint_key"),
+            "verdict": outcome.get("verdict"),
+            "promoted": bool(outcome.get("promoted")),
+            "reason": outcome.get("reason"),
+        }
+        if scope_payload is not None:
+            row["scope"] = scope_payload
+        if combo_payload is not None:
+            row["combo"] = combo_payload
         append_ledger(
             ledger_path,
-            {
-                "schema_version": SCHEMA_VERSION,
-                "experiment_id": f"{run_id}:{index}",
-                "created_utc": created_utc,
-                "run_path": str(destination),
-                "plan_id": plan.get("plan_id"),
-                "scope_key": plan.get("scope_key"),
-                "constraint_key": outcome.get("constraint_key"),
-                "verdict": outcome.get("verdict"),
-                "promoted": bool(outcome.get("promoted")),
-                "reason": outcome.get("reason"),
-            },
+            row,
             allowed_root=root,
         )
     return destination

--- a/tools/ac_harness/alien_scientist.py
+++ b/tools/ac_harness/alien_scientist.py
@@ -166,7 +166,9 @@ def meta_priors(
         if not constraint or constraint in seen:
             continue
         seen.add(constraint)
-        source_combo = _combo_identity(row.get("combo") if isinstance(row.get("combo"), Mapping) else None)
+        source_combo = _combo_identity(
+            row.get("combo") if isinstance(row.get("combo"), Mapping) else None
+        )
         out.append(
             {
                 "constraint_key": constraint,
@@ -656,11 +658,11 @@ def persist_completed_run(
         allowed_root=root,
     )
     scope_payload = (
-        normalized_scope(plan["scope"])
-        if isinstance(plan.get("scope"), Mapping)
-        else None
+        normalized_scope(plan["scope"]) if isinstance(plan.get("scope"), Mapping) else None
     )
-    combo_payload = _combo_identity(plan.get("combo") if isinstance(plan.get("combo"), Mapping) else None)
+    combo_payload = _combo_identity(
+        plan.get("combo") if isinstance(plan.get("combo"), Mapping) else None
+    )
     for index, outcome in enumerate(outcomes):
         row: dict[str, Any] = {
             "schema_version": SCHEMA_VERSION,

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -201,6 +201,71 @@ def stage_l3_summary(outcome: dict | None) -> dict | None:
     return summary
 
 
+def compose_stint_layers(
+    *,
+    plant_artifact: dict | None,
+    archive_payloads: Sequence[dict],
+    laps_remaining: int,
+    fuel_start_l: float,
+    fuel_burn_l_per_lap: float,
+    tyre_temp_target_c: float,
+    tyre_temp_tolerance_c: float,
+    wear_budget_fraction: float,
+    v_top_kmh: float,
+    environment_prior: dict | None = None,
+) -> dict:
+    """Build Layer-0 environment + Layer-4 stint plan blocks for the composed report (#674).
+
+    Failures stay named in the returned dict (never swallowed): a bad archive or unusable plant
+    surfaces as ``ok=False`` with a reason so the pipeline can keep driving with baseline knobs.
+    """
+    from tools.ac_harness.env_observer import (
+        EnvironmentObserverError,
+        EnvironmentState,
+        environment_for_plan,
+        environment_from_archives,
+    )
+    from tools.ac_harness.stint_optimizer import StintInputs, StintOptimizerError, plan_stint
+
+    block: dict = {"ok": False, "environment": None, "stint": None}
+    try:
+        prior = EnvironmentState.from_dict(environment_prior)
+        environment = (
+            environment_from_archives(archive_payloads, prior=prior)
+            if archive_payloads
+            else prior
+        )
+        if environment is not None:
+            block["environment"] = environment_for_plan(environment)
+            block["environment_state"] = environment.to_dict()
+        if plant_artifact is None:
+            raise StintOptimizerError("stint_plant_missing")
+        plan = plan_stint(
+            StintInputs(
+                plant_artifact=plant_artifact,
+                environment=environment,
+                laps_remaining=max(1, int(laps_remaining)),
+                fuel_start_l=fuel_start_l,
+                fuel_burn_l_per_lap=fuel_burn_l_per_lap,
+                tyre_temp_target_c=tyre_temp_target_c,
+                tyre_temp_tolerance_c=tyre_temp_tolerance_c,
+                wear_budget_fraction=wear_budget_fraction,
+                v_top_kmh=v_top_kmh,
+            )
+        )
+        block["stint"] = plan.to_dict()
+        block["inner_loop"] = {
+            "ggv_scale": plan.pace_scale,
+            "l3_params": plan.l3_params,
+            "degraded": plan.degraded,
+            "reasons": list(plan.reasons),
+        }
+        block["ok"] = True
+    except (EnvironmentObserverError, StintOptimizerError, ValueError, TypeError) as exc:
+        block["error"] = str(exc)
+    return block
+
+
 def load_archive_payloads(paths: list[str]) -> tuple[list[dict], list[str]]:
     """Load lap-archive JSON payloads; unreadable files are reported, never silently dropped."""
     payloads: list[dict] = []
@@ -1000,6 +1065,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--scientist-aero-platform", default=None)
     p.add_argument("--scientist-tyre-family", default=None)
     p.add_argument("--scientist-track-archetype", default=None)
+    p.add_argument(
+        "--stint",
+        action="store_true",
+        help="#674 Layer-4: apply stint pace_scale to the base alien drive when a plant is ready "
+        "(environment/stint report blocks are attached whenever computable, even without this flag)",
+    )
+    p.add_argument("--stint-laps", type=int, default=None, help="laps remaining for L4 planning")
+    p.add_argument("--stint-fuel-start-l", type=float, default=30.0)
+    p.add_argument("--stint-fuel-burn-l-per-lap", type=float, default=2.2)
+    p.add_argument("--stint-tyre-temp-target-c", type=float, default=90.0)
+    p.add_argument("--stint-tyre-temp-tolerance-c", type=float, default=5.0)
+    p.add_argument("--stint-wear-budget", type=float, default=0.35)
     return p
 
 
@@ -1027,6 +1104,10 @@ def run_pipeline(
         raise ValueError("--scientist requires --setup, --iterations >= 1, and --laps >= 2")
     if not 1 <= args.scientist_batch_size <= 3:
         raise ValueError("--scientist-batch-size must be between 1 and 3")
+    if args.stint_laps is not None and args.stint_laps < 1:
+        raise ValueError(f"--stint-laps must be >= 1 (got {args.stint_laps})")
+    if not 0.0 < args.stint_wear_budget <= 1.0:
+        raise ValueError("--stint-wear-budget must be in (0, 1]")
     # The BASE drive keeps the #572 one-shot gate: above-1 envelopes are reachable only through
     # the falsification-gated self-play ladder (per-iteration scale overrides), never by passing
     # a bare --ggv-scale > 1 (#579 Codex P1).
@@ -1129,19 +1210,78 @@ def run_pipeline(
         report["sidecar_port_between_stages"] = settled
         print(f"auto-alien: sidecar port between stages: {settled}")
 
+    plant = load_plant_artifact(
+        user_dir,
+        args.car,
+        args.track,
+        setup_key,
+        setup_ini,
+        layout=args.track_layout,
+    )
+    stint_layers = compose_stint_layers(
+        plant_artifact=plant,
+        archive_payloads=[],
+        laps_remaining=args.stint_laps or max(1, args.laps or 1),
+        fuel_start_l=args.stint_fuel_start_l,
+        fuel_burn_l_per_lap=args.stint_fuel_burn_l_per_lap,
+        tyre_temp_target_c=args.stint_tyre_temp_target_c,
+        tyre_temp_tolerance_c=args.stint_tyre_temp_tolerance_c,
+        wear_budget_fraction=args.stint_wear_budget,
+        v_top_kmh=args.max_speed,
+    )
+    report["layers"] = {"pre_drive": stint_layers}
+    drive_scale = None
+    if args.stint and stint_layers.get("ok") and isinstance(stint_layers.get("inner_loop"), dict):
+        drive_scale = float(stint_layers["inner_loop"]["ggv_scale"])
+        report["stint_applied"] = {"ggv_scale": drive_scale, "source": "pre_drive"}
+        print(f"auto-alien: Layer-4 stint pace_scale={drive_scale}")
+    elif args.stint:
+        report["stint_applied"] = {
+            "ggv_scale": None,
+            "source": "pre_drive",
+            "skipped": stint_layers.get("error") or "stint_layers_unavailable",
+        }
+        print(
+            "auto-alien: --stint requested but Layer-4 plan unavailable — "
+            f"{report['stint_applied']['skipped']}; driving with baseline ggv_scale"
+        )
+
     stage_dir = evidence_root / "drive"
-    code = run_stage(drive_argv(args, stage_dir))
+    code = run_stage(drive_argv(args, stage_dir, ggv_scale=drive_scale))
     report["stages"]["drive"] = {"exit_code": code, "evidence_dir": str(stage_dir)}
     if code != 0:
         report["error"] = f"alien drive stage failed (exit {code})"
         print(f"auto-alien: FAIL — {report['error']}")
         return code or 1, report
 
+    base_outcome = load_stage_outcome(stage_dir)
+    post_payloads, post_errors = load_archive_payloads(stage_lap_archives(base_outcome))
+    post_layers = compose_stint_layers(
+        plant_artifact=plant,
+        archive_payloads=post_payloads,
+        laps_remaining=args.stint_laps or max(1, args.laps or 1),
+        fuel_start_l=args.stint_fuel_start_l,
+        fuel_burn_l_per_lap=args.stint_fuel_burn_l_per_lap,
+        tyre_temp_target_c=args.stint_tyre_temp_target_c,
+        tyre_temp_tolerance_c=args.stint_tyre_temp_tolerance_c,
+        wear_budget_fraction=args.stint_wear_budget,
+        v_top_kmh=args.max_speed,
+        environment_prior=(
+            stint_layers.get("environment_state")
+            if isinstance(stint_layers.get("environment_state"), dict)
+            else None
+        ),
+    )
+    if post_errors:
+        post_layers = {**post_layers, "archive_load_errors": post_errors}
+    report["layers"]["post_drive"] = post_layers
+    report["environment"] = post_layers.get("environment") or stint_layers.get("environment")
+    report["stint"] = post_layers.get("stint") or stint_layers.get("stint")
+
     if args.iterations > 0:
         # #577 progressive-envelope self-play. A falsified/stopped ladder is a VALID pipeline
         # outcome — the base drive passed and the report names exactly where and why the ladder
         # ended (keep-last-valid already restored the plant). Only the base stages gate exit.
-        base_outcome = load_stage_outcome(stage_dir)
         base_laps = stage_lap_times_ms(base_outcome)
         print(
             "auto-alien: base drive laps "

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -231,9 +231,7 @@ def compose_stint_layers(
     try:
         prior = EnvironmentState.from_dict(environment_prior)
         environment = (
-            environment_from_archives(archive_payloads, prior=prior)
-            if archive_payloads
-            else prior
+            environment_from_archives(archive_payloads, prior=prior) if archive_payloads else prior
         )
         if environment is not None:
             block["environment"] = environment_for_plan(environment)
@@ -1068,8 +1066,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--stint",
         action="store_true",
-        help="#674 Layer-4: apply stint pace_scale to the base alien drive when a plant is ready "
-        "(environment/stint report blocks are attached whenever computable, even without this flag)",
+        help=(
+            "#674 Layer-4: apply stint pace_scale to the base alien drive when a plant is ready "
+            "(environment/stint report blocks attach whenever computable, even without this flag)"
+        ),
     )
     p.add_argument("--stint-laps", type=int, default=None, help="laps remaining for L4 planning")
     p.add_argument("--stint-fuel-start-l", type=float, default=30.0)

--- a/tools/ac_harness/env_observer.py
+++ b/tools/ac_harness/env_observer.py
@@ -262,9 +262,7 @@ def update_environment(
         last_grip = history[-1].grip_multiplier
         if first_grip is not None and last_grip is not None:
             if abs(last_grip - first_grip) >= grip_drift:
-                reasons.append(
-                    f"grip_span={abs(last_grip - first_grip):.3f}>={grip_drift:.3f}"
-                )
+                reasons.append(f"grip_span={abs(last_grip - first_grip):.3f}>={grip_drift:.3f}")
 
     nonstationary = bool(reasons)
     return EnvironmentState(

--- a/tools/ac_harness/env_observer.py
+++ b/tools/ac_harness/env_observer.py
@@ -1,0 +1,316 @@
+"""Layer-0 environment / track-evolution observer (EPIC #529 / issue #674).
+
+Pure, per-lap updates over harness lap archives. Reuses the thermally tagged lap observer in
+:mod:`tools.ac_harness.ggv_profile` and tracks grip/thermal/pressure drift across successive
+laps so the pipeline can flag non-stationarity instead of silently re-fitting the plant.
+
+This is the EPIC #529 Layer-0 (environment), not the off-sim Lua L0 harness in
+:mod:`tools.ac_harness` package docs.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from tools.ac_harness.ggv_profile import observe_lap_tyre_state
+
+ENV_SCHEMA_VERSION = 1
+DEFAULT_GRIP_DRIFT = 0.08
+DEFAULT_THERMAL_DRIFT_C = 8.0
+DEFAULT_PRESSURE_DRIFT_PSI = 1.5
+DEFAULT_MIN_LAPS_FOR_DRIFT = 2
+_MAX_HISTORY = 32
+
+
+class EnvironmentObserverError(ValueError):
+    """Malformed telemetry or configuration for the Layer-0 observer."""
+
+
+def _finite(value: Any, *, name: str, lo: float | None = None, hi: float | None = None) -> float:
+    if isinstance(value, bool) or value is None:
+        raise EnvironmentObserverError(f"environment_{name}_missing")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise EnvironmentObserverError(f"environment_{name}_invalid") from exc
+    if not math.isfinite(result):
+        raise EnvironmentObserverError(f"environment_{name}_non_finite")
+    if lo is not None and result < lo:
+        raise EnvironmentObserverError(f"environment_{name}_out_of_range")
+    if hi is not None and result > hi:
+        raise EnvironmentObserverError(f"environment_{name}_out_of_range")
+    return result
+
+
+def _optional_finite(
+    value: Any, *, name: str, lo: float | None = None, hi: float | None = None
+) -> float | None:
+    if value is None:
+        return None
+    return _finite(value, name=name, lo=lo, hi=hi)
+
+
+@dataclass(frozen=True)
+class EnvironmentObservation:
+    """One lap's environment-relevant evidence."""
+
+    lap_uuid: str
+    lap_n: int
+    lap_ms: int
+    core_temp_c: float | None
+    pressure_psi: float | None
+    thermal_tag: str | None
+    grip_multiplier: float | None
+    fuel_end_l: float | None
+    wear_mean: float | None
+    fit_eligible: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class EnvironmentState:
+    """Running estimate of track/environment stationarity with uncertainty."""
+
+    schema_version: int = ENV_SCHEMA_VERSION
+    n_laps: int = 0
+    track_grip_mean: float | None = None
+    track_grip_std: float | None = None
+    thermal_mean_c: float | None = None
+    thermal_delta_c: float | None = None
+    pressure_mean_psi: float | None = None
+    pressure_delta_psi: float | None = None
+    nonstationary: bool = False
+    reason: str | None = None
+    reidentify_recommended: bool = False
+    evidence_lap_uuids: tuple[str, ...] = ()
+    history: tuple[EnvironmentObservation, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["evidence_lap_uuids"] = list(self.evidence_lap_uuids)
+        payload["history"] = [obs.to_dict() for obs in self.history]
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> EnvironmentState | None:
+        if data is None:
+            return None
+        if not isinstance(data, Mapping):
+            raise EnvironmentObserverError("environment_state_invalid")
+        if int(data.get("schema_version") or 0) != ENV_SCHEMA_VERSION:
+            raise EnvironmentObserverError("environment_state_unsupported_schema")
+        history_raw = data.get("history") or ()
+        if not isinstance(history_raw, Sequence):
+            raise EnvironmentObserverError("environment_state_history_invalid")
+        history = tuple(
+            EnvironmentObservation(
+                lap_uuid=str(row["lap_uuid"]),
+                lap_n=int(row["lap_n"]),
+                lap_ms=int(row["lap_ms"]),
+                core_temp_c=row.get("core_temp_c"),
+                pressure_psi=row.get("pressure_psi"),
+                thermal_tag=row.get("thermal_tag"),
+                grip_multiplier=row.get("grip_multiplier"),
+                fuel_end_l=row.get("fuel_end_l"),
+                wear_mean=row.get("wear_mean"),
+                fit_eligible=bool(row.get("fit_eligible")),
+            )
+            for row in history_raw
+            if isinstance(row, Mapping)
+        )
+        uuids = data.get("evidence_lap_uuids") or ()
+        return cls(
+            schema_version=ENV_SCHEMA_VERSION,
+            n_laps=int(data.get("n_laps") or 0),
+            track_grip_mean=data.get("track_grip_mean"),
+            track_grip_std=data.get("track_grip_std"),
+            thermal_mean_c=data.get("thermal_mean_c"),
+            thermal_delta_c=data.get("thermal_delta_c"),
+            pressure_mean_psi=data.get("pressure_mean_psi"),
+            pressure_delta_psi=data.get("pressure_delta_psi"),
+            nonstationary=bool(data.get("nonstationary")),
+            reason=data.get("reason"),
+            reidentify_recommended=bool(data.get("reidentify_recommended")),
+            evidence_lap_uuids=tuple(str(u) for u in uuids),
+            history=history,
+        )
+
+
+def _trace_channel_mean(archive: Mapping[str, Any], name: str) -> float | None:
+    trace = archive.get("trace")
+    if not isinstance(trace, Mapping):
+        return None
+    fields = trace.get("fields")
+    samples = trace.get("samples")
+    if not isinstance(fields, list) or not isinstance(samples, list) or name not in fields:
+        return None
+    index = fields.index(name)
+    values: list[float] = []
+    for row in samples:
+        if not isinstance(row, (list, tuple)) or index >= len(row):
+            continue
+        try:
+            value = float(row[index])
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value):
+            values.append(value)
+    if not values:
+        return None
+    return statistics.fmean(values)
+
+
+def _wear_mean(archive: Mapping[str, Any]) -> float | None:
+    wears = [
+        _trace_channel_mean(archive, f"tyreWear_{wheel}") for wheel in ("fl", "fr", "rl", "rr")
+    ]
+    present = [value for value in wears if value is not None]
+    if not present:
+        return None
+    return statistics.fmean(present)
+
+
+def observation_from_lap_archive(payload: Mapping[str, Any]) -> EnvironmentObservation:
+    """Validate one lap archive and extract the Layer-0 observation."""
+    if not isinstance(payload, Mapping):
+        raise EnvironmentObserverError("environment_archive_invalid")
+    lap_uuid = str(payload.get("lap_uuid") or "").strip()
+    if not lap_uuid or len(lap_uuid) > 128:
+        raise EnvironmentObserverError("environment_lap_uuid_invalid")
+    lap = payload.get("lap")
+    if not isinstance(lap, Mapping):
+        raise EnvironmentObserverError("environment_lap_block_missing")
+    lap_n = int(_finite(lap.get("lap_n"), name="lap_n", lo=0, hi=10_000))
+    lap_ms = int(_finite(lap.get("lap_ms"), name="lap_ms", lo=1, hi=3_600_000))
+    if lap.get("is_valid") is not True:
+        raise EnvironmentObserverError("environment_lap_invalid")
+
+    tyre = observe_lap_tyre_state(dict(payload))
+    core = _optional_finite(tyre.get("core_temp_c"), name="core_temp_c", lo=-20.0, hi=200.0)
+    pressure = _optional_finite(tyre.get("pressure_psi"), name="pressure_psi", lo=0.0, hi=60.0)
+    grip = _optional_finite(tyre.get("grip_multiplier"), name="grip_multiplier", lo=0.0, hi=1.0)
+    fuel = _optional_finite(_trace_channel_mean(payload, "fuel"), name="fuel", lo=0.0, hi=200.0)
+    wear = _optional_finite(_wear_mean(payload), name="wear", lo=0.0, hi=1.0)
+    tag = tyre.get("tag")
+    thermal_tag = str(tag) if isinstance(tag, str) and tag else None
+    return EnvironmentObservation(
+        lap_uuid=lap_uuid,
+        lap_n=lap_n,
+        lap_ms=lap_ms,
+        core_temp_c=core,
+        pressure_psi=pressure,
+        thermal_tag=thermal_tag,
+        grip_multiplier=grip,
+        fuel_end_l=fuel,
+        wear_mean=wear,
+        fit_eligible=bool(tyre.get("fit_eligible")),
+    )
+
+
+def update_environment(
+    prior: EnvironmentState | None,
+    observation: EnvironmentObservation,
+    *,
+    grip_drift: float = DEFAULT_GRIP_DRIFT,
+    thermal_drift_c: float = DEFAULT_THERMAL_DRIFT_C,
+    pressure_drift_psi: float = DEFAULT_PRESSURE_DRIFT_PSI,
+    min_laps_for_drift: int = DEFAULT_MIN_LAPS_FOR_DRIFT,
+) -> EnvironmentState:
+    """Fold one observation into the running environment estimate.
+
+    Deliberately does **not** catch per-lap errors: a caller that wraps this in a broad
+    ``except Exception`` would freeze the estimate while the pipeline keeps trusting it.
+    """
+    _finite(grip_drift, name="grip_drift", lo=0.0, hi=1.0)
+    _finite(thermal_drift_c, name="thermal_drift_c", lo=0.0, hi=100.0)
+    _finite(pressure_drift_psi, name="pressure_drift_psi", lo=0.0, hi=20.0)
+    if not isinstance(min_laps_for_drift, int) or min_laps_for_drift < 2:
+        raise EnvironmentObserverError("environment_min_laps_for_drift_invalid")
+
+    history = list(prior.history if prior is not None else ())
+    if any(obs.lap_uuid == observation.lap_uuid for obs in history):
+        raise EnvironmentObserverError("environment_lap_duplicate")
+    history.append(observation)
+    history = history[-_MAX_HISTORY:]
+
+    grips = [obs.grip_multiplier for obs in history if obs.grip_multiplier is not None]
+    thermals = [obs.core_temp_c for obs in history if obs.core_temp_c is not None]
+    pressures = [obs.pressure_psi for obs in history if obs.pressure_psi is not None]
+
+    grip_mean = statistics.fmean(grips) if grips else None
+    grip_std = statistics.pstdev(grips) if len(grips) >= 2 else (0.0 if grips else None)
+    thermal_mean = statistics.fmean(thermals) if thermals else None
+    thermal_delta = (max(thermals) - min(thermals)) if len(thermals) >= 2 else None
+    pressure_mean = statistics.fmean(pressures) if pressures else None
+    pressure_delta = (max(pressures) - min(pressures)) if len(pressures) >= 2 else None
+
+    reasons: list[str] = []
+    if len(history) >= min_laps_for_drift:
+        if grip_std is not None and grip_std >= grip_drift:
+            reasons.append(f"grip_std={grip_std:.3f}>={grip_drift:.3f}")
+        if thermal_delta is not None and thermal_delta >= thermal_drift_c:
+            reasons.append(f"thermal_delta_c={thermal_delta:.2f}>={thermal_drift_c:.2f}")
+        if pressure_delta is not None and pressure_delta >= pressure_drift_psi:
+            reasons.append(f"pressure_delta_psi={pressure_delta:.2f}>={pressure_drift_psi:.2f}")
+        first_grip = history[0].grip_multiplier
+        last_grip = history[-1].grip_multiplier
+        if first_grip is not None and last_grip is not None:
+            if abs(last_grip - first_grip) >= grip_drift:
+                reasons.append(
+                    f"grip_span={abs(last_grip - first_grip):.3f}>={grip_drift:.3f}"
+                )
+
+    nonstationary = bool(reasons)
+    return EnvironmentState(
+        schema_version=ENV_SCHEMA_VERSION,
+        n_laps=len(history),
+        track_grip_mean=round(grip_mean, 5) if grip_mean is not None else None,
+        track_grip_std=round(grip_std, 5) if grip_std is not None else None,
+        thermal_mean_c=round(thermal_mean, 3) if thermal_mean is not None else None,
+        thermal_delta_c=round(thermal_delta, 3) if thermal_delta is not None else None,
+        pressure_mean_psi=round(pressure_mean, 3) if pressure_mean is not None else None,
+        pressure_delta_psi=round(pressure_delta, 3) if pressure_delta is not None else None,
+        nonstationary=nonstationary,
+        reason="; ".join(reasons) if reasons else None,
+        reidentify_recommended=nonstationary,
+        evidence_lap_uuids=tuple(obs.lap_uuid for obs in history),
+        history=tuple(history),
+    )
+
+
+def environment_from_archives(
+    archives: Sequence[Mapping[str, Any]],
+    *,
+    prior: EnvironmentState | None = None,
+) -> EnvironmentState:
+    """Fold a sequence of lap archives into an environment state (fail-loud on bad rows)."""
+    state = prior
+    for payload in archives:
+        state = update_environment(state, observation_from_lap_archive(payload))
+    if state is None:
+        raise EnvironmentObserverError("environment_archives_empty")
+    return state
+
+
+def environment_for_plan(state: EnvironmentState) -> dict[str, Any]:
+    """Compact, JSON-safe view for scientist / stint plan provenance."""
+    return {
+        "schema_version": state.schema_version,
+        "n_laps": state.n_laps,
+        "track_grip_mean": state.track_grip_mean,
+        "track_grip_std": state.track_grip_std,
+        "thermal_mean_c": state.thermal_mean_c,
+        "thermal_delta_c": state.thermal_delta_c,
+        "pressure_mean_psi": state.pressure_mean_psi,
+        "pressure_delta_psi": state.pressure_delta_psi,
+        "nonstationary": state.nonstationary,
+        "reason": state.reason,
+        "reidentify_recommended": state.reidentify_recommended,
+        "evidence_lap_uuids": list(state.evidence_lap_uuids),
+    }

--- a/tools/ac_harness/stint_optimizer.py
+++ b/tools/ac_harness/stint_optimizer.py
@@ -113,12 +113,8 @@ def plan_stint(inputs: StintInputs) -> StintPlan:
     fuel_start = _finite(inputs.fuel_start_l, name="fuel_start_l", lo=0.0, hi=200.0)
     burn = _finite(inputs.fuel_burn_l_per_lap, name="fuel_burn_l_per_lap", lo=0.0, hi=20.0)
     temp_target = _finite(inputs.tyre_temp_target_c, name="tyre_temp_target_c", lo=40.0, hi=140.0)
-    temp_tol = _finite(
-        inputs.tyre_temp_tolerance_c, name="tyre_temp_tolerance_c", lo=0.5, hi=30.0
-    )
-    wear_budget = _finite(
-        inputs.wear_budget_fraction, name="wear_budget_fraction", lo=0.01, hi=1.0
-    )
+    temp_tol = _finite(inputs.tyre_temp_tolerance_c, name="tyre_temp_tolerance_c", lo=0.5, hi=30.0)
+    wear_budget = _finite(inputs.wear_budget_fraction, name="wear_budget_fraction", lo=0.01, hi=1.0)
     v_top = _finite(inputs.v_top_kmh, name="v_top_kmh", lo=40.0, hi=400.0)
 
     reasons: list[str] = []
@@ -126,9 +122,7 @@ def plan_stint(inputs: StintInputs) -> StintPlan:
     pace_scale = 1.0
     l3: L3Params | None = L3Params()
 
-    ready = plant_ready_for_full_consumption(
-        dict(inputs.plant_artifact), require_friction_fit=True
-    )
+    ready = plant_ready_for_full_consumption(dict(inputs.plant_artifact), require_friction_fit=True)
     if ready is not None:
         raise StintOptimizerError(f"stint_plant_unusable:{ready}")
     if plant_ggv_model(dict(inputs.plant_artifact)) is None:

--- a/tools/ac_harness/stint_optimizer.py
+++ b/tools/ac_harness/stint_optimizer.py
@@ -1,0 +1,220 @@
+"""Layer-4 stint-level optimizer (EPIC #529 / issue #674).
+
+Slow-timescale planner that consumes thermally tagged plant fits and a Layer-0 environment
+estimate, then emits targets the QSS+L3 inner loop can consume (pace scale, optional tighter
+:class:`~tools.ac_harness.corner_refine.L3Params`). Never mutates the plant GGV model.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from tools.ac_harness.corner_refine import L3Params
+from tools.ac_harness.env_observer import EnvironmentState
+from tools.ac_harness.plant_id import plant_ggv_model, plant_ready_for_full_consumption
+
+STINT_SCHEMA_VERSION = 1
+DEFAULT_TYRE_TEMP_TARGET_C = 90.0
+DEFAULT_TYRE_TEMP_TOLERANCE_C = 5.0
+DEFAULT_WEAR_BUDGET = 0.35
+DEFAULT_FUEL_START_L = 30.0
+DEFAULT_FUEL_BURN_L_PER_LAP = 2.2
+MIN_PACE_SCALE = 0.85
+NONSTATIONARY_PACE_SCALE = 0.94
+HOT_THERMAL_PACE_SCALE = 0.96
+
+
+class StintOptimizerError(ValueError):
+    """Unsafe or incomplete inputs for the Layer-4 stint planner."""
+
+
+def _finite(value: Any, *, name: str, lo: float | None = None, hi: float | None = None) -> float:
+    if isinstance(value, bool) or value is None:
+        raise StintOptimizerError(f"stint_{name}_missing")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise StintOptimizerError(f"stint_{name}_invalid") from exc
+    if not math.isfinite(result):
+        raise StintOptimizerError(f"stint_{name}_non_finite")
+    if lo is not None and result < lo:
+        raise StintOptimizerError(f"stint_{name}_out_of_range")
+    if hi is not None and result > hi:
+        raise StintOptimizerError(f"stint_{name}_out_of_range")
+    return result
+
+
+@dataclass(frozen=True)
+class StintInputs:
+    """Operator + plant inputs for a multi-lap stint plan."""
+
+    plant_artifact: Mapping[str, Any]
+    environment: EnvironmentState | None
+    laps_remaining: int
+    fuel_start_l: float = DEFAULT_FUEL_START_L
+    fuel_burn_l_per_lap: float = DEFAULT_FUEL_BURN_L_PER_LAP
+    tyre_temp_target_c: float = DEFAULT_TYRE_TEMP_TARGET_C
+    tyre_temp_tolerance_c: float = DEFAULT_TYRE_TEMP_TOLERANCE_C
+    wear_budget_fraction: float = DEFAULT_WEAR_BUDGET
+    v_top_kmh: float = 250.0
+
+
+@dataclass(frozen=True)
+class StintPlan:
+    """Slow-timescale targets for the QSS+L3 inner loop."""
+
+    schema_version: int
+    target_thermal_window_c: tuple[float, float]
+    fuel_target_l: float
+    projected_fuel_end_l: float
+    wear_budget_fraction: float
+    pace_scale: float
+    l3_params: dict[str, Any] | None
+    stationary_required: bool
+    environment_confidence: float
+    degraded: bool
+    reasons: tuple[str, ...]
+    thermal_cohort: dict[str, Any] | None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["target_thermal_window_c"] = list(self.target_thermal_window_c)
+        payload["reasons"] = list(self.reasons)
+        return payload
+
+
+def _thermal_cohort(plant: Mapping[str, Any]) -> dict[str, Any] | None:
+    ggv = plant.get("ggv")
+    if not isinstance(ggv, Mapping):
+        return None
+    cohort = ggv.get("thermal_cohort")
+    return dict(cohort) if isinstance(cohort, Mapping) else None
+
+
+def _environment_confidence(environment: EnvironmentState | None) -> float:
+    if environment is None or environment.n_laps <= 0:
+        return 0.0
+    if environment.nonstationary:
+        return 0.25
+    std = environment.track_grip_std
+    if std is None:
+        return min(1.0, 0.35 + 0.1 * environment.n_laps)
+    # Low grip std → high confidence; clamp.
+    return max(0.35, min(1.0, 1.0 - 4.0 * float(std)))
+
+
+def plan_stint(inputs: StintInputs) -> StintPlan:
+    """Emit slow-timescale stint targets from a plant + optional Layer-0 state."""
+    if not isinstance(inputs.laps_remaining, int) or inputs.laps_remaining < 1:
+        raise StintOptimizerError("stint_laps_remaining_invalid")
+    fuel_start = _finite(inputs.fuel_start_l, name="fuel_start_l", lo=0.0, hi=200.0)
+    burn = _finite(inputs.fuel_burn_l_per_lap, name="fuel_burn_l_per_lap", lo=0.0, hi=20.0)
+    temp_target = _finite(inputs.tyre_temp_target_c, name="tyre_temp_target_c", lo=40.0, hi=140.0)
+    temp_tol = _finite(
+        inputs.tyre_temp_tolerance_c, name="tyre_temp_tolerance_c", lo=0.5, hi=30.0
+    )
+    wear_budget = _finite(
+        inputs.wear_budget_fraction, name="wear_budget_fraction", lo=0.01, hi=1.0
+    )
+    v_top = _finite(inputs.v_top_kmh, name="v_top_kmh", lo=40.0, hi=400.0)
+
+    reasons: list[str] = []
+    degraded = False
+    pace_scale = 1.0
+    l3: L3Params | None = L3Params()
+
+    ready = plant_ready_for_full_consumption(
+        dict(inputs.plant_artifact), require_friction_fit=True
+    )
+    if ready is not None:
+        raise StintOptimizerError(f"stint_plant_unusable:{ready}")
+    if plant_ggv_model(dict(inputs.plant_artifact)) is None:
+        raise StintOptimizerError("stint_plant_missing_uncertainty_fit")
+
+    cohort = _thermal_cohort(inputs.plant_artifact)
+    if cohort is None:
+        degraded = True
+        reasons.append("missing_thermal_cohort")
+        window = (temp_target - temp_tol, temp_target + temp_tol)
+    else:
+        core = _finite(cohort.get("core_temp_c"), name="cohort_core_temp_c", lo=-20.0, hi=200.0)
+        cohort_tol = _finite(
+            cohort.get("core_tolerance_c", temp_tol),
+            name="cohort_core_tolerance_c",
+            lo=0.5,
+            hi=30.0,
+        )
+        # Prefer the plant's identified thermal center; operator target only recenters when the
+        # cohort is far from the requested window.
+        center = core if abs(core - temp_target) <= cohort_tol else temp_target
+        window = (center - cohort_tol, center + cohort_tol)
+        if core > window[1]:
+            pace_scale = min(pace_scale, HOT_THERMAL_PACE_SCALE)
+            reasons.append("cohort_hot_vs_window")
+            degraded = True
+
+    environment = inputs.environment
+    confidence = _environment_confidence(environment)
+    stationary_required = True
+    if environment is not None and environment.nonstationary:
+        pace_scale = min(pace_scale, NONSTATIONARY_PACE_SCALE)
+        # Tighter L3: only the stability floor remains — refuse aggressive z-ladder steps while
+        # the track/environment is drifting.
+        l3 = L3Params(z_ladder=(1.0,), max_rel_std=0.15)
+        reasons.append(environment.reason or "environment_nonstationary")
+        degraded = True
+        stationary_required = True
+
+    projected_end = fuel_start - burn * float(inputs.laps_remaining)
+    if projected_end < 0.0:
+        # Pace derate scales with the fuel shortfall fraction, never below MIN_PACE_SCALE.
+        shortfall = min(1.0, -projected_end / max(fuel_start, 1e-6))
+        fuel_scale = max(MIN_PACE_SCALE, 1.0 - 0.1 * shortfall)
+        pace_scale = min(pace_scale, fuel_scale)
+        reasons.append(f"fuel_shortfall_l={-projected_end:.2f}")
+        degraded = True
+        projected_end = 0.0
+
+    # Keep a small reserve so the final lap is not planned to absolute empty.
+    fuel_target = max(0.5, projected_end)
+
+    if wear_budget < 0.15:
+        pace_scale = min(pace_scale, 0.97)
+        reasons.append("tight_wear_budget")
+        degraded = True
+
+    pace_scale = max(MIN_PACE_SCALE, min(1.0, pace_scale))
+    # v_top is accepted for contract completeness; L4 does not invent a second speed solver.
+    _ = v_top
+
+    return StintPlan(
+        schema_version=STINT_SCHEMA_VERSION,
+        target_thermal_window_c=(round(window[0], 3), round(window[1], 3)),
+        fuel_target_l=round(fuel_target, 3),
+        projected_fuel_end_l=round(projected_end, 3),
+        wear_budget_fraction=round(wear_budget, 4),
+        pace_scale=round(pace_scale, 4),
+        l3_params=l3.to_dict() if l3 is not None else None,
+        stationary_required=stationary_required,
+        environment_confidence=round(confidence, 4),
+        degraded=degraded,
+        reasons=tuple(reasons),
+        thermal_cohort=cohort,
+    )
+
+
+def inner_loop_inputs(plan: StintPlan) -> dict[str, Any]:
+    """Map a stint plan onto existing alien-drive knobs (ggv_scale / L3 params)."""
+    l3_params = None
+    if plan.l3_params is not None:
+        l3_params = L3Params.from_dict(plan.l3_params)
+    return {
+        "ggv_scale": plan.pace_scale,
+        "l3_params": l3_params,
+        "l3_params_dict": plan.l3_params,
+        "degraded": plan.degraded,
+        "reasons": list(plan.reasons),
+    }


### PR DESCRIPTION
## Summary
- Add Layer-0 `env_observer.py` that tracks grip/thermal/pressure drift across lap archives and flags non-stationarity / re-ID.
- Add Layer-4 `stint_optimizer.py` that consumes thermally tagged plant fits + L0 state and emits pace/fuel/wear targets for the QSS+L3 inner loop (`--stint` applies pace_scale).
- Extend `alien_scientist` META priors on the existing `scope_key` ledger with cross-combo transfer provenance (one store).

## Test plan
- [x] `pytest tests/test_env_observer.py tests/test_stint_optimizer.py tests/test_auto_alien_stint_layers.py tests/test_alien_scientist.py tests/test_auto_alien.py`
- [ ] `make ci-fast`
- [ ] Live G1/G2/G3 gates remain deferred on #529 / blocked on #627

Fixes #674