### PR TITLE
feat(harness): codify the off-rig session-0 transport into a harness entrypoint (#697)

### DIFF
--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -359,9 +359,10 @@ Behaviours worth knowing before you debug something:
   substituted before validation, so `--evidence-dir .scratch/harness-evidence/{run_id}` makes the
   in-sim evidence share the transport's run id. The wrapper also exports
   `AC_HARNESS_REMOTE_RUN_ID`.
-- **The run id you pass is authoritative.** `run.json` lives in a writable scratch tree, so `load`
-  binds the payload to the id you asked for and **recomputes** its directory; a forged or stale
-  payload cannot redirect `cleanup` onto a peer's task.
+- **The run id you pass is authoritative.** `run.json` lives in a writable scratch tree, so
+  `poll` / `wait` / `cleanup` bind the payload to the run id you asked for and **recompute** its
+  directory; a forged or stale payload cannot redirect `cleanup` onto a peer's task. (There is no
+  `load` subcommand — that binding happens inside every command that takes a run id.)
 
 You landed in the right session when the run's own first lines report the provenance gate passing:
 

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -347,9 +347,12 @@ Behaviours worth knowing before you debug something:
   agents on the one physical rig: a fixed name lets each clobber the other's registration.
 - **`wait` is bounded.** If the run never starts, the sentinel never appears; an unbounded wait
   would hang for hours with no diagnosis.
-- **`list` only reports; `reap` deletes.** A session that dies before `cleanup` leaves a harmless
-  but accumulating registration behind — `reap` removes every task this module owns, so you never
-  need raw `schtasks /delete`.
+- **`list` only reports; `reap` deletes — under `cleanup`'s rule, not a weaker one.** `reap`
+  removes a task only when that run's **exit sentinel** exists (and its status is a known non-live
+  value), so you never need raw `schtasks /delete`. `Status: Ready` is *not* completion: `/run` is
+  asynchronous, so a task reads `Ready` both between `/create` and `/run` and after `/run` until the
+  wrapper spawns — deleting in either window cancels a peer's launch. An unreadable or unrecognised
+  status **fails closed** (skipped, with the reason reported); `--force` overrides both checks.
 - **The run id you pass is authoritative.** `run.json` lives in a writable scratch tree, so `load`
   binds the payload to the id you asked for and **recomputes** its directory; a forged or stale
   payload cannot redirect `cleanup` onto a peer's task.

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -293,135 +293,59 @@ transport, not the harness:
 Get-Process explorer | Select-Object Id,SessionId # the console session (typically 1)
 ```
 
-### Run in the console session with a `/IT` scheduled task
+### Run in the console session: `tools.ac_harness.remote_launcher` (#697)
 
-`schtasks /IT` means "run only when the user is logged on", so the task executes in the console
-session **and needs no stored credential**. Wrap the harness invocation in a `.cmd` that redirects its
-own logs, then create, run, and poll the task:
+The transport is owned by a harness entrypoint — do **not** hand-run `schtasks` any more. PR #694
+shipped this as a copy/paste runbook and five review rounds then found six real Windows defects in
+it (`<`/`>` parsed as redirection inside the generated `.cmd`; a fixed `/st` that fails once local
+time passes it; `/st` without `/sd` rolling to "earlier today" overnight; a space anywhere in the
+path making Task Scheduler report `create=0`/`run=0` and then never launch; buffered Python leaving
+the poll surface empty on a healthy run; an 8.3 `ShortPath` lookup that *fails open*). Every one of
+those is now a guard that asserts its own precondition in
+[`tools/ac_harness/remote_launcher.py`](../../tools/ac_harness/remote_launcher.py), with the pure
+half unit-tested off-rig in `tests/test_ac_harness_remote_launcher.py`.
 
-Derive every path from the environment and give the task a **per-run name** — a fixed task name lets
-two agents clobber each other's registration on the one rig, and leaves stale tasks behind:
+Start a run — everything after `--` is the harness argv, minus the interpreter:
 
-Everything below is copy/paste-runnable as written — set the four values in step 0 and nothing else.
-**Do not introduce `<angle-bracket>` placeholders here**: `cmd.exe` parses `<` and `>` as redirection
-inside the generated `.cmd`, and both are illegal in Windows path components and task names, so an
-angle-bracket "placeholder" fails before the harness ever starts. Use PowerShell variables, which are
-interpolated into the file.
-
-```powershell
-# 0) the only values to set (no hardcoded user or checkout path)
-$repo   = "$env:USERPROFILE\Projects\ac-copilot-trainer"   # or wherever this clone lives
-$car    = "ks_porsche_911_gt3_r_2016"
-$track  = "magione"
-# Unique per run, and Windows-path/task-name safe (no ':' from the timestamp). The PID+random
-# suffix matters: the threat model here is two agents on ONE rig, and a bare second-resolution
-# stamp lets same-second starts share $task and $ev, so each would overwrite the other's wrapper
-# and task registration.
-# Validate before ANY of these values reach a path, a task name, or the generated .cmd. The pattern
-# mirrors the harness's own `_AC_ID_RE` (`auto_drive.py`) so a legitimate id carrying `-` or `.` is
-# not fail-closed here; it still excludes spaces and every cmd metacharacter (`&  |  >  <  ^  %VAR%`)
-# that would become redirection or injection inside the wrapper Task Scheduler executes.
-foreach ($v in @($car, $track)) {
-    if ($v -notmatch '^[A-Za-z0-9._-]+$') { throw "unsafe car/track id: '$v'" }
-}
-if ($repo -match '[^\u0020-\u007e]') { throw "non-ASCII repo path breaks the ascii-encoded wrapper: $repo" }
-$runId  = "alien-$car-$track-" + (Get-Date -Format "yyyyMMdd-HHmmss") + "-$PID-$(Get-Random -Maximum 9999)"
-$task   = "ac-harness-$runId"                              # never a shared fixed name
-$rel    = ".scratch\harness-evidence\$runId"
-$ev     = "$repo\$rel"
-
-# 1) wrapper (writes its own logs; the SSH session only ever reads files)
-New-Item -ItemType Directory -Force -Path $ev | Out-Null
-Set-Content -LiteralPath "$ev\run.cmd" -Encoding ascii -Value @"
-@echo off
-cd /d "$repo"
-rem Unbuffered: redirected Python is fully buffered, so stdout.log stays empty for minutes and the
-rem SSH-side tail in step 3 looks hung when the run is perfectly healthy.
-set PYTHONUNBUFFERED=1
-".venv\Scripts\python.exe" -u -m tools.ac_harness.auto_alien --car $car --track $track ^
-    --laps 3 --iterations 2 --evidence-dir "$rel" > "$ev\stdout.log" 2> "$ev\stderr.log"
-echo [wrapper] exit=%ERRORLEVEL% >> "$ev\wrapper.log"
-"@
-
-# 2) create + run in the console session ($env:USERNAME, not a literal account).
-#    /st alone is not enough. `/sc once` defaults the start DATE to today, so a bare clock time
-#    computed after ~23:55 lands at 00:xx and is read as earlier TODAY — `/create` then fails with
-#    "The start time of the task cannot be earlier than the current time", precisely during the
-#    overnight runs this path exists for. Derive /st and /sd from the SAME DateTime so a rollover
-#    carries the correct day. The trigger never fires anyway; /run starts the task on demand.
-$when = (Get-Date).AddMinutes(5)
-# Hand /tr the 8.3 SHORT path. If any component of the path contains a space, Task Scheduler
-# accepts the create (rc=0) and the run (rc=0) and then never launches the wrapper — the evidence
-# dir just stays empty and `Last Result` reads -2147024894 (file not found). Quoting does not save
-# it; the short path does. Measured on the rig (see the note below this block).
-$trPath = (New-Object -ComObject Scripting.FileSystemObject).GetFile("$ev\run.cmd").ShortPath
-# FAIL CLOSED. ShortPath returns the LONG path unchanged when 8.3 name generation is disabled on the
-# volume, so on a `C:\Users\First Last\…` profile the recipe would sail through create+run and then
-# silently never launch — the exact failure this line exists to prevent, but now costing the whole
-# step-4 deadline. Refuse instead.
-if ($trPath -match '\s') {
-    throw "8.3 short path unavailable (got '$trPath'). Use a space-free repo/evidence path, or enable 8.3 name generation."
-}
-# /f is kept deliberately. The unique run id above is what prevents a peer agent's task being
-# clobbered; /f is what stops schtasks blocking on its interactive "replace it?" prompt, which was
-# measured on the rig to hang a non-interactive create indefinitely rather than return an error.
-schtasks /create /tn $task /tr $trPath /sc once `
-    /st $when.ToString('HH:mm') /sd $when.ToString('MM/dd/yyyy') `
-    /ru $env:USERNAME /it /f
-if ($LASTEXITCODE -ne 0) { throw "schtasks /create failed ($LASTEXITCODE)" }
-schtasks /run /tn $task
-if ($LASTEXITCODE -ne 0) { schtasks /delete /tn $task /f; throw "schtasks /run failed ($LASTEXITCODE)" }
-
+```bash
+python -m tools.ac_harness.remote_launcher start --label alien-529-911-magione -- \
+    -m tools.ac_harness.auto_alien --car ks_porsche_911_gt3_r_2016 --track magione \
+    --laps 3 --ggv-scale 1.0 --scale-step 0.15 --iterations 2 --max-scale 1.2
 ```
 
-**Steps 3 and 4 are separate blocks on purpose** — do not paste them together with the above. Step 4
-blocks for as long as the run takes, so an agent that pastes everything at once traps its own shell
-there and can neither poll nor report progress. Live in step 3; run step 4 once at the end.
+It prints a JSON handle (`run_id`, `task`, `run_dir`) and returns immediately. Transport logs live
+under `.scratch/harness-remote/<run id>/` (`run.cmd`, `stdout.log`, `stderr.log`, `wrapper.log`,
+`run.json`) — deliberately *beside* the harness's own `--evidence-dir` tree, which the harness keeps
+owning.
 
-```powershell
-# 3) poll from the SSH session (reads only — no AC interaction)
-schtasks /query  /tn $task /fo list | Select-String "^Status"
-Get-Content "$ev\stdout.log" -Tail 30
-Get-Process acs -ErrorAction SilentlyContinue | Select-Object Id,Responding
+Then live in `poll` (read-only — it never touches AC and never deletes the task), and reap at the
+end:
 
+```bash
+python -m tools.ac_harness.remote_launcher poll <run id> --tail 40
+python -m tools.ac_harness.remote_launcher wait <run id> --timeout-s 10800
+python -m tools.ac_harness.remote_launcher cleanup <run id>
+python -m tools.ac_harness.remote_launcher list        # reap tasks a dead session left behind
 ```
 
-```powershell
-# 4) clean up ONLY after the wrapper has logged its exit code. `/run` is asynchronous, so deleting
-#    the task definition in the same unguarded paste can cancel a start that has not spawned yet —
-#    and it removes the only Status handle while the run is still launching. Wait for the sentinel,
-#    but BOUND the wait: if the run never starts, the sentinel never appears and an unbounded loop
-#    would hang forever with no diagnosis.
-$sentinel = "$ev\wrapper.log"
-$deadline = (Get-Date).AddHours(3)   # longer than any ladder you should be running unattended
-function Test-Done { Select-String -Path $sentinel -Pattern "exit=" -Quiet -ErrorAction SilentlyContinue }
-while ((Get-Date) -lt $deadline -and -not (Test-Done)) { Start-Sleep -Seconds 30 }
-if (Test-Done) {
-    Get-Content $sentinel
-    schtasks /delete /tn $task /f
-} else {
-    # No sentinel: report the task's own verdict instead of deleting the evidence silently.
-    schtasks /query /tn $task /fo list /v | Select-String "^Status|^Last Result"
-    Write-Warning "run never wrote exit=; inspect $ev\stderr.log before deleting $task"
-}
-```
+`poll` reports the task `Status`/`Last Result`, whether the wrapper has written its exit sentinel,
+`acs.exe` liveness, the current **rig-lock owner** (arbitration stays in `rig_lock` — the launcher
+does not duplicate it), and tails of both streams. `start --wait-timeout-s <s>` composes start +
+bounded wait + cleanup in one call for an unattended run.
 
-An `auto_alien` ladder runs for tens of minutes, so treat step 3 as the loop you actually live in and
-step 4 as end-of-run housekeeping. If a session dies before step 4, the leftover task is harmless but
-should be reaped by name on the next visit (`schtasks /query | Select-String "ac-harness-"`).
+Behaviours worth knowing before you debug something:
 
-> **A space anywhere in the path silently breaks `/tr`.** Measured on the rig with an evidence dir
-> under `…\space test dir\`: the bare path and a quoted path both gave `create=0`, `run=0`, and then
-> **never executed** (`Last Result: -2147024894`, empty evidence dir — the paste just waits out the
-> step-4 deadline). Wrapping as `cmd.exe /c "…"` failed to create at all (`0x80004005`). The 8.3
-> **short path** worked: `create=0`, `run=0`, `Last Result: 0`, wrapper executed. Hence `$trPath`.
->
-> **`/sd` format is locale-dependent.** `MM/dd/yyyy` (zero-padded) is what this rig accepts; the
-> *culture* short-date pattern is **not** interchangeable — measured on the rig, `M/d/yyyy`,
-> `dd/MM/yyyy` and `yyyy/MM/dd` were all rejected with `0x80004005` while `MM/dd/yyyy` succeeded. If
-> `/create` fails on a differently-localised host, probe the accepted form rather than guessing. Note
-> also that `/sc ONDEMAND` — which would remove the date problem entirely — is **not** accepted by
-> `schtasks /create` here (same `0x80004005`), so `/sc once` plus an explicit date is the working path.
+- **It refuses to run in the console session.** There the task hop is pure overhead, so run the
+  harness directly. It also fails loudly when nobody is logged on at the rig, because a `/IT` task
+  can never run then and AC has no desktop to render on.
+- **`cleanup` refuses an unfinished run** (use `--force` only deliberately). `schtasks /run` is
+  asynchronous: deleting the task definition early can cancel a start that has not spawned yet, and
+  it removes the only `Status` handle while the run is still launching. The exit sentinel
+  (`[wrapper] exit=<rc>` in `wrapper.log`), not `Status: Ready`, is what says a run finished.
+- **Task names are per-run** (`ac-harness-<label>-<stamp>-<pid>-<nonce>`). The threat model is two
+  agents on the one physical rig: a fixed name lets each clobber the other's registration.
+- **`wait` is bounded.** If the run never starts, the sentinel never appears; an unbounded wait
+  would hang for hours with no diagnosis.
 
 You landed in the right session when the run's own first lines report the provenance gate passing:
 
@@ -434,7 +358,7 @@ auto-drive: rig lock acquired -> ...\AC Copilot Trainer\Harness\rig-session.lock
 `installed app provenance: match` is the machine-checkable signal — it means the junction was
 traversed *and* the served tree matches the checkout the harness is running from.
 
-### Pre-run rig invariants (check these before creating the task)
+### Pre-run rig invariants (check these before starting a remote run)
 
 - **The AC app junction serves the primary checkout**, which must sit at the merged `main` tip
   (#575/#543 — a stale checkout serves stale Lua and the run fails in confusing ways).
@@ -458,7 +382,7 @@ traversed *and* the served tree matches the checkout the harness is running from
 | `setup.load` error "no loopback Lua peer connected" | The trainer app isn't (yet) connected to the sidecar — the harness retries for `setup_timeout`; persistent = app not installed/enabled in CSP |
 | Run FAILS with `recovery cap exceeded at <N>m` | Real stall: the car repeatedly stopped at the same spot. Inspect `hud.png` plus `report.drive.control_trace` (especially the forced `recovery:*` rows); do **not** raise the cap to make it "pass" |
 | `acs.exe` dies mid-drive | The main physics packet watchdog fails that attempt and the CLI automatically runs one fresh full launch (bounded by `--sim-death-retries`). Inspect `report.attempts`: every failed attempt, reason, and control trace is retained even when the final attempt passes. |
-| `OSError: [WinError 448] … untrusted mount point` on the app junction | You are running in Windows **session 0** (an SSH logon), which cannot traverse the user-created junction and has no desktop for AC to render on. Not a harness bug and **not** a reason to relax the provenance preflight — re-run through a `schtasks /IT` task in the console session (see *Driving the harness from off-rig*) |
+| `OSError: [WinError 448] … untrusted mount point` on the app junction | You are running in Windows **session 0** (an SSH logon), which cannot traverse the user-created junction and has no desktop for AC to render on. Not a harness bug and **not** a reason to relax the provenance preflight — re-run through `python -m tools.ac_harness.remote_launcher start` (see *Driving the harness from off-rig*) |
 | Two agents, one rig | **Yield**: a single AC instance cannot serve two autonomous sessions (see the issue-277 investigation). Check for a running `acs.exe`/peer sidecar before launching |
 | Sidecar port already in use | That's usually the Game Point launcher's supervised sidecar — the harness reuses it; don't spawn a second |
 

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -310,6 +310,7 @@ Start a run — everything after `--` is the harness argv, minus the interpreter
 ```bash
 python -m tools.ac_harness.remote_launcher start --label alien-529-911-magione -- \
     -m tools.ac_harness.auto_alien --car ks_porsche_911_gt3_r_2016 --track magione \
+    --evidence-dir .scratch/harness-evidence/{run_id} \
     --laps 3 --ggv-scale 1.0 --scale-step 0.15 --iterations 2 --max-scale 1.2
 ```
 

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -325,7 +325,8 @@ end:
 python -m tools.ac_harness.remote_launcher poll <run id> --tail 40
 python -m tools.ac_harness.remote_launcher wait <run id> --timeout-s 10800
 python -m tools.ac_harness.remote_launcher cleanup <run id>
-python -m tools.ac_harness.remote_launcher list        # reap tasks a dead session left behind
+python -m tools.ac_harness.remote_launcher list        # report tasks a dead session left behind
+python -m tools.ac_harness.remote_launcher reap        # ...and actually delete them
 ```
 
 `poll` reports the task `Status`/`Last Result`, whether the wrapper has written its exit sentinel,
@@ -346,6 +347,12 @@ Behaviours worth knowing before you debug something:
   agents on the one physical rig: a fixed name lets each clobber the other's registration.
 - **`wait` is bounded.** If the run never starts, the sentinel never appears; an unbounded wait
   would hang for hours with no diagnosis.
+- **`list` only reports; `reap` deletes.** A session that dies before `cleanup` leaves a harmless
+  but accumulating registration behind — `reap` removes every task this module owns, so you never
+  need raw `schtasks /delete`.
+- **The run id you pass is authoritative.** `run.json` lives in a writable scratch tree, so `load`
+  binds the payload to the id you asked for and **recomputes** its directory; a forged or stale
+  payload cannot redirect `cleanup` onto a peer's task.
 
 You landed in the right session when the run's own first lines report the provenance gate passing:
 

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -315,9 +315,10 @@ python -m tools.ac_harness.remote_launcher start --label alien-529-911-magione -
 ```
 
 It prints a JSON handle (`run_id`, `task`, `run_dir`) and returns immediately. Transport logs live
-under `.scratch/harness-remote/<run id>/` (`run.cmd`, `stdout.log`, `stderr.log`, `wrapper.log`,
-`run.json`) — deliberately *beside* the harness's own `--evidence-dir` tree, which the harness keeps
-owning.
+under `.scratch/harness-remote/<run id>/` (`stdout.log`, `stderr.log`, `run.json`) — deliberately
+*beside* the harness's own `--evidence-dir` tree, which the harness keeps owning. The control file
+and exit sentinel are **not** there; they live under `%LOCALAPPDATA%\AC Copilot Trainer\Harness\
+remote\<run id>\`.
 
 Then live in `poll` (read-only — it never touches AC and never deletes the task), and reap at the
 end:
@@ -344,12 +345,20 @@ Behaviours worth knowing before you debug something:
   asynchronous: deleting the task definition early can cancel a start that has not spawned yet, and
   it removes the only `Status` handle while the run is still launching. The exit sentinel
   (`[wrapper] exit=<rc>` in `wrapper.log`), not `Status: Ready`, is what says a run finished.
-- **The `/sc once` trigger really fires.** `/run` starts the task on demand, but `/create` insists
-  on a start time and Task Scheduler honours it. A run that *finished* before that moment would be
-  executed a second time — and `>` truncates, so the ghost run would silently destroy the first
-  run's `stdout.log`/`stderr.log` and overwrite its in-sim evidence. The wrapper therefore exits
-  immediately when the exit sentinel already exists. (Earlier runbook text claimed "the trigger
-  never fires"; that only held for runs longer than the delay.)
+- **The `/sc once` trigger really fires** — earlier runbook text claimed it never does, which only
+  held for runs *longer* than the start delay. `/create` insists on a start time and Task Scheduler
+  honours it, so a run that finished first would be executed a second time. The trigger is therefore
+  **disabled immediately after `/run`** succeeds; a running instance is unaffected. This is done in
+  the scheduler rather than with a marker file, because every marker lives somewhere a peer agent
+  can write.
+- **Nothing peer-writable is ever executed.** `/tr` points at the repo's own interpreter running the
+  version-controlled `tools/ac_harness/_remote_exec.py`, not at a generated script in `.scratch`.
+  That shim reads a control file, **re-validates every argv token**, recomputes the interpreter, cwd,
+  log paths and sentinel from the validated run id, and spawns with `shell=False`. The control file
+  and exit sentinel live beside the rig lock under `%LOCALAPPDATA%`, not in the shared scratch tree.
+  *Residual, stated plainly:* every agent on this rig runs as the same Windows account, so no
+  filesystem location is beyond a peer's reach — this removes command **injection** and makes
+  tampering fail closed, it does not create isolation.
 - **Task names are per-run** (`ac-harness-<label>-<stamp>-<pid>-<nonce>`). The threat model is two
   agents on the one physical rig: a fixed name lets each clobber the other's registration.
 - **`wait` is bounded.** If the run never starts, the sentinel never appears; an unbounded wait

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -317,8 +317,8 @@ python -m tools.ac_harness.remote_launcher start --label alien-529-911-magione -
 It prints a JSON handle (`run_id`, `task`, `run_dir`) and returns immediately. Transport logs live
 under `.scratch/harness-remote/<run id>/` (`stdout.log`, `stderr.log`, `run.json`) — deliberately
 *beside* the harness's own `--evidence-dir` tree, which the harness keeps owning. The control file
-and exit sentinel are **not** there; they live under `%LOCALAPPDATA%\AC Copilot Trainer\Harness\
-remote\<run id>\`.
+and exit sentinel are **not** there; they live under
+`%LOCALAPPDATA%\AC Copilot Trainer\Harness\remote\<run id>\` (one unbroken path — copy it whole).
 
 Then live in `poll` (read-only — it never touches AC and never deletes the task), and reap at the
 end:

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -347,12 +347,18 @@ Behaviours worth knowing before you debug something:
   agents on the one physical rig: a fixed name lets each clobber the other's registration.
 - **`wait` is bounded.** If the run never starts, the sentinel never appears; an unbounded wait
   would hang for hours with no diagnosis.
-- **`list` only reports; `reap` deletes — under `cleanup`'s rule, not a weaker one.** `reap`
-  removes a task only when that run's **exit sentinel** exists (and its status is a known non-live
-  value), so you never need raw `schtasks /delete`. `Status: Ready` is *not* completion: `/run` is
-  asynchronous, so a task reads `Ready` both between `/create` and `/run` and after `/run` until the
-  wrapper spawns — deleting in either window cancels a peer's launch. An unreadable or unrecognised
-  status **fails closed** (skipped, with the reason reported); `--force` overrides both checks.
+- **`cleanup` and `reap` share one deletion rule, and it is the strict one.** A task is deleted
+  only when *all three* hold: its run wrote the **exit sentinel**; the task reports a known non-live
+  status; and `Last Result` shows it has actually executed. `Status: Ready` is *not* completion —
+  `/run` is asynchronous, so `Ready` covers both the pre-spawn window and the finished state, which
+  is why the result code is checked too (a sentinel planted in the writable scratch tree would
+  otherwise authorise deleting a peer's task before it ever ran). Anything unreadable **fails
+  closed**, with the reason reported; `--force` overrides. `cleanup` exits non-zero when it refuses
+  or the delete fails, so automation can see it.
+- **Correlate payload with transport.** `{run_id}` and `{run_dir}` in the harness argv are
+  substituted before validation, so `--evidence-dir .scratch/harness-evidence/{run_id}` makes the
+  in-sim evidence share the transport's run id. The wrapper also exports
+  `AC_HARNESS_REMOTE_RUN_ID`.
 - **The run id you pass is authoritative.** `run.json` lives in a writable scratch tree, so `load`
   binds the payload to the id you asked for and **recomputes** its directory; a forged or stale
   payload cannot redirect `cleanup` onto a peer's task.

--- a/docs/10_Development/18_Autonomous_Harness.md
+++ b/docs/10_Development/18_Autonomous_Harness.md
@@ -344,6 +344,12 @@ Behaviours worth knowing before you debug something:
   asynchronous: deleting the task definition early can cancel a start that has not spawned yet, and
   it removes the only `Status` handle while the run is still launching. The exit sentinel
   (`[wrapper] exit=<rc>` in `wrapper.log`), not `Status: Ready`, is what says a run finished.
+- **The `/sc once` trigger really fires.** `/run` starts the task on demand, but `/create` insists
+  on a start time and Task Scheduler honours it. A run that *finished* before that moment would be
+  executed a second time — and `>` truncates, so the ghost run would silently destroy the first
+  run's `stdout.log`/`stderr.log` and overwrite its in-sim evidence. The wrapper therefore exits
+  immediately when the exit sentinel already exists. (Earlier runbook text claimed "the trigger
+  never fires"; that only held for runs longer than the delay.)
 - **Task names are per-run** (`ac-harness-<label>-<stamp>-<pid>-<nonce>`). The threat model is two
   agents on the one physical rig: a fixed name lets each clobber the other's registration.
 - **`wait` is bounded.** If the run never starts, the sentinel never appears; an unbounded wait

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -434,88 +434,123 @@ def test_trailing_backslash_is_rejected(bad: str) -> None:
         rl.validate_wrapper_path("repo root", Path(bad))
 
 
-def test_reap_tasks_deletes_every_owned_task(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`list` only reports — this is the command that actually removes them."""
-    names = ["ac-harness-a", "ac-harness-b"]
-    calls: list[list[str]] = []
-
-    class _Ok:
-        returncode = 0
-        stdout = "Status:  Ready\n"
-
-    def _fake_run(argv):  # noqa: ANN001, ANN202
-        calls.append(list(argv))
-        return _Ok()
-
-    monkeypatch.setattr(rl, "_run", _fake_run)
-    seq = iter([names, []])
-    monkeypatch.setattr(rl, "list_stale_tasks", lambda: next(seq))
-    outcome = rl.reap_tasks()
-    assert outcome["remaining"] == []
-    assert all(o["deleted"] for o in outcome["reaped"].values())
-    for n in names:
-        assert ["schtasks", "/delete", "/tn", n, "/f"] in calls
-
-
 # ---------------------------------------------------------------------------
 # reap safety, bounded-wait finiteness, corrupt payload (3rd daemon round)
 # ---------------------------------------------------------------------------
 
 
-def test_reap_skips_a_task_that_is_still_running(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An unconditional sweep would cancel a PEER's live launch — the hazard cleanup refuses."""
+def _seed_finished_run(root: Path, run_id: str) -> None:
+    d = root.joinpath(*rl.RUN_DIR_RELPATH, run_id)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+
+
+class _Ready:
+    returncode = 0
+    stdout = "Status:  Ready\n"
+
+
+def test_reap_skips_a_task_with_no_exit_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`Status: Ready` is NOT completion — /run is async, so Ready covers the pre-spawn window."""
     calls: list[list[str]] = []
-
-    class _Q:
-        returncode = 0
-        stdout = "Status:  Running\n"
-
-    def _fake_run(argv):  # noqa: ANN001, ANN202
-        calls.append(list(argv))
-        return _Q()
-
-    monkeypatch.setattr(rl, "_run", _fake_run)
-    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
-    outcome = rl.reap_tasks()
-    assert outcome["reaped"]["ac-harness-live"]["deleted"] is False
-    assert "Running" in outcome["reaped"]["ac-harness-live"]["skipped"]
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Ready())[1])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-launching"])
+    outcome = rl.reap_tasks(repo_root=tmp_path)
+    assert outcome["reaped"]["ac-harness-launching"]["deleted"] is False
+    assert "no exit sentinel" in outcome["reaped"]["ac-harness-launching"]["skipped"]
     assert not any("/delete" in c for c in calls)
 
 
-def test_reap_force_deletes_even_a_running_task(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_reap_fails_closed_when_the_status_query_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A transient /query failure must not become a licence to delete a live peer task."""
+    _seed_finished_run(tmp_path, "done")
     calls: list[list[str]] = []
 
-    class _Q:
+    class _Broken:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Broken())[1])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-done"])
+    outcome = rl.reap_tasks(repo_root=tmp_path)
+    assert outcome["reaped"]["ac-harness-done"]["deleted"] is False
+    assert "status unknown" in outcome["reaped"]["ac-harness-done"]["skipped"]
+    assert not any("/delete" in c for c in calls)
+
+
+def test_reap_fails_closed_on_an_unrecognised_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _seed_finished_run(tmp_path, "done")
+    calls: list[list[str]] = []
+
+    class _Weird:
+        returncode = 0
+        stdout = "Status:  Somethingelse\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Weird())[1])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-done"])
+    assert rl.reap_tasks(repo_root=tmp_path)["reaped"]["ac-harness-done"]["deleted"] is False
+    assert not any("/delete" in c for c in calls)
+
+
+def test_reap_skips_a_running_task_even_with_a_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _seed_finished_run(tmp_path, "live")
+    calls: list[list[str]] = []
+
+    class _Running:
         returncode = 0
         stdout = "Status:  Running\n"
 
-    def _fake_run(argv):  # noqa: ANN001, ANN202
-        calls.append(list(argv))
-        return _Q()
-
-    monkeypatch.setattr(rl, "_run", _fake_run)
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
-    rl.reap_tasks(force=True)
+    assert rl.reap_tasks(repo_root=tmp_path)["reaped"]["ac-harness-live"]["deleted"] is False
+    assert not any("/delete" in c for c in calls)
+
+
+def test_reap_deletes_a_finished_ready_task(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Sentinel present AND a known-dead status — the only combination that authorises delete."""
+    _seed_finished_run(tmp_path, "done")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Ready())[1])
+    seq = iter([["ac-harness-done"], []])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: next(seq))
+    outcome = rl.reap_tasks(repo_root=tmp_path)
+    assert outcome["reaped"]["ac-harness-done"]["deleted"] is True
+    assert outcome["remaining"] == []
+    assert ["schtasks", "/delete", "/tn", "ac-harness-done", "/f"] in calls
+
+
+def test_reap_force_bypasses_both_guards(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    class _Running:
+        returncode = 0
+        stdout = "Status:  Running\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
+    rl.reap_tasks(repo_root=tmp_path, force=True)
     assert ["schtasks", "/delete", "/tn", "ac-harness-live", "/f"] in calls
 
 
-def test_reap_deletes_a_task_that_is_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_reap_skips_a_task_name_that_is_not_a_valid_run_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     calls: list[list[str]] = []
-
-    class _Q:
-        returncode = 0
-        stdout = "Status:  Ready\n"
-
-    def _fake_run(argv):  # noqa: ANN001, ANN202
-        calls.append(list(argv))
-        return _Q()
-
-    monkeypatch.setattr(rl, "_run", _fake_run)
-    seq = iter([["ac-harness-done"], []])
-    monkeypatch.setattr(rl, "list_stale_tasks", lambda: next(seq))
-    outcome = rl.reap_tasks()
-    assert outcome["reaped"]["ac-harness-done"]["deleted"] is True
-    assert ["schtasks", "/delete", "/tn", "ac-harness-done", "/f"] in calls
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Ready())[1])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-bad/../id"])
+    outcome = rl.reap_tasks(repo_root=tmp_path)
+    assert outcome["reaped"]["ac-harness-bad/../id"]["deleted"] is False
+    assert not any("/delete" in c for c in calls)
 
 
 @pytest.mark.parametrize("bad", [float("inf"), float("nan"), -1.0])

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -1182,10 +1182,10 @@ def test_verdict_still_accepts_a_real_process_exit_code(tmp_path: Path) -> None:
     assert ok is True
 
 
-def test_exec_refuses_to_append_beneath_a_planted_sentinel(
+def test_exec_overwrites_a_planted_sentinel_with_the_real_exit_code(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """An exclusive create is what makes 'first exit= wins' trustworthy."""
+    """A planted `exit=0` must be ERASED, not appended beneath — that is first-wins's premise."""
     control = rl.control_dir_for("planted")
     control.mkdir(parents=True)
     (control / rl.CONTROL_NAME).write_text(
@@ -1194,11 +1194,63 @@ def test_exec_refuses_to_append_beneath_a_planted_sentinel(
     (control / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
 
     class _Done:
-        returncode = 0
+        returncode = 7
 
     monkeypatch.setattr(rl.subprocess, "run", lambda *a, **k: _Done())
-    with pytest.raises(rl.RemoteLaunchError, match="already existed"):
-        rl.execute_control_file("planted")
+    assert rl.execute_control_file("planted") == 7
+    recorded = rl.sentinel_path_for("planted").read_text(encoding="utf-8")
+    assert rl.parse_sentinel(recorded) == 7
+    assert "pre-existing sentinel was overwritten" in recorded
+
+
+def test_failure_path_does_not_leave_a_planted_success_authoritative(tmp_path: Path) -> None:
+    """The asked-for regression: plant exit=0, force the failure path, assert it lost."""
+    control = rl.control_dir_for("forged")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text(
+        json.dumps({"argv": ["-c", "print(1)"]}),
+        encoding="utf-8",  # rejected by the allowlist
+    )
+    (control / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+    with pytest.raises(rl.RemoteLaunchError):
+        rl.execute_control_file("forged")
+    recorded = rl.sentinel_path_for("forged").read_text(encoding="utf-8")
+    assert rl.parse_sentinel(recorded) == rl.EXEC_FAILURE_RC
+    assert rl.parse_sentinel(recorded) != 0
+    # ...and the verdict must not call that run complete.
+    ok, _ = rl.evaluate_deletion(
+        sentinel_exit_code=rl.parse_sentinel(recorded),
+        query_rc=0,
+        fields={"status": "Ready", "last_result": "0"},
+        run_id="forged",
+    )
+    assert ok is False
+
+
+def test_verdict_requires_last_result_to_match_the_sentinel(tmp_path: Path) -> None:
+    """Binds the peer-writable file to an off-disk signal the peer does not control."""
+    ok, reason = rl.evaluate_deletion(
+        sentinel_exit_code=0,
+        query_rc=0,
+        fields={"status": "Ready", "last_result": "5"},
+        run_id="abc-1",
+    )
+    assert ok is False
+    assert "not written by this run's shim" in reason
+
+
+def test_cli_emits_the_handle_when_the_run_is_live_but_the_trigger_stayed_armed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Automation parses stdout JSON; without this it cannot poll a run that IS underway."""
+    run = _run_handle(tmp_path)
+
+    def _boom(argv, **kwargs):  # noqa: ANN001, ANN202
+        raise rl.RemoteLaunchError("trigger still ARMED", run=run)
+
+    monkeypatch.setattr(rl, "start_run", _boom)
+    assert rl.main(["start", "--", "-m", "tools.ac_harness.auto_alien"]) == 3
+    assert run.run_id in capsys.readouterr().out
 
 
 def test_start_run_discards_the_control_dir_when_scheduling_fails(

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -16,6 +16,17 @@ import pytest
 
 from tools.ac_harness import remote_launcher as rl
 
+
+@pytest.fixture(autouse=True)
+def _isolated_control_root(monkeypatch: pytest.MonkeyPatch, tmp_path_factory) -> None:  # noqa: ANN001
+    """Keep the control plane (sentinels, control files) out of the real user profile.
+
+    `control_dir_for` resolves under LOCALAPPDATA, falling back to the home directory off-Windows —
+    without this every test that marks a run finished would litter the developer's profile.
+    """
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path_factory.mktemp("localappdata")))
+
+
 # ---------------------------------------------------------------------------
 # Run ids and task names
 # ---------------------------------------------------------------------------
@@ -85,19 +96,6 @@ def test_validate_wrapper_token_accepts_real_harness_argv(good: str) -> None:
     assert rl.validate_wrapper_token(good) == good
 
 
-def test_quote_wrapper_token_quotes_every_token_not_just_spaced_ones() -> None:
-    """A space-free token can still carry cmd grouping metacharacters (`(dir)`)."""
-    assert rl.quote_wrapper_token("--laps") == '"--laps"'
-    assert rl.quote_wrapper_token("Realistic BB v3") == '"Realistic BB v3"'
-    assert rl.quote_wrapper_token("(dir)") == '"(dir)"'
-
-
-def test_parenthesised_setup_names_survive_validation_but_are_inert() -> None:
-    """`(`/`)` are legal in AC setup names, so must not fail-close; quoting neutralises them."""
-    assert rl.validate_wrapper_token("Realistic BB (v3)") == "Realistic BB (v3)"
-    assert rl.quote_wrapper_token("Realistic BB (v3)") == '"Realistic BB (v3)"'
-
-
 @pytest.mark.parametrize("bad", ["C:/repo%USERNAME%", 'C:/re"po', "C:/a&b", "C:/a|b", "C:/a>b"])
 def test_validate_wrapper_path_rejects_cmd_specials_that_survive_quoting(bad: str) -> None:
     """`%` expands INSIDE double quotes and `"` breaks out — both are legal ASCII path chars."""
@@ -105,48 +103,11 @@ def test_validate_wrapper_path_rejects_cmd_specials_that_survive_quoting(bad: st
         rl.validate_wrapper_path("repo root", Path(bad))
 
 
-def test_render_wrapper_rejects_a_percent_expanding_repo_path(tmp_path: Path) -> None:
-    with pytest.raises(rl.RemoteLaunchError, match="unsafe"):
-        rl.render_wrapper(Path("C:/repo%PATH%"), ["-m", "x"], tmp_path)
-
-
 def test_harness_repo_root_does_not_import_the_payload_module() -> None:
     """The transport must not drag `auto_drive` (the in-sim payload) in just to resolve a path."""
     source = (Path(rl.__file__)).read_text(encoding="utf-8")
     assert "from tools.ac_harness.auto_drive import" not in source
     assert rl.harness_repo_root().joinpath("tools", "ac_harness").is_dir()
-
-
-def test_render_wrapper_encodes_every_measured_requirement(tmp_path: Path) -> None:
-    run_dir = tmp_path / "run"
-    text = rl.render_wrapper(
-        tmp_path, ["-m", "tools.ac_harness.auto_alien", "--laps", "3"], run_dir
-    )
-
-    # Unbuffered both ways: a redirected, buffered Python makes a healthy run look hung.
-    assert "set PYTHONUNBUFFERED=1" in text
-    assert (
-        '".venv\\Scripts\\python.exe" -u "-m" "tools.ac_harness.auto_alien" "--laps" "3"'
-    ) in text
-    # The polling SSH session must only ever read files.
-    assert f'> "{run_dir / rl.STDOUT_NAME}"' in text
-    assert f'2> "{run_dir / rl.STDERR_NAME}"' in text
-    # The exit sentinel is what cleanup waits on (schtasks /run is asynchronous).
-    assert f"echo [wrapper] {rl.SENTINEL_TOKEN}%ERRORLEVEL%" in text
-    assert f'cd /d "{tmp_path}"' in text
-    assert text.isascii()
-
-
-def test_render_wrapper_rejects_a_non_ascii_repo_path(tmp_path: Path) -> None:
-    repo = tmp_path / "caf\u00e9"
-    repo.mkdir()
-    with pytest.raises(rl.RemoteLaunchError, match="non-ASCII"):
-        rl.render_wrapper(repo, ["-m", "x"], repo / "run")
-
-
-def test_render_wrapper_quotes_a_spaced_argv_value(tmp_path: Path) -> None:
-    text = rl.render_wrapper(tmp_path, ["-m", "x", "--setup", "Realistic BB v3"], tmp_path / "r")
-    assert '"--setup" "Realistic BB v3"' in text
 
 
 # ---------------------------------------------------------------------------
@@ -446,7 +407,9 @@ def test_trailing_backslash_is_rejected(bad: str) -> None:
 
 
 def _seed_finished_run(root: Path, run_id: str) -> None:
-    d = root.joinpath(*rl.RUN_DIR_RELPATH, run_id)
+    """Mark a run finished. The sentinel lives in the CONTROL dir, keyed by run id."""
+    root.joinpath(*rl.RUN_DIR_RELPATH, run_id).mkdir(parents=True, exist_ok=True)
+    d = rl.control_dir_for(run_id)
     d.mkdir(parents=True, exist_ok=True)
     (d / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
 
@@ -664,11 +627,6 @@ def test_substitute_run_placeholders_links_payload_to_transport() -> None:
 def test_substitute_run_placeholders_resolves_run_dir() -> None:
     out = rl.substitute_run_placeholders(["{run_dir}"], run_id="abc", run_dir=Path("/r/abc"))
     assert out == [str(Path("/r/abc"))]
-
-
-def test_wrapper_exports_the_run_id_for_correlation(tmp_path: Path) -> None:
-    text = rl.render_wrapper(tmp_path, ["-m", "x"], tmp_path / "run-7")
-    assert "set AC_HARNESS_REMOTE_RUN_ID=run-7" in text
 
 
 def test_cli_cleanup_exits_non_zero_when_delete_was_refused(
@@ -922,37 +880,6 @@ def test_evaluate_deletion_is_pure_over_a_snapshot(tmp_path: Path) -> None:
     assert blocked is False and "not yet run" in reason
 
 
-def test_wrapper_suppresses_a_ghost_trigger_rerun(tmp_path: Path) -> None:
-    """`/sc once` really fires: a run that finished first would otherwise execute AGAIN."""
-    run_dir = tmp_path / "run"
-    text = rl.render_wrapper(tmp_path, ["-m", "x"], run_dir)
-    sentinel = run_dir / rl.SENTINEL_NAME
-    started = run_dir / rl.STARTED_NAME
-    lines = text.splitlines()
-    guard = next(i for i, ln in enumerate(lines) if ln.startswith("if exist") and "exit /b 0" in ln)
-    payload = next(i for i, ln in enumerate(lines) if ".venv" in ln)
-    # The guard must come BEFORE the redirected python call — `>` truncates, so a ghost run that
-    # reached the payload would destroy the first run's logs.
-    assert guard < payload
-    assert f'if exist "{started}" if exist "{sentinel}" exit /b 0' in text
-
-
-def test_ghost_guard_requires_evidence_the_payload_actually_started(tmp_path: Path) -> None:
-    """A LONE planted exit sentinel must not turn the task into a no-op that reports success."""
-    run_dir = tmp_path / "run"
-    text = rl.render_wrapper(tmp_path, ["-m", "x"], run_dir)
-    started = run_dir / rl.STARTED_NAME
-    # Every early-exit path is conditioned on the start marker as well as the sentinel...
-    for line in text.splitlines():
-        if "exit /b 0" in line:
-            assert f'if exist "{started}"' in line
-    # ...and the marker is written by the wrapper itself, immediately before the payload.
-    lines = text.splitlines()
-    mark = next(i for i, ln in enumerate(lines) if ln.startswith("echo [wrapper] started"))
-    payload = next(i for i, ln in enumerate(lines) if ".venv" in ln)
-    assert mark < payload
-
-
 def test_start_run_refuses_to_reuse_an_existing_run_directory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -968,3 +895,78 @@ def test_start_run_refuses_to_reuse_an_existing_run_directory(
 def test_ghost_suppression_note_does_not_corrupt_the_exit_sentinel() -> None:
     """The suppression note must not be mistaken for a second exit code."""
     assert rl.parse_sentinel("[wrapper] exit=0\n[wrapper] ghost trigger suppressed\n") == 0
+
+
+# ---------------------------------------------------------------------------
+# Safe transport: no peer-writable script is ever executed (9th daemon round)
+# ---------------------------------------------------------------------------
+
+
+def test_control_plane_lives_outside_the_shared_scratch_tree(tmp_path: Path) -> None:
+    """`.scratch` is per-worktree and already untrusted — control files must not sit there."""
+    control = rl.control_dir_for("abc-1")
+    assert ".scratch" not in str(control)
+    assert control.name == "abc-1"
+    assert rl.sentinel_path_for("abc-1") == control / rl.SENTINEL_NAME
+
+
+def test_execute_control_file_revalidates_argv_from_disk(tmp_path: Path) -> None:
+    """A tampered control file must fail closed, not inject a command."""
+    control = rl.control_dir_for("evil")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text(
+        json.dumps({"repo_root": str(tmp_path), "argv": ["-m", "x & calc.exe"]}), encoding="utf-8"
+    )
+    with pytest.raises(rl.RemoteLaunchError, match="unsafe argv token"):
+        rl.execute_control_file("evil")
+
+
+def test_execute_control_file_rejects_a_corrupt_payload(tmp_path: Path) -> None:
+    control = rl.control_dir_for("bad")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text("{not json", encoding="utf-8")
+    with pytest.raises(rl.RemoteLaunchError, match="unreadable control file"):
+        rl.execute_control_file("bad")
+
+
+def test_execute_control_file_rejects_an_empty_argv(tmp_path: Path) -> None:
+    control = rl.control_dir_for("empty")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text(
+        json.dumps({"repo_root": str(tmp_path), "argv": []}), encoding="utf-8"
+    )
+    with pytest.raises(rl.RemoteLaunchError, match="no argv"):
+        rl.execute_control_file("empty")
+
+
+def test_execute_control_file_spawns_without_a_shell_and_writes_the_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    control = rl.control_dir_for("ok")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text(
+        json.dumps({"repo_root": str(tmp_path), "argv": ["-m", "payload"]}), encoding="utf-8"
+    )
+    seen: dict = {}
+
+    class _Done:
+        returncode = 7
+
+    def _fake_run(argv, **kwargs):  # noqa: ANN001, ANN202
+        seen["argv"] = list(argv)
+        seen["kwargs"] = kwargs
+        return _Done()
+
+    monkeypatch.setattr(rl.subprocess, "run", _fake_run)
+    assert rl.execute_control_file("ok") == 7
+    # The interpreter and cwd are RECOMPUTED, never taken from the control file.
+    assert seen["argv"][0].endswith("python.exe")
+    assert seen["argv"][1:] == ["-u", "-m", "payload"]
+    assert seen["kwargs"]["cwd"] == str(tmp_path)
+    assert "shell" not in seen["kwargs"]  # subprocess defaults to shell=False
+    assert rl.parse_sentinel(rl.sentinel_path_for("ok").read_text(encoding="utf-8")) == 7
+
+
+def test_parse_sentinel_skips_a_poison_trailing_line() -> None:
+    """A garbled or planted final `exit=` must not hide the real one."""
+    assert rl.parse_sentinel("[wrapper] exit=3\n[wrapper] exit=not-an-int\n") == 3

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -654,10 +654,13 @@ def test_cli_cleanup_exits_zero_on_a_real_delete(
 def test_sentinel_read_failure_does_not_abort_a_reap_pass(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """An OSError on the sentinel must skip the task, not crash the CLI with a traceback."""
-    d = tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "r")
-    d.mkdir(parents=True)
-    (d / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+    """An OSError on the sentinel must skip the task, not crash the CLI with a traceback.
+
+    The sentinel lives in the CONTROL directory — an earlier version of this test seeded the run
+    directory instead, so `is_file()` was False and the OSError branch was never reached.
+    """
+    _seed_finished_run(tmp_path, "r")
+    assert rl.sentinel_path_for("r").is_file()  # precondition: we reach the read at all
     monkeypatch.setattr(
         Path, "read_text", lambda self, **kw: (_ for _ in ()).throw(OSError("permission denied"))
     )
@@ -874,18 +877,6 @@ def test_evaluate_deletion_is_pure_over_a_snapshot(tmp_path: Path) -> None:
     assert blocked is False and "not yet run" in reason
 
 
-def test_start_run_refuses_to_reuse_an_existing_run_directory(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Reusing a run dir would inherit whatever markers it already holds — a plant vector."""
-    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
-    monkeypatch.setattr(rl, "build_run_id", lambda label, **kw: "fixed-id")
-    (tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "fixed-id")).mkdir(parents=True)
-    monkeypatch.setenv("USERNAME", "someone")
-    with pytest.raises(FileExistsError):
-        rl.start_run(["-m", "x"], label="fixed", repo_root=tmp_path)
-
-
 def test_ghost_suppression_note_does_not_corrupt_the_exit_sentinel() -> None:
     """The suppression note must not be mistaken for a second exit code."""
     assert rl.parse_sentinel("[wrapper] exit=0\n[wrapper] ghost trigger suppressed\n") == 0
@@ -909,7 +900,7 @@ def test_execute_control_file_revalidates_argv_from_disk(tmp_path: Path) -> None
     control = rl.control_dir_for("evil")
     control.mkdir(parents=True)
     (control / rl.CONTROL_NAME).write_text(
-        json.dumps({"repo_root": str(tmp_path), "argv": ["-m", "x & calc.exe"]}), encoding="utf-8"
+        json.dumps({"argv": ["-m", "x & calc.exe"]}), encoding="utf-8"
     )
     with pytest.raises(rl.RemoteLaunchError, match="unsafe argv token"):
         rl.execute_control_file("evil")
@@ -926,9 +917,7 @@ def test_execute_control_file_rejects_a_corrupt_payload(tmp_path: Path) -> None:
 def test_execute_control_file_rejects_an_empty_argv(tmp_path: Path) -> None:
     control = rl.control_dir_for("empty")
     control.mkdir(parents=True)
-    (control / rl.CONTROL_NAME).write_text(
-        json.dumps({"repo_root": str(tmp_path), "argv": []}), encoding="utf-8"
-    )
+    (control / rl.CONTROL_NAME).write_text(json.dumps({"argv": []}), encoding="utf-8")
     with pytest.raises(rl.RemoteLaunchError, match="must start with"):
         rl.execute_control_file("empty")
 
@@ -939,8 +928,7 @@ def test_execute_control_file_spawns_without_a_shell_and_writes_the_sentinel(
     control = rl.control_dir_for("ok")
     control.mkdir(parents=True)
     (control / rl.CONTROL_NAME).write_text(
-        json.dumps({"repo_root": str(tmp_path), "argv": ["-m", "tools.ac_harness.auto_alien"]}),
-        encoding="utf-8",
+        json.dumps({"argv": ["-m", "tools.ac_harness.auto_alien"]}), encoding="utf-8"
     )
     seen: dict = {}
 
@@ -957,7 +945,7 @@ def test_execute_control_file_spawns_without_a_shell_and_writes_the_sentinel(
     # The interpreter and cwd are RECOMPUTED, never taken from the control file.
     assert seen["argv"][0].endswith("python.exe")
     assert seen["argv"][1:] == ["-u", "-m", "tools.ac_harness.auto_alien"]
-    assert seen["kwargs"]["cwd"] == str(tmp_path)
+    assert seen["kwargs"]["cwd"] == str(rl.harness_repo_root())
     assert "shell" not in seen["kwargs"]  # subprocess defaults to shell=False
     assert rl.parse_sentinel(rl.sentinel_path_for("ok").read_text(encoding="utf-8")) == 7
 
@@ -1008,7 +996,7 @@ def test_execute_control_file_records_a_sentinel_when_it_fails(tmp_path: Path) -
     control = rl.control_dir_for("boom")
     control.mkdir(parents=True)
     (control / rl.CONTROL_NAME).write_text(
-        json.dumps({"repo_root": str(tmp_path), "argv": ["-c", "print(1)"]}), encoding="utf-8"
+        json.dumps({"argv": ["-c", "print(1)"]}), encoding="utf-8"
     )
     with pytest.raises(rl.RemoteLaunchError):
         rl.execute_control_file("boom")
@@ -1065,3 +1053,47 @@ def test_cleanup_removes_the_control_directory(
     )
     assert rl.cleanup_run(run)["deleted"] is True
     assert not rl.control_dir_for("gone").exists()
+
+
+def test_execute_control_file_rejects_a_foreign_repo_root(tmp_path: Path) -> None:
+    """repo_root selects the INTERPRETER — trusting the control file was the `-c` hole again."""
+    control = rl.control_dir_for("foreign")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text(
+        json.dumps(
+            {
+                "repo_root": str(tmp_path / "elsewhere"),
+                "argv": ["-m", "tools.ac_harness.auto_alien"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(rl.RemoteLaunchError, match="another checkout"):
+        rl.execute_control_file("foreign")
+
+
+def test_discard_control_dir_removes_only_our_files(tmp_path: Path) -> None:
+    """A recursive delete would remove peer-planted content in a peer-writable directory."""
+    control = rl.control_dir_for("mixed")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text("{}", encoding="utf-8")
+    (control / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+    stranger = control / "someone-elses.txt"
+    stranger.write_text("not ours", encoding="utf-8")
+    rl._discard_control_dir("mixed")
+    assert not (control / rl.CONTROL_NAME).exists()
+    assert not (control / rl.SENTINEL_NAME).exists()
+    assert stranger.exists()  # untouched, and the rmdir therefore refuses
+    assert control.exists()
+
+
+def test_start_run_reports_a_run_dir_collision_as_a_launch_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """main() only catches RemoteLaunchError; a bare FileExistsError crashed the CLI."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    monkeypatch.setattr(rl, "build_run_id", lambda label, **kw: "fixed-id")
+    tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "fixed-id").mkdir(parents=True)
+    monkeypatch.setenv("USERNAME", "someone")
+    with pytest.raises(rl.RemoteLaunchError, match="already exists"):
+        rl.start_run(["-m", "tools.ac_harness.auto_alien"], label="fixed", repo_root=tmp_path)

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -1,0 +1,308 @@
+"""Off-rig tests for the #697 console-session transport.
+
+The ``schtasks`` and Windows-session calls are rig-only; everything that decides *what* gets run —
+run ids, wrapper text, ``schtasks`` argv, status/sentinel parsing, the bounded wait, and
+cleanup's refusal to delete an unfinished run — is pure and tested here. Each case pins a defect
+measured on the rig during #693/#699 rather than a hypothetical.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from tools.ac_harness import remote_launcher as rl
+
+# ---------------------------------------------------------------------------
+# Run ids and task names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "a b", "a/b", "a\\b", "..", "a..b", "a:b", "a<b", "a>b"])
+def test_validate_run_component_rejects_path_and_task_metacharacters(bad: str) -> None:
+    with pytest.raises(rl.RemoteLaunchError):
+        rl.validate_run_component("run label", bad)
+
+
+def test_build_run_id_is_unique_per_pid_and_nonce_within_one_second() -> None:
+    """Second resolution alone would let two same-second agents share a run directory."""
+    moment = datetime(2026, 7, 26, 19, 59, 1, tzinfo=UTC)
+    first = rl.build_run_id("alien-529", now=moment, pid=17748, nonce=7359)
+    second = rl.build_run_id("alien-529", now=moment, pid=17749, nonce=7359)
+    third = rl.build_run_id("alien-529", now=moment, pid=17748, nonce=1111)
+    assert first == "alien-529-20260726-195901-17748-7359"
+    assert len({first, second, third}) == 3
+    # The id becomes a path component and a task name, so it must survive its own validator.
+    assert rl.task_name_for(first) == f"{rl.TASK_PREFIX}{first}"
+
+
+def test_build_run_id_rejects_an_unsafe_label() -> None:
+    with pytest.raises(rl.RemoteLaunchError):
+        rl.build_run_id("alien <529>", now=datetime(2026, 7, 26, tzinfo=UTC), pid=1, nonce=2)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "--car=<car>",  # cmd parses < as stdin redirection before the harness ever starts
+        "out>log",
+        "a&b",
+        "a|b",
+        "a^b",
+        "%USERPROFILE%",
+        'say"hi"',
+        "caf\u00e9",  # non-ASCII is mangled to '?' by the ascii-encoded wrapper
+        "line\nbreak",
+    ],
+)
+def test_validate_wrapper_token_rejects_injection_and_redirection(bad: str) -> None:
+    with pytest.raises(rl.RemoteLaunchError):
+        rl.validate_wrapper_token(bad)
+
+
+@pytest.mark.parametrize(
+    "good",
+    [
+        "-m",
+        "tools.ac_harness.auto_alien",
+        "--car",
+        "ks_porsche_911_gt3_r_2016",
+        "--ggv-scale",
+        "1.15",
+        r".scratch\harness-evidence\alien-529",
+        "C:/Users/arsen/Projects/ac-copilot-trainer",
+    ],
+)
+def test_validate_wrapper_token_accepts_real_harness_argv(good: str) -> None:
+    assert rl.validate_wrapper_token(good) == good
+
+
+def test_quote_wrapper_token_only_quotes_spaced_values() -> None:
+    assert rl.quote_wrapper_token("--laps") == "--laps"
+    assert rl.quote_wrapper_token("Realistic BB v3") == '"Realistic BB v3"'
+
+
+def test_render_wrapper_encodes_every_measured_requirement(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    text = rl.render_wrapper(
+        tmp_path, ["-m", "tools.ac_harness.auto_alien", "--laps", "3"], run_dir
+    )
+
+    # Unbuffered both ways: a redirected, buffered Python makes a healthy run look hung.
+    assert "set PYTHONUNBUFFERED=1" in text
+    assert '".venv\\Scripts\\python.exe" -u -m tools.ac_harness.auto_alien --laps 3' in text
+    # The polling SSH session must only ever read files.
+    assert f'> "{run_dir / rl.STDOUT_NAME}"' in text
+    assert f'2> "{run_dir / rl.STDERR_NAME}"' in text
+    # The exit sentinel is what cleanup waits on (schtasks /run is asynchronous).
+    assert f"echo [wrapper] {rl.SENTINEL_TOKEN}%ERRORLEVEL%" in text
+    assert f'cd /d "{tmp_path}"' in text
+    assert text.isascii()
+
+
+def test_render_wrapper_rejects_a_non_ascii_repo_path(tmp_path: Path) -> None:
+    repo = tmp_path / "caf\u00e9"
+    repo.mkdir()
+    with pytest.raises(rl.RemoteLaunchError, match="non-ASCII"):
+        rl.render_wrapper(repo, ["-m", "x"], repo / "run")
+
+
+def test_render_wrapper_quotes_a_spaced_argv_value(tmp_path: Path) -> None:
+    text = rl.render_wrapper(tmp_path, ["-m", "x", "--setup", "Realistic BB v3"], tmp_path / "r")
+    assert '--setup "Realistic BB v3"' in text
+
+
+# ---------------------------------------------------------------------------
+# schtasks argv
+# ---------------------------------------------------------------------------
+
+
+def test_schtasks_create_argv_carries_the_console_session_flags() -> None:
+    argv = rl.schtasks_create_argv(
+        task="ac-harness-x",
+        tr_path="C:/RUN~1.CMD",
+        when=datetime(2026, 7, 26, 20, 4, tzinfo=UTC),
+        run_as="a",
+    )
+    assert argv[:4] == ["schtasks", "/create", "/tn", "ac-harness-x"]
+    # /it is what puts the task in the console session; /f stops the interactive replace prompt
+    # from blocking a non-interactive create.
+    assert "/it" in argv and "/f" in argv
+    assert argv[argv.index("/sc") + 1] == "once"
+    assert argv[argv.index("/st") + 1] == "20:04"
+    assert argv[argv.index("/sd") + 1] == "07/26/2026"
+
+
+def test_schtasks_create_argv_carries_the_day_across_a_midnight_rollover() -> None:
+    """A bare clock time computed after ~23:55 reads as earlier *today* and fails /create."""
+    argv = rl.schtasks_create_argv(
+        task="t",
+        tr_path="p",
+        when=datetime(2026, 7, 26, 23, 58, tzinfo=UTC) + timedelta(minutes=5),
+        run_as="a",
+    )
+    assert argv[argv.index("/st") + 1] == "00:03"
+    assert argv[argv.index("/sd") + 1] == "07/27/2026"
+
+
+def test_schtasks_date_format_is_the_only_one_the_rig_accepts() -> None:
+    """M/d/yyyy, dd/MM/yyyy and yyyy/MM/dd were all rejected with 0x80004005 (#693)."""
+    assert datetime(2026, 7, 6, tzinfo=UTC).strftime(rl.SCHTASKS_DATE_FORMAT) == "07/06/2026"
+
+
+# ---------------------------------------------------------------------------
+# Status / sentinel parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_task_status_reads_status_and_last_result() -> None:
+    text = "TaskName:      \\ac-harness-x\nStatus:        Running\nLast Result:   267009\n"
+    assert rl.parse_task_status(text) == {"status": "Running", "last_result": "267009"}
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("", None),
+        ("[wrapper] exit=0\n", 0),
+        ("[wrapper] exit=1\n", 1),
+        ("[wrapper] exit=0\n[wrapper] exit=3\n", 3),
+        ("[wrapper] exit=%ERRORLEVEL%\n", None),
+    ],
+)
+def test_parse_sentinel(text: str, expected: int | None) -> None:
+    assert rl.parse_sentinel(text) == expected
+
+
+def test_remote_run_round_trips_through_json_payload() -> None:
+    run = rl.RemoteRun(
+        run_id="r",
+        task="ac-harness-r",
+        repo_root="/repo",
+        run_dir="/repo/run",
+        argv=["-m", "x"],
+        started_at="2026-07-26T19:59:01",
+    )
+    assert rl.RemoteRun.from_dict(run.to_dict()) == run
+    assert run.directory == Path("/repo/run")
+
+
+# ---------------------------------------------------------------------------
+# Wait / cleanup behaviour
+# ---------------------------------------------------------------------------
+
+
+def _run_handle(tmp_path: Path) -> rl.RemoteRun:
+    return rl.RemoteRun(
+        run_id="r",
+        task="ac-harness-r",
+        repo_root=str(tmp_path),
+        run_dir=str(tmp_path),
+        argv=["-m", "x"],
+        started_at="2026-07-26T19:59:01",
+    )
+
+
+def test_wait_for_run_returns_as_soon_as_the_sentinel_lands(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    polls = iter([{"finished": False}, {"finished": True, "exit_code": 0}])
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: next(polls))
+    slept: list[float] = []
+    status = rl.wait_for_run(
+        _run_handle(tmp_path),
+        timeout_s=600,
+        interval_s=30,
+        sleep=slept.append,
+        monotonic=lambda: 0.0,
+    )
+    assert status == {"finished": True, "exit_code": 0}
+    assert slept == [30]
+
+
+def test_wait_for_run_is_bounded_when_the_run_never_starts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unbounded wait would hang forever with no diagnosis on a task that never launched."""
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": False})
+    clock = iter([0.0, 0.0, 10.0, 10.0, 10.0])
+    status = rl.wait_for_run(
+        _run_handle(tmp_path),
+        timeout_s=5,
+        interval_s=30,
+        sleep=lambda _s: None,
+        monotonic=lambda: next(clock),
+    )
+    assert status["timed_out"] is True
+
+
+def test_cleanup_run_refuses_to_delete_an_unfinished_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """schtasks /run is asynchronous — an early delete can cancel a start that has not spawned."""
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": False})
+    calls: list[list[str]] = []
+    monkeypatch.setattr(rl, "_run", lambda argv: calls.append(list(argv)))
+    result = rl.cleanup_run(_run_handle(tmp_path))
+    assert result["deleted"] is False
+    assert calls == []
+
+
+def test_cleanup_run_force_deletes_without_the_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": False})
+    calls: list[list[str]] = []
+
+    class _Done:
+        returncode = 0
+
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Done())[1])
+    assert rl.cleanup_run(_run_handle(tmp_path), force=True)["deleted"] is True
+    assert calls == [["schtasks", "/delete", "/tn", "ac-harness-r", "/f"]]
+
+
+def test_list_stale_tasks_only_claims_this_modules_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Query:
+        returncode = 0
+        stdout = (
+            "TaskName: \\ac-harness-alien-529-1\n"
+            "TaskName: \\OneDrive Reporting Task\n"
+            "TaskName: \\ac-harness-alien-529-2\n"
+        )
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _Query())
+    assert rl.list_stale_tasks() == ["ac-harness-alien-529-1", "ac-harness-alien-529-2"]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_start_without_an_argv_fails_loudly() -> None:
+    assert rl.main(["start", "--label", "alien-529"]) == 3
+
+
+def test_cli_start_strips_the_argv_separator(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake_start(argv, *, label, **kwargs):  # noqa: ANN001, ANN202
+        seen["argv"] = list(argv)
+        seen["label"] = label
+        return rl.RemoteRun(
+            run_id="r", task="t", repo_root="/r", run_dir="/r/run", argv=list(argv), started_at="x"
+        )
+
+    monkeypatch.setattr(rl, "start_run", _fake_start)
+    assert (
+        rl.main(["start", "--label", "alien-529", "--", "-m", "tools.ac_harness.auto_alien"]) == 0
+    )
+    assert seen == {"argv": ["-m", "tools.ac_harness.auto_alien"], "label": "alien-529"}

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -867,3 +867,56 @@ def test_cli_start_wait_reports_a_refused_cleanup_in_the_exit_code(
     )
     monkeypatch.setattr(rl, "cleanup_run", lambda r, **kw: {"deleted": False, "reason": "refused"})
     assert rl.main(["start", "--wait-timeout-s", "1", "--", "-m", "x"]) == 1
+
+
+def test_poll_run_issues_exactly_one_schtasks_query(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Two queries doubled subprocess cost AND let the reported status disagree with the verdict."""
+    queries: list[list[str]] = []
+
+    class _Q:
+        returncode = 0
+        stdout = "Status:  Ready\nLast Result:  0\n"
+
+    def _fake_run(argv):  # noqa: ANN001, ANN202
+        if argv[:2] == ["schtasks", "/query"]:
+            queries.append(list(argv))
+        return _Q()
+
+    monkeypatch.setattr(rl, "_run", _fake_run)
+    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_dir: 0)
+    monkeypatch.setattr(rl, "read_rig_session_owner", lambda p: None)
+    status = rl.poll_run(_run_handle(tmp_path))
+    assert len(queries) == 1
+    assert status["verified_complete"] is True
+    # The reported fields and the verdict come from that single snapshot.
+    assert status["status"] == "Ready"
+
+
+def test_verdict_short_circuits_without_a_subprocess_when_no_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(rl, "_run", lambda argv: calls.append(list(argv)))
+    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_dir: None)
+    ok, reason = rl.task_deletion_verdict("ac-harness-r", tmp_path)
+    assert ok is False and "no exit sentinel" in reason
+    assert calls == []
+
+
+def test_evaluate_deletion_is_pure_over_a_snapshot(tmp_path: Path) -> None:
+    ok, _ = rl.evaluate_deletion(
+        sentinel_exit_code=0,
+        query_rc=0,
+        fields={"status": "Ready", "last_result": "0"},
+        run_dir=tmp_path,
+    )
+    assert ok is True
+    blocked, reason = rl.evaluate_deletion(
+        sentinel_exit_code=0,
+        query_rc=0,
+        fields={"status": "Ready", "last_result": str(rl.SCHED_S_TASK_HAS_NOT_YET_RUN)},
+        run_dir=tmp_path,
+    )
+    assert blocked is False and "not yet run" in reason

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -765,3 +765,45 @@ def test_docs_do_not_advertise_a_load_subcommand() -> None:
     assert "remote_launcher load" not in doc
     assert "`load` binds" not in doc
     assert commands  # parser still exposes its subcommands
+
+
+def test_tail_keeps_a_single_very_long_line_instead_of_returning_nothing(tmp_path: Path) -> None:
+    """Dropping the partial first row must not empty the tail when the chunk has no newline."""
+    log = tmp_path / "stdout.log"
+    log.write_text("y" * (rl._TAIL_MAX_BYTES + 4096), encoding="utf-8")
+    rows = rl._tail(log, 5)
+    assert rows and rows[-1].startswith("y")
+
+
+def test_resolve_short_path_retries_with_the_required_buffer_size() -> None:
+    """A too-small buffer is not a failure — GetShortPathNameW returns the size it needs."""
+    long_value = "C:/" + "a" * 2000
+    calls: list[int] = []
+
+    def _fake_get_short(path, buf, size):  # noqa: ANN001, ANN202
+        calls.append(size)
+        if size <= len(long_value):
+            return len(long_value) + 1  # "buffer too small" -> required length
+        buf.value = long_value
+        return len(long_value)
+
+    assert rl.resolve_short_path(Path("C:/whatever"), _fake_get_short) == long_value
+    assert len(calls) == 2 and calls[1] > calls[0]
+
+
+def test_resolve_short_path_raises_when_the_call_genuinely_fails() -> None:
+    assert_raises = pytest.raises(rl.RemoteLaunchError, match="GetShortPathNameW failed")
+    with assert_raises:
+        rl.resolve_short_path(Path("C:/x"), lambda path, buf, size: 0)
+
+
+def test_resolve_short_path_uses_one_call_when_the_first_buffer_fits() -> None:
+    calls: list[int] = []
+
+    def _fake_get_short(path, buf, size):  # noqa: ANN001, ANN202
+        calls.append(size)
+        buf.value = "C:/SHORT~1"
+        return len("C:/SHORT~1")
+
+    assert rl.resolve_short_path(Path("C:/short"), _fake_get_short) == "C:/SHORT~1"
+    assert len(calls) == 1

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -243,7 +243,12 @@ def _run_handle(tmp_path: Path) -> rl.RemoteRun:
 def test_wait_for_run_returns_as_soon_as_the_sentinel_lands(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    polls = iter([{"finished": False}, {"finished": True, "exit_code": 0}])
+    polls = iter(
+        [
+            {"verified_complete": False},
+            {"verified_complete": True, "finished": True, "exit_code": 0},
+        ]
+    )
     monkeypatch.setattr(rl, "poll_run", lambda run, **kw: next(polls))
     slept: list[float] = []
     status = rl.wait_for_run(
@@ -253,7 +258,8 @@ def test_wait_for_run_returns_as_soon_as_the_sentinel_lands(
         sleep=slept.append,
         monotonic=lambda: 0.0,
     )
-    assert status == {"finished": True, "exit_code": 0}
+    assert status["verified_complete"] is True
+    assert status["exit_code"] == 0
     assert slept == [30]
 
 
@@ -261,7 +267,7 @@ def test_wait_for_run_is_bounded_when_the_run_never_starts(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """An unbounded wait would hang forever with no diagnosis on a task that never launched."""
-    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": False})
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"verified_complete": False})
     clock = iter([0.0, 0.0, 10.0, 10.0, 10.0])
     status = rl.wait_for_run(
         _run_handle(tmp_path),
@@ -277,7 +283,7 @@ def test_cleanup_run_refuses_to_delete_an_unfinished_run(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """schtasks /run is asynchronous — an early delete can cancel a start that has not spawned."""
-    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": False})
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"verified_complete": False})
     calls: list[list[str]] = []
     monkeypatch.setattr(rl, "_run", lambda argv: calls.append(list(argv)))
     result = rl.cleanup_run(_run_handle(tmp_path))
@@ -288,7 +294,7 @@ def test_cleanup_run_refuses_to_delete_an_unfinished_run(
 def test_cleanup_run_force_deletes_without_the_sentinel(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": False})
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"verified_complete": False})
     calls: list[list[str]] = []
 
     class _Done:
@@ -631,7 +637,7 @@ def test_cleanup_run_now_applies_the_same_live_status_gate_as_reap(
         stdout = "Status:  Running\nLast Result:  267009\n"
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
-    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": True})
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"verified_complete": False})
     run = rl.RemoteRun(
         run_id="r",
         task="ac-harness-r",
@@ -807,3 +813,57 @@ def test_resolve_short_path_uses_one_call_when_the_first_buffer_fits() -> None:
 
     assert rl.resolve_short_path(Path("C:/short"), _fake_get_short) == "C:/SHORT~1"
     assert len(calls) == 1
+
+
+def test_wait_refuses_a_planted_sentinel_while_the_task_is_still_launching(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A peer can write wrapper.log; `start --wait` must not call that success."""
+    monkeypatch.setattr(
+        rl,
+        "poll_run",
+        lambda run, **kw: {"finished": True, "verified_complete": False, "exit_code": 0},
+    )
+    clock = iter([0.0, 0.0, 99.0, 99.0, 99.0])
+    status = rl.wait_for_run(
+        _run_handle(tmp_path),
+        timeout_s=5,
+        interval_s=1,
+        sleep=lambda _s: None,
+        monotonic=lambda: next(clock),
+    )
+    assert status["timed_out"] is True
+
+
+def test_poll_run_survives_an_unreadable_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cleanup polls first, so a sharing error on wrapper.log must not abort with a traceback."""
+    monkeypatch.setattr(
+        rl, "_sentinel_exit_code", lambda run_dir: (_ for _ in ()).throw(AssertionError("unused"))
+    )
+    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_dir: None)
+    monkeypatch.setattr(rl, "task_deletion_verdict", lambda name, rd: (False, "no sentinel"))
+
+    class _Q:
+        returncode = 0
+        stdout = "Status:  Ready\nLast Result:  0\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _Q())
+    monkeypatch.setattr(rl, "read_rig_session_owner", lambda p: None)
+    status = rl.poll_run(_run_handle(tmp_path))
+    assert status["finished"] is False
+    assert status["verified_complete"] is False
+
+
+def test_cli_start_wait_reports_a_refused_cleanup_in_the_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """On the unattended path a leftover live task must be visible from the exit code."""
+    run = _run_handle(tmp_path)
+    monkeypatch.setattr(rl, "start_run", lambda argv, **kw: run)
+    monkeypatch.setattr(
+        rl, "wait_for_run", lambda r, **kw: {"exit_code": 0, "verified_complete": True}
+    )
+    monkeypatch.setattr(rl, "cleanup_run", lambda r, **kw: {"deleted": False, "reason": "refused"})
+    assert rl.main(["start", "--wait-timeout-s", "1", "--", "-m", "x"]) == 1

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -986,6 +986,11 @@ def test_verdict_reason_names_the_sentinel_it_actually_checks(tmp_path: Path) ->
         ["-m", "os"],
         ["-"],
         [],
+        # The transport must not be able to schedule ITSELF: these two would let a tampered
+        # control file reap a peer's live task or execute another run's control file.
+        ["-m", "tools.ac_harness.remote_launcher", "reap", "--force"],
+        ["-m", "tools.ac_harness._remote_exec", "some-peer-run-id"],
+        ["-m", "tools.ac_harness.rig_lock"],
     ],
 )
 def test_validate_payload_argv_rejects_everything_but_a_harness_module(argv: list[str]) -> None:
@@ -1271,3 +1276,51 @@ def test_start_run_discards_the_control_dir_when_scheduling_fails(
     with pytest.raises(rl.RemoteLaunchError, match="/create failed"):
         rl.start_run(["-m", "tools.ac_harness.auto_alien"], label="x", repo_root=tmp_path)
     assert not rl.control_dir_for("failed-create").exists()
+
+
+def test_payload_allowlist_is_an_explicit_set_excluding_the_transport() -> None:
+    """A `tools.ac_harness.<ident>` pattern still admitted the transport and its shim."""
+    assert "tools.ac_harness.auto_alien" in rl._ALLOWED_PAYLOAD_MODULES
+    assert "tools.ac_harness.remote_launcher" not in rl._ALLOWED_PAYLOAD_MODULES
+    assert "tools.ac_harness._remote_exec" not in rl._ALLOWED_PAYLOAD_MODULES
+
+
+def test_start_run_leaves_no_run_dir_when_the_argv_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A rejected argv used to leave an orphan scratch directory behind for every typo."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    monkeypatch.setenv("USERNAME", "someone")
+    with pytest.raises(rl.RemoteLaunchError):
+        rl.start_run(["-c", "print(1)"], label="x", repo_root=tmp_path)
+    assert (
+        not list(tmp_path.joinpath(*rl.RUN_DIR_RELPATH).glob("*"))
+        if tmp_path.joinpath(*rl.RUN_DIR_RELPATH).exists()
+        else True
+    )
+
+
+def test_start_run_converts_a_permission_error_on_mkdir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """main() only catches RemoteLaunchError; a raw PermissionError bypassed the documented exit."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    monkeypatch.setenv("USERNAME", "someone")
+    monkeypatch.setattr(
+        Path, "mkdir", lambda self, **kw: (_ for _ in ()).throw(PermissionError("denied"))
+    )
+    with pytest.raises(rl.RemoteLaunchError, match="cannot create run directory"):
+        rl.start_run(["-m", "tools.ac_harness.auto_alien"], label="x", repo_root=tmp_path)
+
+
+def test_discard_control_dir_survives_a_sharing_violation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A best-effort cleanup step must not turn a successful delete into a traceback."""
+    control = rl.control_dir_for("locked")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        Path, "unlink", lambda self, **kw: (_ for _ in ()).throw(PermissionError("in use"))
+    )
+    rl._discard_control_dir("locked")  # must not raise

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -447,7 +447,7 @@ def _seed_finished_run(root: Path, run_id: str) -> None:
 
 class _Ready:
     returncode = 0
-    stdout = "Status:  Ready\n"
+    stdout = "Status:  Ready\nLast Result:  0\n"
 
 
 def test_reap_skips_a_task_with_no_exit_sentinel(
@@ -478,7 +478,7 @@ def test_reap_fails_closed_when_the_status_query_fails(
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-done"])
     outcome = rl.reap_tasks(repo_root=tmp_path)
     assert outcome["reaped"]["ac-harness-done"]["deleted"] is False
-    assert "status unknown" in outcome["reaped"]["ac-harness-done"]["skipped"]
+    assert "query failed" in outcome["reaped"]["ac-harness-done"]["skipped"]
     assert not any("/delete" in c for c in calls)
 
 
@@ -490,7 +490,7 @@ def test_reap_fails_closed_on_an_unrecognised_status(
 
     class _Weird:
         returncode = 0
-        stdout = "Status:  Somethingelse\n"
+        stdout = "Status:  Somethingelse\nLast Result:  0\n"
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Weird())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-done"])
@@ -506,7 +506,7 @@ def test_reap_skips_a_running_task_even_with_a_sentinel(
 
     class _Running:
         returncode = 0
-        stdout = "Status:  Running\n"
+        stdout = "Status:  Running\nLast Result:  267009\n"
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
@@ -534,7 +534,7 @@ def test_reap_force_bypasses_both_guards(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
     class _Running:
         returncode = 0
-        stdout = "Status:  Running\n"
+        stdout = "Status:  Running\nLast Result:  267009\n"
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
@@ -575,3 +575,112 @@ def test_load_run_reports_a_payload_missing_required_keys(tmp_path: Path) -> Non
     (d / rl.RUN_JSON_NAME).write_text('{"nope": 1}', encoding="utf-8")
     with pytest.raises(rl.RemoteLaunchError, match="unreadable run payload"):
         rl.load_run("mine", repo_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Shared deletion verdict, run-id correlation, CLI exit codes (5th daemon round)
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_refuses_a_planted_sentinel_before_the_task_ever_ran(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`Ready` covers the PRE-SPAWN window too, so a planted sentinel must not authorise delete."""
+    _seed_finished_run(tmp_path, "victim")
+
+    class _NeverRan:
+        returncode = 0
+        stdout = f"Status:  Ready\nLast Result:  {rl.SCHED_S_TASK_HAS_NOT_YET_RUN}\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _NeverRan())
+    ok, reason = rl.task_deletion_verdict(
+        "ac-harness-victim", tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "victim")
+    )
+    assert ok is False
+    assert "not yet run" in reason
+
+
+def test_verdict_refuses_an_unreadable_last_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _seed_finished_run(tmp_path, "r")
+
+    class _NoResult:
+        returncode = 0
+        stdout = "Status:  Ready\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _NoResult())
+    ok, reason = rl.task_deletion_verdict(
+        "ac-harness-r", tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "r")
+    )
+    assert ok is False
+    assert "unreadable" in reason
+
+
+def test_cleanup_run_now_applies_the_same_live_status_gate_as_reap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cleanup was the WEAKER path: a planted sentinel could delete a still-Running task."""
+    d = tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "r")
+    d.mkdir(parents=True)
+    (d / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    class _Running:
+        returncode = 0
+        stdout = "Status:  Running\nLast Result:  267009\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"finished": True})
+    run = rl.RemoteRun(
+        run_id="r",
+        task="ac-harness-r",
+        repo_root=str(tmp_path),
+        run_dir=str(d),
+        argv=["-m", "x"],
+        started_at="x",
+    )
+    monkeypatch.setattr(
+        rl, "_await_deletion_verdict", lambda n, rd, **kw: rl.task_deletion_verdict(n, rd)
+    )
+    outcome = rl.cleanup_run(run)
+    assert outcome["deleted"] is False
+    assert not any("/delete" in c for c in calls)
+
+
+def test_substitute_run_placeholders_links_payload_to_transport() -> None:
+    """Without this the payload picks its own evidence dir and cannot be correlated with the run."""
+    argv = ["-m", "tools.ac_harness.auto_alien", "--evidence-dir", ".scratch/e/{run_id}"]
+    out = rl.substitute_run_placeholders(argv, run_id="abc-1", run_dir=Path("/r/abc-1"))
+    assert out[-1] == ".scratch/e/abc-1"
+
+
+def test_substitute_run_placeholders_resolves_run_dir() -> None:
+    out = rl.substitute_run_placeholders(["{run_dir}"], run_id="abc", run_dir=Path("/r/abc"))
+    assert out == [str(Path("/r/abc"))]
+
+
+def test_wrapper_exports_the_run_id_for_correlation(tmp_path: Path) -> None:
+    text = rl.render_wrapper(tmp_path, ["-m", "x"], tmp_path / "run-7")
+    assert "set AC_HARNESS_REMOTE_RUN_ID=run-7" in text
+
+
+def test_cli_cleanup_exits_non_zero_when_delete_was_refused(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Automation cannot see a refusal if the CLI always exits 0."""
+    monkeypatch.setattr(rl, "load_run", lambda rid, **kw: _run_handle(tmp_path))
+    monkeypatch.setattr(
+        rl, "cleanup_run", lambda run, force=False: {"deleted": False, "reason": "x"}
+    )
+    assert rl.main(["cleanup", "r"]) == 1
+
+
+def test_cli_cleanup_exits_zero_on_a_real_delete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(rl, "load_run", lambda rid, **kw: _run_handle(tmp_path))
+    monkeypatch.setattr(
+        rl, "cleanup_run", lambda run, force=False: {"deleted": True, "delete_rc": 0}
+    )
+    assert rl.main(["cleanup", "r"]) == 0

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -684,3 +684,84 @@ def test_cli_cleanup_exits_zero_on_a_real_delete(
         rl, "cleanup_run", lambda run, force=False: {"deleted": True, "delete_rc": 0}
     )
     assert rl.main(["cleanup", "r"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Qodo persistent-review findings 2-7
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_read_failure_does_not_abort_a_reap_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An OSError on the sentinel must skip the task, not crash the CLI with a traceback."""
+    d = tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "r")
+    d.mkdir(parents=True)
+    (d / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+    monkeypatch.setattr(
+        Path, "read_text", lambda self, **kw: (_ for _ in ()).throw(OSError("permission denied"))
+    )
+    assert rl._sentinel_exit_code(d) is None
+
+
+def test_list_stale_tasks_raises_rather_than_reporting_an_empty_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty list reads as 'nothing left behind' — it must never come from a FAILED query."""
+
+    class _Broken:
+        returncode = 1
+        stdout = ""
+        stderr = "ERROR: access denied"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _Broken())
+    with pytest.raises(rl.RemoteLaunchError, match="refusing to report an empty task list"):
+        rl.list_stale_tasks()
+
+
+def test_tail_zero_means_no_tail_not_the_whole_file(tmp_path: Path) -> None:
+    """cleanup_run polls with tail=0; returning the whole file printed megabytes of sidecar logs."""
+    log = tmp_path / "stdout.log"
+    log.write_text("\n".join(f"line {i}" for i in range(5000)), encoding="utf-8")
+    assert rl._tail(log, 0) == []
+    assert rl._tail(log, 3) == ["line 4997", "line 4998", "line 4999"]
+
+
+def test_tail_reads_only_the_end_of_a_large_log(tmp_path: Path) -> None:
+    log = tmp_path / "stderr.log"
+    log.write_text("x" * (rl._TAIL_MAX_BYTES * 2) + "\nlast line\n", encoding="utf-8")
+    assert rl._tail(log, 1) == ["last line"]
+
+
+def test_tail_of_a_missing_file_is_empty(tmp_path: Path) -> None:
+    assert rl._tail(tmp_path / "nope.log", 10) == []
+
+
+def test_verdict_reason_names_which_last_result_it_saw(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Refusing on 'currently running' must not report 'has not yet run'."""
+    _seed_finished_run(tmp_path, "r")
+
+    class _Running:
+        returncode = 0
+        stdout = f"Status:  Ready\nLast Result:  {rl.SCHED_S_TASK_IS_CURRENTLY_RUNNING}\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _Running())
+    ok, reason = rl.task_deletion_verdict(
+        "ac-harness-r", tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "r")
+    )
+    assert ok is False
+    assert "currently running" in reason
+    assert "not yet run" not in reason
+
+
+def test_docs_do_not_advertise_a_load_subcommand() -> None:
+    """The runbook claimed a `load` command binds the payload; no such subcommand exists."""
+    commands = {a.dest for a in rl.build_parser()._subparsers._group_actions}  # noqa: SLF001
+    doc = (rl.harness_repo_root() / "docs/10_Development/18_Autonomous_Harness.md").read_text(
+        encoding="utf-8"
+    )
+    assert "remote_launcher load" not in doc
+    assert "`load` binds" not in doc
+    assert commands  # parser still exposes its subcommands

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -970,3 +970,16 @@ def test_execute_control_file_spawns_without_a_shell_and_writes_the_sentinel(
 def test_parse_sentinel_skips_a_poison_trailing_line() -> None:
     """A garbled or planted final `exit=` must not hide the real one."""
     assert rl.parse_sentinel("[wrapper] exit=3\n[wrapper] exit=not-an-int\n") == 3
+
+
+def test_verdict_reason_names_the_sentinel_it_actually_checks(tmp_path: Path) -> None:
+    """The sentinel left `.scratch`; a reason pointing at the old path misdirects the operator."""
+    ok, reason = rl.evaluate_deletion(
+        sentinel_exit_code=None,
+        query_rc=0,
+        fields={},
+        run_dir=tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "abc-1"),
+    )
+    assert ok is False
+    assert str(rl.sentinel_path_for("abc-1")) in reason
+    assert ".scratch" not in reason

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -1005,17 +1005,17 @@ def test_execute_control_file_records_a_sentinel_when_it_fails(tmp_path: Path) -
     assert "RemoteLaunchError" in recorded
 
 
-def test_start_run_fails_closed_when_the_trigger_cannot_be_disabled(
+def test_start_run_surfaces_an_armed_trigger_without_deleting_a_live_run(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A start that leaves the one-shot trigger armed is a second AC session waiting to happen."""
+    """The payload is already running — the old fail-closed delete would have ABORTED it."""
     monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
     monkeypatch.setattr(rl, "short_path", lambda p: str(p))
     monkeypatch.setenv("USERNAME", "someone")
     calls: list[list[str]] = []
 
     class _R:
-        def __init__(self, rc):
+        def __init__(self, rc: int) -> None:
             self.returncode = rc
             self.stdout = ""
             self.stderr = "nope"
@@ -1025,9 +1025,56 @@ def test_start_run_fails_closed_when_the_trigger_cannot_be_disabled(
         return _R(1 if "/change" in argv else 0)
 
     monkeypatch.setattr(rl, "_run", _fake_run)
-    with pytest.raises(rl.RemoteLaunchError, match="trigger still armed"):
+    with pytest.raises(rl.RemoteLaunchError, match="ALREADY RUNNING"):
+        rl.start_run(
+            ["-m", "tools.ac_harness.auto_alien"],
+            label="x",
+            repo_root=tmp_path,
+            sleep=lambda _s: None,
+        )
+    # It must NOT delete: /run already succeeded, so the payload is live.
+    assert not any("/delete" in c for c in calls)
+    # ...and it retried the disable before giving up.
+    assert sum(1 for c in calls if "/change" in c) == 2
+    # A pollable handle survives, so the live run is not orphaned.
+    assert list(tmp_path.joinpath(*rl.RUN_DIR_RELPATH).glob("*/run.json"))
+
+
+def test_start_run_reports_a_failed_cleanup_delete_after_a_failed_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """/run failed so nothing is live — but an un-deleted task keeps its one-shot trigger ARMED."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    monkeypatch.setattr(rl, "short_path", lambda p: str(p))
+    monkeypatch.setenv("USERNAME", "someone")
+
+    class _R:
+        def __init__(self, rc: int) -> None:
+            self.returncode = rc
+            self.stdout = ""
+            self.stderr = "boom"
+
+    def _fake_run(argv):  # noqa: ANN001, ANN202
+        if "/run" in argv or "/delete" in argv:
+            return _R(1)
+        return _R(0)
+
+    monkeypatch.setattr(rl, "_run", _fake_run)
+    with pytest.raises(rl.RemoteLaunchError, match="trigger ARMED"):
         rl.start_run(["-m", "tools.ac_harness.auto_alien"], label="x", repo_root=tmp_path)
-    assert any("/delete" in c for c in calls)
+
+
+def test_start_run_rejects_a_non_harness_payload_at_schedule_time(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`start -- -c print(1)` used to register and RUN a task, rejected only later."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    calls: list[list[str]] = []
+    monkeypatch.setattr(rl, "_run", lambda argv: calls.append(list(argv)))
+    monkeypatch.setenv("USERNAME", "someone")
+    with pytest.raises(rl.RemoteLaunchError, match="must start with"):
+        rl.start_run(["-c", "print(1)"], label="x", repo_root=tmp_path)
+    assert calls == []  # nothing scheduled
 
 
 def test_cleanup_removes_the_control_directory(

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -164,7 +164,10 @@ def test_parse_task_status_reads_status_and_last_result() -> None:
         ("", None),
         ("[wrapper] exit=0\n", 0),
         ("[wrapper] exit=1\n", 1),
-        ("[wrapper] exit=0\n[wrapper] exit=3\n", 3),
+        (
+            "[wrapper] exit=3\n[wrapper] exit=0\n",
+            3,
+        ),  # first wins: a later append cannot forge success
         ("[wrapper] exit=%ERRORLEVEL%\n", None),
     ],
 )
@@ -950,9 +953,14 @@ def test_execute_control_file_spawns_without_a_shell_and_writes_the_sentinel(
     assert rl.parse_sentinel(rl.sentinel_path_for("ok").read_text(encoding="utf-8")) == 7
 
 
-def test_parse_sentinel_skips_a_poison_trailing_line() -> None:
-    """A garbled or planted final `exit=` must not hide the real one."""
-    assert rl.parse_sentinel("[wrapper] exit=3\n[wrapper] exit=not-an-int\n") == 3
+def test_parse_sentinel_skips_a_poison_line() -> None:
+    """A garbled `exit=` must not hide the real one."""
+    assert rl.parse_sentinel("[wrapper] exit=not-an-int\n[wrapper] exit=3\n") == 3
+
+
+def test_parse_sentinel_ignores_a_forged_success_appended_after_a_real_failure() -> None:
+    """The control dir is same-user writable, so a peer can append after the shim's single write."""
+    assert rl.parse_sentinel("[wrapper] exit=1\n[wrapper] exit=0\n") == 1
 
 
 def test_verdict_reason_names_the_sentinel_it_actually_checks(tmp_path: Path) -> None:
@@ -1144,3 +1152,70 @@ def test_start_run_reports_a_run_dir_collision_as_a_launch_error(
     monkeypatch.setenv("USERNAME", "someone")
     with pytest.raises(rl.RemoteLaunchError, match="already exists"):
         rl.start_run(["-m", "tools.ac_harness.auto_alien"], label="fixed", repo_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "last_result",
+    [267008, 267010, 267012, 267016, -2147024894],
+)
+def test_verdict_fails_closed_on_scheduler_status_and_launch_failure_codes(
+    last_result: int, tmp_path: Path
+) -> None:
+    """Only two SCHED_S_* codes were rejected; the rest read as 'the payload ran and finished'."""
+    ok, reason = rl.evaluate_deletion(
+        sentinel_exit_code=0,
+        query_rc=0,
+        fields={"status": "Ready", "last_result": str(last_result)},
+        run_id="abc-1",
+    )
+    assert ok is False
+    assert "failing closed" in reason
+
+
+def test_verdict_still_accepts_a_real_process_exit_code(tmp_path: Path) -> None:
+    ok, _ = rl.evaluate_deletion(
+        sentinel_exit_code=0,
+        query_rc=0,
+        fields={"status": "Ready", "last_result": "0"},
+        run_id="abc-1",
+    )
+    assert ok is True
+
+
+def test_exec_refuses_to_append_beneath_a_planted_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An exclusive create is what makes 'first exit= wins' trustworthy."""
+    control = rl.control_dir_for("planted")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text(
+        json.dumps({"argv": ["-m", "tools.ac_harness.auto_alien"]}), encoding="utf-8"
+    )
+    (control / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+
+    class _Done:
+        returncode = 0
+
+    monkeypatch.setattr(rl.subprocess, "run", lambda *a, **k: _Done())
+    with pytest.raises(rl.RemoteLaunchError, match="already existed"):
+        rl.execute_control_file("planted")
+
+
+def test_start_run_discards_the_control_dir_when_scheduling_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unregistered task is invisible to reap, so its control dir would leak forever."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    monkeypatch.setattr(rl, "short_path", lambda p: str(p))
+    monkeypatch.setattr(rl, "build_run_id", lambda label, **kw: "failed-create")
+    monkeypatch.setenv("USERNAME", "someone")
+
+    class _R:
+        returncode = 1
+        stdout = ""
+        stderr = "denied"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _R())
+    with pytest.raises(rl.RemoteLaunchError, match="/create failed"):
+        rl.start_run(["-m", "tools.ac_harness.auto_alien"], label="x", repo_root=tmp_path)
+    assert not rl.control_dir_for("failed-create").exists()

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -441,6 +441,7 @@ def test_reap_tasks_deletes_every_owned_task(monkeypatch: pytest.MonkeyPatch) ->
 
     class _Ok:
         returncode = 0
+        stdout = "Status:  Ready\n"
 
     def _fake_run(argv):  # noqa: ANN001, ANN202
         calls.append(list(argv))
@@ -452,4 +453,90 @@ def test_reap_tasks_deletes_every_owned_task(monkeypatch: pytest.MonkeyPatch) ->
     outcome = rl.reap_tasks()
     assert outcome["remaining"] == []
     assert all(o["deleted"] for o in outcome["reaped"].values())
-    assert calls == [["schtasks", "/delete", "/tn", n, "/f"] for n in names]
+    for n in names:
+        assert ["schtasks", "/delete", "/tn", n, "/f"] in calls
+
+
+# ---------------------------------------------------------------------------
+# reap safety, bounded-wait finiteness, corrupt payload (3rd daemon round)
+# ---------------------------------------------------------------------------
+
+
+def test_reap_skips_a_task_that_is_still_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unconditional sweep would cancel a PEER's live launch — the hazard cleanup refuses."""
+    calls: list[list[str]] = []
+
+    class _Q:
+        returncode = 0
+        stdout = "Status:  Running\n"
+
+    def _fake_run(argv):  # noqa: ANN001, ANN202
+        calls.append(list(argv))
+        return _Q()
+
+    monkeypatch.setattr(rl, "_run", _fake_run)
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
+    outcome = rl.reap_tasks()
+    assert outcome["reaped"]["ac-harness-live"]["deleted"] is False
+    assert "Running" in outcome["reaped"]["ac-harness-live"]["skipped"]
+    assert not any("/delete" in c for c in calls)
+
+
+def test_reap_force_deletes_even_a_running_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    class _Q:
+        returncode = 0
+        stdout = "Status:  Running\n"
+
+    def _fake_run(argv):  # noqa: ANN001, ANN202
+        calls.append(list(argv))
+        return _Q()
+
+    monkeypatch.setattr(rl, "_run", _fake_run)
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
+    rl.reap_tasks(force=True)
+    assert ["schtasks", "/delete", "/tn", "ac-harness-live", "/f"] in calls
+
+
+def test_reap_deletes_a_task_that_is_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    class _Q:
+        returncode = 0
+        stdout = "Status:  Ready\n"
+
+    def _fake_run(argv):  # noqa: ANN001, ANN202
+        calls.append(list(argv))
+        return _Q()
+
+    monkeypatch.setattr(rl, "_run", _fake_run)
+    seq = iter([["ac-harness-done"], []])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: next(seq))
+    outcome = rl.reap_tasks()
+    assert outcome["reaped"]["ac-harness-done"]["deleted"] is True
+    assert ["schtasks", "/delete", "/tn", "ac-harness-done", "/f"] in calls
+
+
+@pytest.mark.parametrize("bad", [float("inf"), float("nan"), -1.0])
+def test_wait_for_run_rejects_a_non_finite_timeout(bad: float, tmp_path: Path) -> None:
+    """`--timeout-s inf` would never expire — the exact hang the bounded wait exists to prevent."""
+    with pytest.raises(rl.RemoteLaunchError, match="finite"):
+        rl.wait_for_run(_run_handle(tmp_path), timeout_s=bad, sleep=lambda _s: None)
+
+
+def test_load_run_reports_a_corrupt_payload_as_a_launch_error(tmp_path: Path) -> None:
+    """A truncated run.json must take the module's error path, not raise a raw JSONDecodeError."""
+    d = tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "mine")
+    d.mkdir(parents=True)
+    (d / rl.RUN_JSON_NAME).write_text('{"run_id": "mi', encoding="utf-8")
+    with pytest.raises(rl.RemoteLaunchError, match="unreadable run payload"):
+        rl.load_run("mine", repo_root=tmp_path)
+
+
+def test_load_run_reports_a_payload_missing_required_keys(tmp_path: Path) -> None:
+    d = tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "mine")
+    d.mkdir(parents=True)
+    (d / rl.RUN_JSON_NAME).write_text('{"nope": 1}', encoding="utf-8")
+    with pytest.raises(rl.RemoteLaunchError, match="unreadable run payload"):
+        rl.load_run("mine", repo_root=tmp_path)

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -8,6 +8,7 @@ measured on the rig during #693/#699 rather than a hypothetical.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -354,3 +355,101 @@ def test_cleanup_run_refuses_a_task_name_that_does_not_match_its_run_id(
     with pytest.raises(rl.RemoteLaunchError, match="does not match this run id"):
         rl.cleanup_run(hijacked, force=True)
     assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Payload-identity binding, trailing backslash, reap (2nd daemon round)
+# ---------------------------------------------------------------------------
+
+
+def _write_run_json(root: Path, run_id: str, payload: dict) -> None:
+    d = root.joinpath(*rl.RUN_DIR_RELPATH, run_id)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / rl.RUN_JSON_NAME).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_load_run_rejects_a_payload_naming_a_different_run(tmp_path: Path) -> None:
+    """A self-consistent forgery must not pass: the REQUESTED id is authoritative."""
+    _write_run_json(
+        tmp_path,
+        "mine",
+        {
+            "run_id": "someone-else",
+            "task": rl.task_name_for("someone-else"),
+            "repo_root": str(tmp_path),
+            "run_dir": str(tmp_path / "planted"),
+            "argv": [],
+            "started_at": "x",
+        },
+    )
+    with pytest.raises(rl.RemoteLaunchError, match="names a different run"):
+        rl.load_run("mine", repo_root=tmp_path)
+
+
+def test_load_run_rejects_a_payload_claiming_another_task(tmp_path: Path) -> None:
+    _write_run_json(
+        tmp_path,
+        "mine",
+        {
+            "run_id": "mine",
+            "task": "ac-harness-a-peers-run",
+            "repo_root": str(tmp_path),
+            "run_dir": str(tmp_path),
+            "argv": [],
+            "started_at": "x",
+        },
+    )
+    with pytest.raises(rl.RemoteLaunchError, match="does not own"):
+        rl.load_run("mine", repo_root=tmp_path)
+
+
+def test_load_run_recomputes_run_dir_instead_of_trusting_the_payload(tmp_path: Path) -> None:
+    """A planted `[wrapper] exit=0` outside the canonical dir must not make a run look finished."""
+    planted = tmp_path / "planted"
+    planted.mkdir()
+    (planted / rl.SENTINEL_NAME).write_text("[wrapper] exit=0\n", encoding="utf-8")
+    _write_run_json(
+        tmp_path,
+        "mine",
+        {
+            "run_id": "mine",
+            "task": rl.task_name_for("mine"),
+            "repo_root": str(tmp_path),
+            "run_dir": str(planted),
+            "argv": [],
+            "started_at": "x",
+        },
+    )
+    run = rl.load_run("mine", repo_root=tmp_path)
+    assert run.directory == tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "mine")
+    assert not (run.directory / rl.SENTINEL_NAME).exists()
+
+
+@pytest.mark.parametrize("bad", ["C:/repo\\", "--evidence-dir=x\\"])
+def test_trailing_backslash_is_rejected(bad: str) -> None:
+    """`\\"` is an ESCAPED QUOTE to the Windows CRT argv parser, so the quoting does not close."""
+    with pytest.raises(rl.RemoteLaunchError, match="trailing backslash"):
+        rl.validate_wrapper_token(bad)
+    with pytest.raises(rl.RemoteLaunchError, match="trailing backslash"):
+        rl.validate_wrapper_path("repo root", Path(bad))
+
+
+def test_reap_tasks_deletes_every_owned_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`list` only reports — this is the command that actually removes them."""
+    names = ["ac-harness-a", "ac-harness-b"]
+    calls: list[list[str]] = []
+
+    class _Ok:
+        returncode = 0
+
+    def _fake_run(argv):  # noqa: ANN001, ANN202
+        calls.append(list(argv))
+        return _Ok()
+
+    monkeypatch.setattr(rl, "_run", _fake_run)
+    seq = iter([names, []])
+    monkeypatch.setattr(rl, "list_stale_tasks", lambda: next(seq))
+    outcome = rl.reap_tasks()
+    assert outcome["remaining"] == []
+    assert all(o["deleted"] for o in outcome["reaped"].values())
+    assert calls == [["schtasks", "/delete", "/tn", n, "/f"] for n in names]

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -84,9 +84,36 @@ def test_validate_wrapper_token_accepts_real_harness_argv(good: str) -> None:
     assert rl.validate_wrapper_token(good) == good
 
 
-def test_quote_wrapper_token_only_quotes_spaced_values() -> None:
-    assert rl.quote_wrapper_token("--laps") == "--laps"
+def test_quote_wrapper_token_quotes_every_token_not_just_spaced_ones() -> None:
+    """A space-free token can still carry cmd grouping metacharacters (`(dir)`)."""
+    assert rl.quote_wrapper_token("--laps") == '"--laps"'
     assert rl.quote_wrapper_token("Realistic BB v3") == '"Realistic BB v3"'
+    assert rl.quote_wrapper_token("(dir)") == '"(dir)"'
+
+
+def test_parenthesised_setup_names_survive_validation_but_are_inert() -> None:
+    """`(`/`)` are legal in AC setup names, so must not fail-close; quoting neutralises them."""
+    assert rl.validate_wrapper_token("Realistic BB (v3)") == "Realistic BB (v3)"
+    assert rl.quote_wrapper_token("Realistic BB (v3)") == '"Realistic BB (v3)"'
+
+
+@pytest.mark.parametrize("bad", ["C:/repo%USERNAME%", 'C:/re"po', "C:/a&b", "C:/a|b", "C:/a>b"])
+def test_validate_wrapper_path_rejects_cmd_specials_that_survive_quoting(bad: str) -> None:
+    """`%` expands INSIDE double quotes and `"` breaks out — both are legal ASCII path chars."""
+    with pytest.raises(rl.RemoteLaunchError, match="unsafe"):
+        rl.validate_wrapper_path("repo root", Path(bad))
+
+
+def test_render_wrapper_rejects_a_percent_expanding_repo_path(tmp_path: Path) -> None:
+    with pytest.raises(rl.RemoteLaunchError, match="unsafe"):
+        rl.render_wrapper(Path("C:/repo%PATH%"), ["-m", "x"], tmp_path)
+
+
+def test_harness_repo_root_does_not_import_the_payload_module() -> None:
+    """The transport must not drag `auto_drive` (the in-sim payload) in just to resolve a path."""
+    source = (Path(rl.__file__)).read_text(encoding="utf-8")
+    assert "from tools.ac_harness.auto_drive import" not in source
+    assert rl.harness_repo_root().joinpath("tools", "ac_harness").is_dir()
 
 
 def test_render_wrapper_encodes_every_measured_requirement(tmp_path: Path) -> None:
@@ -97,7 +124,9 @@ def test_render_wrapper_encodes_every_measured_requirement(tmp_path: Path) -> No
 
     # Unbuffered both ways: a redirected, buffered Python makes a healthy run look hung.
     assert "set PYTHONUNBUFFERED=1" in text
-    assert '".venv\\Scripts\\python.exe" -u -m tools.ac_harness.auto_alien --laps 3' in text
+    assert (
+        '".venv\\Scripts\\python.exe" -u "-m" "tools.ac_harness.auto_alien" "--laps" "3"'
+    ) in text
     # The polling SSH session must only ever read files.
     assert f'> "{run_dir / rl.STDOUT_NAME}"' in text
     assert f'2> "{run_dir / rl.STDERR_NAME}"' in text
@@ -116,7 +145,7 @@ def test_render_wrapper_rejects_a_non_ascii_repo_path(tmp_path: Path) -> None:
 
 def test_render_wrapper_quotes_a_spaced_argv_value(tmp_path: Path) -> None:
     text = rl.render_wrapper(tmp_path, ["-m", "x", "--setup", "Realistic BB v3"], tmp_path / "r")
-    assert '--setup "Realistic BB v3"' in text
+    assert '"--setup" "Realistic BB v3"' in text
 
 
 # ---------------------------------------------------------------------------
@@ -306,3 +335,22 @@ def test_cli_start_strips_the_argv_separator(monkeypatch: pytest.MonkeyPatch) ->
         rl.main(["start", "--label", "alien-529", "--", "-m", "tools.ac_harness.auto_alien"]) == 0
     )
     assert seen == {"argv": ["-m", "tools.ac_harness.auto_alien"], "label": "alien-529"}
+
+
+def test_cleanup_run_refuses_a_task_name_that_does_not_match_its_run_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`run.json` is on disk; a stray edit must not let cleanup reap a peer's task."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(rl, "_run", lambda argv: calls.append(list(argv)))
+    hijacked = rl.RemoteRun(
+        run_id="r",
+        task="ac-harness-someone-elses-run",
+        repo_root=str(tmp_path),
+        run_dir=str(tmp_path),
+        argv=["-m", "x"],
+        started_at="2026-07-26T19:59:01",
+    )
+    with pytest.raises(rl.RemoteLaunchError, match="does not match this run id"):
+        rl.cleanup_run(hijacked, force=True)
+    assert calls == []

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -927,13 +927,42 @@ def test_wrapper_suppresses_a_ghost_trigger_rerun(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     text = rl.render_wrapper(tmp_path, ["-m", "x"], run_dir)
     sentinel = run_dir / rl.SENTINEL_NAME
+    started = run_dir / rl.STARTED_NAME
     lines = text.splitlines()
     guard = next(i for i, ln in enumerate(lines) if ln.startswith("if exist") and "exit /b 0" in ln)
     payload = next(i for i, ln in enumerate(lines) if ".venv" in ln)
     # The guard must come BEFORE the redirected python call — `>` truncates, so a ghost run that
     # reached the payload would destroy the first run's logs.
     assert guard < payload
-    assert f'if exist "{sentinel}" exit /b 0' in text
+    assert f'if exist "{started}" if exist "{sentinel}" exit /b 0' in text
+
+
+def test_ghost_guard_requires_evidence_the_payload_actually_started(tmp_path: Path) -> None:
+    """A LONE planted exit sentinel must not turn the task into a no-op that reports success."""
+    run_dir = tmp_path / "run"
+    text = rl.render_wrapper(tmp_path, ["-m", "x"], run_dir)
+    started = run_dir / rl.STARTED_NAME
+    # Every early-exit path is conditioned on the start marker as well as the sentinel...
+    for line in text.splitlines():
+        if "exit /b 0" in line:
+            assert f'if exist "{started}"' in line
+    # ...and the marker is written by the wrapper itself, immediately before the payload.
+    lines = text.splitlines()
+    mark = next(i for i, ln in enumerate(lines) if ln.startswith("echo [wrapper] started"))
+    payload = next(i for i, ln in enumerate(lines) if ".venv" in ln)
+    assert mark < payload
+
+
+def test_start_run_refuses_to_reuse_an_existing_run_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reusing a run dir would inherit whatever markers it already holds — a plant vector."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    monkeypatch.setattr(rl, "build_run_id", lambda label, **kw: "fixed-id")
+    (tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "fixed-id")).mkdir(parents=True)
+    monkeypatch.setenv("USERNAME", "someone")
+    with pytest.raises(FileExistsError):
+        rl.start_run(["-m", "x"], label="fixed", repo_root=tmp_path)
 
 
 def test_ghost_suppression_note_does_not_corrupt_the_exit_sentinel() -> None:

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -426,7 +426,7 @@ def test_reap_skips_a_task_with_no_exit_sentinel(
     calls: list[list[str]] = []
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Ready())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-launching"])
-    outcome = rl.reap_tasks(repo_root=tmp_path)
+    outcome = rl.reap_tasks()
     assert outcome["reaped"]["ac-harness-launching"]["deleted"] is False
     assert "no exit sentinel" in outcome["reaped"]["ac-harness-launching"]["skipped"]
     assert not any("/delete" in c for c in calls)
@@ -445,7 +445,7 @@ def test_reap_fails_closed_when_the_status_query_fails(
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Broken())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-done"])
-    outcome = rl.reap_tasks(repo_root=tmp_path)
+    outcome = rl.reap_tasks()
     assert outcome["reaped"]["ac-harness-done"]["deleted"] is False
     assert "query failed" in outcome["reaped"]["ac-harness-done"]["skipped"]
     assert not any("/delete" in c for c in calls)
@@ -463,7 +463,7 @@ def test_reap_fails_closed_on_an_unrecognised_status(
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Weird())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-done"])
-    assert rl.reap_tasks(repo_root=tmp_path)["reaped"]["ac-harness-done"]["deleted"] is False
+    assert rl.reap_tasks()["reaped"]["ac-harness-done"]["deleted"] is False
     assert not any("/delete" in c for c in calls)
 
 
@@ -479,7 +479,7 @@ def test_reap_skips_a_running_task_even_with_a_sentinel(
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
-    assert rl.reap_tasks(repo_root=tmp_path)["reaped"]["ac-harness-live"]["deleted"] is False
+    assert rl.reap_tasks()["reaped"]["ac-harness-live"]["deleted"] is False
     assert not any("/delete" in c for c in calls)
 
 
@@ -492,7 +492,7 @@ def test_reap_deletes_a_finished_ready_task(
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Ready())[1])
     seq = iter([["ac-harness-done"], []])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: next(seq))
-    outcome = rl.reap_tasks(repo_root=tmp_path)
+    outcome = rl.reap_tasks()
     assert outcome["reaped"]["ac-harness-done"]["deleted"] is True
     assert outcome["remaining"] == []
     assert ["schtasks", "/delete", "/tn", "ac-harness-done", "/f"] in calls
@@ -507,7 +507,7 @@ def test_reap_force_bypasses_both_guards(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Running())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-live"])
-    rl.reap_tasks(repo_root=tmp_path, force=True)
+    rl.reap_tasks(force=True)
     assert ["schtasks", "/delete", "/tn", "ac-harness-live", "/f"] in calls
 
 
@@ -517,7 +517,7 @@ def test_reap_skips_a_task_name_that_is_not_a_valid_run_id(
     calls: list[list[str]] = []
     monkeypatch.setattr(rl, "_run", lambda argv: (calls.append(list(argv)), _Ready())[1])
     monkeypatch.setattr(rl, "list_stale_tasks", lambda: ["ac-harness-bad/../id"])
-    outcome = rl.reap_tasks(repo_root=tmp_path)
+    outcome = rl.reap_tasks()
     assert outcome["reaped"]["ac-harness-bad/../id"]["deleted"] is False
     assert not any("/delete" in c for c in calls)
 
@@ -562,9 +562,7 @@ def test_verdict_refuses_a_planted_sentinel_before_the_task_ever_ran(
         stdout = f"Status:  Ready\nLast Result:  {rl.SCHED_S_TASK_HAS_NOT_YET_RUN}\n"
 
     monkeypatch.setattr(rl, "_run", lambda argv: _NeverRan())
-    ok, reason = rl.task_deletion_verdict(
-        "ac-harness-victim", tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "victim")
-    )
+    ok, reason = rl.task_deletion_verdict("ac-harness-victim", "victim")
     assert ok is False
     assert "not yet run" in reason
 
@@ -579,9 +577,7 @@ def test_verdict_refuses_an_unreadable_last_result(
         stdout = "Status:  Ready\n"
 
     monkeypatch.setattr(rl, "_run", lambda argv: _NoResult())
-    ok, reason = rl.task_deletion_verdict(
-        "ac-harness-r", tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "r")
-    )
+    ok, reason = rl.task_deletion_verdict("ac-harness-r", "r")
     assert ok is False
     assert "unreadable" in reason
 
@@ -610,7 +606,7 @@ def test_cleanup_run_now_applies_the_same_live_status_gate_as_reap(
         started_at="x",
     )
     monkeypatch.setattr(
-        rl, "_await_deletion_verdict", lambda n, rd, **kw: rl.task_deletion_verdict(n, rd)
+        rl, "_await_deletion_verdict", lambda n, rid, **kw: rl.task_deletion_verdict(n, rid)
     )
     outcome = rl.cleanup_run(run)
     assert outcome["deleted"] is False
@@ -665,7 +661,7 @@ def test_sentinel_read_failure_does_not_abort_a_reap_pass(
     monkeypatch.setattr(
         Path, "read_text", lambda self, **kw: (_ for _ in ()).throw(OSError("permission denied"))
     )
-    assert rl._sentinel_exit_code(d) is None
+    assert rl._sentinel_exit_code("r") is None
 
 
 def test_list_stale_tasks_raises_rather_than_reporting_an_empty_set(
@@ -712,9 +708,7 @@ def test_verdict_reason_names_which_last_result_it_saw(
         stdout = f"Status:  Ready\nLast Result:  {rl.SCHED_S_TASK_IS_CURRENTLY_RUNNING}\n"
 
     monkeypatch.setattr(rl, "_run", lambda argv: _Running())
-    ok, reason = rl.task_deletion_verdict(
-        "ac-harness-r", tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "r")
-    )
+    ok, reason = rl.task_deletion_verdict("ac-harness-r", "r")
     assert ok is False
     assert "currently running" in reason
     assert "not yet run" not in reason
@@ -798,10 +792,10 @@ def test_poll_run_survives_an_unreadable_sentinel(
 ) -> None:
     """cleanup polls first, so a sharing error on wrapper.log must not abort with a traceback."""
     monkeypatch.setattr(
-        rl, "_sentinel_exit_code", lambda run_dir: (_ for _ in ()).throw(AssertionError("unused"))
+        rl, "_sentinel_exit_code", lambda run_id: (_ for _ in ()).throw(AssertionError("unused"))
     )
-    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_dir: None)
-    monkeypatch.setattr(rl, "task_deletion_verdict", lambda name, rd: (False, "no sentinel"))
+    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_id: None)
+    monkeypatch.setattr(rl, "task_deletion_verdict", lambda name, rid: (False, "no sentinel"))
 
     class _Q:
         returncode = 0
@@ -843,7 +837,7 @@ def test_poll_run_issues_exactly_one_schtasks_query(
         return _Q()
 
     monkeypatch.setattr(rl, "_run", _fake_run)
-    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_dir: 0)
+    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_id: 0)
     monkeypatch.setattr(rl, "read_rig_session_owner", lambda p: None)
     status = rl.poll_run(_run_handle(tmp_path))
     assert len(queries) == 1
@@ -857,8 +851,8 @@ def test_verdict_short_circuits_without_a_subprocess_when_no_sentinel(
 ) -> None:
     calls: list[list[str]] = []
     monkeypatch.setattr(rl, "_run", lambda argv: calls.append(list(argv)))
-    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_dir: None)
-    ok, reason = rl.task_deletion_verdict("ac-harness-r", tmp_path)
+    monkeypatch.setattr(rl, "_sentinel_exit_code", lambda run_id: None)
+    ok, reason = rl.task_deletion_verdict("ac-harness-r", "r")
     assert ok is False and "no exit sentinel" in reason
     assert calls == []
 
@@ -868,14 +862,14 @@ def test_evaluate_deletion_is_pure_over_a_snapshot(tmp_path: Path) -> None:
         sentinel_exit_code=0,
         query_rc=0,
         fields={"status": "Ready", "last_result": "0"},
-        run_dir=tmp_path,
+        run_id="abc-1",
     )
     assert ok is True
     blocked, reason = rl.evaluate_deletion(
         sentinel_exit_code=0,
         query_rc=0,
         fields={"status": "Ready", "last_result": str(rl.SCHED_S_TASK_HAS_NOT_YET_RUN)},
-        run_dir=tmp_path,
+        run_id="abc-1",
     )
     assert blocked is False and "not yet run" in reason
 
@@ -935,7 +929,7 @@ def test_execute_control_file_rejects_an_empty_argv(tmp_path: Path) -> None:
     (control / rl.CONTROL_NAME).write_text(
         json.dumps({"repo_root": str(tmp_path), "argv": []}), encoding="utf-8"
     )
-    with pytest.raises(rl.RemoteLaunchError, match="no argv"):
+    with pytest.raises(rl.RemoteLaunchError, match="must start with"):
         rl.execute_control_file("empty")
 
 
@@ -945,7 +939,8 @@ def test_execute_control_file_spawns_without_a_shell_and_writes_the_sentinel(
     control = rl.control_dir_for("ok")
     control.mkdir(parents=True)
     (control / rl.CONTROL_NAME).write_text(
-        json.dumps({"repo_root": str(tmp_path), "argv": ["-m", "payload"]}), encoding="utf-8"
+        json.dumps({"repo_root": str(tmp_path), "argv": ["-m", "tools.ac_harness.auto_alien"]}),
+        encoding="utf-8",
     )
     seen: dict = {}
 
@@ -961,7 +956,7 @@ def test_execute_control_file_spawns_without_a_shell_and_writes_the_sentinel(
     assert rl.execute_control_file("ok") == 7
     # The interpreter and cwd are RECOMPUTED, never taken from the control file.
     assert seen["argv"][0].endswith("python.exe")
-    assert seen["argv"][1:] == ["-u", "-m", "payload"]
+    assert seen["argv"][1:] == ["-u", "-m", "tools.ac_harness.auto_alien"]
     assert seen["kwargs"]["cwd"] == str(tmp_path)
     assert "shell" not in seen["kwargs"]  # subprocess defaults to shell=False
     assert rl.parse_sentinel(rl.sentinel_path_for("ok").read_text(encoding="utf-8")) == 7
@@ -978,8 +973,95 @@ def test_verdict_reason_names_the_sentinel_it_actually_checks(tmp_path: Path) ->
         sentinel_exit_code=None,
         query_rc=0,
         fields={},
-        run_dir=tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "abc-1"),
+        run_id="abc-1",
     )
     assert ok is False
     assert str(rl.sentinel_path_for("abc-1")) in reason
     assert ".scratch" not in reason
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["-c", "import os;os.system(chr(99))"],  # RCE: JSON needs no shell quoting
+        ["-c", "print(1)"],
+        ["C:/Users/Public/evil.py"],
+        ["-m", "runpy"],
+        ["-m", "os"],
+        ["-"],
+        [],
+    ],
+)
+def test_validate_payload_argv_rejects_everything_but_a_harness_module(argv: list[str]) -> None:
+    """Token validation alone permitted `python -c <expression>` — console-session RCE."""
+    with pytest.raises(rl.RemoteLaunchError):
+        rl.validate_payload_argv(argv)
+
+
+def test_validate_payload_argv_accepts_a_harness_module_with_args() -> None:
+    argv = ["-m", "tools.ac_harness.auto_alien", "--car", "ks_x", "--laps", "3"]
+    assert rl.validate_payload_argv(argv) == argv
+
+
+def test_execute_control_file_records_a_sentinel_when_it_fails(tmp_path: Path) -> None:
+    """Without this, poll/wait spin to their deadline and cleanup refuses — no diagnosis."""
+    control = rl.control_dir_for("boom")
+    control.mkdir(parents=True)
+    (control / rl.CONTROL_NAME).write_text(
+        json.dumps({"repo_root": str(tmp_path), "argv": ["-c", "print(1)"]}), encoding="utf-8"
+    )
+    with pytest.raises(rl.RemoteLaunchError):
+        rl.execute_control_file("boom")
+    recorded = rl.sentinel_path_for("boom").read_text(encoding="utf-8")
+    assert rl.parse_sentinel(recorded) == rl.EXEC_FAILURE_RC
+    assert "RemoteLaunchError" in recorded
+
+
+def test_start_run_fails_closed_when_the_trigger_cannot_be_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A start that leaves the one-shot trigger armed is a second AC session waiting to happen."""
+    monkeypatch.setattr(rl, "assert_transport_needed", lambda: (0, 1))
+    monkeypatch.setattr(rl, "short_path", lambda p: str(p))
+    monkeypatch.setenv("USERNAME", "someone")
+    calls: list[list[str]] = []
+
+    class _R:
+        def __init__(self, rc):
+            self.returncode = rc
+            self.stdout = ""
+            self.stderr = "nope"
+
+    def _fake_run(argv):  # noqa: ANN001, ANN202
+        calls.append(list(argv))
+        return _R(1 if "/change" in argv else 0)
+
+    monkeypatch.setattr(rl, "_run", _fake_run)
+    with pytest.raises(rl.RemoteLaunchError, match="trigger still armed"):
+        rl.start_run(["-m", "tools.ac_harness.auto_alien"], label="x", repo_root=tmp_path)
+    assert any("/delete" in c for c in calls)
+
+
+def test_cleanup_removes_the_control_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unique run ids mean an un-removed control dir leaks a folder per run, forever."""
+    _seed_finished_run(tmp_path, "gone")
+    assert rl.control_dir_for("gone").exists()
+
+    class _Ok:
+        returncode = 0
+        stdout = "Status:  Ready\nLast Result:  0\n"
+
+    monkeypatch.setattr(rl, "_run", lambda argv: _Ok())
+    monkeypatch.setattr(rl, "poll_run", lambda run, **kw: {"verified_complete": True})
+    run = rl.RemoteRun(
+        run_id="gone",
+        task=rl.task_name_for("gone"),
+        repo_root=str(tmp_path),
+        run_dir=str(tmp_path.joinpath(*rl.RUN_DIR_RELPATH, "gone")),
+        argv=["-m", "tools.ac_harness.auto_alien"],
+        started_at="x",
+    )
+    assert rl.cleanup_run(run)["deleted"] is True
+    assert not rl.control_dir_for("gone").exists()

--- a/tests/test_ac_harness_remote_launcher.py
+++ b/tests/test_ac_harness_remote_launcher.py
@@ -920,3 +920,22 @@ def test_evaluate_deletion_is_pure_over_a_snapshot(tmp_path: Path) -> None:
         run_dir=tmp_path,
     )
     assert blocked is False and "not yet run" in reason
+
+
+def test_wrapper_suppresses_a_ghost_trigger_rerun(tmp_path: Path) -> None:
+    """`/sc once` really fires: a run that finished first would otherwise execute AGAIN."""
+    run_dir = tmp_path / "run"
+    text = rl.render_wrapper(tmp_path, ["-m", "x"], run_dir)
+    sentinel = run_dir / rl.SENTINEL_NAME
+    lines = text.splitlines()
+    guard = next(i for i, ln in enumerate(lines) if ln.startswith("if exist") and "exit /b 0" in ln)
+    payload = next(i for i, ln in enumerate(lines) if ".venv" in ln)
+    # The guard must come BEFORE the redirected python call — `>` truncates, so a ghost run that
+    # reached the payload would destroy the first run's logs.
+    assert guard < payload
+    assert f'if exist "{sentinel}" exit /b 0' in text
+
+
+def test_ghost_suppression_note_does_not_corrupt_the_exit_sentinel() -> None:
+    """The suppression note must not be mistaken for a second exit code."""
+    assert rl.parse_sentinel("[wrapper] exit=0\n[wrapper] ghost trigger suppressed\n") == 0

--- a/tools/ac_harness/_remote_exec.py
+++ b/tools/ac_harness/_remote_exec.py
@@ -23,11 +23,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from tools.ac_harness.remote_launcher import (  # noqa: E402
-    EXEC_FAILURE_RC,
-    RemoteLaunchError,
-    execute_control_file,
-)
+from tools.ac_harness.remote_launcher import EXEC_FAILURE_RC, execute_control_file  # noqa: E402
 
 if __name__ == "__main__":
     # Exit with the SAME code the sentinel records. Task Scheduler surfaces this as `Last Result`,
@@ -35,6 +31,12 @@ if __name__ == "__main__":
     # failure exits EXEC_FAILURE_RC rather than letting the traceback pick an unrelated code.
     try:
         raise SystemExit(execute_control_file(sys.argv[1] if len(sys.argv) > 1 else ""))
-    except RemoteLaunchError as exc:
-        print(f"remote-exec: {exc}", file=sys.stderr)
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - deliberate: see below
+        # EVERY failure exits EXEC_FAILURE_RC, not just RemoteLaunchError. execute_control_file
+        # records that code in the sentinel for any exception, and evaluate_deletion now requires
+        # Last Result == sentinel — so letting a FileNotFoundError exit 1 would make the two
+        # disagree permanently and block cleanup/reap on that task forever.
+        print(f"remote-exec: {type(exc).__name__}: {exc}", file=sys.stderr)
         raise SystemExit(EXEC_FAILURE_RC) from exc

--- a/tools/ac_harness/_remote_exec.py
+++ b/tools/ac_harness/_remote_exec.py
@@ -23,7 +23,18 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from tools.ac_harness.remote_launcher import execute_control_file  # noqa: E402
+from tools.ac_harness.remote_launcher import (  # noqa: E402
+    EXEC_FAILURE_RC,
+    RemoteLaunchError,
+    execute_control_file,
+)
 
 if __name__ == "__main__":
-    raise SystemExit(execute_control_file(sys.argv[1] if len(sys.argv) > 1 else ""))
+    # Exit with the SAME code the sentinel records. Task Scheduler surfaces this as `Last Result`,
+    # and the deletion verdict now requires the two to agree — a binding that only holds if a
+    # failure exits EXEC_FAILURE_RC rather than letting the traceback pick an unrelated code.
+    try:
+        raise SystemExit(execute_control_file(sys.argv[1] if len(sys.argv) > 1 else ""))
+    except RemoteLaunchError as exc:
+        print(f"remote-exec: {exc}", file=sys.stderr)
+        raise SystemExit(EXEC_FAILURE_RC) from exc

--- a/tools/ac_harness/_remote_exec.py
+++ b/tools/ac_harness/_remote_exec.py
@@ -1,0 +1,29 @@
+"""Console-session entry point for :mod:`tools.ac_harness.remote_launcher` (#697).
+
+Task Scheduler's ``/tr`` used to point at a generated ``run.cmd`` inside the shared, agent-writable
+``.scratch`` tree. That made the scheduled payload a **peer-writable script**: any agent on the rig
+could replace it between ``/create`` and first execution and have Task Scheduler run an arbitrary
+command in the console session as the logged-on user. Executing a file we already treat as untrusted
+was the defect; relocating it would not have fixed it.
+
+``/tr`` now points at the repo's own interpreter running *this* file — version-controlled code, the
+same trust boundary the harness already runs under — which reads a control file, re-validates every
+argv token, and spawns the payload **without a shell**.
+
+Run as a script rather than ``-m`` because ``schtasks`` has no working-directory option, so the repo
+root is derived from this file's location and put on ``sys.path`` before the package import.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.ac_harness.remote_launcher import execute_control_file  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(execute_control_file(sys.argv[1] if len(sys.argv) > 1 else ""))

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import random
 import re
@@ -487,7 +488,15 @@ def load_run(run_id: str, *, repo_root: Path | None = None) -> RemoteRun:
     payload = run_dir / RUN_JSON_NAME
     if not payload.is_file():
         raise RemoteLaunchError(f"no such remote run: {payload}")
-    run = RemoteRun.from_dict(json.loads(payload.read_text(encoding="utf-8")))
+    # The payload lives in a writable scratch tree, so treat it as untrusted INPUT, not as a
+    # trusted structure: a truncated or hand-edited file must surface as the module's own error
+    # (which the CLI turns into a clean exit 3), never as a JSONDecodeError/KeyError traceback.
+    try:
+        run = RemoteRun.from_dict(json.loads(payload.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError, UnicodeDecodeError) as exc:
+        raise RemoteLaunchError(
+            f"unreadable run payload {payload}: {type(exc).__name__}: {exc}"
+        ) from exc
     expected_task = task_name_for(requested)
     if run.run_id != requested:
         raise RemoteLaunchError(
@@ -550,6 +559,14 @@ def wait_for_run(
     The wait is bounded on purpose: when the run never starts the sentinel never appears, and an
     unbounded loop would hang forever with no diagnosis.
     """
+    for label, value in (("timeout_s", timeout_s), ("interval_s", interval_s)):
+        # argparse's `type=float` happily accepts `inf` and `nan`. With `inf` the deadline is never
+        # reached, so the wait is unbounded — precisely the hang this function exists to prevent;
+        # with `nan` every comparison is False and the sleep collapses toward a busy spin.
+        if not math.isfinite(value) or value < 0:
+            raise RemoteLaunchError(
+                f"{label} must be a finite, non-negative number (got {value!r})"
+            )
     deadline = monotonic() + timeout_s
     while True:
         status = poll_run(run)
@@ -597,16 +614,30 @@ def list_stale_tasks() -> list[str]:
     return names
 
 
-def reap_tasks() -> dict[str, Any]:
-    """Delete every still-registered task this module owns.
+#: Task states that mean a launch is still in flight. Deleting one of these cancels a start that
+#: has not spawned yet and drops the only ``Status`` handle — the same hazard :func:`cleanup_run`
+#: refuses for a single run, which ``reap`` must not reintroduce across every run on the rig.
+_LIVE_TASK_STATES = {"running", "queued"}
+
+
+def reap_tasks(*, force: bool = False) -> dict[str, Any]:
+    """Delete still-registered tasks this module owns, **skipping ones still in flight**.
 
     ``list`` deliberately only reports; this is the command that actually removes them. A session
-    that dies before ``cleanup`` leaves a harmless but accumulating registration behind, and without
-    this the operator is left running raw ``schtasks /delete`` — which is the hand-run path this
-    module exists to retire.
+    that dies before ``cleanup`` leaves an accumulating registration behind, and without this the
+    operator falls back to raw ``schtasks /delete`` — the hand-run path this module retires.
+
+    But this module's threat model is *two agents, one rig*: an unconditional sweep would delete a
+    **peer's live task** mid-launch. So a task reporting ``Running``/``Queued`` is skipped unless
+    ``force`` is set, and the skip is reported rather than silently swallowed.
     """
     results: dict[str, Any] = {}
     for name in list_stale_tasks():
+        queried = _run(["schtasks", "/query", "/tn", name, "/fo", "list", "/v"])
+        state = parse_task_status(queried.stdout).get("status", "")
+        if not force and state.strip().lower() in _LIVE_TASK_STATES:
+            results[name] = {"deleted": False, "skipped": f"task is {state.strip()}"}
+            continue
         deleted = _run(["schtasks", "/delete", "/tn", name, "/f"])
         results[name] = {"deleted": deleted.returncode == 0, "rc": deleted.returncode}
     return {"reaped": results, "remaining": list_stale_tasks()}
@@ -672,7 +703,14 @@ def build_parser() -> argparse.ArgumentParser:
     wait.add_argument("--interval-s", type=float, default=30.0)
 
     sub.add_parser("list", help="list this module's still-registered tasks (read-only)")
-    sub.add_parser("reap", help="DELETE every still-registered task this module owns")
+    reap = sub.add_parser(
+        "reap", help="DELETE still-registered tasks this module owns (skips in-flight ones)"
+    )
+    reap.add_argument(
+        "--force",
+        action="store_true",
+        help="also delete Running/Queued tasks — cancels a live launch, possibly a peer's",
+    )
     return p
 
 
@@ -720,7 +758,7 @@ def main(raw_args: Sequence[str] | None = None) -> int:
             print(json.dumps(list_stale_tasks(), indent=2))
             return 0
         if args.command == "reap":
-            outcome = reap_tasks()
+            outcome = reap_tasks(force=args.force)
             print(json.dumps(outcome, indent=2, default=str))
             return 0 if not outcome["remaining"] else 1
     except RemoteLaunchError as exc:

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -328,7 +328,10 @@ def parse_task_status(text: str) -> dict[str, str]:
 
 def parse_sentinel(text: str) -> int | None:
     """The wrapper's exit code, or ``None`` while the run has not finished."""
-    for line in reversed(text.splitlines()):
+    # FIRST valid `exit=` wins, not the last. The shim writes exactly one, exclusively-created, so
+    # the earliest parsable value is the real one; scanning from the end let a peer append
+    # `[wrapper] exit=0` after a genuine `exit=1` and hand automation a forged success.
+    for line in text.splitlines():
         marker = line.find(SENTINEL_TOKEN)
         if marker >= 0:
             tail = line[marker + len(SENTINEL_TOKEN) :].strip()
@@ -524,9 +527,17 @@ def _execute_validated(requested: str) -> int:
             env=env,
             check=False,
         )
-    sentinel = control_dir_for(requested) / SENTINEL_NAME
-    with sentinel.open("a", encoding="utf-8") as fh:
-        fh.write(f"[wrapper] {SENTINEL_TOKEN}{completed.returncode}\n")
+    sentinel = sentinel_path_for(requested)
+    try:
+        # Exclusive create: the shim is the only writer, so an existing sentinel at this point
+        # means someone else put it there. Failing loudly beats appending beneath a forgery.
+        with sentinel.open("x", encoding="utf-8") as fh:
+            fh.write(f"[wrapper] {SENTINEL_TOKEN}{completed.returncode}\n")
+    except FileExistsError as exc:
+        raise RemoteLaunchError(
+            f"exit sentinel {sentinel} already existed before this run finished — refusing to "
+            "append beneath a value this shim did not write"
+        ) from exc
     return completed.returncode
 
 
@@ -589,6 +600,21 @@ def start_run(
     account = run_as or os.environ.get("USERNAME") or ""
     if not account:
         raise RemoteLaunchError("cannot resolve the logged-on account for /ru (USERNAME unset)")
+    run = RemoteRun(
+        run_id=run_id,
+        task=task,
+        repo_root=str(root),
+        run_dir=str(run_dir),
+        argv=list(resolved_argv),
+        started_at=moment.isoformat(timespec="seconds"),
+    )
+    # Persist the handle BEFORE anything can launch. If this write failed after `/run`, the payload
+    # could already be live with the one-shot trigger still armed and no way for the caller to poll
+    # or clean it up.
+    (run_dir / RUN_JSON_NAME).write_text(
+        json.dumps(run.to_dict(), indent=2) + "\n", encoding="utf-8"
+    )
+
     when = moment + timedelta(minutes=start_delay_minutes)
     # `/tr` runs the repo's own interpreter against a version-controlled shim — NOT a generated
     # script inside the agent-writable scratch tree. Executing that file was command injection: a
@@ -598,6 +624,9 @@ def start_run(
     tr_path = f"{short_path(root / '.venv' / 'Scripts' / 'python.exe')} {short_path(shim)} {run_id}"
     created = _run(schtasks_create_argv(task=task, tr_path=tr_path, when=when, run_as=account))
     if created.returncode != 0:
+        # Nothing is registered, so reap_tasks will never find this run — discard its control
+        # directory here or it leaks in the user's profile for every failed attempt.
+        _discard_control_dir(run_id)
         raise RemoteLaunchError(
             f"schtasks /create failed ({created.returncode}): {created.stdout}{created.stderr}"
         )
@@ -608,6 +637,8 @@ def start_run(
         # fires ~start_delay later with no handle for anyone to poll or clean up.
         removed = _run(["schtasks", "/delete", "/tn", task, "/f"])
         detail = f"schtasks /run failed ({started.returncode}): {started.stdout}{started.stderr}"
+        if removed.returncode == 0:
+            _discard_control_dir(run_id)
         if removed.returncode != 0:
             detail += (
                 f" — AND the cleanup delete failed ({removed.returncode}), so task {task!r} is "
@@ -619,18 +650,6 @@ def start_run(
     # left armed, it fires at its scheduled time and executes the payload a second time if the run
     # already finished. Disabling removes that class outright — no filesystem marker can do it,
     # because every marker lives somewhere a peer can write. A running instance is unaffected.
-    run = RemoteRun(
-        run_id=run_id,
-        task=task,
-        repo_root=str(root),
-        run_dir=str(run_dir),
-        argv=list(resolved_argv),
-        started_at=moment.isoformat(timespec="seconds"),
-    )
-    (run_dir / RUN_JSON_NAME).write_text(
-        json.dumps(run.to_dict(), indent=2) + "\n", encoding="utf-8"
-    )
-
     # The payload is now LIVE. Disabling the one-shot trigger is still required, but a failure here
     # must NOT be "cleaned up" by deleting the task: this module documents that /run is asynchronous
     # and that deleting the definition can cancel a start still spawning — so the old fail-closed
@@ -916,6 +935,11 @@ _KNOWN_DEAD_TASK_STATES = {"ready", "disabled"}
 #: last command is ``echo``, so ``Last Result`` can be 0 while the harness rc was not.
 SCHED_S_TASK_HAS_NOT_YET_RUN = 267011
 SCHED_S_TASK_IS_CURRENTLY_RUNNING = 267009
+#: `Last Result` values in 0x41300-0x41308 are Task Scheduler STATUS codes, not process exit codes.
+#: Rejecting only "not yet run" and "currently running" left SCHED_S_TASK_READY (267008),
+#: SCHED_S_TASK_DISABLED (267010) and the rest reading as "the payload ran and finished" — so the
+#: third gate never actually proved execution. Anything in this range fails closed.
+_SCHED_STATUS_RESULT_RANGE = range(0x41300, 0x41309)
 
 
 def sentinel_path_for(run_id: str) -> Path:
@@ -976,6 +1000,16 @@ def evaluate_deletion(
         return False, "task has not yet run (pre-spawn Ready window) — refusing to cancel a launch"
     if last_result == SCHED_S_TASK_IS_CURRENTLY_RUNNING:
         return False, "last result says the task is currently running — refusing to cancel it"
+    if last_result in _SCHED_STATUS_RESULT_RANGE:
+        return False, (
+            f"last result 0x{last_result:X} is a Task Scheduler status code, not a process exit "
+            "code — the payload's own completion is unproven, failing closed"
+        )
+    if last_result < 0:
+        return False, (
+            f"last result {last_result} is a launch failure (e.g. 0x{last_result & 0xFFFFFFFF:X}), "
+            "so the payload never ran — failing closed"
+        )
     return True, ""
 
 

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -54,12 +54,12 @@ off-rig; only the ``schtasks``/session calls are Windows-only.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import math
 import os
 import random
 import re
-import shutil
 import subprocess
 import sys
 import time
@@ -494,7 +494,18 @@ def _execute_validated(requested: str) -> int:
         raise RemoteLaunchError(f"unreadable control file {control}: {exc}") from exc
     if not isinstance(payload, dict):
         raise RemoteLaunchError(f"control file {control} is not an object")
-    repo_root = validate_wrapper_path("repo root", Path(str(payload.get("repo_root", ""))))
+    # repo_root is NOT taken from the control file. Validating its characters was not enough:
+    # it selects the interpreter (`<repo_root>/.venv/Scripts/python.exe`) and the log directory, so
+    # a forged control file could point execution at an arbitrary python and writes at an arbitrary
+    # tree — the same class as the `-c` hole, one layer down. It is recomputed from THIS module's
+    # own location, and a control file that disagrees is rejected rather than silently overridden.
+    repo_root = harness_repo_root()
+    declared = str(payload.get("repo_root", ""))
+    if declared and Path(declared).resolve() != repo_root:
+        raise RemoteLaunchError(
+            f"control file {control} declares repo_root {declared!r} but this shim lives under "
+            f"{repo_root} — refusing to run a payload aimed at another checkout"
+        )
     argv = validate_payload_argv(payload.get("argv", []))
 
     run_dir = repo_root.joinpath(*RUN_DIR_RELPATH, requested)
@@ -549,7 +560,15 @@ def start_run(
     # exist_ok=False on purpose: a per-run id should never collide, and REUSING a directory would
     # inherit whatever markers it already holds (a stale or planted sentinel), which is exactly the
     # vector the wrapper's start-marker guard exists to close. A collision is a loud error.
-    run_dir.mkdir(parents=True, exist_ok=False)
+    try:
+        run_dir.mkdir(parents=True, exist_ok=False)
+    except FileExistsError as exc:
+        # main() only catches RemoteLaunchError; a bare FileExistsError would crash the CLI with a
+        # traceback instead of the documented exit code.
+        raise RemoteLaunchError(
+            f"run directory {run_dir} already exists — refusing to reuse it (it could carry a "
+            "stale or planted control/sentinel state)"
+        ) from exc
 
     resolved_argv = substitute_run_placeholders(argv, run_id=run_id, run_dir=run_dir)
     validate_wrapper_path("repo root", root)
@@ -773,9 +792,17 @@ def _discard_control_dir(run_id: str) -> None:
     (control file + sentinel) into the user's profile.
     """
     try:
-        shutil.rmtree(control_dir_for(run_id), ignore_errors=True)
+        control = control_dir_for(run_id)
     except RemoteLaunchError:
-        pass  # unvalidatable id — nothing of ours to remove
+        return  # unvalidatable id — nothing of ours to remove
+    # Delete only the two files this module writes, then rmdir. A recursive delete would remove
+    # peer-planted content in a directory this module itself documents as peer-writable, and
+    # `ignore_errors=True` would swallow the very failure that means the leak is still there.
+    for name in (CONTROL_NAME, SENTINEL_NAME):
+        with contextlib.suppress(FileNotFoundError):
+            (control / name).unlink()
+    with contextlib.suppress(FileNotFoundError, OSError):
+        control.rmdir()  # refuses if anything unexpected remains — deliberately not forced
 
 
 def _await_deletion_verdict(

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -1,0 +1,619 @@
+"""Run a harness command in the rig's **console session** from an off-rig SSH login (#697).
+
+An OpenSSH logon on the rig is a *network* logon and lands in Windows **session 0**. Two
+independent consequences make a session-0 harness run impossible, and neither is a harness bug
+(#693):
+
+1. Session 0 enforces the redirection-trust mitigation, so it refuses to traverse the non-admin
+   ``apps/lua/ac_copilot_trainer`` junction. The #575 app-provenance preflight is the first code to
+   touch it, so the run dies with ``OSError: [WinError 448] … untrusted mount point`` and *looks*
+   like a harness defect.
+2. Session 0 has no interactive desktop; Assetto Corsa renders on the console session.
+
+The working transport is a ``schtasks /IT`` task ("run only when the user is logged on"), which
+executes in the console session and needs no stored credential. PR #694 documented that as a
+copy/paste runbook; five review rounds then found **six real Windows defects in a documentation
+block**, which is the argument this module exists: the transport is intricate enough that every
+off-rig session must not re-derive it by hand.
+
+Every measured Windows fact from #693/#699 is encoded here as a guard that asserts its own
+precondition, because the failure mode that costs a whole overnight run is a fail-*open* guard —
+one that lets ``schtasks`` report ``create=0``/``run=0`` while the wrapper never executes:
+
+* ``/tr`` gets the **8.3 short path**. A space anywhere in the path makes Task Scheduler accept the
+  create and the run and then never launch the wrapper (``Last Result: -2147024894``). Quoting does
+  not save it. :func:`short_path` therefore **raises** when 8.3 generation is disabled and the
+  returned path still contains whitespace, rather than proceeding into a silent multi-hour wait.
+* ``/sd`` is derived from the same ``datetime`` as ``/st`` and formatted ``MM/dd/yyyy``.
+  ``/sc once`` defaults the start date to today, so a bare clock time computed after ~23:55 rolls
+  to ``00:xx`` and is read as earlier *today* — ``/create`` then fails precisely during the
+  overnight runs this path exists for. The *culture* short-date pattern is **not**
+  interchangeable: ``M/d/yyyy``, ``dd/MM/yyyy`` and ``yyyy/MM/dd`` were all rejected on the rig
+  with ``0x80004005``.
+  (``/sc ONDEMAND``, which would remove the date problem entirely, is also rejected.)
+* The task name carries a **per-run** id (timestamp + pid + nonce). The threat model is two agents
+  on one physical rig: a fixed name lets each clobber the other's registration, and same-second
+  starts would otherwise collide. ``/f`` is still passed, because a duplicate ``create`` without it
+  does not error — it *blocks* on the interactive "replace it?" prompt.
+* Every token interpolated into the generated ``.cmd`` is validated first. ``cmd.exe`` parses ``<``
+  and ``>`` as redirection, and ``&``/``|``/``^``/``%VAR%`` are injection inside a file Task
+  Scheduler executes as the logged-on user.
+* The wrapper is written **ASCII**; a non-ASCII path is mangled to ``?`` by the encoder, producing a
+  wrapper whose ``cd /d`` and redirects point nowhere while ``schtasks`` still reports success.
+* The wrapper sets ``PYTHONUNBUFFERED=1`` and passes ``-u``: redirected Python is otherwise fully
+  buffered, so the poll surface looks hung for minutes on a perfectly healthy run.
+
+Ownership arbitration is **not** duplicated here — the spawned harness takes the cross-worktree rig
+lock itself (:mod:`tools.ac_harness.rig_lock`); :func:`poll_run` only *reports* the current owner so
+a caller can see who holds the rig without racing for it.
+
+The pure half (run ids, wrapper rendering, ``schtasks`` argv, status parsing) is unit-tested
+off-rig; only the ``schtasks``/session calls are Windows-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from tools.ac_harness.auto_drive import harness_repo_root
+from tools.ac_harness.rig_lock import default_rig_session_lock_path, read_rig_session_owner
+
+#: Transport logs live beside (not inside) the harness's own evidence tree: the run directory holds
+#: the wrapper and its redirected streams, the harness keeps owning ``--evidence-dir``.
+RUN_DIR_RELPATH = (".scratch", "harness-remote")
+#: Every task this module creates is named ``ac-harness-<run id>`` so a stale one is reapable by
+#: prefix without touching unrelated scheduled tasks.
+TASK_PREFIX = "ac-harness-"
+WRAPPER_NAME = "run.cmd"
+STDOUT_NAME = "stdout.log"
+STDERR_NAME = "stderr.log"
+#: The wrapper appends ``[wrapper] exit=<rc>`` as its last act. Its presence — not the task's
+#: ``Status`` — is what says the run finished: ``schtasks /run`` is asynchronous, so deleting the
+#: task on ``Status: Ready`` alone can cancel a start that has not spawned yet.
+SENTINEL_NAME = "wrapper.log"
+SENTINEL_TOKEN = "exit="
+RUN_JSON_NAME = "run.json"
+
+#: ``/sd`` format measured as the only accepted one on the rig (see the module docstring).
+SCHTASKS_DATE_FORMAT = "%m/%d/%Y"
+SCHTASKS_TIME_FORMAT = "%H:%M"
+#: The trigger never fires — ``/run`` starts the task on demand — but ``/sc once`` requires a start
+#: time that is not in the past, so it is placed safely ahead.
+DEFAULT_START_DELAY_MINUTES = 5
+
+#: Run-id / task-name alphabet: safe as a Windows path component *and* a Task Scheduler name.
+_RUN_COMPONENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+#: Tokens interpolated into the generated ``.cmd``. Excludes whitespace-free cmd metacharacters
+#: (``& | < > ^ %``), quotes, and everything outside printable ASCII. Spaces are allowed because
+#: :func:`render_wrapper` quotes such tokens; a token may not contain a quote of its own.
+_WRAPPER_TOKEN_RE = re.compile(r"^[ !#$()*+,\-./0-9:;=?@A-Z\[\]_a-z{}~\\]+$")
+
+_INVALID_SESSION = 0xFFFFFFFF
+
+
+class RemoteLaunchError(RuntimeError):
+    """A transport precondition failed. Never raised for a harness-level (in-sim) failure."""
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested off-rig)
+# ---------------------------------------------------------------------------
+
+
+def validate_run_component(kind: str, value: str) -> str:
+    """Reject a run-id fragment that could act as a path segment or a task-name metacharacter."""
+    if not value or ".." in value or not _RUN_COMPONENT_RE.match(value):
+        raise RemoteLaunchError(f"unsafe {kind} {value!r} (allowed: letters/digits/._-)")
+    return value
+
+
+def build_run_id(
+    label: str,
+    *,
+    now: datetime,
+    pid: int,
+    nonce: int,
+) -> str:
+    """A per-run id that is unique across concurrent agents and safe in a path and a task name.
+
+    Second resolution alone is not enough: two agents starting in the same second on the one rig
+    would share the run directory, each overwriting the other's wrapper and task registration.
+    """
+    validate_run_component("run label", label)
+    return f"{label}-{now:%Y%m%d-%H%M%S}-{pid}-{nonce}"
+
+
+def validate_wrapper_token(token: str) -> str:
+    """Reject an argv token that would become redirection or injection inside the wrapper."""
+    if not token:
+        raise RemoteLaunchError("empty argv token")
+    if not _WRAPPER_TOKEN_RE.match(token):
+        raise RemoteLaunchError(
+            f"unsafe argv token {token!r}: only printable ASCII without quotes or "
+            "cmd metacharacters (& | < > ^ %) may reach the generated .cmd"
+        )
+    return token
+
+
+def quote_wrapper_token(token: str) -> str:
+    """Quote a validated token for ``cmd.exe`` (quotes are already excluded by validation)."""
+    return f'"{token}"' if " " in token else token
+
+
+def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
+    """Render the ``.cmd`` Task Scheduler executes in the console session.
+
+    ``argv`` is the harness command *without* the interpreter: ``["-m", "tools.ac_harness.…", …]``.
+    The wrapper redirects its own streams so the polling SSH session only ever *reads* files, and
+    appends the exit sentinel as its last act.
+    """
+    for part in (str(repo_root), str(run_dir)):
+        if not part.isascii():
+            raise RemoteLaunchError(
+                f"non-ASCII path {part!r} would be mangled to '?' by the ascii-encoded wrapper"
+            )
+    tokens = " ".join(quote_wrapper_token(validate_wrapper_token(a)) for a in argv)
+    stdout_path = run_dir / STDOUT_NAME
+    stderr_path = run_dir / STDERR_NAME
+    sentinel_path = run_dir / SENTINEL_NAME
+    return (
+        "@echo off\r\n"
+        f'cd /d "{repo_root}"\r\n'
+        "rem Redirected Python is fully buffered; without this the poll surface looks hung for\r\n"
+        "rem minutes on a healthy run.\r\n"
+        "set PYTHONUNBUFFERED=1\r\n"
+        f'".venv\\Scripts\\python.exe" -u {tokens} > "{stdout_path}" 2> "{stderr_path}"\r\n'
+        f'echo [wrapper] {SENTINEL_TOKEN}%ERRORLEVEL% >> "{sentinel_path}"\r\n'
+    )
+
+
+def task_name_for(run_id: str) -> str:
+    """The scheduled-task name for a run id."""
+    return f"{TASK_PREFIX}{validate_run_component('run id', run_id)}"
+
+
+def schtasks_create_argv(
+    *,
+    task: str,
+    tr_path: str,
+    when: datetime,
+    run_as: str,
+) -> list[str]:
+    """The ``schtasks /create`` argv.
+
+    ``/st`` and ``/sd`` are derived from the **same** ``datetime`` so a start time that rolls past
+    midnight carries the correct day; ``/it`` is what puts the task in the console session; ``/f``
+    prevents the interactive "replace it?" prompt from blocking a non-interactive create.
+    """
+    return [
+        "schtasks",
+        "/create",
+        "/tn",
+        task,
+        "/tr",
+        tr_path,
+        "/sc",
+        "once",
+        "/st",
+        when.strftime(SCHTASKS_TIME_FORMAT),
+        "/sd",
+        when.strftime(SCHTASKS_DATE_FORMAT),
+        "/ru",
+        run_as,
+        "/it",
+        "/f",
+    ]
+
+
+def parse_task_status(text: str) -> dict[str, str]:
+    """Pull ``Status`` / ``Last Result`` out of ``schtasks /query /fo list /v`` output."""
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip().lower()
+        if key in {"status", "last result"}:
+            fields.setdefault(key.replace(" ", "_"), value.strip())
+    return fields
+
+
+def parse_sentinel(text: str) -> int | None:
+    """The wrapper's exit code, or ``None`` while the run has not finished."""
+    for line in reversed(text.splitlines()):
+        marker = line.find(SENTINEL_TOKEN)
+        if marker >= 0:
+            tail = line[marker + len(SENTINEL_TOKEN) :].strip()
+            try:
+                return int(tail)
+            except ValueError:
+                return None
+    return None
+
+
+@dataclass(frozen=True)
+class RemoteRun:
+    """Everything a later poll needs; persisted as ``run.json`` inside the run directory."""
+
+    run_id: str
+    task: str
+    repo_root: str
+    run_dir: str
+    argv: list[str]
+    started_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> RemoteRun:
+        return cls(
+            run_id=str(payload["run_id"]),
+            task=str(payload["task"]),
+            repo_root=str(payload["repo_root"]),
+            run_dir=str(payload["run_dir"]),
+            argv=[str(a) for a in payload.get("argv", [])],
+            started_at=str(payload.get("started_at", "")),
+        )
+
+    @property
+    def directory(self) -> Path:
+        return Path(self.run_dir)
+
+
+# ---------------------------------------------------------------------------
+# Windows-only transport
+# ---------------------------------------------------------------------------
+
+
+def current_session_id() -> int:
+    """Windows session of this process (an SSH logon reports 0)."""
+    import ctypes
+
+    session = ctypes.c_ulong()
+    if not ctypes.windll.kernel32.ProcessIdToSessionId(  # type: ignore[attr-defined]
+        ctypes.c_ulong(os.getpid()), ctypes.byref(session)
+    ):
+        raise RemoteLaunchError("ProcessIdToSessionId failed")
+    return int(session.value)
+
+
+def console_session_id() -> int:
+    """Session id of the physical console, or ``_INVALID_SESSION`` when nobody is logged on."""
+    import ctypes
+
+    return int(ctypes.windll.kernel32.WTSGetActiveConsoleSessionId())  # type: ignore[attr-defined]
+
+
+def assert_transport_needed() -> tuple[int, int]:
+    """Refuse when the task hop is pure overhead, and fail loudly when it cannot work.
+
+    Returns ``(current session, console session)``.
+    """
+    current = current_session_id()
+    console = console_session_id()
+    if console == _INVALID_SESSION:
+        raise RemoteLaunchError(
+            "no active console session — nobody is logged on at the rig, so a /IT task can never "
+            "run and AC has no desktop to render on. Log in at the rig first."
+        )
+    if current == console:
+        raise RemoteLaunchError(
+            f"already running in the console session ({current}); run the harness directly — "
+            "the scheduled-task hop would be pure overhead"
+        )
+    return current, console
+
+
+def short_path(path: Path) -> str:
+    """The 8.3 short path for ``/tr``; **raises** rather than silently handing back a spaced path.
+
+    ``GetShortPathNameW`` returns the long path unchanged when 8.3 name generation is disabled on
+    the volume. Returning that would make ``schtasks`` report success and never launch the wrapper.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    get_short = ctypes.windll.kernel32.GetShortPathNameW  # type: ignore[attr-defined]
+    get_short.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    get_short.restype = wintypes.DWORD
+    buf = ctypes.create_unicode_buffer(1024)
+    size = get_short(str(path), buf, len(buf))
+    if size == 0 or size >= len(buf):
+        raise RemoteLaunchError(f"GetShortPathNameW failed for {path}")
+    resolved = buf.value
+    if any(ch.isspace() for ch in resolved):
+        raise RemoteLaunchError(
+            f"8.3 short path unavailable (got {resolved!r}). Task Scheduler accepts a spaced /tr "
+            "and then never launches it — use a space-free repo path or enable 8.3 name generation."
+        )
+    return resolved
+
+
+def _run(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        list(argv), capture_output=True, text=True, check=False
+    )
+
+
+def start_run(
+    argv: Sequence[str],
+    *,
+    label: str,
+    repo_root: Path | None = None,
+    now: datetime | None = None,
+    run_as: str | None = None,
+    start_delay_minutes: int = DEFAULT_START_DELAY_MINUTES,
+) -> RemoteRun:
+    """Create and start a per-run console-session task for ``argv``; returns its handle."""
+    assert_transport_needed()
+    root = (repo_root or harness_repo_root()).resolve()
+    # schtasks reads the rig's LOCAL wall clock, so /st and /sd must be local — not UTC.
+    moment = now or datetime.now(UTC).astimezone()
+    run_id = build_run_id(
+        label,
+        now=moment,
+        pid=os.getpid(),
+        nonce=random.randrange(1000, 9999),  # noqa: S311
+    )
+    run_dir = root.joinpath(*RUN_DIR_RELPATH, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    wrapper = run_dir / WRAPPER_NAME
+    wrapper.write_text(render_wrapper(root, argv, run_dir), encoding="ascii", newline="")
+
+    task = task_name_for(run_id)
+    account = run_as or os.environ.get("USERNAME") or ""
+    if not account:
+        raise RemoteLaunchError("cannot resolve the logged-on account for /ru (USERNAME unset)")
+    when = moment + timedelta(minutes=start_delay_minutes)
+    created = _run(
+        schtasks_create_argv(task=task, tr_path=short_path(wrapper), when=when, run_as=account)
+    )
+    if created.returncode != 0:
+        raise RemoteLaunchError(
+            f"schtasks /create failed ({created.returncode}): {created.stdout}{created.stderr}"
+        )
+    started = _run(["schtasks", "/run", "/tn", task])
+    if started.returncode != 0:
+        _run(["schtasks", "/delete", "/tn", task, "/f"])
+        raise RemoteLaunchError(
+            f"schtasks /run failed ({started.returncode}): {started.stdout}{started.stderr}"
+        )
+
+    run = RemoteRun(
+        run_id=run_id,
+        task=task,
+        repo_root=str(root),
+        run_dir=str(run_dir),
+        argv=list(argv),
+        started_at=moment.isoformat(timespec="seconds"),
+    )
+    (run_dir / RUN_JSON_NAME).write_text(
+        json.dumps(run.to_dict(), indent=2) + "\n", encoding="utf-8"
+    )
+    return run
+
+
+def load_run(run_id: str, *, repo_root: Path | None = None) -> RemoteRun:
+    """Rehydrate a run handle written by :func:`start_run`."""
+    root = (repo_root or harness_repo_root()).resolve()
+    payload = root.joinpath(
+        *RUN_DIR_RELPATH, validate_run_component("run id", run_id), RUN_JSON_NAME
+    )
+    if not payload.is_file():
+        raise RemoteLaunchError(f"no such remote run: {payload}")
+    return RemoteRun.from_dict(json.loads(payload.read_text(encoding="utf-8")))
+
+
+def _tail(path: Path, lines: int) -> list[str]:
+    if not path.is_file():
+        return []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return text.splitlines()[-lines:] if lines > 0 else text.splitlines()
+
+
+def poll_run(run: RemoteRun, *, tail: int = 30) -> dict[str, Any]:
+    """Read-only status: task fields, wrapper exit, log tails, ``acs.exe`` liveness, rig owner.
+
+    Never touches AC and never deletes the task — a poll must be safe to run in a tight loop.
+    """
+    queried = _run(["schtasks", "/query", "/tn", run.task, "/fo", "list", "/v"])
+    sentinel = run.directory / SENTINEL_NAME
+    exit_code = (
+        parse_sentinel(sentinel.read_text(encoding="utf-8", errors="replace"))
+        if sentinel.is_file()
+        else None
+    )
+    acs = _run(["tasklist", "/fi", "imagename eq acs.exe", "/nh"])
+    return {
+        "run_id": run.run_id,
+        "task": run.task,
+        "task_query_rc": queried.returncode,
+        **parse_task_status(queried.stdout),
+        "finished": exit_code is not None,
+        "exit_code": exit_code,
+        "acs_running": "acs.exe" in acs.stdout.lower(),
+        "rig_lock_owner": read_rig_session_owner(default_rig_session_lock_path()),
+        "stdout_tail": _tail(run.directory / STDOUT_NAME, tail),
+        "stderr_tail": _tail(run.directory / STDERR_NAME, min(tail, 10)),
+    }
+
+
+def wait_for_run(
+    run: RemoteRun,
+    *,
+    timeout_s: float,
+    interval_s: float = 30.0,
+    sleep=time.sleep,  # noqa: ANN001 - injectable clock for tests
+    monotonic=time.monotonic,  # noqa: ANN001
+) -> dict[str, Any]:
+    """Block until the wrapper writes its exit sentinel, or the bounded deadline passes.
+
+    The wait is bounded on purpose: when the run never starts the sentinel never appears, and an
+    unbounded loop would hang forever with no diagnosis.
+    """
+    deadline = monotonic() + timeout_s
+    while True:
+        status = poll_run(run)
+        if status["finished"]:
+            return status
+        if monotonic() >= deadline:
+            status["timed_out"] = True
+            return status
+        sleep(min(interval_s, max(0.0, deadline - monotonic())))
+
+
+def cleanup_run(run: RemoteRun, *, force: bool = False) -> dict[str, Any]:
+    """Delete the task once the wrapper has logged its exit code.
+
+    Refuses on an unfinished run unless ``force``: ``/run`` is asynchronous, so deleting the task
+    definition early can cancel a start that has not spawned yet, and it removes the only ``Status``
+    handle while the run is still launching.
+    """
+    status = poll_run(run, tail=0)
+    if not status["finished"] and not force:
+        return {"deleted": False, "reason": "run has not written its exit sentinel", **status}
+    deleted = _run(["schtasks", "/delete", "/tn", run.task, "/f"])
+    return {"deleted": deleted.returncode == 0, "delete_rc": deleted.returncode, **status}
+
+
+def list_stale_tasks() -> list[str]:
+    """Task names this module owns that are still registered (reap after a session dies)."""
+    queried = _run(["schtasks", "/query", "/fo", "list"])
+    names: list[str] = []
+    for line in queried.stdout.splitlines():
+        key, _, value = line.partition(":")
+        if key.strip().lower() == "taskname":
+            name = value.strip().lstrip("\\")
+            if name.startswith(TASK_PREFIX):
+                names.append(name)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m tools.ac_harness.remote_launcher",
+        description=(
+            "Run a harness command in the rig's console session from an off-rig SSH login (#697). "
+            "Diagnosis of why this is needed: docs/10_Development/18_Autonomous_Harness.md."
+        ),
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start", help="create + run a console-session task for a harness argv")
+    start.add_argument(
+        "--label",
+        default="harness",
+        help="run-id prefix (letters/digits/._- only); e.g. alien-529-911-magione",
+    )
+    start.add_argument(
+        "--wait-timeout-s",
+        type=float,
+        default=None,
+        help="block until the wrapper exits (bounded); omit to return immediately",
+    )
+    start.add_argument(
+        "--keep-task",
+        action="store_true",
+        help="do not delete the task after a completed --wait-timeout-s run",
+    )
+    start.add_argument(
+        "argv",
+        nargs=argparse.REMAINDER,
+        help=(
+            "harness argv after `--`, without the interpreter "
+            "(e.g. -m tools.ac_harness.auto_alien --car … --track …)"
+        ),
+    )
+
+    for name, help_text in (
+        ("poll", "read-only status for a run id"),
+        ("cleanup", "delete the task for a finished run id"),
+    ):
+        cmd = sub.add_parser(name, help=help_text)
+        cmd.add_argument("run_id")
+        if name == "poll":
+            cmd.add_argument("--tail", type=int, default=30)
+        else:
+            cmd.add_argument(
+                "--force", action="store_true", help="delete even without the exit sentinel"
+            )
+
+    wait = sub.add_parser("wait", help="block (bounded) until a run writes its exit sentinel")
+    wait.add_argument("run_id")
+    wait.add_argument("--timeout-s", type=float, default=3 * 60 * 60)
+    wait.add_argument("--interval-s", type=float, default=30.0)
+
+    sub.add_parser("list", help="list this module's still-registered tasks")
+    return p
+
+
+def _strip_separator(argv: list[str]) -> list[str]:
+    return argv[1:] if argv and argv[0] == "--" else argv
+
+
+def main(raw_args: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(raw_args)
+    try:
+        if args.command == "start":
+            harness_argv = _strip_separator(list(args.argv))
+            if not harness_argv:
+                raise RemoteLaunchError("no harness argv given (pass it after `--`)")
+            run = start_run(harness_argv, label=args.label)
+            print(json.dumps(run.to_dict(), indent=2))
+            if args.wait_timeout_s is None:
+                return 0
+            status = wait_for_run(run, timeout_s=args.wait_timeout_s)
+            print(json.dumps(status, indent=2, default=str))
+            if status.get("timed_out"):
+                return 2
+            if not args.keep_task:
+                print(json.dumps(cleanup_run(run), indent=2, default=str))
+            return 0 if status.get("exit_code") == 0 else 1
+        if args.command == "poll":
+            print(
+                json.dumps(poll_run(load_run(args.run_id), tail=args.tail), indent=2, default=str)
+            )
+            return 0
+        if args.command == "wait":
+            status = wait_for_run(
+                load_run(args.run_id), timeout_s=args.timeout_s, interval_s=args.interval_s
+            )
+            print(json.dumps(status, indent=2, default=str))
+            return 2 if status.get("timed_out") else (0 if status.get("exit_code") == 0 else 1)
+        if args.command == "cleanup":
+            print(
+                json.dumps(
+                    cleanup_run(load_run(args.run_id), force=args.force), indent=2, default=str
+                )
+            )
+            return 0
+        if args.command == "list":
+            print(json.dumps(list_stale_tasks(), indent=2))
+            return 0
+    except RemoteLaunchError as exc:
+        print(f"remote-launcher: {exc}", file=sys.stderr)
+        return 3
+    return 3
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI glue
+    raise SystemExit(main())

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -592,19 +592,22 @@ def poll_run(run: RemoteRun, *, tail: int = 30) -> dict[str, Any]:
     Never touches AC and never deletes the task — a poll must be safe to run in a tight loop.
     """
     queried = _run(["schtasks", "/query", "/tn", run.task, "/fo", "list", "/v"])
-    sentinel = run.directory / SENTINEL_NAME
-    exit_code = (
-        parse_sentinel(sentinel.read_text(encoding="utf-8", errors="replace"))
-        if sentinel.is_file()
-        else None
-    )
+    # Single sentinel reader: a permission/sharing error on wrapper.log must not abort a poll (and
+    # therefore cleanup, which polls first) with a traceback.
+    exit_code = _sentinel_exit_code(run.directory)
+    verified, verified_reason = task_deletion_verdict(run.task, run.directory)
     acs = _run(["tasklist", "/fi", "imagename eq acs.exe", "/nh"])
     return {
         "run_id": run.run_id,
         "task": run.task,
         "task_query_rc": queried.returncode,
         **parse_task_status(queried.stdout),
+        # `finished` is the RAW sentinel signal, kept for diagnosis. `verified_complete` is the
+        # strict one (sentinel + known-dead status + a Last Result showing it actually ran) and is
+        # what anything acting on the run must use — a peer can write into the scratch tree.
         "finished": exit_code is not None,
+        "verified_complete": verified,
+        "verified_reason": verified_reason,
         "exit_code": exit_code,
         "acs_running": "acs.exe" in acs.stdout.lower(),
         "rig_lock_owner": read_rig_session_owner(default_rig_session_lock_path()),
@@ -623,6 +626,9 @@ def wait_for_run(
 ) -> dict[str, Any]:
     """Block until the wrapper writes its exit sentinel, or the bounded deadline passes.
 
+    Completion is the same strict predicate :func:`cleanup_run` and :func:`reap_tasks` use, not the
+    bare presence of an exit sentinel.
+
     The wait is bounded on purpose: when the run never starts the sentinel never appears, and an
     unbounded loop would hang forever with no diagnosis.
     """
@@ -637,7 +643,10 @@ def wait_for_run(
     deadline = monotonic() + timeout_s
     while True:
         status = poll_run(run)
-        if status["finished"]:
+        # NOT `finished`: that is the raw sentinel, which a peer sharing this rig's writable
+        # .scratch tree can plant — making an unattended `start --wait-timeout-s` exit 0 while the
+        # /IT task is still launching. cleanup/reap already refuse that; the wait must too.
+        if status["verified_complete"]:
             return status
         if monotonic() >= deadline:
             status["timed_out"] = True
@@ -930,9 +939,16 @@ def main(raw_args: Sequence[str] | None = None) -> int:
             print(json.dumps(status, indent=2, default=str))
             if status.get("timed_out"):
                 return 2
+            rc = 0 if status.get("exit_code") == 0 else 1
             if not args.keep_task:
-                print(json.dumps(cleanup_run(run), indent=2, default=str))
-            return 0 if status.get("exit_code") == 0 else 1
+                cleaned = cleanup_run(run)
+                print(json.dumps(cleaned, indent=2, default=str))
+                # A refused or failed cleanup leaves a live task registration behind. On the
+                # unattended path that must be visible in the exit code, exactly as the standalone
+                # cleanup command reports it.
+                if not cleaned.get("deleted") or cleaned.get("delete_rc", 0) != 0:
+                    rc = rc or 1
+            return rc
         if args.command == "poll":
             print(
                 json.dumps(poll_run(load_run(args.run_id), tail=args.tail), indent=2, default=str)

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -217,6 +217,29 @@ def quote_wrapper_token(token: str) -> str:
     return f'"{token}"'
 
 
+#: Placeholders a caller may use in the harness argv; substituted before token validation so the
+#: payload can name the same run the transport does (e.g. ``--evidence-dir …/{run_id}``).
+RUN_ID_PLACEHOLDER = "{run_id}"
+RUN_DIR_PLACEHOLDER = "{run_dir}"
+
+
+def substitute_run_placeholders(argv: Sequence[str], *, run_id: str, run_dir: Path) -> list[str]:
+    """Resolve ``{run_id}`` / ``{run_dir}`` in the harness argv.
+
+    Without this the payload is blind to the transport's run id: transport logs land under
+    ``.scratch/harness-remote/<run id>/`` while the harness picks its own evidence directory name,
+    so a crash in ``stderr.log`` cannot be correlated with the in-sim evidence it belongs to. (The
+    PowerShell runbook this module replaced linked them by hand with ``--evidence-dir "$rel"``.)
+
+    Substitution happens **before** :func:`validate_wrapper_token`, so the resolved value is
+    validated like any other token rather than trusted for having come from us.
+    """
+    return [
+        token.replace(RUN_ID_PLACEHOLDER, run_id).replace(RUN_DIR_PLACEHOLDER, str(run_dir))
+        for token in argv
+    ]
+
+
 def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
     """Render the ``.cmd`` Task Scheduler executes in the console session.
 
@@ -236,6 +259,8 @@ def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
         "rem Redirected Python is fully buffered; without this the poll surface looks hung for\r\n"
         "rem minutes on a healthy run.\r\n"
         "set PYTHONUNBUFFERED=1\r\n"
+        # Correlation handle for anything that reads the environment rather than argv.
+        f"set AC_HARNESS_REMOTE_RUN_ID={run_dir.name}\r\n"
         f'".venv\\Scripts\\python.exe" -u {tokens} > "{stdout_path}" 2> "{stderr_path}"\r\n'
         f'echo [wrapper] {SENTINEL_TOKEN}%ERRORLEVEL% >> "{sentinel_path}"\r\n'
     )
@@ -433,8 +458,9 @@ def start_run(
     run_dir = root.joinpath(*RUN_DIR_RELPATH, run_id)
     run_dir.mkdir(parents=True, exist_ok=True)
 
+    resolved_argv = substitute_run_placeholders(argv, run_id=run_id, run_dir=run_dir)
     wrapper = run_dir / WRAPPER_NAME
-    wrapper.write_text(render_wrapper(root, argv, run_dir), encoding="ascii", newline="")
+    wrapper.write_text(render_wrapper(root, resolved_argv, run_dir), encoding="ascii", newline="")
 
     task = task_name_for(run_id)
     account = run_as or os.environ.get("USERNAME") or ""
@@ -460,7 +486,7 @@ def start_run(
         task=task,
         repo_root=str(root),
         run_dir=str(run_dir),
-        argv=list(argv),
+        argv=list(resolved_argv),
         started_at=moment.isoformat(timespec="seconds"),
     )
     (run_dir / RUN_JSON_NAME).write_text(
@@ -578,6 +604,30 @@ def wait_for_run(
         sleep(min(interval_s, max(0.0, deadline - monotonic())))
 
 
+def _await_deletion_verdict(
+    name: str,
+    run_dir: Path,
+    *,
+    attempts: int = 4,
+    delay_s: float = 2.0,
+    sleep=time.sleep,  # noqa: ANN001 - injectable clock for tests
+) -> tuple[bool, str]:
+    """:func:`task_deletion_verdict` with a short retry for the end-of-wrapper race.
+
+    Immediately after ``wait_for_run`` returns, the sentinel exists but Task Scheduler may still
+    report ``Running`` for a moment while it reaps the wrapper. That is a legitimate transient, not
+    a live peer — so retry briefly rather than refusing a caller who did everything right.
+    """
+    reason = ""
+    for attempt in range(attempts):
+        ok, reason = task_deletion_verdict(name, run_dir)
+        if ok:
+            return True, ""
+        if attempt < attempts - 1:
+            sleep(delay_s)
+    return False, reason
+
+
 def cleanup_run(run: RemoteRun, *, force: bool = False) -> dict[str, Any]:
     """Delete the task once the wrapper has logged its exit code.
 
@@ -595,8 +645,14 @@ def cleanup_run(run: RemoteRun, *, force: bool = False) -> dict[str, Any]:
             f"(expected {expected!r}) — run.json may have been edited or points at a peer's task"
         )
     status = poll_run(run, tail=0)
-    if not status["finished"] and not force:
-        return {"deleted": False, "reason": "run has not written its exit sentinel", **status}
+    if not force:
+        # Historically this required only the exit sentinel, which made it the WEAKER path than
+        # reap despite the docs claiming the reverse: wrapper.log lives in the same agent-writable
+        # tree run.json does, so a planted sentinel while the task was still Running would delete a
+        # live /IT task and kill its console-session process tree. One shared rule now.
+        ok, reason = _await_deletion_verdict(run.task, run.directory)
+        if not ok:
+            return {"deleted": False, "reason": reason, **status}
     deleted = _run(["schtasks", "/delete", "/tn", run.task, "/f"])
     return {"deleted": deleted.returncode == 0, "delete_rc": deleted.returncode, **status}
 
@@ -619,6 +675,55 @@ def list_stale_tasks() -> list[str]:
 #: this set only as a *secondary* signal: it is emphatically **not** proof of completion (see
 #: :func:`reap_tasks`), which is why the sentinel check below is the primary gate.
 _KNOWN_DEAD_TASK_STATES = {"ready", "disabled"}
+#: ``Last Result`` values from ``schtasks``. ``Ready`` alone cannot distinguish "finished" from
+#: "created but never started", so the *result* code separates them: a never-run task reports
+#: ``SCHED_S_TASK_HAS_NOT_YET_RUN``. (``267009`` — currently running — was observed live on this
+#: rig mid-drive.) Deliberately NOT compared against the wrapper's own exit code: the wrapper's
+#: last command is ``echo``, so ``Last Result`` can be 0 while the harness rc was not.
+SCHED_S_TASK_HAS_NOT_YET_RUN = 267011
+SCHED_S_TASK_IS_CURRENTLY_RUNNING = 267009
+
+
+def _sentinel_exit_code(run_dir: Path) -> int | None:
+    """The wrapper's recorded exit code, or ``None`` when the run has not finished."""
+    sentinel = run_dir / SENTINEL_NAME
+    if not sentinel.is_file():
+        return None
+    return parse_sentinel(sentinel.read_text(encoding="utf-8", errors="replace"))
+
+
+def task_deletion_verdict(name: str, run_dir: Path) -> tuple[bool, str]:
+    """May this task be deleted? Returns ``(ok, reason_when_not)``. **Fails closed.**
+
+    Both :func:`cleanup_run` and :func:`reap_tasks` go through here so there is exactly one rule,
+    and it is the strict one. Three independent things must all hold:
+
+    1. **The wrapper wrote its exit sentinel.** ``schtasks /run`` is asynchronous, so nothing about
+       the task's own state proves the run reached its end.
+    2. **The task reports a known non-live status.** An unreadable, missing, or unrecognised status
+       is *not* permission — a guard that fail-opens on a transient query failure removes a live
+       peer task at the one moment the evidence is missing.
+    3. **The task has actually executed.** ``Ready`` covers *both* the pre-spawn window and
+       completion, so a sentinel planted in the writable scratch tree during the pre-spawn window
+       would otherwise authorise deleting a peer's task before it ever ran.
+    """
+    if _sentinel_exit_code(run_dir) is None:
+        return False, f"no exit sentinel at {run_dir / SENTINEL_NAME} — may still be launching"
+    queried = _run(["schtasks", "/query", "/tn", name, "/fo", "list", "/v"])
+    if queried.returncode != 0:
+        return False, f"status query failed (rc={queried.returncode}) — failing closed"
+    fields = parse_task_status(queried.stdout)
+    state = fields.get("status", "").strip().lower()
+    if state not in _KNOWN_DEAD_TASK_STATES:
+        return False, f"status {state!r} is not a known non-live state — failing closed"
+    raw_result = fields.get("last_result", "").strip()
+    try:
+        last_result = int(raw_result, 0)
+    except ValueError:
+        return False, f"last result {raw_result!r} unreadable — failing closed"
+    if last_result in (SCHED_S_TASK_HAS_NOT_YET_RUN, SCHED_S_TASK_IS_CURRENTLY_RUNNING):
+        return False, "task has not yet run (pre-spawn Ready window) — refusing to cancel a launch"
+    return True, ""
 
 
 def _run_dir_for_task(name: str, root: Path) -> Path | None:
@@ -664,23 +769,9 @@ def reap_tasks(*, repo_root: Path | None = None, force: bool = False) -> dict[st
             if run_dir is None:
                 results[name] = {"deleted": False, "skipped": "task name is not a valid run id"}
                 continue
-            sentinel = run_dir / SENTINEL_NAME
-            finished = sentinel.is_file() and (
-                parse_sentinel(sentinel.read_text(encoding="utf-8", errors="replace")) is not None
-            )
-            if not finished:
-                results[name] = {
-                    "deleted": False,
-                    "skipped": f"no exit sentinel at {sentinel} — may still be launching",
-                }
-                continue
-            queried = _run(["schtasks", "/query", "/tn", name, "/fo", "list", "/v"])
-            state = parse_task_status(queried.stdout).get("status", "").strip().lower()
-            if queried.returncode != 0 or state not in _KNOWN_DEAD_TASK_STATES:
-                results[name] = {
-                    "deleted": False,
-                    "skipped": f"status unknown (rc={queried.returncode}, status={state!r})",
-                }
+            ok, reason = task_deletion_verdict(name, run_dir)
+            if not ok:
+                results[name] = {"deleted": False, "skipped": reason}
                 continue
         deleted = _run(["schtasks", "/delete", "/tn", name, "/f"])
         results[name] = {"deleted": deleted.returncode == 0, "rc": deleted.returncode}
@@ -723,8 +814,9 @@ def build_parser() -> argparse.ArgumentParser:
         "argv",
         nargs=argparse.REMAINDER,
         help=(
-            "harness argv after `--`, without the interpreter "
-            "(e.g. -m tools.ac_harness.auto_alien --car … --track …)"
+            "harness argv after `--`, without the interpreter (e.g. -m "
+            "tools.ac_harness.auto_alien --car … --track …). {run_id}/{run_dir} are substituted, "
+            "so --evidence-dir .scratch/harness-evidence/{run_id} correlates payload with transport"
         ),
     )
 
@@ -792,11 +884,12 @@ def main(raw_args: Sequence[str] | None = None) -> int:
             print(json.dumps(status, indent=2, default=str))
             return 2 if status.get("timed_out") else (0 if status.get("exit_code") == 0 else 1)
         if args.command == "cleanup":
-            print(
-                json.dumps(
-                    cleanup_run(load_run(args.run_id), force=args.force), indent=2, default=str
-                )
-            )
+            outcome = cleanup_run(load_run(args.run_id), force=args.force)
+            print(json.dumps(outcome, indent=2, default=str))
+            # A refusal ("still launching", "status unknown") and a failed `schtasks /delete` are
+            # both outcomes automation must be able to see from the exit code alone.
+            if not outcome.get("deleted") or outcome.get("delete_rc", 0) != 0:
+                return 1
             return 0
         if args.command == "list":
             print(json.dumps(list_stale_tasks(), indent=2))

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -544,6 +544,7 @@ def start_run(
     now: datetime | None = None,
     run_as: str | None = None,
     start_delay_minutes: int = DEFAULT_START_DELAY_MINUTES,
+    sleep=time.sleep,  # noqa: ANN001 - injectable for tests
 ) -> RemoteRun:
     """Create and start a per-run console-session task for ``argv``; returns its handle."""
     assert_transport_needed()
@@ -572,8 +573,11 @@ def start_run(
 
     resolved_argv = substitute_run_placeholders(argv, run_id=run_id, run_dir=run_dir)
     validate_wrapper_path("repo root", root)
-    for token in resolved_argv:
-        validate_wrapper_token(token)
+    # Validate at the boundary where the caller can still be told. Previously only
+    # execute_control_file() applied the module allowlist, so `start -- -c print(1)` created a
+    # control file, registered AND ran a task, and returned exit 0 — the rejection arrived later,
+    # in the console session, where nobody was listening.
+    resolved_argv = validate_payload_argv(resolved_argv)
     control = control_dir_for(run_id)
     control.mkdir(parents=True, exist_ok=True)
     (control / CONTROL_NAME).write_text(
@@ -599,25 +603,22 @@ def start_run(
         )
     started = _run(["schtasks", "/run", "/tn", task])
     if started.returncode != 0:
-        _run(["schtasks", "/delete", "/tn", task, "/f"])
-        raise RemoteLaunchError(
-            f"schtasks /run failed ({started.returncode}): {started.stdout}{started.stderr}"
-        )
+        # /run failed, so nothing was launched and deleting cannot abort a live payload. The delete
+        # itself must be checked though: a task left registered keeps its one-shot trigger armed and
+        # fires ~start_delay later with no handle for anyone to poll or clean up.
+        removed = _run(["schtasks", "/delete", "/tn", task, "/f"])
+        detail = f"schtasks /run failed ({started.returncode}): {started.stdout}{started.stderr}"
+        if removed.returncode != 0:
+            detail += (
+                f" — AND the cleanup delete failed ({removed.returncode}), so task {task!r} is "
+                f"still registered with its one-shot trigger ARMED and will fire around "
+                f"{when:%Y-%m-%d %H:%M}. Remove it by hand."
+            )
+        raise RemoteLaunchError(detail)
     # Disable the trigger now that the on-demand start has happened. `/sc once` is a REAL trigger:
     # left armed, it fires at its scheduled time and executes the payload a second time if the run
     # already finished. Disabling removes that class outright — no filesystem marker can do it,
     # because every marker lives somewhere a peer can write. A running instance is unaffected.
-    disabled = _run(["schtasks", "/change", "/tn", task, "/disable"])
-    if disabled.returncode != 0:
-        # Proceeding here would hand back a "successful" start with the `/sc once` trigger still
-        # armed — i.e. a second AC session and truncated logs ~start_delay later. Fail closed.
-        _run(["schtasks", "/delete", "/tn", task, "/f"])
-        raise RemoteLaunchError(
-            f"schtasks /change /disable failed ({disabled.returncode}): "
-            f"{(disabled.stderr or disabled.stdout or '').strip()[:200]} — refusing to start with "
-            "the one-shot trigger still armed"
-        )
-
     run = RemoteRun(
         run_id=run_id,
         task=task,
@@ -629,6 +630,25 @@ def start_run(
     (run_dir / RUN_JSON_NAME).write_text(
         json.dumps(run.to_dict(), indent=2) + "\n", encoding="utf-8"
     )
+
+    # The payload is now LIVE. Disabling the one-shot trigger is still required, but a failure here
+    # must NOT be "cleaned up" by deleting the task: this module documents that /run is asynchronous
+    # and that deleting the definition can cancel a start still spawning — so the old fail-closed
+    # delete could abort the very run it had just launched, while reporting the start as failed.
+    # Retry, then surface the armed trigger loudly and leave the run (and its handle) intact.
+    disabled = _run(["schtasks", "/change", "/tn", task, "/disable"])
+    if disabled.returncode != 0:
+        sleep(2.0)
+        disabled = _run(["schtasks", "/change", "/tn", task, "/disable"])
+    if disabled.returncode != 0:
+        raise RemoteLaunchError(
+            f"schtasks /change /disable failed ({disabled.returncode}): "
+            f"{(disabled.stderr or disabled.stdout or '').strip()[:200]} — the run is ALREADY "
+            f"RUNNING and its handle is at {run_dir / RUN_JSON_NAME}, so the task was NOT deleted "
+            f"(that would abort it). The one-shot trigger is still ARMED and will re-fire around "
+            f"{when:%Y-%m-%d %H:%M}: disable or delete task {task!r} before then."
+        )
+
     return run
 
 

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -114,12 +114,22 @@ _WRAPPER_TOKEN_RE = re.compile(r"^[ !#$()*+,\-./0-9:;=?@A-Z\[\]_a-z{}~\\]+$")
 #: pointing where they were meant to.
 _WRAPPER_PATH_FORBIDDEN = set('%"<>&|^\r\n\t')
 
-#: The ONLY payload shape this transport will run. Token-level validation is not enough: argv
-#: reaches the interpreter as a JSON string list, so no shell quoting is needed and `-c` plus a
-#: bare expression (`;`, `()`, `+`, `chr(...)`) — or a plain script path — would be console-session
-#: RCE from a tampered control file. The transport exists to run harness modules; anything else
-#: fails closed.
-_ALLOWED_PAYLOAD_MODULE_RE = re.compile(r"^tools\.ac_harness\.[A-Za-z0-9_]+$")
+#: The ONLY payload modules this transport will run — an explicit set, not a namespace pattern.
+#:
+#: A pattern like ``tools.ac_harness.<ident>`` looked tight but left the transport able to schedule
+#: **itself**: ``-m tools.ac_harness.remote_launcher reap --force`` would delete a peer's live /IT
+#: task, and ``-m tools.ac_harness._remote_exec <other-run-id>`` would execute a different run's
+#: control file. Blocking `-c` while leaving those reachable is a confused deputy, so the transport
+#: and its shim are excluded by construction here.
+_ALLOWED_PAYLOAD_MODULES = frozenset(
+    {
+        "tools.ac_harness.auto_alien",
+        "tools.ac_harness.auto_drive",
+        "tools.ac_harness.plant_id",
+        "tools.ac_harness.alien_scientist",
+        "tools.ac_harness.corner_refine",
+    }
+)
 #: Exit code recorded when the console-session shim itself fails before/around the payload, so a
 #: broken run reports a real failure instead of leaving poll/wait hanging until their deadline.
 EXEC_FAILURE_RC = 253
@@ -238,10 +248,12 @@ def validate_payload_argv(argv: Sequence[str]) -> list[str]:
             f"payload argv must start with '-m <module>' (got {tokens[:2]!r}) — the transport runs "
             "harness modules, never -c, stdin, or a script path"
         )
-    if not _ALLOWED_PAYLOAD_MODULE_RE.match(tokens[1]):
+    if tokens[1] not in _ALLOWED_PAYLOAD_MODULES:
         raise RemoteLaunchError(
-            f"module {tokens[1]!r} is not an allowlisted harness module "
-            "(expected tools.ac_harness.<name>)"
+            f"module {tokens[1]!r} is not an allowlisted payload module. Allowed: "
+            + ", ".join(sorted(_ALLOWED_PAYLOAD_MODULES))
+            + " — the transport and its shim are deliberately excluded so a tampered control file "
+            "cannot turn this into `reap --force` against a peer's live task."
         )
     return tokens
 
@@ -581,27 +593,32 @@ def start_run(
         pid=os.getpid(),
         nonce=random.randrange(1000, 9999),  # noqa: S311
     )
+    validate_wrapper_path("repo root", root)
+    # Validate BEFORE creating anything on disk. Rejecting at the boundary is what lets the caller
+    # be told, and doing it after mkdir left an orphan run directory behind for every rejected
+    # argv — a simple operator typo accumulated scratch state. Placeholders can only appear in
+    # later arguments, so the `-m <allowlisted module>` shape is checkable on the raw argv here;
+    # the substituted form is re-validated below.
+    validate_payload_argv(argv)
+
     run_dir = root.joinpath(*RUN_DIR_RELPATH, run_id)
     # exist_ok=False on purpose: a per-run id should never collide, and REUSING a directory would
-    # inherit whatever markers it already holds (a stale or planted sentinel), which is exactly the
-    # vector the wrapper's start-marker guard exists to close. A collision is a loud error.
+    # inherit whatever markers it already holds (a stale or planted sentinel). A collision is a
+    # loud error. EVERY OSError is converted — main() only catches RemoteLaunchError, so a bare
+    # PermissionError would hand automation a traceback instead of the documented exit code.
     try:
         run_dir.mkdir(parents=True, exist_ok=False)
     except FileExistsError as exc:
-        # main() only catches RemoteLaunchError; a bare FileExistsError would crash the CLI with a
-        # traceback instead of the documented exit code.
         raise RemoteLaunchError(
             f"run directory {run_dir} already exists — refusing to reuse it (it could carry a "
             "stale or planted control/sentinel state)"
         ) from exc
+    except OSError as exc:
+        raise RemoteLaunchError(f"cannot create run directory {run_dir}: {exc}") from exc
 
-    resolved_argv = substitute_run_placeholders(argv, run_id=run_id, run_dir=run_dir)
-    validate_wrapper_path("repo root", root)
-    # Validate at the boundary where the caller can still be told. Previously only
-    # execute_control_file() applied the module allowlist, so `start -- -c print(1)` created a
-    # control file, registered AND ran a task, and returned exit 0 — the rejection arrived later,
-    # in the console session, where nobody was listening.
-    resolved_argv = validate_payload_argv(resolved_argv)
+    resolved_argv = validate_payload_argv(
+        substitute_run_placeholders(argv, run_id=run_id, run_dir=run_dir)
+    )
     control = control_dir_for(run_id)
     control.mkdir(parents=True, exist_ok=True)
     (control / CONTROL_NAME).write_text(
@@ -852,9 +869,11 @@ def _discard_control_dir(run_id: str) -> None:
     # peer-planted content in a directory this module itself documents as peer-writable, and
     # `ignore_errors=True` would swallow the very failure that means the leak is still there.
     for name in (CONTROL_NAME, SENTINEL_NAME):
-        with contextlib.suppress(FileNotFoundError):
+        # Best-effort by design: a PermissionError / sharing violation here must not turn a
+        # successful task deletion into a traceback out of cleanup or a reap pass.
+        with contextlib.suppress(OSError):
             (control / name).unlink()
-    with contextlib.suppress(FileNotFoundError, OSError):
+    with contextlib.suppress(OSError):
         control.rmdir()  # refuses if anything unexpected remains — deliberately not forced
 
 

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -76,7 +76,6 @@ RUN_DIR_RELPATH = (".scratch", "harness-remote")
 #: Every task this module creates is named ``ac-harness-<run id>`` so a stale one is reapable by
 #: prefix without touching unrelated scheduled tasks.
 TASK_PREFIX = "ac-harness-"
-WRAPPER_NAME = "run.cmd"
 STDOUT_NAME = "stdout.log"
 STDERR_NAME = "stderr.log"
 #: The wrapper appends ``[wrapper] exit=<rc>`` as its last act. Its presence — not the task's
@@ -85,9 +84,13 @@ STDERR_NAME = "stderr.log"
 SENTINEL_NAME = "wrapper.log"
 SENTINEL_TOKEN = "exit="
 RUN_JSON_NAME = "run.json"
-#: Written by the wrapper immediately BEFORE the payload, so it is evidence the payload actually
-#: started — which a bare exit sentinel is not (that file is plantable in the shared scratch tree).
-STARTED_NAME = "run.started"
+#: Control file (the argv Task Scheduler will run) kept OUT of the repo's shared `.scratch` tree —
+#: that tree is checked out per worktree, trivially discoverable, and the module already treats it
+#: as untrusted. This lives beside the rig lock instead. Same-user isolation is not achievable on
+#: this rig (every agent runs as the logged-on account), so this reduces exposure rather than
+#: eliminating it; the real protection is that `_remote_exec` re-validates every token and spawns
+#: without a shell.
+CONTROL_NAME = "control.json"
 
 #: ``/sd`` format measured as the only accepted one on the rig (see the module docstring).
 SCHTASKS_DATE_FORMAT = "%m/%d/%Y"
@@ -98,14 +101,11 @@ DEFAULT_START_DELAY_MINUTES = 5
 
 #: Run-id / task-name alphabet: safe as a Windows path component *and* a Task Scheduler name.
 _RUN_COMPONENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
-#: Tokens interpolated into the generated ``.cmd``. Excludes the cmd metacharacters that survive
-#: quoting (``%`` expands even inside double quotes) and the quote character itself (it would close
-#: the quoting :func:`quote_wrapper_token` adds), plus everything outside printable ASCII.
-#:
-#: ``(`` and ``)`` ARE allowed even though they are cmd grouping metacharacters: AC setup names
-#: legitimately contain them (``auto_drive._SETUP_NAME_RE``), so rejecting them would fail-close a
-#: valid ``--setup``. They are made inert by :func:`quote_wrapper_token`, which quotes **every**
-#: token — inside double quotes ``(``/``)``/``!``/``^`` are literal.
+#: Argv tokens accepted for the payload. The transport no longer builds a shell string — the
+#: payload is spawned with ``shell=False`` — so this is defence in depth rather than quoting: it
+#: keeps a tampered control file from smuggling anything exotic past
+#: :func:`execute_control_file`'s re-validation. ``(``/``)`` stay allowed because AC setup names
+#: legitimately contain them (``auto_drive._SETUP_NAME_RE``).
 _WRAPPER_TOKEN_RE = re.compile(r"^[ !#$()*+,\-./0-9:;=?@A-Z\[\]_a-z{}~\\]+$")
 #: Characters that must never appear in a path interpolated into the wrapper. ``%`` expands inside
 #: double quotes, and ``"`` breaks out of them — both are legal ASCII in a Windows path, so an
@@ -114,6 +114,20 @@ _WRAPPER_TOKEN_RE = re.compile(r"^[ !#$()*+,\-./0-9:;=?@A-Z\[\]_a-z{}~\\]+$")
 _WRAPPER_PATH_FORBIDDEN = set('%"<>&|^\r\n\t')
 
 _INVALID_SESSION = 0xFFFFFFFF
+
+
+def control_dir_for(run_id: str, *, local_app_data: str | Path | None = None) -> Path:
+    """Where a run's control file and exit sentinel live — **outside** the repo's scratch tree.
+
+    ``.scratch`` is checked out per worktree, trivially discoverable, and this module already treats
+    it as untrusted (forged ``run.json``, planted sentinels). Keeping the *control plane* there is
+    what let a peer replace the scheduled command outright. Same-user isolation is not achievable on
+    this rig — every agent runs as the logged-on account — so this reduces exposure rather than
+    eliminating it; the hard part is done by :func:`execute_control_file`, which re-validates every
+    token and spawns without a shell.
+    """
+    base = default_rig_session_lock_path(local_app_data=local_app_data).parent
+    return base / "remote" / validate_run_component("run id", run_id)
 
 
 class RemoteLaunchError(RuntimeError):
@@ -179,13 +193,12 @@ def build_run_id(
 
 
 def _reject_trailing_backslash(kind: str, text: str) -> None:
-    """Reject a trailing ``\\`` — it escapes the closing quote in the Windows CRT argv parser.
+    """Reject a trailing ``\\``.
 
-    :func:`quote_wrapper_token` wraps every token as ``"<token>"``. The CRT parser that builds
-    ``argv`` for ``python.exe`` treats ``\\"`` as an *escaped quote*, so a token ending in a
-    backslash does not close its quoted region: the argument swallows what follows and the harness
-    receives something other than what was validated. Windows paths and AC ids never need a trailing
-    separator, so refusing is cheaper than a doubling routine and cannot silently mis-quote.
+    Kept after the move off a generated ``.cmd``: the Windows CRT argv parser still treats ``\\"``
+    as an escaped quote wherever a value is later re-quoted (``schtasks /tr``, any downstream tool),
+    and Windows paths and AC ids never need a trailing separator — so refusing costs nothing and
+    removes a whole class of mis-parse.
     """
     if text.endswith("\\"):
         raise RemoteLaunchError(
@@ -205,19 +218,6 @@ def validate_wrapper_token(token: str) -> str:
             "cmd metacharacters (& | < > ^ %) may reach the generated .cmd"
         )
     return token
-
-
-def quote_wrapper_token(token: str) -> str:
-    """Quote a validated token for ``cmd.exe``.
-
-    **Every** token is quoted, not just the ones containing spaces. A space-free token can still
-    carry cmd grouping metacharacters — ``(dir)`` would change how Task Scheduler parses the
-    generated line rather than being passed through to Python. Inside double quotes those become
-    literal, and the Windows CRT strips the quotes before ``argv`` reaches the interpreter, so the
-    harness sees exactly the token that was validated. The quote character itself is excluded by
-    :data:`_WRAPPER_TOKEN_RE`, so this cannot be closed early.
-    """
-    return f'"{token}"'
 
 
 #: Placeholders a caller may use in the harness argv; substituted before token validation so the
@@ -241,51 +241,6 @@ def substitute_run_placeholders(argv: Sequence[str], *, run_id: str, run_dir: Pa
         token.replace(RUN_ID_PLACEHOLDER, run_id).replace(RUN_DIR_PLACEHOLDER, str(run_dir))
         for token in argv
     ]
-
-
-def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
-    """Render the ``.cmd`` Task Scheduler executes in the console session.
-
-    ``argv`` is the harness command *without* the interpreter: ``["-m", "tools.ac_harness.…", …]``.
-    The wrapper redirects its own streams so the polling SSH session only ever *reads* files, and
-    appends the exit sentinel as its last act.
-    """
-    validate_wrapper_path("repo root", repo_root)
-    validate_wrapper_path("run directory", run_dir)
-    tokens = " ".join(quote_wrapper_token(validate_wrapper_token(a)) for a in argv)
-    stdout_path = run_dir / STDOUT_NAME
-    stderr_path = run_dir / STDERR_NAME
-    sentinel_path = run_dir / SENTINEL_NAME
-    started_path = run_dir / STARTED_NAME
-    return (
-        "@echo off\r\n"
-        f'cd /d "{repo_root}"\r\n'
-        # `/run` starts this on demand, but the `/sc once` trigger `/create` insists on is REAL and
-        # still fires at its scheduled time. A run that finished before that moment would execute a
-        # SECOND time — `>` truncates, so the ghost silently destroys the first run's stdout/stderr
-        # and overwrites its in-sim evidence while the agent is polling or disconnected. The
-        # sentinel only exists once the wrapper has completed, so it is the exact idempotency key.
-        # (A trigger that fires *during* the first run is already suppressed by Task Scheduler's
-        # default "do not start a new instance" policy; this covers the after-completion case.)
-        # Suppression requires BOTH markers. Keying only on the exit sentinel would let a peer
-        # plant `[wrapper] exit=0` between /run and the wrapper body and turn the whole task into a
-        # no-op that still reports Ready + Last Result 0 — i.e. `start --wait` returning success
-        # without the harness ever launching. `run.started` is written by the wrapper itself just
-        # before the payload, so requiring it means suppression rests on evidence the payload ran
-        # at least once. A lone planted sentinel no longer stops execution, and the real run
-        # appends its own `exit=` afterwards, which is the one parse_sentinel reads.
-        f'if exist "{started_path}" if exist "{sentinel_path}" '
-        f'echo [wrapper] ghost trigger suppressed>>"{sentinel_path}"\r\n'
-        f'if exist "{started_path}" if exist "{sentinel_path}" exit /b 0\r\n'
-        f'echo [wrapper] started>"{started_path}"\r\n'
-        "rem Redirected Python is fully buffered; without this the poll surface looks hung for\r\n"
-        "rem minutes on a healthy run.\r\n"
-        "set PYTHONUNBUFFERED=1\r\n"
-        # Correlation handle for anything that reads the environment rather than argv.
-        f"set AC_HARNESS_REMOTE_RUN_ID={run_dir.name}\r\n"
-        f'".venv\\Scripts\\python.exe" -u {tokens} > "{stdout_path}" 2> "{stderr_path}"\r\n'
-        f'echo [wrapper] {SENTINEL_TOKEN}%ERRORLEVEL% >> "{sentinel_path}"\r\n'
-    )
 
 
 def task_name_for(run_id: str) -> str:
@@ -348,7 +303,10 @@ def parse_sentinel(text: str) -> int | None:
             try:
                 return int(tail)
             except ValueError:
-                return None
+                # Keep scanning older lines. Returning None here let a single garbled (or planted)
+                # trailing `exit=` hide a real one, so wait/cleanup would believe a finished run
+                # never ended — blocking non-force cleanup and reap until timeout.
+                continue
     return None
 
 
@@ -465,6 +423,50 @@ def short_path(path: Path) -> str:
     return resolved
 
 
+def execute_control_file(run_id: str) -> int:
+    """Run a prepared payload in the console session. Invoked by ``_remote_exec`` via ``/tr``.
+
+    Everything load-bearing is **recomputed** from the validated run id rather than trusted from the
+    control file: the interpreter, the working directory, the log paths and the sentinel path. Only
+    the argv and the repo root come from disk, and both are re-validated here — so even a tampered
+    control file cannot inject a command, only fail closed. The payload is spawned with
+    ``shell=False``.
+    """
+    requested = validate_run_component("run id", run_id)
+    control = control_dir_for(requested) / CONTROL_NAME
+    try:
+        payload = json.loads(control.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise RemoteLaunchError(f"unreadable control file {control}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RemoteLaunchError(f"control file {control} is not an object")
+    repo_root = validate_wrapper_path("repo root", Path(str(payload.get("repo_root", ""))))
+    argv = [validate_wrapper_token(str(t)) for t in payload.get("argv", [])]
+    if not argv:
+        raise RemoteLaunchError(f"control file {control} carries no argv")
+
+    run_dir = repo_root.joinpath(*RUN_DIR_RELPATH, requested)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    interpreter = repo_root / ".venv" / "Scripts" / "python.exe"
+    env = dict(os.environ, PYTHONUNBUFFERED="1", AC_HARNESS_REMOTE_RUN_ID=requested)
+    with (
+        (run_dir / STDOUT_NAME).open("w", encoding="utf-8", errors="replace") as out,
+        (run_dir / STDERR_NAME).open("w", encoding="utf-8", errors="replace") as err,
+    ):
+        completed = subprocess.run(  # noqa: S603 - validated argv, shell=False, fixed interpreter
+            [str(interpreter), "-u", *argv],
+            cwd=str(repo_root),
+            stdout=out,
+            stderr=err,
+            env=env,
+            check=False,
+        )
+    sentinel = control_dir_for(requested) / SENTINEL_NAME
+    with sentinel.open("a", encoding="utf-8") as fh:
+        fh.write(f"[wrapper] {SENTINEL_TOKEN}{completed.returncode}\n")
+    return completed.returncode
+
+
 def _run(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603 - fixed argv, no shell
         list(argv), capture_output=True, text=True, check=False
@@ -498,17 +500,28 @@ def start_run(
     run_dir.mkdir(parents=True, exist_ok=False)
 
     resolved_argv = substitute_run_placeholders(argv, run_id=run_id, run_dir=run_dir)
-    wrapper = run_dir / WRAPPER_NAME
-    wrapper.write_text(render_wrapper(root, resolved_argv, run_dir), encoding="ascii", newline="")
+    validate_wrapper_path("repo root", root)
+    for token in resolved_argv:
+        validate_wrapper_token(token)
+    control = control_dir_for(run_id)
+    control.mkdir(parents=True, exist_ok=True)
+    (control / CONTROL_NAME).write_text(
+        json.dumps({"repo_root": str(root), "argv": list(resolved_argv)}, indent=2) + "\n",
+        encoding="utf-8",
+    )
 
     task = task_name_for(run_id)
     account = run_as or os.environ.get("USERNAME") or ""
     if not account:
         raise RemoteLaunchError("cannot resolve the logged-on account for /ru (USERNAME unset)")
     when = moment + timedelta(minutes=start_delay_minutes)
-    created = _run(
-        schtasks_create_argv(task=task, tr_path=short_path(wrapper), when=when, run_as=account)
-    )
+    # `/tr` runs the repo's own interpreter against a version-controlled shim — NOT a generated
+    # script inside the agent-writable scratch tree. Executing that file was command injection: a
+    # peer could replace it between /create and first execution and have Task Scheduler run
+    # anything in the console session as the logged-on user.
+    shim = Path(__file__).resolve().with_name("_remote_exec.py")
+    tr_path = f"{short_path(root / '.venv' / 'Scripts' / 'python.exe')} {short_path(shim)} {run_id}"
+    created = _run(schtasks_create_argv(task=task, tr_path=tr_path, when=when, run_as=account))
     if created.returncode != 0:
         raise RemoteLaunchError(
             f"schtasks /create failed ({created.returncode}): {created.stdout}{created.stderr}"
@@ -519,6 +532,11 @@ def start_run(
         raise RemoteLaunchError(
             f"schtasks /run failed ({started.returncode}): {started.stdout}{started.stderr}"
         )
+    # Disable the trigger now that the on-demand start has happened. `/sc once` is a REAL trigger:
+    # left armed, it fires at its scheduled time and executes the payload a second time if the run
+    # already finished. Disabling removes that class outright — no filesystem marker can do it,
+    # because every marker lives somewhere a peer can write. A running instance is unaffected.
+    _run(["schtasks", "/change", "/tn", task, "/disable"])
 
     run = RemoteRun(
         run_id=run_id,
@@ -778,9 +796,18 @@ SCHED_S_TASK_HAS_NOT_YET_RUN = 267011
 SCHED_S_TASK_IS_CURRENTLY_RUNNING = 267009
 
 
+def sentinel_path_for(run_id: str) -> Path:
+    """Exit-sentinel path for a run id, outside the shared scratch tree."""
+    return control_dir_for(run_id) / SENTINEL_NAME
+
+
 def _sentinel_exit_code(run_dir: Path) -> int | None:
-    """The wrapper's recorded exit code, or ``None`` when the run has not finished."""
-    sentinel = run_dir / SENTINEL_NAME
+    """The recorded exit code for a run, or ``None`` when it has not finished.
+
+    ``run_dir`` is the *log* directory; the sentinel itself is keyed by its run id and lives in the
+    control directory, so a peer writing into ``.scratch`` cannot fabricate completion.
+    """
+    sentinel = sentinel_path_for(run_dir.name)
     try:
         if not sentinel.is_file():
             return None

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -67,7 +67,6 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from tools.ac_harness.auto_drive import harness_repo_root
 from tools.ac_harness.rig_lock import default_rig_session_lock_path, read_rig_session_owner
 
 #: Transport logs live beside (not inside) the harness's own evidence tree: the run directory holds
@@ -95,10 +94,20 @@ DEFAULT_START_DELAY_MINUTES = 5
 
 #: Run-id / task-name alphabet: safe as a Windows path component *and* a Task Scheduler name.
 _RUN_COMPONENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
-#: Tokens interpolated into the generated ``.cmd``. Excludes whitespace-free cmd metacharacters
-#: (``& | < > ^ %``), quotes, and everything outside printable ASCII. Spaces are allowed because
-#: :func:`render_wrapper` quotes such tokens; a token may not contain a quote of its own.
+#: Tokens interpolated into the generated ``.cmd``. Excludes the cmd metacharacters that survive
+#: quoting (``%`` expands even inside double quotes) and the quote character itself (it would close
+#: the quoting :func:`quote_wrapper_token` adds), plus everything outside printable ASCII.
+#:
+#: ``(`` and ``)`` ARE allowed even though they are cmd grouping metacharacters: AC setup names
+#: legitimately contain them (``auto_drive._SETUP_NAME_RE``), so rejecting them would fail-close a
+#: valid ``--setup``. They are made inert by :func:`quote_wrapper_token`, which quotes **every**
+#: token — inside double quotes ``(``/``)``/``!``/``^`` are literal.
 _WRAPPER_TOKEN_RE = re.compile(r"^[ !#$()*+,\-./0-9:;=?@A-Z\[\]_a-z{}~\\]+$")
+#: Characters that must never appear in a path interpolated into the wrapper. ``%`` expands inside
+#: double quotes, and ``"`` breaks out of them — both are legal ASCII in a Windows path, so an
+#: ``isascii()`` check alone is not enough to keep ``cd /d``, the redirects, and the sentinel append
+#: pointing where they were meant to.
+_WRAPPER_PATH_FORBIDDEN = set('%"<>&|^\r\n\t')
 
 _INVALID_SESSION = 0xFFFFFFFF
 
@@ -110,6 +119,35 @@ class RemoteLaunchError(RuntimeError):
 # ---------------------------------------------------------------------------
 # Pure helpers (unit-tested off-rig)
 # ---------------------------------------------------------------------------
+
+
+def harness_repo_root() -> Path:
+    """Repo root of the checkout this module was imported from.
+
+    Resolved locally rather than imported from :mod:`tools.ac_harness.auto_drive`: that module is
+    the *payload* this transport launches, and pulling it in at import time would drag the whole
+    in-sim harness (and its dependencies) into a wrapper whose only job is to hand an argv to Task
+    Scheduler. Both live in ``tools/ac_harness/``, so ``parents[2]`` is the same root by
+    construction.
+    """
+    return Path(__file__).resolve().parents[2]
+
+
+def validate_wrapper_path(kind: str, path: Path) -> Path:
+    """Reject a path that would rewrite the generated ``.cmd`` instead of sitting inside it."""
+    text = str(path)
+    if not text.isascii():
+        raise RemoteLaunchError(
+            f"non-ASCII {kind} {text!r} would be mangled to '?' by the ascii-encoded wrapper"
+        )
+    bad = sorted(_WRAPPER_PATH_FORBIDDEN & set(text))
+    if bad:
+        raise RemoteLaunchError(
+            f"unsafe {kind} {text!r}: contains {bad!r}. `%` expands even inside double quotes and "
+            '`"` breaks out of them, so such a path can rewrite `cd /d`, the redirects, or the '
+            "exit sentinel while schtasks still reports success."
+        )
+    return path
 
 
 def validate_run_component(kind: str, value: str) -> str:
@@ -148,8 +186,16 @@ def validate_wrapper_token(token: str) -> str:
 
 
 def quote_wrapper_token(token: str) -> str:
-    """Quote a validated token for ``cmd.exe`` (quotes are already excluded by validation)."""
-    return f'"{token}"' if " " in token else token
+    """Quote a validated token for ``cmd.exe``.
+
+    **Every** token is quoted, not just the ones containing spaces. A space-free token can still
+    carry cmd grouping metacharacters — ``(dir)`` would change how Task Scheduler parses the
+    generated line rather than being passed through to Python. Inside double quotes those become
+    literal, and the Windows CRT strips the quotes before ``argv`` reaches the interpreter, so the
+    harness sees exactly the token that was validated. The quote character itself is excluded by
+    :data:`_WRAPPER_TOKEN_RE`, so this cannot be closed early.
+    """
+    return f'"{token}"'
 
 
 def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
@@ -159,11 +205,8 @@ def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
     The wrapper redirects its own streams so the polling SSH session only ever *reads* files, and
     appends the exit sentinel as its last act.
     """
-    for part in (str(repo_root), str(run_dir)):
-        if not part.isascii():
-            raise RemoteLaunchError(
-                f"non-ASCII path {part!r} would be mangled to '?' by the ascii-encoded wrapper"
-            )
+    validate_wrapper_path("repo root", repo_root)
+    validate_wrapper_path("run directory", run_dir)
     tokens = " ".join(quote_wrapper_token(validate_wrapper_token(a)) for a in argv)
     stdout_path = run_dir / STDOUT_NAME
     stderr_path = run_dir / STDERR_NAME
@@ -483,6 +526,15 @@ def cleanup_run(run: RemoteRun, *, force: bool = False) -> dict[str, Any]:
     definition early can cancel a start that has not spawned yet, and it removes the only ``Status``
     handle while the run is still launching.
     """
+    # The task name comes off disk (`run.json`), which a peer session or a stray edit can change.
+    # Deleting whatever name it holds would let this reap another agent's task on the shared rig and
+    # drop its Status handle mid-run, so bind the name to the run id before touching schtasks.
+    expected = task_name_for(run.run_id)
+    if run.task != expected:
+        raise RemoteLaunchError(
+            f"refusing to delete task {run.task!r}: it does not match this run id "
+            f"(expected {expected!r}) — run.json may have been edited or points at a peer's task"
+        )
     status = poll_run(run, tail=0)
     if not status["finished"] and not force:
         return {"deleted": False, "reason": "run has not written its exit sentinel", **status}

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -59,6 +59,7 @@ import math
 import os
 import random
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -112,6 +113,16 @@ _WRAPPER_TOKEN_RE = re.compile(r"^[ !#$()*+,\-./0-9:;=?@A-Z\[\]_a-z{}~\\]+$")
 #: ``isascii()`` check alone is not enough to keep ``cd /d``, the redirects, and the sentinel append
 #: pointing where they were meant to.
 _WRAPPER_PATH_FORBIDDEN = set('%"<>&|^\r\n\t')
+
+#: The ONLY payload shape this transport will run. Token-level validation is not enough: argv
+#: reaches the interpreter as a JSON string list, so no shell quoting is needed and `-c` plus a
+#: bare expression (`;`, `()`, `+`, `chr(...)`) — or a plain script path — would be console-session
+#: RCE from a tampered control file. The transport exists to run harness modules; anything else
+#: fails closed.
+_ALLOWED_PAYLOAD_MODULE_RE = re.compile(r"^tools\.ac_harness\.[A-Za-z0-9_]+$")
+#: Exit code recorded when the console-session shim itself fails before/around the payload, so a
+#: broken run reports a real failure instead of leaving poll/wait hanging until their deadline.
+EXEC_FAILURE_RC = 253
 
 _INVALID_SESSION = 0xFFFFFFFF
 
@@ -205,6 +216,27 @@ def _reject_trailing_backslash(kind: str, text: str) -> None:
             f"unsafe {kind} {text!r}: a trailing backslash escapes the closing quote in the "
             "Windows CRT argv parser, so the quoted region does not end where it appears to"
         )
+
+
+def validate_payload_argv(argv: Sequence[str]) -> list[str]:
+    """Accept only ``-m <allowlisted harness module> [args…]``.
+
+    Rejects ``-c``, ``-`` (stdin), ``runpy``-style indirection and any first token that looks like a
+    filesystem path — each of which turns a tampered control file back into arbitrary code in the
+    console session, which is the whole thing this transport exists to prevent.
+    """
+    tokens = [validate_wrapper_token(str(t)) for t in argv]
+    if len(tokens) < 2 or tokens[0] != "-m":
+        raise RemoteLaunchError(
+            f"payload argv must start with '-m <module>' (got {tokens[:2]!r}) — the transport runs "
+            "harness modules, never -c, stdin, or a script path"
+        )
+    if not _ALLOWED_PAYLOAD_MODULE_RE.match(tokens[1]):
+        raise RemoteLaunchError(
+            f"module {tokens[1]!r} is not an allowlisted harness module "
+            "(expected tools.ac_harness.<name>)"
+        )
+    return tokens
 
 
 def validate_wrapper_token(token: str) -> str:
@@ -433,6 +465,28 @@ def execute_control_file(run_id: str) -> int:
     ``shell=False``.
     """
     requested = validate_run_component("run id", run_id)
+    try:
+        return _execute_validated(requested)
+    except BaseException as exc:
+        # ALWAYS leave a sentinel. Without one, an unreadable control file, a rejected argv or a
+        # missing interpreter left poll/wait spinning to their deadline and cleanup/reap refusing
+        # to delete — the "unbounded wait with no diagnosis" the bounded wait exists to avoid.
+        _record_exec_failure(requested, exc)
+        raise
+
+
+def _record_exec_failure(run_id: str, exc: BaseException) -> None:
+    sentinel = sentinel_path_for(run_id)
+    try:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        with sentinel.open("a", encoding="utf-8") as fh:
+            fh.write(f"[wrapper] {type(exc).__name__}: {exc}\n")
+            fh.write(f"[wrapper] {SENTINEL_TOKEN}{EXEC_FAILURE_RC}\n")
+    except OSError:
+        pass  # nothing further we can do; the caller still raises
+
+
+def _execute_validated(requested: str) -> int:
     control = control_dir_for(requested) / CONTROL_NAME
     try:
         payload = json.loads(control.read_text(encoding="utf-8"))
@@ -441,9 +495,7 @@ def execute_control_file(run_id: str) -> int:
     if not isinstance(payload, dict):
         raise RemoteLaunchError(f"control file {control} is not an object")
     repo_root = validate_wrapper_path("repo root", Path(str(payload.get("repo_root", ""))))
-    argv = [validate_wrapper_token(str(t)) for t in payload.get("argv", [])]
-    if not argv:
-        raise RemoteLaunchError(f"control file {control} carries no argv")
+    argv = validate_payload_argv(payload.get("argv", []))
 
     run_dir = repo_root.joinpath(*RUN_DIR_RELPATH, requested)
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -536,7 +588,16 @@ def start_run(
     # left armed, it fires at its scheduled time and executes the payload a second time if the run
     # already finished. Disabling removes that class outright — no filesystem marker can do it,
     # because every marker lives somewhere a peer can write. A running instance is unaffected.
-    _run(["schtasks", "/change", "/tn", task, "/disable"])
+    disabled = _run(["schtasks", "/change", "/tn", task, "/disable"])
+    if disabled.returncode != 0:
+        # Proceeding here would hand back a "successful" start with the `/sc once` trigger still
+        # armed — i.e. a second AC session and truncated logs ~start_delay later. Fail closed.
+        _run(["schtasks", "/delete", "/tn", task, "/f"])
+        raise RemoteLaunchError(
+            f"schtasks /change /disable failed ({disabled.returncode}): "
+            f"{(disabled.stderr or disabled.stdout or '').strip()[:200]} — refusing to start with "
+            "the one-shot trigger still armed"
+        )
 
     run = RemoteRun(
         run_id=run_id,
@@ -637,7 +698,7 @@ def poll_run(run: RemoteRun, *, tail: int = 30) -> dict[str, Any]:
     queried = _run(["schtasks", "/query", "/tn", run.task, "/fo", "list", "/v"])
     # Single sentinel reader: a permission/sharing error on wrapper.log must not abort a poll (and
     # therefore cleanup, which polls first) with a traceback.
-    exit_code = _sentinel_exit_code(run.directory)
+    exit_code = _sentinel_exit_code(run.run_id)
     fields = parse_task_status(queried.stdout)
     # Same snapshot the fields below are reported from — a second query would both double the
     # subprocess cost per poll and let the reported status disagree with the verdict beside it.
@@ -645,7 +706,7 @@ def poll_run(run: RemoteRun, *, tail: int = 30) -> dict[str, Any]:
         sentinel_exit_code=exit_code,
         query_rc=queried.returncode,
         fields=fields,
-        run_dir=run.directory,
+        run_id=run.run_id,
     )
     acs = _run(["tasklist", "/fi", "imagename eq acs.exe", "/nh"])
     return {
@@ -705,9 +766,21 @@ def wait_for_run(
         sleep(min(interval_s, max(0.0, deadline - monotonic())))
 
 
+def _discard_control_dir(run_id: str) -> None:
+    """Remove a run's control directory once its task is gone.
+
+    Run ids are unique per attempt, so without this every single run permanently leaks a folder
+    (control file + sentinel) into the user's profile.
+    """
+    try:
+        shutil.rmtree(control_dir_for(run_id), ignore_errors=True)
+    except RemoteLaunchError:
+        pass  # unvalidatable id — nothing of ours to remove
+
+
 def _await_deletion_verdict(
     name: str,
-    run_dir: Path,
+    run_id: str,
     *,
     attempts: int = 4,
     delay_s: float = 2.0,
@@ -721,7 +794,7 @@ def _await_deletion_verdict(
     """
     reason = ""
     for attempt in range(attempts):
-        ok, reason = task_deletion_verdict(name, run_dir)
+        ok, reason = task_deletion_verdict(name, run_id)
         if ok:
             return True, ""
         if attempt < attempts - 1:
@@ -751,10 +824,12 @@ def cleanup_run(run: RemoteRun, *, force: bool = False) -> dict[str, Any]:
         # reap despite the docs claiming the reverse: wrapper.log lives in the same agent-writable
         # tree run.json does, so a planted sentinel while the task was still Running would delete a
         # live /IT task and kill its console-session process tree. One shared rule now.
-        ok, reason = _await_deletion_verdict(run.task, run.directory)
+        ok, reason = _await_deletion_verdict(run.task, run.run_id)
         if not ok:
             return {"deleted": False, "reason": reason, **status}
     deleted = _run(["schtasks", "/delete", "/tn", run.task, "/f"])
+    if deleted.returncode == 0:
+        _discard_control_dir(run.run_id)
     return {"deleted": deleted.returncode == 0, "delete_rc": deleted.returncode, **status}
 
 
@@ -801,13 +876,15 @@ def sentinel_path_for(run_id: str) -> Path:
     return control_dir_for(run_id) / SENTINEL_NAME
 
 
-def _sentinel_exit_code(run_dir: Path) -> int | None:
+def _sentinel_exit_code(run_id: str) -> int | None:
     """The recorded exit code for a run, or ``None`` when it has not finished.
 
-    ``run_dir`` is the *log* directory; the sentinel itself is keyed by its run id and lives in the
-    control directory, so a peer writing into ``.scratch`` cannot fabricate completion.
+    Keyed by **run id**, not by a directory: the sentinel lives in the control directory, so taking
+    a log path here was structurally misleading — it made a global status check look local, and
+    forced :func:`reap_tasks` to synthesise a fake path inside its own checkout to reap a peer's
+    task.
     """
-    sentinel = sentinel_path_for(run_dir.name)
+    sentinel = sentinel_path_for(run_id)
     try:
         if not sentinel.is_file():
             return None
@@ -821,7 +898,7 @@ def _sentinel_exit_code(run_dir: Path) -> int | None:
 
 
 def evaluate_deletion(
-    *, sentinel_exit_code: int | None, query_rc: int, fields: dict[str, str], run_dir: Path
+    *, sentinel_exit_code: int | None, query_rc: int, fields: dict[str, str], run_id: str
 ) -> tuple[bool, str]:
     """The deletion rule as a **pure** function over one already-taken snapshot.
 
@@ -836,7 +913,7 @@ def evaluate_deletion(
         # file this check never reads — the exact class of misleading diagnostic being fixed here.
         return (
             False,
-            f"no exit sentinel at {sentinel_path_for(run_dir.name)} — may still be launching",
+            f"no exit sentinel at {sentinel_path_for(run_id)} — may still be launching",
         )
     if query_rc != 0:
         return False, f"status query failed (rc={query_rc}) — failing closed"
@@ -855,7 +932,7 @@ def evaluate_deletion(
     return True, ""
 
 
-def task_deletion_verdict(name: str, run_dir: Path) -> tuple[bool, str]:
+def task_deletion_verdict(name: str, run_id: str) -> tuple[bool, str]:
     """May this task be deleted? Returns ``(ok, reason_when_not)``. **Fails closed.**
 
     Both :func:`cleanup_run` and :func:`reap_tasks` go through here so there is exactly one rule,
@@ -870,33 +947,36 @@ def task_deletion_verdict(name: str, run_dir: Path) -> tuple[bool, str]:
        completion, so a sentinel planted in the writable scratch tree during the pre-spawn window
        would otherwise authorise deleting a peer's task before it ever ran.
     """
-    exit_code = _sentinel_exit_code(run_dir)
+    exit_code = _sentinel_exit_code(run_id)
     if exit_code is None:
         # Short-circuit: no sentinel is already dispositive, so skip the subprocess entirely. This
         # is the common case while a run is in flight, and reap calls it once per registered task.
-        return evaluate_deletion(sentinel_exit_code=None, query_rc=0, fields={}, run_dir=run_dir)
+        return evaluate_deletion(sentinel_exit_code=None, query_rc=0, fields={}, run_id=run_id)
     queried = _run(["schtasks", "/query", "/tn", name, "/fo", "list", "/v"])
     return evaluate_deletion(
         sentinel_exit_code=exit_code,
         query_rc=queried.returncode,
         fields=parse_task_status(queried.stdout),
-        run_dir=run_dir,
+        run_id=run_id,
     )
 
 
-def _run_dir_for_task(name: str, root: Path) -> Path | None:
-    """Canonical run directory for a task name, or ``None`` when the name is not ours."""
+def _run_id_for_task(name: str) -> str | None:
+    """Run id behind a task name, or ``None`` when the name is not ours.
+
+    Returns the id rather than a directory: reaping a peer's task must not depend on any path
+    inside *this* checkout.
+    """
     if not name.startswith(TASK_PREFIX):
         return None
     run_id = name[len(TASK_PREFIX) :]
     try:
-        validate_run_component("run id", run_id)
+        return validate_run_component("run id", run_id)
     except RemoteLaunchError:
         return None
-    return root.joinpath(*RUN_DIR_RELPATH, run_id)
 
 
-def reap_tasks(*, repo_root: Path | None = None, force: bool = False) -> dict[str, Any]:
+def reap_tasks(*, force: bool = False) -> dict[str, Any]:
     """Delete still-registered tasks this module owns, using :func:`cleanup_run`'s own rule.
 
     ``list`` deliberately only reports; this is the command that actually removes them. A session
@@ -919,19 +999,20 @@ def reap_tasks(*, repo_root: Path | None = None, force: bool = False) -> dict[st
 
     ``force`` overrides both, and every skip is reported rather than silently swallowed.
     """
-    root = (repo_root or harness_repo_root()).resolve()
     results: dict[str, Any] = {}
     for name in list_stale_tasks():
         if not force:
-            run_dir = _run_dir_for_task(name, root)
-            if run_dir is None:
+            run_id = _run_id_for_task(name)
+            if run_id is None:
                 results[name] = {"deleted": False, "skipped": "task name is not a valid run id"}
                 continue
-            ok, reason = task_deletion_verdict(name, run_dir)
+            ok, reason = task_deletion_verdict(name, run_id)
             if not ok:
                 results[name] = {"deleted": False, "skipped": reason}
                 continue
         deleted = _run(["schtasks", "/delete", "/tn", name, "/f"])
+        if deleted.returncode == 0 and name.startswith(TASK_PREFIX):
+            _discard_control_dir(name[len(TASK_PREFIX) :])
         results[name] = {"deleted": deleted.returncode == 0, "rc": deleted.returncode}
     return {"reaped": results, "remaining": list_stale_tasks()}
 

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -614,30 +614,74 @@ def list_stale_tasks() -> list[str]:
     return names
 
 
-#: Task states that mean a launch is still in flight. Deleting one of these cancels a start that
-#: has not spawned yet and drops the only ``Status`` handle — the same hazard :func:`cleanup_run`
-#: refuses for a single run, which ``reap`` must not reintroduce across every run on the rig.
-_LIVE_TASK_STATES = {"running", "queued"}
+#: Task states that are known NOT to be mid-launch. Everything else — ``Running``, ``Queued``, an
+#: unparseable status, or a failed query — is treated as possibly-live and skipped. ``Ready`` is in
+#: this set only as a *secondary* signal: it is emphatically **not** proof of completion (see
+#: :func:`reap_tasks`), which is why the sentinel check below is the primary gate.
+_KNOWN_DEAD_TASK_STATES = {"ready", "disabled"}
 
 
-def reap_tasks(*, force: bool = False) -> dict[str, Any]:
-    """Delete still-registered tasks this module owns, **skipping ones still in flight**.
+def _run_dir_for_task(name: str, root: Path) -> Path | None:
+    """Canonical run directory for a task name, or ``None`` when the name is not ours."""
+    if not name.startswith(TASK_PREFIX):
+        return None
+    run_id = name[len(TASK_PREFIX) :]
+    try:
+        validate_run_component("run id", run_id)
+    except RemoteLaunchError:
+        return None
+    return root.joinpath(*RUN_DIR_RELPATH, run_id)
+
+
+def reap_tasks(*, repo_root: Path | None = None, force: bool = False) -> dict[str, Any]:
+    """Delete still-registered tasks this module owns, using :func:`cleanup_run`'s own rule.
 
     ``list`` deliberately only reports; this is the command that actually removes them. A session
     that dies before ``cleanup`` leaves an accumulating registration behind, and without this the
     operator falls back to raw ``schtasks /delete`` — the hand-run path this module retires.
 
-    But this module's threat model is *two agents, one rig*: an unconditional sweep would delete a
-    **peer's live task** mid-launch. So a task reporting ``Running``/``Queued`` is skipped unless
-    ``force`` is set, and the skip is reported rather than silently swallowed.
+    The threat model is *two agents, one rig*, so this must obey exactly the rule
+    :func:`cleanup_run` encodes and no weaker one:
+
+    * **``Status: Ready`` is not completion.** ``schtasks /run`` is asynchronous, so a task reads
+      ``Ready`` in the window between ``/create`` and ``/run``, and again after ``/run`` until the
+      wrapper actually spawns. Deleting during either window cancels a peer's start and drops the
+      only ``Status`` handle. The **exit sentinel** under the canonical
+      ``.scratch/harness-remote/<run id>/`` — derived from the task name, never from an on-disk
+      payload — is the authority, exactly as in :func:`cleanup_run`.
+    * **Unknown status fails closed.** If ``/query`` errors, returns nothing, or yields a status
+      this module does not recognise, the task is skipped rather than deleted. A guard that
+      fail-*opens* on a transient query failure is worse than none: it silently removes a live peer
+      task at the one moment the evidence is missing.
+
+    ``force`` overrides both, and every skip is reported rather than silently swallowed.
     """
+    root = (repo_root or harness_repo_root()).resolve()
     results: dict[str, Any] = {}
     for name in list_stale_tasks():
-        queried = _run(["schtasks", "/query", "/tn", name, "/fo", "list", "/v"])
-        state = parse_task_status(queried.stdout).get("status", "")
-        if not force and state.strip().lower() in _LIVE_TASK_STATES:
-            results[name] = {"deleted": False, "skipped": f"task is {state.strip()}"}
-            continue
+        if not force:
+            run_dir = _run_dir_for_task(name, root)
+            if run_dir is None:
+                results[name] = {"deleted": False, "skipped": "task name is not a valid run id"}
+                continue
+            sentinel = run_dir / SENTINEL_NAME
+            finished = sentinel.is_file() and (
+                parse_sentinel(sentinel.read_text(encoding="utf-8", errors="replace")) is not None
+            )
+            if not finished:
+                results[name] = {
+                    "deleted": False,
+                    "skipped": f"no exit sentinel at {sentinel} — may still be launching",
+                }
+                continue
+            queried = _run(["schtasks", "/query", "/tn", name, "/fo", "list", "/v"])
+            state = parse_task_status(queried.stdout).get("status", "").strip().lower()
+            if queried.returncode != 0 or state not in _KNOWN_DEAD_TASK_STATES:
+                results[name] = {
+                    "deleted": False,
+                    "skipped": f"status unknown (rc={queried.returncode}, status={state!r})",
+                }
+                continue
         deleted = _run(["schtasks", "/delete", "/tn", name, "/f"])
         results[name] = {"deleted": deleted.returncode == 0, "rc": deleted.returncode}
     return {"reaped": results, "remaining": list_stale_tasks()}
@@ -709,7 +753,7 @@ def build_parser() -> argparse.ArgumentParser:
     reap.add_argument(
         "--force",
         action="store_true",
-        help="also delete Running/Queued tasks — cancels a live launch, possibly a peer's",
+        help="delete without the sentinel/status checks — cancels a live launch, possibly a peer's",
     )
     return p
 

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -404,6 +404,24 @@ def assert_transport_needed() -> tuple[int, int]:
     return current, console
 
 
+def resolve_short_path(path: Path, get_short) -> str:  # noqa: ANN001 - injected Win32 callable
+    """Buffer-growth wrapper around ``GetShortPathNameW``; separated so it is testable off-Windows.
+
+    A too-small buffer is **not** a failure: the call returns the REQUIRED length, so retry at that
+    size rather than refusing a long-but-perfectly-valid repo/run path.
+    """
+    import ctypes
+
+    buf = ctypes.create_unicode_buffer(1024)
+    size = get_short(str(path), buf, len(buf))
+    if size >= len(buf):
+        buf = ctypes.create_unicode_buffer(size + 1)
+        size = get_short(str(path), buf, len(buf))
+    if size == 0 or size >= len(buf):
+        raise RemoteLaunchError(f"GetShortPathNameW failed for {path}")
+    return buf.value
+
+
 def short_path(path: Path) -> str:
     """The 8.3 short path for ``/tr``; **raises** rather than silently handing back a spaced path.
 
@@ -416,16 +434,7 @@ def short_path(path: Path) -> str:
     get_short = ctypes.windll.kernel32.GetShortPathNameW  # type: ignore[attr-defined]
     get_short.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
     get_short.restype = wintypes.DWORD
-    # A too-small buffer is not a failure: the call returns the REQUIRED length, so retry at that
-    # size rather than refusing a long-but-perfectly-valid repo/run path.
-    buf = ctypes.create_unicode_buffer(1024)
-    size = get_short(str(path), buf, len(buf))
-    if size >= len(buf):
-        buf = ctypes.create_unicode_buffer(size + 1)
-        size = get_short(str(path), buf, len(buf))
-    if size == 0 or size >= len(buf):
-        raise RemoteLaunchError(f"GetShortPathNameW failed for {path}")
-    resolved = buf.value
+    resolved = resolve_short_path(path, get_short)
     if any(ch.isspace() for ch in resolved):
         raise RemoteLaunchError(
             f"8.3 short path unavailable (got {resolved!r}). Task Scheduler accepts a spaced /tr "
@@ -568,8 +577,11 @@ def _tail(path: Path, lines: int) -> list[str]:
         return []
     text = blob.decode("utf-8", errors="replace")
     rows = text.splitlines()
-    if start > 0 and rows:
-        # The seek can land mid-line (and mid-codepoint); drop that partial first row.
+    if start > 0 and len(rows) > 1:
+        # The seek can land mid-line (and mid-codepoint), so drop that partial first row — but
+        # ONLY when another row survives it. A chunk containing no newline at all (one very long
+        # log line) is entirely "partial", and dropping it would report an empty tail for a
+        # non-empty log, hiding exactly the diagnostics a poll is for.
         rows = rows[1:]
     return rows[-lines:]
 

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -144,6 +144,13 @@ def control_dir_for(run_id: str, *, local_app_data: str | Path | None = None) ->
 class RemoteLaunchError(RuntimeError):
     """A transport precondition failed. Never raised for a harness-level (in-sim) failure."""
 
+    def __init__(self, message: str, *, run: RemoteRun | None = None) -> None:
+        super().__init__(message)
+        #: Set when the payload is already LIVE despite the error, so the CLI can still emit the
+        #: handle. Without it, automation parsing stdout never learns the run id and cannot
+        #: poll/wait/cleanup a run that is genuinely underway.
+        self.run = run
+
 
 # ---------------------------------------------------------------------------
 # Pure helpers (unit-tested off-rig)
@@ -478,15 +485,31 @@ def execute_control_file(run_id: str) -> int:
         raise
 
 
-def _record_exec_failure(run_id: str, exc: BaseException) -> None:
+def _write_sentinel(run_id: str, rc: int, note: str = "") -> None:
+    """Record the run's real exit code as the FIRST line, overwriting anything already there.
+
+    The shim is the only legitimate writer, so a pre-existing sentinel has no standing — it was
+    planted. **Truncating** rather than appending is what makes `parse_sentinel`'s first-wins rule
+    trustworthy: an earlier forged `exit=0` is erased, and a later appended one loses. (Appending
+    beneath a planted value, which the failure path used to do, silently handed the forgery the
+    authoritative slot and undid the exclusive-create guard it was paired with.)
+    """
     sentinel = sentinel_path_for(run_id)
     try:
+        existed = sentinel.is_file()
         sentinel.parent.mkdir(parents=True, exist_ok=True)
-        with sentinel.open("a", encoding="utf-8") as fh:
-            fh.write(f"[wrapper] {type(exc).__name__}: {exc}\n")
-            fh.write(f"[wrapper] {SENTINEL_TOKEN}{EXEC_FAILURE_RC}\n")
+        with sentinel.open("w", encoding="utf-8") as fh:
+            fh.write(f"[wrapper] {SENTINEL_TOKEN}{rc}\n")
+            if note:
+                fh.write(f"[wrapper] {note}\n")
+            if existed:
+                fh.write("[wrapper] a pre-existing sentinel was overwritten (not written by us)\n")
     except OSError:
         pass  # nothing further we can do; the caller still raises
+
+
+def _record_exec_failure(run_id: str, exc: BaseException) -> None:
+    _write_sentinel(run_id, EXEC_FAILURE_RC, note=f"{type(exc).__name__}: {exc}")
 
 
 def _execute_validated(requested: str) -> int:
@@ -527,17 +550,7 @@ def _execute_validated(requested: str) -> int:
             env=env,
             check=False,
         )
-    sentinel = sentinel_path_for(requested)
-    try:
-        # Exclusive create: the shim is the only writer, so an existing sentinel at this point
-        # means someone else put it there. Failing loudly beats appending beneath a forgery.
-        with sentinel.open("x", encoding="utf-8") as fh:
-            fh.write(f"[wrapper] {SENTINEL_TOKEN}{completed.returncode}\n")
-    except FileExistsError as exc:
-        raise RemoteLaunchError(
-            f"exit sentinel {sentinel} already existed before this run finished — refusing to "
-            "append beneath a value this shim did not write"
-        ) from exc
+    _write_sentinel(requested, completed.returncode)
     return completed.returncode
 
 
@@ -665,7 +678,8 @@ def start_run(
             f"{(disabled.stderr or disabled.stdout or '').strip()[:200]} — the run is ALREADY "
             f"RUNNING and its handle is at {run_dir / RUN_JSON_NAME}, so the task was NOT deleted "
             f"(that would abort it). The one-shot trigger is still ARMED and will re-fire around "
-            f"{when:%Y-%m-%d %H:%M}: disable or delete task {task!r} before then."
+            f"{when:%Y-%m-%d %H:%M}: disable or delete task {task!r} before then.",
+            run=run,
         )
 
     return run
@@ -1010,6 +1024,15 @@ def evaluate_deletion(
             f"last result {last_result} is a launch failure (e.g. 0x{last_result & 0xFFFFFFFF:X}), "
             "so the payload never ran — failing closed"
         )
+    if last_result != sentinel_exit_code:
+        # Task Scheduler's Last Result is now the shim's own process exit code, which the shim sets
+        # equal to the value it records. They can only disagree if something other than the shim
+        # wrote the sentinel. (The old `.cmd` wrapper ended in `echo`, so this cross-check was not
+        # available then; with the Python shim it is, and it binds the file to an off-disk signal.)
+        return False, (
+            f"exit sentinel says {sentinel_exit_code} but Task Scheduler's last result is "
+            f"{last_result} — the sentinel was not written by this run's shim, failing closed"
+        )
     return True, ""
 
 
@@ -1226,6 +1249,10 @@ def main(raw_args: Sequence[str] | None = None) -> int:
             print(json.dumps(outcome, indent=2, default=str))
             return 0 if not outcome["remaining"] else 1
     except RemoteLaunchError as exc:
+        # Emit the handle on stdout even on the error path when the payload is live, so automation
+        # parsing JSON can still poll/wait/cleanup instead of scraping prose from stderr.
+        if getattr(exc, "run", None) is not None:
+            print(json.dumps(exc.run.to_dict(), indent=2))
         print(f"remote-launcher: {exc}", file=sys.stderr)
         return 3
     return 3

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -595,13 +595,21 @@ def poll_run(run: RemoteRun, *, tail: int = 30) -> dict[str, Any]:
     # Single sentinel reader: a permission/sharing error on wrapper.log must not abort a poll (and
     # therefore cleanup, which polls first) with a traceback.
     exit_code = _sentinel_exit_code(run.directory)
-    verified, verified_reason = task_deletion_verdict(run.task, run.directory)
+    fields = parse_task_status(queried.stdout)
+    # Same snapshot the fields below are reported from — a second query would both double the
+    # subprocess cost per poll and let the reported status disagree with the verdict beside it.
+    verified, verified_reason = evaluate_deletion(
+        sentinel_exit_code=exit_code,
+        query_rc=queried.returncode,
+        fields=fields,
+        run_dir=run.directory,
+    )
     acs = _run(["tasklist", "/fi", "imagename eq acs.exe", "/nh"])
     return {
         "run_id": run.run_id,
         "task": run.task,
         "task_query_rc": queried.returncode,
-        **parse_task_status(queried.stdout),
+        **fields,
         # `finished` is the RAW sentinel signal, kept for diagnosis. `verified_complete` is the
         # strict one (sentinel + known-dead status + a Last Result showing it actually ran) and is
         # what anything acting on the run must use — a peer can write into the scratch tree.
@@ -760,6 +768,35 @@ def _sentinel_exit_code(run_dir: Path) -> int | None:
     return parse_sentinel(text)
 
 
+def evaluate_deletion(
+    *, sentinel_exit_code: int | None, query_rc: int, fields: dict[str, str], run_dir: Path
+) -> tuple[bool, str]:
+    """The deletion rule as a **pure** function over one already-taken snapshot.
+
+    Split out from :func:`task_deletion_verdict` so a caller that has already queried the task and
+    read the sentinel — :func:`poll_run` — reuses that snapshot instead of taking a second one. Two
+    snapshots meant two ``schtasks`` subprocesses per poll *and*, worse, a reported
+    ``status``/``last_result`` that could disagree with the verdict computed beside it.
+    """
+    if sentinel_exit_code is None:
+        return False, f"no exit sentinel at {run_dir / SENTINEL_NAME} — may still be launching"
+    if query_rc != 0:
+        return False, f"status query failed (rc={query_rc}) — failing closed"
+    state = fields.get("status", "").strip().lower()
+    if state not in _KNOWN_DEAD_TASK_STATES:
+        return False, f"status {state!r} is not a known non-live state — failing closed"
+    raw_result = fields.get("last_result", "").strip()
+    try:
+        last_result = int(raw_result, 0)
+    except ValueError:
+        return False, f"last result {raw_result!r} unreadable — failing closed"
+    if last_result == SCHED_S_TASK_HAS_NOT_YET_RUN:
+        return False, "task has not yet run (pre-spawn Ready window) — refusing to cancel a launch"
+    if last_result == SCHED_S_TASK_IS_CURRENTLY_RUNNING:
+        return False, "last result says the task is currently running — refusing to cancel it"
+    return True, ""
+
+
 def task_deletion_verdict(name: str, run_dir: Path) -> tuple[bool, str]:
     """May this task be deleted? Returns ``(ok, reason_when_not)``. **Fails closed.**
 
@@ -775,25 +812,18 @@ def task_deletion_verdict(name: str, run_dir: Path) -> tuple[bool, str]:
        completion, so a sentinel planted in the writable scratch tree during the pre-spawn window
        would otherwise authorise deleting a peer's task before it ever ran.
     """
-    if _sentinel_exit_code(run_dir) is None:
-        return False, f"no exit sentinel at {run_dir / SENTINEL_NAME} — may still be launching"
+    exit_code = _sentinel_exit_code(run_dir)
+    if exit_code is None:
+        # Short-circuit: no sentinel is already dispositive, so skip the subprocess entirely. This
+        # is the common case while a run is in flight, and reap calls it once per registered task.
+        return evaluate_deletion(sentinel_exit_code=None, query_rc=0, fields={}, run_dir=run_dir)
     queried = _run(["schtasks", "/query", "/tn", name, "/fo", "list", "/v"])
-    if queried.returncode != 0:
-        return False, f"status query failed (rc={queried.returncode}) — failing closed"
-    fields = parse_task_status(queried.stdout)
-    state = fields.get("status", "").strip().lower()
-    if state not in _KNOWN_DEAD_TASK_STATES:
-        return False, f"status {state!r} is not a known non-live state — failing closed"
-    raw_result = fields.get("last_result", "").strip()
-    try:
-        last_result = int(raw_result, 0)
-    except ValueError:
-        return False, f"last result {raw_result!r} unreadable — failing closed"
-    if last_result == SCHED_S_TASK_HAS_NOT_YET_RUN:
-        return False, "task has not yet run (pre-spawn Ready window) — refusing to cancel a launch"
-    if last_result == SCHED_S_TASK_IS_CURRENTLY_RUNNING:
-        return False, "last result says the task is currently running — refusing to cancel it"
-    return True, ""
+    return evaluate_deletion(
+        sentinel_exit_code=exit_code,
+        query_rc=queried.returncode,
+        fields=parse_task_status(queried.stdout),
+        run_dir=run_dir,
+    )
 
 
 def _run_dir_for_task(name: str, root: Path) -> Path | None:

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -62,7 +62,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -140,6 +140,7 @@ def validate_wrapper_path(kind: str, path: Path) -> Path:
         raise RemoteLaunchError(
             f"non-ASCII {kind} {text!r} would be mangled to '?' by the ascii-encoded wrapper"
         )
+    _reject_trailing_backslash(kind, text)
     bad = sorted(_WRAPPER_PATH_FORBIDDEN & set(text))
     if bad:
         raise RemoteLaunchError(
@@ -173,10 +174,27 @@ def build_run_id(
     return f"{label}-{now:%Y%m%d-%H%M%S}-{pid}-{nonce}"
 
 
+def _reject_trailing_backslash(kind: str, text: str) -> None:
+    """Reject a trailing ``\\`` — it escapes the closing quote in the Windows CRT argv parser.
+
+    :func:`quote_wrapper_token` wraps every token as ``"<token>"``. The CRT parser that builds
+    ``argv`` for ``python.exe`` treats ``\\"`` as an *escaped quote*, so a token ending in a
+    backslash does not close its quoted region: the argument swallows what follows and the harness
+    receives something other than what was validated. Windows paths and AC ids never need a trailing
+    separator, so refusing is cheaper than a doubling routine and cannot silently mis-quote.
+    """
+    if text.endswith("\\"):
+        raise RemoteLaunchError(
+            f"unsafe {kind} {text!r}: a trailing backslash escapes the closing quote in the "
+            "Windows CRT argv parser, so the quoted region does not end where it appears to"
+        )
+
+
 def validate_wrapper_token(token: str) -> str:
     """Reject an argv token that would become redirection or injection inside the wrapper."""
     if not token:
         raise RemoteLaunchError("empty argv token")
+    _reject_trailing_backslash("argv token", token)
     if not _WRAPPER_TOKEN_RE.match(token):
         raise RemoteLaunchError(
             f"unsafe argv token {token!r}: only printable ASCII without quotes or "
@@ -451,14 +469,38 @@ def start_run(
 
 
 def load_run(run_id: str, *, repo_root: Path | None = None) -> RemoteRun:
-    """Rehydrate a run handle written by :func:`start_run`."""
+    """Rehydrate a run handle, **bound to the requested id and its canonical location**.
+
+    ``run.json`` is an on-disk file in a world-writable scratch tree, so nothing in it may be
+    trusted to name what this process acts on. Checking ``task`` against ``task_name_for(run_id)``
+    using two fields *from the same payload* is not enough: a self-consistent forgery passes, and
+    an unvalidated ``run_dir`` lets a planted ``[wrapper] exit=0`` sentinel make :func:`poll_run`
+    report ``finished`` — after which ``cleanup`` deletes a **peer agent's** ``/IT`` task
+    mid-launch, the exact shared-rig clobber this module exists to prevent.
+
+    So the requested id is authoritative: the payload's ``run_id``/``task`` must equal what was
+    asked for, and ``run_dir`` is **recomputed** from the canonical root rather than read.
+    """
     root = (repo_root or harness_repo_root()).resolve()
-    payload = root.joinpath(
-        *RUN_DIR_RELPATH, validate_run_component("run id", run_id), RUN_JSON_NAME
-    )
+    requested = validate_run_component("run id", run_id)
+    run_dir = root.joinpath(*RUN_DIR_RELPATH, requested)
+    payload = run_dir / RUN_JSON_NAME
     if not payload.is_file():
         raise RemoteLaunchError(f"no such remote run: {payload}")
-    return RemoteRun.from_dict(json.loads(payload.read_text(encoding="utf-8")))
+    run = RemoteRun.from_dict(json.loads(payload.read_text(encoding="utf-8")))
+    expected_task = task_name_for(requested)
+    if run.run_id != requested:
+        raise RemoteLaunchError(
+            f"{payload} declares run_id {run.run_id!r} but was loaded as {requested!r} — "
+            "refusing to act on a payload that names a different run"
+        )
+    if run.task != expected_task:
+        raise RemoteLaunchError(
+            f"{payload} declares task {run.task!r}, expected {expected_task!r} — "
+            "refusing to act on a task this run id does not own"
+        )
+    # Recompute rather than trust: a payload-supplied run_dir could point at a planted sentinel.
+    return replace(run, run_dir=str(run_dir))
 
 
 def _tail(path: Path, lines: int) -> list[str]:
@@ -543,7 +585,7 @@ def cleanup_run(run: RemoteRun, *, force: bool = False) -> dict[str, Any]:
 
 
 def list_stale_tasks() -> list[str]:
-    """Task names this module owns that are still registered (reap after a session dies)."""
+    """Task names this module owns that are still registered. Read-only — see :func:`reap_tasks`."""
     queried = _run(["schtasks", "/query", "/fo", "list"])
     names: list[str] = []
     for line in queried.stdout.splitlines():
@@ -553,6 +595,21 @@ def list_stale_tasks() -> list[str]:
             if name.startswith(TASK_PREFIX):
                 names.append(name)
     return names
+
+
+def reap_tasks() -> dict[str, Any]:
+    """Delete every still-registered task this module owns.
+
+    ``list`` deliberately only reports; this is the command that actually removes them. A session
+    that dies before ``cleanup`` leaves a harmless but accumulating registration behind, and without
+    this the operator is left running raw ``schtasks /delete`` — which is the hand-run path this
+    module exists to retire.
+    """
+    results: dict[str, Any] = {}
+    for name in list_stale_tasks():
+        deleted = _run(["schtasks", "/delete", "/tn", name, "/f"])
+        results[name] = {"deleted": deleted.returncode == 0, "rc": deleted.returncode}
+    return {"reaped": results, "remaining": list_stale_tasks()}
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +671,8 @@ def build_parser() -> argparse.ArgumentParser:
     wait.add_argument("--timeout-s", type=float, default=3 * 60 * 60)
     wait.add_argument("--interval-s", type=float, default=30.0)
 
-    sub.add_parser("list", help="list this module's still-registered tasks")
+    sub.add_parser("list", help="list this module's still-registered tasks (read-only)")
+    sub.add_parser("reap", help="DELETE every still-registered task this module owns")
     return p
 
 
@@ -661,6 +719,10 @@ def main(raw_args: Sequence[str] | None = None) -> int:
         if args.command == "list":
             print(json.dumps(list_stale_tasks(), indent=2))
             return 0
+        if args.command == "reap":
+            outcome = reap_tasks()
+            print(json.dumps(outcome, indent=2, default=str))
+            return 0 if not outcome["remaining"] else 1
     except RemoteLaunchError as exc:
         print(f"remote-launcher: {exc}", file=sys.stderr)
         return 3

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -256,6 +256,15 @@ def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
     return (
         "@echo off\r\n"
         f'cd /d "{repo_root}"\r\n'
+        # `/run` starts this on demand, but the `/sc once` trigger `/create` insists on is REAL and
+        # still fires at its scheduled time. A run that finished before that moment would execute a
+        # SECOND time — `>` truncates, so the ghost silently destroys the first run's stdout/stderr
+        # and overwrites its in-sim evidence while the agent is polling or disconnected. The
+        # sentinel only exists once the wrapper has completed, so it is the exact idempotency key.
+        # (A trigger that fires *during* the first run is already suppressed by Task Scheduler's
+        # default "do not start a new instance" policy; this covers the after-completion case.)
+        f'if exist "{sentinel_path}" echo [wrapper] ghost trigger suppressed>>"{sentinel_path}"\r\n'
+        f'if exist "{sentinel_path}" exit /b 0\r\n'
         "rem Redirected Python is fully buffered; without this the poll surface looks hung for\r\n"
         "rem minutes on a healthy run.\r\n"
         "set PYTHONUNBUFFERED=1\r\n"

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -85,6 +85,9 @@ STDERR_NAME = "stderr.log"
 SENTINEL_NAME = "wrapper.log"
 SENTINEL_TOKEN = "exit="
 RUN_JSON_NAME = "run.json"
+#: Written by the wrapper immediately BEFORE the payload, so it is evidence the payload actually
+#: started — which a bare exit sentinel is not (that file is plantable in the shared scratch tree).
+STARTED_NAME = "run.started"
 
 #: ``/sd`` format measured as the only accepted one on the rig (see the module docstring).
 SCHTASKS_DATE_FORMAT = "%m/%d/%Y"
@@ -253,6 +256,7 @@ def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
     stdout_path = run_dir / STDOUT_NAME
     stderr_path = run_dir / STDERR_NAME
     sentinel_path = run_dir / SENTINEL_NAME
+    started_path = run_dir / STARTED_NAME
     return (
         "@echo off\r\n"
         f'cd /d "{repo_root}"\r\n'
@@ -263,8 +267,17 @@ def render_wrapper(repo_root: Path, argv: Sequence[str], run_dir: Path) -> str:
         # sentinel only exists once the wrapper has completed, so it is the exact idempotency key.
         # (A trigger that fires *during* the first run is already suppressed by Task Scheduler's
         # default "do not start a new instance" policy; this covers the after-completion case.)
-        f'if exist "{sentinel_path}" echo [wrapper] ghost trigger suppressed>>"{sentinel_path}"\r\n'
-        f'if exist "{sentinel_path}" exit /b 0\r\n'
+        # Suppression requires BOTH markers. Keying only on the exit sentinel would let a peer
+        # plant `[wrapper] exit=0` between /run and the wrapper body and turn the whole task into a
+        # no-op that still reports Ready + Last Result 0 — i.e. `start --wait` returning success
+        # without the harness ever launching. `run.started` is written by the wrapper itself just
+        # before the payload, so requiring it means suppression rests on evidence the payload ran
+        # at least once. A lone planted sentinel no longer stops execution, and the real run
+        # appends its own `exit=` afterwards, which is the one parse_sentinel reads.
+        f'if exist "{started_path}" if exist "{sentinel_path}" '
+        f'echo [wrapper] ghost trigger suppressed>>"{sentinel_path}"\r\n'
+        f'if exist "{started_path}" if exist "{sentinel_path}" exit /b 0\r\n'
+        f'echo [wrapper] started>"{started_path}"\r\n'
         "rem Redirected Python is fully buffered; without this the poll surface looks hung for\r\n"
         "rem minutes on a healthy run.\r\n"
         "set PYTHONUNBUFFERED=1\r\n"
@@ -479,7 +492,10 @@ def start_run(
         nonce=random.randrange(1000, 9999),  # noqa: S311
     )
     run_dir = root.joinpath(*RUN_DIR_RELPATH, run_id)
-    run_dir.mkdir(parents=True, exist_ok=True)
+    # exist_ok=False on purpose: a per-run id should never collide, and REUSING a directory would
+    # inherit whatever markers it already holds (a stale or planted sentinel), which is exactly the
+    # vector the wrapper's start-marker guard exists to close. A collision is a loud error.
+    run_dir.mkdir(parents=True, exist_ok=False)
 
     resolved_argv = substitute_run_placeholders(argv, run_id=run_id, run_dir=run_dir)
     wrapper = run_dir / WRAPPER_NAME

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -416,8 +416,13 @@ def short_path(path: Path) -> str:
     get_short = ctypes.windll.kernel32.GetShortPathNameW  # type: ignore[attr-defined]
     get_short.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
     get_short.restype = wintypes.DWORD
+    # A too-small buffer is not a failure: the call returns the REQUIRED length, so retry at that
+    # size rather than refusing a long-but-perfectly-valid repo/run path.
     buf = ctypes.create_unicode_buffer(1024)
     size = get_short(str(path), buf, len(buf))
+    if size >= len(buf):
+        buf = ctypes.create_unicode_buffer(size + 1)
+        size = get_short(str(path), buf, len(buf))
     if size == 0 or size >= len(buf):
         raise RemoteLaunchError(f"GetShortPathNameW failed for {path}")
     resolved = buf.value
@@ -538,11 +543,35 @@ def load_run(run_id: str, *, repo_root: Path | None = None) -> RemoteRun:
     return replace(run, run_dir=str(run_dir))
 
 
+#: Cap on how much of a log is read to satisfy a tail. A drive stage writes megabytes of relay
+#: chatter to stderr, so reading whole files would make every poll scale with log size.
+_TAIL_MAX_BYTES = 256 * 1024
+
+
 def _tail(path: Path, lines: int) -> list[str]:
-    if not path.is_file():
+    """Last ``lines`` lines of a log, reading only the tail of the file.
+
+    ``lines <= 0`` means **no tail** — it previously returned the *entire* file, and
+    :func:`cleanup_run` calls :func:`poll_run` with ``tail=0``, so a cleanup could load and
+    JSON-print megabytes of sidecar logs.
+    """
+    if lines <= 0:
         return []
-    text = path.read_text(encoding="utf-8", errors="replace")
-    return text.splitlines()[-lines:] if lines > 0 else text.splitlines()
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            start = max(0, size - _TAIL_MAX_BYTES)
+            fh.seek(start)
+            blob = fh.read()
+    except OSError:
+        return []
+    text = blob.decode("utf-8", errors="replace")
+    rows = text.splitlines()
+    if start > 0 and rows:
+        # The seek can land mid-line (and mid-codepoint); drop that partial first row.
+        rows = rows[1:]
+    return rows[-lines:]
 
 
 def poll_run(run: RemoteRun, *, tail: int = 30) -> dict[str, Any]:
@@ -658,8 +687,19 @@ def cleanup_run(run: RemoteRun, *, force: bool = False) -> dict[str, Any]:
 
 
 def list_stale_tasks() -> list[str]:
-    """Task names this module owns that are still registered. Read-only — see :func:`reap_tasks`."""
+    """Task names this module owns that are still registered. Read-only — see :func:`reap_tasks`.
+
+    Raises rather than returning an empty list when the query fails: an empty result is what an
+    operator reads as "nothing left behind", so silently returning it on a failed ``schtasks`` call
+    would let ``reap`` exit 0 with live registrations still on the rig.
+    """
     queried = _run(["schtasks", "/query", "/fo", "list"])
+    if queried.returncode != 0:
+        raise RemoteLaunchError(
+            f"schtasks /query failed (rc={queried.returncode}): "
+            f"{(queried.stderr or queried.stdout or '').strip()[:200]} — refusing to report an "
+            "empty task list, which would read as 'nothing left behind'"
+        )
     names: list[str] = []
     for line in queried.stdout.splitlines():
         key, _, value = line.partition(":")
@@ -687,9 +727,16 @@ SCHED_S_TASK_IS_CURRENTLY_RUNNING = 267009
 def _sentinel_exit_code(run_dir: Path) -> int | None:
     """The wrapper's recorded exit code, or ``None`` when the run has not finished."""
     sentinel = run_dir / SENTINEL_NAME
-    if not sentinel.is_file():
+    try:
+        if not sentinel.is_file():
+            return None
+        text = sentinel.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        # A transient IO/permission failure must not abort a reap pass with a traceback (main()
+        # only catches RemoteLaunchError). Unreadable == unproven == fail closed: the caller then
+        # skips this task, which is the safe direction.
         return None
-    return parse_sentinel(sentinel.read_text(encoding="utf-8", errors="replace"))
+    return parse_sentinel(text)
 
 
 def task_deletion_verdict(name: str, run_dir: Path) -> tuple[bool, str]:
@@ -721,8 +768,10 @@ def task_deletion_verdict(name: str, run_dir: Path) -> tuple[bool, str]:
         last_result = int(raw_result, 0)
     except ValueError:
         return False, f"last result {raw_result!r} unreadable — failing closed"
-    if last_result in (SCHED_S_TASK_HAS_NOT_YET_RUN, SCHED_S_TASK_IS_CURRENTLY_RUNNING):
+    if last_result == SCHED_S_TASK_HAS_NOT_YET_RUN:
         return False, "task has not yet run (pre-spawn Ready window) — refusing to cancel a launch"
+    if last_result == SCHED_S_TASK_IS_CURRENTLY_RUNNING:
+        return False, "last result says the task is currently running — refusing to cancel it"
     return True, ""
 
 

--- a/tools/ac_harness/remote_launcher.py
+++ b/tools/ac_harness/remote_launcher.py
@@ -831,7 +831,13 @@ def evaluate_deletion(
     ``status``/``last_result`` that could disagree with the verdict computed beside it.
     """
     if sentinel_exit_code is None:
-        return False, f"no exit sentinel at {run_dir / SENTINEL_NAME} — may still be launching"
+        # Name the file actually consulted. The sentinel moved out of the log directory when the
+        # control plane left `.scratch`; reporting the old path would send an operator to inspect a
+        # file this check never reads — the exact class of misleading diagnostic being fixed here.
+        return (
+            False,
+            f"no exit sentinel at {sentinel_path_for(run_dir.name)} — may still be launching",
+        )
     if query_rc != 0:
         return False, f"status query failed (rc={query_rc}) — failing closed"
     state = fields.get("status", "").strip().lower()


### PR DESCRIPTION
Closes #697.

## What

An SSH logon on the rig lands in Windows **session 0**, which cannot traverse the AC app junction (`WinError 448`) and has no interactive desktop for AC to render on — so the harness must run in the console session via a `schtasks /IT` task ([#693](https://github.com/agorokh/ac-copilot-trainer/issues/693)).

PR #694 shipped that as a copy/paste runbook. Five review rounds then found **six real Windows defects in a documentation block**, and PR #699 had to fix a *fail-open* guard in it post-merge. That is the argument for this issue: the transport is intricate enough that no off-rig session should re-derive it by hand.

New `tools/ac_harness/remote_launcher.py` owns the session-0 → session-1 hop end to end. Every measured Windows fact from #693/#699 is encoded as a guard that asserts its own precondition:

| Measured failure | Guard |
|---|---|
| A space anywhere in the path → `create=0`, `run=0`, wrapper **never executes** (`Last Result: -2147024894`) | `/tr` gets the 8.3 short path; `short_path()` **raises** when 8.3 generation is disabled and the result still has whitespace (the fail-open case #699 fixed in prose) |
| `/st` without `/sd`, or a fixed `/st`, fails once local time passes it — i.e. overnight | `/st` and `/sd` derive from the **same** datetime, formatted `MM/dd/yyyy` (the only pattern the rig accepts; `M/d/yyyy`, `dd/MM/yyyy`, `yyyy/MM/dd` all gave `0x80004005`) |
| A fixed task name lets two agents on one rig clobber each other | per-run name `ac-harness-<label>-<stamp>-<pid>-<nonce>`; `/f` still passed so a duplicate create cannot block on the interactive "replace it?" prompt |
| `<`/`>` in the generated `.cmd` parse as redirection; `&`/`\|`/`^`/`%VAR%` are injection | every argv token validated before interpolation; spaced tokens quoted |
| `Set-Content -Encoding ascii` mangles non-ASCII paths to `?` while `schtasks` still reports success | wrapper written ASCII, non-ASCII repo/run path rejected up front |
| Redirected Python is fully buffered — the poll surface looks hung for minutes on a healthy run | wrapper sets `PYTHONUNBUFFERED=1` **and** passes `-u` |

## Surface

```bash
python -m tools.ac_harness.remote_launcher start --label alien-529-911-magione -- \
    -m tools.ac_harness.auto_alien --car ks_porsche_911_gt3_r_2016 --track magione --laps 3
python -m tools.ac_harness.remote_launcher poll <run id> --tail 40
python -m tools.ac_harness.remote_launcher wait <run id> --timeout-s 10800
python -m tools.ac_harness.remote_launcher cleanup <run id>
python -m tools.ac_harness.remote_launcher list
```

- `poll` is read-only — task `Status`/`Last Result`, exit sentinel, `acs.exe` liveness, the current **rig-lock owner**, and tails of both streams. Safe in a tight loop; never touches AC, never deletes the task.
- `cleanup` **refuses** an unfinished run without `--force`: `schtasks /run` is asynchronous, so an early delete can cancel a start that has not spawned yet. The `[wrapper] exit=<rc>` sentinel — not `Status: Ready` — is what says a run finished.
- `wait` is bounded, because on a run that never starts the sentinel never appears.
- `start` **refuses to run in the console session** (the hop would be pure overhead) and fails loudly when nobody is logged on (a `/IT` task can never run then).
- Ownership arbitration is **not** duplicated: the spawned harness takes the cross-worktree lock itself; the launcher only *reports* the owner.
- Transport logs live under `.scratch/harness-remote/<run id>/`, deliberately beside the harness's own `--evidence-dir` tree.

## Acceptance criteria

- [x] One documented entrypoint replaces the manual `schtasks` recipe; the runbook keeps only the session-0 *diagnosis* as prose and points at the entrypoint.
- [x] Per-run task naming; task deleted after the run; concurrent invocations cannot collide.
- [x] No hardcoded account or checkout path (`harness_repo_root()` + `%USERNAME%`).
- [x] Off-sim unit tests cover wrapper generation, task-name uniqueness, the `schtasks` argv (incl. the midnight rollover), status/sentinel parsing, the bounded wait, and cleanup's refusal — 49 tests; the `schtasks` calls themselves stay rig-gated.
- [ ] `make ci-fast` green — running.
- [ ] **Live**: an off-rig session drives a real `auto_alien` run through the entrypoint to `installed app provenance: match` and a completed stage, with no task left behind.

## Verification

- `pytest tests/test_ac_harness_remote_launcher.py` → **49 passed**; `ruff format`/`check` clean.
- Live proof is pending on this branch — the rig is currently mid-ladder on the #529 pace gates through the *documented* recipe this PR replaces. The live run through the entrypoint follows on the same rig once that finishes.

Refs #693 (the procedure this codifies) · #529 (whose live gates depend on off-rig runs) · #575 (the provenance preflight that makes the session-0 failure visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)