### PR TITLE
feat(coaching): Coach V2 phase-slot, calibration, between-lap advice (#675)

### DIFF
--- a/tests/test_between_lap_advice.py
+++ b/tests/test_between_lap_advice.py
@@ -1,0 +1,68 @@
+"""#675 Part 2 — between-lap corner_advice selection (fail-closed validation)."""
+
+from __future__ import annotations
+
+from tools.ai_sidecar.coaching.between_lap import (
+    select_between_lap_advice,
+    select_focus_corner,
+    validate_corner_advice,
+)
+from tools.ai_sidecar.coaching_diagnosis import Diagnosis, RootError
+from tools.ai_sidecar.coaching_ledger import CoachingLedger
+from tools.ai_sidecar.track_reference import CornerReference
+
+
+def _refs(*indexes: int) -> list[CornerReference]:
+    out = []
+    for i, idx in enumerate(indexes):
+        lo = 0.1 * (i + 1)
+        out.append(
+            CornerReference(
+                index=idx,
+                spline_lo=lo,
+                spline_hi=lo + 0.05,
+                apex_spline=lo + 0.02,
+                optimal_apex_kmh=100.0,
+            )
+        )
+    return out
+
+
+def test_validate_rejects_unknown_corner() -> None:
+    refs = _refs(0, 1)
+    assert validate_corner_advice(corner=9, text="BRAKE LATER NEXT LAP", refs=refs) is None
+    assert validate_corner_advice(corner=1, text="ok", refs=refs) is None  # too short
+    ok = validate_corner_advice(corner=1, text="BRAKE LATER NEXT LAP", refs=refs)
+    assert ok is not None and ok["corner"] == 1 and ok["corner_label"] == "T1"
+
+
+def test_select_focus_prefers_ledger_focus() -> None:
+    ledger = CoachingLedger(hysteresis=1, assess_laps=0, lap_budget=4)
+    ledger.begin_lap(1)
+    ledger.record_pass(2, Diagnosis(RootError.EARLY_BRAKE, {}), time_lost_s=0.4, valid=True)
+    ledger.record_pass(0, Diagnosis(RootError.SLOW_APEX, {}), time_lost_s=0.1, valid=True)
+    assert select_focus_corner(ledger, valid_corners=[0, 1, 2]) == 2
+
+
+def test_select_between_lap_rules_fallback_without_ollama(monkeypatch) -> None:
+    monkeypatch.setenv("AC_COPILOT_OLLAMA_ENABLE", "0")
+    refs = _refs(0, 1, 2)
+    ledger = CoachingLedger(hysteresis=1, assess_laps=0, lap_budget=4)
+    ledger.begin_lap(1)
+    ledger.record_pass(1, Diagnosis(RootError.EARLY_BRAKE, {}), time_lost_s=0.5, valid=True)
+    advice = select_between_lap_advice(refs=refs, ledger=ledger, use_ollama=False)
+    assert advice is not None
+    assert advice["corner"] == 1
+    assert "T1" in advice["text"] or "NEXT LAP" in advice["text"]
+
+
+def test_select_between_lap_uses_ranking_when_ledger_empty(monkeypatch) -> None:
+    monkeypatch.setenv("AC_COPILOT_OLLAMA_ENABLE", "0")
+    refs = _refs(0, 3)
+    advice = select_between_lap_advice(
+        refs=refs,
+        ledger=None,
+        improvement_ranking=[{"corner": 3, "suggestion": "carry more"}],
+        use_ollama=False,
+    )
+    assert advice is not None and advice["corner"] == 3

--- a/tests/test_between_lap_advice.py
+++ b/tests/test_between_lap_advice.py
@@ -32,8 +32,11 @@ def test_validate_rejects_unknown_corner() -> None:
     refs = _refs(0, 1)
     assert validate_corner_advice(corner=9, text="BRAKE LATER NEXT LAP", refs=refs) is None
     assert validate_corner_advice(corner=1, text="ok", refs=refs) is None  # too short
-    ok = validate_corner_advice(corner=1, text="BRAKE LATER NEXT LAP", refs=refs)
-    assert ok is not None and ok["corner"] == 1 and ok["corner_label"] == "T1"
+    # index 0 → user-facing T1 (matches observer / voice spoken labels)
+    ok0 = validate_corner_advice(corner=0, text="BRAKE LATER NEXT LAP", refs=refs)
+    assert ok0 is not None and ok0["corner"] == 0 and ok0["corner_label"] == "T1"
+    ok1 = validate_corner_advice(corner=1, text="BRAKE LATER NEXT LAP", refs=refs)
+    assert ok1 is not None and ok1["corner"] == 1 and ok1["corner_label"] == "T2"
 
 
 def test_select_focus_prefers_ledger_focus() -> None:
@@ -53,7 +56,8 @@ def test_select_between_lap_rules_fallback_without_ollama(monkeypatch) -> None:
     advice = select_between_lap_advice(refs=refs, ledger=ledger, use_ollama=False)
     assert advice is not None
     assert advice["corner"] == 1
-    assert "T1" in advice["text"] or "NEXT LAP" in advice["text"]
+    assert advice["corner_label"] == "T2"
+    assert "T2" in advice["text"] or "NEXT LAP" in advice["text"]
 
 
 def test_select_between_lap_uses_ranking_when_ledger_empty(monkeypatch) -> None:
@@ -65,4 +69,4 @@ def test_select_between_lap_uses_ranking_when_ledger_empty(monkeypatch) -> None:
         improvement_ranking=[{"corner": 3, "suggestion": "carry more"}],
         use_ollama=False,
     )
-    assert advice is not None and advice["corner"] == 3
+    assert advice is not None and advice["corner"] == 3 and advice["corner_label"] == "T4"

--- a/tests/test_coaching_runtime.py
+++ b/tests/test_coaching_runtime.py
@@ -294,3 +294,34 @@ def test_wrap_finalizes_passes_before_begin_lap():
     assert r.index in rt.ledger._speak_set
     assert rt.ledger.state(r.index) is not None
     assert rt.ledger.state(r.index).root is not RootError.NONE
+
+
+def test_off_pace_reference_suppresses_prime_and_save():
+    """#675 Part 4: when the reference is slower than the driver's rolling best, mute cues."""
+    from tools.ai_sidecar.lap_dynamics import lap_trace_from_archive
+
+    archive = _ref()
+    rt = build_coach_runtime(archive)
+    assert rt is not None
+    assert rt.reference_lap_ms is not None
+    # Driver posts a faster lap than the reference → reference is off-pace.
+    rt.note_completed_lap(rt.reference_lap_ms - 1500.0, is_valid=True)
+    assert rt._off_pace_reference is True
+    assert rt.cue_suppress_reason == "reference_slower_than_rolling_best"
+
+    rt.ledger.assess_laps = 0
+    r = next(ref for ref in rt.refs if rt.ref_sigs[ref.index].brake_point_spline is not None)
+    st = rt.ledger._states.setdefault(r.index, CornerState(r.index))
+    st.status = Status.ARMED
+    st.root = RootError.EARLY_BRAKE
+    st.time_lost_s = 5.0
+    rt.ledger.begin_lap(3)
+    rt.ledger._speak_set = {r.index}
+    fire_at = rt.anchors[r.index].brake
+    rt._last_spline = (fire_at - 0.01) % 1.0
+    advs = rt.observe({"spline": fire_at + 0.001, "speed": 140.0, "brake": 0.0, "lap": 3})
+    assert not any(a.detail.get("coach") == "prime" for a in advs)
+
+    # Calibration still folds (Part 0/3) even under the off-pace gate.
+    n = rt.calibrate_from_driver_lap(lap_trace_from_archive(archive), track_id="magione")
+    assert n >= 0  # may be 0 if onsets don't match windows; must not raise

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -493,6 +493,7 @@ def _real_observer():
 def test_calibrate_brake_marks_from_lap_updates_observer(tmp_path, monkeypatch):
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(server, "_coach_runtime", None)  # #675: prefer-v2 target must not steal
     monkeypatch.setattr(
         server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
     )
@@ -511,6 +512,7 @@ def test_calibrate_brake_marks_from_lap_updates_observer(tmp_path, monkeypatch):
 def test_calibration_skips_explicitly_invalid_lap(tmp_path, monkeypatch):
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(server, "_coach_runtime", None)
     monkeypatch.setattr(
         server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
     )
@@ -533,6 +535,7 @@ def test_unresolvable_frame_does_not_reserve_the_calibration_key(tmp_path, monke
     reserve the dedup key — the archive-backed re-send of the SAME lap must still calibrate."""
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(server, "_coach_runtime", None)
     monkeypatch.setattr(
         server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
     )
@@ -553,6 +556,7 @@ def test_late_resend_after_a_newer_lap_is_still_deduped(tmp_path, monkeypatch):
     slot — a brainOnly re-send of lap N arriving AFTER lap N+1 folded must not refold lap N."""
     obs = _real_observer()
     monkeypatch.setattr(server, "_observer", obs)
+    monkeypatch.setattr(server, "_coach_runtime", None)
     monkeypatch.setattr(
         server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
     )
@@ -580,16 +584,46 @@ def test_late_resend_after_a_newer_lap_is_still_deduped(tmp_path, monkeypatch):
     assert after_lap4 == laps_folded + 1
 
 
-def test_calibration_inactive_when_coach_v2_owns_the_cue_path(monkeypatch):
-    """PR #525 review: with coach v2 routing live telemetry, folding laps into the LEGACY
-    observer would log 'calibrated' with zero effect on the spoken cues — the task must not
-    be scheduled at all."""
+def test_calibration_active_when_coach_v2_owns_the_cue_path(monkeypatch):
+    """#675 Part 0: alien-line / Coach v2 must NOT silently bypass brake calibration.
+
+    PR #525 skipped calibration while v2 owned cues (legacy observer marks would not affect
+    speech). V2 now has its own calibrate path, so the gate stays active whenever a live
+    producer exists.
+    """
     monkeypatch.setattr(server, "_observer", _real_observer())
     monkeypatch.setattr(server, "_coach_runtime", object())
     monkeypatch.delenv("AC_COPILOT_BRAKE_CAL", raising=False)
-    assert server._brake_calibration_active() is False
+    assert server._brake_calibration_active() is True
+    assert server._brake_calibration_target() is server._coach_runtime
     monkeypatch.setattr(server, "_coach_runtime", None)
     assert server._brake_calibration_active() is True
+    assert server._brake_calibration_target() is server._observer
+
+
+def test_calibrate_brake_marks_from_lap_updates_coach_v2(tmp_path, monkeypatch):
+    """#675: with AC_COPILOT_COACH_V2 path live, calibration folds into CoachRuntime anchors."""
+    from tools.ai_sidecar.coaching_runtime import build_coach_runtime
+
+    archive = _corner_archive()
+    coach = build_coach_runtime(archive)
+    assert coach is not None
+    monkeypatch.setattr(server, "_coach_runtime", coach)
+    monkeypatch.setattr(server, "_observer", None)
+    monkeypatch.setattr(
+        server, "_recent_brake_cal_keys", server._recent_brake_cal_keys.__class__(maxlen=8)
+    )
+    monkeypatch.delenv("AC_COPILOT_OLLAMA_ENABLE", raising=False)
+    path = _write_lap_archive(tmp_path, archive)
+    before = {idx: anc.brake for idx, anc in coach.anchors.items()}
+    asyncio.run(server._calibrate_brake_marks_from_lap({"archivePath": path, "lap": 3}))
+    assert coach._driver_brake_points, "v2 must calibrate at least one corner from the driver lap"
+    # brainOnly re-send of the SAME lap must not double-weight
+    n0 = next(iter(coach._driver_brake_points.values()))[1]
+    asyncio.run(server._calibrate_brake_marks_from_lap({"archivePath": path, "lap": 3}))
+    assert next(iter(coach._driver_brake_points.values()))[1] == n0
+    # At least one anchor should have been rewritten from the calibrated action point.
+    assert any(coach.anchors[i].brake != before[i] for i in before) or coach._driver_brake_points
 
 
 # ---------------------------------------------------------------- #531 Part D/E server wiring

--- a/tests/test_server_observer_wiring.py
+++ b/tests/test_server_observer_wiring.py
@@ -626,6 +626,50 @@ def test_calibrate_brake_marks_from_lap_updates_coach_v2(tmp_path, monkeypatch):
     assert any(coach.anchors[i].brake != before[i] for i in before) or coach._driver_brake_points
 
 
+def test_between_lap_plain_frame_does_not_poison_rolling_best(tmp_path, monkeypatch):
+    """#687 daemon: validity-blind plain lap_complete must not fold into rolling-best."""
+    from tools.ai_sidecar.coaching_runtime import build_coach_runtime
+
+    archive = _corner_archive()
+    coach = build_coach_runtime(archive)
+    assert coach is not None and coach.reference_lap_ms is not None
+    monkeypatch.setattr(server, "_coach_runtime", coach)
+    monkeypatch.setattr(
+        server,
+        "_recent_between_lap_fold_keys",
+        server._recent_between_lap_fold_keys.__class__(maxlen=8),
+    )
+    monkeypatch.setattr(
+        server,
+        "_recent_between_lap_advice_keys",
+        server._recent_between_lap_advice_keys.__class__(maxlen=8),
+    )
+    bogus_fast = coach.reference_lap_ms - 5000.0
+    # plain frame: no archive, no isValid — must not fold
+    asyncio.run(
+        server._coach_v2_between_lap(
+            object(),
+            {"lap": 3, "lapTimeMs": bogus_fast},
+            reply_coaching=False,
+        )
+    )
+    assert coach._rolling_best_lap_ms is None
+    assert coach._off_pace_reference is False
+    # archive-backed INVALID re-send: fold with is_valid=False (no rolling-best update)
+    bad = dict(archive)
+    bad["lap"] = {**(archive.get("lap") or {}), "is_valid": False, "lap_ms": bogus_fast}
+    path = _write_lap_archive(tmp_path, bad)
+    asyncio.run(
+        server._coach_v2_between_lap(
+            object(),
+            {"lap": 3, "lapTimeMs": bogus_fast, "archivePath": path},
+            reply_coaching=False,
+        )
+    )
+    assert coach._rolling_best_lap_ms is None
+    assert coach._off_pace_reference is False
+
+
 # ---------------------------------------------------------------- #531 Part D/E server wiring
 def test_cue_payload_carries_audio_routing_by_register(monkeypatch):
     """#531 Part E: urgent/critical cues route authoritative_pc; calm/alert tablet_native."""

--- a/tests/test_voice_scheduler.py
+++ b/tests/test_voice_scheduler.py
@@ -188,6 +188,29 @@ def test_release_cue_is_deferred_until_brake_alarm_finishes() -> None:
     assert pb.current is not None and pb.current.kind == "brake_release"
 
 
+def test_prepare_heads_up_is_reslotted_behind_exit_info_clip() -> None:
+    """#675 phase-slot RESLOT: prepare must not drop behind a playing exit micro-verdict."""
+    sched, pb, clock = _scheduler(VoiceConfig(ttl_s=5.0))
+    # exit confirm / micro-verdict (info) is still playing
+    sched.submit(make_advisory(kind="confirm", urgency="info", register="calm", corner=1))
+    assert sched.process_pending(clock()) is not None
+    assert pb.current is not None and pb.current.urgency == "info"
+
+    clock.advance(0.1)
+    # next corner prepare heads-up arrives — previously dropped every tap (T2 residual)
+    sched.submit(make_advisory(kind="late_brake", urgency="prepare", register="calm", corner=2))
+    assert sched.process_pending(clock()) is None
+    assert pb.current is not None and pb.current.urgency == "info"
+    assert not pb.cancelled
+
+    pb.finish()
+    clock.advance(0.05)
+    spoken = sched.process_pending(clock())
+    assert spoken is not None
+    assert spoken.urgency == "prepare"
+    assert spoken.kind == "late_brake"
+
+
 def test_stale_advisory_is_dropped_by_ttl() -> None:
     sched, pb, clock = _scheduler(VoiceConfig(ttl_s=1.5))
     sched.submit(make_advisory(kind="late_brake", urgency="act", corner=2))  # enqueued at t0

--- a/tools/ai_sidecar/coaching/between_lap.py
+++ b/tools/ai_sidecar/coaching/between_lap.py
@@ -1,0 +1,165 @@
+"""Between-lap improvement selector — exactly one next-lap ``corner_advice`` (#675 Part 2).
+
+Chooses the single highest-value corner from the Coach v2 ledger (or a ranked improvement
+list), optionally asks Ollama for a short phrase, and **fail-closes** on hallucinated corner
+identity / empty text before anything is spoken.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from tools.ai_sidecar.coaching.llm_coach import call_ollama_generate, debrief_feature_enabled
+from tools.ai_sidecar.coaching_diagnosis import PHRASE, RootError
+from tools.ai_sidecar.coaching_ledger import CoachingLedger, Status
+from tools.ai_sidecar.track_reference import CornerReference
+
+_log = logging.getLogger("ai_sidecar.coaching.between_lap")
+
+_CORNER_LABEL_MAX = 64
+
+
+def _corner_in_refs(corner: int, refs: Sequence[CornerReference]) -> bool:
+    return any(r.index == corner for r in refs)
+
+
+def _rules_phrase(root: RootError | None, corner: int) -> str:
+    if root is not None and root != RootError.NONE and root in PHRASE:
+        return f"NEXT LAP T{corner}: {PHRASE[root]}"
+    return f"NEXT LAP: FOCUS T{corner}"
+
+
+def select_focus_corner(
+    ledger: CoachingLedger | None,
+    improvement_ranking: Sequence[Mapping[str, Any]] | None = None,
+    *,
+    valid_corners: Sequence[int] | None = None,
+) -> int | None:
+    """Pick exactly one corner index, or ``None`` when nothing is coachable."""
+    allowed = set(valid_corners) if valid_corners is not None else None
+
+    if ledger is not None:
+        focus = ledger.focus_corner()
+        if focus is not None and (allowed is None or focus in allowed):
+            return focus
+        # Scan the declared corner set for any live root ranked by time lost.
+        scan = allowed if allowed is not None else set()
+        candidates = []
+        for idx in scan:
+            st = ledger.state(idx)
+            if (
+                st is not None
+                and st.root != RootError.NONE
+                and st.status
+                in (Status.ARMED, Status.PRIMED, Status.DETECTING, Status.HEALING)
+            ):
+                candidates.append(st)
+        if candidates:
+            return max(candidates, key=lambda s: s.time_lost_s).corner
+
+    for row in improvement_ranking or ():
+        if not isinstance(row, Mapping):
+            continue
+        raw = row.get("corner")
+        try:
+            corner = int(raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if allowed is not None and corner not in allowed:
+            continue
+        return corner
+    return None
+
+
+def validate_corner_advice(
+    *,
+    corner: int | None,
+    text: str | None,
+    refs: Sequence[CornerReference],
+) -> dict[str, Any] | None:
+    """Fail-closed validator: known corner identity + non-empty text, or ``None``."""
+    if corner is None or not isinstance(corner, int) or isinstance(corner, bool):
+        return None
+    if corner < 0 or not _corner_in_refs(corner, refs):
+        _log.info("between-lap advice rejected: unknown corner=%s", corner)
+        return None
+    if not isinstance(text, str):
+        return None
+    cleaned = " ".join(text.strip().split())
+    if len(cleaned) < 4 or len(cleaned.split()) < 2:
+        _log.info("between-lap advice rejected: empty/short text for corner=%s", corner)
+        return None
+    if len(cleaned) > 120:
+        cleaned = cleaned[:120].rstrip()
+    label = f"T{corner}"
+    if len(label) > _CORNER_LABEL_MAX:
+        return None
+    return {"corner": corner, "corner_label": label, "text": cleaned}
+
+
+def compose_between_lap_advice(
+    *,
+    corner: int,
+    root: RootError | None,
+    refs: Sequence[CornerReference],
+    use_ollama: bool = True,
+) -> dict[str, Any] | None:
+    """Build one validated between-lap advice payload (Ollama optional, rules fallback)."""
+    if not _corner_in_refs(corner, refs):
+        return None
+    text: str | None = None
+    if use_ollama and debrief_feature_enabled():
+        root_s = str(root) if root and root != RootError.NONE else "general"
+        phrase = PHRASE.get(root, "improve the corner") if root else "improve the corner"
+        prompt = (
+            "You coach Assetto Corsa. Reply with ONE short next-lap focus command.\n"
+            "RULES: Max 10 words. UPPERCASE. Name the corner as "
+            f"T{corner}. Use verbs BRAKE/LIFT/CARRY/TURN/HOLD only.\n"
+            f"Focus root={root_s}; suggested={phrase}\n"
+            f"NOW: next-lap focus for T{corner} ->"
+        )
+        raw = call_ollama_generate(
+            prompt,
+            temperature=0.2,
+            num_predict=24,
+            timeout_sec=10.0,
+        )
+        if raw:
+            for line in raw.strip().splitlines():
+                candidate = line.strip().strip("\"'")
+                for pre in ("Action:", "Reply:", "Command:", "ANSWER:", "->", "=>"):
+                    if candidate.upper().startswith(pre.upper()):
+                        candidate = candidate[len(pre) :].strip()
+                if "." in candidate:
+                    candidate = candidate.split(".", 1)[0].strip() + "."
+                words = [w for w in candidate.split() if w]
+                if len(words) >= 2 and len(candidate) >= 4:
+                    text = candidate.upper()[:120]
+                    break
+    if not text:
+        text = _rules_phrase(root, corner)
+    return validate_corner_advice(corner=corner, text=text, refs=refs)
+
+
+def select_between_lap_advice(
+    *,
+    refs: Sequence[CornerReference],
+    ledger: CoachingLedger | None = None,
+    improvement_ranking: Sequence[Mapping[str, Any]] | None = None,
+    use_ollama: bool = True,
+) -> dict[str, Any] | None:
+    """Select and validate exactly one next-lap improvement point for ``corner_advice``."""
+    valid = [r.index for r in refs]
+    corner = select_focus_corner(ledger, improvement_ranking, valid_corners=valid)
+    if corner is None:
+        return None
+    root: RootError | None = None
+    if ledger is not None:
+        st = ledger.state(corner)
+        if st is not None and st.root != RootError.NONE:
+            root = st.root
+    return compose_between_lap_advice(
+        corner=corner, root=root, refs=refs, use_ollama=use_ollama
+    )

--- a/tools/ai_sidecar/coaching/between_lap.py
+++ b/tools/ai_sidecar/coaching/between_lap.py
@@ -25,10 +25,16 @@ def _corner_in_refs(corner: int, refs: Sequence[CornerReference]) -> bool:
     return any(r.index == corner for r in refs)
 
 
+def _turn_label(corner: int) -> str:
+    """User-facing turn label — ``CornerReference.index`` is 0-based; spoken labels are T1.."""
+    return f"T{corner + 1}"
+
+
 def _rules_phrase(root: RootError | None, corner: int) -> str:
+    label = _turn_label(corner)
     if root is not None and root != RootError.NONE and root in PHRASE:
-        return f"NEXT LAP T{corner}: {PHRASE[root]}"
-    return f"NEXT LAP: FOCUS T{corner}"
+        return f"NEXT LAP {label}: {PHRASE[root]}"
+    return f"NEXT LAP: FOCUS {label}"
 
 
 def select_focus_corner(
@@ -92,7 +98,7 @@ def validate_corner_advice(
         return None
     if len(cleaned) > 120:
         cleaned = cleaned[:120].rstrip()
-    label = f"T{corner}"
+    label = _turn_label(corner)
     if len(label) > _CORNER_LABEL_MAX:
         return None
     return {"corner": corner, "corner_label": label, "text": cleaned}
@@ -112,12 +118,13 @@ def compose_between_lap_advice(
     if use_ollama and debrief_feature_enabled():
         root_s = str(root) if root and root != RootError.NONE else "general"
         phrase = PHRASE.get(root, "improve the corner") if root else "improve the corner"
+        label = _turn_label(corner)
         prompt = (
             "You coach Assetto Corsa. Reply with ONE short next-lap focus command.\n"
             "RULES: Max 10 words. UPPERCASE. Name the corner as "
-            f"T{corner}. Use verbs BRAKE/LIFT/CARRY/TURN/HOLD only.\n"
+            f"{label}. Use verbs BRAKE/LIFT/CARRY/TURN/HOLD only.\n"
             f"Focus root={root_s}; suggested={phrase}\n"
-            f"NOW: next-lap focus for T{corner} ->"
+            f"NOW: next-lap focus for {label} ->"
         )
         raw = call_ollama_generate(
             prompt,

--- a/tools/ai_sidecar/coaching/between_lap.py
+++ b/tools/ai_sidecar/coaching/between_lap.py
@@ -52,8 +52,7 @@ def select_focus_corner(
             if (
                 st is not None
                 and st.root != RootError.NONE
-                and st.status
-                in (Status.ARMED, Status.PRIMED, Status.DETECTING, Status.HEALING)
+                and st.status in (Status.ARMED, Status.PRIMED, Status.DETECTING, Status.HEALING)
             ):
                 candidates.append(st)
         if candidates:
@@ -160,6 +159,4 @@ def select_between_lap_advice(
         st = ledger.state(corner)
         if st is not None and st.root != RootError.NONE:
             root = st.root
-    return compose_between_lap_advice(
-        corner=corner, root=root, refs=refs, use_ollama=use_ollama
-    )
+    return compose_between_lap_advice(corner=corner, root=root, refs=refs, use_ollama=use_ollama)

--- a/tools/ai_sidecar/coaching_runtime.py
+++ b/tools/ai_sidecar/coaching_runtime.py
@@ -41,9 +41,23 @@ from tools.ai_sidecar.driver_progression import (
     cue_policy_from_profile,
     default_cue_policy,
 )
-from tools.ai_sidecar.lap_dynamics import CornerSignature, corner_signatures, lap_trace_from_archive
-from tools.ai_sidecar.realtime_observer import Advisory
-from tools.ai_sidecar.track_reference import CornerReference, build_references
+from tools.ai_sidecar.lap_dynamics import (
+    CornerSignature,
+    LapTrace,
+    corner_signatures,
+    lap_trace_from_archive,
+)
+from tools.ai_sidecar.realtime_observer import (
+    _CAL_EMA_ALPHA,
+    CAL_MATCH_TOL_M,
+    Advisory,
+    _signed_spline_delta,
+)
+from tools.ai_sidecar.track_reference import (
+    CornerReference,
+    build_references,
+    sustained_brake_onsets,
+)
 
 #: Roots that demand more speed / later braking — suppressed at the grip ceiling (P3).
 #: LATE_BRAKE maps to "Brake earlier." and is NOT grip-gated (still valid at the grip ceiling).
@@ -128,6 +142,17 @@ class CoachRuntime:
             "corners": [],
         }
     )
+    brake_lead_s: float = _DEFAULT_LEAD_S
+    track_id: str | None = None
+    track_layout: str | None = None
+    reference_lap_ms: float | None = None
+    #: per-corner driver brake action-point EMA (issue #675 Parts 0/3): (spline, n_laps).
+    _driver_brake_points: dict[int, tuple[float, int]] = field(default_factory=dict)
+    _rolling_best_lap_ms: float | None = None
+    #: Part 4 — when the active reference is slower than the driver's rolling best, reference-
+    #: derived brake/turn cues are suppressed (visible via :attr:`cue_suppress_reason`).
+    _off_pace_reference: bool = False
+    cue_suppress_reason: str = ""
     _pass: dict[int, _PassState] = field(default_factory=dict)
     _last_spline: float | None = None
     _last_lap: float | None = None
@@ -145,6 +170,8 @@ class CoachRuntime:
 
         Without this, stale ``_lap``/``_last_spline``/per-corner passes + a RETIRED ledger carry
         across stints, which silently suppresses cues until the sidecar process is restarted.
+        Per-driver brake calibration and the rolling-best / off-pace gate persist
+        (driver knowledge).
         """
         self.ledger.clear_session()
         self._pass = {r.index: _PassState() for r in self.refs}
@@ -154,6 +181,101 @@ class CoachRuntime:
         self._pending_wrap_finals = False
         self._pending_pre_lap = None
         self.ledger.begin_lap(self._lap)
+
+    def note_completed_lap(self, lap_time_ms: float | None, *, is_valid: bool = True) -> None:
+        """Fold a finished lap into the rolling-best / off-pace-reference gate (#675 Part 4)."""
+        if not is_valid or lap_time_ms is None:
+            return
+        try:
+            ms = float(lap_time_ms)
+        except (TypeError, ValueError):
+            return
+        if ms <= 0.0 or ms != ms:
+            return
+        if self._rolling_best_lap_ms is None or ms < self._rolling_best_lap_ms:
+            self._rolling_best_lap_ms = ms
+        self._refresh_off_pace_gate()
+
+    def _refresh_off_pace_gate(self) -> None:
+        ref = self.reference_lap_ms
+        best = self._rolling_best_lap_ms
+        if ref is None or best is None:
+            self._off_pace_reference = False
+            self.cue_suppress_reason = ""
+            return
+        if ref > best:
+            self._off_pace_reference = True
+            self.cue_suppress_reason = "reference_slower_than_rolling_best"
+        else:
+            self._off_pace_reference = False
+            self.cue_suppress_reason = ""
+
+    def calibrate_from_driver_lap(
+        self,
+        lap: LapTrace,
+        *,
+        track_id: str | None = None,
+        track_layout: str | None = None,
+    ) -> int:
+        """Fold one valid driver lap into per-corner brake action-point EMAs (#675 Parts 0/3).
+
+        Mirrors :meth:`RealtimeObserver.calibrate_from_driver_lap` guards (track/layout match,
+        metric tolerance, EMA alpha) but updates the v2 cue producer: PRIME brake anchors and the
+        SAVE ``brake_point_spline`` on :attr:`ref_sigs`. Returns the number of corners updated.
+        """
+        if track_id and self.track_id and track_id != self.track_id:
+            return 0
+        if track_layout and self.track_layout and track_layout != self.track_layout:
+            return 0
+        tol = CAL_MATCH_TOL_M / max(self.track_length_m, 1.0)
+        updated = 0
+        for ref in self.refs:
+            sig = self.ref_sigs.get(ref.index)
+            if sig is None or sig.brake_point_spline is None:
+                continue
+            cur = self._driver_brake_points.get(ref.index)
+            anchor = cur[0] if cur is not None else sig.brake_point_spline
+            lo_a, hi_a = anchor - tol, anchor + 2.0 * tol
+            if lo_a < 0.0:
+                windows = [(lo_a % 1.0, 1.0), (0.0, hi_a)]
+            elif hi_a > 1.0:
+                windows = [(lo_a, 1.0), (0.0, hi_a % 1.0)]
+            else:
+                windows = [(lo_a, hi_a)]
+            onsets: list[float] = []
+            seen: set[float] = set()
+            for w_lo, w_hi in windows:
+                for onset in sustained_brake_onsets(lap, w_lo, w_hi):
+                    if onset not in seen:
+                        seen.add(onset)
+                        onsets.append(onset)
+            if not onsets:
+                continue
+            best = min(onsets, key=lambda o: abs(_signed_spline_delta(o, anchor)))
+            if abs(_signed_spline_delta(best, anchor)) > tol:
+                continue
+            if cur is None:
+                candidate = best % 1.0
+                n = 1
+            else:
+                ema, n_prev = cur
+                candidate = (ema + _CAL_EMA_ALPHA * _signed_spline_delta(best, ema)) % 1.0
+                n = n_prev + 1
+            self._driver_brake_points[ref.index] = (candidate, n)
+            self._apply_brake_calibration(ref.index, candidate)
+            updated += 1
+        return updated
+
+    def _apply_brake_calibration(self, corner_idx: int, brake_point: float) -> None:
+        """Move the PRIME fire point and SAVE action point to a calibrated brake mark."""
+        sig = self.ref_sigs.get(corner_idx)
+        v_ref = sig.entry_speed_kmh if sig is not None else 150.0
+        lead = _lead_spline(v_ref, self.track_length_m, self.brake_lead_s)
+        anc = self.anchors.get(corner_idx)
+        if anc is not None:
+            anc.brake = (brake_point - lead) % 1.0
+        if sig is not None:
+            self.ref_sigs[corner_idx] = replace(sig, brake_point_spline=brake_point % 1.0)
 
     def _advance_lap_after_wrap(self, out: list[Advisory]) -> None:
         """Finalize open passes, then advance the ledger lap (speak-set needs fresh diagnoses)."""
@@ -209,10 +331,12 @@ class CoachRuntime:
             anc = self.anchors[r.index]
 
             # 1. PRIME — fire on crossing the armed root's anchor (before the action point).
+            # Part 4 off-pace: still advance ledger state (due_prime spends budget) but do not speak
+            # reference-derived brake/turn cues when the reference itself is slower than the driver.
             root = self.ledger.armed_root(r.index)
             if root is not None and _crossed(self._last_spline, spline, anc.for_root(root)):
                 spoken = self.ledger.due_prime(r.index)
-                if spoken is not None:
+                if spoken is not None and not self._off_pace_reference:
                     gst = self.ledger.state(r.index)
                     reg = gst.register if gst else "urgent"
                     inten = gst.intensity if gst else 0.5
@@ -248,10 +372,12 @@ class CoachRuntime:
         _accumulate_core(st, r, spline, speed, brake, throttle, steer)
 
         # SAVE: past the reference brake point, still coasting (no brake), carrying speed → "Brake!"
+        # Suppressed under Part 4 off-pace (would coach toward a slower reference).
         ref_sig = self.ref_sigs.get(r.index)
         ref_bp = ref_sig.brake_point_spline if ref_sig else None
         if (
-            not st.save_fired
+            not self._off_pace_reference
+            and not st.save_fired
             and ref_bp is not None
             and spline > ref_bp + _SAVE_LATE_BRAKE_MARGIN
             and spline < r.apex_spline
@@ -579,11 +705,18 @@ def build_coach_runtime(
     geom = {s.index: s for s in corner_signatures(ref_lap)}  # for anchor timing only
     track_obj = reference_archive.get("track")
     track_m = _DEFAULT_TRACK_M
+    track_id: str | None = None
+    track_layout: str | None = None
     if isinstance(track_obj, dict):
         try:
             track_m = float(track_obj.get("lengthM") or _DEFAULT_TRACK_M)
         except (TypeError, ValueError):
             track_m = _DEFAULT_TRACK_M
+        tid = track_obj.get("id")
+        track_id = tid if isinstance(tid, str) and tid.strip() else None
+        tlayout = track_obj.get("layout")
+        track_layout = tlayout if isinstance(tlayout, str) and tlayout.strip() else None
+    reference_lap_ms = _archive_lap_ms(reference_archive)
     anchors: dict[int, _Anchors] = {}
     for r in refs:
         sig = geom.get(r.index)
@@ -695,7 +828,29 @@ def build_coach_runtime(
         ledger=ledger,
         cue_policy=policy,
         frontier=frontier,
+        brake_lead_s=lead_s,
+        track_id=track_id,
+        track_layout=track_layout,
+        reference_lap_ms=reference_lap_ms,
     )
+
+
+def _archive_lap_ms(archive: Mapping[str, Any]) -> float | None:
+    """Best-effort lap time (ms) from a reference/driver archive ``lap`` block."""
+    lap = archive.get("lap")
+    if not isinstance(lap, Mapping):
+        return None
+    for key in ("lap_ms", "lapTimeMs", "time_ms", "lap_time_ms"):
+        raw = lap.get(key)
+        if raw is None or isinstance(raw, bool):
+            continue
+        try:
+            ms = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if ms > 0.0 and ms == ms:
+            return ms
+    return None
 
 
 def _env_int(name: str, default: int, *, min_value: int = 0) -> int:

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -104,6 +104,7 @@ from tools.ai_sidecar.external_protocol import (
 from tools.ai_sidecar.protocol import (
     EVENT_ANALYSIS_ERROR,
     EVENT_COACHING_RESPONSE,
+    EVENT_CORNER_ADVICE,
     EVENT_CORNER_QUERY,
     PROTOCOL_VERSION,
     build_brain_followup,
@@ -312,6 +313,10 @@ def public_voice_runtime_status() -> dict[str, object]:
         if frontier_reason and not re.fullmatch(r"[a-z0-9_]+", frontier_reason):
             public_frontier["reason"] = "alien_frontier_error"
         status["coach_frontier"] = public_frontier
+    # #675 Part 4 — machine-code suppress reason for timing reports (no paths / free text).
+    suppress = getattr(_coach_runtime, "cue_suppress_reason", "") or ""
+    if isinstance(suppress, str) and re.fullmatch(r"[a-z0-9_]+", suppress):
+        status["cue_suppress_reason"] = suppress
     return status
 
 
@@ -792,6 +797,78 @@ async def _send_brain_followup(websocket: Any, inbound: dict[str, Any]) -> None:
     await _safe_send(websocket, followup)
 
 
+async def _coach_v2_between_lap(
+    websocket: Any, inbound: dict[str, Any], *, reply_coaching: bool
+) -> None:
+    """#675 Parts 2/4: update off-pace gate and emit one between-lap ``corner_advice``.
+
+    Fail-closed: invalid/unknown corners and empty LLM text never dispatch. Does not raise into
+    the websocket loop — calibration/advice gaps are logged, not swallowed into a silent success.
+    Deduped across the plain ``lap_complete`` + archive-backed ``brainOnly`` re-send.
+    """
+    coach = _coach_runtime
+    if coach is None:
+        return
+    lap_n, lap_ms = inbound.get("lap"), inbound.get("lapTimeMs")
+    if lap_n is not None and lap_ms is not None:
+        key = f"lap:{lap_n}:{lap_ms}"
+    else:
+        key = str(inbound.get("archivePath") or "") or f"lap:{lap_n}"
+    # Off-pace gate updates on the first sighting; advice emission is once per physical lap.
+    already = key in _recent_between_lap_keys
+    if not already:
+        _recent_between_lap_keys.append(key)
+    is_valid = True
+    if str(inbound.get("archivePath") or "").strip() or (
+        isinstance(inbound.get("trace"), dict) and inbound.get("trace", {}).get("samples")
+    ):
+        try:
+            loaded = await asyncio.to_thread(resolve_lap_archive, inbound)
+            if isinstance(loaded, dict):
+                lap_meta = loaded.get("lap")
+                if isinstance(lap_meta, dict):
+                    if lap_meta.get("is_valid") is False:
+                        is_valid = False
+                    if lap_ms is None:
+                        lap_ms = lap_meta.get("lap_ms") or lap_meta.get("lapTimeMs")
+        except Exception as e:
+            logger.info("coach v2 between-lap archive load skipped: %s", e)
+    if not already:
+        coach.note_completed_lap(lap_ms, is_valid=is_valid)
+    if already or not is_valid or not reply_coaching:
+        return
+    ranking = inbound.get("improvementRanking")
+    if not isinstance(ranking, list):
+        ranking = None
+    try:
+        from tools.ai_sidecar.coaching.between_lap import select_between_lap_advice
+
+        advice = await asyncio.to_thread(
+            select_between_lap_advice,
+            refs=coach.refs,
+            ledger=coach.ledger,
+            improvement_ranking=ranking,
+            use_ollama=True,
+        )
+    except Exception:
+        logger.exception("coach v2 between-lap selector failed")
+        return
+    if advice is None:
+        return
+    await _safe_send(
+        websocket,
+        {
+            "protocol": PROTOCOL_VERSION,
+            "event": EVENT_CORNER_ADVICE,
+            "corner": advice["corner_label"],
+            "cornerIndex": advice["corner"],
+            "lap": inbound.get("lap"),
+            "text": advice["text"],
+            "slot": "between_lap",
+        },
+    )
+
+
 def _brake_calibration_enabled() -> bool:
     """Per-driver brake-mark calibration (issue #522): on by default, ``AC_COPILOT_BRAKE_CAL=0``
     disables."""
@@ -799,14 +876,22 @@ def _brake_calibration_enabled() -> bool:
 
 
 def _brake_calibration_active() -> bool:
-    """Calibration folds into the LEGACY observer's marks — the default live cue producer.
+    """Calibration folds into the live cue producer (#522 legacy observer, #675 Coach v2).
 
-    With coach v2 active (``AC_COPILOT_COACH_V2=1``), ``_publish_coaching_cues`` routes
-    telemetry through ``_coach_runtime`` instead, so folding laps into ``_observer`` would log
-    "calibrated" while having zero effect on the spoken cues — misleading. Skip; v2-side
-    calibration is tracked as #522 V2 scope (PR #525 review).
+    Alien-line launches set ``AC_COPILOT_COACH_V2=1`` (``supervisor.py``); without a v2-side
+    calibrate path that would silently bypass per-driver brake marks. Prefer ``_coach_runtime``
+    when present so spoken cue anchors actually move.
     """
-    return _observer is not None and _coach_runtime is None and _brake_calibration_enabled()
+    if not _brake_calibration_enabled():
+        return False
+    return _coach_runtime is not None or _observer is not None
+
+
+def _brake_calibration_target() -> Any | None:
+    """The producer whose marks/anchors calibration must update to affect spoken cues."""
+    if _coach_runtime is not None:
+        return _coach_runtime
+    return _observer
 
 
 #: recent lap_complete identities already folded into calibration — the plain lap_complete frame
@@ -815,18 +900,21 @@ def _brake_calibration_active() -> bool:
 #: bounded set of recent keys is kept, not just the last one (PR #525 review). The most recent
 #: reservation is tracked separately so a failed load can roll itself back.
 _recent_brake_cal_keys: deque[str] = deque(maxlen=8)
+#: same physical-lap identity guard for between-lap ``corner_advice`` (plain + brainOnly).
+_recent_between_lap_keys: deque[str] = deque(maxlen=8)
 
 
 async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
-    """Fold the driver's completed lap into the observer's per-zone brake-mark EMA (#522).
+    """Fold the driver's completed lap into the live producer's brake-mark EMA (#522 / #675).
 
     Runs as a background task on lap_complete: loads the lap archive off the loop (safe-path
     validated by :func:`resolve_lap_archive`), skips explicitly-invalid laps (a cut lap's brake
     points are not calibration data), and applies the EMA update on the event loop — the same
-    loop that calls ``observer.observe``, so there is no cross-thread mutation.
+    loop that calls ``observe``, so there is no cross-thread mutation. Targets Coach v2 when
+    active so alien-line launches do not silently bypass calibration.
     """
-    observer = _observer
-    if observer is None:
+    target = _brake_calibration_target()
+    if target is None:
         return
     # A frame with neither an inline trace nor an archivePath can never resolve: return WITHOUT
     # reserving the dedup key, or the archive-backed brainOnly re-send racing this task would see
@@ -877,13 +965,18 @@ async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:
     track_obj = archive.get("track")
     track_id = track_obj.get("id") if isinstance(track_obj, dict) else None
     track_layout = track_obj.get("layout") if isinstance(track_obj, dict) else None
-    updated = observer.calibrate_from_driver_lap(
+    updated = target.calibrate_from_driver_lap(
         trace,
         track_id=track_id if isinstance(track_id, str) else None,
         track_layout=track_layout if isinstance(track_layout, str) else None,
     )
     if updated:
-        logger.info("brake marks calibrated from the driver's lap: %d zone(s) updated", updated)
+        producer = "coach_v2" if target is _coach_runtime else "observer"
+        logger.info(
+            "brake marks calibrated from the driver's lap (%s): %d zone(s) updated",
+            producer,
+            updated,
+        )
 
 
 async def _safe_send(websocket: Any, payload: dict[str, Any]) -> None:
@@ -2531,6 +2624,13 @@ async def _handler(websocket: Any, reply_coaching: bool) -> None:
                     cal_task = asyncio.create_task(_calibrate_brake_marks_from_lap(data))
                     _background_tasks.add(cal_task)
                     cal_task.add_done_callback(_background_tasks.discard)
+                # #675 Parts 2/4: off-pace gate always; between-lap corner_advice when coaching on.
+                if _coach_runtime is not None:
+                    v2_task = asyncio.create_task(
+                        _coach_v2_between_lap(websocket, data, reply_coaching=reply_coaching)
+                    )
+                    _background_tasks.add(v2_task)
+                    v2_task.add_done_callback(_background_tasks.discard)
 
             # Archive-backed activation frames are emitted after Lua knows the final archive path.
             # They should only run the brain, not the generic rules ack or Ollama narration.

--- a/tools/ai_sidecar/server.py
+++ b/tools/ai_sidecar/server.py
@@ -814,17 +814,17 @@ async def _coach_v2_between_lap(
         key = f"lap:{lap_n}:{lap_ms}"
     else:
         key = str(inbound.get("archivePath") or "") or f"lap:{lap_n}"
-    # Off-pace gate updates on the first sighting; advice emission is once per physical lap.
-    already = key in _recent_between_lap_keys
-    if not already:
-        _recent_between_lap_keys.append(key)
+    # Off-pace fold requires KNOWN validity — a plain lap_complete without archive/trace must
+    # not default to valid and poison _rolling_best_lap_ms before the brainOnly re-send (#687).
     is_valid = True
+    validity_known = False
     if str(inbound.get("archivePath") or "").strip() or (
         isinstance(inbound.get("trace"), dict) and inbound.get("trace", {}).get("samples")
     ):
         try:
             loaded = await asyncio.to_thread(resolve_lap_archive, inbound)
             if isinstance(loaded, dict):
+                validity_known = True
                 lap_meta = loaded.get("lap")
                 if isinstance(lap_meta, dict):
                     if lap_meta.get("is_valid") is False:
@@ -833,9 +833,17 @@ async def _coach_v2_between_lap(
                         lap_ms = lap_meta.get("lap_ms") or lap_meta.get("lapTimeMs")
         except Exception as e:
             logger.info("coach v2 between-lap archive load skipped: %s", e)
-    if not already:
+    else:
+        for flag_key in ("isValid", "is_valid", "valid"):
+            raw = inbound.get(flag_key)
+            if isinstance(raw, bool):
+                is_valid = raw
+                validity_known = True
+                break
+    if validity_known and key not in _recent_between_lap_fold_keys:
+        _recent_between_lap_fold_keys.append(key)
         coach.note_completed_lap(lap_ms, is_valid=is_valid)
-    if already or not is_valid or not reply_coaching:
+    if not is_valid or not reply_coaching or key in _recent_between_lap_advice_keys:
         return
     ranking = inbound.get("improvementRanking")
     if not isinstance(ranking, list):
@@ -855,6 +863,7 @@ async def _coach_v2_between_lap(
         return
     if advice is None:
         return
+    _recent_between_lap_advice_keys.append(key)
     await _safe_send(
         websocket,
         {
@@ -900,8 +909,11 @@ def _brake_calibration_target() -> Any | None:
 #: bounded set of recent keys is kept, not just the last one (PR #525 review). The most recent
 #: reservation is tracked separately so a failed load can roll itself back.
 _recent_brake_cal_keys: deque[str] = deque(maxlen=8)
-#: same physical-lap identity guard for between-lap ``corner_advice`` (plain + brainOnly).
-_recent_between_lap_keys: deque[str] = deque(maxlen=8)
+#: same physical-lap identity guards for between-lap fold / ``corner_advice`` (plain + brainOnly).
+#: Kept separate so a validity-blind plain frame can reserve advice without permanently blocking
+#: an archive-backed fold on the re-send (#687 daemon review).
+_recent_between_lap_fold_keys: deque[str] = deque(maxlen=8)
+_recent_between_lap_advice_keys: deque[str] = deque(maxlen=8)
 
 
 async def _calibrate_brake_marks_from_lap(inbound: dict[str, Any]) -> None:

--- a/tools/ai_sidecar/voice/scheduler.py
+++ b/tools/ai_sidecar/voice/scheduler.py
@@ -19,6 +19,9 @@ The
 * **Cooldown** — a minimum gap between two cues of the same *kind*. ``act`` is **exempt**: a fresh
   ``act`` cue is never delayed or dropped by cooldown/TTL/dedup machinery.
 * **Verbosity** — cues below the configured verbosity floor are suppressed.
+* **Phase-slot reslot (#675)** — a ``prepare`` heads-up that would otherwise drop behind a still-
+  playing ``info`` exit micro-verdict is deferred until the channel frees (same pattern as
+  ``brake_release`` behind a brake alarm), so the next corner's mark is not silently lost.
 
 The arbitration in :meth:`process_pending` is a pure function of the injected ``clock`` and the
 injected :class:`~tools.ai_sidecar.voice.playback.Playback`, so it is fully unit-testable with a
@@ -119,6 +122,15 @@ class Scheduler:
             self._pending = []
         if deferred is not None:
             winner, enqueued_at = deferred
+            # Deferred prepare can sit behind an exit clip long enough to go stale — drop it
+            # rather than speaking late (#675 phase-slot + existing TTL contract).
+            if (now - enqueued_at) > self._config.ttl_s:
+                _log.debug(
+                    "voice: dropping stale deferred %s (age=%.3fs)",
+                    winner.clip_id,
+                    now - enqueued_at,
+                )
+                return None
             return self._dispatch(winner, now, enqueued_at=enqueued_at)
 
         candidates: list[tuple[Utterance, float, int]] = []
@@ -205,6 +217,18 @@ class Scheduler:
                 with self._lock:
                     self._deferred.append((winner, enqueued_at if enqueued_at is not None else now))
                 _log.debug("voice: defer %s until %s finishes", winner.clip_id, current.clip_id)
+                return None
+            elif winner.urgency == "prepare" and current.urgency == "info":
+                # #675 phase-slot RESLOT: prepare heads-up never barges over an exit micro-verdict
+                # (confirm/info), but dropping it was the T2-on-every-tap residual — hold until
+                # the channel frees, then speak if still inside TTL.
+                with self._lock:
+                    self._deferred.append((winner, enqueued_at if enqueued_at is not None else now))
+                _log.debug(
+                    "voice: phase-slot reslot %s until %s finishes",
+                    winner.clip_id,
+                    current.clip_id,
+                )
                 return None
             else:
                 # Channel busy with an equal/higher cue; the moment for this one has passed — drop

--- a/tools/ai_sidecar/voice/semantic_timeliness.py
+++ b/tools/ai_sidecar/voice/semantic_timeliness.py
@@ -345,8 +345,8 @@ def analyze(
 
     # Per-pass coverage guarantee (#522), stated directly: reference brake passes the observer
     # flagged (crossed) vs those that drew an ACTIONABLE cue (cued). A crossed-but-uncued pass
-    # (e.g. the T2 heads-up lost behind a still-playing exit debrief) is #522 V2 phase-slot
-    # scheduler scope — surfaced here, not regressed into this gate.
+    # (e.g. the T2 heads-up lost behind a still-playing exit debrief) is owned by the #675
+    # phase-slot RESLOT in ``voice/scheduler.py`` — surfaced here, not regressed into this gate.
     zones_crossed = len(brake_mark_occ)
     zones_cued = len(coached_occ)
 


### PR DESCRIPTION
## Summary
- **Part 0/3:** Close the alien-line / `AC_COPILOT_COACH_V2=1` brake-calibration bypass — `_brake_calibration_active` stays true when Coach v2 owns cues, and `_calibrate_brake_marks_from_lap` folds into `CoachRuntime` brake anchors (same double-fold / invalid-lap guards as the legacy observer).
- **Part 1:** Phase-slot RESLOT in `voice/scheduler.py` — a `prepare` heads-up behind a playing `info` exit micro-verdict is deferred (not dropped), fixing the T2-dropped-on-every-tap residual.
- **Part 2:** Between-lap selector (`coaching/between_lap.py`) emits exactly one validated `corner_advice` after lap complete (Ollama optional, rules fallback; fail-closed on unknown corner / empty text).
- **Part 4:** Off-pace reference refusal — when the reference lap is slower than the driver's rolling best, reference-derived PRIME/SAVE cues are suppressed; reason exposed on `/health` as `cue_suppress_reason`.

Fixes #675

## Test plan
- [x] `make ci-fast` (local)
- [x] `tests/test_between_lap_advice.py`, scheduler RESLOT test, coach-v2 calibration wiring tests, off-pace suppress test
- [ ] CI green on PR
- [ ] Harness / semantic-timeliness when a rig session is available (`semantic_timeliness.py --assert-coaching`)

## Design notes
Council lean (gemini + perplexity): Option A (calibrate CoachRuntime directly) + RESLOT prepare behind exit info. Coordination: #672 also touches `supervisor.py` but this PR does not change it (launcher already sets `AC_COPILOT_COACH_V2=1` under `alien_line`).