### PR TITLE
docs(harness): fail closed in the off-rig recipe instead of hanging (#697)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -317,11 +317,12 @@ $track  = "magione"
 # suffix matters: the threat model here is two agents on ONE rig, and a bare second-resolution
 # stamp lets same-second starts share $task and $ev, so each would overwrite the other's wrapper
 # and task registration.
-# Validate before ANY of these values reach a path, a task name, or the generated .cmd. AC content
-# ids are `[A-Za-z0-9_]`; anything else here would either break New-Item/schtasks or, worse, land
-# cmd metacharacters (`&  |  >  <  ^  %VAR%`) inside an executable wrapper.
+# Validate before ANY of these values reach a path, a task name, or the generated .cmd. The pattern
+# mirrors the harness's own `_AC_ID_RE` (`auto_drive.py`) so a legitimate id carrying `-` or `.` is
+# not fail-closed here; it still excludes spaces and every cmd metacharacter (`&  |  >  <  ^  %VAR%`)
+# that would become redirection or injection inside the wrapper Task Scheduler executes.
 foreach ($v in @($car, $track)) {
-    if ($v -notmatch '^[A-Za-z0-9_]+$') { throw "unsafe car/track id: '$v'" }
+    if ($v -notmatch '^[A-Za-z0-9._-]+$') { throw "unsafe car/track id: '$v'" }
 }
 if ($repo -match '[^\u0020-\u007e]') { throw "non-ASCII repo path breaks the ascii-encoded wrapper: $repo" }
 $runId  = "alien-$car-$track-" + (Get-Date -Format "yyyyMMdd-HHmmss") + "-$PID-$(Get-Random -Maximum 9999)"
@@ -359,7 +360,7 @@ $trPath = (New-Object -ComObject Scripting.FileSystemObject).GetFile("$ev\run.cm
 # silently never launch — the exact failure this line exists to prevent, but now costing the whole
 # step-4 deadline. Refuse instead.
 if ($trPath -match '\s') {
-    throw "8.3 short path unavailable (got '$trPath'). Use a space-free \$repo/\$ev, or enable 8.3 name generation."
+    throw "8.3 short path unavailable (got '$trPath'). Use a space-free repo/evidence path, or enable 8.3 name generation."
 }
 # /f is kept deliberately. The unique run id above is what prevents a peer agent's task being
 # clobbered; /f is what stops schtasks blocking on its interactive "replace it?" prompt, which was

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -317,6 +317,13 @@ $track  = "magione"
 # suffix matters: the threat model here is two agents on ONE rig, and a bare second-resolution
 # stamp lets same-second starts share $task and $ev, so each would overwrite the other's wrapper
 # and task registration.
+# Validate before ANY of these values reach a path, a task name, or the generated .cmd. AC content
+# ids are `[A-Za-z0-9_]`; anything else here would either break New-Item/schtasks or, worse, land
+# cmd metacharacters (`&  |  >  <  ^  %VAR%`) inside an executable wrapper.
+foreach ($v in @($car, $track)) {
+    if ($v -notmatch '^[A-Za-z0-9_]+$') { throw "unsafe car/track id: '$v'" }
+}
+if ($repo -match '[^\u0020-\u007e]') { throw "non-ASCII repo path breaks the ascii-encoded wrapper: $repo" }
 $runId  = "alien-$car-$track-" + (Get-Date -Format "yyyyMMdd-HHmmss") + "-$PID-$(Get-Random -Maximum 9999)"
 $task   = "ac-harness-$runId"                              # never a shared fixed name
 $rel    = ".scratch\harness-evidence\$runId"
@@ -347,6 +354,13 @@ $when = (Get-Date).AddMinutes(5)
 # dir just stays empty and `Last Result` reads -2147024894 (file not found). Quoting does not save
 # it; the short path does. Measured on the rig (see the note below this block).
 $trPath = (New-Object -ComObject Scripting.FileSystemObject).GetFile("$ev\run.cmd").ShortPath
+# FAIL CLOSED. ShortPath returns the LONG path unchanged when 8.3 name generation is disabled on the
+# volume, so on a `C:\Users\First Last\…` profile the recipe would sail through create+run and then
+# silently never launch — the exact failure this line exists to prevent, but now costing the whole
+# step-4 deadline. Refuse instead.
+if ($trPath -match '\s') {
+    throw "8.3 short path unavailable (got '$trPath'). Use a space-free \$repo/\$ev, or enable 8.3 name generation."
+}
 # /f is kept deliberately. The unique run id above is what prevents a peer agent's task being
 # clobbered; /f is what stops schtasks blocking on its interactive "replace it?" prompt, which was
 # measured on the rig to hang a non-interactive create indefinitely rather than return an error.
@@ -357,11 +371,21 @@ if ($LASTEXITCODE -ne 0) { throw "schtasks /create failed ($LASTEXITCODE)" }
 schtasks /run /tn $task
 if ($LASTEXITCODE -ne 0) { schtasks /delete /tn $task /f; throw "schtasks /run failed ($LASTEXITCODE)" }
 
+```
+
+**Steps 3 and 4 are separate blocks on purpose** — do not paste them together with the above. Step 4
+blocks for as long as the run takes, so an agent that pastes everything at once traps its own shell
+there and can neither poll nor report progress. Live in step 3; run step 4 once at the end.
+
+```powershell
 # 3) poll from the SSH session (reads only — no AC interaction)
 schtasks /query  /tn $task /fo list | Select-String "^Status"
 Get-Content "$ev\stdout.log" -Tail 30
 Get-Process acs -ErrorAction SilentlyContinue | Select-Object Id,Responding
 
+```
+
+```powershell
 # 4) clean up ONLY after the wrapper has logged its exit code. `/run` is asynchronous, so deleting
 #    the task definition in the same unguarded paste can cancel a start that has not spawned yet —
 #    and it removes the only Status handle while the run is still launching. Wait for the sentinel,


### PR DESCRIPTION
Refs #697 (does not close it — that issue owns codifying this as a script).

## Why now

The self-hosted reviewer posted these **2m23s after PR #694 merged**, so they were never gating. Three are objectively correct and leave `main` carrying a runbook that can **fail open**, so I'm fixing them rather than parking them behind #697.

## Fixed

**1. `ShortPath` fails open.** `Scripting.FileSystemObject` returns the *long* path unchanged when 8.3 name generation is disabled on the volume. On a `C:\Users\First Last\…` profile the recipe would sail through `create`+`run` and then silently never launch — the exact failure the short path was added to prevent, except now it burns the whole step-4 deadline first. Now:

```powershell
if ($trPath -match '\s') {
    throw "8.3 short path unavailable (got '$trPath'). Use a space-free $repo/$ev, or enable 8.3 name generation."
}
```

**2. `$car`/`$track` interpolated raw into an executable `.cmd`.** They also feed the task name and evidence path. AC content ids are `[A-Za-z0-9_]` in practice, but nothing enforced it, and a value carrying `&  |  >  <  ^  %VAR%` becomes redirection or injection inside the wrapper Task Scheduler runs. Validated before use.

**3. `Set-Content -Encoding ascii` mangles non-ASCII paths.** A non-ASCII profile path becomes `?`, so `cd /d` and the log redirects point nowhere while `schtasks` still reports success. The repo path is rejected up front.

**4. Steps 3 and 4 split into separate blocks.** Step 4 blocks for the length of the run, so an agent pasting the whole thing at once traps its own shell there and can neither poll nor report progress — which directly contradicted the text telling it to live in step 3.

## Verified on the rig, not asserted

```
--- car/track validation ---
  'ks_porsche_911_gt3_r_2016' -> accept
  'magione'                   -> accept
  'bad&name'                  -> REJECT
  'has space'                 -> REJECT
--- non-ASCII repo guard ---
  'C:\Users\arsen\Projects\ac-copilot-trainer' -> accept
  'C:\Users\Arsén\Projects\x'                  -> REJECT (correct)
  'C:\Users\中\Projects\x'                      -> REJECT (correct)
--- ShortPath fail-closed check ---
  C:\Users\arsen\.scratch\fcprobe      -> 'C:\Users\arsen\SCRATC~1\fcprobe\run.cmd'   => proceed
  C:\Users\arsen\.scratch\fc probe dir -> 'C:\Users\arsen\SCRATC~1\FCPROB~1\run.cmd'  => proceed
```

Honest scope on that last one: this rig has 8.3 enabled, so both dirs resolve space-free and take the `proceed` branch. The `throw` branch is a fail-closed assertion whose predicate I verified, not a path I could exercise without disabling 8.3 volume-wide.

Two reviewer points are **not** addressed here and stay on #697: extracting this into `scripts/run_in_console.ps1`, and a locale-aware `/sd` resolution. Both are script-shaped, not paste-shaped.

Docs policy `OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
