### PR TITLE
docs(vault): correct the #703 handoff — live verification 3/3 blocked at CSP hijack

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Next Session Handoff.md
@@ -2,7 +2,7 @@
 type: handoff
 status: active
 memory_tier: canonical
-last_updated: 2026-07-28T17:05:00Z
+last_updated: 2026-07-28T17:10:00Z
 relates_to:
   - AcCopilotTrainer/03_Investigations/issue-703-decoupled-ladder-2026-07-28.md
   - AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
@@ -151,13 +151,22 @@ decoupled ladder — #529 ladder 3's rung caps at 1.15 on the first step, so bot
 No Magione ladder has yet retained a refit across a falsified top rung on the rig. Two attempts
 this session both died **before self-play started**:
 
-- `alien-703-live-20260728T165135Z` — base drive failed `stage=hijack`, *"CSP did not accept the
-  carcsw hijack"*, 1 attempt. This is the known shape-2 overlay flake (vault #466: hijack lands
-  ~1/4 on full launch cycles; **retry full cycles**). The pipeline aborted before `run_selfplay`,
-  so **the plant was never mutated** — verified still 7 merges / 7 measured lateral bins, last
-  merge `{adopted: 1, raised: 5}`.
-- A retry was launched at session end; its outcome is in
-  `.scratch/harness-evidence/alien-703-live-retry-*.log`.
+- **3 of 3 attempts failed identically** at `stage=hijack`, *"CSP did not accept the carcsw
+  hijack"*, each on its own full launch cycle with the rig cleared in between
+  (`alien-703-live-20260728T165135Z`, `alien-703-live-retry-20260728T165739Z`,
+  `alien-703-live-try3-20260728T170328Z`). This is the known shape-2 overlay flake (vault #466:
+  hijack lands ~1/4 on full cycles) — but 3/3 with a clean rig each time reads as a **persistent
+  rig/CSP condition today**, not variance. It is the third-party CSP init wedge tracked in
+  #619/#625/#627 and is **not fixable from this repo**.
+- Every attempt aborted in the drive stage **before `run_selfplay`**, so the ladder logic was never
+  exercised live and **the plant was never mutated** — proven by hash, not inference: the live
+  artifact is byte-identical (`sha256[:12] = 65c7b467a9eb`) to the pre-session backup.
+- **One corroborating observation** from attempt 3's preflight, which got far enough to build the
+  line: `alien line cache (QSS 86.27s, vmax 236.9 km/h, plant fit 08e4835fe7f5)`. That is the
+  *refined* floor from #529 ladder 3's retained refit, read back across invocations — the second
+  half of AC 5 ("a later run's line build reports the lower QSS floor") behaving correctly on an
+  inherited plant. It does **not** verify the first half (a refit surviving a *falsified* rung
+  under the decoupled ladder), which still needs a drive that actually starts.
 
 **Plant safety:** backed up before any live attempt to
 `plant_id/ks_porsche_911_gt3_r_2016__magione.json.bak-pre703-20260728` (7 merges verified). Restore


### PR DESCRIPTION
Corrects the #703 handoff with the **actual** outcome of the live-verification attempts. Vault-only — diff is strictly under `docs/01_Vault/**`.

The handoff shipped in [PR #715](https://github.com/agorokh/ac-copilot-trainer/pull/715) said a retry "was launched at session end; its outcome is in …log", which left the next session to go dig. The outcome is now known and understating it would be the [epic-body-delivery-drift](../03_Investigations/backlog-reconcile-2026-07-24.md) pitfall in miniature — a stale body that reads as more complete than reality.

## What changed

**3 of 3 live attempts failed identically** at `stage=hijack` (*"CSP did not accept the carcsw hijack"*), each on its own full launch cycle with the rig cleared in between. The vault records this flake as landing ~1/4 on full cycles (#466), so one failure is unremarkable — but 3/3 with a clean rig each time reads as a **persistent rig/CSP condition today**, not variance. It is the third-party CSP init wedge tracked in #619/#625/#627 and is not fixable from this repo.

**The plant was never mutated — proven, not inferred.** Every attempt aborted in the drive stage *before* `run_selfplay`, and the live artifact is byte-identical to the pre-session backup (`sha256[:12] = 65c7b467a9eb`). The operator's G2-winning fit (7 self-play merges) is exactly as it was.

**One corroborating observation** worth keeping: attempt 3 got far enough to build the line and reported `alien line cache (QSS 86.27s, vmax 236.9 km/h, plant fit 08e4835fe7f5)` — the *refined* floor from #529 ladder 3's retained refit, read back across invocations. That is the **second** half of AC 5 ("a later run's line build reports the lower QSS floor") behaving correctly on an inherited plant. It does **not** verify the first half — a refit surviving a *falsified* rung under the decoupled ladder — which still needs a drive that actually starts. The handoff says so explicitly rather than letting a partial signal read as the criterion.

AC 5 therefore remains **open**, with the resume recipe and expected step sequence already recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
