### PR TITLE
docs(vault): record PR #699 off-rig fail-closed hardening (#693/#697)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -2,7 +2,7 @@
 type: current-focus
 status: active
 memory_tier: canonical
-last_updated: 2026-07-27T00:40:00Z
+last_updated: 2026-07-27T01:20:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-695-qss-apex-envelope-2026-07-26.md
   - AcCopilotTrainer/03_Investigations/issue-693-off-rig-session0-2026-07-26.md
@@ -62,6 +62,12 @@ self-play ladder its top envelope step). Issue #695 CLOSED. Detail:
 MERGED [`49f90f1`](https://github.com/agorokh/ac-copilot-trainer/commit/49f90f1) — #693 off-rig
 launch path (SSH lands in Windows session 0; `schtasks /IT` recipe, live-verified). Issue #693
 CLOSED; codify-as-script follow-up **#697** OPEN. Detail:
+[[issue-693-off-rig-session0-2026-07-26]].
+
+**Delivered (2026-07-27):** PR [#699](https://github.com/agorokh/ac-copilot-trainer/pull/699)
+MERGED [`c5afa50`](https://github.com/agorokh/ac-copilot-trainer/commit/c5afa50) — off-rig recipe
+fails closed rather than hanging (8.3 `ShortPath` fail-open, unvalidated `$car`/`$track` into an
+executable `.cmd`, ascii-mangled non-ASCII paths, blocking-wait block split). Detail:
 [[issue-693-off-rig-session0-2026-07-26]].
 
 **In flight (2026-07-26):** EPIC [#529](https://github.com/agorokh/ac-copilot-trainer/issues/529) —

--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-27T00:40:00Z
+last_updated: 2026-07-27T01:20:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-695-qss-apex-envelope-2026-07-26.md
   - AcCopilotTrainer/03_Investigations/issue-693-off-rig-session0-2026-07-26.md
@@ -142,6 +142,13 @@ Windows **session 0** (#693). The AC app junction was also found serving a non-m
 **Still open on #529, stated honestly:** G1 pace (≤86.84 s) **not met** at 88.425 s; G2 (<82.7 s) not
 met; G1b not attempted; **G3 needs a human driving multiple sessions** (operator-gated, not
 rig-gated); P4's first real rig scientist batch not run.
+
+**Also delivered (2026-07-27):** PR [#699](https://github.com/agorokh/ac-copilot-trainer/pull/699)
+MERGED [`c5afa50`](https://github.com/agorokh/ac-copilot-trainer/commit/c5afa50) — the off-rig recipe
+now **fails closed** instead of hanging: `ShortPath` returns the long path when 8.3 generation is
+disabled (silent 3 h wait), `$car`/`$track` were interpolated raw into an executable `.cmd`, and
+ascii encoding mangles non-ASCII paths. Guards assert their own preconditions; steps 3/4 split so an
+agent cannot paste itself into a blocking wait. #697 still OPEN for the script.
 
 ## RESUME — #529 pace gates, blocked on a rig reboot
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-693-off-rig-session0-2026-07-26.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-693-off-rig-session0-2026-07-26.md
@@ -3,7 +3,7 @@ type: investigation
 status: active
 memory_tier: canonical
 created: 2026-07-26
-updated: 2026-07-26
+updated: 2026-07-27
 issue: https://github.com/agorokh/ac-copilot-trainer/issues/693
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-575-stale-app-junction-2026-07-15.md
@@ -64,3 +64,25 @@ Five rounds, six real Windows defects — the strongest argument for #697:
   found on `chore/issue-677-post-merge-vault` @ `971c103` (already on main as `b80ab38`), i.e. the
   #575/#543 stale-Lua trap, and detached to `origin/main`.
 - `main` may be pinned by a peer worktree — `git switch main` fails; **detach at `origin/main`** instead.
+
+## Post-merge hardening (PR #699, `c5afa50`)
+
+The self-hosted reviewer posted three more findings **2m23s after #694 merged** — never gating, but
+they left `main` carrying a runbook that could **fail open**, so they were fixed immediately rather
+than deferred to #697:
+
+- **`ShortPath` fails open.** `FileSystemObject` returns the LONG path unchanged when 8.3 name
+  generation is disabled, so on a `C:\Users\First Last\…` profile the recipe passes create+run and
+  then silently never launches — the very failure the short path was added to prevent, now costing
+  the whole step-4 deadline. Now throws when `$trPath` still contains whitespace.
+- **`$car`/`$track` were interpolated raw into an executable `.cmd`** (and into the task name and
+  evidence path). Validated against the harness's own `_AC_ID_RE` (`^[A-Za-z0-9._-]+$`) — a first
+  attempt used `^[A-Za-z0-9_]+$`, which was *stricter than the harness* and would have fail-closed
+  legitimate ids carrying `-` or `.`.
+- **`Set-Content -Encoding ascii` mangles non-ASCII paths** to `?`, producing a wrapper whose `cd /d`
+  and redirects point nowhere while `schtasks` still reports success. Repo path rejected up front.
+- Steps 3 and 4 split into separate blocks: step 4 blocks for the length of the run, so an agent
+  pasting the whole thing at once traps its own shell and can neither poll nor report.
+
+**Lesson:** a fail-safe that can *fail open* is worse than none — it converts a loud error into a
+silent multi-hour wait. Every guard added here asserts its own precondition.


### PR DESCRIPTION
Vault-only. Diff is strictly under `docs/01_Vault/**`.

The #698 handoff was written before PR #699 merged, so the SAVE did not reflect the last change on `main`. This closes that gap across the #693 investigation node, `Next Session Handoff`, and `Current Focus`.

Records the durable lesson from that round: **a fail-safe that can fail *open* is worse than none.** `FileSystemObject.ShortPath` silently returns the long path when 8.3 name generation is disabled, which turned a loud error into a silent multi-hour wait — exactly the failure the short path had been added to prevent. Every guard added now asserts its own precondition.

Also notes the near-miss where the first validation gate was **stricter than the harness's own `_AC_ID_RE`** and would have fail-closed legitimate car ids containing `-` or `.`.

Docs policy `OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
