### PR TITLE
fix(harness): make the QSS apex solve envelope-feasible by construction (#695)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -262,6 +262,87 @@ launch, probe outcome, and re-bake stats so a recycle's timing is visible.
 > tracked on #466. Until then a `--setup` run may stall at the overlay; a plain no-setup drive is
 > reliable.
 
+## Driving the harness from off-rig (the Windows session-0 trap)
+
+An agent working from another host (macOS laptop, another Mac, CI) reaches the rig over SSH. **A
+command run directly in that SSH session can never drive AC**, for two independent reasons — fix the
+transport, not the harness:
+
+1. **The app junction is untraversable from session 0.** An OpenSSH logon is a *network* logon and
+   lands in Windows **session 0**, where the redirection-trust policy is enforced. `apps/lua/ac_copilot_trainer`
+   is a junction created by a non-admin user, so session 0 refuses to follow it. The #575
+   app-provenance preflight is the first code to touch it, so the run dies there:
+
+   ```text
+   OSError: [WinError 448] The path cannot be traversed because it contains an untrusted mount point:
+     'C:\Program Files (x86)\Steam\steamapps\common\assettocorsa\apps\lua\ac_copilot_trainer'
+     at auto_drive.app_install_provenance -> installed.is_dir()
+   ```
+
+2. **Session 0 has no interactive desktop.** AC renders on the console session. Even with traversal
+   working, a session-0 launch could not produce a real drive.
+
+> **Do not "fix" this by relaxing the provenance preflight or the junction.** The preflight is what
+> catches a stale app (#543/#575); the junction is how the rig serves the checkout. Both are correct —
+> the SSH session is the wrong place to run from.
+
+### Confirm which session you are in
+
+```powershell
+(Get-Process -Id $PID).SessionId                 # SSH session reports 0
+Get-Process explorer | Select-Object Id,SessionId # the console session (typically 1)
+```
+
+### Run in the console session with a `/IT` scheduled task
+
+`schtasks /IT` means "run only when the user is logged on", so the task executes in the console
+session **and needs no stored credential**. Wrap the harness invocation in a `.cmd` that redirects its
+own logs, then create, run, and poll the task:
+
+```powershell
+# 1) wrapper (writes its own logs; the SSH session only ever reads files)
+$ev = "C:\Users\arsen\Projects\ac-copilot-trainer\.scratch\harness-evidence\<run-id>"
+New-Item -ItemType Directory -Force -Path $ev | Out-Null
+Set-Content -LiteralPath "$ev\run.cmd" -Encoding ascii -Value @"
+@echo off
+cd /d C:\Users\arsen\Projects\ac-copilot-trainer
+".venv\Scripts\python.exe" -m tools.ac_harness.auto_alien --car <car> --track <track> ^
+    --laps 3 --iterations 2 --evidence-dir <relative-evidence-dir> > "$ev\stdout.log" 2> "$ev\stderr.log"
+echo [wrapper] exit=%ERRORLEVEL% >> "$ev\wrapper.log"
+"@
+
+# 2) create + run in the console session
+schtasks /create /tn "ac-harness-run" /tr "$ev\run.cmd" /sc once /st 23:59 /ru <user> /it /f
+schtasks /run    /tn "ac-harness-run"
+
+# 3) poll from the SSH session (reads only — no AC interaction)
+schtasks /query  /tn "ac-harness-run" /fo list | Select-String "^Status"
+Get-Content "$ev\stdout.log" -Tail 30
+Get-Process acs -ErrorAction SilentlyContinue | Select-Object Id,Responding
+```
+
+You landed in the right session when the run's own first lines report the provenance gate passing:
+
+```text
+auto-drive: installed app provenance: match
+auto-drive: preflight ok
+auto-drive: rig lock acquired -> ...\AC Copilot Trainer\Harness\rig-session.lock
+```
+
+`installed app provenance: match` is the machine-checkable signal — it means the junction was
+traversed *and* the served tree matches the checkout the harness is running from.
+
+### Pre-run rig invariants (check these before creating the task)
+
+- **The AC app junction serves the primary checkout**, which must sit at the merged `main` tip
+  (#575/#543 — a stale checkout serves stale Lua and the run fails in confusing ways).
+- **`main` may be checked out by another worktree**, in which case `git switch main` fails with
+  `fatal: 'main' is already used by worktree at …`. Detach instead — `git switch --detach origin/main`
+  — which leaves every branch ref and peer worktree untouched.
+- **One rig, one session.** The harness takes a cross-worktree lock at
+  `%LOCALAPPDATA%\AC Copilot Trainer\Harness\rig-session.lock`; check for a live `acs.exe` or a peer
+  sidecar before starting, and let the lock arbitrate rather than killing processes.
+
 ## Troubleshooting (hard-won rig lore — read before debugging)
 
 | Symptom | Cause / fix |
@@ -275,6 +356,7 @@ launch, probe outcome, and re-bake stats so a recycle's timing is visible.
 | `setup.load` error "no loopback Lua peer connected" | The trainer app isn't (yet) connected to the sidecar — the harness retries for `setup_timeout`; persistent = app not installed/enabled in CSP |
 | Run FAILS with `recovery cap exceeded at <N>m` | Real stall: the car repeatedly stopped at the same spot. Inspect `hud.png` plus `report.drive.control_trace` (especially the forced `recovery:*` rows); do **not** raise the cap to make it "pass" |
 | `acs.exe` dies mid-drive | The main physics packet watchdog fails that attempt and the CLI automatically runs one fresh full launch (bounded by `--sim-death-retries`). Inspect `report.attempts`: every failed attempt, reason, and control trace is retained even when the final attempt passes. |
+| `OSError: [WinError 448] … untrusted mount point` on the app junction | You are running in Windows **session 0** (an SSH logon), which cannot traverse the user-created junction and has no desktop for AC to render on. Not a harness bug and **not** a reason to relax the provenance preflight — re-run through a `schtasks /IT` task in the console session (see *Driving the harness from off-rig*) |
 | Two agents, one rig | **Yield**: a single AC instance cannot serve two autonomous sessions (see the issue-277 investigation). Check for a running `acs.exe`/peer sidecar before launching |
 | Sidecar port already in use | That's usually the Game Point launcher's supervised sidecar — the harness reuses it; don't spawn a second |
 

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -1189,3 +1189,120 @@ def test_merge_selfplay_requires_uncertainty_aware_models():
         merge_selfplay_model(prior, aware)
     with pytest.raises(ValueError, match="uncertainty-aware"):
         merge_selfplay_model(aware, prior)
+
+
+# ---------------------------------------------------------------------------
+# #695: the lateral envelope is a STEP function of speed (uncertainty bins), so the apex solve
+# must produce a feasible speed by construction rather than trusting a fixed-iteration fixed point.
+# ---------------------------------------------------------------------------
+def _step_edge_bins() -> tuple[dict, ...]:
+    """30 x 10 km/h bins whose lateral ``safe_g`` steps DOWN across the 60 km/h edge.
+
+    Mirrors the shape observed on the live Magione 911 GT3 R plant that lost the #529 self-play
+    ladder its top envelope step: 50-60 km/h held more grip than 60-70 km/h, so an apex solved with
+    the 50-60 value can land in 60-70 and demand grip the plant does not grant there.
+    """
+
+    def channel(safe_g: float) -> dict:
+        return {
+            "mean_g": safe_g + 0.05,
+            "epistemic_std_g": 0.02,
+            "safe_g": safe_g,
+            "n": 60,
+            "source": "measured",
+        }
+
+    bins = []
+    for i in range(30):
+        lo = i * 10.0
+        safe_lat = 1.0712 if lo == 50.0 else 1.0590
+        bins.append(
+            {
+                "speed_min_kmh": lo,
+                "speed_max_kmh": lo + 10.0,
+                "lateral": channel(safe_lat),
+                "brake": channel(1.2),
+                "drive": channel(0.5),
+            }
+        )
+    return tuple(bins)
+
+
+def _step_edge_plant() -> GGVModel:
+    from dataclasses import replace as dc_replace
+
+    return dc_replace(_prior(), uncertainty_bins=_step_edge_bins())
+
+
+def test_apex_speed_never_exceeds_the_lateral_envelope_across_bin_edges():
+    """Every curvature must yield an apex whose lateral demand fits the plant (#695).
+
+    Fails on the pre-fix solver: the bare 8-step fixed point settles on the high branch of the
+    60 km/h edge for a band of curvatures, demanding up to 1.4x the safe envelope.
+    """
+    from tools.ac_harness.ggv_profile import apex_speed
+
+    plant = _step_edge_plant()
+    v_top = 232.0 / 3.6
+    violations = []
+    kappa = 0.002
+    while kappa < 0.20:
+        v = apex_speed(kappa, plant, v_top_ms=v_top, v_floor_ms=8.0)
+        ay_limit = plant.ay_max(v)
+        if v * v * kappa > ay_limit * (1.0 + 1e-9) and v < v_top:
+            violations.append((kappa, v, (v * v * kappa) / ay_limit))
+        kappa += 0.00025
+    assert violations == [], (
+        f"{len(violations)} infeasible apex speeds, worst {max(r for *_, r in violations):.4f}x"
+    )
+
+
+def test_apex_speed_stays_at_the_binding_edge_not_conservative_everywhere():
+    """The guard must only lower infeasible points — a smooth-region apex is unchanged."""
+    from tools.ac_harness.ggv_profile import apex_speed
+
+    plant = _step_edge_plant()
+    v_top = 232.0 / 3.6
+    # 150-160 km/h region: flat safe_g on both sides, so the fixed point is already consistent.
+    kappa = plant.ay_max(43.0) / (43.0 * 43.0)
+    v = apex_speed(kappa, plant, v_top_ms=v_top)
+    assert v * v * kappa <= plant.ay_max(v) * (1.0 + 1e-9)
+    # It should sit AT the envelope, not well under it (no blanket conservatism).
+    assert (v * v * kappa) / plant.ay_max(v) > 0.99
+
+
+def test_forward_backward_profile_is_envelope_feasible_on_a_step_edge_plant():
+    """The whole QSS profile — not just the apex — must satisfy the envelope (#695).
+
+    ``alien_line._verify_lateral_envelope`` re-checks this with a float-noise tolerance and fails
+    the line build otherwise, which is how the ladder lost its ggv_scale=1.15 step.
+    """
+    plant = _step_edge_plant()
+    # A cyclic line sweeping curvature through the 60 km/h binding band.
+    pts = []
+    n = 720
+    for i in range(n):
+        theta = 2.0 * math.pi * i / n
+        r = 26.0 + 10.0 * math.sin(3.0 * theta)  # radii ~16-36 m -> apex speeds around the edge
+        pts.append((r * math.cos(theta), r * math.sin(theta)))
+    seg = seg_lengths(pts)
+    kappa = curvature_profile(pts)
+    v, _ax = forward_backward_profile(kappa, seg, plant, v_top_ms=232.0 / 3.6)
+    worst = 0.0
+    for i, vi in enumerate(v):
+        if kappa[i] <= 1e-6:
+            continue
+        worst = max(worst, (vi * vi * kappa[i]) / plant.ay_max(vi))
+    assert worst <= 1.0 + 1e-6, f"QSS profile exceeds the lateral envelope: {worst:.4f}x ay_max"
+
+
+def test_velocity_floor_never_lifts_a_point_above_the_envelope():
+    """A corner whose feasible apex is under ``v_floor_ms`` keeps that apex, floor regardless."""
+    from tools.ac_harness.ggv_profile import apex_speed
+
+    plant = _step_edge_plant()
+    # Curvature tight enough that the feasible apex is well under the 8 m/s drivability floor.
+    kappa = plant.ay_max(5.0) / (5.0 * 5.0) * 1.6
+    v = apex_speed(kappa, plant, v_top_ms=232.0 / 3.6, v_floor_ms=8.0)
+    assert v * v * kappa <= plant.ay_max(v) * (1.0 + 1e-9)
+    assert v < 8.0

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -1423,3 +1423,42 @@ def test_lateral_envelope_floor_is_a_true_lower_bound():
         while v <= 340.0 / 3.6:
             assert floor_ay <= plant.ay_max(v) + 1e-12, f"floor {floor_ay} > ay_max({v})"
             v += 0.25
+
+
+def test_sub_floor_apex_does_not_block_the_braking_pass():
+    """A corner whose apex is under ``v_floor_ms`` must still be brakeable (#695 review).
+
+    Deriving the drivability floor from the apex would make that apex a hard minimum, so the
+    backward pass could no longer lower the point even when the propagation constraint demands it.
+    """
+    from tools.ac_harness.ggv_profile import apex_speed
+
+    plant = _step_edge_plant()
+    v_floor = 8.0
+    # Point 0: apex just under the floor. Point 1: a far tighter corner right after it, with a short
+    # segment, so braking into point 1 requires point 0 below its own local apex.
+    k0 = plant.ay_max(7.0) / (7.0 * 7.0)
+    k1 = plant.ay_max(3.0) / (3.0 * 3.0)
+    apex0 = apex_speed(k0, plant, v_top_ms=232.0 / 3.6, v_floor_ms=v_floor)
+    assert apex0 < v_floor, "fixture must put the apex under the drivability floor"
+    kappa = [k0, k1, k1, k1]
+    seg = [0.5, 0.5, 0.5, 0.5]
+    v, _ax = forward_backward_profile(kappa, seg, plant, v_top_ms=232.0 / 3.6, v_floor_ms=v_floor)
+    assert v[0] < apex0, (
+        f"braking pass could not lower a sub-floor apex ({v[0]:.3f} vs {apex0:.3f})"
+    )
+    for i, vi in enumerate(v):
+        if kappa[i] > 1e-6:
+            assert vi * vi * kappa[i] <= plant.ay_max(vi) * (1.0 + 1e-9)
+
+
+def test_drivability_floor_still_holds_where_the_apex_allows_it():
+    """The floor is not abandoned — a point whose apex clears it keeps a non-zero minimum."""
+    plant = _step_edge_plant()
+    v_floor = 8.0
+    # Gentle curvature everywhere: every apex is far above the floor, and a slow neighbour must not
+    # drag a point below the drivability minimum.
+    kappa = [1e-7] * 4
+    seg = [0.2, 0.2, 0.2, 0.2]
+    v, _ax = forward_backward_profile(kappa, seg, plant, v_top_ms=232.0 / 3.6, v_floor_ms=v_floor)
+    assert min(v) >= v_floor - 1e-9

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -1306,3 +1306,120 @@ def test_velocity_floor_never_lifts_a_point_above_the_envelope():
     v = apex_speed(kappa, plant, v_top_ms=232.0 / 3.6, v_floor_ms=8.0)
     assert v * v * kappa <= plant.ay_max(v) * (1.0 + 1e-9)
     assert v < 8.0
+
+
+def _step_up_bins() -> tuple[dict, ...]:
+    """Bins whose lateral ``safe_g`` steps UP with speed across 40 km/h.
+
+    The opposite-direction transition from :func:`_step_edge_bins`: here *lowering* a speed across
+    the edge moves into LESS grip, so a braking/traction cap that looks safe because it is smaller
+    can still land outside the envelope (#695 review).
+    """
+
+    def channel(safe_g: float) -> dict:
+        return {
+            "mean_g": safe_g + 0.05,
+            "epistemic_std_g": 0.02,
+            "safe_g": safe_g,
+            "n": 60,
+            "source": "measured",
+        }
+
+    bins = []
+    for i in range(30):
+        lo = i * 10.0
+        safe_lat = 0.75 if lo < 40.0 else 1.45
+        bins.append(
+            {
+                "speed_min_kmh": lo,
+                "speed_max_kmh": lo + 10.0,
+                "lateral": channel(safe_lat),
+                "brake": channel(1.2),
+                "drive": channel(0.5),
+            }
+        )
+    return tuple(bins)
+
+
+def test_lowering_a_speed_across_an_upward_bin_edge_stays_feasible():
+    """A smaller speed is not automatically a safer one when the envelope steps (#695 review)."""
+    from tools.ac_harness.ggv_profile import feasible_speed_at_or_below
+
+    plant = _step_up_plant()
+    # Feasible just above the edge, where the higher bin grants 1.45 g.
+    v_hi = 40.5 / 3.6
+    kappa = plant.ay_max(v_hi) / (v_hi * v_hi)
+    assert v_hi * v_hi * kappa <= plant.ay_max(v_hi) * (1.0 + 1e-9)
+    # A tiny propagation cap drops it below the edge into 0.75 g — naively "safer", actually not.
+    v_lo = 39.5 / 3.6
+    assert v_lo * v_lo * kappa > plant.ay_max(v_lo), "fixture must expose the downward crossing"
+    corrected = feasible_speed_at_or_below(v_lo, kappa, plant)
+    assert corrected <= v_lo
+    assert corrected * corrected * kappa <= plant.ay_max(corrected) * (1.0 + 1e-9)
+
+
+def _step_up_plant() -> GGVModel:
+    from dataclasses import replace as dc_replace
+
+    return dc_replace(_prior(), uncertainty_bins=_step_up_bins())
+
+
+def test_forward_backward_profile_feasible_on_an_upward_step_plant():
+    """Whole-profile feasibility on an upward-stepping envelope (broad guard, not a reproduction).
+
+    Honest scope: this passes even with the propagation feasibility check neutered, because the
+    backward pass only lowers points *toward* an apex, so a lowered value stays at or above that
+    apex and therefore in the same-or-higher bin. The downward-crossing rule is proved directly by
+    :func:`test_lowering_a_speed_across_an_upward_bin_edge_stays_feasible`; this test exists so a
+    future change to the propagation dynamics that *does* start producing sub-apex speeds cannot
+    reintroduce the violation silently.
+    """
+    plant = _step_up_plant()
+    pts = []
+    n = 720
+    for i in range(n):
+        theta = 2.0 * math.pi * i / n
+        r = 14.0 + 6.0 * math.sin(5.0 * theta)
+        pts.append((r * math.cos(theta), r * math.sin(theta)))
+    seg = seg_lengths(pts)
+    kappa = curvature_profile(pts)
+    v, _ax = forward_backward_profile(kappa, seg, plant, v_top_ms=232.0 / 3.6)
+    worst = 0.0
+    for i, vi in enumerate(v):
+        if kappa[i] > 1e-6:
+            worst = max(worst, (vi * vi * kappa[i]) / plant.ay_max(vi))
+    assert worst <= 1.0 + 1e-6, f"profile exceeds the envelope: {worst:.4f}x ay_max"
+
+
+def test_exhausted_descent_budget_falls_back_to_a_feasible_speed():
+    """With zero descent steps the solver must still not return an infeasible speed (#695 review).
+
+    Guards the branch Qodo flagged: a fixed budget that proves insufficient must degrade to the
+    provably-feasible global floor, never return the violating candidate.
+    """
+    from tools.ac_harness.ggv_profile import (
+        feasible_speed_at_or_below,
+        lateral_envelope_floor_ms2,
+    )
+
+    plant = _step_edge_plant()
+    floor_ay = lateral_envelope_floor_ms2(plant)
+    assert floor_ay > 0.0
+    kappa = 0.0545  # inside the band that violates by ~1.4x on the pre-fix solver
+    v_bad = 16.29
+    assert v_bad * v_bad * kappa > plant.ay_max(v_bad), "fixture must start infeasible"
+    v = feasible_speed_at_or_below(v_bad, kappa, plant, descent_steps=0)
+    assert v * v * kappa <= plant.ay_max(v) * (1.0 + 1e-9)
+    assert v < v_bad
+
+
+def test_lateral_envelope_floor_is_a_true_lower_bound():
+    """The fallback floor must not exceed ``ay_max`` anywhere, or it would not be safe to use."""
+    from tools.ac_harness.ggv_profile import lateral_envelope_floor_ms2
+
+    for plant in (_step_edge_plant(), _step_up_plant(), _prior()):
+        floor_ay = lateral_envelope_floor_ms2(plant)
+        v = 0.0
+        while v <= 340.0 / 3.6:
+            assert floor_ay <= plant.ay_max(v) + 1e-12, f"floor {floor_ay} > ay_max({v})"
+            v += 0.25

--- a/tests/test_ggv_profile.py
+++ b/tests/test_ggv_profile.py
@@ -1403,10 +1403,10 @@ def test_exhausted_descent_budget_falls_back_to_a_feasible_speed():
     )
 
     plant = _step_edge_plant()
-    floor_ay = lateral_envelope_floor_ms2(plant)
+    v_bad = 16.29
+    floor_ay = lateral_envelope_floor_ms2(plant, v_bad)
     assert floor_ay > 0.0
     kappa = 0.0545  # inside the band that violates by ~1.4x on the pre-fix solver
-    v_bad = 16.29
     assert v_bad * v_bad * kappa > plant.ay_max(v_bad), "fixture must start infeasible"
     v = feasible_speed_at_or_below(v_bad, kappa, plant, descent_steps=0)
     assert v * v * kappa <= plant.ay_max(v) * (1.0 + 1e-9)
@@ -1414,15 +1414,47 @@ def test_exhausted_descent_budget_falls_back_to_a_feasible_speed():
 
 
 def test_lateral_envelope_floor_is_a_true_lower_bound():
-    """The fallback floor must not exceed ``ay_max`` anywhere, or it would not be safe to use."""
+    """The fallback floor must not exceed ``ay_max`` anywhere in range, or it is not safe to use."""
     from tools.ac_harness.ggv_profile import lateral_envelope_floor_ms2
 
+    v_max = 340.0 / 3.6
     for plant in (_step_edge_plant(), _step_up_plant(), _prior()):
-        floor_ay = lateral_envelope_floor_ms2(plant)
+        floor_ay = lateral_envelope_floor_ms2(plant, v_max)
         v = 0.0
-        while v <= 340.0 / 3.6:
+        while v <= v_max:
             assert floor_ay <= plant.ay_max(v) + 1e-12, f"floor {floor_ay} > ay_max({v})"
             v += 0.25
+
+
+def test_lateral_envelope_floor_holds_for_a_binless_model_losing_grip_with_speed():
+    """A smooth model with NO bins whose grip falls with speed has its minimum at the top (#695).
+
+    Sampling only ``v=0`` would return that model's *maximum* and silently break the lower-bound
+    invariant the exhausted-budget fallback depends on.
+    """
+    from dataclasses import replace as dc_replace
+
+    from tools.ac_harness.ggv_profile import (
+        feasible_speed_at_or_below,
+        lateral_envelope_floor_ms2,
+    )
+
+    # Negative aero term: lateral grip DECREASES with speed, and no uncertainty bins at all.
+    plant = dc_replace(_prior(), k_aero_lat=-1.0e-4, uncertainty_bins=())
+    assert not plant.uncertainty_aware
+    v_max = 240.0 / 3.6
+    assert plant.ay_max(v_max) < plant.ay_max(0.0), "fixture must lose grip with speed"
+
+    floor_ay = lateral_envelope_floor_ms2(plant, v_max)
+    v = 0.0
+    while v <= v_max:
+        assert floor_ay <= plant.ay_max(v) + 1e-12, f"floor {floor_ay} > ay_max({v})"
+        v += 0.25
+
+    # And the fallback path built on it must still return a feasible speed.
+    kappa = 0.01
+    v_out = feasible_speed_at_or_below(v_max, kappa, plant, descent_steps=0)
+    assert v_out * v_out * kappa <= plant.ay_max(v_out) * (1.0 + 1e-9)
 
 
 def test_sub_floor_apex_does_not_block_the_braking_pass():

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -411,7 +411,9 @@ class AutoDriveReport:
     """Structured result of one composed autonomous self-test run."""
 
     ok: bool
-    stage: str  # preflight | launch | hijack | setup | pipeline | drive | cleanup | done
+    stage: (
+        str  # preflight | alien_line | launch | hijack | setup | pipeline | drive | cleanup | done
+    )
     launched: bool = False
     hijacked: bool = False
     drive: DriveStats | None = None
@@ -4477,6 +4479,20 @@ def _main_impl(
         )
         if alien_error is not None:
             print(f"auto-drive: {alien_error}")
+            # Emit the evidence bundle even on this pre-launch exit. Without it the composed
+            # self-play oracle sees no report.json at all and can only report "stage report
+            # missing", which reads as a physical falsification of the envelope step when the
+            # real cause was an asset/solver failure that never put the car on track (#695).
+            write_evidence(
+                evidence_dir,
+                AutoDriveReport(
+                    ok=False,
+                    stage="alien_line",
+                    error=alien_error,
+                    car_id=config.car_id,
+                    track_id=config.track_id,
+                ),
+            )
             return 2
 
     sidecar_proc = None

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -1810,22 +1810,27 @@ _APEX_FIXED_POINT_STEPS = 8
 _APEX_DESCENT_STEPS = 64
 
 
-def lateral_envelope_floor_ms2(ggv: GGVModel) -> float:
-    """A speed-independent lower bound on ``ay_max`` over the model's whole speed support.
+def lateral_envelope_floor_ms2(ggv: GGVModel, v_max_ms: float) -> float:
+    """A lower bound on ``ay_max`` over ``[0, v_max_ms]`` — the range a descent can land in.
 
     Used as the provably-feasible fallback when an iterative descent runs out of budget: for any
     ``kappa``, ``v = sqrt(floor/kappa)`` satisfies ``v²·κ = floor <= ay_max(v)`` by definition of a
     lower bound, so it can never violate the envelope.
 
     ``ay_max`` is piecewise in v (a smooth point model clipped by a per-bin ``safe_g``), so its
-    minimum lies on a bin boundary. Scanning both edges of every bin plus zero covers that whether
-    the point model rises or falls with speed, and uses only the public accessor rather than
-    re-deriving the model internals.
+    minimum over an interval lies on a bin boundary or an interval endpoint. Scanning zero, both
+    edges of every bin inside the interval, and ``v_max_ms`` itself covers that **whether the point
+    model rises or falls with speed** — the endpoint matters because a model with no bins at all and
+    a negative ``k_aero_lat`` has its minimum at the top of the range, not at zero, so sampling only
+    zero would return that model's *maximum* and break the bound (#695 review). Uses only the public
+    accessor rather than re-deriving the model internals.
     """
-    speeds = [0.0]
+    speeds = [0.0, max(0.0, v_max_ms)]
     for speed_bin in ggv.uncertainty_bins:
-        speeds.append(float(speed_bin["speed_min_kmh"]) / 3.6)
-        speeds.append(float(speed_bin["speed_max_kmh"]) / 3.6)
+        for edge_kmh in (speed_bin["speed_min_kmh"], speed_bin["speed_max_kmh"]):
+            edge = float(edge_kmh) / 3.6
+            if 0.0 <= edge <= v_max_ms:
+                speeds.append(edge)
     return min(ggv.ay_max(v) for v in speeds)
 
 
@@ -1858,8 +1863,9 @@ def feasible_speed_at_or_below(
             return vi
         vi = math.sqrt(ay_limit / kappa)
     # Budget exhausted (a pathological envelope, or a bin count beyond the descent budget): drop to
-    # the global floor rather than returning a speed the verifier will reject.
-    return min(vi, math.sqrt(lateral_envelope_floor_ms2(ggv) / kappa))
+    # the floor over the range we could have landed in, rather than returning a speed the verifier
+    # will reject. Bounding over [0, v_ms] is what makes the fallback provably feasible.
+    return min(vi, math.sqrt(lateral_envelope_floor_ms2(ggv, v_ms) / kappa))
 
 
 def apex_speed(

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -1804,6 +1804,53 @@ def seg_lengths(plane: list[tuple[float, float]]) -> list[float]:
     ]
 
 
+# Apex solve budget. The fixed point converges in a handful of steps where ``ay_max`` is smooth;
+# the descent guard then needs at most one step per uncertainty bin it walks down through.
+_APEX_FIXED_POINT_STEPS = 8
+_APEX_DESCENT_STEPS = 64
+
+
+def apex_speed(
+    kappa: float,
+    ggv: GGVModel,
+    *,
+    v_top_ms: float,
+    v_floor_ms: float = 0.0,
+) -> float:
+    """Largest speed at ``kappa`` whose lateral demand fits the envelope: ``v²·κ <= ay_max(v)``.
+
+    ``GGVModel.ay_max`` is **not continuous in v** — :meth:`GGVModel._uncertainty_safe_g` selects
+    ``safe_g`` from discrete speed bins (#543), so the envelope is a step function of speed. A bare
+    fixed point ``v <- sqrt(ay_max(v)/κ)`` on a discontinuous map need not converge: it can settle
+    on the *high* branch of a bin edge, where the speed it returns lands in a lower-grip bin than
+    the one used to compute it. That yields an apex the plant cannot support, which
+    :func:`~tools.ac_harness.alien_line._verify_lateral_envelope` then rejects with its float-noise
+    tolerance — the solver handing its own verifier infeasible input (#695: 445/3960 curvature
+    samples violating on a real Magione plant, worst 1.40x).
+
+    So iterate, then **descend until the constraint actually holds**. A violation means
+    ``ay_max(v) < v²·κ``, so the corrective iterate is strictly smaller; with finitely many bins the
+    descent terminates. The returned speed satisfies the envelope by construction, not by assertion.
+
+    ``v_floor_ms`` is a drivability floor and is applied only when it does not break the envelope —
+    raising an infeasible corner back over the limit would reintroduce the same defect.
+    """
+    if kappa <= 0.0:
+        return v_top_ms
+    vi = v_top_ms
+    for _ in range(_APEX_FIXED_POINT_STEPS):
+        vi = min(v_top_ms, math.sqrt(ggv.ay_max(vi) / kappa))
+    for _ in range(_APEX_DESCENT_STEPS):
+        ay_limit = ggv.ay_max(vi)
+        if vi * vi * kappa <= ay_limit:
+            break
+        # Strictly decreasing: ay_limit < vi²·κ here, so sqrt(ay_limit/κ) < vi.
+        vi = math.sqrt(ay_limit / kappa)
+    if v_floor_ms > vi and v_floor_ms * v_floor_ms * kappa <= ggv.ay_max(v_floor_ms):
+        return v_floor_ms
+    return vi
+
+
 def forward_backward_profile(
     kappa: list[float],
     seg: list[float],
@@ -1815,21 +1862,23 @@ def forward_backward_profile(
 ) -> tuple[list[float], list[float]]:
     """Quasi-steady-state minimum-time speed profile over a cyclic line.
 
-    1. apex speed from lateral grip (fixed-point, grip depends on v);
+    1. apex speed from lateral grip (:func:`apex_speed` — envelope-feasible by construction even
+       though the uncertainty-aware grip is a step function of v);
     2. backward pass: braking limited by the friction ellipse with speed-dependent grip;
     3. forward pass: accel limited by ellipse + traction/power cap.
     Returns (v_target_ms per point, ax_ff per point [m/s^2, +accel/-decel]).
     """
     n = len(kappa)
-    # 1) apex (fixed-point on v because ay_max depends on v)
+    # 1) apex (envelope-feasible by construction; ay_max is a step function of v — see apex_speed)
     v = [v_top_ms] * n
     for i in range(n):
         k = kappa[i]
         if k > 1e-6:
-            vi = v_top_ms
-            for _ in range(8):
-                vi = min(v_top_ms, math.sqrt(ggv.ay_max(vi) / k))
-            v[i] = max(v_floor_ms, vi)
+            v[i] = apex_speed(k, ggv, v_top_ms=v_top_ms, v_floor_ms=v_floor_ms)
+    # The drivability floor is per-point: a corner whose feasible apex is below ``v_floor_ms`` must
+    # keep its apex, otherwise the propagation passes would clamp it back over the lateral envelope
+    # and hand the verifier the very infeasible profile the apex solve just avoided (#695).
+    floor = [min(v_floor_ms, v[i]) for i in range(n)]
     # 2) backward (braking) - ellipse uses the lateral g implied by apex usage
     for _ in range(passes):
         for j in range(n):
@@ -1838,13 +1887,13 @@ def forward_backward_profile(
             ds = seg[i]
             if ds <= 1e-6:  # coincident points must share speed, else propagation chain breaks
                 if v[nx] < v[i]:
-                    v[i] = max(v_floor_ms, v[nx])
+                    v[i] = max(floor[i], v[nx])
                 continue
             ay_used = v[i] * v[i] * kappa[i]
             ax = ggv.ax_brake_avail(ay_used, v[i])
             cap = math.sqrt(v[nx] * v[nx] + 2.0 * ax * ds)
             if cap < v[i]:
-                v[i] = max(v_floor_ms, cap)
+                v[i] = max(floor[i], cap)
     # 3) forward (accel)
     for _ in range(passes):
         for i in range(n):
@@ -1852,13 +1901,13 @@ def forward_backward_profile(
             ds = seg[pv]
             if ds <= 1e-6:  # coincident points must share speed
                 if v[pv] < v[i]:
-                    v[i] = max(v_floor_ms, v[pv])
+                    v[i] = max(floor[i], v[pv])
                 continue
             ay_used = v[pv] * v[pv] * kappa[pv]
             ax = ggv.ax_drive_avail(ay_used, v[pv])
             cap = math.sqrt(v[pv] * v[pv] + 2.0 * ax * ds)
             if cap < v[i]:
-                v[i] = max(v_floor_ms, cap)
+                v[i] = max(floor[i], cap)
     v = [min(v_top_ms, x) for x in v]
     # ax feedforward from the profile (central, cyclic): a = v*dv/ds
     ax_ff = []

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -1810,6 +1810,58 @@ _APEX_FIXED_POINT_STEPS = 8
 _APEX_DESCENT_STEPS = 64
 
 
+def lateral_envelope_floor_ms2(ggv: GGVModel) -> float:
+    """A speed-independent lower bound on ``ay_max`` over the model's whole speed support.
+
+    Used as the provably-feasible fallback when an iterative descent runs out of budget: for any
+    ``kappa``, ``v = sqrt(floor/kappa)`` satisfies ``v²·κ = floor <= ay_max(v)`` by definition of a
+    lower bound, so it can never violate the envelope.
+
+    ``ay_max`` is piecewise in v (a smooth point model clipped by a per-bin ``safe_g``), so its
+    minimum lies on a bin boundary. Scanning both edges of every bin plus zero covers that whether
+    the point model rises or falls with speed, and uses only the public accessor rather than
+    re-deriving the model internals.
+    """
+    speeds = [0.0]
+    for speed_bin in ggv.uncertainty_bins:
+        speeds.append(float(speed_bin["speed_min_kmh"]) / 3.6)
+        speeds.append(float(speed_bin["speed_max_kmh"]) / 3.6)
+    return min(ggv.ay_max(v) for v in speeds)
+
+
+def feasible_speed_at_or_below(
+    v_ms: float,
+    kappa: float,
+    ggv: GGVModel,
+    *,
+    descent_steps: int = _APEX_DESCENT_STEPS,
+) -> float:
+    """The largest speed ``<= v_ms`` whose lateral demand fits the envelope at ``kappa``.
+
+    Every speed this module hands downstream must satisfy ``v²·κ <= ay_max(v)``, and **lowering** a
+    speed is not automatically safe: the envelope is a step function of speed (#543 uncertainty
+    bins), so a decrease that crosses a bin edge downward can land in a *lower*-grip bin and turn a
+    feasible speed infeasible (a 40.1 -> 39.9 km/h step on the live Magione plant drops the limit
+    29% while ``v²`` falls 1%). So the braking/traction propagation passes and the drivability floor
+    route their candidates through here too, not just the apex solve (#695).
+
+    Terminates feasible in every case: each descent step is strictly decreasing (a violation means
+    ``ay_max(v) < v²·κ``, hence ``sqrt(ay_max(v)/κ) < v``), and if the budget is exhausted anyway
+    the result falls back to :func:`lateral_envelope_floor_ms2`, feasible by construction.
+    """
+    if kappa <= 0.0:
+        return v_ms
+    vi = v_ms
+    for _ in range(descent_steps):
+        ay_limit = ggv.ay_max(vi)
+        if vi * vi * kappa <= ay_limit:
+            return vi
+        vi = math.sqrt(ay_limit / kappa)
+    # Budget exhausted (a pathological envelope, or a bin count beyond the descent budget): drop to
+    # the global floor rather than returning a speed the verifier will reject.
+    return min(vi, math.sqrt(lateral_envelope_floor_ms2(ggv) / kappa))
+
+
 def apex_speed(
     kappa: float,
     ggv: GGVModel,
@@ -1828,24 +1880,19 @@ def apex_speed(
     tolerance — the solver handing its own verifier infeasible input (#695: 445/3960 curvature
     samples violating on a real Magione plant, worst 1.40x).
 
-    So iterate, then **descend until the constraint actually holds**. A violation means
-    ``ay_max(v) < v²·κ``, so the corrective iterate is strictly smaller; with finitely many bins the
-    descent terminates. The returned speed satisfies the envelope by construction, not by assertion.
+    So iterate, then hand the result to :func:`feasible_speed_at_or_below`, which descends until
+    the constraint holds and falls back to a provably-feasible floor if its budget runs out. The
+    returned speed satisfies the envelope by construction, not by assertion.
 
-    ``v_floor_ms`` is a drivability floor and is applied only when it does not break the envelope —
-    raising an infeasible corner back over the limit would reintroduce the same defect.
+    ``v_floor_ms`` is a drivability floor, applied only when it is itself feasible — raising an
+    infeasible corner back over the limit would reintroduce the same defect.
     """
     if kappa <= 0.0:
         return v_top_ms
     vi = v_top_ms
     for _ in range(_APEX_FIXED_POINT_STEPS):
         vi = min(v_top_ms, math.sqrt(ggv.ay_max(vi) / kappa))
-    for _ in range(_APEX_DESCENT_STEPS):
-        ay_limit = ggv.ay_max(vi)
-        if vi * vi * kappa <= ay_limit:
-            break
-        # Strictly decreasing: ay_limit < vi²·κ here, so sqrt(ay_limit/κ) < vi.
-        vi = math.sqrt(ay_limit / kappa)
+    vi = feasible_speed_at_or_below(vi, kappa, ggv)
     if v_floor_ms > vi and v_floor_ms * v_floor_ms * kappa <= ggv.ay_max(v_floor_ms):
         return v_floor_ms
     return vi
@@ -1875,10 +1922,21 @@ def forward_backward_profile(
         k = kappa[i]
         if k > 1e-6:
             v[i] = apex_speed(k, ggv, v_top_ms=v_top_ms, v_floor_ms=v_floor_ms)
-    # The drivability floor is per-point: a corner whose feasible apex is below ``v_floor_ms`` must
-    # keep its apex, otherwise the propagation passes would clamp it back over the lateral envelope
-    # and hand the verifier the very infeasible profile the apex solve just avoided (#695).
-    floor = [min(v_floor_ms, v[i]) for i in range(n)]
+    # The drivability floor is per-point and itself envelope-checked: a corner whose feasible apex
+    # is below ``v_floor_ms`` keeps that apex, else the propagation passes would clamp it back over
+    # the lateral envelope and hand the verifier the very infeasible profile the apex solve just
+    # avoided. ``min`` alone is not enough: the envelope is non-monotonic in v, so even a lower
+    # floor can sit in a lower-grip bin (#695).
+    floor = [feasible_speed_at_or_below(min(v_floor_ms, v[i]), kappa[i], ggv) for i in range(n)]
+
+    def lowered(i: int, candidate: float) -> float:
+        """Apply a propagation cap at point ``i``, keeping the result envelope-feasible.
+
+        Lowering a speed can cross a bin edge downward into less grip, so a smaller number is not
+        automatically a safer one (#695 review).
+        """
+        return feasible_speed_at_or_below(max(floor[i], candidate), kappa[i], ggv)
+
     # 2) backward (braking) - ellipse uses the lateral g implied by apex usage
     for _ in range(passes):
         for j in range(n):
@@ -1887,13 +1945,13 @@ def forward_backward_profile(
             ds = seg[i]
             if ds <= 1e-6:  # coincident points must share speed, else propagation chain breaks
                 if v[nx] < v[i]:
-                    v[i] = max(floor[i], v[nx])
+                    v[i] = lowered(i, v[nx])
                 continue
             ay_used = v[i] * v[i] * kappa[i]
             ax = ggv.ax_brake_avail(ay_used, v[i])
             cap = math.sqrt(v[nx] * v[nx] + 2.0 * ax * ds)
             if cap < v[i]:
-                v[i] = max(floor[i], cap)
+                v[i] = lowered(i, cap)
     # 3) forward (accel)
     for _ in range(passes):
         for i in range(n):
@@ -1901,14 +1959,15 @@ def forward_backward_profile(
             ds = seg[pv]
             if ds <= 1e-6:  # coincident points must share speed
                 if v[pv] < v[i]:
-                    v[i] = max(floor[i], v[pv])
+                    v[i] = lowered(i, v[pv])
                 continue
             ay_used = v[pv] * v[pv] * kappa[pv]
             ax = ggv.ax_drive_avail(ay_used, v[pv])
             cap = math.sqrt(v[pv] * v[pv] + 2.0 * ax * ds)
             if cap < v[i]:
-                v[i] = max(floor[i], cap)
-    v = [min(v_top_ms, x) for x in v]
+                v[i] = lowered(i, cap)
+    # The top-speed clamp is itself a lowering, so it goes through the same feasibility check.
+    v = [lowered(i, min(v_top_ms, x)) for i, x in enumerate(v)]
     # ax feedforward from the profile (central, cyclic): a = v*dv/ds
     ax_ff = []
     for i in range(n):

--- a/tools/ac_harness/ggv_profile.py
+++ b/tools/ac_harness/ggv_profile.py
@@ -1922,20 +1922,29 @@ def forward_backward_profile(
         k = kappa[i]
         if k > 1e-6:
             v[i] = apex_speed(k, ggv, v_top_ms=v_top_ms, v_floor_ms=v_floor_ms)
-    # The drivability floor is per-point and itself envelope-checked: a corner whose feasible apex
-    # is below ``v_floor_ms`` keeps that apex, else the propagation passes would clamp it back over
-    # the lateral envelope and hand the verifier the very infeasible profile the apex solve just
-    # avoided. ``min`` alone is not enough: the envelope is non-monotonic in v, so even a lower
-    # floor can sit in a lower-grip bin (#695).
-    floor = [feasible_speed_at_or_below(min(v_floor_ms, v[i]), kappa[i], ggv) for i in range(n)]
+    # The drivability floor is per-point and itself envelope-checked, because the envelope is
+    # non-monotonic in v: ``min(v_floor_ms, …)`` alone is not enough, since even a *lower* floor can
+    # sit in a lower-grip bin and break the envelope the apex solve just satisfied (#695).
+    #
+    # It must NOT be derived from the apex. A corner whose feasible apex is already below
+    # ``v_floor_ms`` has no drivability floor to enforce — clamping it to its own apex would make
+    # the apex a hard minimum and stop the braking/traction passes lowering it at all, even when
+    # the propagation constraint requires it (#695 review). Such a point gets a floor of zero;
+    # envelope feasibility of any lower candidate is `lowered()`'s job, not the floor's.
+    floor = [
+        feasible_speed_at_or_below(v_floor_ms, kappa[i], ggv) if v[i] >= v_floor_ms else 0.0
+        for i in range(n)
+    ]
 
     def lowered(i: int, candidate: float) -> float:
         """Apply a propagation cap at point ``i``, keeping the result envelope-feasible.
 
         Lowering a speed can cross a bin edge downward into less grip, so a smaller number is not
-        automatically a safer one (#695 review).
+        automatically a safer one (#695 review). Correct the candidate first, then re-apply the
+        drivability floor — itself feasible — so the floor never re-lifts the point over the
+        envelope and never blocks a required propagation cap.
         """
-        return feasible_speed_at_or_below(max(floor[i], candidate), kappa[i], ggv)
+        return max(floor[i], feasible_speed_at_or_below(candidate, kappa[i], ggv))
 
     # 2) backward (braking) - ellipse uses the lateral g implied by apex usage
     for _ in range(passes):


### PR DESCRIPTION
Closes #695. Surfaced while driving EPIC #529's rig-gated pace gates.

## What happened

The `--iterations 6 --max-scale 1.15` self-play ladder on `ks_porsche_911_gt3_r_2016 @ magione` set a new best measured flying lap — **88.425 s** at `ggv_scale=1.10`, beating #577's 92.567 s — then lost its final envelope step:

```
auto-alien: iteration 5 plant refined (lateral bins adopted=2 raised=1)
auto-alien: iteration 5/6 drive (ggv_scale=1.15, laps=3)
auto-drive: alien line build failed — QSS profile exceeds the plant lateral envelope at point 355:
            v=16.68 m/s, kappa=0.03845 -> 1.0020x ay_max
auto-alien: iteration 5 FALSIFIED (stage report missing (drive stage did not produce report.json))
```

No spin, no invalid lap, no recovery — **the 1.15 envelope was never driven.** The ladder stopped on a solver defect wearing a falsification's clothes.

## Root cause

`GGVModel.ay_max` is **not continuous in v**. `_uncertainty_safe_g` selects `safe_g` from discrete 10 km/h bins (#543), so the lateral envelope is a step function of speed. `forward_backward_profile` solved the apex with a bare fixed-iteration fixed point:

```python
vi = v_top_ms
for _ in range(8):
    vi = min(v_top_ms, math.sqrt(ggv.ay_max(vi) / k))
```

On a discontinuous map that need not converge — it can settle on the **high branch** of a bin edge, returning a speed that lands in a lower-grip bin than the one used to compute it, with no check that the result is feasible. `alien_line._verify_lateral_envelope` then rejects the build with `_ENVELOPE_TOL = 1e-6`.

**The verifier is right; the solver was handing it infeasible input.** The docstring's claim that the profile respects the envelope "by construction" simply did not hold for a binned envelope.

## Not a one-off — latent on the plant that is on the rig right now

Sweeping `kappa` over 0.002–0.20 (~3,960 samples) against the persisted `ks_porsche_911_gt3_r_2016__magione.json`:

| | violations (`ratio > 1+1e-6`) | worst ratio |
|---|---|---|
| before | **445 / 3960 (11%)** | **1.4004×** |
| after | **0 / 3960** | **1.0000** |

Violations cluster on the bin edges the artifact actually has — a downward step at 60 km/h (50–60 `safe_g=1.0712` → 60–70 `1.0590`) and the 40–50 `safe_g` spike. 1.40× is the solver asking for 40% more lateral grip than the uncertainty-safe envelope grants; the only reason it had not bitten earlier is that previous plants' bin structure put the violating bands off the driven curvature range.

## Changes

- **`apex_speed()`** extracted: iterate, then **descend until `v²·κ <= ay_max(v)` actually holds**. A violation means `ay_max(v) < v²·κ`, so the corrective iterate is strictly smaller; with finitely many bins it terminates. Feasible by construction, not by assertion.
- **Per-point drivability floor**: `max(v_floor_ms, cap)` in the propagation passes could clamp a corner whose feasible apex is below 8 m/s back over the envelope, reintroducing the same defect after the apex solve avoided it.
- **Evidence on the pre-launch exit**: the alien-asset failure path returned before writing `report.json`, so the self-play oracle could only say `stage report missing`. It now emits `stage="alien_line"` with the real reason — #577's contract is that *the report names the falsification*, and naming the wrong thing would have an operator conclude the 1.15 envelope was physically falsified.

**No evidence gate is weakened.** `_ENVELOPE_TOL` is untouched; only the previously-infeasible samples move (typically 0.57% slower there, 15.5% worst case), and every already-feasible curvature is unchanged.

## Verification

- New regression tests build a plant with the **real** bin shape (a `safe_g` step down across the 60 km/h edge) and assert zero envelope violations across a curvature sweep, whole-profile feasibility on a cyclic line, and that the floor cannot lift a point over the limit. **3 of the 4 fail on the pre-fix solver** (verified by restoring the old apex and re-running); the 4th is an anti-over-correction guard that must pass both ways.
- `make ci-fast` → `ci-fast: OK`.
- **Live verification of the ladder's 1.15 step through `auto_alien`'s own unmodified path is still owed** and is listed on #695's acceptance criteria. I am running it on the rig; the numeric sweep proves the mechanism, not the outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
