### PR TITLE
fix(simhub): harden enrichment lifecycle after #689 (#534)

### DIFF
--- a/tests/test_simhub_car_enrichment_contract.py
+++ b/tests/test_simhub_car_enrichment_contract.py
@@ -53,9 +53,11 @@ def test_connection_heartbeat_preserves_identity_only_within_fresh_epoch() -> No
 
 
 def test_bridge_shutdown_invalidates_worker_before_deferred_disposal() -> None:
-    end_branch = SOURCE.split("public void End", 1)[1].split(
-        "private async Task RunAsync", 1
-    )[0]
+    init_branch = SOURCE.split("public void Init", 1)[1].split("public void DataUpdate", 1)[0]
+    end_branch = SOURCE.split("public void End", 1)[1].split("private async Task RunAsync", 1)[0]
+    assert "CancellationTokenSource source = new CancellationTokenSource();" in init_branch
+    assert "RunAsync(source.Token, generation)" in init_branch
+    assert "RunAsync(cancellation.Token, generation)" not in init_branch
     assert "Interlocked.Increment(ref lifecycleGeneration);" in end_branch
     assert "runningWorker.Wait(TimeSpan.FromSeconds(2))" in end_branch
     assert "runningWorker.ContinueWith(" in end_branch

--- a/tests/test_simhub_car_enrichment_contract.py
+++ b/tests/test_simhub_car_enrichment_contract.py
@@ -48,8 +48,28 @@ def test_connection_heartbeat_preserves_identity_only_within_fresh_epoch() -> No
     )[0]
     assert "lastConnectionTimestamp" in connection_branch
     assert "bool wasFresh = TrainerIsFresh();" in connection_branch
-    assert "if (!wasFresh || !TrainerIsFresh())" in connection_branch
+    assert "bool isFresh = TrainerIsFresh();" in connection_branch
+    assert "if (!wasFresh || !isFresh)" in connection_branch
     assert "ClearIdentity();" in connection_branch
+    assert "if (!wasFresh && isFresh)" in connection_branch
+    assert "awaitingFreshSessionReplay" in connection_branch
+    assert "return true;" in connection_branch
+
+
+def test_fresh_epoch_requests_and_waits_for_lua_session_replay() -> None:
+    receive_loop = SOURCE.split("while (!token.IsCancellationRequested", 1)[1].split(
+        "private Uri SidecarUri()", 1
+    )[0]
+    assert "bool requestSessionReplay = ApplySnapshot(message, generation);" in receive_loop
+    assert "if (requestSessionReplay)" in receive_loop
+    assert r'"topics\":[\"session\"]' in receive_loop
+    session_branch = SOURCE.split('if (!String.Equals(topic, "session"', 1)[1].split(
+        "string resolvedClass", 1
+    )[0]
+    assert "awaitingFreshSessionReplay" in session_branch
+    assert 'ToDouble(Value(frame, "snapshot_age_ms")) > TrainerFreshMilliseconds' in session_branch
+    assert "return false;" in session_branch
+    assert "Interlocked.Exchange(ref awaitingFreshSessionReplay, 0);" in SOURCE
 
 
 def test_bridge_shutdown_invalidates_worker_before_deferred_disposal() -> None:

--- a/tests/test_simhub_car_enrichment_contract.py
+++ b/tests/test_simhub_car_enrichment_contract.py
@@ -42,12 +42,28 @@ def test_bridge_subscribes_to_authoritative_identity_and_fails_closed() -> None:
     assert "ConnectAsync" not in data_update
 
 
-def test_connection_heartbeat_preserves_last_session_identity() -> None:
+def test_connection_heartbeat_preserves_identity_only_within_fresh_epoch() -> None:
     connection_branch = SOURCE.split('if (String.Equals(topic, "connection"', 1)[1].split(
         'if (!String.Equals(topic, "session"', 1
     )[0]
     assert "lastConnectionTimestamp" in connection_branch
-    assert "ClearIdentity" not in connection_branch
+    assert "bool wasFresh = TrainerIsFresh();" in connection_branch
+    assert "if (!wasFresh || !TrainerIsFresh())" in connection_branch
+    assert "ClearIdentity();" in connection_branch
+
+
+def test_bridge_shutdown_invalidates_worker_before_deferred_disposal() -> None:
+    end_branch = SOURCE.split("public void End", 1)[1].split(
+        "private async Task RunAsync", 1
+    )[0]
+    assert "Interlocked.Increment(ref lifecycleGeneration);" in end_branch
+    assert "runningWorker.Wait(TimeSpan.FromSeconds(2))" in end_branch
+    assert "runningWorker.ContinueWith(" in end_branch
+    assert end_branch.index("Interlocked.Increment(ref lifecycleGeneration);") < end_branch.index(
+        "source.Cancel();"
+    )
+    assert "IsCurrentGeneration(generation)" in SOURCE
+    assert "ApplySnapshot(message, generation)" in SOURCE
 
 
 def test_bridge_uses_launcher_resolved_endpoint_and_resets_backoff_on_handshake() -> None:
@@ -64,6 +80,8 @@ def test_bridge_uses_launcher_resolved_endpoint_and_resets_backoff_on_handshake(
     assert '"AC Copilot Trainer"' in SOURCE
     assert '"GamePoint"' in SOURCE
     assert '"settings.json"' in SOURCE
+    assert 'Value(settings, "sidecar_port")' in SOURCE
+    assert 'Value(settings, "port")' not in SOURCE
     assert "File.ReadAllText(path)" in SOURCE
     hello_branch = SOURCE.split("if (!IsHelloAck(hello))", 1)[1].split(
         "sidecarConnected = true", 1

--- a/tests/test_simhub_car_enrichment_contract.py
+++ b/tests/test_simhub_car_enrichment_contract.py
@@ -86,6 +86,25 @@ def test_bridge_shutdown_invalidates_worker_before_deferred_disposal() -> None:
     )
     assert "IsCurrentGeneration(generation)" in SOURCE
     assert "ApplySnapshot(message, generation)" in SOURCE
+    assert "private readonly object lifecycleGate = new object();" in SOURCE
+    apply_branch = SOURCE.split("private bool ApplySnapshot", 1)[1].split(
+        "private Dictionary<string, object> ParseObject", 1
+    )[0]
+    assert "lock (lifecycleGate)" in apply_branch
+    assert apply_branch.index("lock (lifecycleGate)") < apply_branch.index(
+        "Interlocked.Exchange(\n                        ref lastConnectionTimestamp"
+    )
+    assert apply_branch.index("lock (lifecycleGate)") < apply_branch.index(
+        "Interlocked.Exchange(\n                    ref carClass"
+    )
+    assert "MarkSidecarConnected(generation)" in SOURCE
+    mark_connected = SOURCE.split("private bool MarkSidecarConnected", 1)[1].split(
+        "private string CurrentCarClass", 1
+    )[0]
+    assert "lock (lifecycleGate)" in mark_connected
+    assert mark_connected.index("IsCurrentGeneration(generation)") < mark_connected.index(
+        "sidecarConnected = true;"
+    )
 
 
 def test_bridge_uses_launcher_resolved_endpoint_and_resets_backoff_on_handshake() -> None:

--- a/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
+++ b/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
@@ -44,8 +44,9 @@ namespace AcCopilot.CarEnrichment
             this.AttachDelegate("TrainerConnected", () => TrainerIsFresh());
 
             int generation = Interlocked.Increment(ref lifecycleGeneration);
-            cancellation = new CancellationTokenSource();
-            worker = Task.Run(() => RunAsync(cancellation.Token, generation));
+            CancellationTokenSource source = new CancellationTokenSource();
+            cancellation = source;
+            worker = Task.Run(() => RunAsync(source.Token, generation));
             SimHub.Logging.Current.Info("AC Copilot car enrichment bridge started");
         }
 

--- a/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
+++ b/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
@@ -30,6 +30,7 @@ namespace AcCopilot.CarEnrichment
         private string classSource = "";
         private int registryVersion;
         private long lastConnectionTimestamp;
+        private int awaitingFreshSessionReplay;
         private volatile bool sidecarConnected;
 
         public PluginManager PluginManager { get; set; }
@@ -187,7 +188,15 @@ namespace AcCopilot.CarEnrichment
                     {
                         break;
                     }
-                    ApplySnapshot(message, generation);
+                    bool requestSessionReplay = ApplySnapshot(message, generation);
+                    if (requestSessionReplay)
+                    {
+                        await SendAsync(
+                            socket,
+                            "{\"v\":1,\"type\":\"state.subscribe\","
+                                + "\"topics\":[\"session\"]}",
+                            token).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -316,23 +325,23 @@ namespace AcCopilot.CarEnrichment
                     StringComparison.Ordinal);
         }
 
-        private void ApplySnapshot(string message, int generation)
+        private bool ApplySnapshot(string message, int generation)
         {
             if (!IsCurrentGeneration(generation))
             {
-                return;
+                return false;
             }
             Dictionary<string, object> frame = ParseObject(message);
             if (frame == null
                 || !String.Equals(Value(frame, "type") as string, "state.snapshot",
                     StringComparison.Ordinal))
             {
-                return;
+                return false;
             }
             Dictionary<string, object> payload = Value(frame, "payload") as Dictionary<string, object>;
             if (payload == null)
             {
-                return;
+                return false;
             }
 
             string topic = Value(frame, "topic") as string;
@@ -347,18 +356,34 @@ namespace AcCopilot.CarEnrichment
                 Interlocked.Exchange(
                     ref lastConnectionTimestamp,
                     Stopwatch.GetTimestamp() - replayAgeTicks);
-                if (!wasFresh || !TrainerIsFresh())
+                bool isFresh = TrainerIsFresh();
+                if (!wasFresh || !isFresh)
                 {
                     // A heartbeat gap starts a new identity epoch. Do not allow a
                     // resumed connection frame to resurrect the previous car before
                     // a fresh session snapshot arrives.
                     ClearIdentity();
                 }
-                return;
+                if (!wasFresh && isFresh)
+                {
+                    // Session is event-driven. Ask Lua to replay it whenever a fresh
+                    // heartbeat starts or resumes an epoch; the sidecar can otherwise
+                    // replay its old cached session before Lua confirms current state.
+                    Interlocked.Exchange(ref awaitingFreshSessionReplay, 1);
+                    return true;
+                }
+                return false;
             }
             if (!String.Equals(topic, "session", StringComparison.Ordinal))
             {
-                return;
+                return false;
+            }
+            if (Interlocked.CompareExchange(ref awaitingFreshSessionReplay, 0, 0) != 0
+                && ToDouble(Value(frame, "snapshot_age_ms")) > TrainerFreshMilliseconds)
+            {
+                // The sidecar immediately replays its cache on subscribe. During
+                // recovery, ignore that old identity and wait for Lua's fresh replay.
+                return false;
             }
 
             string resolvedClass = Value(payload, "car_class") as string;
@@ -371,6 +396,8 @@ namespace AcCopilot.CarEnrichment
             Interlocked.Exchange(ref carId, resolvedCarId ?? "");
             Interlocked.Exchange(ref classSource, resolvedSource ?? "");
             Interlocked.Exchange(ref registryVersion, resolvedVersion);
+            Interlocked.Exchange(ref awaitingFreshSessionReplay, 0);
+            return false;
         }
 
         private Dictionary<string, object> ParseObject(string message)
@@ -479,6 +506,7 @@ namespace AcCopilot.CarEnrichment
         {
             sidecarConnected = false;
             Interlocked.Exchange(ref lastConnectionTimestamp, 0);
+            Interlocked.Exchange(ref awaitingFreshSessionReplay, 0);
             ClearIdentity();
         }
 

--- a/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
+++ b/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
@@ -22,6 +22,7 @@ namespace AcCopilot.CarEnrichment
         private const int MaximumFrameBytes = 65536;
 
         private readonly JavaScriptSerializer serializer = new JavaScriptSerializer();
+        private readonly object lifecycleGate = new object();
         private CancellationTokenSource cancellation;
         private Task worker;
         private int lifecycleGeneration;
@@ -44,7 +45,12 @@ namespace AcCopilot.CarEnrichment
             this.AttachDelegate("SidecarConnected", () => sidecarConnected);
             this.AttachDelegate("TrainerConnected", () => TrainerIsFresh());
 
-            int generation = Interlocked.Increment(ref lifecycleGeneration);
+            int generation;
+            lock (lifecycleGate)
+            {
+                generation = Interlocked.Increment(ref lifecycleGeneration);
+                ClearConnectionUnsafe();
+            }
             CancellationTokenSource source = new CancellationTokenSource();
             cancellation = source;
             worker = Task.Run(() => RunAsync(source.Token, generation));
@@ -58,7 +64,11 @@ namespace AcCopilot.CarEnrichment
 
         public void End(PluginManager pluginManager)
         {
-            Interlocked.Increment(ref lifecycleGeneration);
+            lock (lifecycleGate)
+            {
+                Interlocked.Increment(ref lifecycleGeneration);
+                ClearConnectionUnsafe();
+            }
             CancellationTokenSource source = cancellation;
             Task runningWorker = worker;
             cancellation = null;
@@ -80,7 +90,6 @@ namespace AcCopilot.CarEnrichment
                     workerStopped = true;
                 }
             }
-            ClearConnection();
             if (source != null)
             {
                 if (workerStopped)
@@ -167,12 +176,11 @@ namespace AcCopilot.CarEnrichment
                 {
                     throw new InvalidDataException("sidecar did not return hello_ack");
                 }
-                if (token.IsCancellationRequested || !IsCurrentGeneration(generation))
+                if (token.IsCancellationRequested || !MarkSidecarConnected(generation))
                 {
                     return;
                 }
                 onConnected();
-                sidecarConnected = true;
                 await SendAsync(
                     socket,
                     "{\"v\":1,\"type\":\"state.subscribe\","
@@ -344,60 +352,68 @@ namespace AcCopilot.CarEnrichment
                 return false;
             }
 
-            string topic = Value(frame, "topic") as string;
-            if (String.Equals(topic, "connection", StringComparison.Ordinal))
+            lock (lifecycleGate)
             {
-                bool wasFresh = TrainerIsFresh();
-                double replayAgeMilliseconds = Math.Min(
-                    Math.Max(ToDouble(Value(frame, "snapshot_age_ms")), 0),
-                    TrainerFreshMilliseconds + 1);
-                long replayAgeTicks = (long)(
-                    replayAgeMilliseconds * Stopwatch.Frequency / 1000.0);
-                Interlocked.Exchange(
-                    ref lastConnectionTimestamp,
-                    Stopwatch.GetTimestamp() - replayAgeTicks);
-                bool isFresh = TrainerIsFresh();
-                if (!wasFresh || !isFresh)
+                if (!IsCurrentGeneration(generation))
                 {
-                    // A heartbeat gap starts a new identity epoch. Do not allow a
-                    // resumed connection frame to resurrect the previous car before
-                    // a fresh session snapshot arrives.
-                    ClearIdentity();
+                    return false;
                 }
-                if (!wasFresh && isFresh)
-                {
-                    // Session is event-driven. Ask Lua to replay it whenever a fresh
-                    // heartbeat starts or resumes an epoch; the sidecar can otherwise
-                    // replay its old cached session before Lua confirms current state.
-                    Interlocked.Exchange(ref awaitingFreshSessionReplay, 1);
-                    return true;
-                }
-                return false;
-            }
-            if (!String.Equals(topic, "session", StringComparison.Ordinal))
-            {
-                return false;
-            }
-            if (Interlocked.CompareExchange(ref awaitingFreshSessionReplay, 0, 0) != 0
-                && ToDouble(Value(frame, "snapshot_age_ms")) > TrainerFreshMilliseconds)
-            {
-                // The sidecar immediately replays its cache on subscribe. During
-                // recovery, ignore that old identity and wait for Lua's fresh replay.
-                return false;
-            }
 
-            string resolvedClass = Value(payload, "car_class") as string;
-            string resolvedCarId = Value(payload, "car_id") as string;
-            string resolvedSource = Value(payload, "car_class_source") as string;
-            int resolvedVersion = ToInt32(Value(payload, "car_class_registry_version"));
-            Interlocked.Exchange(
-                ref carClass,
-                String.IsNullOrWhiteSpace(resolvedClass) ? UnknownClass : resolvedClass);
-            Interlocked.Exchange(ref carId, resolvedCarId ?? "");
-            Interlocked.Exchange(ref classSource, resolvedSource ?? "");
-            Interlocked.Exchange(ref registryVersion, resolvedVersion);
-            Interlocked.Exchange(ref awaitingFreshSessionReplay, 0);
-            return false;
+                string topic = Value(frame, "topic") as string;
+                if (String.Equals(topic, "connection", StringComparison.Ordinal))
+                {
+                    bool wasFresh = TrainerIsFresh();
+                    double replayAgeMilliseconds = Math.Min(
+                        Math.Max(ToDouble(Value(frame, "snapshot_age_ms")), 0),
+                        TrainerFreshMilliseconds + 1);
+                    long replayAgeTicks = (long)(
+                        replayAgeMilliseconds * Stopwatch.Frequency / 1000.0);
+                    Interlocked.Exchange(
+                        ref lastConnectionTimestamp,
+                        Stopwatch.GetTimestamp() - replayAgeTicks);
+                    bool isFresh = TrainerIsFresh();
+                    if (!wasFresh || !isFresh)
+                    {
+                        // A heartbeat gap starts a new identity epoch. Do not allow a
+                        // resumed connection frame to resurrect the previous car before
+                        // a fresh session snapshot arrives.
+                        ClearIdentity();
+                    }
+                    if (!wasFresh && isFresh)
+                    {
+                        // Session is event-driven. Ask Lua to replay it whenever a fresh
+                        // heartbeat starts or resumes an epoch; the sidecar can otherwise
+                        // replay its old cached session before Lua confirms current state.
+                        Interlocked.Exchange(ref awaitingFreshSessionReplay, 1);
+                        return true;
+                    }
+                    return false;
+                }
+                if (!String.Equals(topic, "session", StringComparison.Ordinal))
+                {
+                    return false;
+                }
+                if (Interlocked.CompareExchange(ref awaitingFreshSessionReplay, 0, 0) != 0
+                    && ToDouble(Value(frame, "snapshot_age_ms")) > TrainerFreshMilliseconds)
+                {
+                    // The sidecar immediately replays its cache on subscribe. During
+                    // recovery, ignore that old identity and wait for Lua's fresh replay.
+                    return false;
+                }
+
+                string resolvedClass = Value(payload, "car_class") as string;
+                string resolvedCarId = Value(payload, "car_id") as string;
+                string resolvedSource = Value(payload, "car_class_source") as string;
+                int resolvedVersion = ToInt32(Value(payload, "car_class_registry_version"));
+                Interlocked.Exchange(
+                    ref carClass,
+                    String.IsNullOrWhiteSpace(resolvedClass) ? UnknownClass : resolvedClass);
+                Interlocked.Exchange(ref carId, resolvedCarId ?? "");
+                Interlocked.Exchange(ref classSource, resolvedSource ?? "");
+                Interlocked.Exchange(ref registryVersion, resolvedVersion);
+                Interlocked.Exchange(ref awaitingFreshSessionReplay, 0);
+                return false;
+            }
         }
 
         private Dictionary<string, object> ParseObject(string message)
@@ -474,6 +490,19 @@ namespace AcCopilot.CarEnrichment
             return Volatile.Read(ref lifecycleGeneration) == generation;
         }
 
+        private bool MarkSidecarConnected(int generation)
+        {
+            lock (lifecycleGate)
+            {
+                if (!IsCurrentGeneration(generation))
+                {
+                    return false;
+                }
+                sidecarConnected = true;
+                return true;
+            }
+        }
+
         private string CurrentCarClass()
         {
             return TrainerIsFresh() ? Interlocked.CompareExchange(ref carClass, null, null) : UnknownClass;
@@ -502,7 +531,7 @@ namespace AcCopilot.CarEnrichment
             Interlocked.Exchange(ref registryVersion, 0);
         }
 
-        private void ClearConnection()
+        private void ClearConnectionUnsafe()
         {
             sidecarConnected = false;
             Interlocked.Exchange(ref lastConnectionTimestamp, 0);
@@ -512,9 +541,12 @@ namespace AcCopilot.CarEnrichment
 
         private void ClearConnection(int generation)
         {
-            if (IsCurrentGeneration(generation))
+            lock (lifecycleGate)
             {
-                ClearConnection();
+                if (IsCurrentGeneration(generation))
+                {
+                    ClearConnectionUnsafe();
+                }
             }
         }
     }

--- a/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
+++ b/tools/simhub_car_enrichment/AcCopilot.CarEnrichment/AcCopilotDataPlugin.cs
@@ -24,6 +24,7 @@ namespace AcCopilot.CarEnrichment
         private readonly JavaScriptSerializer serializer = new JavaScriptSerializer();
         private CancellationTokenSource cancellation;
         private Task worker;
+        private int lifecycleGeneration;
         private string carClass = UnknownClass;
         private string carId = "";
         private string classSource = "";
@@ -42,8 +43,9 @@ namespace AcCopilot.CarEnrichment
             this.AttachDelegate("SidecarConnected", () => sidecarConnected);
             this.AttachDelegate("TrainerConnected", () => TrainerIsFresh());
 
+            int generation = Interlocked.Increment(ref lifecycleGeneration);
             cancellation = new CancellationTokenSource();
-            worker = Task.Run(() => RunAsync(cancellation.Token));
+            worker = Task.Run(() => RunAsync(cancellation.Token, generation));
             SimHub.Logging.Current.Info("AC Copilot car enrichment bridge started");
         }
 
@@ -54,38 +56,57 @@ namespace AcCopilot.CarEnrichment
 
         public void End(PluginManager pluginManager)
         {
-            if (cancellation != null)
+            Interlocked.Increment(ref lifecycleGeneration);
+            CancellationTokenSource source = cancellation;
+            Task runningWorker = worker;
+            cancellation = null;
+            worker = null;
+            if (source != null)
             {
-                cancellation.Cancel();
+                source.Cancel();
             }
-            if (worker != null)
+            bool workerStopped = runningWorker == null;
+            if (runningWorker != null)
             {
                 try
                 {
-                    worker.Wait(TimeSpan.FromSeconds(2));
+                    workerStopped = runningWorker.Wait(TimeSpan.FromSeconds(2));
                 }
                 catch (AggregateException)
                 {
                     // Cancellation and socket teardown are expected during SimHub exit.
+                    workerStopped = true;
                 }
             }
             ClearConnection();
-            if (cancellation != null)
+            if (source != null)
             {
-                cancellation.Dispose();
+                if (workerStopped)
+                {
+                    source.Dispose();
+                }
+                else
+                {
+                    runningWorker.ContinueWith(
+                        _ => source.Dispose(),
+                        CancellationToken.None,
+                        TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
             }
             SimHub.Logging.Current.Info("AC Copilot car enrichment bridge stopped");
         }
 
-        private async Task RunAsync(CancellationToken token)
+        private async Task RunAsync(CancellationToken token, int generation)
         {
             int retryMilliseconds = 500;
-            while (!token.IsCancellationRequested)
+            while (!token.IsCancellationRequested && IsCurrentGeneration(generation))
             {
                 try
                 {
                     await ConnectAndConsumeAsync(
                         token,
+                        generation,
                         () => retryMilliseconds = 500).ConfigureAwait(false);
                     retryMilliseconds = 500;
                 }
@@ -100,9 +121,13 @@ namespace AcCopilot.CarEnrichment
                 }
                 finally
                 {
-                    ClearConnection();
+                    ClearConnection(generation);
                 }
 
+                if (!IsCurrentGeneration(generation))
+                {
+                    return;
+                }
                 try
                 {
                     await Task.Delay(retryMilliseconds, token).ConfigureAwait(false);
@@ -117,6 +142,7 @@ namespace AcCopilot.CarEnrichment
 
         private async Task ConnectAndConsumeAsync(
             CancellationToken token,
+            int generation,
             Action onConnected)
         {
             using (ClientWebSocket socket = new ClientWebSocket())
@@ -139,6 +165,10 @@ namespace AcCopilot.CarEnrichment
                 {
                     throw new InvalidDataException("sidecar did not return hello_ack");
                 }
+                if (token.IsCancellationRequested || !IsCurrentGeneration(generation))
+                {
+                    return;
+                }
                 onConnected();
                 sidecarConnected = true;
                 await SendAsync(
@@ -147,14 +177,16 @@ namespace AcCopilot.CarEnrichment
                         + "\"topics\":[\"connection\",\"session\"]}",
                     token).ConfigureAwait(false);
 
-                while (!token.IsCancellationRequested && socket.State == WebSocketState.Open)
+                while (!token.IsCancellationRequested
+                    && IsCurrentGeneration(generation)
+                    && socket.State == WebSocketState.Open)
                 {
                     string message = await ReceiveTextAsync(socket, token).ConfigureAwait(false);
                     if (message == null)
                     {
                         break;
                     }
-                    ApplySnapshot(message);
+                    ApplySnapshot(message, generation);
                 }
             }
         }
@@ -283,8 +315,12 @@ namespace AcCopilot.CarEnrichment
                     StringComparison.Ordinal);
         }
 
-        private void ApplySnapshot(string message)
+        private void ApplySnapshot(string message, int generation)
         {
+            if (!IsCurrentGeneration(generation))
+            {
+                return;
+            }
             Dictionary<string, object> frame = ParseObject(message);
             if (frame == null
                 || !String.Equals(Value(frame, "type") as string, "state.snapshot",
@@ -301,6 +337,7 @@ namespace AcCopilot.CarEnrichment
             string topic = Value(frame, "topic") as string;
             if (String.Equals(topic, "connection", StringComparison.Ordinal))
             {
+                bool wasFresh = TrainerIsFresh();
                 double replayAgeMilliseconds = Math.Min(
                     Math.Max(ToDouble(Value(frame, "snapshot_age_ms")), 0),
                     TrainerFreshMilliseconds + 1);
@@ -309,6 +346,13 @@ namespace AcCopilot.CarEnrichment
                 Interlocked.Exchange(
                     ref lastConnectionTimestamp,
                     Stopwatch.GetTimestamp() - replayAgeTicks);
+                if (!wasFresh || !TrainerIsFresh())
+                {
+                    // A heartbeat gap starts a new identity epoch. Do not allow a
+                    // resumed connection frame to resurrect the previous car before
+                    // a fresh session snapshot arrives.
+                    ClearIdentity();
+                }
                 return;
             }
             if (!String.Equals(topic, "session", StringComparison.Ordinal))
@@ -397,6 +441,11 @@ namespace AcCopilot.CarEnrichment
                 && elapsedMilliseconds <= TrainerFreshMilliseconds;
         }
 
+        private bool IsCurrentGeneration(int generation)
+        {
+            return Volatile.Read(ref lifecycleGeneration) == generation;
+        }
+
         private string CurrentCarClass()
         {
             return TrainerIsFresh() ? Interlocked.CompareExchange(ref carClass, null, null) : UnknownClass;
@@ -430,6 +479,14 @@ namespace AcCopilot.CarEnrichment
             sidecarConnected = false;
             Interlocked.Exchange(ref lastConnectionTimestamp, 0);
             ClearIdentity();
+        }
+
+        private void ClearConnection(int generation)
+        {
+            if (IsCurrentGeneration(generation))
+            {
+                ClearConnection();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- invalidate stale SimHub bridge workers across plugin lifecycle boundaries
- serialize generation validation with every worker-owned state commit
- clear retained car identity when a heartbeat starts or resumes a fresh epoch
- request Lua's event-driven session replay and reject the sidecar's stale cached identity
- defer cancellation-token disposal until a slow worker actually exits
- lock the real Game Point `sidecar_port` settings contract

## Context

Follow-up to merged PR #689. Its latest current-SHA advisory review landed after merge and identified two correct runtime defects. The third claimed `sidecar_port` should be `port`; repository settings serialization and tests prove `sidecar_port` is the canonical key, so this PR adds a guard instead of changing it.

## Validation

- `make ci-fast` — 3,521 passed, 73 skipped; 87.12% coverage; Ruff, Bandit, policy, and CSP checks clean
- Release build against installed SimHub 9.11 SDK — 0 warnings/errors
- compiled-DLL reflection scenario — stale cached class stays `unknown`; fresh Lua replay restores it; heartbeat recovery repeats the same safe handshake
- compiled-DLL generation scenario — a timed-out old worker cannot overwrite the newer lifecycle's identity
- compiled-DLL shutdown scenario — CTS remains alive after the 2 s bounded wait and is disposed after worker completion

Refs #534
