### PR TITLE
fix(voice): preserve critical brake articulation (#381)

### DIFF
--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -124,6 +124,27 @@ def test_bake_accepts_float32_external_backend(tmp_path) -> None:
     assert max(abs(v[0]) for v in struct.iter_unpack("<h", raw)) > 1000
 
 
+def test_bank_policy_hook_runs_after_normalization_not_during_synthesis(tmp_path) -> None:
+    class _ValidatingToneBackend(ToneBackend):
+        def __init__(self) -> None:
+            self.validated: list[str] = []
+
+        def validate_baked_clip(self, text: str, register: str, out_path: Path) -> None:
+            del text, register
+            with wave.open(str(out_path), "rb") as wf:
+                assert wf.getframerate() == 22050
+                assert wf.getnchannels() == 1
+                assert wf.getsampwidth() == 2
+            self.validated.append(out_path.name)
+
+    backend = _ValidatingToneBackend()
+    backend.synthesize("Brake!", "critical", tmp_path / "benchmark.wav", 22050)
+    assert backend.validated == []  # bench_voices uses the unchecked, measurable render path.
+
+    manifest = bake_bank(tmp_path / "bank", backend, samplerate=22050)
+    assert len(backend.validated) == len(manifest.clips)
+
+
 def test_tone_backend_registers_are_distinct(tmp_path) -> None:
     # Issue #381: the register (intensity tier) must produce measurably distinct audio even from the
     # stdlib CI backend, so CI exercises calm/alert/urgent/critical end-to-end.
@@ -277,37 +298,59 @@ def _first_sample(path: Path) -> int:
 
 
 @pytest.mark.parametrize(
-    ("text", "register", "duration_ms", "error"),
+    ("text", "register", "audible_ms", "duration_ms", "error"),
     [
-        ("Brake.", "alert", 450, None),
-        ("Brake.", "alert", 451, "brake act cue must be at most 450 ms"),
-        ("Brake.", "urgent", 450, None),
-        ("Brake.", "urgent", 451, "brake act cue must be at most 450 ms"),
-        ("Brake!", "critical", 379, "articulation must be at least 380 ms"),
-        ("Brake!", "critical", 380, None),
-        ("Brake!", "critical", 450, None),
-        ("Brake!", "critical", 451, "brake act cue must be at most 450 ms"),
+        ("Brake.", "alert", 450, 450, None),
+        ("Brake.", "alert", 451, 451, "brake act cue must be at most 450 ms"),
+        ("Brake.", "urgent", 450, 450, None),
+        ("Brake.", "urgent", 451, 451, "brake act cue must be at most 450 ms"),
+        ("Brake!", "critical", 0, 380, "audible articulation must extend"),
+        ("Brake!", "critical", 355, 380, "audible articulation must extend"),
+        ("Brake!", "critical", 360, 380, None),
+        ("Brake!", "critical", 375, 450, None),
+        ("Brake!", "critical", 451, 451, "brake act cue must be at most 450 ms"),
     ],
 )
-def test_kokoro_brake_act_duration_window(
+def test_kokoro_brake_act_timing_window(
     tmp_path: Path,
     text: str,
     register: str,
+    audible_ms: int,
     duration_ms: int,
     error: str | None,
 ) -> None:
     out = tmp_path / "brake.wav"
-    _write_pcm16_wav(out, samplerate=1000, value=0, frames=duration_ms)
+    with wave.open(str(out), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(1000)
+        wf.writeframes(
+            struct.pack(
+                f"<{duration_ms}h", *([1000] * audible_ms), *([0] * (duration_ms - audible_ms))
+            )
+        )
     backend = object.__new__(KokoroBackend)
+    backend._voice = "am_fenrir"
 
     if error:
         with pytest.raises(RuntimeError, match=error):
-            backend._validate_brake_act_duration(text, register, out)
+            backend.validate_baked_clip(text, register, out)
     else:
-        backend._validate_brake_act_duration(text, register, out)
+        backend.validate_baked_clip(text, register, out)
 
     # The narrow duration contract is for the one-syllable alarm only, not every critical phrase.
-    backend._validate_brake_act_duration("Save tyres!", "critical", out)
+    backend.validate_baked_clip("Save tyres!", "critical", out)
+
+
+def test_kokoro_articulation_floor_is_scoped_to_operator_calibrated_voice(tmp_path) -> None:
+    out = tmp_path / "short-but-audible.wav"
+    _write_pcm16_wav(out, samplerate=1000, value=1000, frames=300)
+    backend = object.__new__(KokoroBackend)
+    backend._voice = "af_heart"
+
+    # Different voices remain benchmarkable/bakeable below Fenrir's empirically calibrated floor;
+    # the universal action-cue ceiling is still enforced for every Kokoro voice.
+    backend.validate_baked_clip("Brake!", "critical", out)
 
 
 class _CopyShaper:

--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -136,12 +136,17 @@ def test_tone_backend_registers_are_distinct(tmp_path) -> None:
 
 
 def test_speech_backends_keep_act_registers_fast() -> None:
-    # Issue #381: the real neural backends must bake terse act registers at an assertive pace.
-    # Otherwise a valid v3 manifest can still fail the runtime brake-alarm timing report.
+    # Issue #381: Kokoro's base pace and the ffmpeg tempo step stack. The shaper owns escalation
+    # across active registers; their common bounded base keeps the final consonant articulated.
     assert KokoroBackend._REGISTER_SPEED["calm"] < KokoroBackend._REGISTER_SPEED["alert"]
-    assert KokoroBackend._REGISTER_SPEED["alert"] < KokoroBackend._REGISTER_SPEED["urgent"]
-    assert KokoroBackend._REGISTER_SPEED["urgent"] < KokoroBackend._REGISTER_SPEED["critical"]
-    assert KokoroBackend._REGISTER_SPEED["critical"] >= 1.4
+    assert len(
+        {
+            KokoroBackend._REGISTER_SPEED["alert"],
+            KokoroBackend._REGISTER_SPEED["urgent"],
+            KokoroBackend._REGISTER_SPEED["critical"],
+        }
+    ) == 1
+    assert 1.20 <= KokoroBackend._REGISTER_SPEED["critical"] <= 1.25
 
     assert (
         PiperBackend._REGISTER_LENGTH_SCALE["calm"] > PiperBackend._REGISTER_LENGTH_SCALE["alert"]
@@ -273,6 +278,33 @@ def _write_pcm16_wav(path: Path, *, samplerate: int, value: int, frames: int = 1
 def _first_sample(path: Path) -> int:
     with wave.open(str(path), "rb") as wf:
         return struct.unpack("<h", wf.readframes(1))[0]
+
+
+@pytest.mark.parametrize(
+    ("duration_ms", "raises"),
+    [
+        (379, True),
+        (380, False),
+        (450, False),
+        (451, True),
+    ],
+)
+def test_kokoro_critical_brake_articulation_window(
+    tmp_path: Path, duration_ms: int, raises: bool
+) -> None:
+    out = tmp_path / "critical.wav"
+    _write_pcm16_wav(out, samplerate=1000, value=0, frames=duration_ms)
+    backend = object.__new__(KokoroBackend)
+
+    if raises:
+        with pytest.raises(RuntimeError, match="articulation must be 380-450 ms"):
+            backend._validate_critical_brake_articulation("Brake!", "critical", out)
+    else:
+        backend._validate_critical_brake_articulation("Brake!", "critical", out)
+
+    # The narrow duration contract is for the one-syllable alarm only, not every critical phrase.
+    backend._validate_critical_brake_articulation("Save tyres!", "critical", out)
+    backend._validate_critical_brake_articulation("Brake!", "urgent", out)
 
 
 class _CopyShaper:

--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -136,19 +136,12 @@ def test_tone_backend_registers_are_distinct(tmp_path) -> None:
 
 
 def test_speech_backends_keep_act_registers_fast() -> None:
-    # Issue #381: Kokoro's base pace and the ffmpeg tempo step stack. The shaper owns escalation
-    # across active registers; their common bounded base keeps the final consonant articulated.
+    # Issue #381: Kokoro quantizes terse utterance durations, so the shaped WAV contract below is
+    # authoritative. These base-speed rails preserve the measured <=450 ms active ladder while
+    # leaving critical enough articulation room for the final consonant.
     assert KokoroBackend._REGISTER_SPEED["calm"] < KokoroBackend._REGISTER_SPEED["alert"]
-    assert (
-        len(
-            {
-                KokoroBackend._REGISTER_SPEED["alert"],
-                KokoroBackend._REGISTER_SPEED["urgent"],
-                KokoroBackend._REGISTER_SPEED["critical"],
-            }
-        )
-        == 1
-    )
+    assert KokoroBackend._REGISTER_SPEED["alert"] >= 1.26
+    assert KokoroBackend._REGISTER_SPEED["urgent"] >= 1.28
     assert 1.20 <= KokoroBackend._REGISTER_SPEED["critical"] <= 1.25
 
     assert (
@@ -284,30 +277,37 @@ def _first_sample(path: Path) -> int:
 
 
 @pytest.mark.parametrize(
-    ("duration_ms", "raises"),
+    ("text", "register", "duration_ms", "error"),
     [
-        (379, True),
-        (380, False),
-        (450, False),
-        (451, True),
+        ("Brake.", "alert", 450, None),
+        ("Brake.", "alert", 451, "brake act cue must be at most 450 ms"),
+        ("Brake.", "urgent", 450, None),
+        ("Brake.", "urgent", 451, "brake act cue must be at most 450 ms"),
+        ("Brake!", "critical", 379, "articulation must be at least 380 ms"),
+        ("Brake!", "critical", 380, None),
+        ("Brake!", "critical", 450, None),
+        ("Brake!", "critical", 451, "brake act cue must be at most 450 ms"),
     ],
 )
-def test_kokoro_critical_brake_articulation_window(
-    tmp_path: Path, duration_ms: int, raises: bool
+def test_kokoro_brake_act_duration_window(
+    tmp_path: Path,
+    text: str,
+    register: str,
+    duration_ms: int,
+    error: str | None,
 ) -> None:
-    out = tmp_path / "critical.wav"
+    out = tmp_path / "brake.wav"
     _write_pcm16_wav(out, samplerate=1000, value=0, frames=duration_ms)
     backend = object.__new__(KokoroBackend)
 
-    if raises:
-        with pytest.raises(RuntimeError, match="articulation must be 380-450 ms"):
-            backend._validate_critical_brake_articulation("Brake!", "critical", out)
+    if error:
+        with pytest.raises(RuntimeError, match=error):
+            backend._validate_brake_act_duration(text, register, out)
     else:
-        backend._validate_critical_brake_articulation("Brake!", "critical", out)
+        backend._validate_brake_act_duration(text, register, out)
 
     # The narrow duration contract is for the one-syllable alarm only, not every critical phrase.
-    backend._validate_critical_brake_articulation("Save tyres!", "critical", out)
-    backend._validate_critical_brake_articulation("Brake!", "urgent", out)
+    backend._validate_brake_act_duration("Save tyres!", "critical", out)
 
 
 class _CopyShaper:

--- a/tests/test_voice_bake.py
+++ b/tests/test_voice_bake.py
@@ -139,13 +139,16 @@ def test_speech_backends_keep_act_registers_fast() -> None:
     # Issue #381: Kokoro's base pace and the ffmpeg tempo step stack. The shaper owns escalation
     # across active registers; their common bounded base keeps the final consonant articulated.
     assert KokoroBackend._REGISTER_SPEED["calm"] < KokoroBackend._REGISTER_SPEED["alert"]
-    assert len(
-        {
-            KokoroBackend._REGISTER_SPEED["alert"],
-            KokoroBackend._REGISTER_SPEED["urgent"],
-            KokoroBackend._REGISTER_SPEED["critical"],
-        }
-    ) == 1
+    assert (
+        len(
+            {
+                KokoroBackend._REGISTER_SPEED["alert"],
+                KokoroBackend._REGISTER_SPEED["urgent"],
+                KokoroBackend._REGISTER_SPEED["critical"],
+            }
+        )
+        == 1
+    )
     assert 1.20 <= KokoroBackend._REGISTER_SPEED["critical"] <= 1.25
 
     assert (

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -292,15 +292,19 @@ class KokoroBackend:
     lazily so the bake module stays importable without it.
     """
 
-    #: Per-register synthesis speed. Kokoro renders neutral speech before the shaper adds the
-    #: baked tone. The hot tiers need an assertive base pace so one-word act cues stay inside the
-    #: <=450 ms brake-alarm budget after the full 48 kHz rig bake.
+    #: Per-register synthesis speed. The shaper already owns the active-register tempo ladder, so
+    #: alert/urgent/critical share one articulation-safe base instead of double-accelerating the
+    #: final consonant (operator A/B finding, issue #381). The shaped production ladder remains
+    #: monotonic and keeps the critical ``Brake!`` inside its 450 ms alarm budget.
     _REGISTER_SPEED: dict[str, float] = {
         "calm": 0.95,
-        "alert": 1.26,
-        "urgent": 1.35,
-        "critical": 1.45,
+        "alert": 1.25,
+        "urgent": 1.25,
+        "critical": 1.25,
     }
+
+    _CRITICAL_BRAKE_MIN_MS = 380.0
+    _CRITICAL_BRAKE_MAX_MS = 450.0
 
     def __init__(
         self,
@@ -339,6 +343,23 @@ class KokoroBackend:
             raw = Path(tmp) / "raw.wav"
             sf.write(str(raw), samples, sr, subtype="PCM_16")
             self._shaper.shape(raw, out_path, register, samplerate)
+        self._validate_critical_brake_articulation(text, register, out_path)
+
+    def _validate_critical_brake_articulation(
+        self, text: str, register: str, out_path: Path
+    ) -> None:
+        """Fail a Kokoro bake whose critical brake is clipped or too slow to be actionable."""
+        if register != "critical" or text.strip().casefold() != "brake!":
+            return
+        with wave.open(str(out_path), "rb") as wf:
+            duration_ms = wf.getnframes() * 1000.0 / wf.getframerate()
+        if not self._CRITICAL_BRAKE_MIN_MS <= duration_ms <= self._CRITICAL_BRAKE_MAX_MS:
+            raise RuntimeError(
+                "critical Brake! articulation must be "
+                f"{self._CRITICAL_BRAKE_MIN_MS:.0f}-"
+                f"{self._CRITICAL_BRAKE_MAX_MS:.0f} ms after shaping; "
+                f"got {duration_ms:.1f} ms"
+            )
 
 
 class PiperBackend:

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -304,8 +304,10 @@ class KokoroBackend:
         "critical": 1.25,
     }
 
-    _CRITICAL_BRAKE_MIN_MS = 380.0
+    _CRITICAL_BRAKE_MIN_AUDIBLE_TAIL_MS = 360.0
     _BRAKE_ACT_MAX_MS = 450.0
+    _AUDIBLE_WINDOW_MS = 5.0
+    _AUDIBLE_FLOOR_DBFS = -45.0
 
     def __init__(
         self,
@@ -344,10 +346,14 @@ class KokoroBackend:
             raw = Path(tmp) / "raw.wav"
             sf.write(str(raw), samples, sr, subtype="PCM_16")
             self._shaper.shape(raw, out_path, register, samplerate)
-        self._validate_brake_act_duration(text, register, out_path)
 
-    def _validate_brake_act_duration(self, text: str, register: str, out_path: Path) -> None:
-        """Fail a Kokoro bake whose brake act cue is clipped or too slow to be actionable."""
+    def validate_baked_clip(self, text: str, register: str, out_path: Path) -> None:
+        """Fail a bank bake whose shaped brake cue is clipped or too slow to be actionable.
+
+        This hook is intentionally separate from :meth:`synthesize`: the voice benchmark must be
+        able to render and measure an out-of-contract voice instead of reporting the backend as
+        unavailable. ``bake_bank`` invokes it after final WAV normalization.
+        """
         normalized = text.strip().casefold()
         if register not in {"alert", "urgent", "critical"} or normalized not in {
             "brake.",
@@ -355,18 +361,43 @@ class KokoroBackend:
         }:
             return
         with wave.open(str(out_path), "rb") as wf:
-            duration_ms = wf.getnframes() * 1000.0 / wf.getframerate()
+            frames = wf.getnframes()
+            samplerate = wf.getframerate()
+            duration_ms = frames * 1000.0 / samplerate
+            if wf.getnchannels() != 1 or wf.getsampwidth() != 2:
+                raise RuntimeError(
+                    "brake act cue validation requires normalized mono PCM16 WAV output"
+                )
+            samples = struct.unpack(f"<{frames}h", wf.readframes(frames)) if frames else ()
         if duration_ms > self._BRAKE_ACT_MAX_MS:
             raise RuntimeError(
                 "brake act cue must be at most "
                 f"{self._BRAKE_ACT_MAX_MS:.0f} ms after shaping; "
                 f"got {duration_ms:.1f} ms"
             )
-        if register == "critical" and duration_ms < self._CRITICAL_BRAKE_MIN_MS:
+        if register != "critical":
+            return
+        # The audible-tail floor is a perceptual calibration for the operator-approved
+        # ``am_fenrir`` artifact, not a universal phoneme-duration claim. Other Kokoro voices
+        # still receive the actionable <=450 ms ceiling and remain measurable in bench_voices;
+        # they need their own listening calibration before an articulation floor is enforced.
+        if self._voice != "am_fenrir":
+            return
+
+        window_frames = max(1, round(samplerate * self._AUDIBLE_WINDOW_MS / 1000.0))
+        audible_floor = 32768.0 * 10.0 ** (self._AUDIBLE_FLOOR_DBFS / 20.0)
+        last_audible_frame = 0
+        for start in range(0, len(samples), window_frames):
+            window = samples[start : start + window_frames]
+            rms = math.sqrt(sum(sample * sample for sample in window) / len(window))
+            if rms >= audible_floor:
+                last_audible_frame = start + len(window)
+        audible_tail_ms = last_audible_frame * 1000.0 / samplerate
+        if audible_tail_ms < self._CRITICAL_BRAKE_MIN_AUDIBLE_TAIL_MS:
             raise RuntimeError(
-                "critical Brake! articulation must be at least "
-                f"{self._CRITICAL_BRAKE_MIN_MS:.0f} ms after shaping; "
-                f"got {duration_ms:.1f} ms"
+                "critical Brake! audible articulation must extend to at least "
+                f"{self._CRITICAL_BRAKE_MIN_AUDIBLE_TAIL_MS:.0f} ms after shaping; "
+                f"last audible 5 ms window ended at {audible_tail_ms:.1f} ms"
             )
 
 
@@ -593,9 +624,12 @@ def bake_bank(out_dir: str | Path, backend: VoiceBackend, *, samplerate: int = 4
             backend.synthesize(phrase.text, phrase.register, target, samplerate)
 
     clips: dict[str, ClipEntry] = {}
+    validator = getattr(backend, "validate_baked_clip", None)
     for phrase, fp in targets:
         fname = fp.name
         _normalize_wav(fp, samplerate)
+        if callable(validator):
+            validator(phrase.text, phrase.register, fp)
         data = fp.read_bytes()
         clips[phrase.clip_id] = ClipEntry(
             clip_id=phrase.clip_id,

--- a/tools/ai_sidecar/voice/bake.py
+++ b/tools/ai_sidecar/voice/bake.py
@@ -292,19 +292,20 @@ class KokoroBackend:
     lazily so the bake module stays importable without it.
     """
 
-    #: Per-register synthesis speed. The shaper already owns the active-register tempo ladder, so
-    #: alert/urgent/critical share one articulation-safe base instead of double-accelerating the
-    #: final consonant (operator A/B finding, issue #381). The shaped production ladder remains
-    #: monotonic and keeps the critical ``Brake!`` inside its 450 ms alarm budget.
+    #: Per-register synthesis speed. Kokoro quantizes short utterances into different duration
+    #: bands, so these bases are tuned against the *shaped output* rather than required to be
+    #: monotonic themselves: alert/urgent retain the <=450 ms act-cue budget while critical leaves
+    #: enough room for its final consonant (operator A/B finding, issue #381). The shaped
+    #: production ladder remains monotonic.
     _REGISTER_SPEED: dict[str, float] = {
         "calm": 0.95,
-        "alert": 1.25,
-        "urgent": 1.25,
+        "alert": 1.26,
+        "urgent": 1.28,
         "critical": 1.25,
     }
 
     _CRITICAL_BRAKE_MIN_MS = 380.0
-    _CRITICAL_BRAKE_MAX_MS = 450.0
+    _BRAKE_ACT_MAX_MS = 450.0
 
     def __init__(
         self,
@@ -343,21 +344,28 @@ class KokoroBackend:
             raw = Path(tmp) / "raw.wav"
             sf.write(str(raw), samples, sr, subtype="PCM_16")
             self._shaper.shape(raw, out_path, register, samplerate)
-        self._validate_critical_brake_articulation(text, register, out_path)
+        self._validate_brake_act_duration(text, register, out_path)
 
-    def _validate_critical_brake_articulation(
-        self, text: str, register: str, out_path: Path
-    ) -> None:
-        """Fail a Kokoro bake whose critical brake is clipped or too slow to be actionable."""
-        if register != "critical" or text.strip().casefold() != "brake!":
+    def _validate_brake_act_duration(self, text: str, register: str, out_path: Path) -> None:
+        """Fail a Kokoro bake whose brake act cue is clipped or too slow to be actionable."""
+        normalized = text.strip().casefold()
+        if register not in {"alert", "urgent", "critical"} or normalized not in {
+            "brake.",
+            "brake!",
+        }:
             return
         with wave.open(str(out_path), "rb") as wf:
             duration_ms = wf.getnframes() * 1000.0 / wf.getframerate()
-        if not self._CRITICAL_BRAKE_MIN_MS <= duration_ms <= self._CRITICAL_BRAKE_MAX_MS:
+        if duration_ms > self._BRAKE_ACT_MAX_MS:
             raise RuntimeError(
-                "critical Brake! articulation must be "
-                f"{self._CRITICAL_BRAKE_MIN_MS:.0f}-"
-                f"{self._CRITICAL_BRAKE_MAX_MS:.0f} ms after shaping; "
+                "brake act cue must be at most "
+                f"{self._BRAKE_ACT_MAX_MS:.0f} ms after shaping; "
+                f"got {duration_ms:.1f} ms"
+            )
+        if register == "critical" and duration_ms < self._CRITICAL_BRAKE_MIN_MS:
+            raise RuntimeError(
+                "critical Brake! articulation must be at least "
+                f"{self._CRITICAL_BRAKE_MIN_MS:.0f} ms after shaping; "
                 f"got {duration_ms:.1f} ms"
             )
 

--- a/tools/ai_sidecar/voice/vocabulary.py
+++ b/tools/ai_sidecar/voice/vocabulary.py
@@ -100,9 +100,10 @@ URGENCIES: tuple[str, ...] = ("info", "prepare", "act")
 #: clone.
 VOICE_PERSONA_ID = "race-engineer-original-v1"
 VOICE_PERSONA_LICENSE = "project-authored; no unconsented real-person clone"
-# v4 restores the final consonant articulation of critical Kokoro cues while retaining the
-# <=450 ms alarm budget (operator A/B finding, issue #381).
-INTENSITY_CHAIN_VERSION = 4
+# v5 restores the final consonant articulation of critical Kokoro cues while retaining the
+# <=450 ms act-cue budget across alert/urgent/critical (operator A/B finding, issue #381).
+# v4 was an unshipped experimental bake that slowed alert beyond the budget; v5 invalidates it.
+INTENSITY_CHAIN_VERSION = 5
 
 #: Bump when the per-register prosody delivery changes: the ffmpeg filter chains in
 #: ``bake._prosody_filter`` (shaped speech backends) or ``bake.ToneBackend``'s register tone table

--- a/tools/ai_sidecar/voice/vocabulary.py
+++ b/tools/ai_sidecar/voice/vocabulary.py
@@ -100,7 +100,9 @@ URGENCIES: tuple[str, ...] = ("info", "prepare", "act")
 #: clone.
 VOICE_PERSONA_ID = "race-engineer-original-v1"
 VOICE_PERSONA_LICENSE = "project-authored; no unconsented real-person clone"
-INTENSITY_CHAIN_VERSION = 3
+# v4 restores the final consonant articulation of critical Kokoro cues while retaining the
+# <=450 ms alarm budget (operator A/B finding, issue #381).
+INTENSITY_CHAIN_VERSION = 4
 
 #: Bump when the per-register prosody delivery changes: the ffmpeg filter chains in
 #: ``bake._prosody_filter`` (shaped speech backends) or ``bake.ToneBackend``'s register tone table


### PR DESCRIPTION
## Summary
- preserve Kokoro's final consonant on the critical `Brake!` cue without losing urgency
- enforce the shaped `Brake` action-cue ceiling across alert, urgent, and critical registers
- validate Fenrir's audible articulation at bank-bake time without suppressing voice benchmarks
- retain a voice-scoped articulation floor and bump the bake signature to intensity-chain v5

## Real-bank evidence
- full Kokoro `am_fenrir` bank: `kokoro:am_fenrir+ff8+race-engineer-original-v1+prosody2+intensity5`
- manifest valid: 76 clips
- shaped `Brake` ladder: alert 432.6 ms, urgent 412.9 ms, critical 409.9 ms
- original rejected clip: last audible 5 ms window ends at 330.0 ms
- approved production bank: all 76 clips pass the post-normalization policy
- final critical production clip played through the rig's default USB speakers
- operator confirmed the corrected ending sounds complete on 2026-07-25

## Verification
- `make ci-fast`
- 3479 passed, 73 skipped; 87.15% coverage
- Bandit and repository policy checks pass
- real-bank policy validation passes

Fixes #381.