### PR TITLE
feat(harness): verify treatment RECEIPT for the #625 A/B — record which init perturbers were actually injected into acs.exe (#719)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
+++ b/docs/01_Vault/AcCopilotTrainer/00_System/Current Focus.md
@@ -56,15 +56,20 @@ relates_to:
 
 **Repo:** ac-copilot-trainer.
 
+**In flight (2026-07-29):** PR [#721](https://github.com/agorokh/ac-copilot-trainer/pull/721) —
+**#719 treatment-receipt verification** for the #625 A/B. Report `resilient-launch-report/v3`,
+plan/analysis **v4**, `--expect-perturbers`, contradicted-boot exclusion + unique salvage paths,
+64-bit Python preflight for module snapshots. Physical 16-reboot A/B still operator-gated (#625).
+Live protocol: [issue-625-boot-scoped-redesign-2026-07-28](../03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md).
+
 **Delivered (2026-07-28):** PR [#717](https://github.com/agorokh/ac-copilot-trainer/pull/717)
 MERGED [`d78c10b`](https://github.com/agorokh/ac-copilot-trainer/commit/d78c10b730da9968c4995957313ba340efcdcdde)
 — **#710 launch-cycle delivery recorded, CLOSED**. `never_live` no longer conflates "acs.exe
 appeared and exited" with "nothing was spawned": every attempt records `cycle_delivered`
-(`resilient-launch-report/v2`), and the #625 analysis scores onset and the burst window in
-**delivered cycles** (`init-perturber-ab-analysis/v3`, plan `/v3`) instead of discarding any boot
-that contained an undelivered attempt — each of which costs a physical reboot. Off-rig only by
-construction; **not rig-verified** (the flag only becomes observable when the #625 experiment runs,
-still blocked at the CSP hijack per #703/#716). Node:
+(`resilient-launch-report/v2` then **v3** with perturbers under #719), and the #625 analysis scores
+onset and the burst window in **delivered cycles** (`init-perturber-ab-analysis/v3` → **v4** with
+treatment receipt). Off-rig only by construction; **not rig-verified** until the #625 experiment
+runs. Node:
 [issue-710-cycle-delivered-2026-07-28](../03_Investigations/issue-710-cycle-delivered-2026-07-28.md).
 
 **Delivered (2026-07-28):** PR [#707](https://github.com/agorokh/ac-copilot-trainer/pull/707)

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
@@ -93,8 +93,11 @@ delivered cycles, so a boot containing a merely undelivered attempt scores inste
   settings fix + reboot. Exit is nonzero — scripted boot chains must treat that as stop-and-fix.
 - Analyzer **excludes** contradicted boots (and drops their block); never re-labels. Unverified
   receipt withholds causal conclusions (`treatment_receipt_unverified`) without inventing exclusions.
-- `go_live_timeout` must be ≥ 5 s (injection race ~3 s). Absence on `FROZE` is only dispositive when
-  `elapsed_s ≥ 5`. Module sampling requires **64-bit Python** on the rig.
+- `go_live_timeout` must be ≥ 5 s (injection race ~3 s). Absence is dispositive only on delivered
+  `stable`/`froze` (post-go-live: packet advanced + entry ready + drivable — past the race by
+  construction). `elapsed_s` is **not** used (includes pre-launch work). Module sampling requires
+  **64-bit Python** on the rig; mid-attempt PID replacement freezes evidence if any injection was
+  already seen, else re-pins cleanly.
 
 Design detail: [[issue-719-treatment-receipt-2026-07-28]].
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
@@ -79,17 +79,24 @@ spawned"~~ — **RESOLVED 2026-07-28 by [#710](https://github.com/agorokh/ac-cop
 delivered cycles, so a boot containing a merely undelivered attempt scores instead of being dropped.
 `onset_ambiguous` narrows to genuinely unknown delivery.
 
-## Open limitation — treatment receipt is NOT verified (#719)
+## Treatment receipt is verified (#719) — plan/report/analysis **v4**
 
-**Read this before spending the 16 reboots.** Each boot's arm label comes only from this plan file —
-the operator's assertion that they toggled the two settings before *that* reboot. Nothing observes
-whether the perturbers were actually injected into `acs.exe`. One boot that does not receive its
-assigned condition corrupts the exact block permutation test with **no detectable signature** in any
-current artifact.
+**Read this before spending the 16 reboots.** PR #721 lands treatment-**receipt** verification:
 
-Tracked as [#719](https://github.com/agorokh/ac-copilot-trainer/issues/719), with the full design in
-[[issue-719-treatment-receipt-2026-07-28]]. Until it lands, the run's arm labels rest on manual
-discipline across 16 reboots in randomized order.
+- **Report schema** `resilient-launch-report/v3` records per-attempt + boot roll-up `perturbers`
+  (`injected` / `not_observed` / `unavailable`). v2 reports are refused.
+- **Plan/analysis schema** `init-perturber-ab-plan/v4` + `…-analysis/v4` pre-register the receipt
+  policy. v3 plans are refused — regenerate with `python -m tools.ac_harness.init_perturber_ab plan`.
+- Plan commands emit `--expect-perturbers on|off`. Off-arm positive sighting (or on-arm STABLE miss)
+  stops the trial loop early with a **unique** salvage path
+  `{stem}.arm_contradicted.{UTC}Z{suffix}` so the planned exclusive JSON stays free for re-run after
+  settings fix + reboot. Exit is nonzero — scripted boot chains must treat that as stop-and-fix.
+- Analyzer **excludes** contradicted boots (and drops their block); never re-labels. Unverified
+  receipt withholds causal conclusions (`treatment_receipt_unverified`) without inventing exclusions.
+- `go_live_timeout` must be ≥ 5 s (injection race ~3 s). Absence on `FROZE` is only dispositive when
+  `elapsed_s ≥ 5`. Module sampling requires **64-bit Python** on the rig.
+
+Design detail: [[issue-719-treatment-receipt-2026-07-28]].
 
 ## Verified rig facts (AG_PC, 2026-07-28) — do not re-derive
 

--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
@@ -94,10 +94,10 @@ delivered cycles, so a boot containing a merely undelivered attempt scores inste
 - Analyzer **excludes** contradicted boots (and drops their block); never re-labels. Unverified
   receipt withholds causal conclusions (`treatment_receipt_unverified`) without inventing exclusions.
 - `go_live_timeout` must be ≥ 5 s (injection race ~3 s). Absence is dispositive only on delivered
-  `stable`/`froze` (post-go-live: packet advanced + entry ready + drivable — past the race by
-  construction). `elapsed_s` is **not** used (includes pre-launch work). Module sampling requires
-  **64-bit Python** on the rig; mid-attempt PID replacement freezes evidence if any injection was
-  already seen, else re-pins cleanly.
+  **`stable`** (full stability window past the race). `froze` misses stay non-dispositive.
+  Module sampling requires **64-bit Python** on the rig; mid-attempt PID replacement freezes
+  presence and invalidates absence if injection was seen. Analyzer resolves
+  `{stem}.arm_contradicted.*` salvage when the planned report is absent.
 
 Design detail: [[issue-719-treatment-receipt-2026-07-28]].
 

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -91,12 +91,24 @@ def _write_boot_report(
     for index, (verdict, delivery) in enumerate(zip(verdicts, flags, strict=True), start=1):
         counts[verdict] += 1
         minute = start_minute + index
+        # Only stable is post-race for absence; keep injected on any verdict, demote
+        # not_observed to unavailable on non-stable rows so analyze fixtures stay confirmed.
+        row_evidence = dict(evidence)
+        if verdict != "stable":
+            row_evidence = {
+                key: (
+                    value
+                    if value == "injected"
+                    else ("unavailable" if value == "not_observed" else value)
+                )
+                for key, value in evidence.items()
+            }
         log.append(
             {
                 "attempt": index,
                 "verdict": verdict,
                 "cycle_delivered": delivery,
-                "perturbers": dict(evidence),
+                "perturbers": row_evidence,
                 "started_at_utc": f"2026-07-28T{minute // 60:02d}:{minute % 60:02d}:00Z",
                 "elapsed_s": 12.5,
                 "uptime_h": round(uptime_start + index * 0.05, 4),
@@ -150,7 +162,22 @@ def _boot(
     perturbers: dict[str, str] | None = None,
 ) -> BootObservation:
     flags = _default_delivery(verdicts) if delivered is None else delivered
-    evidence = tuple(sorted((perturbers or _default_perturbers_for(condition)).items()))
+    base = dict(perturbers or _default_perturbers_for(condition))
+
+    def _row_evidence(verdict: str) -> tuple[tuple[str, str], ...]:
+        # Only stable is post-race for absence; demote not_observed on other verdicts.
+        if verdict == "stable":
+            return tuple(sorted(base.items()))
+        demoted = {
+            key: (
+                value
+                if value == "injected"
+                else ("unavailable" if value == "not_observed" else value)
+            )
+            for key, value in base.items()
+        }
+        return tuple(sorted(demoted.items()))
+
     return BootObservation(
         boot=number,
         condition=condition,
@@ -162,7 +189,7 @@ def _boot(
                 elapsed_s=12.5,
                 uptime_h=uptime_start + index * 0.05,
                 cycle_delivered=delivery,
-                perturbers=evidence,
+                perturbers=_row_evidence(verdict),
             )
             for index, (verdict, delivery) in enumerate(zip(verdicts, flags, strict=True), start=1)
         ),
@@ -1583,7 +1610,7 @@ class TestTreatmentReceipt:
                     sorted({"steam_overlay": "not_observed", "nvidia_capture": "injected"}.items())
                 ),
             ),
-        )
+        )  # both stable: only stable is post-race for absence (Codex P1 on #721)
         boot = BootObservation(boot=1, condition="overlays_on", launches=launches)
         # Union would be both injected; per-launch is incomplete → contradicted, not confirmed.
         state = {"steam_overlay": "injected", "nvidia_capture": "injected"}

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -1563,9 +1563,9 @@ class TestTreatmentReceipt:
         launches = (
             LaunchObservation(
                 launch=1,
-                verdict="froze",
+                verdict="stable",
                 started_at_utc="2026-07-28T10:01:00Z",
-                elapsed_s=12.5,
+                elapsed_s=150.0,
                 uptime_h=0.5,
                 cycle_delivered=True,
                 perturbers=tuple(
@@ -1574,9 +1574,9 @@ class TestTreatmentReceipt:
             ),
             LaunchObservation(
                 launch=2,
-                verdict="froze",
+                verdict="stable",
                 started_at_utc="2026-07-28T10:02:00Z",
-                elapsed_s=12.5,
+                elapsed_s=150.0,
                 uptime_h=0.55,
                 cycle_delivered=True,
                 perturbers=tuple(
@@ -1615,22 +1615,22 @@ class TestTreatmentReceipt:
         summary = summarize_boot(short_nl)
         assert summary.treatment == TREATMENT_UNVERIFIED
 
-        # A dispositive miss is not erased by a sibling unavailable live launch.
+        # A stable miss is not erased by a sibling unavailable live launch.
         mixed = (
             LaunchObservation(
                 launch=1,
-                verdict="froze",
+                verdict="stable",
                 started_at_utc="2026-07-28T10:01:00Z",
-                elapsed_s=12.5,
+                elapsed_s=150.0,
                 uptime_h=0.5,
                 cycle_delivered=True,
                 perturbers=tuple(sorted(_ABSENT_PERTURBERS.items())),
             ),
             LaunchObservation(
                 launch=2,
-                verdict="froze",
+                verdict="stable",
                 started_at_utc="2026-07-28T10:02:00Z",
-                elapsed_s=12.5,
+                elapsed_s=150.0,
                 uptime_h=0.55,
                 cycle_delivered=True,
                 perturbers=tuple(sorted(_UNAVAILABLE_PERTURBERS.items())),
@@ -1683,8 +1683,8 @@ class TestTreatmentReceipt:
             assert summary.treatment == TREATMENT_UNVERIFIED
             assert summary.usable is True
 
-    def test_short_froze_miss_is_unverified_not_contradicted(self):
-        """Codex P1: FROZE inside the injection-race floor cannot invent absence."""
+    def test_wedged_init_miss_is_unverified_not_contradicted(self):
+        """Codex P1: wedged_init never reached readiness — absence is non-dispositive."""
         from tools.ac_harness.init_perturber_ab import (
             TREATMENT_UNVERIFIED,
             BootObservation,
@@ -1692,16 +1692,16 @@ class TestTreatmentReceipt:
             treatment_receipt,
         )
 
-        short = LaunchObservation(
+        wedged = LaunchObservation(
             launch=1,
-            verdict="froze",
+            verdict="wedged_init",
             started_at_utc="2026-07-28T10:01:00Z",
-            elapsed_s=2.0,  # below MIN_ABSENCE_ELAPSED_S
+            elapsed_s=80.0,
             uptime_h=0.5,
             cycle_delivered=True,
             perturbers=tuple(sorted(_ABSENT_PERTURBERS.items())),
         )
-        boot = BootObservation(boot=1, condition="overlays_on", launches=(short,))
+        boot = BootObservation(boot=1, condition="overlays_on", launches=(wedged,))
         verdict, _detail = treatment_receipt(
             "overlays_on", dict(_ABSENT_PERTURBERS), launches=boot.launches
         )

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -115,6 +115,10 @@ def _write_boot_report(
         "launch": launch or _launch_config(len(verdicts)),
         "attempts_log": log,
     }
+    if condition == "overlays_on":
+        payload["expect_perturbers"] = "on"
+    elif condition == "overlays_off":
+        payload["expect_perturbers"] = "off"
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -346,6 +350,7 @@ def test_report_must_cover_every_planned_launch(tmp_path: Path) -> None:
     plan = _two_boot_plan()
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=["stable"] * (_LAUNCHES - 1),
         start_minute=0,
         uptime_start=0.5,
@@ -359,6 +364,7 @@ def test_report_attempts_header_must_match_its_log(tmp_path: Path) -> None:
     plan = _two_boot_plan()
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=["stable"] * (_LAUNCHES - 2),
         start_minute=0,
         uptime_start=0.5,
@@ -371,7 +377,13 @@ def test_report_attempts_header_must_match_its_log(tmp_path: Path) -> None:
 def test_report_counts_must_match_the_attempts_log(tmp_path: Path) -> None:
     plan = _two_boot_plan()
     path = tmp_path / plan["boots"][0]["report"]
-    _write_boot_report(path, verdicts=["stable"] * _LAUNCHES, start_minute=0, uptime_start=0.5)
+    _write_boot_report(
+        path,
+        condition=plan["boots"][0]["condition"],
+        verdicts=["stable"] * _LAUNCHES,
+        start_minute=0,
+        uptime_start=0.5,
+    )
     payload = json.loads(path.read_text(encoding="utf-8"))
     payload["counts"]["stable"] = 0
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -381,7 +393,13 @@ def test_report_counts_must_match_the_attempts_log(tmp_path: Path) -> None:
 
 def _mutate_first_report(tmp_path: Path, plan: dict[str, object], mutate) -> None:
     path = tmp_path / plan["boots"][0]["report"]
-    _write_boot_report(path, verdicts=["stable"] * _LAUNCHES, start_minute=0, uptime_start=0.5)
+    _write_boot_report(
+        path,
+        condition=plan["boots"][0]["condition"],
+        verdicts=["stable"] * _LAUNCHES,
+        start_minute=0,
+        uptime_start=0.5,
+    )
     payload = json.loads(path.read_text(encoding="utf-8"))
     mutate(payload)
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -435,6 +453,7 @@ def test_delivery_flags_survive_the_report_round_trip(tmp_path: Path) -> None:
     verdicts = ["stable"] * 9 + ["never_live"] + ["froze"] + ["stable"] * 9
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=verdicts,
         start_minute=0,
         uptime_start=0.5,
@@ -452,6 +471,7 @@ def test_incomplete_experiment_is_refused(tmp_path: Path) -> None:
     plan = _two_boot_plan()
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=["stable"] * _LAUNCHES,
         start_minute=0,
         uptime_start=0.5,
@@ -470,6 +490,7 @@ def test_continuous_uptime_across_a_boundary_is_refused(tmp_path: Path) -> None:
     # Boot 1 launches at minutes 1..20 -> last uptime 0.5 + 20*0.05 = 1.5h at minute 20.
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=["stable"] * _LAUNCHES,
         start_minute=0,
         uptime_start=0.5,
@@ -478,6 +499,7 @@ def test_continuous_uptime_across_a_boundary_is_refused(tmp_path: Path) -> None:
     # (1.5h + 0.6833h = 2.1833h, minus the +0.05 the writer adds for launch 1) -> no reboot.
     _write_boot_report(
         tmp_path / plan["boots"][1]["report"],
+        condition=plan["boots"][1]["condition"],
         verdicts=["stable"] * _LAUNCHES,
         start_minute=60,
         uptime_start=1.5 + (41 / 60) - 0.05,
@@ -540,6 +562,7 @@ def test_reboot_is_accepted_even_when_the_operator_waits_a_long_time(tmp_path: P
     # Boot 1 ends at uptime 1.5h.
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=["stable"] * _LAUNCHES,
         start_minute=0,
         uptime_start=0.5,
@@ -549,6 +572,7 @@ def test_reboot_is_accepted_even_when_the_operator_waits_a_long_time(tmp_path: P
     # did not track the ~16h of wall clock since boot 1's final launch.
     _write_boot_report(
         tmp_path / plan["boots"][1]["report"],
+        condition=plan["boots"][1]["condition"],
         verdicts=_stable_then_freeze(14),
         start_minute=1000,
         uptime_start=9.0,
@@ -562,12 +586,14 @@ def test_boot_boundary_accepts_a_real_reboot(tmp_path: Path) -> None:
     plan = _two_boot_plan()
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=["stable"] * _LAUNCHES,
         start_minute=0,
         uptime_start=2.0,
     )
     _write_boot_report(
         tmp_path / plan["boots"][1]["report"],
+        condition=plan["boots"][1]["condition"],
         verdicts=_stable_then_freeze(14),
         start_minute=200,
         uptime_start=0.1,
@@ -580,7 +606,13 @@ def test_boot_boundary_accepts_a_real_reboot(tmp_path: Path) -> None:
 def test_mid_boot_uptime_drop_is_refused(tmp_path: Path) -> None:
     plan = _two_boot_plan()
     path = tmp_path / plan["boots"][0]["report"]
-    _write_boot_report(path, verdicts=["stable"] * _LAUNCHES, start_minute=0, uptime_start=0.5)
+    _write_boot_report(
+        path,
+        condition=plan["boots"][0]["condition"],
+        verdicts=["stable"] * _LAUNCHES,
+        start_minute=0,
+        uptime_start=0.5,
+    )
     payload = json.loads(path.read_text(encoding="utf-8"))
     payload["attempts_log"][10]["uptime_h"] = 0.01
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -594,6 +626,7 @@ def test_report_launch_must_match_plan(tmp_path: Path) -> None:
     wrong["car"] = "wrong_car"
     _write_boot_report(
         tmp_path / plan["boots"][0]["report"],
+        condition=plan["boots"][0]["condition"],
         verdicts=["stable"] * _LAUNCHES,
         start_minute=0,
         uptime_start=0.5,
@@ -1615,6 +1648,7 @@ class TestTreatmentReceipt:
         path = tmp_path / plan["boots"][0]["report"]
         _write_boot_report(
             path,
+            condition=plan["boots"][0]["condition"],
             verdicts=["stable"] * _LAUNCHES,
             start_minute=0,
             uptime_start=0.5,
@@ -1648,6 +1682,41 @@ class TestTreatmentReceipt:
             )
             assert summary.treatment == TREATMENT_UNVERIFIED
             assert summary.usable is True
+
+    def test_short_froze_miss_is_unverified_not_contradicted(self):
+        """Codex P1: FROZE inside the injection-race floor cannot invent absence."""
+        from tools.ac_harness.init_perturber_ab import (
+            TREATMENT_UNVERIFIED,
+            BootObservation,
+            LaunchObservation,
+            treatment_receipt,
+        )
+
+        short = LaunchObservation(
+            launch=1,
+            verdict="froze",
+            started_at_utc="2026-07-28T10:01:00Z",
+            elapsed_s=2.0,  # below MIN_ABSENCE_ELAPSED_S
+            uptime_h=0.5,
+            cycle_delivered=True,
+            perturbers=tuple(sorted(_ABSENT_PERTURBERS.items())),
+        )
+        boot = BootObservation(boot=1, condition="overlays_on", launches=(short,))
+        verdict, _detail = treatment_receipt(
+            "overlays_on", dict(_ABSENT_PERTURBERS), launches=boot.launches
+        )
+        assert verdict == TREATMENT_UNVERIFIED
+
+    def test_go_live_timeout_below_injection_floor_is_rejected(self) -> None:
+        """Codex P2: plans must not allow WEDGED_INIT inside the measured race."""
+        from tools.ac_harness.init_perturber_ab import MIN_GO_LIVE_TIMEOUT_S, build_plan
+
+        with pytest.raises(ValueError, match="go_live_timeout"):
+            build_plan(
+                6,
+                launches_per_boot=_LAUNCHES,
+                go_live_timeout=MIN_GO_LIVE_TIMEOUT_S - 0.1,
+            )
 
     def test_one_sighting_anywhere_in_the_boot_is_dispositive(self):
         """Union across launches: the injection races startup, so early misses prove nothing."""
@@ -1712,6 +1781,7 @@ def test_early_arm_contradiction_report_is_loadable(tmp_path: Path) -> None:
     path = reports_dir / first["report"]
     _write_boot_report(
         path,
+        condition="overlays_off",
         verdicts=["froze"],
         start_minute=10,
         uptime_start=0.5,
@@ -1722,7 +1792,7 @@ def test_early_arm_contradiction_report_is_loadable(tmp_path: Path) -> None:
     payload = json.loads(path.read_text(encoding="utf-8"))
     payload["arm_contradicted"] = True
     payload["expect_perturbers"] = "off"
-    # Plan boots[0] is overlays_on in the helper — force the planned condition to off for this case.
+    # Force the planned condition to off for this case (helper may have drawn either arm).
     plan["boots"][0] = {**first, "condition": "overlays_off"}
     path.write_text(json.dumps(payload), encoding="utf-8")
     observations = load_observations(plan, reports_dir, require_complete=False)

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -1554,14 +1554,33 @@ class TestTreatmentReceipt:
         summary = summarize_boot(early)
         assert summary.treatment == TREATMENT_UNVERIFIED
 
-        # Delivered never_live after go-live timeout is long enough to contradict.
-        long_nl = _boot(
+        # Short delivered never_live (early acs.exe death) is still non-dispositive.
+        short_nl = _boot(
             1,
             "overlays_on",
             ["never_live"] * 5,
             delivered=[True] * 5,
             perturbers=_ABSENT_PERTURBERS,
         )
+        summary = summarize_boot(short_nl)
+        assert summary.treatment == TREATMENT_UNVERIFIED
+
+        # Full go-live-timeout never_live (elapsed near DEFAULT_GO_LIVE_TIMEOUT) contradicts.
+        from tools.ac_harness.resilient_launch import DEFAULT_GO_LIVE_TIMEOUT
+
+        long_launches = tuple(
+            LaunchObservation(
+                launch=index,
+                verdict="never_live",
+                started_at_utc=f"2026-07-28T10:{index:02d}:00Z",
+                elapsed_s=DEFAULT_GO_LIVE_TIMEOUT,
+                uptime_h=0.5 + index * 0.05,
+                cycle_delivered=True,
+                perturbers=tuple(sorted(_ABSENT_PERTURBERS.items())),
+            )
+            for index in range(1, 6)
+        )
+        long_nl = BootObservation(boot=1, condition="overlays_on", launches=long_launches)
         summary = summarize_boot(long_nl)
         assert summary.treatment == TREATMENT_CONTRADICTED
 

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -91,10 +91,10 @@ def _write_boot_report(
     for index, (verdict, delivery) in enumerate(zip(verdicts, flags, strict=True), start=1):
         counts[verdict] += 1
         minute = start_minute + index
-        # Only stable is post-race for absence; keep injected on any verdict, demote
-        # not_observed to unavailable on non-stable rows so analyze fixtures stay confirmed.
+        # Keep injected on any verdict. Demote not_observed only on never_live / wedged_init
+        # (not post-go-live); freze/stable keep not_observed for off-arm confirmation.
         row_evidence = dict(evidence)
-        if verdict != "stable":
+        if verdict in ("never_live", "wedged_init"):
             row_evidence = {
                 key: (
                     value
@@ -165,8 +165,8 @@ def _boot(
     base = dict(perturbers or _default_perturbers_for(condition))
 
     def _row_evidence(verdict: str) -> tuple[tuple[str, str], ...]:
-        # Only stable is post-race for absence; demote not_observed on other verdicts.
-        if verdict == "stable":
+        # freze/stable keep not_observed for off-arm confirmation; demote only pre-go-live.
+        if verdict not in ("never_live", "wedged_init"):
             return tuple(sorted(base.items()))
         demoted = {
             key: (

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -1710,10 +1710,10 @@ class TestTreatmentReceipt:
             assert summary.treatment == TREATMENT_UNVERIFIED
             assert summary.usable is True
 
-    def test_wedged_init_miss_is_contradicted_when_timeout_cleared_race(self):
-        """With go_live_timeout floor ≥5s, wedged_init lived past the injection race."""
+    def test_wedged_init_miss_is_unverified_not_contradicted(self):
+        """WEDGED_INIT never finished init — absence is non-dispositive (Codex P1)."""
         from tools.ac_harness.init_perturber_ab import (
-            TREATMENT_CONTRADICTED,
+            TREATMENT_UNVERIFIED,
             BootObservation,
             LaunchObservation,
             treatment_receipt,
@@ -1732,7 +1732,31 @@ class TestTreatmentReceipt:
         verdict, _detail = treatment_receipt(
             "overlays_on", dict(_ABSENT_PERTURBERS), launches=boot.launches
         )
-        assert verdict == TREATMENT_CONTRADICTED
+        assert verdict == TREATMENT_UNVERIFIED
+
+    def test_froze_with_full_injection_confirms_on_arm(self):
+        """Codex P1: positive injection is dispositive on any delivered verdict."""
+        from tools.ac_harness.init_perturber_ab import (
+            TREATMENT_CONFIRMED,
+            BootObservation,
+            LaunchObservation,
+            treatment_receipt,
+        )
+
+        froze = LaunchObservation(
+            launch=1,
+            verdict="froze",
+            started_at_utc="2026-07-28T10:01:00Z",
+            elapsed_s=12.5,
+            uptime_h=0.5,
+            cycle_delivered=True,
+            perturbers=tuple(sorted(_INJECTED_PERTURBERS.items())),
+        )
+        boot = BootObservation(boot=1, condition="overlays_on", launches=(froze,))
+        verdict, _detail = treatment_receipt(
+            "overlays_on", dict(_INJECTED_PERTURBERS), launches=boot.launches
+        )
+        assert verdict == TREATMENT_CONFIRMED
 
     def test_go_live_timeout_below_injection_floor_is_rejected(self) -> None:
         """Codex P2: plans must not allow WEDGED_INIT inside the measured race."""

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -73,14 +73,20 @@ def _write_boot_report(
     attempts: int | None = None,
     delivered: list[bool | None] | None = None,
     perturbers: dict[str, str] | None = None,
+    condition: str | None = None,
 ) -> None:
     """Emit one ``resilient_launch --trials N`` style report for a whole boot."""
     counts = {"stable": 0, "froze": 0, "wedged_init": 0, "never_live": 0}
     flags = _default_delivery(verdicts) if delivered is None else delivered
-    # Default to "we could not look" so a fixture that says nothing about treatment yields
-    # `unverified` and falls back to the planned label — the pre-#719 behaviour. Tests that care
-    # about treatment receipt pass explicit evidence.
-    evidence = perturbers or _UNAVAILABLE_PERTURBERS
+    # Prefer arm-matching evidence so analysis fixtures are not silently `unverified` under the
+    # receipt gate (#721). Explicit `perturbers=` still wins; unavailable is the pre-receipt default
+    # only when no condition is known.
+    if perturbers is not None:
+        evidence = perturbers
+    elif condition is not None:
+        evidence = _default_perturbers_for(condition)
+    else:
+        evidence = _UNAVAILABLE_PERTURBERS
     log = []
     for index, (verdict, delivery) in enumerate(zip(verdicts, flags, strict=True), start=1):
         counts[verdict] += 1
@@ -120,6 +126,16 @@ def _stable_then_freeze(onset: int, total: int = _LAUNCHES) -> list[str]:
     return verdicts[:total]
 
 
+def _default_perturbers_for(condition: str) -> dict[str, str]:
+    """Matching receipt evidence so analysis fixtures are not silently unverified (#721)."""
+
+    if condition == "overlays_on":
+        return dict(_INJECTED_PERTURBERS)
+    if condition == "overlays_off":
+        return dict(_ABSENT_PERTURBERS)
+    return dict(_UNAVAILABLE_PERTURBERS)
+
+
 def _boot(
     number: int,
     condition: str,
@@ -130,7 +146,7 @@ def _boot(
     perturbers: dict[str, str] | None = None,
 ) -> BootObservation:
     flags = _default_delivery(verdicts) if delivered is None else delivered
-    evidence = tuple(sorted((perturbers or _UNAVAILABLE_PERTURBERS).items()))
+    evidence = tuple(sorted((perturbers or _default_perturbers_for(condition)).items()))
     return BootObservation(
         boot=number,
         condition=condition,
@@ -1399,6 +1415,7 @@ def test_analyze_cli_round_trip(capsys, tmp_path, monkeypatch) -> None:
             verdicts=_stable_then_freeze(next(onsets[boot["condition"]])),
             start_minute=index * 100,
             uptime_start=0.1,
+            condition=boot["condition"],
         )
     assert main(["analyze", "--plan", str(plan_path), "--reports-dir", str(scratch)]) == 0
     printed = capsys.readouterr().out
@@ -1554,7 +1571,7 @@ class TestTreatmentReceipt:
         summary = summarize_boot(early)
         assert summary.treatment == TREATMENT_UNVERIFIED
 
-        # Short delivered never_live (early acs.exe death) is still non-dispositive.
+        # Delivered never_live is never dispositive for absence (elapsed includes pre-launch work).
         short_nl = _boot(
             1,
             "overlays_on",
@@ -1564,25 +1581,6 @@ class TestTreatmentReceipt:
         )
         summary = summarize_boot(short_nl)
         assert summary.treatment == TREATMENT_UNVERIFIED
-
-        # Full go-live-timeout never_live (elapsed near DEFAULT_GO_LIVE_TIMEOUT) contradicts.
-        from tools.ac_harness.resilient_launch import DEFAULT_GO_LIVE_TIMEOUT
-
-        long_launches = tuple(
-            LaunchObservation(
-                launch=index,
-                verdict="never_live",
-                started_at_utc=f"2026-07-28T10:{index:02d}:00Z",
-                elapsed_s=DEFAULT_GO_LIVE_TIMEOUT,
-                uptime_h=0.5 + index * 0.05,
-                cycle_delivered=True,
-                perturbers=tuple(sorted(_ABSENT_PERTURBERS.items())),
-            )
-            for index in range(1, 6)
-        )
-        long_nl = BootObservation(boot=1, condition="overlays_on", launches=long_launches)
-        summary = summarize_boot(long_nl)
-        assert summary.treatment == TREATMENT_CONTRADICTED
 
         # A dispositive miss is not erased by a sibling unavailable live launch.
         mixed = (

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -1543,7 +1543,7 @@ class TestTreatmentReceipt:
         assert summary.usable is False
         assert summary.unusable_reason == "treatment_contradicted"
 
-        # Early never_live-only looks are non-dispositive for the on arm.
+        # Undelivered never_live looks are non-dispositive for the on arm.
         early = _boot(
             1,
             "overlays_on",
@@ -1553,6 +1553,45 @@ class TestTreatmentReceipt:
         )
         summary = summarize_boot(early)
         assert summary.treatment == TREATMENT_UNVERIFIED
+
+        # Delivered never_live after go-live timeout is long enough to contradict.
+        long_nl = _boot(
+            1,
+            "overlays_on",
+            ["never_live"] * 5,
+            delivered=[True] * 5,
+            perturbers=_ABSENT_PERTURBERS,
+        )
+        summary = summarize_boot(long_nl)
+        assert summary.treatment == TREATMENT_CONTRADICTED
+
+        # A dispositive miss is not erased by a sibling unavailable live launch.
+        mixed = (
+            LaunchObservation(
+                launch=1,
+                verdict="froze",
+                started_at_utc="2026-07-28T10:01:00Z",
+                elapsed_s=12.5,
+                uptime_h=0.5,
+                cycle_delivered=True,
+                perturbers=tuple(sorted(_ABSENT_PERTURBERS.items())),
+            ),
+            LaunchObservation(
+                launch=2,
+                verdict="froze",
+                started_at_utc="2026-07-28T10:02:00Z",
+                elapsed_s=12.5,
+                uptime_h=0.55,
+                cycle_delivered=True,
+                perturbers=tuple(sorted(_UNAVAILABLE_PERTURBERS.items())),
+            ),
+        )
+        verdict, _detail = treatment_receipt(
+            "overlays_on",
+            {"steam_overlay": "not_observed", "nvidia_capture": "unavailable"},
+            launches=mixed,
+        )
+        assert verdict == TREATMENT_CONTRADICTED
 
     def test_incomplete_perturber_keys_are_rejected(self, tmp_path: Path) -> None:
         plan = _two_boot_plan()

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -1466,6 +1466,26 @@ class TestTreatmentReceipt:
         assert off.treatment == TREATMENT_CONFIRMED
         assert on.usable and off.usable
 
+    def test_partial_on_arm_injection_is_not_confirmation(self):
+        """Codex P1 on #721: both planned overlays must match; one of two is not enough."""
+        from tools.ac_harness.init_perturber_ab import (
+            TREATMENT_CONTRADICTED,
+            TREATMENT_UNVERIFIED,
+            treatment_receipt,
+        )
+
+        half_injected = {"steam_overlay": "injected", "nvidia_capture": "not_observed"}
+        mixed_unknown = {"steam_overlay": "injected", "nvidia_capture": "unavailable"}
+        off_mixed = {"steam_overlay": "not_observed", "nvidia_capture": "unavailable"}
+
+        verdict, _detail = treatment_receipt("overlays_on", half_injected)
+        assert verdict == TREATMENT_CONTRADICTED
+        verdict, _detail = treatment_receipt("overlays_on", mixed_unknown)
+        assert verdict == TREATMENT_UNVERIFIED
+        # Off arm: partial unknown is unverified, not a free confirmation.
+        verdict, _detail = treatment_receipt("overlays_off", off_mixed)
+        assert verdict == TREATMENT_UNVERIFIED
+
     def test_unavailable_evidence_is_unverified_not_contradicted(self):
         """No information must fall back to the plan, never manufacture an exclusion."""
         from tools.ac_harness.init_perturber_ab import (
@@ -1530,6 +1550,56 @@ class TestTreatmentReceipt:
         assert len(blocks) == 1
         # The surviving block carries no usable difference, so it cannot enter the statistic.
         assert blocks[0].onset_difference is None
+
+
+def test_early_arm_contradiction_report_is_loadable(tmp_path: Path) -> None:
+    """Codex P1 on #721: fail-fast off-arm stop must parse as a contradicted boot, not corrupt."""
+    from tools.ac_harness.init_perturber_ab import TREATMENT_CONTRADICTED, summarize_boot
+
+    plan = _two_boot_plan()
+    reports_dir = tmp_path
+    first = plan["boots"][0]
+    # Planned off arm, stopped after one injected sighting — shorter than launches_per_boot.
+    path = reports_dir / first["report"]
+    _write_boot_report(
+        path,
+        verdicts=["froze"],
+        start_minute=10,
+        uptime_start=0.5,
+        launch=_launch_config(plan["launches_per_boot"]),
+        attempts=1,
+        perturbers=_INJECTED_PERTURBERS,
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["arm_contradicted"] = True
+    payload["expect_perturbers"] = "off"
+    # Plan boots[0] is overlays_on in the helper — force the planned condition to off for this case.
+    plan["boots"][0] = {**first, "condition": "overlays_off"}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    observations = load_observations(plan, reports_dir, require_complete=False)
+    assert len(observations) == 1
+    assert len(observations[0].launches) == 1
+    summary = summarize_boot(observations[0])
+    assert summary.treatment == TREATMENT_CONTRADICTED
+    assert summary.usable is False
+    assert summary.unusable_reason == "treatment_contradicted"
+
+
+def test_plan_commands_emit_expect_perturbers(tmp_path, monkeypatch, capsys) -> None:
+    """Codex P2 on #721: generated plan lines must activate the fail-fast arm check."""
+    from tools.ac_harness.init_perturber_ab import main
+
+    monkeypatch.setattr(ab_mod, "repo_checkout_root", lambda: tmp_path)
+    out = tmp_path / ".scratch" / "plan.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    assert main(["plan", "--out", str(out), "--boots-per-arm", "6", "--seed", "1"]) == 0
+    printed = capsys.readouterr().out
+    assert "--expect-perturbers on" in printed
+    assert "--expect-perturbers off" in printed
+    plan = json.loads(out.read_text(encoding="utf-8"))
+    # Both arms appear in the printed schedule; counts match the planned boots.
+    assert sum(boot["condition"] == "overlays_on" for boot in plan["boots"]) == 6
+    assert sum(boot["condition"] == "overlays_off" for boot in plan["boots"]) == 6
 
 
 def test_v2_reports_are_rejected_with_a_reason(tmp_path: Path) -> None:

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -1710,10 +1710,10 @@ class TestTreatmentReceipt:
             assert summary.treatment == TREATMENT_UNVERIFIED
             assert summary.usable is True
 
-    def test_wedged_init_miss_is_unverified_not_contradicted(self):
-        """Codex P1: wedged_init never reached readiness — absence is non-dispositive."""
+    def test_wedged_init_miss_is_contradicted_when_timeout_cleared_race(self):
+        """With go_live_timeout floor ≥5s, wedged_init lived past the injection race."""
         from tools.ac_harness.init_perturber_ab import (
-            TREATMENT_UNVERIFIED,
+            TREATMENT_CONTRADICTED,
             BootObservation,
             LaunchObservation,
             treatment_receipt,
@@ -1732,7 +1732,7 @@ class TestTreatmentReceipt:
         verdict, _detail = treatment_receipt(
             "overlays_on", dict(_ABSENT_PERTURBERS), launches=boot.launches
         )
-        assert verdict == TREATMENT_UNVERIFIED
+        assert verdict == TREATMENT_CONTRADICTED
 
     def test_go_live_timeout_below_injection_floor_is_rejected(self) -> None:
         """Codex P2: plans must not allow WEDGED_INIT inside the measured race."""

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -204,8 +204,14 @@ def test_randomization_reference_set_is_the_full_two_to_the_blocks() -> None:
 
 def test_plan_is_boot_scoped_and_records_the_operator_gate() -> None:
     plan = build_plan(6, generated_at_utc="2026-07-28T12:00:00Z")
-    assert plan["schema"] == "init-perturber-ab-plan/v3"
-    assert plan["supersedes"] == [WITHDRAWN_PLAN_SCHEMA, SUPERSEDED_PLAN_SCHEMA]
+    assert plan["schema"] == "init-perturber-ab-plan/v4"
+    assert plan["supersedes"] == [
+        WITHDRAWN_PLAN_SCHEMA,
+        SUPERSEDED_PLAN_SCHEMA,
+        "init-perturber-ab-plan/v3",
+    ]
+    assert plan["treatment_receipt"]["enabled"] is True
+    assert plan["treatment_receipt"]["expect_perturbers_in_commands"] is True
     assert plan["operator_owned_settings"] is True
     assert plan["protocol"]["reboot_before_every_boot"] is True
     assert plan["protocol"]["graceful_first_teardown_both_arms"] is True
@@ -1477,14 +1483,101 @@ class TestTreatmentReceipt:
         half_injected = {"steam_overlay": "injected", "nvidia_capture": "not_observed"}
         mixed_unknown = {"steam_overlay": "injected", "nvidia_capture": "unavailable"}
         off_mixed = {"steam_overlay": "not_observed", "nvidia_capture": "unavailable"}
+        # On-arm confirmation is per live-session launch (not a boot-wide union).
+        live_half = _boot(1, "overlays_on", _stable_then_freeze(8), perturbers=half_injected)
+        live_mixed = _boot(1, "overlays_on", _stable_then_freeze(8), perturbers=mixed_unknown)
 
-        verdict, _detail = treatment_receipt("overlays_on", half_injected)
+        verdict, _detail = treatment_receipt(
+            "overlays_on", half_injected, launches=live_half.launches
+        )
         assert verdict == TREATMENT_CONTRADICTED
-        verdict, _detail = treatment_receipt("overlays_on", mixed_unknown)
+        verdict, _detail = treatment_receipt(
+            "overlays_on", mixed_unknown, launches=live_mixed.launches
+        )
         assert verdict == TREATMENT_UNVERIFIED
         # Off arm: partial unknown is unverified, not a free confirmation.
         verdict, _detail = treatment_receipt("overlays_off", off_mixed)
         assert verdict == TREATMENT_UNVERIFIED
+
+    def test_on_arm_requires_per_live_launch_full_injection(self):
+        """Boot-wide union must not confirm when no single live acs.exe had both overlays."""
+        from tools.ac_harness.init_perturber_ab import (
+            TREATMENT_CONTRADICTED,
+            TREATMENT_UNVERIFIED,
+            BootObservation,
+            LaunchObservation,
+            summarize_boot,
+            treatment_receipt,
+        )
+
+        launches = (
+            LaunchObservation(
+                launch=1,
+                verdict="froze",
+                started_at_utc="2026-07-28T10:01:00Z",
+                elapsed_s=12.5,
+                uptime_h=0.5,
+                cycle_delivered=True,
+                perturbers=tuple(
+                    sorted({"steam_overlay": "injected", "nvidia_capture": "not_observed"}.items())
+                ),
+            ),
+            LaunchObservation(
+                launch=2,
+                verdict="froze",
+                started_at_utc="2026-07-28T10:02:00Z",
+                elapsed_s=12.5,
+                uptime_h=0.55,
+                cycle_delivered=True,
+                perturbers=tuple(
+                    sorted({"steam_overlay": "not_observed", "nvidia_capture": "injected"}.items())
+                ),
+            ),
+        )
+        boot = BootObservation(boot=1, condition="overlays_on", launches=launches)
+        # Union would be both injected; per-launch is incomplete → contradicted, not confirmed.
+        state = {"steam_overlay": "injected", "nvidia_capture": "injected"}
+        verdict, _detail = treatment_receipt("overlays_on", state, launches=launches)
+        assert verdict == TREATMENT_CONTRADICTED
+        summary = summarize_boot(boot)
+        assert summary.usable is False
+        assert summary.unusable_reason == "treatment_contradicted"
+
+        # Early never_live-only looks are non-dispositive for the on arm.
+        early = _boot(
+            1,
+            "overlays_on",
+            ["never_live"] * 5,
+            delivered=[False] * 5,
+            perturbers=_ABSENT_PERTURBERS,
+        )
+        summary = summarize_boot(early)
+        assert summary.treatment == TREATMENT_UNVERIFIED
+
+    def test_incomplete_perturber_keys_are_rejected(self, tmp_path: Path) -> None:
+        plan = _two_boot_plan()
+        path = tmp_path / plan["boots"][0]["report"]
+        _write_boot_report(
+            path,
+            verdicts=["stable"] * _LAUNCHES,
+            start_minute=0,
+            uptime_start=0.5,
+            launch=_launch_config(_LAUNCHES),
+        )
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        for row in payload["attempts_log"]:
+            row["perturbers"] = {"steam_overlay": "injected"}  # missing nvidia_capture
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(ValueError, match="perturbers keys must be exactly"):
+            load_observations(plan, tmp_path, require_complete=False)
+
+    def test_pre_treatment_v3_plans_are_rejected(self, tmp_path: Path) -> None:
+        from tools.ac_harness.init_perturber_ab import PRE_TREATMENT_PLAN_SCHEMA, load_plan
+
+        stale = tmp_path / "plan.json"
+        stale.write_text(json.dumps({"schema": PRE_TREATMENT_PLAN_SCHEMA}), encoding="utf-8")
+        with pytest.raises(ValueError, match="treatment-receipt"):
+            load_plan(stale)
 
     def test_unavailable_evidence_is_unverified_not_contradicted(self):
         """No information must fall back to the plan, never manufacture an exclusion."""

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -57,6 +57,12 @@ def _default_delivery(verdicts: list[str]) -> list[bool | None]:
     return [verdict != "never_live" for verdict in verdicts]
 
 
+#: "We could not look" — the honest no-information default for fixtures (#719).
+_UNAVAILABLE_PERTURBERS = {"steam_overlay": "unavailable", "nvidia_capture": "unavailable"}
+_INJECTED_PERTURBERS = {"steam_overlay": "injected", "nvidia_capture": "injected"}
+_ABSENT_PERTURBERS = {"steam_overlay": "not_observed", "nvidia_capture": "not_observed"}
+
+
 def _write_boot_report(
     path: Path,
     *,
@@ -66,10 +72,15 @@ def _write_boot_report(
     launch: dict[str, object] | None = None,
     attempts: int | None = None,
     delivered: list[bool | None] | None = None,
+    perturbers: dict[str, str] | None = None,
 ) -> None:
     """Emit one ``resilient_launch --trials N`` style report for a whole boot."""
     counts = {"stable": 0, "froze": 0, "wedged_init": 0, "never_live": 0}
     flags = _default_delivery(verdicts) if delivered is None else delivered
+    # Default to "we could not look" so a fixture that says nothing about treatment yields
+    # `unverified` and falls back to the planned label — the pre-#719 behaviour. Tests that care
+    # about treatment receipt pass explicit evidence.
+    evidence = perturbers or _UNAVAILABLE_PERTURBERS
     log = []
     for index, (verdict, delivery) in enumerate(zip(verdicts, flags, strict=True), start=1):
         counts[verdict] += 1
@@ -79,6 +90,7 @@ def _write_boot_report(
                 "attempt": index,
                 "verdict": verdict,
                 "cycle_delivered": delivery,
+                "perturbers": dict(evidence),
                 "started_at_utc": f"2026-07-28T{minute // 60:02d}:{minute % 60:02d}:00Z",
                 "elapsed_s": 12.5,
                 "uptime_h": round(uptime_start + index * 0.05, 4),
@@ -115,8 +127,10 @@ def _boot(
     *,
     uptime_start: float = 0.5,
     delivered: list[bool | None] | None = None,
+    perturbers: dict[str, str] | None = None,
 ) -> BootObservation:
     flags = _default_delivery(verdicts) if delivered is None else delivered
+    evidence = tuple(sorted((perturbers or _UNAVAILABLE_PERTURBERS).items()))
     return BootObservation(
         boot=number,
         condition=condition,
@@ -128,6 +142,7 @@ def _boot(
                 elapsed_s=12.5,
                 uptime_h=uptime_start + index * 0.05,
                 cycle_delivered=delivery,
+                perturbers=evidence,
             )
             for index, (verdict, delivery) in enumerate(zip(verdicts, flags, strict=True), start=1)
         ),
@@ -1408,3 +1423,144 @@ def test_analyze_cli_reports_a_clean_error_for_a_withdrawn_plan(capsys, tmp_path
     stale.write_text(json.dumps({"schema": WITHDRAWN_PLAN_SCHEMA}), encoding="utf-8")
     assert main(["analyze", "--plan", str(stale), "--reports-dir", str(tmp_path)]) == 2
     assert "withdrawn" in capsys.readouterr().err
+
+
+class TestTreatmentReceipt:
+    """#719 — a boot that did not RECEIVE its assigned condition cannot inform the contrast."""
+
+    def test_off_arm_with_an_injected_perturber_is_contradicted_and_excluded(self):
+        from tools.ac_harness.init_perturber_ab import (
+            TREATMENT_CONTRADICTED,
+            summarize_boot,
+        )
+
+        boot = _boot(1, "overlays_off", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS)
+        summary = summarize_boot(boot)
+        assert summary.treatment == TREATMENT_CONTRADICTED
+        assert summary.usable is False
+        assert summary.unusable_reason == "treatment_contradicted"
+        assert "overlays_off" in (summary.treatment_detail or "")
+
+    def test_on_arm_never_observing_the_perturber_is_contradicted(self):
+        """Symmetric at BOOT level even though one attempt cannot refute the `on` arm."""
+        from tools.ac_harness.init_perturber_ab import (
+            TREATMENT_CONTRADICTED,
+            summarize_boot,
+        )
+
+        boot = _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_ABSENT_PERTURBERS)
+        summary = summarize_boot(boot)
+        assert summary.treatment == TREATMENT_CONTRADICTED
+        assert summary.usable is False
+
+    def test_matching_arms_are_confirmed_and_stay_usable(self):
+        from tools.ac_harness.init_perturber_ab import TREATMENT_CONFIRMED, summarize_boot
+
+        on = summarize_boot(
+            _boot(1, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS)
+        )
+        off = summarize_boot(
+            _boot(2, "overlays_off", _stable_then_freeze(14), perturbers=_ABSENT_PERTURBERS)
+        )
+        assert on.treatment == TREATMENT_CONFIRMED
+        assert off.treatment == TREATMENT_CONFIRMED
+        assert on.usable and off.usable
+
+    def test_unavailable_evidence_is_unverified_not_contradicted(self):
+        """No information must fall back to the plan, never manufacture an exclusion."""
+        from tools.ac_harness.init_perturber_ab import (
+            TREATMENT_UNVERIFIED,
+            summarize_boot,
+        )
+
+        for condition in ("overlays_on", "overlays_off"):
+            summary = summarize_boot(
+                _boot(1, condition, _stable_then_freeze(8), perturbers=_UNAVAILABLE_PERTURBERS)
+            )
+            assert summary.treatment == TREATMENT_UNVERIFIED
+            assert summary.usable is True
+
+    def test_one_sighting_anywhere_in_the_boot_is_dispositive(self):
+        """Union across launches: the injection races startup, so early misses prove nothing."""
+        from tools.ac_harness.init_perturber_ab import (
+            BootObservation,
+            LaunchObservation,
+            boot_perturber_state,
+        )
+
+        launches = tuple(
+            LaunchObservation(
+                launch=index,
+                verdict="stable",
+                started_at_utc=f"2026-07-28T10:{index:02d}:00Z",
+                elapsed_s=12.5,
+                uptime_h=0.5 + index * 0.05,
+                cycle_delivered=True,
+                perturbers=tuple(sorted(evidence.items())),
+            )
+            for index, evidence in enumerate(
+                [
+                    {"steam_overlay": "unavailable"},
+                    {"steam_overlay": "not_observed"},
+                    {"steam_overlay": "injected"},
+                    {"steam_overlay": "not_observed"},
+                ],
+                start=1,
+            )
+        )
+        state = boot_perturber_state(
+            BootObservation(boot=1, condition="overlays_off", launches=launches)
+        )
+        assert state["steam_overlay"] == "injected"
+
+    def test_a_contradicted_boot_drops_its_whole_block(self):
+        """The block is the unit of inference — excluding one boot must remove the pair."""
+        from tools.ac_harness.init_perturber_ab import _summarize_blocks, summarize_boot
+
+        boots = [
+            summarize_boot(
+                _boot(1, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS)
+            ),
+            summarize_boot(
+                # Planned OFF but the overlay was demonstrably injected: label is a lie.
+                _boot(2, "overlays_off", _stable_then_freeze(14), perturbers=_INJECTED_PERTURBERS)
+            ),
+        ]
+        blocks = _summarize_blocks(boots)
+        assert len(blocks) == 1
+        # The surviving block carries no usable difference, so it cannot enter the statistic.
+        assert blocks[0].onset_difference is None
+
+
+def test_v2_reports_are_rejected_with_a_reason(tmp_path: Path) -> None:
+    """#719 — a v2 report has no treatment evidence, so its arm label cannot be cross-checked."""
+    plan = _two_boot_plan()
+
+    def drop_perturbers(payload: dict) -> None:
+        payload["schema"] = "resilient-launch-report/v2"
+        payload.pop("perturbers", None)
+        for row in payload["attempts_log"]:
+            row.pop("perturbers")
+
+    _mutate_first_report(tmp_path, plan, drop_perturbers)
+    with pytest.raises(ValueError, match="resilient-launch-report/v2"):
+        load_observations(plan, tmp_path, require_complete=False)
+
+
+def test_missing_perturbers_key_is_rejected(tmp_path: Path) -> None:
+    plan = _two_boot_plan()
+    _mutate_first_report(tmp_path, plan, lambda p: p["attempts_log"][2].pop("perturbers"))
+    with pytest.raises(ValueError, match="missing perturbers"):
+        load_observations(plan, tmp_path, require_complete=False)
+
+
+def test_unknown_perturber_evidence_value_is_rejected(tmp_path: Path) -> None:
+    """A tri-state that silently accepts a fourth value is not a tri-state."""
+    plan = _two_boot_plan()
+    _mutate_first_report(
+        tmp_path,
+        plan,
+        lambda p: p["attempts_log"][0]["perturbers"].__setitem__("steam_overlay", "probably"),
+    )
+    with pytest.raises(ValueError, match="invalid perturber evidence"):
+        load_observations(plan, tmp_path, require_complete=False)

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2654,21 +2654,23 @@ class TestPerturberTreatmentReceipt:
         assert report.arm_contradicted is True
         assert report.stable == 1
 
-    def test_pid_replacement_freezes_presence_and_invalidates_absence(self):
-        """Codex P1: keep injected; convert leftover not_observed to unavailable on replace."""
+    def test_pid_replacement_latches_injection_without_on_arm_union(self):
+        """Codex P1: latch off-arm injection; reset so on-arm cannot inherit corpse full set."""
         from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
 
         watch = PerturberWatch()
+        watch.observe(frozenset({"gameoverlayrenderer64.dll", "nvspcap64.dll", "ntdll.dll"}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        latched = {name for name in ("steam_overlay", "nvidia_capture") if watch.injected(name)}
+        watch.reset()
+        # Replacement only has Steam — on-arm must not see full injection from the latch alone.
         watch.observe(frozenset({"gameoverlayrenderer64.dll"}))
-        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
-        assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.NOT_OBSERVED)
-        watch.freeze_presence_only()
-        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
-        assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.UNAVAILABLE)
-        # Clean re-pin path still resets when no injection was seen.
-        clean = PerturberWatch()
-        clean.observe(frozenset({"ntdll.dll"}))
-        clean.reset()
-        clean.observe(frozenset({"nvspcap64.dll"}))
-        assert clean.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
-        assert clean.evidence()["nvidia_capture"] == str(PerturberEvidence.INJECTED)
+        evidence = dict(watch.evidence())
+        for name in latched:
+            evidence[name] = str(PerturberEvidence.INJECTED)
+        assert evidence["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        # After reset, nvidia is only latched if it was on the corpse; if we latched both,
+        # the emission overlays both — for off-arm. On-arm confirmation requires stable
+        # per-launch full set from the live watch before latch overlay; analyzer uses
+        # per-launch rows. Unit-level: latch is a plain dict overlay of injected keys.
+        assert "nvidia_capture" in latched

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2633,11 +2633,12 @@ class TestPerturberTreatmentReceipt:
             "nvidia_capture": str(PerturberEvidence.NOT_OBSERVED),
         }
         assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.STABLE) is True
-        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is False
+        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is True
+        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.WEDGED_INIT) is False
 
         def watch(_attempt: int) -> AttemptOutcome:
             return AttemptOutcome(
-                LaunchVerdict.STABLE,
+                LaunchVerdict.FROZE,
                 cycle_delivered=True,
                 perturbers=evidence,
             )
@@ -2651,4 +2652,16 @@ class TestPerturberTreatmentReceipt:
         )
         assert report.attempts == 1
         assert report.arm_contradicted is True
-        assert report.stable == 1
+        assert report.froze == 1
+
+    def test_pid_replacement_resets_injected_union(self):
+        """Codex P1: Steam on PID A + NVIDIA on PID B must not invent full treatment."""
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        watch.observe(frozenset({"gameoverlayrenderer64.dll"}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        watch.reset()
+        watch.observe(frozenset({"nvspcap64.dll"}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.INJECTED)

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2507,3 +2507,17 @@ class TestPerturberTreatmentReceipt:
         # Dispositive presence still records through the partial path.
         watch.note_injected(frozenset({"gameoverlayrenderer64.dll"}))
         assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+
+    def test_early_miss_then_failed_looks_is_unavailable_not_absent(self):
+        """Codex P1: a race-window miss must not stick after later snapshots fail."""
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        watch.observe(frozenset({"ntdll.dll"}))  # early miss
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        watch.observe(None)  # later failure
+        watch.observe(None)
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)
+        # A final successful miss restores not_observed (post-race look).
+        watch.observe(frozenset({"ntdll.dll"}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2533,3 +2533,78 @@ class TestPerturberTreatmentReceipt:
         watch.note_injected(frozenset({"ntdll.dll"}))
         watch.observe(None)
         assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)
+
+    def test_empty_pid_poll_must_not_clear_prior_absence(self):
+        """Cursor MEDIUM: gone acs.exe is not a failed look — leave post-race miss intact."""
+        from tools.ac_harness.resilient_launch import (
+            PerturberEvidence,
+            PerturberWatch,
+            fold_perturber_snapshots,
+        )
+
+        watch = PerturberWatch()
+        watch.observe(frozenset({"ntdll.dll"}))  # post-race miss
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        fold_perturber_snapshots(watch, pids_empty=True)
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        # Contrast: a real failed look at a live process does invalidate.
+        fold_perturber_snapshots(watch, enum_failed=True)
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)
+
+    def test_fold_partial_and_full_pid_samples(self):
+        """fold_perturber_snapshots covers partial invalidation and full multi-PID observe."""
+        from tools.ac_harness.resilient_launch import (
+            PerturberEvidence,
+            PerturberWatch,
+            fold_perturber_snapshots,
+        )
+
+        watch = PerturberWatch()
+        watch.observe(frozenset({"ntdll.dll"}))
+        fold_perturber_snapshots(
+            watch,
+            successes=[frozenset({"ntdll.dll"})],
+            any_pid_failed=True,
+        )
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)
+
+        watch2 = PerturberWatch()
+        fold_perturber_snapshots(
+            watch2,
+            successes=[
+                frozenset({"ntdll.dll"}),
+                frozenset({"gameoverlayrenderer64.dll"}),
+            ],
+            any_pid_failed=False,
+        )
+        assert watch2.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+
+    def test_arm_contradicted_salvage_path_is_unique_per_timestamp(self, tmp_path):
+        """Cursor MEDIUM: salvage names must not collide under exclusive publish."""
+        from tools.ac_harness.resilient_launch import (
+            LaunchReport,
+            LaunchVerdict,
+            _arm_contradicted_salvage_path,
+            _write_report_json,
+        )
+
+        base = tmp_path / "boot3.json"
+        first = _arm_contradicted_salvage_path(base, when=1_753_766_510.100000)
+        second = _arm_contradicted_salvage_path(base, when=1_753_766_510.200000)
+        assert first != second
+        assert first.name.startswith("boot3.arm_contradicted.")
+        assert first.suffix == ".json"
+        # No colons — Windows path safety.
+        assert ":" not in first.name
+        report = LaunchReport(
+            verdict=LaunchVerdict.FROZE,
+            attempts=1,
+            froze=1,
+            never_live=0,
+            stable=0,
+            arm_contradicted=True,
+        )
+        assert _write_report_json(report, first) is True
+        assert _write_report_json(report, second) is True
+        # Same timestamp would refuse overwrite — uniqueness is what makes retry work.
+        assert _write_report_json(report, first) is False

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2494,3 +2494,16 @@ class TestPerturberTreatmentReceipt:
                 uptime_hours=lambda: None,
                 expect_perturbers="overlays_off",
             )
+
+    def test_partial_multi_pid_sample_does_not_invent_absence(self):
+        """Codex P1: a failed PID snapshot must not turn a miss on another PID into not_observed."""
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        # One PID opened cleanly with no overlay; the other failed — presence unknown for absence.
+        watch.note_injected(frozenset({"ntdll.dll"}))
+        assert watch.successful_looks == 0
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)
+        # Dispositive presence still records through the partial path.
+        watch.note_injected(frozenset({"gameoverlayrenderer64.dll"}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2521,3 +2521,15 @@ class TestPerturberTreatmentReceipt:
         # A final successful miss restores not_observed (post-race look).
         watch.observe(frozenset({"ntdll.dll"}))
         assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+
+    def test_partial_pid_sample_invalidates_prior_absence(self):
+        """Cursor HIGH: note_injected alone must not leave a sticky not_observed."""
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        watch.observe(frozenset({"ntdll.dll"}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        # Partial multi-PID path: union injection then invalidate absence.
+        watch.note_injected(frozenset({"ntdll.dll"}))
+        watch.observe(None)
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2633,12 +2633,12 @@ class TestPerturberTreatmentReceipt:
             "nvidia_capture": str(PerturberEvidence.NOT_OBSERVED),
         }
         assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.STABLE) is True
-        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.WEDGED_INIT) is True
+        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.WEDGED_INIT) is False
         assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is False
 
         def watch(_attempt: int) -> AttemptOutcome:
             return AttemptOutcome(
-                LaunchVerdict.WEDGED_INIT,
+                LaunchVerdict.STABLE,
                 cycle_delivered=True,
                 perturbers=evidence,
             )
@@ -2652,7 +2652,7 @@ class TestPerturberTreatmentReceipt:
         )
         assert report.attempts == 1
         assert report.arm_contradicted is True
-        assert report.wedged_init == 1
+        assert report.stable == 1
 
     def test_pid_replacement_latches_injection_without_on_arm_union(self):
         """Codex P1: latch off-arm injection; reset so on-arm cannot inherit corpse full set."""

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2654,14 +2654,20 @@ class TestPerturberTreatmentReceipt:
         assert report.arm_contradicted is True
         assert report.froze == 1
 
-    def test_pid_replacement_resets_injected_union(self):
-        """Codex P1: Steam on PID A + NVIDIA on PID B must not invent full treatment."""
+    def test_pid_replacement_freezes_when_injection_already_seen(self):
+        """Codex P1: keep injected sightings; do not union new PIDs after presence is known."""
         from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
 
         watch = PerturberWatch()
         watch.observe(frozenset({"gameoverlayrenderer64.dll"}))
         assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
-        watch.reset()
-        watch.observe(frozenset({"nvspcap64.dll"}))
-        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
-        assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.INJECTED)
+        # Freezing (no further observe) preserves the off-arm signal and avoids inventing
+        # full treatment by sampling a replacement process.
+        assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.NOT_OBSERVED)
+        # Clean re-pin path still resets when no injection was seen.
+        clean = PerturberWatch()
+        clean.observe(frozenset({"ntdll.dll"}))
+        clean.reset()
+        clean.observe(frozenset({"nvspcap64.dll"}))
+        assert clean.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        assert clean.evidence()["nvidia_capture"] == str(PerturberEvidence.INJECTED)

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2633,12 +2633,12 @@ class TestPerturberTreatmentReceipt:
             "nvidia_capture": str(PerturberEvidence.NOT_OBSERVED),
         }
         assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.STABLE) is True
-        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is True
+        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is False
         assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.WEDGED_INIT) is False
 
         def watch(_attempt: int) -> AttemptOutcome:
             return AttemptOutcome(
-                LaunchVerdict.FROZE,
+                LaunchVerdict.STABLE,
                 cycle_delivered=True,
                 perturbers=evidence,
             )
@@ -2652,7 +2652,7 @@ class TestPerturberTreatmentReceipt:
         )
         assert report.attempts == 1
         assert report.arm_contradicted is True
-        assert report.froze == 1
+        assert report.stable == 1
 
     def test_pid_replacement_freezes_presence_and_invalidates_absence(self):
         """Codex P1: keep injected; convert leftover not_observed to unavailable on replace."""

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2388,11 +2388,22 @@ class TestPerturberTreatmentReceipt:
         assert report.arm_contradicted is True
         assert report.expect_perturbers == "off"
         # Without the counters running before the break, this attempt would appear in the log but
-        # not in `cycles`, and the analyzer would reject the report as corrupt.
+        # not in `cycles`/`counts`, and the analyzer would reject the report as corrupt
+        # (cursor HIGH / Codex P1 on #721).
         assert report.cycles_delivered == 1
+        assert report.froze == 1
+        assert report.stable == 0
+        assert report.never_live == 0
+        assert report.wedged_init == 0
         assert len(report.attempts_log) == 1
         payload = report.as_dict()
         assert payload["cycles"]["delivered"] == len(payload["attempts_log"])
+        assert payload["counts"] == {
+            "stable": 0,
+            "froze": 1,
+            "wedged_init": 0,
+            "never_live": 0,
+        }
         assert payload["arm_contradicted"] is True
 
     def test_matching_off_arm_runs_the_whole_budget(self):

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2569,6 +2569,8 @@ class TestPerturberTreatmentReceipt:
         assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)
 
         watch2 = PerturberWatch()
+        # primary_only (default): only the first snapshot is classified — unioning two
+        # PIDs would invent full treatment when Steam and NVIDIA sit on different processes.
         fold_perturber_snapshots(
             watch2,
             successes=[
@@ -2577,7 +2579,14 @@ class TestPerturberTreatmentReceipt:
             ],
             any_pid_failed=False,
         )
-        assert watch2.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        assert watch2.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        watch3 = PerturberWatch()
+        fold_perturber_snapshots(
+            watch3,
+            successes=[frozenset({"gameoverlayrenderer64.dll", "nvspcap64.dll"})],
+        )
+        assert watch3.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        assert watch3.evidence()["nvidia_capture"] == str(PerturberEvidence.INJECTED)
 
     def test_arm_contradicted_salvage_path_is_unique_per_timestamp(self, tmp_path):
         """Cursor MEDIUM: salvage names must not collide under exclusive publish."""
@@ -2608,3 +2617,42 @@ class TestPerturberTreatmentReceipt:
         assert _write_report_json(report, second) is True
         # Same timestamp would refuse overwrite — uniqueness is what makes retry work.
         assert _write_report_json(report, first) is False
+
+    def test_stable_on_arm_miss_stops_the_loop(self):
+        """Codex P1: STABLE + successful miss makes on-arm confirmation impossible."""
+        from tools.ac_harness.resilient_launch import (
+            AttemptOutcome,
+            LaunchVerdict,
+            PerturberEvidence,
+            contradicts_expectation,
+            run_retry_loop,
+        )
+
+        evidence = {
+            "steam_overlay": str(PerturberEvidence.NOT_OBSERVED),
+            "nvidia_capture": str(PerturberEvidence.NOT_OBSERVED),
+        }
+        assert (
+            contradicts_expectation(evidence, "on", verdict=LaunchVerdict.STABLE) is True
+        )
+        assert (
+            contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is False
+        )
+
+        def watch(_attempt: int) -> AttemptOutcome:
+            return AttemptOutcome(
+                LaunchVerdict.STABLE,
+                cycle_delivered=True,
+                perturbers=evidence,
+            )
+
+        report = run_retry_loop(
+            watch,
+            max_attempts=24,
+            stop_on_stable=False,
+            uptime_hours=lambda: None,
+            expect_perturbers="on",
+        )
+        assert report.attempts == 1
+        assert report.arm_contradicted is True
+        assert report.stable == 1

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2654,16 +2654,17 @@ class TestPerturberTreatmentReceipt:
         assert report.arm_contradicted is True
         assert report.froze == 1
 
-    def test_pid_replacement_freezes_when_injection_already_seen(self):
-        """Codex P1: keep injected sightings; do not union new PIDs after presence is known."""
+    def test_pid_replacement_freezes_presence_and_invalidates_absence(self):
+        """Codex P1: keep injected; convert leftover not_observed to unavailable on replace."""
         from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
 
         watch = PerturberWatch()
         watch.observe(frozenset({"gameoverlayrenderer64.dll"}))
         assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
-        # Freezing (no further observe) preserves the off-arm signal and avoids inventing
-        # full treatment by sampling a replacement process.
         assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.NOT_OBSERVED)
+        watch.freeze_presence_only()
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.UNAVAILABLE)
         # Clean re-pin path still resets when no injection was seen.
         clean = PerturberWatch()
         clean.observe(frozenset({"ntdll.dll"}))

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2633,12 +2633,12 @@ class TestPerturberTreatmentReceipt:
             "nvidia_capture": str(PerturberEvidence.NOT_OBSERVED),
         }
         assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.STABLE) is True
+        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.WEDGED_INIT) is True
         assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is False
-        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.WEDGED_INIT) is False
 
         def watch(_attempt: int) -> AttemptOutcome:
             return AttemptOutcome(
-                LaunchVerdict.STABLE,
+                LaunchVerdict.WEDGED_INIT,
                 cycle_delivered=True,
                 perturbers=evidence,
             )
@@ -2652,7 +2652,7 @@ class TestPerturberTreatmentReceipt:
         )
         assert report.attempts == 1
         assert report.arm_contradicted is True
-        assert report.stable == 1
+        assert report.wedged_init == 1
 
     def test_pid_replacement_latches_injection_without_on_arm_union(self):
         """Codex P1: latch off-arm injection; reset so on-arm cannot inherit corpse full set."""

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -2632,12 +2632,8 @@ class TestPerturberTreatmentReceipt:
             "steam_overlay": str(PerturberEvidence.NOT_OBSERVED),
             "nvidia_capture": str(PerturberEvidence.NOT_OBSERVED),
         }
-        assert (
-            contradicts_expectation(evidence, "on", verdict=LaunchVerdict.STABLE) is True
-        )
-        assert (
-            contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is False
-        )
+        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.STABLE) is True
+        assert contradicts_expectation(evidence, "on", verdict=LaunchVerdict.FROZE) is False
 
         def watch(_attempt: int) -> AttemptOutcome:
             return AttemptOutcome(

--- a/tests/test_resilient_launch.py
+++ b/tests/test_resilient_launch.py
@@ -937,7 +937,7 @@ class TestRetryLoop:
             lambda i: LaunchVerdict.STABLE, max_attempts=1, uptime_hours=lambda: None
         )
         payload = json_module.loads(json_module.dumps(report.as_dict()))
-        assert payload["schema"] == "resilient-launch-report/v2"
+        assert payload["schema"] == "resilient-launch-report/v3"
         assert payload["verdict"] == "stable"
         assert payload["counts"] == {
             "stable": 1,
@@ -2287,3 +2287,199 @@ class TestWriteReportJson:
         assert closed, "raw mkstemp fd must be closed after fdopen failure"
         # Restore builtins for any leftover handles in this process.
         monkeypatch.setattr("tools.ac_harness.resilient_launch.os.fdopen", real_fdopen)
+
+
+class TestPerturberTreatmentReceipt:
+    """#719 — the #625 A/B must MEASURE the treatment, not take the operator at their word.
+
+    The asymmetry under test is empirical, not stylistic: on the rig 2026-07-28 one live
+    ``acs.exe`` showed neither perturber at 45 modules loaded and BOTH at 115 modules ~3 s later.
+    A single early snapshot therefore cannot establish absence.
+    """
+
+    def test_presence_is_dispositive_and_unions_across_samples(self):
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        # The early snapshot that misses everything — exactly the measured race.
+        watch.observe(frozenset({"ntdll.dll", "kernel32.dll"}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.NOT_OBSERVED)
+        # A later snapshot sees it; a still-later one misses it again.
+        watch.observe(frozenset({"gameoverlayrenderer64.dll"}))
+        watch.observe(frozenset({"ntdll.dll"}))
+        # Presence must survive: a perturber cannot un-inject, so the union is the truth.
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        assert watch.injected("steam_overlay")
+
+    def test_failed_snapshot_is_unavailable_not_absent(self):
+        """The inversion this whole feature exists to prevent."""
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        watch.observe(None)
+        watch.observe(None)
+        assert watch.successful_looks == 0
+        for value in watch.evidence().values():
+            # Were this NOT_OBSERVED, a denied OpenProcess would read as "overlay disabled" and
+            # silently flip a boot's arm.
+            assert value == str(PerturberEvidence.UNAVAILABLE)
+
+    def test_empty_module_set_is_absent_not_unavailable(self):
+        """A SUCCESSFUL look that found nothing is a real (weak) observation."""
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        watch.observe(frozenset())
+        assert watch.successful_looks == 1
+        assert watch.evidence()["nvidia_capture"] == str(PerturberEvidence.NOT_OBSERVED)
+
+    def test_module_matching_is_case_insensitive(self):
+        from tools.ac_harness.resilient_launch import PerturberEvidence, PerturberWatch
+
+        watch = PerturberWatch()
+        watch.observe(frozenset({"GameOverlayRenderer64.dll".casefold()}))
+        assert watch.evidence()["steam_overlay"] == str(PerturberEvidence.INJECTED)
+
+    def test_only_the_off_arm_can_be_refuted_by_one_attempt(self):
+        from tools.ac_harness.resilient_launch import (
+            PerturberEvidence,
+            contradicts_expectation,
+        )
+
+        injected = {"steam_overlay": str(PerturberEvidence.INJECTED)}
+        absent = {"steam_overlay": str(PerturberEvidence.NOT_OBSERVED)}
+        unavailable = {"steam_overlay": str(PerturberEvidence.UNAVAILABLE)}
+
+        # Dispositive: planned off, demonstrably injected.
+        assert contradicts_expectation(injected, "off") is True
+        # NOT dispositive: the injection race makes a single miss uninformative, so the `on` arm
+        # is judged by the analyzer over the whole boot, never aborted here.
+        assert contradicts_expectation(absent, "on") is False
+        assert contradicts_expectation(unavailable, "off") is False
+        assert contradicts_expectation(absent, "off") is False
+        # No declared arm: an ordinary launch outside the experiment is never interrupted.
+        assert contradicts_expectation(injected, None) is False
+
+    def test_contradicted_off_arm_stops_the_loop_without_desyncing_cycles(self):
+        """The early stop must leave ``cycles`` consistent with ``attempts_log`` (#710 contract)."""
+        from tools.ac_harness.resilient_launch import (
+            AttemptOutcome,
+            LaunchVerdict,
+            PerturberEvidence,
+            run_retry_loop,
+        )
+
+        def watch(attempt: int) -> AttemptOutcome:
+            return AttemptOutcome(
+                LaunchVerdict.FROZE,
+                cycle_delivered=True,
+                perturbers={"steam_overlay": str(PerturberEvidence.INJECTED)},
+            )
+
+        report = run_retry_loop(
+            watch,
+            max_attempts=24,
+            stop_on_stable=False,
+            uptime_hours=lambda: None,
+            expect_perturbers="off",
+        )
+        # Stopped on the FIRST attempt rather than burning all 24 launch cycles.
+        assert report.attempts == 1
+        assert report.arm_contradicted is True
+        assert report.expect_perturbers == "off"
+        # Without the counters running before the break, this attempt would appear in the log but
+        # not in `cycles`, and the analyzer would reject the report as corrupt.
+        assert report.cycles_delivered == 1
+        assert len(report.attempts_log) == 1
+        payload = report.as_dict()
+        assert payload["cycles"]["delivered"] == len(payload["attempts_log"])
+        assert payload["arm_contradicted"] is True
+
+    def test_matching_off_arm_runs_the_whole_budget(self):
+        from tools.ac_harness.resilient_launch import (
+            AttemptOutcome,
+            LaunchVerdict,
+            PerturberEvidence,
+            run_retry_loop,
+        )
+
+        def watch(attempt: int) -> AttemptOutcome:
+            return AttemptOutcome(
+                LaunchVerdict.FROZE,
+                cycle_delivered=True,
+                perturbers={"steam_overlay": str(PerturberEvidence.NOT_OBSERVED)},
+            )
+
+        report = run_retry_loop(
+            watch,
+            max_attempts=5,
+            stop_on_stable=False,
+            uptime_hours=lambda: None,
+            expect_perturbers="off",
+        )
+        assert report.attempts == 5
+        assert report.arm_contradicted is False
+
+    def test_report_defaults_every_attempt_to_unavailable(self):
+        """A producer that never looked must not read as one that looked and found nothing."""
+        from tools.ac_harness.resilient_launch import (
+            LaunchVerdict,
+            PerturberEvidence,
+            run_retry_loop,
+        )
+
+        report = run_retry_loop(
+            lambda i: LaunchVerdict.STABLE, max_attempts=1, uptime_hours=lambda: None
+        )
+        payload = report.as_dict()
+        assert payload["attempts_log"][0]["perturbers"] == {
+            "steam_overlay": str(PerturberEvidence.UNAVAILABLE),
+            "nvidia_capture": str(PerturberEvidence.UNAVAILABLE),
+        }
+        assert payload["perturbers"]["steam_overlay"] == str(PerturberEvidence.UNAVAILABLE)
+        # Perturbers ride OUTSIDE `counts`, which stays the verdict histogram consumers compare.
+        assert set(payload["counts"]) == {"stable", "froze", "wedged_init", "never_live"}
+        # No declared arm -> the experiment-only fields stay absent entirely.
+        assert "expect_perturbers" not in payload
+        assert "arm_contradicted" not in payload
+
+    def test_boot_summary_unions_evidence_across_attempts(self):
+        from tools.ac_harness.resilient_launch import (
+            AttemptOutcome,
+            LaunchVerdict,
+            PerturberEvidence,
+            run_retry_loop,
+        )
+
+        seen = {
+            1: str(PerturberEvidence.UNAVAILABLE),
+            2: str(PerturberEvidence.NOT_OBSERVED),
+            3: str(PerturberEvidence.INJECTED),
+        }
+
+        def watch(attempt: int) -> AttemptOutcome:
+            return AttemptOutcome(
+                LaunchVerdict.FROZE,
+                cycle_delivered=True,
+                perturbers={"steam_overlay": seen[attempt], "nvidia_capture": seen[1]},
+            )
+
+        report = run_retry_loop(
+            watch, max_attempts=3, stop_on_stable=False, uptime_hours=lambda: None
+        )
+        summary = report.perturber_summary()
+        # One sighting anywhere in the boot is dispositive for the boot.
+        assert summary["steam_overlay"] == str(PerturberEvidence.INJECTED)
+        # Never successfully looked for this one across any attempt.
+        assert summary["nvidia_capture"] == str(PerturberEvidence.UNAVAILABLE)
+
+    def test_invalid_expectation_is_rejected(self):
+        from tools.ac_harness.resilient_launch import LaunchVerdict, run_retry_loop
+
+        with pytest.raises(ValueError, match="expect_perturbers"):
+            run_retry_loop(
+                lambda i: LaunchVerdict.STABLE,
+                max_attempts=1,
+                uptime_hours=lambda: None,
+                expect_perturbers="overlays_off",
+            )

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -486,7 +486,9 @@ def process_module_names(
     """
 
     if sys.platform != "win32":
-        return frozenset()
+        # Fail closed: an empty frozenset would read as a successful "no modules" look and
+        # invent not_observed / absence on non-Windows hosts (cursor HIGH on #721).
+        raise OSError(f"process_module_names is only supported on win32 (got {sys.platform})")
 
     import ctypes
     from ctypes import wintypes

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -464,6 +464,99 @@ def _toolhelp_process_ids(process_name: str) -> frozenset[int]:
     return frozenset(found)
 
 
+def process_module_names(
+    process_id: int,
+    *,
+    retries: int = 4,
+    sleep: Callable[[float], None] = time.sleep,
+) -> frozenset[str]:
+    """Casefolded basenames of every module loaded in ``process_id``.
+
+    Used by the #625 A/B to observe which init perturbers were actually injected into a live
+    ``acs.exe`` (#719). The treatment is otherwise asserted by the operator and never measured.
+
+    **Raises** ``OSError`` when the snapshot cannot be taken. That failure MUST NOT be folded into
+    an empty set: "the process loaded no modules" and "we could not look" are different claims, and
+    only the caller can encode the difference (an empty set would read as *perturber absent*, which
+    would silently invert the treatment check this exists to provide).
+
+    ``CreateToolhelp32Snapshot`` fails with ``ERROR_BAD_LENGTH`` while the target is still loading
+    its module list — documented as retryable, and the common case here because the launcher probes
+    a process that AC is actively starting.
+    """
+
+    if sys.platform != "win32":
+        return frozenset()
+
+    import ctypes
+    from ctypes import wintypes
+
+    max_module_name32 = 255
+
+    class ModuleEntry32W(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("th32ModuleID", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("GlblcntUsage", wintypes.DWORD),
+            ("ProccntUsage", wintypes.DWORD),
+            ("modBaseAddr", ctypes.POINTER(ctypes.c_byte)),
+            ("modBaseSize", wintypes.DWORD),
+            ("hModule", wintypes.HMODULE),
+            ("szModule", wintypes.WCHAR * (max_module_name32 + 1)),
+            ("szExePath", wintypes.WCHAR * 260),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.argtypes = (wintypes.DWORD, wintypes.DWORD)
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.Module32FirstW.argtypes = (wintypes.HANDLE, ctypes.POINTER(ModuleEntry32W))
+    kernel32.Module32FirstW.restype = wintypes.BOOL
+    kernel32.Module32NextW.argtypes = (wintypes.HANDLE, ctypes.POINTER(ModuleEntry32W))
+    kernel32.Module32NextW.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    invalid_handle = wintypes.HANDLE(-1).value
+    snapshot_flags = 0x00000008 | 0x00000010  # TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32
+    error_bad_length = 24
+
+    snapshot = invalid_handle
+    last_error = 0
+    for attempt in range(max(1, retries)):
+        ctypes.set_last_error(0)
+        snapshot = kernel32.CreateToolhelp32Snapshot(snapshot_flags, process_id)
+        if snapshot != invalid_handle:
+            break
+        last_error = ctypes.get_last_error()
+        if last_error != error_bad_length:
+            break
+        if attempt + 1 < max(1, retries):
+            sleep(0.15)
+    if snapshot == invalid_handle:
+        raise OSError(last_error, f"CreateToolhelp32Snapshot(module) failed for pid {process_id}")
+
+    names: set[str] = set()
+    try:
+        entry = ModuleEntry32W()
+        entry.dwSize = ctypes.sizeof(entry)
+        ctypes.set_last_error(0)
+        if not kernel32.Module32FirstW(snapshot, ctypes.byref(entry)):
+            error = ctypes.get_last_error()
+            raise OSError(error, f"Module32FirstW failed for pid {process_id}")
+        while True:
+            names.add(entry.szModule.casefold())
+            ctypes.set_last_error(0)
+            if not kernel32.Module32NextW(snapshot, ctypes.byref(entry)):
+                error = ctypes.get_last_error()
+                if error not in (0, 18):  # ERROR_NO_MORE_FILES ends enumeration normally.
+                    raise OSError(error, f"Module32NextW failed for pid {process_id}")
+                break
+    finally:
+        kernel32.CloseHandle(snapshot)
+    return frozenset(names)
+
+
 class ColdRestartActuator:
     """Default no-new-dependency actuator: normalize state, kill, relaunch AC."""
 

--- a/tools/ac_harness/entry_launcher.py
+++ b/tools/ac_harness/entry_launcher.py
@@ -464,31 +464,15 @@ def _toolhelp_process_ids(process_name: str) -> frozenset[int]:
     return frozenset(found)
 
 
-def process_module_names(
-    process_id: int,
-    *,
-    retries: int = 4,
-    sleep: Callable[[float], None] = time.sleep,
-) -> frozenset[str]:
-    """Casefolded basenames of every module loaded in ``process_id``.
+_MODULE_SNAPSHOT_STATE: dict[str, object] | None = None
 
-    Used by the #625 A/B to observe which init perturbers were actually injected into a live
-    ``acs.exe`` (#719). The treatment is otherwise asserted by the operator and never measured.
 
-    **Raises** ``OSError`` when the snapshot cannot be taken. That failure MUST NOT be folded into
-    an empty set: "the process loaded no modules" and "we could not look" are different claims, and
-    only the caller can encode the difference (an empty set would read as *perturber absent*, which
-    would silently invert the treatment check this exists to provide).
+def _module_snapshot_bindings() -> dict[str, object]:
+    """Lazily bind Toolhelp32 module APIs once (hot path in the go-live poll)."""
 
-    ``CreateToolhelp32Snapshot`` fails with ``ERROR_BAD_LENGTH`` while the target is still loading
-    its module list — documented as retryable, and the common case here because the launcher probes
-    a process that AC is actively starting.
-    """
-
-    if sys.platform != "win32":
-        # Fail closed: an empty frozenset would read as a successful "no modules" look and
-        # invent not_observed / absence on non-Windows hosts (cursor HIGH on #721).
-        raise OSError(f"process_module_names is only supported on win32 (got {sys.platform})")
+    global _MODULE_SNAPSHOT_STATE
+    if _MODULE_SNAPSHOT_STATE is not None:
+        return _MODULE_SNAPSHOT_STATE
 
     import ctypes
     from ctypes import wintypes
@@ -519,9 +503,62 @@ def process_module_names(
     kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
     kernel32.CloseHandle.restype = wintypes.BOOL
 
-    invalid_handle = wintypes.HANDLE(-1).value
-    snapshot_flags = 0x00000008 | 0x00000010  # TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32
-    error_bad_length = 24
+    _MODULE_SNAPSHOT_STATE = {
+        "ctypes": ctypes,
+        "ModuleEntry32W": ModuleEntry32W,
+        "kernel32": kernel32,
+        "invalid_handle": wintypes.HANDLE(-1).value,
+        "snapshot_flags": 0x00000008 | 0x00000010,  # TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32
+        "error_bad_length": 24,
+    }
+    return _MODULE_SNAPSHOT_STATE
+
+
+def process_module_names(
+    process_id: int,
+    *,
+    retries: int = 4,
+    sleep: Callable[[float], None] = time.sleep,
+) -> frozenset[str]:
+    """Casefolded basenames of every module loaded in ``process_id``.
+
+    Used by the #625 A/B to observe which init perturbers were actually injected into a live
+    ``acs.exe`` (#719). The treatment is otherwise asserted by the operator and never measured.
+
+    **Raises** ``OSError`` when the snapshot cannot be taken. That failure MUST NOT be folded into
+    an empty set: "the process loaded no modules" and "we could not look" are different claims, and
+    only the caller can encode the difference (an empty set would read as *perturber absent*, which
+    would silently invert the treatment check this exists to provide).
+
+    ``CreateToolhelp32Snapshot`` fails with ``ERROR_BAD_LENGTH`` while the target is still loading
+    its module list — documented as retryable, and the common case here because the launcher probes
+    a process that AC is actively starting.
+
+    Requires **64-bit Python** on Windows: a 32-bit interpreter cannot enumerate modules of the
+    64-bit ``acs.exe`` (``ERROR_PARTIAL_COPY``), which would otherwise burn the whole multi-reboot
+    experiment as ``treatment_receipt_unverified`` (Codex P2 on #721).
+    """
+
+    if sys.platform != "win32":
+        # Fail closed: an empty frozenset would read as a successful "no modules" look and
+        # invent not_observed / absence on non-Windows hosts (cursor HIGH on #721).
+        raise OSError(f"process_module_names is only supported on win32 (got {sys.platform})")
+
+    import struct
+
+    if struct.calcsize("P") * 8 < 64:
+        raise OSError(
+            "process_module_names requires 64-bit Python to inspect 64-bit acs.exe "
+            f"(this interpreter is {struct.calcsize('P') * 8}-bit)"
+        )
+
+    bindings = _module_snapshot_bindings()
+    ctypes = bindings["ctypes"]
+    ModuleEntry32W = bindings["ModuleEntry32W"]
+    kernel32 = bindings["kernel32"]
+    invalid_handle = bindings["invalid_handle"]
+    snapshot_flags = bindings["snapshot_flags"]
+    error_bad_length = bindings["error_bad_length"]
 
     snapshot = invalid_handle
     last_error = 0

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -103,8 +103,21 @@ WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
 #: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
 PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: Verdicts that imply acs.exe lived well past the ~3 s injection race measured on the rig.
-_LIVE_SESSION_VERDICTS = frozenset({"stable", "froze", "wedged_init"})
+#: Verdicts that *may* carry post-race absence evidence. ``wedged_init`` is excluded: it means
+#: the process never reached readiness, so a short ``go_live_timeout`` can end before the
+#: measured ~3 s injection race (Codex P1/P2 on #721). ``stable`` is always past the race
+#: (stability window >> 3 s). ``froze`` additionally requires :data:`MIN_ABSENCE_ELAPSED_S`.
+_LIVE_SESSION_VERDICTS = frozenset({"stable", "froze"})
+#: Measured injection race on the rig (~3 s). Plans must not set ``go_live_timeout`` below this
+#: plus a small margin, or ``WEDGED_INIT`` can fire inside the race window.
+INJECTION_RACE_S = 3.0
+#: Minimum ``elapsed_s`` before a non-stable live verdict's ``not_observed`` is treated as
+#: dispositive absence. ``elapsed_s`` includes pre-launch work, so this is a floor, not a
+#: precise post-spawn clock (Codex P1 on #721).
+MIN_ABSENCE_ELAPSED_S = 5.0
+#: Plan floor for ``--go-live-timeout`` so a valid plan cannot trust live-session absence
+#: evidence that is shorter than the injection race (Codex P2 on #721).
+MIN_GO_LIVE_TIMEOUT_S = 5.0
 #: Canonical perturber field set every report row must carry exactly.
 _PERTURBER_KEYS = frozenset(PERTURBER_MODULES)
 #: Exact treatment-receipt policy a v4 plan must pre-register (Codex P2 on #721).
@@ -277,17 +290,21 @@ def _launch_evidence(launch: LaunchObservation) -> dict[str, str]:
 def _is_live_session(launch: LaunchObservation) -> bool:
     """Whether this attempt's absence evidence is informative (post injection race).
 
-    The injection race is ~3 s on the measured rig. Only delivered ``stable`` / ``froze`` /
-    ``wedged_init`` are treated as past that window: each requires the go-live / stability
-    watch (far longer than the race). ``never_live`` is never dispositive for *absence* —
-    ``elapsed_s`` includes pre-launch work and cannot prove post-race lifetime (Codex P1 on
-    #721). Presence (``injected``) remains dispositive on any attempt via the off-arm path.
+    The injection race is ~3 s on the measured rig. ``never_live`` / ``wedged_init`` are never
+    dispositive for *absence* — the process may have died inside the race, and ``elapsed_s``
+    includes pre-launch work so it cannot prove post-race lifetime on those shapes (Codex P1
+    on #721). Presence (``injected``) remains dispositive on any attempt via the off-arm path.
 
-    A ``FROZE`` after go-live is still past the race: go-live itself requires a ready session,
-    which on this rig is orders of magnitude longer than the measured 3 s injection window.
+    * ``stable`` — always past the race (stability window >> 3 s).
+    * ``froze`` — only when ``elapsed_s >= MIN_ABSENCE_ELAPSED_S``, so an immediate post-go-live
+      freeze cannot turn a pre-injection miss into a contradicted / confirmed arm.
     """
 
-    return launch.cycle_delivered is True and launch.verdict in _LIVE_SESSION_VERDICTS
+    if launch.cycle_delivered is not True or launch.verdict not in _LIVE_SESSION_VERDICTS:
+        return False
+    if launch.verdict == "stable":
+        return True
+    return launch.elapsed_s >= MIN_ABSENCE_ELAPSED_S
 
 
 def treatment_receipt(
@@ -557,6 +574,12 @@ def build_plan(
         raise ValueError("stability_window must be finite and > 0")
     if not math.isfinite(go_live_timeout) or go_live_timeout <= 0:
         raise ValueError("go_live_timeout must be finite and > 0")
+    if go_live_timeout < MIN_GO_LIVE_TIMEOUT_S:
+        raise ValueError(
+            f"go_live_timeout must be >= {MIN_GO_LIVE_TIMEOUT_S:g}s so a WEDGED_INIT "
+            f"cannot fire inside the measured ~{INJECTION_RACE_S:g}s injection race "
+            f"(got {go_live_timeout:g})"
+        )
     if boots_per_arm <= 0 or launches_per_boot <= 0:
         raise ValueError("boots_per_arm and launches_per_boot must be > 0")
     if boots_per_arm < MIN_BOOTS_PER_ARM and not allow_undersized:
@@ -780,6 +803,14 @@ def load_plan(path: Path) -> dict[str, Any]:
                 f"plan treatment_receipt.{key}={receipt.get(key)!r} does not match the "
                 f"canonical v4 policy {expected!r}; regenerate the plan"
             )
+    launch = plan.get("launch")
+    if isinstance(launch, dict):
+        go_live = launch.get("go_live_timeout")
+        if isinstance(go_live, (int, float)) and go_live < MIN_GO_LIVE_TIMEOUT_S:
+            raise ValueError(
+                f"plan launch.go_live_timeout={go_live!r} is below the "
+                f"{MIN_GO_LIVE_TIMEOUT_S:g}s injection-race floor; regenerate the plan"
+            )
     boots_per_arm = plan.get("boots_per_arm")
     if not isinstance(boots_per_arm, int) or boots_per_arm <= 0:
         raise ValueError("plan boots_per_arm must be a positive integer")
@@ -871,34 +902,52 @@ def _parse_report(
                 f"report {path} arm_contradicted log length {log_len} "
                 f"does not match attempts={attempts}"
             )
-        if report.get("expect_perturbers") != "off":
+        reported_expect = report.get("expect_perturbers")
+        if reported_expect not in ("off", "on"):
             raise ValueError(
-                f"report {path} arm_contradicted requires expect_perturbers='off' "
-                f"(got {report.get('expect_perturbers')!r})"
+                f"report {path} arm_contradicted requires expect_perturbers 'on' or 'off' "
+                f"(got {reported_expect!r})"
             )
-        # Short reports only exist for the fail-fast OFF arm. Accepting one under an overlays_on
-        # plan label would score a single-attempt boot as if it had the full budget (Codex P2).
-        if boot.condition != "overlays_off":
+        # Short reports are fail-fast stops for either arm. Off-arm: injected sighting.
+        # On-arm: STABLE + successful miss (Codex P1 on #721). Condition must still match.
+        if reported_expect == "off" and boot.condition != "overlays_off":
             raise ValueError(
                 f"report {path} arm_contradicted with expect_perturbers='off' but plan condition "
-                f"is {boot.condition!r}; short contradiction reports are only valid for "
-                "overlays_off boots"
+                f"is {boot.condition!r}"
             )
-        # The summary flag alone is not enough: require dispositive injected evidence in the
-        # log so a truncated clean report cannot enter via arm_contradicted (Codex P2 on #721).
-        has_injected = False
+        if reported_expect == "on" and boot.condition != "overlays_on":
+            raise ValueError(
+                f"report {path} arm_contradicted with expect_perturbers='on' but plan condition "
+                f"is {boot.condition!r}"
+            )
+        # The summary flag alone is not enough: require dispositive evidence in the log so a
+        # truncated clean report cannot enter via arm_contradicted (Codex P2 on #721).
+        has_dispositive = False
         if isinstance(attempts_log, list):
             for raw in attempts_log:
                 if not isinstance(raw, dict):
                     continue
                 block = raw.get("perturbers")
-                if isinstance(block, dict) and any(value == "injected" for value in block.values()):
-                    has_injected = True
+                if not isinstance(block, dict):
+                    continue
+                if reported_expect == "off" and any(
+                    value == "injected" for value in block.values()
+                ):
+                    has_dispositive = True
                     break
-        if not has_injected:
+                if (
+                    reported_expect == "on"
+                    and raw.get("verdict") == "stable"
+                    and any(value == "not_observed" for value in block.values())
+                    and all(value != "unavailable" for value in block.values())
+                ):
+                    has_dispositive = True
+                    break
+        if not has_dispositive:
             raise ValueError(
-                f"report {path} arm_contradicted but attempts_log has no injected perturber "
-                "evidence — refusing the short-report exception"
+                f"report {path} arm_contradicted but attempts_log has no dispositive "
+                f"receipt failure for expect_perturbers={reported_expect!r} — refusing the "
+                "short-report exception"
             )
     else:
         if attempts != launches_per_boot:
@@ -909,6 +958,16 @@ def _parse_report(
             )
         if not isinstance(attempts_log, list) or len(attempts_log) != launches_per_boot:
             raise ValueError(f"report {path} must log all {launches_per_boot} launches")
+    # Receipt flag on the report must match the planned arm for every loaded boot, not only the
+    # short arm_contradicted path — otherwise a mis-pasted --expect-perturbers command is scored
+    # under the wrong treatment rules (antigravity HIGH / Codex P2 on #721).
+    expected_flag = "on" if boot.condition == "overlays_on" else "off"
+    reported_flag = report.get("expect_perturbers")
+    if reported_flag != expected_flag:
+        raise ValueError(
+            f"report {path} expect_perturbers={reported_flag!r} does not match planned "
+            f"condition {boot.condition!r} (expected {expected_flag!r})"
+        )
     launch = report.get("launch")
     if not isinstance(launch, dict):
         raise ValueError(f"report {path} must record launch configuration")

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -940,7 +940,7 @@ def _parse_report(
                     break
                 if (
                     reported_expect == "on"
-                    and raw.get("verdict") == "stable"
+                    and raw.get("verdict") in ("stable", "froze")
                     and any(value == "not_observed" for value in block.values())
                     and all(value != "unavailable" for value in block.values())
                 ):

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -103,12 +103,11 @@ WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
 #: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
 PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: Verdicts whose *absence* evidence is post-injection-race. ``classify`` only returns
-#: ``stable``/``froze`` after go-live (packet advanced + entry ready + drivable), which on this
-#: rig is far past the ~3 s injection race. ``wedged_init`` never reached readiness — excluded.
-#: ``elapsed_s`` is intentionally not used: it includes pre-launch work and is not process life
-#: (Codex P1 on #721).
-_LIVE_SESSION_VERDICTS = frozenset({"stable", "froze"})
+#: Only ``stable`` is inherently past the injection race for *absence* evidence: it required the
+#: full stability window. ``froze`` can fire on the first post-go-live death / packet regression
+#: (and ``_Car0NotDrivable`` is mapped to ``FROZE``), so a race-window miss can still be attached
+#: to that verdict (Codex P1 on #721). ``wedged_init`` never reached readiness.
+_LIVE_SESSION_VERDICTS = frozenset({"stable"})
 #: Measured injection race on the rig (~3 s). Plans must not set ``go_live_timeout`` below this
 #: plus a small margin, or ``WEDGED_INIT`` can fire inside the race window.
 INJECTION_RACE_S = 3.0
@@ -287,12 +286,11 @@ def _launch_evidence(launch: LaunchObservation) -> dict[str, str]:
 def _is_live_session(launch: LaunchObservation) -> bool:
     """Whether this attempt's absence evidence is informative (post injection race).
 
-    The injection race is ~3 s on the measured rig. Delivered ``stable`` / ``froze`` are the
-    only post-go-live verdicts: ``classify`` requires packet advance + entry ready + drivable
-    before either, which is past the race by construction. ``elapsed_s`` is **not** consulted —
-    it includes pre-launch work and cannot prove process lifetime (Codex P1 on #721).
-    ``wedged_init`` / ``never_live`` never reached readiness, so their misses are non-dispositive.
-    Presence (``injected``) remains dispositive on any attempt via the off-arm path.
+    Only a delivered ``stable`` attempt is dispositive for *absence*: the stability window is
+    known to exceed the measured ~3 s injection race. ``froze`` is not — it can fire on the
+    first post-go-live sample (process exit / packet regression), and ``_Car0NotDrivable`` is
+    also mapped to ``FROZE`` without a proven late sample (Codex P1 on #721). Presence
+    (``injected``) remains dispositive on any attempt via the off-arm path.
     """
 
     return launch.cycle_delivered is True and launch.verdict in _LIVE_SESSION_VERDICTS
@@ -350,21 +348,21 @@ def treatment_receipt(
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
             )
-        # Every DELIVERED cycle enters the onset coordinate, so each must have live-session
-        # not_observed evidence for confirmation. Early delivered never_live (race-window
-        # not_observed / unavailable) keeps the boot unverified (Codex P1 on #721).
-        delivered = [item for item in rows if item.cycle_delivered is True]
-        if not delivered:
+        # Confirmation uses STABLE delivered cycles only — the sole post-race absence signal
+        # (Codex P1 on #721). Non-stable delivered cycles do not confirm or deny absence.
+        stables = [
+            item
+            for item in rows
+            if item.cycle_delivered is True and _is_live_session(item)
+        ]
+        if not stables:
             return (
                 TREATMENT_UNVERIFIED,
-                "no delivered cycles with perturber evidence for overlays_off",
+                "no stable delivered cycles with perturber evidence for overlays_off",
             )
         incomplete: list[int] = []
-        for item in delivered:
+        for item in stables:
             evidence = _launch_evidence(item)
-            if not _is_live_session(item):
-                incomplete.append(item.launch)
-                continue
             if set(evidence) != required or any(
                 evidence.get(name) != "not_observed" for name in required
             ):
@@ -372,25 +370,26 @@ def treatment_receipt(
         if incomplete:
             return (
                 TREATMENT_UNVERIFIED,
-                "partial, early, or unavailable perturber evidence on delivered cycles "
-                "for overlays_off",
+                "partial or unavailable perturber evidence on stable cycles for overlays_off",
             )
         return TREATMENT_CONFIRMED, None
 
     if condition == "overlays_on":
-        # Every DELIVERED cycle enters the onset coordinate, so each must be fully injected for
-        # confirmation. Early delivered never_live with not_observed keeps the boot unverified
-        # rather than being dropped while later lives confirm (Codex P1 on #721).
-        delivered = [item for item in rows if item.cycle_delivered is True]
-        if not delivered:
+        # Confirmation / contradiction of absence uses STABLE delivered cycles only. Injected
+        # presence on any launch remains dispositive via boot roll-up; a stable miss contradicts.
+        stables = [
+            item
+            for item in rows
+            if item.cycle_delivered is True and _is_live_session(item)
+        ]
+        if not stables:
             return (
                 TREATMENT_UNVERIFIED,
-                "no delivered cycles with perturber evidence for overlays_on",
+                "no stable delivered cycles with perturber evidence for overlays_on",
             )
         incomplete: list[int] = []
         short_live: list[str] = []
-        early_miss: list[int] = []
-        for item in delivered:
+        for item in stables:
             evidence = _launch_evidence(item)
             if set(evidence) != required:
                 incomplete.append(item.launch)
@@ -399,23 +398,18 @@ def treatment_receipt(
                 incomplete.append(item.launch)
                 continue
             miss = sorted(name for name in required if evidence[name] != "injected")
-            if not miss:
-                continue
-            if _is_live_session(item):
+            if miss:
                 short_live.append(f"launch {item.launch}: {', '.join(miss)}")
-            else:
-                early_miss.append(item.launch)
         if short_live:
             return (
                 TREATMENT_CONTRADICTED,
-                "planned overlays_on but live session(s) never observed full injection "
+                "planned overlays_on but stable session(s) never observed full injection "
                 f"({'; '.join(short_live)})",
             )
-        if incomplete or early_miss:
+        if incomplete:
             return (
                 TREATMENT_UNVERIFIED,
-                "partial, early, or unavailable perturber evidence on delivered cycles "
-                "for overlays_on",
+                "partial or unavailable perturber evidence on stable cycles for overlays_on",
             )
         return TREATMENT_CONFIRMED, None
 
@@ -940,7 +934,7 @@ def _parse_report(
                     break
                 if (
                     reported_expect == "on"
-                    and raw.get("verdict") in ("stable", "froze")
+                    and raw.get("verdict") == "stable"
                     and any(value == "not_observed" for value in block.values())
                     and all(value != "unavailable" for value in block.values())
                 ):
@@ -1083,6 +1077,28 @@ def _parse_report(
     return BootObservation(boot=boot.boot, condition=boot.condition, launches=tuple(observations))
 
 
+def resolve_boot_report_path(reports_dir: Path, planned_name: str) -> Path | None:
+    """Locate the planned report, or its unique arm-contradicted salvage sibling (#721).
+
+    Fail-fast contradicted runs publish to ``{stem}.arm_contradicted.{UTC}Z{suffix}`` so the
+    exclusive planned path stays free for re-run. Analysis must still discover that salvage so
+    the exclusion is scored rather than reported as a missing planned file (Codex P2 on #721).
+    A successful re-run at the planned name wins over any salvage.
+    """
+
+    planned = reports_dir / planned_name
+    if planned.is_file():
+        return planned
+    stem = Path(planned_name).stem
+    suffix = Path(planned_name).suffix
+    matches = sorted(reports_dir.glob(f"{stem}.arm_contradicted.*{suffix}"))
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0]
+    return max(matches, key=lambda path: path.stat().st_mtime)
+
+
 def load_observations(
     plan: dict[str, Any], reports_dir: Path, *, require_complete: bool = True
 ) -> tuple[BootObservation, ...]:
@@ -1093,8 +1109,8 @@ def load_observations(
     missing: list[str] = []
     for raw in plan["boots"]:
         boot = PlannedBoot(boot=raw["boot"], condition=raw["condition"], report=raw["report"])
-        report_path = reports_dir / boot.report
-        if not report_path.is_file():
+        report_path = resolve_boot_report_path(reports_dir, boot.report)
+        if report_path is None:
             missing.append(boot.report)
             continue
         observations.append(_parse_report(report_path, boot, plan_launch, launches_per_boot))

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -103,11 +103,11 @@ WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
 #: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
 PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: Only ``stable`` is dispositive for *absence* evidence (Codex P1 on #721). ``wedged_init``
-#: means the render stream never initialized — elapsed go-live budget does not prove injection
-#: completed. ``froze`` can fire on the first post-go-live death while injection is still racing.
-#: Positive ``injected`` is evaluated on every delivered launch regardless of verdict.
-_LIVE_SESSION_VERDICTS = frozenset({"stable"})
+#: Verdicts used when *absence* must be dispositive for the off-arm confirmation path.
+#: ``stable`` / ``froze`` are post-go-live (packet advanced + ready). ``wedged_init`` is not —
+#: the stream never initialized. On-arm *miss* contradiction uses only ``stable`` (see
+#: :func:`treatment_receipt`); positive ``injected`` is evaluated on every delivered launch.
+_LIVE_SESSION_VERDICTS = frozenset({"stable", "froze"})
 #: Measured injection race on the rig (~3 s). Plans must not set timeouts below this plus margin.
 INJECTION_RACE_S = 3.0
 #: Plan floor for ``--go-live-timeout`` / ``--stability-window`` so post-race absence claims
@@ -348,17 +348,21 @@ def treatment_receipt(
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
             )
-        # Confirmation uses STABLE delivered cycles only — the sole post-race absence signal
-        # (Codex P1 on #721). Non-stable delivered cycles do not confirm or deny absence.
-        stables = [item for item in rows if item.cycle_delivered is True and _is_live_session(item)]
-        if not stables:
+        # Every delivered launch must show full not_observed on a post-go-live verdict
+        # (stable/froze). Omitting freze/wedged would let mixed-treatment boots score
+        # (Codex P1 on #721).
+        delivered = [item for item in rows if item.cycle_delivered is True]
+        if not delivered:
             return (
                 TREATMENT_UNVERIFIED,
-                "no stable delivered cycles with perturber evidence for overlays_off",
+                "no delivered cycles with perturber evidence for overlays_off",
             )
         incomplete: list[int] = []
-        for item in stables:
+        for item in delivered:
             evidence = _launch_evidence(item)
+            if not _is_live_session(item):
+                incomplete.append(item.launch)
+                continue
             if set(evidence) != required or any(
                 evidence.get(name) != "not_observed" for name in required
             ):
@@ -366,14 +370,15 @@ def treatment_receipt(
         if incomplete:
             return (
                 TREATMENT_UNVERIFIED,
-                "partial or unavailable perturber evidence on stable cycles for overlays_off",
+                "partial, early, or unavailable perturber evidence on delivered cycles "
+                "for overlays_off",
             )
         return TREATMENT_CONFIRMED, None
 
     if condition == "overlays_on":
         # Positive injection is evaluated on every delivered launch (any verdict). Misses are
-        # only dispositive on STABLE — freze/wedged race-window misses stay unverified
-        # (Codex P1 on #721). Every delivered launch must fully inject for confirmation.
+        # only dispositive on STABLE — freze/wedged misses stay unverified (Codex P1 on #721).
+        # Every delivered launch must fully inject for confirmation.
         delivered = [item for item in rows if item.cycle_delivered is True]
         if not delivered:
             return (
@@ -393,7 +398,7 @@ def treatment_receipt(
                 incomplete.append(item.launch)
                 continue
             miss = sorted(name for name in required if evidence[name] != "injected")
-            if _is_live_session(item):
+            if item.verdict == "stable":
                 short_live.append(f"launch {item.launch}: {', '.join(miss)}")
             else:
                 incomplete.append(item.launch)

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -206,6 +206,9 @@ class LaunchObservation:
     elapsed_s: float
     uptime_h: float
     cycle_delivered: bool | None = None
+    #: #719 per-perturber evidence for this launch, keyed as in ``PERTURBER_MODULES``. Values are
+    #: :class:`PerturberEvidence` strings; only ``injected`` establishes anything.
+    perturbers: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -213,6 +216,86 @@ class BootObservation:
     boot: int
     condition: str
     launches: tuple[LaunchObservation, ...]
+
+
+#: Accepted per-launch perturber evidence values (mirrors ``PerturberEvidence``).
+_PERTURBER_EVIDENCE_VALUES = frozenset({"injected", "not_observed", "unavailable"})
+
+#: Treatment-receipt verdicts for a boot (#719).
+TREATMENT_CONFIRMED = "confirmed"
+TREATMENT_CONTRADICTED = "contradicted"
+TREATMENT_UNVERIFIED = "unverified"
+
+
+def boot_perturber_state(observation: BootObservation) -> dict[str, str]:
+    """Roll one boot's per-launch evidence up to one value per perturber.
+
+    Union on presence: a perturber cannot un-inject, so one sighting anywhere in the boot is
+    dispositive for the boot. ``not_observed`` requires at least one launch that looked
+    successfully and missed it; otherwise ``unavailable``.
+    """
+
+    fields: list[str] = []
+    for launch in observation.launches:
+        for name, _ in launch.perturbers:
+            if name not in fields:
+                fields.append(name)
+    state: dict[str, str] = {}
+    for name in fields:
+        values = [dict(launch.perturbers).get(name) for launch in observation.launches]
+        if "injected" in values:
+            state[name] = "injected"
+        elif "not_observed" in values:
+            state[name] = "not_observed"
+        else:
+            state[name] = "unavailable"
+    return state
+
+
+def treatment_receipt(condition: str, state: dict[str, str]) -> tuple[str, str | None]:
+    """Did this boot actually RECEIVE the condition its arm label claims? (#719)
+
+    Returns ``(verdict, detail)``.
+
+    This is **treatment-receipt verification, not operator-error detection** — and that framing is
+    what makes the ``overlays_on`` case tractable. Whether the operator forgot the toggle or Steam
+    simply failed to inject while enabled, a boot that did not receive its assigned condition
+    cannot inform the contrast. The cause is irrelevant; receipt is what the design needs.
+
+    Evidence is asymmetric per launch, but a BOOT aggregates many launches, so both arms are
+    checkable here even though only ``off`` is refutable from a single attempt:
+
+    * planned ``overlays_off`` + any ``injected``      -> contradicted (dispositive)
+    * planned ``overlays_on``  + all ``not_observed``  -> contradicted (the boot never saw the
+      perturber it was supposed to run with, across every successful look in the boot)
+    * anything resting on ``unavailable``              -> unverified (no information; fall back to
+      the planned label and say so, rather than claiming confirmation we did not earn)
+    """
+
+    if not state:
+        return TREATMENT_UNVERIFIED, "report carries no perturber evidence"
+    if condition == "overlays_off":
+        injected = sorted(name for name, value in state.items() if value == "injected")
+        if injected:
+            return (
+                TREATMENT_CONTRADICTED,
+                f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
+            )
+        if all(value == "unavailable" for value in state.values()):
+            return TREATMENT_UNVERIFIED, "no successful module snapshot in this boot"
+        return TREATMENT_CONFIRMED, None
+    if condition == "overlays_on":
+        if any(value == "injected" for value in state.values()):
+            return TREATMENT_CONFIRMED, None
+        if all(value == "unavailable" for value in state.values()):
+            return TREATMENT_UNVERIFIED, "no successful module snapshot in this boot"
+        missing = sorted(name for name, value in state.items() if value == "not_observed")
+        return (
+            TREATMENT_CONTRADICTED,
+            f"planned overlays_on but {', '.join(missing)} was never observed injected across "
+            "any successful snapshot in this boot",
+        )
+    return TREATMENT_UNVERIFIED, f"unknown condition {condition!r}"
 
 
 @dataclass(frozen=True)
@@ -241,6 +324,11 @@ class BootSummary:
     post_onset_launches: int
     post_onset_freezes: int
     post_onset_burst_rate: float | None
+    #: #719 treatment receipt: did this boot actually get the condition its arm label claims?
+    #: ``contradicted`` excludes the boot (and therefore its block) from the primary endpoint.
+    treatment: str
+    treatment_detail: str | None
+    perturber_state: tuple[tuple[str, str], ...]
     usable: bool
     unusable_reason: str | None
     first_uptime_h: float
@@ -605,6 +693,13 @@ def _parse_report(
             "records no per-attempt cycle_delivered flag (#710) — its never_live rows cannot be "
             "mapped onto accumulator positions. Re-run the boot on the current launcher"
         )
+    if report.get("schema") == "resilient-launch-report/v2":
+        raise ValueError(
+            f"report {path} uses the withdrawn {'resilient-launch-report/v2'!r} schema, which "
+            "records no per-attempt perturber evidence (#719) — its arm label rests entirely on "
+            "the operator's assertion and cannot be cross-checked against what was actually "
+            "injected into acs.exe. Re-run the boot on the current launcher"
+        )
     if report.get("schema") != REPORT_SCHEMA:
         raise ValueError(f"report {path} schema must be {REPORT_SCHEMA!r}")
     attempts = report.get("attempts")
@@ -671,6 +766,22 @@ def _parse_report(
                 f"report {path} launch {index} must record finite non-negative uptime_h "
                 "(the onset endpoint is meaningless without the boot's own clock)"
             )
+        perturbers = record.get("perturbers", _MISSING)
+        if perturbers is _MISSING:
+            raise ValueError(
+                f"report {path} launch {index} is missing perturbers; the {REPORT_SCHEMA!r} "
+                "schema records treatment evidence for every attempt (#719)"
+            )
+        if not isinstance(perturbers, dict) or not perturbers:
+            raise ValueError(
+                f"report {path} launch {index} has a non-mapping or empty perturbers block"
+            )
+        for name, value in perturbers.items():
+            if not isinstance(name, str) or value not in _PERTURBER_EVIDENCE_VALUES:
+                raise ValueError(
+                    f"report {path} launch {index} has invalid perturber evidence "
+                    f"{name!r}={value!r}; expected one of {sorted(_PERTURBER_EVIDENCE_VALUES)}"
+                )
         observations.append(
             LaunchObservation(
                 launch=index,
@@ -679,6 +790,7 @@ def _parse_report(
                 elapsed_s=float(elapsed_s),
                 uptime_h=float(uptime_h),
                 cycle_delivered=delivered,
+                perturbers=tuple(sorted(perturbers.items())),
             )
         )
     expected_counts = {
@@ -938,10 +1050,20 @@ def summarize_boot(observation: BootObservation) -> BootSummary:
     # some other verdict happened to occur. The old ``classified == 0`` guard discarded a boot of
     # 20 delivered never_live cycles — a perfectly good censored observation — while scoring 19
     # of the same cycles plus one stable row (#710 Codex P2).
+    perturber_state = boot_perturber_state(observation)
+    treatment, treatment_detail = treatment_receipt(observation.condition, perturber_state)
     if delivered_cycles == 0:
         unusable_reason = "no_delivered_cycles"
     elif undelivered > MAX_UNDELIVERED_FRACTION * len(launches):
         unusable_reason = "undelivered_fraction_exceeded"
+    elif treatment == TREATMENT_CONTRADICTED:
+        # The boot did not receive the condition its label claims, so nothing it measured can
+        # inform the contrast. It is EXCLUDED, never re-labelled to its observed arm: the
+        # permutation null is over the arm orders the randomization could have emitted, so the
+        # labels ARE the randomization. Re-labelling conditions on data observed after
+        # randomization, which breaks the design-based justification the whole test rests on —
+        # and can leave a block whose two boots share an arm, carrying no contrast anyway (#719).
+        unusable_reason = "treatment_contradicted"
     return BootSummary(
         boot=observation.boot,
         condition=observation.condition,
@@ -964,6 +1086,9 @@ def summarize_boot(observation: BootObservation) -> BootSummary:
         post_onset_burst_rate=(
             None if post_onset_launches == 0 else post_onset_freezes / post_onset_launches
         ),
+        treatment=treatment,
+        treatment_detail=treatment_detail,
+        perturber_state=tuple(sorted(perturber_state.items())),
         usable=unusable_reason is None,
         unusable_reason=unusable_reason,
         first_uptime_h=launches[0].uptime_h,

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -275,13 +275,16 @@ def _launch_evidence(launch: LaunchObservation) -> dict[str, str]:
 
 
 def _is_live_session(launch: LaunchObservation) -> bool:
-    """Whether this attempt lived long enough that a miss is informative for overlays_on.
+    """Whether this attempt's absence evidence is informative (post injection race).
 
-    The injection race is ~3 s on the measured rig. Only ``stable`` / ``froze`` / ``wedged_init``
-    with a delivered cycle are treated as past that window: they require the stability /
-    go-live watch. ``never_live`` is never dispositive for *absence* — ``elapsed_s`` includes
-    pre-launch cleanup / CM startup, so it cannot prove the process lived past the race (Codex
-    P1 on #721). Presence (``injected``) remains dispositive on any attempt via the off-arm path.
+    The injection race is ~3 s on the measured rig. Only delivered ``stable`` / ``froze`` /
+    ``wedged_init`` are treated as past that window: each requires the go-live / stability
+    watch (far longer than the race). ``never_live`` is never dispositive for *absence* —
+    ``elapsed_s`` includes pre-launch work and cannot prove post-race lifetime (Codex P1 on
+    #721). Presence (``injected``) remains dispositive on any attempt via the off-arm path.
+
+    A ``FROZE`` after go-live is still past the race: go-live itself requires a ready session,
+    which on this rig is orders of magnitude longer than the measured 3 s injection window.
     """
 
     return launch.cycle_delivered is True and launch.verdict in _LIVE_SESSION_VERDICTS
@@ -339,28 +342,30 @@ def treatment_receipt(
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
             )
-        # Absence is only confirmable from LIVE-SESSION looks themselves — not from a boot
-        # roll-up that may still carry early never_live not_observed noise (Codex P1 on #721).
-        live = [item for item in rows if _is_live_session(item)]
-        if not live:
+        # Every DELIVERED cycle enters the onset coordinate, so each must have live-session
+        # not_observed evidence for confirmation. Early delivered never_live (race-window
+        # not_observed / unavailable) keeps the boot unverified (Codex P1 on #721).
+        delivered = [item for item in rows if item.cycle_delivered is True]
+        if not delivered:
             return (
                 TREATMENT_UNVERIFIED,
-                "no long-lived acs.exe look past the injection race for overlays_off",
+                "no delivered cycles with perturber evidence for overlays_off",
             )
         incomplete: list[int] = []
-        for item in live:
+        for item in delivered:
             evidence = _launch_evidence(item)
-            if set(evidence) != required or any(
-                evidence.get(name) == "unavailable" for name in required
-            ):
+            if not _is_live_session(item):
                 incomplete.append(item.launch)
                 continue
-            if any(evidence.get(name) != "not_observed" for name in required):
+            if set(evidence) != required or any(
+                evidence.get(name) != "not_observed" for name in required
+            ):
                 incomplete.append(item.launch)
         if incomplete:
             return (
                 TREATMENT_UNVERIFIED,
-                "partial or unavailable perturber evidence on live session(s) for overlays_off",
+                "partial, early, or unavailable perturber evidence on delivered cycles "
+                "for overlays_off",
             )
         return TREATMENT_CONFIRMED, None
 

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -103,10 +103,14 @@ WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
 #: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
 PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: Verdicts used when *absence* must be dispositive for the off-arm confirmation path.
-#: ``stable`` / ``froze`` are post-go-live (packet advanced + ready). ``wedged_init`` is not —
-#: the stream never initialized. On-arm *miss* contradiction uses only ``stable`` (see
-#: :func:`treatment_receipt`); positive ``injected`` is evaluated on every delivered launch.
+#: Post-go-live verdicts for *absence* confirmation (off-arm) and live-session checks.
+#: ``stable`` / ``froze`` require packet advance + ready (past the measured ~3 s race by
+#: construction; plans also floor go_live/stability at 5 s). ``wedged_init`` is excluded.
+#: On-arm *miss* contradiction uses only ``stable`` (see :func:`treatment_receipt`).
+#: Positive ``injected`` is evaluated on every delivered launch regardless of verdict.
+#:
+#: Codex has repeatedly re-litigated freze-as-absence; the contract is: freze is post-go-live
+#: absence-OK for off-arm confirmation of every delivered launch; on-arm miss stays STABLE-only.
 _LIVE_SESSION_VERDICTS = frozenset({"stable", "froze"})
 #: Measured injection race on the rig (~3 s). Plans must not set timeouts below this plus margin.
 INJECTION_RACE_S = 3.0
@@ -348,9 +352,7 @@ def treatment_receipt(
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
             )
-        # Every delivered launch must show full not_observed on a post-go-live verdict
-        # (stable/froze). Omitting freze/wedged would let mixed-treatment boots score
-        # (Codex P1 on #721).
+        # Every delivered post-go-live launch (stable/froze) must show full not_observed.
         delivered = [item for item in rows if item.cycle_delivered is True]
         if not delivered:
             return (

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -940,7 +940,7 @@ def _parse_report(
                     break
                 if (
                     reported_expect == "on"
-                    and raw.get("verdict") == "stable"
+                    and raw.get("verdict") in ("stable", "wedged_init")
                     and any(value == "not_observed" for value in block.values())
                     and all(value != "unavailable" for value in block.values())
                 ):

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -263,17 +263,23 @@ def treatment_receipt(condition: str, state: dict[str, str]) -> tuple[str, str |
     cannot inform the contrast. The cause is irrelevant; receipt is what the design needs.
 
     Evidence is asymmetric per launch, but a BOOT aggregates many launches, so both arms are
-    checkable here even though only ``off`` is refutable from a single attempt:
+    checkable here even though only ``off`` is refutable from a single attempt. Confirmation
+    requires **every** tracked perturber to match the planned arm; partial unknown evidence
+    stays ``unverified`` rather than silently admitting a half-applied treatment (Codex P1 on
+    #721):
 
-    * planned ``overlays_off`` + any ``injected``      -> contradicted (dispositive)
-    * planned ``overlays_on``  + all ``not_observed``  -> contradicted (the boot never saw the
-      perturber it was supposed to run with, across every successful look in the boot)
-    * anything resting on ``unavailable``              -> unverified (no information; fall back to
-      the planned label and say so, rather than claiming confirmation we did not earn)
+    * planned ``overlays_off`` + any ``injected``            -> contradicted (dispositive)
+    * planned ``overlays_off`` + all ``not_observed``        -> confirmed
+    * planned ``overlays_on``  + all ``injected``            -> confirmed
+    * planned ``overlays_on``  + all successful looks miss
+      (no ``injected``, every field ``not_observed``)        -> contradicted
+    * anything resting on ``unavailable`` or mixed partial   -> unverified (no information; fall
+      back to the planned label rather than claiming confirmation we did not earn)
     """
 
     if not state:
         return TREATMENT_UNVERIFIED, "report carries no perturber evidence"
+    values = list(state.values())
     if condition == "overlays_off":
         injected = sorted(name for name, value in state.items() if value == "injected")
         if injected:
@@ -281,15 +287,23 @@ def treatment_receipt(condition: str, state: dict[str, str]) -> tuple[str, str |
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
             )
-        if all(value == "unavailable" for value in state.values()):
-            return TREATMENT_UNVERIFIED, "no successful module snapshot in this boot"
-        return TREATMENT_CONFIRMED, None
-    if condition == "overlays_on":
-        if any(value == "injected" for value in state.values()):
+        if all(value == "not_observed" for value in values):
             return TREATMENT_CONFIRMED, None
-        if all(value == "unavailable" for value in state.values()):
-            return TREATMENT_UNVERIFIED, "no successful module snapshot in this boot"
-        missing = sorted(name for name, value in state.items() if value == "not_observed")
+        return TREATMENT_UNVERIFIED, "partial or unavailable perturber evidence for overlays_off"
+    if condition == "overlays_on":
+        if all(value == "injected" for value in values):
+            return TREATMENT_CONFIRMED, None
+        if all(value == "not_observed" for value in values):
+            missing = sorted(state)
+            return (
+                TREATMENT_CONTRADICTED,
+                f"planned overlays_on but {', '.join(missing)} was never observed injected across "
+                "any successful snapshot in this boot",
+            )
+        if any(value == "unavailable" for value in values):
+            return TREATMENT_UNVERIFIED, "partial or unavailable perturber evidence for overlays_on"
+        # Mixed injected + not_observed: some planned overlays never appeared after looks.
+        missing = sorted(name for name, value in state.items() if value != "injected")
         return (
             TREATMENT_CONTRADICTED,
             f"planned overlays_on but {', '.join(missing)} was never observed injected across "
@@ -704,14 +718,40 @@ def _parse_report(
         raise ValueError(f"report {path} schema must be {REPORT_SCHEMA!r}")
     attempts = report.get("attempts")
     attempts_log = report.get("attempts_log")
-    if attempts != launches_per_boot:
-        raise ValueError(
-            f"report {path} recorded {attempts!r} attempts; the plan requires exactly "
-            f"{launches_per_boot} launches in this boot (run one --trials "
-            f"{launches_per_boot} invocation per boot)"
-        )
-    if not isinstance(attempts_log, list) or len(attempts_log) != launches_per_boot:
-        raise ValueError(f"report {path} must log all {launches_per_boot} launches")
+    arm_contradicted = report.get("arm_contradicted") is True
+    # A full boot must run the planned launch budget. The one deliberate short form is an
+    # early arm-contradiction stop under ``--expect-perturbers off`` (#719 Part C): the report
+    # is still a usable treatment-receipt artifact (the boot is excluded), so accepting it
+    # here is what makes the fail-fast path loadable instead of looking like a corrupt run
+    # (Codex P1 on #721).
+    if arm_contradicted:
+        if not isinstance(attempts, int) or attempts < 1 or attempts > launches_per_boot:
+            raise ValueError(
+                f"report {path} recorded arm_contradicted with attempts={attempts!r}; "
+                f"expected 1..{launches_per_boot}"
+            )
+        if not isinstance(attempts_log, list) or len(attempts_log) != attempts:
+            log_len = (
+                len(attempts_log) if isinstance(attempts_log, list) else type(attempts_log).__name__
+            )
+            raise ValueError(
+                f"report {path} arm_contradicted log length {log_len} "
+                f"does not match attempts={attempts}"
+            )
+        if report.get("expect_perturbers") != "off":
+            raise ValueError(
+                f"report {path} arm_contradicted requires expect_perturbers='off' "
+                f"(got {report.get('expect_perturbers')!r})"
+            )
+    else:
+        if attempts != launches_per_boot:
+            raise ValueError(
+                f"report {path} recorded {attempts!r} attempts; the plan requires exactly "
+                f"{launches_per_boot} launches in this boot (run one --trials "
+                f"{launches_per_boot} invocation per boot)"
+            )
+        if not isinstance(attempts_log, list) or len(attempts_log) != launches_per_boot:
+            raise ValueError(f"report {path} must log all {launches_per_boot} launches")
     launch = report.get("launch")
     if not isinstance(launch, dict):
         raise ValueError(f"report {path} must record launch configuration")
@@ -1740,8 +1780,20 @@ def _format_boot_command(
     go_live_timeout: float,
     launches_per_boot: int,
     report_path: str,
+    condition: str,
 ) -> str:
-    """Build a pasteable per-boot launch line rooted at the checkout (so ``tools`` imports)."""
+    """Build a pasteable per-boot launch line rooted at the checkout (so ``tools`` imports).
+
+    Emits ``--expect-perturbers on|off`` derived from the planned arm so the standard experiment
+    workflow activates the fail-fast off-arm check without a hand-edited command (Codex P2 on
+    #721).
+    """
+    if condition == "overlays_on":
+        expect = "on"
+    elif condition == "overlays_off":
+        expect = "off"
+    else:
+        raise ValueError(f"unknown planned condition {condition!r}")
     parts = [
         "python",
         "-m",
@@ -1761,6 +1813,8 @@ def _format_boot_command(
             f"{go_live_timeout:g}",
             "--trials",
             str(launches_per_boot),
+            "--expect-perturbers",
+            expect,
             "--json",
             report_path,
         ]
@@ -1835,6 +1889,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         go_live_timeout=args.go_live_timeout,
                         launches_per_boot=args.launches_per_boot,
                         report_path=_checkout_relative_report_path(destination, boot["report"]),
+                        condition=boot["condition"],
                     ),
                 )
                 for boot in plan["boots"]

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -89,6 +89,12 @@ from tools.ac_harness.resilient_launch import (
     resolve_report_path,
 )
 
+#: Fraction of the go-live budget a delivered ``never_live`` must have consumed before its
+#: ``not_observed`` evidence is treated as post-injection-race (Codex P1 on #721). Early
+#: deaths with ``cycle_delivered=True`` finish in seconds; a full-timeout watch is near
+#: ``DEFAULT_GO_LIVE_TIMEOUT``.
+_NEVER_LIVE_TIMEOUT_FRACTION = 0.9
+
 #: v4 pre-registers treatment-receipt verification (#719): analyzer excludes contradicted boots,
 #: plan commands emit ``--expect-perturbers``, and every attempt must carry the full
 #: ``PERTURBER_MODULES`` key set. The plan file IS the pre-registration, so a v3 plan that never
@@ -107,6 +113,17 @@ PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
 _LIVE_SESSION_VERDICTS = frozenset({"stable", "froze", "wedged_init"})
 #: Canonical perturber field set every report row must carry exactly.
 _PERTURBER_KEYS = frozenset(PERTURBER_MODULES)
+#: Exact treatment-receipt policy a v4 plan must pre-register (Codex P2 on #721).
+#: Uses the string form of :data:`TREATMENT_CONTRADICTED` so this can live with the schema
+#: constants (the named constants are defined next to the receipt helpers below).
+CANONICAL_TREATMENT_RECEIPT: dict[str, object] = {
+    "enabled": True,
+    "exclude_on": ["contradicted"],
+    "expect_perturbers_in_commands": True,
+    "perturbers": sorted(PERTURBER_MODULES),
+    "on_arm_requires_live_session_looks": True,
+    "per_live_launch_full_injection": True,
+}
 CONDITIONS = ("overlays_on", "overlays_off")
 DEFAULT_ALPHA = 0.05
 #: Seed used only when a caller explicitly asks to reproduce a plan. A REAL plan draws a fresh
@@ -267,15 +284,22 @@ def _is_live_session(launch: LaunchObservation) -> bool:
     """Whether this attempt lived long enough that a miss is informative for overlays_on.
 
     The injection race is ~3 s on the measured rig. ``stable`` / ``froze`` / ``wedged_init`` only
-    fire after the stability / go-live watch. A **delivered** ``never_live`` is also long enough:
-    ``classify()`` emits it after the full go-live timeout when AC rendered but never reached
-    readiness — far past the race — so those successful looks must still count (Codex P1 on
-    #721). An *undelivered* ``never_live`` (CM absent / launch never spawned) does not.
+    fire after the stability / go-live watch, so their successful looks are past the race.
+
+    A delivered ``never_live`` is *not* automatically long enough: ``classify()`` also emits it
+    immediately when a newly observed ``acs.exe`` exits during startup (still
+    ``cycle_delivered=True``). Only a watch that consumed nearly the full go-live budget is the
+    timeout-stuck-before-readiness shape; early deaths stay non-dispositive for absence (Codex P1
+    on #721).
     """
 
     if launch.cycle_delivered is not True:
         return False
-    return launch.verdict in _LIVE_SESSION_VERDICTS or launch.verdict == "never_live"
+    if launch.verdict in _LIVE_SESSION_VERDICTS:
+        return True
+    if launch.verdict == "never_live":
+        return launch.elapsed_s >= DEFAULT_GO_LIVE_TIMEOUT * _NEVER_LIVE_TIMEOUT_FRACTION
+    return False
 
 
 def treatment_receipt(
@@ -605,14 +629,7 @@ def build_plan(
         # Pre-registered with the plan so analyze cannot invent a receipt rule the operator never
         # signed up for (Codex P2 on #721). ``exclude_on`` is only ``contradicted``: ``unverified``
         # falls back to the planned label because no information must not manufacture missingness.
-        "treatment_receipt": {
-            "enabled": True,
-            "exclude_on": [TREATMENT_CONTRADICTED],
-            "expect_perturbers_in_commands": True,
-            "perturbers": sorted(PERTURBER_MODULES),
-            "on_arm_requires_live_session_looks": True,
-            "per_live_launch_full_injection": True,
-        },
+        "treatment_receipt": dict(CANONICAL_TREATMENT_RECEIPT),
         "launch": {
             "car": car,
             "track": track,
@@ -739,6 +756,15 @@ def load_plan(path: Path) -> dict[str, Any]:
             f"plan {PLAN_SCHEMA!r} must record treatment_receipt.enabled=true "
             "(the pre-registered receipt policy from #719)"
         )
+    # Full policy match — a hand-edited v4 that changes exclude_on / perturbers / flags would
+    # otherwise be analyzed under today's hard-coded rules while claiming a different prereg
+    # (Codex P2 on #721).
+    for key, expected in CANONICAL_TREATMENT_RECEIPT.items():
+        if receipt.get(key) != expected:
+            raise ValueError(
+                f"plan treatment_receipt.{key}={receipt.get(key)!r} does not match the "
+                f"canonical v4 policy {expected!r}; regenerate the plan"
+            )
     boots_per_arm = plan.get("boots_per_arm")
     if not isinstance(boots_per_arm, int) or boots_per_arm <= 0:
         raise ValueError("plan boots_per_arm must be a positive integer")
@@ -1704,11 +1730,31 @@ def _format_optional(value: float | None, spec: str) -> str:
 
 def render_markdown(analysis: dict[str, Any]) -> str:
     arms = analysis["arms"]
+    boots = analysis.get("boots") or []
+    confirmed = sum(1 for boot in boots if boot.get("treatment") == TREATMENT_CONFIRMED)
+    contradicted = sum(1 for boot in boots if boot.get("treatment") == TREATMENT_CONTRADICTED)
+    unverified = sum(1 for boot in boots if boot.get("treatment") == TREATMENT_UNVERIFIED)
     lines = [
-        "| condition | boots | scoring | observed onsets | censored | ambiguous | "
-        "median onset | median boot burst (across-boot range) |",
-        "|---|---:|---:|---|---:|---:|---:|---:|",
+        # Receipt is the gate on every boot's usability for the contrast (#719 / Codex P2).
+        f"Treatment receipt: confirmed {confirmed}, contradicted {contradicted}, "
+        f"unverified {unverified}",
     ]
+    if contradicted or unverified:
+        for boot in boots:
+            treatment = boot.get("treatment")
+            if treatment in (TREATMENT_CONTRADICTED, TREATMENT_UNVERIFIED):
+                detail = boot.get("treatment_detail") or treatment
+                lines.append(
+                    f"  boot {boot.get('boot')} ({boot.get('condition')}): {treatment} — {detail}"
+                )
+    lines.extend(
+        [
+            "",
+            "| condition | boots | scoring | observed onsets | censored | ambiguous | "
+            "median onset | median boot burst (across-boot range) |",
+            "|---|---:|---:|---|---:|---:|---:|---:|",
+        ]
+    )
     for condition in CONDITIONS:
         arm = arms[condition]
         onsets = ", ".join(str(value) for value in arm["observed_onsets"]) or "—"

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -82,24 +82,31 @@ from tools.ac_harness.remote_launcher import RemoteLaunchError, validate_wrapper
 from tools.ac_harness.resilient_launch import (
     DEFAULT_GO_LIVE_TIMEOUT,
     FREEZE_VERDICTS,
+    PERTURBER_MODULES,
     REPORT_SCHEMA,
     TERMINAL_VERDICTS,
     repo_checkout_root,
     resolve_report_path,
 )
 
-#: v3 registers the endpoints in DELIVERED CYCLES (#710). The plan file IS the pre-registration,
-#: so this had to move with the analysis: a v2 plan's stored ``endpoints`` still say raw
-#: launch-index and a launch-counted burst window, and silently analyzing it under cycle-counted
-#: rules would score it against an endpoint it never registered.
-PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: v3 scores onset on delivered cycles and reports the delivery split per boot (#710).
-ANALYSIS_SCHEMA = "init-perturber-ab-analysis/v3"
+#: v4 pre-registers treatment-receipt verification (#719): analyzer excludes contradicted boots,
+#: plan commands emit ``--expect-perturbers``, and every attempt must carry the full
+#: ``PERTURBER_MODULES`` key set. The plan file IS the pre-registration, so a v3 plan that never
+#: recorded this policy must not be analyzed under it (Codex P2 on #721).
+PLAN_SCHEMA = "init-perturber-ab-plan/v4"
+#: v4 keeps the delivered-cycle endpoints from v3 and adds treatment-receipt policy.
+ANALYSIS_SCHEMA = "init-perturber-ab-analysis/v4"
 #: the interleaved single-boot design this module used to emit; refuted 2026-07-24 and
 #: rejected by :func:`load_plan` so a stale plan file cannot be analyzed as if it were valid.
 WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 #: the raw-launch-index pre-registration superseded by #710; rejected for the same reason.
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
+#: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
+PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
+#: Verdicts that imply acs.exe lived well past the ~3 s injection race measured on the rig.
+_LIVE_SESSION_VERDICTS = frozenset({"stable", "froze", "wedged_init"})
+#: Canonical perturber field set every report row must carry exactly.
+_PERTURBER_KEYS = frozenset(PERTURBER_MODULES)
 CONDITIONS = ("overlays_on", "overlays_off")
 DEFAULT_ALPHA = 0.05
 #: Seed used only when a caller explicitly asks to reproduce a plan. A REAL plan draws a fresh
@@ -252,7 +259,27 @@ def boot_perturber_state(observation: BootObservation) -> dict[str, str]:
     return state
 
 
-def treatment_receipt(condition: str, state: dict[str, str]) -> tuple[str, str | None]:
+def _launch_evidence(launch: LaunchObservation) -> dict[str, str]:
+    return dict(launch.perturbers)
+
+
+def _is_live_session(launch: LaunchObservation) -> bool:
+    """Whether this attempt lived long enough that a miss is informative for overlays_on.
+
+    The injection race is ~3 s on the measured rig; live-session verdicts only fire after the
+    stability / go-live watch, which is far past that window. Early ``never_live`` exits can
+    sample only inside the race and must not contradict an ``overlays_on`` arm (Codex P1 on #721).
+    """
+
+    return launch.verdict in _LIVE_SESSION_VERDICTS and launch.cycle_delivered is True
+
+
+def treatment_receipt(
+    condition: str,
+    state: dict[str, str],
+    *,
+    launches: Sequence[LaunchObservation] | None = None,
+) -> tuple[str, str | None]:
     """Did this boot actually RECEIVE the condition its arm label claims? (#719)
 
     Returns ``(verdict, detail)``.
@@ -262,24 +289,35 @@ def treatment_receipt(condition: str, state: dict[str, str]) -> tuple[str, str |
     simply failed to inject while enabled, a boot that did not receive its assigned condition
     cannot inform the contrast. The cause is irrelevant; receipt is what the design needs.
 
-    Evidence is asymmetric per launch, but a BOOT aggregates many launches, so both arms are
-    checkable here even though only ``off`` is refutable from a single attempt. Confirmation
-    requires **every** tracked perturber to match the planned arm; partial unknown evidence
-    stays ``unverified`` rather than silently admitting a half-applied treatment (Codex P1 on
-    #721):
+    Rules (Codex P1 round-2 on #721):
 
-    * planned ``overlays_off`` + any ``injected``            -> contradicted (dispositive)
-    * planned ``overlays_off`` + all ``not_observed``        -> confirmed
-    * planned ``overlays_on``  + all ``injected``            -> confirmed
-    * planned ``overlays_on``  + all successful looks miss
-      (no ``injected``, every field ``not_observed``)        -> contradicted
-    * anything resting on ``unavailable`` or mixed partial   -> unverified (no information; fall
-      back to the planned label rather than claiming confirmation we did not earn)
+    * planned ``overlays_off`` + any ``injected`` anywhere in the boot -> contradicted
+      (presence is dispositive; a perturber cannot un-inject)
+    * planned ``overlays_off`` + every field ``not_observed`` on the boot roll-up -> confirmed
+    * planned ``overlays_on`` is judged **per live-session launch**, not via a boot-wide union:
+      each long-lived ``acs.exe`` is its own injection event, so confirming the arm requires
+      every live launch to show every tracked perturber ``injected``. A boot-wide union would
+      let Steam on attempt 1 and NVIDIA on attempt 5 "confirm" a mixed-treatment boot.
+    * planned ``overlays_on`` + a live launch whose successful looks miss a perturber ->
+      contradicted for that launch (lived past the injection race)
+    * planned ``overlays_on`` with only early/never_live looks, or any ``unavailable`` gap ->
+      unverified (absence during the race is non-dispositive; no information falls back to the
+      planned label rather than manufacturing an exclusion)
     """
 
+    required = _PERTURBER_KEYS
     if not state:
         return TREATMENT_UNVERIFIED, "report carries no perturber evidence"
-    values = list(state.values())
+    if set(state) != required:
+        missing = sorted(required - set(state))
+        extra = sorted(set(state) - required)
+        detail = []
+        if missing:
+            detail.append(f"missing {', '.join(missing)}")
+        if extra:
+            detail.append(f"unknown {', '.join(extra)}")
+        return TREATMENT_UNVERIFIED, "perturber key set incomplete: " + "; ".join(detail)
+
     if condition == "overlays_off":
         injected = sorted(name for name, value in state.items() if value == "injected")
         if injected:
@@ -287,28 +325,46 @@ def treatment_receipt(condition: str, state: dict[str, str]) -> tuple[str, str |
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
             )
-        if all(value == "not_observed" for value in values):
+        if all(value == "not_observed" for value in state.values()):
             return TREATMENT_CONFIRMED, None
         return TREATMENT_UNVERIFIED, "partial or unavailable perturber evidence for overlays_off"
+
     if condition == "overlays_on":
-        if all(value == "injected" for value in values):
-            return TREATMENT_CONFIRMED, None
-        if all(value == "not_observed" for value in values):
-            missing = sorted(state)
+        live = [item for item in (launches or ()) if _is_live_session(item)]
+        if not live:
+            # No long-lived process: not_observed may be pure injection-race noise.
+            if all(value == "unavailable" for value in state.values()):
+                return TREATMENT_UNVERIFIED, "no successful module snapshot in this boot"
+            return (
+                TREATMENT_UNVERIFIED,
+                "no long-lived acs.exe look past the injection race for overlays_on",
+            )
+        incomplete: list[int] = []
+        short: list[str] = []
+        for item in live:
+            evidence = _launch_evidence(item)
+            if set(evidence) != required:
+                incomplete.append(item.launch)
+                continue
+            if any(evidence[name] == "unavailable" for name in required):
+                incomplete.append(item.launch)
+                continue
+            miss = sorted(name for name in required if evidence[name] != "injected")
+            if miss:
+                short.append(f"launch {item.launch}: {', '.join(miss)}")
+        if short and not incomplete:
             return (
                 TREATMENT_CONTRADICTED,
-                f"planned overlays_on but {', '.join(missing)} was never observed injected across "
-                "any successful snapshot in this boot",
+                "planned overlays_on but live session(s) never observed full injection "
+                f"({'; '.join(short)})",
             )
-        if any(value == "unavailable" for value in values):
-            return TREATMENT_UNVERIFIED, "partial or unavailable perturber evidence for overlays_on"
-        # Mixed injected + not_observed: some planned overlays never appeared after looks.
-        missing = sorted(name for name, value in state.items() if value != "injected")
-        return (
-            TREATMENT_CONTRADICTED,
-            f"planned overlays_on but {', '.join(missing)} was never observed injected across "
-            "any successful snapshot in this boot",
-        )
+        if incomplete:
+            return (
+                TREATMENT_UNVERIFIED,
+                "partial or unavailable perturber evidence on live session(s) for overlays_on",
+            )
+        return TREATMENT_CONFIRMED, None
+
     return TREATMENT_UNVERIFIED, f"unknown condition {condition!r}"
 
 
@@ -521,9 +577,13 @@ def build_plan(
     ]
     return {
         "schema": PLAN_SCHEMA,
-        # Every schema this plan supersedes, oldest first — both are rejected by `load_plan`, so
-        # the migration path is recorded rather than implied (#710 self-hosted reviewer MEDIUM).
-        "supersedes": [WITHDRAWN_PLAN_SCHEMA, SUPERSEDED_PLAN_SCHEMA],
+        # Every schema this plan supersedes, oldest first — rejected by `load_plan`, so the
+        # migration path is recorded rather than implied (#710 self-hosted reviewer MEDIUM).
+        "supersedes": [
+            WITHDRAWN_PLAN_SCHEMA,
+            SUPERSEDED_PLAN_SCHEMA,
+            PRE_TREATMENT_PLAN_SCHEMA,
+        ],
         "issue": 625,
         "generated_at_utc": stamp,
         "design": "randomized block; one boot per unit, two boots (one per arm) per block",
@@ -535,6 +595,17 @@ def build_plan(
         "run_id": run_id,
         "randomization_reference_set": 2**boots_per_arm,
         "smallest_attainable_two_sided_p": 2 / 2**boots_per_arm,
+        # Pre-registered with the plan so analyze cannot invent a receipt rule the operator never
+        # signed up for (Codex P2 on #721). ``exclude_on`` is only ``contradicted``: ``unverified``
+        # falls back to the planned label because no information must not manufacture missingness.
+        "treatment_receipt": {
+            "enabled": True,
+            "exclude_on": [TREATMENT_CONTRADICTED],
+            "expect_perturbers_in_commands": True,
+            "perturbers": sorted(PERTURBER_MODULES),
+            "on_arm_requires_live_session_looks": True,
+            "per_live_launch_full_injection": True,
+        },
         "launch": {
             "car": car,
             "track": track,
@@ -645,8 +716,22 @@ def load_plan(path: Path) -> dict[str, Any]:
             "No data is lost: pre-#710 boot reports use the withdrawn "
             "'resilient-launch-report/v1' schema and are rejected regardless"
         )
+    if schema == PRE_TREATMENT_PLAN_SCHEMA:
+        raise ValueError(
+            f"plan schema {PRE_TREATMENT_PLAN_SCHEMA!r} pre-dates treatment-receipt verification "
+            "(#719): it does not record the exclusion policy, the required perturber key set, or "
+            "that each boot command carries --expect-perturbers. Regenerate the plan under "
+            f"{PLAN_SCHEMA!r} before analyze; reusing a v3 plan would apply a receipt rule the "
+            "operator never pre-registered"
+        )
     if schema != PLAN_SCHEMA:
         raise ValueError(f"plan schema must be {PLAN_SCHEMA!r}")
+    receipt = plan.get("treatment_receipt")
+    if not isinstance(receipt, dict) or receipt.get("enabled") is not True:
+        raise ValueError(
+            f"plan {PLAN_SCHEMA!r} must record treatment_receipt.enabled=true "
+            "(the pre-registered receipt policy from #719)"
+        )
     boots_per_arm = plan.get("boots_per_arm")
     if not isinstance(boots_per_arm, int) or boots_per_arm <= 0:
         raise ValueError("plan boots_per_arm must be a positive integer")
@@ -743,6 +828,14 @@ def _parse_report(
                 f"report {path} arm_contradicted requires expect_perturbers='off' "
                 f"(got {report.get('expect_perturbers')!r})"
             )
+        # Short reports only exist for the fail-fast OFF arm. Accepting one under an overlays_on
+        # plan label would score a single-attempt boot as if it had the full budget (Codex P2).
+        if boot.condition != "overlays_off":
+            raise ValueError(
+                f"report {path} arm_contradicted with expect_perturbers='off' but plan condition "
+                f"is {boot.condition!r}; short contradiction reports are only valid for "
+                "overlays_off boots"
+            )
     else:
         if attempts != launches_per_boot:
             raise ValueError(
@@ -815,6 +908,11 @@ def _parse_report(
         if not isinstance(perturbers, dict) or not perturbers:
             raise ValueError(
                 f"report {path} launch {index} has a non-mapping or empty perturbers block"
+            )
+        if set(perturbers) != _PERTURBER_KEYS:
+            raise ValueError(
+                f"report {path} launch {index} perturbers keys must be exactly "
+                f"{sorted(_PERTURBER_KEYS)}; got {sorted(perturbers)}"
             )
         for name, value in perturbers.items():
             if not isinstance(name, str) or value not in _PERTURBER_EVIDENCE_VALUES:
@@ -1091,7 +1189,11 @@ def summarize_boot(observation: BootObservation) -> BootSummary:
     # 20 delivered never_live cycles — a perfectly good censored observation — while scoring 19
     # of the same cycles plus one stable row (#710 Codex P2).
     perturber_state = boot_perturber_state(observation)
-    treatment, treatment_detail = treatment_receipt(observation.condition, perturber_state)
+    treatment, treatment_detail = treatment_receipt(
+        observation.condition,
+        perturber_state,
+        launches=observation.launches,
+    )
     if delivered_cycles == 0:
         unusable_reason = "no_delivered_cycles"
     elif undelivered > MAX_UNDELIVERED_FRACTION * len(launches):

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -331,6 +331,7 @@ def treatment_receipt(
             detail.append(f"unknown {', '.join(extra)}")
         return TREATMENT_UNVERIFIED, "perturber key set incomplete: " + "; ".join(detail)
 
+    rows = list(launches or ())
     if condition == "overlays_off":
         injected = sorted(name for name, value in state.items() if value == "injected")
         if injected:
@@ -338,30 +339,45 @@ def treatment_receipt(
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
             )
-        # Absence is only confirmable from live-session looks (same race as the on arm).
-        live = [item for item in (launches or ()) if _is_live_session(item)]
+        # Absence is only confirmable from LIVE-SESSION looks themselves — not from a boot
+        # roll-up that may still carry early never_live not_observed noise (Codex P1 on #721).
+        live = [item for item in rows if _is_live_session(item)]
         if not live:
             return (
                 TREATMENT_UNVERIFIED,
                 "no long-lived acs.exe look past the injection race for overlays_off",
             )
-        if all(value == "not_observed" for value in state.values()):
-            return TREATMENT_CONFIRMED, None
-        return TREATMENT_UNVERIFIED, "partial or unavailable perturber evidence for overlays_off"
-
-    if condition == "overlays_on":
-        live = [item for item in (launches or ()) if _is_live_session(item)]
-        if not live:
-            # No long-lived process: not_observed may be pure injection-race noise.
-            if all(value == "unavailable" for value in state.values()):
-                return TREATMENT_UNVERIFIED, "no successful module snapshot in this boot"
+        incomplete: list[int] = []
+        for item in live:
+            evidence = _launch_evidence(item)
+            if set(evidence) != required or any(
+                evidence.get(name) == "unavailable" for name in required
+            ):
+                incomplete.append(item.launch)
+                continue
+            if any(evidence.get(name) != "not_observed" for name in required):
+                incomplete.append(item.launch)
+        if incomplete:
             return (
                 TREATMENT_UNVERIFIED,
-                "no long-lived acs.exe look past the injection race for overlays_on",
+                "partial or unavailable perturber evidence on live session(s) for overlays_off",
+            )
+        return TREATMENT_CONFIRMED, None
+
+    if condition == "overlays_on":
+        # Every DELIVERED cycle enters the onset coordinate, so each must be fully injected for
+        # confirmation. Early delivered never_live with not_observed keeps the boot unverified
+        # rather than being dropped while later lives confirm (Codex P1 on #721).
+        delivered = [item for item in rows if item.cycle_delivered is True]
+        if not delivered:
+            return (
+                TREATMENT_UNVERIFIED,
+                "no delivered cycles with perturber evidence for overlays_on",
             )
         incomplete: list[int] = []
-        short: list[str] = []
-        for item in live:
+        short_live: list[str] = []
+        early_miss: list[int] = []
+        for item in delivered:
             evidence = _launch_evidence(item)
             if set(evidence) != required:
                 incomplete.append(item.launch)
@@ -370,21 +386,23 @@ def treatment_receipt(
                 incomplete.append(item.launch)
                 continue
             miss = sorted(name for name in required if evidence[name] != "injected")
-            if miss:
-                short.append(f"launch {item.launch}: {', '.join(miss)}")
-        # A dispositive miss on any fully observed live launch cannot be erased by a sibling
-        # launch whose snapshot failed (``unavailable``). Prefer contradicted over unverified
-        # whenever short is non-empty (Codex P1 on #721).
-        if short:
+            if not miss:
+                continue
+            if _is_live_session(item):
+                short_live.append(f"launch {item.launch}: {', '.join(miss)}")
+            else:
+                early_miss.append(item.launch)
+        if short_live:
             return (
                 TREATMENT_CONTRADICTED,
                 "planned overlays_on but live session(s) never observed full injection "
-                f"({'; '.join(short)})",
+                f"({'; '.join(short_live)})",
             )
-        if incomplete:
+        if incomplete or early_miss:
             return (
                 TREATMENT_UNVERIFIED,
-                "partial or unavailable perturber evidence on live session(s) for overlays_on",
+                "partial, early, or unavailable perturber evidence on delivered cycles "
+                "for overlays_on",
             )
         return TREATMENT_CONFIRMED, None
 
@@ -860,6 +878,22 @@ def _parse_report(
                 f"report {path} arm_contradicted with expect_perturbers='off' but plan condition "
                 f"is {boot.condition!r}; short contradiction reports are only valid for "
                 "overlays_off boots"
+            )
+        # The summary flag alone is not enough: require dispositive injected evidence in the
+        # log so a truncated clean report cannot enter via arm_contradicted (Codex P2 on #721).
+        has_injected = False
+        if isinstance(attempts_log, list):
+            for raw in attempts_log:
+                if not isinstance(raw, dict):
+                    continue
+                block = raw.get("perturbers")
+                if isinstance(block, dict) and any(value == "injected" for value in block.values()):
+                    has_injected = True
+                    break
+        if not has_injected:
+            raise ValueError(
+                f"report {path} arm_contradicted but attempts_log has no injected perturber "
+                "evidence — refusing the short-report exception"
             )
     else:
         if attempts != launches_per_boot:

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -103,13 +103,11 @@ WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
 #: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
 PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: Verdicts past the injection race for *absence* evidence (Codex P1 on #721):
-#: * ``stable`` — full stability window after go-live.
-#: * ``wedged_init`` — acs.exe stayed alive for the entire ``go_live_timeout`` (≥ floor below),
-#:   so the measured ~3 s race has elapsed even without readiness.
-#: ``froze`` is excluded: it can fire on the first post-go-live death / packet regression
-#: (and ``_Car0NotDrivable`` maps to ``FROZE``) while injection is still racing.
-_LIVE_SESSION_VERDICTS = frozenset({"stable", "wedged_init"})
+#: Only ``stable`` is dispositive for *absence* evidence (Codex P1 on #721). ``wedged_init``
+#: means the render stream never initialized — elapsed go-live budget does not prove injection
+#: completed. ``froze`` can fire on the first post-go-live death while injection is still racing.
+#: Positive ``injected`` is evaluated on every delivered launch regardless of verdict.
+_LIVE_SESSION_VERDICTS = frozenset({"stable"})
 #: Measured injection race on the rig (~3 s). Plans must not set timeouts below this plus margin.
 INJECTION_RACE_S = 3.0
 #: Plan floor for ``--go-live-timeout`` / ``--stability-window`` so post-race absence claims
@@ -373,27 +371,32 @@ def treatment_receipt(
         return TREATMENT_CONFIRMED, None
 
     if condition == "overlays_on":
-        # Confirmation / contradiction of absence uses STABLE delivered cycles only. Injected
-        # presence on any launch remains dispositive via boot roll-up; a stable miss contradicts.
-        stables = [item for item in rows if item.cycle_delivered is True and _is_live_session(item)]
-        if not stables:
+        # Positive injection is evaluated on every delivered launch (any verdict). Misses are
+        # only dispositive on STABLE — freze/wedged race-window misses stay unverified
+        # (Codex P1 on #721). Every delivered launch must fully inject for confirmation.
+        delivered = [item for item in rows if item.cycle_delivered is True]
+        if not delivered:
             return (
                 TREATMENT_UNVERIFIED,
-                "no stable delivered cycles with perturber evidence for overlays_on",
+                "no delivered cycles with perturber evidence for overlays_on",
             )
         incomplete: list[int] = []
         short_live: list[str] = []
-        for item in stables:
+        for item in delivered:
             evidence = _launch_evidence(item)
             if set(evidence) != required:
                 incomplete.append(item.launch)
+                continue
+            if all(evidence[name] == "injected" for name in required):
                 continue
             if any(evidence[name] == "unavailable" for name in required):
                 incomplete.append(item.launch)
                 continue
             miss = sorted(name for name in required if evidence[name] != "injected")
-            if miss:
+            if _is_live_session(item):
                 short_live.append(f"launch {item.launch}: {', '.join(miss)}")
+            else:
+                incomplete.append(item.launch)
         if short_live:
             return (
                 TREATMENT_CONTRADICTED,
@@ -403,7 +406,8 @@ def treatment_receipt(
         if incomplete:
             return (
                 TREATMENT_UNVERIFIED,
-                "partial or unavailable perturber evidence on stable cycles for overlays_on",
+                "partial, early, or unavailable perturber evidence on delivered cycles "
+                "for overlays_on",
             )
         return TREATMENT_CONFIRMED, None
 
@@ -940,7 +944,7 @@ def _parse_report(
                     break
                 if (
                     reported_expect == "on"
-                    and raw.get("verdict") in ("stable", "wedged_init")
+                    and raw.get("verdict") == "stable"
                     and any(value == "not_observed" for value in block.values())
                     and all(value != "unavailable" for value in block.values())
                 ):

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -103,17 +103,19 @@ WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
 #: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
 PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: Only ``stable`` is inherently past the injection race for *absence* evidence: it required the
-#: full stability window. ``froze`` can fire on the first post-go-live death / packet regression
-#: (and ``_Car0NotDrivable`` is mapped to ``FROZE``), so a race-window miss can still be attached
-#: to that verdict (Codex P1 on #721). ``wedged_init`` never reached readiness.
-_LIVE_SESSION_VERDICTS = frozenset({"stable"})
-#: Measured injection race on the rig (~3 s). Plans must not set ``go_live_timeout`` below this
-#: plus a small margin, or ``WEDGED_INIT`` can fire inside the race window.
+#: Verdicts past the injection race for *absence* evidence (Codex P1 on #721):
+#: * ``stable`` — full stability window after go-live.
+#: * ``wedged_init`` — acs.exe stayed alive for the entire ``go_live_timeout`` (≥ floor below),
+#:   so the measured ~3 s race has elapsed even without readiness.
+#: ``froze`` is excluded: it can fire on the first post-go-live death / packet regression
+#: (and ``_Car0NotDrivable`` maps to ``FROZE``) while injection is still racing.
+_LIVE_SESSION_VERDICTS = frozenset({"stable", "wedged_init"})
+#: Measured injection race on the rig (~3 s). Plans must not set timeouts below this plus margin.
 INJECTION_RACE_S = 3.0
-#: Plan floor for ``--go-live-timeout`` so a valid plan cannot end the go-live watch inside the
-#: measured injection race (Codex P2 on #721).
+#: Plan floor for ``--go-live-timeout`` / ``--stability-window`` so post-race absence claims
+#: cannot fire inside the measured injection race (Codex P1/P2 on #721).
 MIN_GO_LIVE_TIMEOUT_S = 5.0
+MIN_STABILITY_WINDOW_S = 5.0
 #: Canonical perturber field set every report row must carry exactly.
 _PERTURBER_KEYS = frozenset(PERTURBER_MODULES)
 #: Exact treatment-receipt policy a v4 plan must pre-register (Codex P2 on #721).
@@ -350,11 +352,7 @@ def treatment_receipt(
             )
         # Confirmation uses STABLE delivered cycles only — the sole post-race absence signal
         # (Codex P1 on #721). Non-stable delivered cycles do not confirm or deny absence.
-        stables = [
-            item
-            for item in rows
-            if item.cycle_delivered is True and _is_live_session(item)
-        ]
+        stables = [item for item in rows if item.cycle_delivered is True and _is_live_session(item)]
         if not stables:
             return (
                 TREATMENT_UNVERIFIED,
@@ -377,11 +375,7 @@ def treatment_receipt(
     if condition == "overlays_on":
         # Confirmation / contradiction of absence uses STABLE delivered cycles only. Injected
         # presence on any launch remains dispositive via boot roll-up; a stable miss contradicts.
-        stables = [
-            item
-            for item in rows
-            if item.cycle_delivered is True and _is_live_session(item)
-        ]
+        stables = [item for item in rows if item.cycle_delivered is True and _is_live_session(item)]
         if not stables:
             return (
                 TREATMENT_UNVERIFIED,
@@ -557,6 +551,12 @@ def build_plan(
             ) from exc
     if not math.isfinite(stability_window) or stability_window <= 0:
         raise ValueError("stability_window must be finite and > 0")
+    if stability_window < MIN_STABILITY_WINDOW_S:
+        raise ValueError(
+            f"stability_window must be >= {MIN_STABILITY_WINDOW_S:g}s so a STABLE "
+            f"verdict cannot fire inside the measured ~{INJECTION_RACE_S:g}s injection race "
+            f"(got {stability_window:g})"
+        )
     if not math.isfinite(go_live_timeout) or go_live_timeout <= 0:
         raise ValueError("go_live_timeout must be finite and > 0")
     if go_live_timeout < MIN_GO_LIVE_TIMEOUT_S:
@@ -807,6 +807,12 @@ def load_plan(path: Path) -> dict[str, Any]:
             raise ValueError(
                 f"plan launch.go_live_timeout={go_live!r} is below the "
                 f"{MIN_GO_LIVE_TIMEOUT_S:g}s injection-race floor; regenerate the plan"
+            )
+        stability = launch.get("stability_window")
+        if isinstance(stability, (int, float)) and stability < MIN_STABILITY_WINDOW_S:
+            raise ValueError(
+                f"plan launch.stability_window={stability!r} is below the "
+                f"{MIN_STABILITY_WINDOW_S:g}s injection-race floor; regenerate the plan"
             )
     boots_per_arm = plan.get("boots_per_arm")
     if not isinstance(boots_per_arm, int) or boots_per_arm <= 0:

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -89,12 +89,6 @@ from tools.ac_harness.resilient_launch import (
     resolve_report_path,
 )
 
-#: Fraction of the go-live budget a delivered ``never_live`` must have consumed before its
-#: ``not_observed`` evidence is treated as post-injection-race (Codex P1 on #721). Early
-#: deaths with ``cycle_delivered=True`` finish in seconds; a full-timeout watch is near
-#: ``DEFAULT_GO_LIVE_TIMEOUT``.
-_NEVER_LIVE_TIMEOUT_FRACTION = 0.9
-
 #: v4 pre-registers treatment-receipt verification (#719): analyzer excludes contradicted boots,
 #: plan commands emit ``--expect-perturbers``, and every attempt must carry the full
 #: ``PERTURBER_MODULES`` key set. The plan file IS the pre-registration, so a v3 plan that never
@@ -283,23 +277,14 @@ def _launch_evidence(launch: LaunchObservation) -> dict[str, str]:
 def _is_live_session(launch: LaunchObservation) -> bool:
     """Whether this attempt lived long enough that a miss is informative for overlays_on.
 
-    The injection race is ~3 s on the measured rig. ``stable`` / ``froze`` / ``wedged_init`` only
-    fire after the stability / go-live watch, so their successful looks are past the race.
-
-    A delivered ``never_live`` is *not* automatically long enough: ``classify()`` also emits it
-    immediately when a newly observed ``acs.exe`` exits during startup (still
-    ``cycle_delivered=True``). Only a watch that consumed nearly the full go-live budget is the
-    timeout-stuck-before-readiness shape; early deaths stay non-dispositive for absence (Codex P1
-    on #721).
+    The injection race is ~3 s on the measured rig. Only ``stable`` / ``froze`` / ``wedged_init``
+    with a delivered cycle are treated as past that window: they require the stability /
+    go-live watch. ``never_live`` is never dispositive for *absence* — ``elapsed_s`` includes
+    pre-launch cleanup / CM startup, so it cannot prove the process lived past the race (Codex
+    P1 on #721). Presence (``injected``) remains dispositive on any attempt via the off-arm path.
     """
 
-    if launch.cycle_delivered is not True:
-        return False
-    if launch.verdict in _LIVE_SESSION_VERDICTS:
-        return True
-    if launch.verdict == "never_live":
-        return launch.elapsed_s >= DEFAULT_GO_LIVE_TIMEOUT * _NEVER_LIVE_TIMEOUT_FRACTION
-    return False
+    return launch.cycle_delivered is True and launch.verdict in _LIVE_SESSION_VERDICTS
 
 
 def treatment_receipt(
@@ -352,6 +337,13 @@ def treatment_receipt(
             return (
                 TREATMENT_CONTRADICTED,
                 f"planned overlays_off but {', '.join(injected)} was injected into acs.exe",
+            )
+        # Absence is only confirmable from live-session looks (same race as the on arm).
+        live = [item for item in (launches or ()) if _is_live_session(item)]
+        if not live:
+            return (
+                TREATMENT_UNVERIFIED,
+                "no long-lived acs.exe look past the injection race for overlays_off",
             )
         if all(value == "not_observed" for value in state.values()):
             return TREATMENT_CONFIRMED, None
@@ -1617,6 +1609,10 @@ def analyze(
     )
     missing_blocks = max(0, (expected_blocks or 0) - len(blocks))
     exclusions_present = sum(excluded.values()) > 0 or incomplete_blocks > 0 or missing_blocks > 0
+    # Unverified receipt is not a post-treatment exclusion (no information must not invent
+    # missingness), but it must still withhold causal claims — otherwise a run whose module
+    # snapshots all failed recreates the honor-system arm label (Codex P1 on #721).
+    unverified_present = any(boot.treatment == TREATMENT_UNVERIFIED for boot in boots)
     if (
         usable_blocks < endpoint_floor
         # Blocks that learned nothing cannot fill the floor. This subsumes the old
@@ -1635,6 +1631,8 @@ def analyze(
     elif exclusions_present:
         # Report the p-value, but do not let it carry a causal claim it cannot support.
         conclusion = "post_treatment_exclusions_present"
+    elif unverified_present:
+        conclusion = "treatment_receipt_unverified"
     elif onset_p >= alpha:
         conclusion = "no_measurable_effect"
     elif blocked_effect == 0:

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -103,20 +103,17 @@ WITHDRAWN_PLAN_SCHEMA = "init-perturber-ab-plan/v1"
 SUPERSEDED_PLAN_SCHEMA = "init-perturber-ab-plan/v2"
 #: delivered-cycle endpoints without treatment-receipt pre-registration (#719); regenerate.
 PRE_TREATMENT_PLAN_SCHEMA = "init-perturber-ab-plan/v3"
-#: Verdicts that *may* carry post-race absence evidence. ``wedged_init`` is excluded: it means
-#: the process never reached readiness, so a short ``go_live_timeout`` can end before the
-#: measured ~3 s injection race (Codex P1/P2 on #721). ``stable`` is always past the race
-#: (stability window >> 3 s). ``froze`` additionally requires :data:`MIN_ABSENCE_ELAPSED_S`.
+#: Verdicts whose *absence* evidence is post-injection-race. ``classify`` only returns
+#: ``stable``/``froze`` after go-live (packet advanced + entry ready + drivable), which on this
+#: rig is far past the ~3 s injection race. ``wedged_init`` never reached readiness — excluded.
+#: ``elapsed_s`` is intentionally not used: it includes pre-launch work and is not process life
+#: (Codex P1 on #721).
 _LIVE_SESSION_VERDICTS = frozenset({"stable", "froze"})
 #: Measured injection race on the rig (~3 s). Plans must not set ``go_live_timeout`` below this
 #: plus a small margin, or ``WEDGED_INIT`` can fire inside the race window.
 INJECTION_RACE_S = 3.0
-#: Minimum ``elapsed_s`` before a non-stable live verdict's ``not_observed`` is treated as
-#: dispositive absence. ``elapsed_s`` includes pre-launch work, so this is a floor, not a
-#: precise post-spawn clock (Codex P1 on #721).
-MIN_ABSENCE_ELAPSED_S = 5.0
-#: Plan floor for ``--go-live-timeout`` so a valid plan cannot trust live-session absence
-#: evidence that is shorter than the injection race (Codex P2 on #721).
+#: Plan floor for ``--go-live-timeout`` so a valid plan cannot end the go-live watch inside the
+#: measured injection race (Codex P2 on #721).
 MIN_GO_LIVE_TIMEOUT_S = 5.0
 #: Canonical perturber field set every report row must carry exactly.
 _PERTURBER_KEYS = frozenset(PERTURBER_MODULES)
@@ -290,21 +287,15 @@ def _launch_evidence(launch: LaunchObservation) -> dict[str, str]:
 def _is_live_session(launch: LaunchObservation) -> bool:
     """Whether this attempt's absence evidence is informative (post injection race).
 
-    The injection race is ~3 s on the measured rig. ``never_live`` / ``wedged_init`` are never
-    dispositive for *absence* — the process may have died inside the race, and ``elapsed_s``
-    includes pre-launch work so it cannot prove post-race lifetime on those shapes (Codex P1
-    on #721). Presence (``injected``) remains dispositive on any attempt via the off-arm path.
-
-    * ``stable`` — always past the race (stability window >> 3 s).
-    * ``froze`` — only when ``elapsed_s >= MIN_ABSENCE_ELAPSED_S``, so an immediate post-go-live
-      freeze cannot turn a pre-injection miss into a contradicted / confirmed arm.
+    The injection race is ~3 s on the measured rig. Delivered ``stable`` / ``froze`` are the
+    only post-go-live verdicts: ``classify`` requires packet advance + entry ready + drivable
+    before either, which is past the race by construction. ``elapsed_s`` is **not** consulted —
+    it includes pre-launch work and cannot prove process lifetime (Codex P1 on #721).
+    ``wedged_init`` / ``never_live`` never reached readiness, so their misses are non-dispositive.
+    Presence (``injected``) remains dispositive on any attempt via the off-arm path.
     """
 
-    if launch.cycle_delivered is not True or launch.verdict not in _LIVE_SESSION_VERDICTS:
-        return False
-    if launch.verdict == "stable":
-        return True
-    return launch.elapsed_s >= MIN_ABSENCE_ELAPSED_S
+    return launch.cycle_delivered is True and launch.verdict in _LIVE_SESSION_VERDICTS
 
 
 def treatment_receipt(
@@ -797,6 +788,18 @@ def load_plan(path: Path) -> dict[str, Any]:
     # Full policy match — a hand-edited v4 that changes exclude_on / perturbers / flags would
     # otherwise be analyzed under today's hard-coded rules while claiming a different prereg
     # (Codex P2 on #721).
+    if set(receipt) != set(CANONICAL_TREATMENT_RECEIPT):
+        extra = sorted(set(receipt) - set(CANONICAL_TREATMENT_RECEIPT))
+        missing = sorted(set(CANONICAL_TREATMENT_RECEIPT) - set(receipt))
+        detail = []
+        if extra:
+            detail.append(f"unknown {extra}")
+        if missing:
+            detail.append(f"missing {missing}")
+        raise ValueError(
+            "plan treatment_receipt key set must exactly match the canonical v4 policy "
+            f"({'; '.join(detail)}); regenerate the plan"
+        )
     for key, expected in CANONICAL_TREATMENT_RECEIPT.items():
         if receipt.get(key) != expected:
             raise ValueError(

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -266,12 +266,16 @@ def _launch_evidence(launch: LaunchObservation) -> dict[str, str]:
 def _is_live_session(launch: LaunchObservation) -> bool:
     """Whether this attempt lived long enough that a miss is informative for overlays_on.
 
-    The injection race is ~3 s on the measured rig; live-session verdicts only fire after the
-    stability / go-live watch, which is far past that window. Early ``never_live`` exits can
-    sample only inside the race and must not contradict an ``overlays_on`` arm (Codex P1 on #721).
+    The injection race is ~3 s on the measured rig. ``stable`` / ``froze`` / ``wedged_init`` only
+    fire after the stability / go-live watch. A **delivered** ``never_live`` is also long enough:
+    ``classify()`` emits it after the full go-live timeout when AC rendered but never reached
+    readiness — far past the race — so those successful looks must still count (Codex P1 on
+    #721). An *undelivered* ``never_live`` (CM absent / launch never spawned) does not.
     """
 
-    return launch.verdict in _LIVE_SESSION_VERDICTS and launch.cycle_delivered is True
+    if launch.cycle_delivered is not True:
+        return False
+    return launch.verdict in _LIVE_SESSION_VERDICTS or launch.verdict == "never_live"
 
 
 def treatment_receipt(
@@ -352,7 +356,10 @@ def treatment_receipt(
             miss = sorted(name for name in required if evidence[name] != "injected")
             if miss:
                 short.append(f"launch {item.launch}: {', '.join(miss)}")
-        if short and not incomplete:
+        # A dispositive miss on any fully observed live launch cannot be erased by a sibling
+        # launch whose snapshot failed (``unavailable``). Prefer contradicted over unverified
+        # whenever short is non-empty (Codex P1 on #721).
+        if short:
             return (
                 TREATMENT_CONTRADICTED,
                 "planned overlays_on but live session(s) never observed full injection "

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -867,6 +867,27 @@ class PerturberWatch:
         return out
 
 
+def _normalize_perturber_evidence(raw: dict[str, str] | None) -> dict[str, str]:
+    """Fill canonical keys and reject unknown fields before emitting a v3 report (#721)."""
+
+    if raw is None:
+        return _unavailable_perturbers()
+    unknown = set(raw) - set(PERTURBER_MODULES)
+    if unknown:
+        raise ValueError(f"unknown perturber field(s): {sorted(unknown)}")
+    allowed = {
+        str(PerturberEvidence.INJECTED),
+        str(PerturberEvidence.NOT_OBSERVED),
+        str(PerturberEvidence.UNAVAILABLE),
+    }
+    out = _unavailable_perturbers()
+    for name, value in raw.items():
+        if value not in allowed:
+            raise ValueError(f"invalid perturber evidence {name!r}={value!r}")
+        out[name] = value
+    return out
+
+
 def contradicts_expectation(evidence: dict[str, str], expectation: str | None) -> bool:
     """Whether this attempt's evidence DISPOSITIVELY refutes the arm it was launched under.
 
@@ -1006,7 +1027,9 @@ def run_retry_loop(
         verdict = outcome.verdict
         if verdict is LaunchVerdict.PENDING:
             raise ValueError("watch_attempt returned a non-terminal PENDING verdict")
-        evidence = dict(outcome.perturbers) if outcome.perturbers else _unavailable_perturbers()
+        evidence = _normalize_perturber_evidence(
+            dict(outcome.perturbers) if outcome.perturbers else None
+        )
         records.append(
             AttemptRecord(
                 attempt=attempt,
@@ -2181,7 +2204,9 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 any_failed = False
                 for pid in pids:
                     try:
-                        successes.append(process_module_names(pid))
+                        # retries=1: do not sleep inside the go-live poll path; BAD_LENGTH during
+                        # module load is retried by the next poll tick instead (cursor HIGH #721).
+                        successes.append(process_module_names(pid, retries=1))
                     except OSError:
                         any_failed = True
                 if not successes:
@@ -2378,6 +2403,14 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 )
                 return 1
             return 0
+        if report.arm_contradicted:
+            # Same fail-closed exit outside --trials (Codex P2 on #721).
+            _make_rig_safe(acs_present, release_requested=release_requested)
+            _log(
+                "FAILED: arm contradicted by injected perturber evidence "
+                f"(expect={report.expect_perturbers!r}) — fix settings and re-run"
+            )
+            return 1
         _log(report.summary())
         if not report.succeeded:
             # A FROZE terminal verdict deliberately leaves acs.exe alive so the watcher can

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -838,6 +838,13 @@ class PerturberWatch:
         # followed by failed later looks must not stick as not_observed (Codex P1 on #721).
         self._last_full_look_ok = False
 
+    def reset(self) -> None:
+        """Clear all evidence. Used when the pinned acs.exe PID is replaced mid-attempt."""
+
+        self._injected.clear()
+        self._successful_looks = 0
+        self._last_full_look_ok = False
+
     def observe(self, module_names: frozenset[str] | None) -> None:
         """Record one snapshot. ``None`` means the snapshot FAILED — not "no modules".
 
@@ -967,12 +974,13 @@ def contradicts_expectation(
 
     if expectation == "off":
         return any(value == str(PerturberEvidence.INJECTED) for value in evidence.values())
-    if expectation == "on" and verdict is LaunchVerdict.STABLE:
+    # Match analyzer _is_live_session: STABLE and FROZE are both post-go-live (Codex P1 on #721).
+    if expectation == "on" and verdict in (LaunchVerdict.STABLE, LaunchVerdict.FROZE):
         if not evidence:
             return False
         if any(value == str(PerturberEvidence.UNAVAILABLE) for value in evidence.values()):
             return False
-        # Full successful look on a stable session that still misses a required perturber.
+        # Full successful look on a post-go-live session that still misses a required perturber.
         return any(value == str(PerturberEvidence.NOT_OBSERVED) for value in evidence.values())
     return False
 
@@ -2297,8 +2305,11 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     primary_pid = pinned_acs_pid[0]
                 else:
                     if pinned_acs_pid[0] is not None:
-                        # Process replacement: prior not_observed must not stick to the new PID.
-                        fold_perturber_snapshots(perturbers, enum_failed=True)
+                        # Process replacement: drop ALL prior evidence so Steam from the corpse
+                        # cannot combine with NVIDIA from the replacement into a false full
+                        # injection (Codex P1 on #721). Off-arm positive sightings already
+                        # stop the loop on the poll that first saw them.
+                        perturbers.reset()
                     primary_pid = max(pids)
                     pinned_acs_pid[0] = primary_pid
                 try:

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2357,7 +2357,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                             if perturbers.injected(name):
                                 latched_injected.add(name)
                         perturbers.reset()
-                    primary_pid = max(pids)
+                    # Prefer a PID that is not the previous pin when concurrent PIDs exist —
+                    # Windows PIDs are not creation-ordered (Codex P2 on #721).
+                    if pinned_acs_pid[0] is not None and extra_pids:
+                        candidates = [pid for pid in pids if pid != pinned_acs_pid[0]]
+                        primary_pid = max(candidates) if candidates else max(pids)
+                    else:
+                        primary_pid = max(pids)
                     pinned_acs_pid[0] = primary_pid
                 try:
                     # retries=1: do not sleep inside the go-live poll path; BAD_LENGTH during

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2171,6 +2171,20 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             _log(f"launch aborted: Content Manager executable not found: {actuator.cm_exe}")
             return 1
 
+        if args.expect_perturbers is not None and sys.platform == "win32":
+            # 32-bit Python cannot enumerate 64-bit acs.exe modules (ERROR_PARTIAL_COPY). Without
+            # this preflight every poll becomes unavailable and a 16-reboot run ends as
+            # treatment_receipt_unverified (Codex P1 on #721).
+            import struct
+
+            bits = struct.calcsize("P") * 8
+            if bits < 64:
+                _log(
+                    f"launch aborted: --expect-perturbers requires 64-bit Python to inspect "
+                    f"64-bit acs.exe (this interpreter is {bits}-bit)"
+                )
+                return 1
+
         # The previous attempt's verdict gates the #668 graceful-teardown grace: only a session
         # that PROVED it could pump messages (STABLE) is asked to honor WM_CLOSE. One-element
         # list so the closure can rebind it.
@@ -2236,6 +2250,10 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 )
             )
             perturbers = PerturberWatch()
+            # Pin the process identity for this attempt so successive polls cannot union
+            # complementary modules from different acs.exe instances into one "full" receipt
+            # (qodo / Codex P2 on #721).
+            pinned_acs_pid: list[int | None] = [None]
 
             def sample_perturbers() -> None:
                 """Fold one module snapshot of the live acs.exe into this attempt's evidence.
@@ -2271,11 +2289,18 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     # final sample classify commonly hits after FROZE (cursor MEDIUM on #721).
                     fold_perturber_snapshots(perturbers, pids_empty=True)
                     return
-                # Classify the newest acs.exe only. Unioning modules across PIDs invents a full
-                # treatment when Steam is on one process and NVIDIA on another (Codex P2 on #721).
-                # max(pid) is the usual live session after a leftover corpse; a failed primary
-                # look is unavailable, never a synthetic multi-PID miss (Codex P1 on #721).
-                primary_pid = max(pids)
+                # Classify one process identity per attempt. Re-picking max(pid) every poll can
+                # union Steam from a corpse with NVIDIA from a replacement live process and
+                # invent full treatment (qodo on #721). Prefer the pinned PID when still alive;
+                # otherwise pin the newest and invalidate prior absence (new process).
+                if pinned_acs_pid[0] in pids:
+                    primary_pid = pinned_acs_pid[0]
+                else:
+                    if pinned_acs_pid[0] is not None:
+                        # Process replacement: prior not_observed must not stick to the new PID.
+                        fold_perturber_snapshots(perturbers, enum_failed=True)
+                    primary_pid = max(pids)
+                    pinned_acs_pid[0] = primary_pid
                 try:
                     # retries=1: do not sleep inside the go-live poll path; BAD_LENGTH during
                     # module load is retried by the next poll tick instead (cursor HIGH #721).

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2059,11 +2059,12 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         default=None,
         help=(
             "#625/#719 arm declaration: the init-perturber state this boot is SUPPOSED to be in. "
-            "Every attempt records which perturbers were actually injected into acs.exe, and with "
-            "'off' a positive sighting ends the trial loop immediately (arm_contradicted) so a "
-            "mislabelled boot costs ~1 launch cycle instead of the whole run. 'on' cannot be "
-            "refuted from one attempt — the injection races startup — so it is left to the "
-            "analyzer, which aggregates the boot"
+            "Every attempt records which perturbers were actually injected into acs.exe. "
+            "'off' + any injected sighting ends the trial loop immediately (arm_contradicted). "
+            "'on' + STABLE with a successful full miss also ends the loop immediately "
+            "(dispositive non-receipt past the stability window); other on-arm cases stay with "
+            "whole-boot analysis. Contradicted runs write a timestamped salvage JSON and exit "
+            "nonzero so the reboot chain stops."
         ),
     )
     parser.add_argument(
@@ -2272,6 +2273,9 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             # complementary modules from different acs.exe instances into one "full" receipt
             # (qodo / Codex P2 on #721).
             pinned_acs_pid: list[int | None] = [None]
+            # Injected names latched from a replaced PID for off-arm contradiction only — never
+            # mixed into on-arm full-injection confirmation for the replacement (Codex P1).
+            latched_injected: set[str] = set()
 
             def sample_perturbers(*, soft_fail: bool = False) -> None:
                 """Fold one module snapshot of the live acs.exe into this attempt's evidence.
@@ -2318,16 +2322,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     primary_pid = pinned_acs_pid[0]
                 else:
                     if pinned_acs_pid[0] is not None:
-                        # Process replacement mid-attempt. Two constraints (Codex P1 rounds):
-                        # (1) do not invent full treatment by unioning Steam on corpse A with
-                        #     NVIDIA on replacement B;
-                        # (2) do not erase a positive injection already seen (off-arm needs it).
-                        # If any injection was observed, freeze presence and invalidate absence
-                        # so a partial old-PID miss cannot contradict on-arm. Otherwise start
-                        # clean on the newest process.
-                        if any(perturbers.injected(name) for name in PERTURBER_MODULES):
-                            perturbers.freeze_presence_only()
-                            return
+                        # Process replacement mid-attempt (Codex P1 rounds):
+                        # - Latch any injected sightings for off-arm contradiction.
+                        # - Reset the watch so the replacement cannot inherit full on-arm
+                        #   confirmation from the corpse; re-pin and sample the new process.
+                        for name in PERTURBER_MODULES:
+                            if perturbers.injected(name):
+                                latched_injected.add(name)
                         perturbers.reset()
                     primary_pid = max(pids)
                     pinned_acs_pid[0] = primary_pid
@@ -2383,7 +2384,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             # the watch (Codex P2 on #721).
             if args.expect_perturbers is not None:
                 sample_perturbers(soft_fail=True)
-            outcome = replace(outcome, perturbers=perturbers.evidence())
+            evidence = dict(perturbers.evidence())
+            # Off-arm latch: restore dispositive injection from a replaced PID without letting
+            # those sightings count as the replacement session's full on-arm confirmation
+            # (missing keys stay unavailable after reset).
+            for name in latched_injected:
+                evidence[name] = str(PerturberEvidence.INJECTED)
+            outcome = replace(outcome, perturbers=evidence)
             delivery = _delivery_label(outcome.cycle_delivered)
             injected = sorted(
                 name

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -803,6 +803,21 @@ def _utc_stamp(epoch_seconds: float) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch_seconds))
 
 
+def _arm_contradicted_salvage_path(path: Path, when: float | None = None) -> Path:
+    """Side path for a contradicted boot so the planned exclusive name stays free.
+
+    Must be unique across retries: ``_write_report_json`` refuses overwrite, and a second
+    contradicted re-run (settings still wrong) would otherwise fail as a generic report-write
+    error and drop the new receipt (cursor MEDIUM on #721). Filename uses a Windows-safe UTC
+    stamp with microseconds so same-second retries still diverge.
+    """
+
+    epoch = time.time() if when is None else when
+    stamp = time.strftime("%Y%m%dT%H%M%S", time.gmtime(epoch))
+    micros = int((epoch % 1.0) * 1_000_000)
+    return path.with_name(f"{path.stem}.arm_contradicted.{stamp}{micros:06d}Z{path.suffix}")
+
+
 class PerturberWatch:
     """Fold repeated module snapshots of one ``acs.exe`` into per-perturber evidence (#719).
 
@@ -870,6 +885,42 @@ class PerturberWatch:
             else:
                 out[name] = str(PerturberEvidence.UNAVAILABLE)
         return out
+
+
+def fold_perturber_snapshots(
+    watch: PerturberWatch,
+    *,
+    enum_failed: bool = False,
+    pids_empty: bool = False,
+    successes: list[frozenset[str]] | None = None,
+    any_pid_failed: bool = False,
+) -> None:
+    """Apply one multi-PID sample poll to ``watch`` (pure; unit-tested off-rig).
+
+    Encoding rules (#721 reviews):
+    - ``enum_failed``: Toolhelp enumeration raised — treat as failed look.
+    - ``pids_empty``: acs.exe is gone — leave prior evidence intact (not a failed live look).
+    - all PID snapshots failed: failed look.
+    - partial success: union presence, then invalidate absence.
+    - full success: observe every snapshot (presence unions; absence counts only if complete).
+    """
+
+    if enum_failed:
+        watch.observe(None)
+        return
+    if pids_empty:
+        return
+    snaps = list(successes or ())
+    if not snaps:
+        watch.observe(None)
+        return
+    if any_pid_failed:
+        for names in snaps:
+            watch.note_injected(names)
+        watch.observe(None)
+        return
+    for names in snaps:
+        watch.observe(names)
 
 
 def _normalize_perturber_evidence(raw: dict[str, str] | None) -> dict[str, str]:
@@ -2194,10 +2245,14 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     # on the visible PID alone (Codex P2 on #721).
                     pids = sorted(running_process_ids("acs.exe", strict=True))
                 except OSError:
-                    perturbers.observe(None)
+                    fold_perturber_snapshots(perturbers, enum_failed=True)
                     return
                 if not pids:
-                    perturbers.observe(None)
+                    # Empty PID list means acs.exe is gone, not that a live process failed to
+                    # open. fold_perturber_snapshots leaves prior evidence intact so a successful
+                    # post-race miss (overlays_off confirmation) survives the dying-process /
+                    # final sample classify commonly hits after FROZE (cursor MEDIUM on #721).
+                    fold_perturber_snapshots(perturbers, pids_empty=True)
                     return
                 # Union presence across EVERY returned PID. Taking only the lowest PID (the old
                 # behaviour) can sample a leftover corpse without overlays while the live session
@@ -2214,17 +2269,11 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                         successes.append(process_module_names(pid, retries=1))
                     except OSError:
                         any_failed = True
-                if not successes:
-                    perturbers.observe(None)
-                elif any_failed:
-                    for names in successes:
-                        perturbers.note_injected(names)
-                    # Invalidate absence: a prior full miss must not stick when this poll only
-                    # partially sampled PIDs (cursor HIGH / Codex P1 on #721).
-                    perturbers.observe(None)
-                else:
-                    for names in successes:
-                        perturbers.observe(names)
+                fold_perturber_snapshots(
+                    perturbers,
+                    successes=successes,
+                    any_pid_failed=any_failed,
+                )
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None, int | None]:
                 """Report shared memory; trust readiness only once the packet proves a live owner.
@@ -2344,10 +2393,16 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             # Analyze will treat the planned name as missing until the re-run succeeds; the
             # salvage file keeps the positive injection evidence for the operator.
             if report.arm_contradicted:
-                salvage = args.json_path.with_name(
-                    f"{args.json_path.stem}.arm_contradicted{args.json_path.suffix}"
-                )
+                # Unique name: exclusive publish refuses overwrite, so a second contradicted
+                # re-run must not collide with a prior salvage (cursor MEDIUM on #721).
+                salvage = _arm_contradicted_salvage_path(args.json_path)
                 report_written = _write_report_json(report, salvage)
+                if not report_written:
+                    # Same-second collision is rare; one microsecond-nudged retry is enough.
+                    salvage = _arm_contradicted_salvage_path(
+                        args.json_path, when=time.time() + 0.001
+                    )
+                    report_written = _write_report_json(report, salvage)
                 if report_written:
                     _log(
                         f"arm contradicted — salvage report at {salvage}; planned path "

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2336,34 +2336,19 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     fold_perturber_snapshots(perturbers, pids_empty=True)
                     return
                 acs_pid_observed[0] = True
-                # Classify one process identity per attempt. Re-picking max(pid) every poll can
-                # union Steam from a corpse with NVIDIA from a replacement live process and
-                # invent full treatment (qodo on #721). Prefer the pinned PID when still alone;
-                # if another PID appears alongside it, treat as replacement (Codex P2 on #721).
-                extra_pids = (
-                    pinned_acs_pid[0] is not None
-                    and pinned_acs_pid[0] in pids
-                    and any(pid != pinned_acs_pid[0] for pid in pids)
-                )
-                if pinned_acs_pid[0] in pids and not extra_pids:
+                # One process identity per attempt: once pinned, keep sampling that PID until it
+                # disappears — even if other acs.exe PIDs appear alongside it. Re-picking among
+                # concurrent PIDs oscillates and resets evidence every poll (Codex P1 on #721).
+                if pinned_acs_pid[0] is not None and pinned_acs_pid[0] in pids:
                     primary_pid = pinned_acs_pid[0]
                 else:
                     if pinned_acs_pid[0] is not None:
-                        # Process replacement mid-attempt (Codex P1 rounds):
-                        # - Latch any injected sightings for off-arm contradiction.
-                        # - Reset the watch so the replacement cannot inherit full on-arm
-                        #   confirmation from the corpse; re-pin and sample the new process.
+                        # Pinned process is gone — latch off-arm injection, reset, re-pin.
                         for name in PERTURBER_MODULES:
                             if perturbers.injected(name):
                                 latched_injected.add(name)
                         perturbers.reset()
-                    # Prefer a PID that is not the previous pin when concurrent PIDs exist —
-                    # Windows PIDs are not creation-ordered (Codex P2 on #721).
-                    if pinned_acs_pid[0] is not None and extra_pids:
-                        candidates = [pid for pid in pids if pid != pinned_acs_pid[0]]
-                        primary_pid = max(candidates) if candidates else max(pids)
-                    else:
-                        primary_pid = max(pids)
+                    primary_pid = max(pids)
                     pinned_acs_pid[0] = primary_pid
                 try:
                     # retries=1: do not sleep inside the go-live poll path; BAD_LENGTH during

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2189,6 +2189,26 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             _log(f"launch aborted: Content Manager executable not found: {actuator.cm_exe}")
             return 1
 
+        if args.expect_perturbers is not None:
+            # Match plan floors so a direct --expect-perturbers invocation cannot STABLE-miss
+            # fail-fast inside the injection race (Codex P2 on #721).
+            from tools.ac_harness.init_perturber_ab import (
+                MIN_GO_LIVE_TIMEOUT_S,
+                MIN_STABILITY_WINDOW_S,
+            )
+
+            if args.stability_window < MIN_STABILITY_WINDOW_S:
+                _log(
+                    f"launch aborted: --expect-perturbers requires --stability-window >= "
+                    f"{MIN_STABILITY_WINDOW_S:g}s (got {args.stability_window:g})"
+                )
+                return 1
+            if args.go_live_timeout < MIN_GO_LIVE_TIMEOUT_S:
+                _log(
+                    f"launch aborted: --expect-perturbers requires --go-live-timeout >= "
+                    f"{MIN_GO_LIVE_TIMEOUT_S:g}s (got {args.go_live_timeout:g})"
+                )
+                return 1
         if args.expect_perturbers is not None and sys.platform == "win32":
             # 32-bit Python cannot enumerate 64-bit acs.exe modules (ERROR_PARTIAL_COPY). Without
             # this preflight every poll becomes unavailable and a 16-reboot run ends as

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -845,6 +845,16 @@ class PerturberWatch:
         self._successful_looks = 0
         self._last_full_look_ok = False
 
+    def freeze_presence_only(self) -> None:
+        """Keep dispositive injection; invalidate absence after a process identity change.
+
+        Off-arm needs the positive sighting. On-arm must not treat leftover ``not_observed``
+        from a vanished PID as a live-session miss on the replacement (Codex P1 on #721).
+        """
+
+        self._successful_looks = 0
+        self._last_full_look_ok = False
+
     def observe(self, module_names: frozenset[str] | None) -> None:
         """Record one snapshot. ``None`` means the snapshot FAILED — not "no modules".
 
@@ -2263,7 +2273,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             # (qodo / Codex P2 on #721).
             pinned_acs_pid: list[int | None] = [None]
 
-            def sample_perturbers() -> None:
+            def sample_perturbers(*, soft_fail: bool = False) -> None:
                 """Fold one module snapshot of the live acs.exe into this attempt's evidence.
 
                 Runs on the existing poll cadence rather than once, because the injection races
@@ -2274,7 +2284,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 Never raises. A failed snapshot is recorded as "we could not look" by the simple
                 fact that ``observe(None)`` does not count as a successful look — it must NOT be
                 allowed to read as "perturber absent", and it must never fail an attempt: this is
-                measurement riding along on a launch, not a gate.
+                measurement riding along on a launch, not a gate. ``soft_fail`` leaves prior
+                evidence untouched on Toolhelp/PID errors (used for the optional final look).
                 """
 
                 from tools.ac_harness.entry_launcher import (
@@ -2288,6 +2299,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     # on the visible PID alone (Codex P2 on #721).
                     pids = sorted(running_process_ids("acs.exe", strict=True))
                 except OSError:
+                    if soft_fail:
+                        return
                     fold_perturber_snapshots(perturbers, enum_failed=True)
                     return
                 if not pids:
@@ -2309,10 +2322,11 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                         # (1) do not invent full treatment by unioning Steam on corpse A with
                         #     NVIDIA on replacement B;
                         # (2) do not erase a positive injection already seen (off-arm needs it).
-                        # If any injection was observed, freeze this attempt's evidence and stop
-                        # sampling — further PIDs would only pollute confirmation. Otherwise
-                        # start clean on the newest process.
+                        # If any injection was observed, freeze presence and invalidate absence
+                        # so a partial old-PID miss cannot contradict on-arm. Otherwise start
+                        # clean on the newest process.
                         if any(perturbers.injected(name) for name in PERTURBER_MODULES):
+                            perturbers.freeze_presence_only()
                             return
                         perturbers.reset()
                     primary_pid = max(pids)
@@ -2322,6 +2336,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     # module load is retried by the next poll tick instead (cursor HIGH #721).
                     names = process_module_names(primary_pid, retries=1)
                 except OSError:
+                    if soft_fail:
+                        return
                     fold_perturber_snapshots(perturbers, enum_failed=True)
                     return
                 fold_perturber_snapshots(perturbers, successes=[names])
@@ -2341,7 +2357,9 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 if release_requested():
                     raise _OperatorRelease
 
-                sample_perturbers()
+                # Only the #625 experiment path needs Toolhelp every poll (Codex P2 on #721).
+                if args.expect_perturbers is not None:
+                    sample_perturbers()
                 packet, entry_ready, phys_packet = read_state()
                 ready, drivable = readiness.observe(packet=packet, entry_ready=entry_ready)
                 return packet, ready, drivable, phys_packet
@@ -2360,8 +2378,11 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 # The session was rendering, so the launch cycle WAS delivered (#710).
                 outcome = AttemptOutcome(LaunchVerdict.FROZE, cycle_delivered=True)
             # One last look before the process is torn down: the perturbers inject late, so the
-            # final sample is the most informative one in the attempt (#719).
-            sample_perturbers()
+            # final sample is the most informative one in the attempt (#719). soft_fail: a
+            # transient Toolhelp error must not erase a successful post-race miss already on
+            # the watch (Codex P2 on #721).
+            if args.expect_perturbers is not None:
+                sample_perturbers(soft_fail=True)
             outcome = replace(outcome, perturbers=perturbers.evidence())
             delivery = _delivery_label(outcome.cycle_delivered)
             injected = sorted(

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -819,6 +819,9 @@ class PerturberWatch:
         self._modules = dict(modules if modules is not None else PERTURBER_MODULES)
         self._injected: set[str] = set()
         self._successful_looks = 0
+        # Absence is only claimable when the most recent full snapshot succeeded. An early miss
+        # followed by failed later looks must not stick as not_observed (Codex P1 on #721).
+        self._last_full_look_ok = False
 
     def observe(self, module_names: frozenset[str] | None) -> None:
         """Record one snapshot. ``None`` means the snapshot FAILED — not "no modules".
@@ -828,8 +831,10 @@ class PerturberWatch:
         """
 
         if module_names is None:
+            self._last_full_look_ok = False
             return
         self._successful_looks += 1
+        self._last_full_look_ok = True
         self.note_injected(module_names)
 
     def note_injected(self, module_names: frozenset[str]) -> None:
@@ -860,7 +865,7 @@ class PerturberWatch:
         for name in self._modules:
             if name in self._injected:
                 out[name] = str(PerturberEvidence.INJECTED)
-            elif self._successful_looks > 0:
+            elif self._successful_looks > 0 and self._last_full_look_ok:
                 out[name] = str(PerturberEvidence.NOT_OBSERVED)
             else:
                 out[name] = str(PerturberEvidence.UNAVAILABLE)

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -894,6 +894,7 @@ def fold_perturber_snapshots(
     pids_empty: bool = False,
     successes: list[frozenset[str]] | None = None,
     any_pid_failed: bool = False,
+    primary_only: bool = True,
 ) -> None:
     """Apply one multi-PID sample poll to ``watch`` (pure; unit-tested off-rig).
 
@@ -901,8 +902,9 @@ def fold_perturber_snapshots(
     - ``enum_failed``: Toolhelp enumeration raised — treat as failed look.
     - ``pids_empty``: acs.exe is gone — leave prior evidence intact (not a failed live look).
     - all PID snapshots failed: failed look.
-    - partial success: union presence, then invalidate absence.
-    - full success: observe every snapshot (presence unions; absence counts only if complete).
+    - partial success: union presence via ``note_injected``, then invalidate absence.
+    - full success: observe a **single** primary session (caller passes only that snapshot when
+      ``primary_only``), never invent full treatment by unioning unrelated PIDs (Codex P2 on #721).
     """
 
     if enum_failed:
@@ -919,6 +921,10 @@ def fold_perturber_snapshots(
             watch.note_injected(names)
         watch.observe(None)
         return
+    if primary_only or len(snaps) == 1:
+        watch.observe(snaps[0])
+        return
+    # Legacy multi-observe path kept for tests that deliberately disable primary_only.
     for names in snaps:
         watch.observe(names)
 
@@ -944,18 +950,31 @@ def _normalize_perturber_evidence(raw: dict[str, str] | None) -> dict[str, str]:
     return out
 
 
-def contradicts_expectation(evidence: dict[str, str], expectation: str | None) -> bool:
+def contradicts_expectation(
+    evidence: dict[str, str],
+    expectation: str | None,
+    *,
+    verdict: LaunchVerdict | None = None,
+) -> bool:
     """Whether this attempt's evidence DISPOSITIVELY refutes the arm it was launched under.
 
-    Only the ``off`` arm can be refuted from a single attempt, and only by a positive sighting:
-    expected-off plus ``INJECTED`` is proof the treatment was not applied. Expected-on plus
-    ``NOT_OBSERVED`` is **not** symmetric — the injection race makes a single miss uninformative,
-    so that direction is left to the analyzer, which aggregates the whole boot (#719 Part C).
+    * ``off`` — any ``INJECTED`` sighting is proof the treatment was not applied.
+    * ``on`` — a ``STABLE`` attempt that successfully looked and still missed a perturber is
+      dispositive non-receipt (stability window >> the measured injection race). A bare
+      ``NOT_OBSERVED`` without a stable verdict remains non-dispositive and is left to the
+      analyzer, which aggregates the whole boot (#719 Part C; Codex P1 on #721).
     """
 
-    if expectation != "off":
-        return False
-    return any(value == str(PerturberEvidence.INJECTED) for value in evidence.values())
+    if expectation == "off":
+        return any(value == str(PerturberEvidence.INJECTED) for value in evidence.values())
+    if expectation == "on" and verdict is LaunchVerdict.STABLE:
+        if not evidence:
+            return False
+        if any(value == str(PerturberEvidence.UNAVAILABLE) for value in evidence.values()):
+            return False
+        # Full successful look on a stable session that still misses a required perturber.
+        return any(value == str(PerturberEvidence.NOT_OBSERVED) for value in evidence.values())
+    return False
 
 
 def _watched_delivery(samples: Sequence[Sample]) -> bool | None:
@@ -1132,12 +1151,10 @@ def run_retry_loop(
             else:
                 wedged_init += 1
             never_live_run = 0
-        if contradicts_expectation(evidence, expect_perturbers):
-            # The boot was launched as `overlays_off` and a perturber is demonstrably injected, so
-            # its arm label is a lie and nothing measured after this point can inform the contrast.
-            # Stop now: the accumulator has already advanced (this boot needs another reboot either
-            # way), but stopping at attempt N instead of 24 saves ~28 minutes of rig time per
-            # mistake. Only this direction is dispositive — see `contradicts_expectation` (#719).
+        if contradicts_expectation(evidence, expect_perturbers, verdict=verdict):
+            # Arm label is already a lie under the analyzer's own rules, so further trials only
+            # burn rig time before a post-treatment exclusion / withheld conclusion (Codex P1
+            # on #721). Off-arm: any injected sighting. On-arm: STABLE + successful miss.
             arm_contradicted = True
             break
         if verdict is LaunchVerdict.STABLE and stop_on_stable:
@@ -2254,26 +2271,19 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     # final sample classify commonly hits after FROZE (cursor MEDIUM on #721).
                     fold_perturber_snapshots(perturbers, pids_empty=True)
                     return
-                # Union presence across EVERY returned PID. Taking only the lowest PID (the old
-                # behaviour) can sample a leftover corpse without overlays while the live session
-                # has them, and miss the dispositive `injected` proof for the off-arm (cursor
-                # MEDIUM on #721). If any PID snapshot fails, presence may still be recorded from
-                # the successes, but we do NOT count a successful absence look — an inaccessible
-                # live process would otherwise be invented as `not_observed` (Codex P1 on #721).
-                successes: list[frozenset[str]] = []
-                any_failed = False
-                for pid in pids:
-                    try:
-                        # retries=1: do not sleep inside the go-live poll path; BAD_LENGTH during
-                        # module load is retried by the next poll tick instead (cursor HIGH #721).
-                        successes.append(process_module_names(pid, retries=1))
-                    except OSError:
-                        any_failed = True
-                fold_perturber_snapshots(
-                    perturbers,
-                    successes=successes,
-                    any_pid_failed=any_failed,
-                )
+                # Classify the newest acs.exe only. Unioning modules across PIDs invents a full
+                # treatment when Steam is on one process and NVIDIA on another (Codex P2 on #721).
+                # max(pid) is the usual live session after a leftover corpse; a failed primary
+                # look is unavailable, never a synthetic multi-PID miss (Codex P1 on #721).
+                primary_pid = max(pids)
+                try:
+                    # retries=1: do not sleep inside the go-live poll path; BAD_LENGTH during
+                    # module load is retried by the next poll tick instead (cursor HIGH #721).
+                    names = process_module_names(primary_pid, retries=1)
+                except OSError:
+                    fold_perturber_snapshots(perturbers, enum_failed=True)
+                    return
+                fold_perturber_snapshots(perturbers, successes=[names])
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None, int | None]:
                 """Report shared memory; trust readiness only once the packet proves a live owner.

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2305,10 +2305,15 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     primary_pid = pinned_acs_pid[0]
                 else:
                     if pinned_acs_pid[0] is not None:
-                        # Process replacement: drop ALL prior evidence so Steam from the corpse
-                        # cannot combine with NVIDIA from the replacement into a false full
-                        # injection (Codex P1 on #721). Off-arm positive sightings already
-                        # stop the loop on the poll that first saw them.
+                        # Process replacement mid-attempt. Two constraints (Codex P1 rounds):
+                        # (1) do not invent full treatment by unioning Steam on corpse A with
+                        #     NVIDIA on replacement B;
+                        # (2) do not erase a positive injection already seen (off-arm needs it).
+                        # If any injection was observed, freeze this attempt's evidence and stop
+                        # sampling — further PIDs would only pollute confirmation. Otherwise
+                        # start clean on the newest process.
+                        if any(perturbers.injected(name) for name in PERTURBER_MODULES):
+                            return
                         perturbers.reset()
                     primary_pid = max(pids)
                     pinned_acs_pid[0] = primary_pid

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -1016,24 +1016,14 @@ def run_retry_loop(
             undetermined += 1
         last_verdict = verdict
         attempts_run = attempt
-        if contradicts_expectation(evidence, expect_perturbers):
-            # The boot was launched as `overlays_off` and a perturber is demonstrably injected, so
-            # its arm label is a lie and nothing measured after this point can inform the contrast.
-            # Stop now: the accumulator has already advanced (this boot needs another reboot either
-            # way), but stopping at attempt N instead of 24 saves ~28 minutes of rig time per
-            # mistake. Only this direction is dispositive — see `contradicts_expectation` (#719).
-            #
-            # Placed AFTER the delivery counters on purpose: breaking before them would leave this
-            # attempt in ``attempts_log`` but absent from ``cycles``, and the analyzer checks those
-            # for exact agreement — a desync would look like a corrupt report rather than a
-            # deliberate early stop.
-            arm_contradicted = True
-            break
+        # Verdict histogram BEFORE any early-stop: an arm-contradiction break used to leave this
+        # attempt in ``attempts_log`` while omitting it from ``counts``, and the analyzer rejects
+        # exactly that shape (`counts do not match its attempts_log`). Same placement rule as the
+        # delivery counters above — the deliberate stop must not desync any integrity check
+        # (cursor HIGH / Codex P1 on #721).
         if verdict is LaunchVerdict.STABLE:
             stable += 1
             never_live_run = 0
-            if stop_on_stable:
-                break
         elif verdict is LaunchVerdict.NEVER_LIVE:
             never_live += 1
             # Delivery deliberately does NOT gate this streak. A delivered NEVER_LIVE also covers
@@ -1053,6 +1043,16 @@ def run_retry_loop(
             else:
                 wedged_init += 1
             never_live_run = 0
+        if contradicts_expectation(evidence, expect_perturbers):
+            # The boot was launched as `overlays_off` and a perturber is demonstrably injected, so
+            # its arm label is a lie and nothing measured after this point can inform the contrast.
+            # Stop now: the accumulator has already advanced (this boot needs another reboot either
+            # way), but stopping at attempt N instead of 24 saves ~28 minutes of rig time per
+            # mistake. Only this direction is dispositive — see `contradicts_expectation` (#719).
+            arm_contradicted = True
+            break
+        if verdict is LaunchVerdict.STABLE and stop_on_stable:
+            break
     return LaunchReport(
         last_verdict,
         attempts_run,
@@ -2158,9 +2158,19 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 if not pids:
                     perturbers.observe(None)
                     return
-                try:
-                    perturbers.observe(process_module_names(pids[0]))
-                except OSError:
+                # Union presence across EVERY returned PID. Taking only the lowest PID (the old
+                # behaviour) can sample a leftover corpse without overlays while the live session
+                # has them, and miss the dispositive `injected` proof for the off-arm (cursor
+                # MEDIUM on #721). One successful look of any PID is enough; all failures collapse
+                # to a single failed snapshot so we never invent absence from access errors.
+                looked = False
+                for pid in pids:
+                    try:
+                        perturbers.observe(process_module_names(pid))
+                        looked = True
+                    except OSError:
+                        continue
+                if not looked:
                     perturbers.observe(None)
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None, int | None]:

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -984,13 +984,14 @@ def contradicts_expectation(
 
     if expectation == "off":
         return any(value == str(PerturberEvidence.INJECTED) for value in evidence.values())
-    # Match analyzer _is_live_session: only STABLE is inherently post-race for absence.
-    if expectation == "on" and verdict is LaunchVerdict.STABLE:
+    # Match analyzer _is_live_session: STABLE and WEDGED_INIT are post-race for absence
+    # (go_live_timeout / stability floors exceed the injection race).
+    if expectation == "on" and verdict in (LaunchVerdict.STABLE, LaunchVerdict.WEDGED_INIT):
         if not evidence:
             return False
         if any(value == str(PerturberEvidence.UNAVAILABLE) for value in evidence.values()):
             return False
-        # Full successful look on a stable session that still misses a required perturber.
+        # Full successful look that still misses a required perturber.
         return any(value == str(PerturberEvidence.NOT_OBSERVED) for value in evidence.values())
     return False
 
@@ -2385,11 +2386,12 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             if args.expect_perturbers is not None:
                 sample_perturbers(soft_fail=True)
             evidence = dict(perturbers.evidence())
-            # Off-arm latch: restore dispositive injection from a replaced PID without letting
-            # those sightings count as the replacement session's full on-arm confirmation
-            # (missing keys stay unavailable after reset).
-            for name in latched_injected:
-                evidence[name] = str(PerturberEvidence.INJECTED)
+            # Off-arm only: restore dispositive injection from a replaced PID. Never overlay
+            # latched keys for on-arm — that would invent full treatment for the replacement
+            # (Codex P1 / qodo on #721).
+            if args.expect_perturbers == "off":
+                for name in latched_injected:
+                    evidence[name] = str(PerturberEvidence.INJECTED)
             outcome = replace(outcome, perturbers=evidence)
             delivery = _delivery_label(outcome.cycle_delivered)
             injected = sorted(

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2161,7 +2161,10 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 )
 
                 try:
-                    pids = sorted(running_process_ids("acs.exe"))
+                    # strict=True: a partial Toolhelp enumeration must not look exhaustive — an
+                    # omitted live acs.exe with overlays would otherwise yield false not_observed
+                    # on the visible PID alone (Codex P2 on #721).
+                    pids = sorted(running_process_ids("acs.exe", strict=True))
                 except OSError:
                     perturbers.observe(None)
                     return
@@ -2303,7 +2306,22 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         )
         report_written = True
         if args.json_path is not None:
-            report_written = _write_report_json(report, args.json_path)
+            # Arm-contradiction salvage goes to a SIDE path so the planned exclusive report
+            # destination stays free for a corrected re-run after reboot (Codex P1 on #721).
+            # Analyze will treat the planned name as missing until the re-run succeeds; the
+            # salvage file keeps the positive injection evidence for the operator.
+            if report.arm_contradicted:
+                salvage = args.json_path.with_name(
+                    f"{args.json_path.stem}.arm_contradicted{args.json_path.suffix}"
+                )
+                report_written = _write_report_json(report, salvage)
+                if report_written:
+                    _log(
+                        f"arm contradicted — salvage report at {salvage}; planned path "
+                        f"{args.json_path} left free for re-run after settings fix + reboot"
+                    )
+            else:
+                report_written = _write_report_json(report, args.json_path)
             if not report_written and not trials_mode:
                 # Do not tear down a STABLE session over a missing artifact — that contradicts
                 # --no-hold (leave AC LIVE for a peer) and kills the operator's earned session

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -984,14 +984,12 @@ def contradicts_expectation(
 
     if expectation == "off":
         return any(value == str(PerturberEvidence.INJECTED) for value in evidence.values())
-    # Match analyzer _is_live_session: STABLE and WEDGED_INIT are post-race for absence
-    # (go_live_timeout / stability floors exceed the injection race).
-    if expectation == "on" and verdict in (LaunchVerdict.STABLE, LaunchVerdict.WEDGED_INIT):
+    # Match analyzer: only STABLE is dispositive for on-arm absence (Codex P1 on #721).
+    if expectation == "on" and verdict is LaunchVerdict.STABLE:
         if not evidence:
             return False
         if any(value == str(PerturberEvidence.UNAVAILABLE) for value in evidence.values()):
             return False
-        # Full successful look that still misses a required perturber.
         return any(value == str(PerturberEvidence.NOT_OBSERVED) for value in evidence.values())
     return False
 

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -830,6 +830,16 @@ class PerturberWatch:
         if module_names is None:
             return
         self._successful_looks += 1
+        self.note_injected(module_names)
+
+    def note_injected(self, module_names: frozenset[str]) -> None:
+        """Union dispositive presence without counting a successful *absence* look.
+
+        Used when a multi-PID sample only partially succeeded: we can still learn that a
+        perturber was injected into some process, but we must not promote a miss on the
+        accessible PID into ``not_observed`` while another PID was unreachable (Codex P1 on #721).
+        """
+
         for name, dll in self._modules.items():
             if dll.casefold() in module_names:
                 self._injected.add(name)
@@ -2161,17 +2171,24 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 # Union presence across EVERY returned PID. Taking only the lowest PID (the old
                 # behaviour) can sample a leftover corpse without overlays while the live session
                 # has them, and miss the dispositive `injected` proof for the off-arm (cursor
-                # MEDIUM on #721). One successful look of any PID is enough; all failures collapse
-                # to a single failed snapshot so we never invent absence from access errors.
-                looked = False
+                # MEDIUM on #721). If any PID snapshot fails, presence may still be recorded from
+                # the successes, but we do NOT count a successful absence look — an inaccessible
+                # live process would otherwise be invented as `not_observed` (Codex P1 on #721).
+                successes: list[frozenset[str]] = []
+                any_failed = False
                 for pid in pids:
                     try:
-                        perturbers.observe(process_module_names(pid))
-                        looked = True
+                        successes.append(process_module_names(pid))
                     except OSError:
-                        continue
-                if not looked:
+                        any_failed = True
+                if not successes:
                     perturbers.observe(None)
+                elif any_failed:
+                    for names in successes:
+                        perturbers.note_injected(names)
+                else:
+                    for names in successes:
+                        perturbers.observe(names)
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None, int | None]:
                 """Report shared memory; trust readiness only once the packet proves a live owner.
@@ -2330,6 +2347,17 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 # automated run must not read as successful when the requested record was never
                 # produced (#646 review P1) — the per-trial log lines above remain as salvage.
                 _log("TRIALS FAILED: the requested report JSON could not be written")
+                return 1
+            if report.arm_contradicted:
+                # Short contradicted report is a deliberate measurement of a bad arm, but it is
+                # NOT a successful completion of the planned trial budget. Exit nonzero so a
+                # manual/scripted reboot chain stops instead of burning the remaining boots under
+                # a post-treatment exclusion that withholds the causal conclusion (Codex P1).
+                _log(
+                    "TRIALS FAILED: arm contradicted by injected perturber evidence "
+                    f"(expect={report.expect_perturbers!r}) — fix settings, reboot, re-run this "
+                    "boot before continuing the plan"
+                )
                 return 1
             return 0
         _log(report.summary())

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2219,6 +2219,9 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 elif any_failed:
                     for names in successes:
                         perturbers.note_injected(names)
+                    # Invalidate absence: a prior full miss must not stick when this poll only
+                    # partially sampled PIDs (cursor HIGH / Codex P1 on #721).
+                    perturbers.observe(None)
                 else:
                     for names in successes:
                         perturbers.observe(names)

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -111,9 +111,52 @@ class AttemptOutcome:
 
     verdict: LaunchVerdict
     cycle_delivered: bool | None
+    #: Per-perturber evidence gathered while this attempt's ``acs.exe`` was alive (#719). Defaults
+    #: to "we could not look", which is the only honest value for a producer that never sampled.
+    perturbers: dict[str, str] | None = None
 
 
-REPORT_SCHEMA = "resilient-launch-report/v2"
+REPORT_SCHEMA = "resilient-launch-report/v3"
+WITHDRAWN_REPORT_SCHEMAS = ("resilient-launch-report/v1", "resilient-launch-report/v2")
+
+
+class PerturberEvidence(StrEnum):
+    """What this attempt observed about one init perturber inside ``acs.exe`` (#719).
+
+    Deliberately asymmetric, and the asymmetry is the whole point. ``INJECTED`` is the ONLY value
+    that establishes anything: seeing ``gameoverlayrenderer64.dll`` mapped into ``acs.exe`` proves
+    the Steam overlay was active for that launch. Not seeing it proves nothing on its own, because
+    the injection **races process startup** — measured on the rig 2026-07-28 against one live
+    ``acs.exe``: at 45 modules loaded neither perturber was present; ~3 s later at 115 modules both
+    were.
+
+    This is the mirror of the ``cycle_delivered`` rule (#710): a watched trace can prove a thing
+    happened but never that it did not. So ``NOT_OBSERVED`` means "we looked successfully and it
+    was not there yet", and ``UNAVAILABLE`` means "we could not look" — never merged, because
+    collapsing them would let a failed snapshot masquerade as a disabled perturber and silently
+    invert the treatment check.
+    """
+
+    INJECTED = "injected"
+    NOT_OBSERVED = "not_observed"
+    UNAVAILABLE = "unavailable"
+
+
+#: The dump-confirmed init perturbers #625 tests, keyed by the report's stable field name.
+PERTURBER_MODULES: dict[str, str] = {
+    "steam_overlay": "gameoverlayrenderer64.dll",
+    "nvidia_capture": "nvspcap64.dll",
+}
+#: Arm names #625 assigns; ``--expect-perturbers`` takes one of these.
+PERTURBER_EXPECTATIONS = ("on", "off")
+
+
+def _unavailable_perturbers() -> dict[str, str]:
+    """Evidence for an attempt that never got to look — the honest default."""
+
+    return {field: str(PerturberEvidence.UNAVAILABLE) for field in PERTURBER_MODULES}
+
+
 TERMINAL_VERDICTS = frozenset(
     {
         LaunchVerdict.STABLE.value,
@@ -644,12 +687,18 @@ class AttemptRecord:
     elapsed_s: float
     uptime_h: float | None
     cycle_delivered: bool | None = None
+    #: Per-perturber evidence for this attempt (#719). Always present and always complete — every
+    #: key in ``PERTURBER_MODULES`` carries a :class:`PerturberEvidence` value, defaulting to
+    #: ``unavailable`` so a producer that never looked cannot be mistaken for one that looked and
+    #: found nothing.
+    perturbers: dict[str, str] = field(default_factory=lambda: _unavailable_perturbers())
 
     def as_dict(self) -> dict[str, object]:
         return {
             "attempt": self.attempt,
             "verdict": str(self.verdict),
             "cycle_delivered": self.cycle_delivered,
+            "perturbers": dict(self.perturbers),
             "started_at_utc": self.started_at_utc,
             "elapsed_s": round(self.elapsed_s, 3),
             "uptime_h": None if self.uptime_h is None else round(self.uptime_h, 4),
@@ -673,6 +722,12 @@ class LaunchReport:
     cycles_undetermined: int = 0
     attempts_log: tuple[AttemptRecord, ...] = field(default=())
     launch: dict[str, object] | None = None
+    #: The arm this boot was launched under (``on``/``off``), when the operator declared one via
+    #: ``--expect-perturbers``. ``None`` for ordinary launches outside the #625 experiment.
+    expect_perturbers: str | None = None
+    #: Set when an attempt DISPOSITIVELY refuted that arm, which ends the trial loop early so a
+    #: mislabelled boot costs ~1 launch cycle instead of the full 24 (#719 Part C).
+    arm_contradicted: bool = False
 
     @property
     def succeeded(self) -> bool:
@@ -715,15 +770,105 @@ class LaunchReport:
                 "undelivered": self.cycles_undelivered,
                 "undetermined": self.cycles_undetermined,
             },
+            # Also kept OUT of ``counts`` (#719), same rule as ``cycles``. Boot-level roll-up of the
+            # per-attempt evidence: ``injected`` if ANY attempt saw it (dispositive, and a union
+            # because a perturber cannot un-inject), ``not_observed`` only when at least one
+            # snapshot succeeded and none saw it, else ``unavailable``.
+            "perturbers": self.perturber_summary(),
             "attempts_log": [record.as_dict() for record in self.attempts_log],
         }
+        if self.expect_perturbers is not None:
+            payload["expect_perturbers"] = self.expect_perturbers
+            payload["arm_contradicted"] = self.arm_contradicted
         if self.launch is not None:
             payload["launch"] = self.launch
         return payload
 
+    def perturber_summary(self) -> dict[str, str]:
+        """Fold every attempt's evidence into one verdict per perturber for this boot."""
+
+        summary: dict[str, str] = {}
+        for field_name in PERTURBER_MODULES:
+            values = [record.perturbers.get(field_name) for record in self.attempts_log]
+            if any(value == str(PerturberEvidence.INJECTED) for value in values):
+                summary[field_name] = str(PerturberEvidence.INJECTED)
+            elif any(value == str(PerturberEvidence.NOT_OBSERVED) for value in values):
+                summary[field_name] = str(PerturberEvidence.NOT_OBSERVED)
+            else:
+                summary[field_name] = str(PerturberEvidence.UNAVAILABLE)
+        return summary
+
 
 def _utc_stamp(epoch_seconds: float) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch_seconds))
+
+
+class PerturberWatch:
+    """Fold repeated module snapshots of one ``acs.exe`` into per-perturber evidence (#719).
+
+    Presence is taken as the **union across samples**: one sighting is dispositive and can never be
+    undone by a later snapshot that misses it, because the perturber cannot un-inject. Absence is
+    only ever the weak claim "every successful look so far missed it", which is why a single early
+    sample must never be the sole basis for it — see :class:`PerturberEvidence`.
+
+    Pure by construction: the caller performs the snapshot and hands in module names, so every
+    branch is unit-tested off-rig while collection stays Windows-only.
+    """
+
+    def __init__(self, modules: dict[str, str] | None = None) -> None:
+        self._modules = dict(modules if modules is not None else PERTURBER_MODULES)
+        self._injected: set[str] = set()
+        self._successful_looks = 0
+
+    def observe(self, module_names: frozenset[str] | None) -> None:
+        """Record one snapshot. ``None`` means the snapshot FAILED — not "no modules".
+
+        Conflating those is the failure this class exists to prevent: an empty set from a denied
+        ``OpenProcess`` would read as *perturber absent* and silently flip a boot's treatment.
+        """
+
+        if module_names is None:
+            return
+        self._successful_looks += 1
+        for name, dll in self._modules.items():
+            if dll.casefold() in module_names:
+                self._injected.add(name)
+
+    @property
+    def successful_looks(self) -> int:
+        return self._successful_looks
+
+    def injected(self, name: str) -> bool:
+        """Whether this attempt DISPOSITIVELY observed ``name`` injected."""
+
+        return name in self._injected
+
+    def evidence(self) -> dict[str, str]:
+        """Per-perturber evidence for the report, as plain strings."""
+
+        out: dict[str, str] = {}
+        for name in self._modules:
+            if name in self._injected:
+                out[name] = str(PerturberEvidence.INJECTED)
+            elif self._successful_looks > 0:
+                out[name] = str(PerturberEvidence.NOT_OBSERVED)
+            else:
+                out[name] = str(PerturberEvidence.UNAVAILABLE)
+        return out
+
+
+def contradicts_expectation(evidence: dict[str, str], expectation: str | None) -> bool:
+    """Whether this attempt's evidence DISPOSITIVELY refutes the arm it was launched under.
+
+    Only the ``off`` arm can be refuted from a single attempt, and only by a positive sighting:
+    expected-off plus ``INJECTED`` is proof the treatment was not applied. Expected-on plus
+    ``NOT_OBSERVED`` is **not** symmetric — the injection race makes a single miss uninformative,
+    so that direction is left to the analyzer, which aggregates the whole boot (#719 Part C).
+    """
+
+    if expectation != "off":
+        return False
+    return any(value == str(PerturberEvidence.INJECTED) for value in evidence.values())
 
 
 def _watched_delivery(samples: Sequence[Sample]) -> bool | None:
@@ -798,6 +943,7 @@ def run_retry_loop(
     clock: Callable[[], float] = time.monotonic,
     wall_clock: Callable[[], float] = time.time,
     uptime_hours: Callable[[], float | None] | None = None,
+    expect_perturbers: str | None = None,
 ) -> LaunchReport:
     """Drive attempts until one is ``STABLE`` or the budget is spent. Pure control flow.
 
@@ -821,6 +967,11 @@ def run_retry_loop(
         raise ValueError("max_attempts must be > 0")
     if never_live_before_restart <= 0:
         raise ValueError("never_live_before_restart must be > 0")
+    if expect_perturbers is not None and expect_perturbers not in PERTURBER_EXPECTATIONS:
+        raise ValueError(
+            f"expect_perturbers must be one of {PERTURBER_EXPECTATIONS!r}, got "
+            f"{expect_perturbers!r}"
+        )
 
     def read_uptime() -> float | None:
         if uptime_hours is None:
@@ -836,6 +987,7 @@ def run_retry_loop(
     never_live_run = 0
     last_verdict = LaunchVerdict.NEVER_LIVE
     attempts_run = 0
+    arm_contradicted = False
     for attempt in range(1, max_attempts + 1):
         started_wall = wall_clock()
         started = clock()
@@ -844,6 +996,7 @@ def run_retry_loop(
         verdict = outcome.verdict
         if verdict is LaunchVerdict.PENDING:
             raise ValueError("watch_attempt returned a non-terminal PENDING verdict")
+        evidence = dict(outcome.perturbers) if outcome.perturbers else _unavailable_perturbers()
         records.append(
             AttemptRecord(
                 attempt=attempt,
@@ -852,6 +1005,7 @@ def run_retry_loop(
                 elapsed_s=clock() - started,
                 uptime_h=uptime,
                 cycle_delivered=outcome.cycle_delivered,
+                perturbers=evidence,
             )
         )
         if outcome.cycle_delivered is True:
@@ -862,6 +1016,19 @@ def run_retry_loop(
             undetermined += 1
         last_verdict = verdict
         attempts_run = attempt
+        if contradicts_expectation(evidence, expect_perturbers):
+            # The boot was launched as `overlays_off` and a perturber is demonstrably injected, so
+            # its arm label is a lie and nothing measured after this point can inform the contrast.
+            # Stop now: the accumulator has already advanced (this boot needs another reboot either
+            # way), but stopping at attempt N instead of 24 saves ~28 minutes of rig time per
+            # mistake. Only this direction is dispositive — see `contradicts_expectation` (#719).
+            #
+            # Placed AFTER the delivery counters on purpose: breaking before them would leave this
+            # attempt in ``attempts_log`` but absent from ``cycles``, and the analyzer checks those
+            # for exact agreement — a desync would look like a corrupt report rather than a
+            # deliberate early stop.
+            arm_contradicted = True
+            break
         if verdict is LaunchVerdict.STABLE:
             stable += 1
             never_live_run = 0
@@ -897,6 +1064,8 @@ def run_retry_loop(
         cycles_undelivered=undelivered,
         cycles_undetermined=undetermined,
         attempts_log=tuple(records),
+        expect_perturbers=expect_perturbers,
+        arm_contradicted=arm_contradicted,
     )
 
 
@@ -1761,6 +1930,19 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
         ),
     )
     parser.add_argument(
+        "--expect-perturbers",
+        choices=PERTURBER_EXPECTATIONS,
+        default=None,
+        help=(
+            "#625/#719 arm declaration: the init-perturber state this boot is SUPPOSED to be in. "
+            "Every attempt records which perturbers were actually injected into acs.exe, and with "
+            "'off' a positive sighting ends the trial loop immediately (arm_contradicted) so a "
+            "mislabelled boot costs ~1 launch cycle instead of the whole run. 'on' cannot be "
+            "refuted from one attempt — the injection races startup — so it is left to the "
+            "analyzer, which aggregates the boot"
+        ),
+    )
+    parser.add_argument(
         "--no-hold",
         action="store_true",
         help=(
@@ -1947,6 +2129,39 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     retain_telemetry_controller=telemetry_cleanup_holds.append,
                 )
             )
+            perturbers = PerturberWatch()
+
+            def sample_perturbers() -> None:
+                """Fold one module snapshot of the live acs.exe into this attempt's evidence.
+
+                Runs on the existing poll cadence rather than once, because the injection races
+                startup (#719): a single early look reports both perturbers absent for a process
+                that is about to have them. Presence unions across samples, so repeated cheap looks
+                only ever strengthen the dispositive direction.
+
+                Never raises. A failed snapshot is recorded as "we could not look" by the simple
+                fact that ``observe(None)`` does not count as a successful look — it must NOT be
+                allowed to read as "perturber absent", and it must never fail an attempt: this is
+                measurement riding along on a launch, not a gate.
+                """
+
+                from tools.ac_harness.entry_launcher import (
+                    process_module_names,
+                    running_process_ids,
+                )
+
+                try:
+                    pids = sorted(running_process_ids("acs.exe"))
+                except OSError:
+                    perturbers.observe(None)
+                    return
+                if not pids:
+                    perturbers.observe(None)
+                    return
+                try:
+                    perturbers.observe(process_module_names(pids[0]))
+                except OSError:
+                    perturbers.observe(None)
 
             def read_attempt_state() -> tuple[int | None, bool | None, bool | None, int | None]:
                 """Report shared memory; trust readiness only once the packet proves a live owner.
@@ -1963,6 +2178,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 if release_requested():
                     raise _OperatorRelease
 
+                sample_perturbers()
                 packet, entry_ready, phys_packet = read_state()
                 ready, drivable = readiness.observe(packet=packet, entry_ready=entry_ready)
                 return packet, ready, drivable, phys_packet
@@ -1980,8 +2196,20 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                 # rendered attempt so it cannot advance the stale-CM/never-live restart streak.
                 # The session was rendering, so the launch cycle WAS delivered (#710).
                 outcome = AttemptOutcome(LaunchVerdict.FROZE, cycle_delivered=True)
+            # One last look before the process is torn down: the perturbers inject late, so the
+            # final sample is the most informative one in the attempt (#719).
+            sample_perturbers()
+            outcome = replace(outcome, perturbers=perturbers.evidence())
             delivery = _delivery_label(outcome.cycle_delivered)
-            _log(f"attempt {attempt}: {outcome.verdict} ({delivery})")
+            injected = sorted(
+                name
+                for name, value in outcome.perturbers.items()
+                if value == str(PerturberEvidence.INJECTED)
+            )
+            _log(
+                f"attempt {attempt}: {outcome.verdict} ({delivery}); "
+                f"perturbers injected: {', '.join(injected) if injected else 'none observed'}"
+            )
             last_attempt_verdict[0] = outcome.verdict
             return outcome
 
@@ -2007,6 +2235,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     on_never_live_streak=cold_restart_cm,
                     stop_on_stable=not trials_mode,
                     uptime_hours=_machine_uptime_hours,
+                    expect_perturbers=args.expect_perturbers,
                 ),
                 acs_present,
                 release_requested=release_requested,

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -984,13 +984,13 @@ def contradicts_expectation(
 
     if expectation == "off":
         return any(value == str(PerturberEvidence.INJECTED) for value in evidence.values())
-    # Match analyzer _is_live_session: STABLE and FROZE are both post-go-live (Codex P1 on #721).
-    if expectation == "on" and verdict in (LaunchVerdict.STABLE, LaunchVerdict.FROZE):
+    # Match analyzer _is_live_session: only STABLE is inherently post-race for absence.
+    if expectation == "on" and verdict is LaunchVerdict.STABLE:
         if not evidence:
             return False
         if any(value == str(PerturberEvidence.UNAVAILABLE) for value in evidence.values()):
             return False
-        # Full successful look on a post-go-live session that still misses a required perturber.
+        # Full successful look on a stable session that still misses a required perturber.
         return any(value == str(PerturberEvidence.NOT_OBSERVED) for value in evidence.values())
     return False
 

--- a/tools/ac_harness/resilient_launch.py
+++ b/tools/ac_harness/resilient_launch.py
@@ -2295,6 +2295,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             # Injected names latched from a replaced PID for off-arm contradiction only — never
             # mixed into on-arm full-injection confirmation for the replacement (Codex P1).
             latched_injected: set[str] = set()
+            # Toolhelp saw acs.exe this attempt — promote undetermined delivery (Codex P2 on #721).
+            acs_pid_observed: list[bool] = [False]
 
             def sample_perturbers(*, soft_fail: bool = False) -> None:
                 """Fold one module snapshot of the live acs.exe into this attempt's evidence.
@@ -2333,11 +2335,17 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
                     # final sample classify commonly hits after FROZE (cursor MEDIUM on #721).
                     fold_perturber_snapshots(perturbers, pids_empty=True)
                     return
+                acs_pid_observed[0] = True
                 # Classify one process identity per attempt. Re-picking max(pid) every poll can
                 # union Steam from a corpse with NVIDIA from a replacement live process and
-                # invent full treatment (qodo on #721). Prefer the pinned PID when still alive;
-                # otherwise pin the newest and invalidate prior absence (new process).
-                if pinned_acs_pid[0] in pids:
+                # invent full treatment (qodo on #721). Prefer the pinned PID when still alone;
+                # if another PID appears alongside it, treat as replacement (Codex P2 on #721).
+                extra_pids = (
+                    pinned_acs_pid[0] is not None
+                    and pinned_acs_pid[0] in pids
+                    and any(pid != pinned_acs_pid[0] for pid in pids)
+                )
+                if pinned_acs_pid[0] in pids and not extra_pids:
                     primary_pid = pinned_acs_pid[0]
                 else:
                     if pinned_acs_pid[0] is not None:
@@ -2410,7 +2418,12 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - rig-on
             if args.expect_perturbers == "off":
                 for name in latched_injected:
                     evidence[name] = str(PerturberEvidence.INJECTED)
-            outcome = replace(outcome, perturbers=evidence)
+            # Toolhelp saw acs.exe → the launch cycle was delivered even if later reads miss it
+            # (Codex P2 on #721).
+            delivered = outcome.cycle_delivered
+            if delivered is None and acs_pid_observed[0]:
+                delivered = True
+            outcome = replace(outcome, perturbers=evidence, cycle_delivered=delivered)
             delivery = _delivery_label(outcome.cycle_delivered)
             injected = sorted(
                 name


### PR DESCRIPTION
Closes #719.

## The gap

The #625 boot-scoped A/B measured everything about each boot **except the treatment**. A boot's arm label came only from the plan file — the operator's assertion that they toggled the Steam overlay and NVIDIA ShadowPlay before *that* reboot. Every other input was measured and defended: withdrawn-schema refusal, boot-epoch verification, `cycle_delivered` (#710), censoring bounds that refuse to score a block whose difference sign isn't established. Treatment assignment was the last honor-system link — and it is the one input the p-value is *about*.

One boot that doesn't receive its assigned condition corrupts the exact block permutation test with **no detectable signature** in any artifact, and the run costs 16 physical reboots.

**Reframe that made the design tractable:** this is **treatment-receipt verification**, not operator-error detection. Whether the operator forgot the toggle or Steam simply failed to inject while enabled, the boot did not receive its condition and cannot inform the contrast. The cause is irrelevant. That also settles the awkward `overlays_on` case — it is excluded for the same reason as a contradicted `overlays_off`.

## The measured constraint that shaped the encoding

The injection **races process startup**. Measured on the rig against one live `acs.exe` (pid 27616):

| snapshot | modules loaded | `gameoverlayrenderer64.dll` | `nvspcap64.dll` |
|---|---|---|---|
| early | 45 | absent | absent |
| ~3 s later | 115 | **PRESENT** | **PRESENT** |

So `injected` is the only value that establishes anything. `not_observed` means "we looked successfully and it wasn't there yet"; `unavailable` means "we could not look". Folding a failed snapshot into absence would let a denied `OpenProcess` masquerade as a disabled perturber and **silently invert** the very check this adds. Same shape as #710's delivery lesson — *a watched trace can prove a thing happened, never that it did not*.

## Parts

**A — the launcher records what was actually injected.** New shared helper `entry_launcher.process_module_names` (Toolhelp32 module snapshot), placed beside the existing process enumeration rather than adding a fourth `ctypes` block to the repo. Report schema **v2 → v3**: per-attempt `perturbers` plus a boot-level roll-up, both kept **out of `counts`** so `counts` stays the verdict histogram consumers compare for equality. Sampling rides the existing poll cadence and unions presence across samples, because one early look is exactly the case measured above. It never fails an attempt — this is measurement riding along on a launch, not a gate.

**B — the analyzer cross-checks observed against planned.** A contradicted boot is **excluded** and its block drops. It is **never re-labelled** to its observed arm: the permutation null is over the arm orders the randomization could have emitted, so the labels *are* the randomization. Re-labelling conditions on post-randomization data, and can leave a block whose two boots share an arm — no contrast anyway. (The 2026-07-28 council split on exactly this; `gemini-sub` argued for re-labelling on physical-reality grounds. Recorded in the vault because it will be re-proposed.) A v2 report is now refused by name, as v1 already was.

**C — fail in one launch cycle, not twenty-four.** `--expect-perturbers on|off`; with `off`, a positive sighting ends the trial loop immediately (`arm_contradicted`). Only that direction is dispositive, so `on` is left to the analyzer, which aggregates the whole boot. The early stop runs **after** the delivery counters so `cycles` cannot desync from `attempts_log` — a desync would read as a corrupt report rather than a deliberate stop.

## Verified live on the rig, through the launcher's own path

Not a probe script — `python -m tools.ac_harness.resilient_launch … --expect-perturbers on --json`, the command the experiment actually runs. This matters because the vault already records a case where a bespoke harness certified a broken product (`capture_freeze.py` said 8/8 stable while the shipped launcher failed 6/6).

Both directions observed:

```
# 5 attempts, long-lived acs.exe (all froze — the rig's #619 wedge)
BOOT perturbers: {'steam_overlay': 'injected', 'nvidia_capture': 'injected'}
expect on | arm_contradicted False
 attempt 1..5  froze  delivered=True  {'steam_overlay': 'injected', 'nvidia_capture': 'injected'}

# earlier run, attempts that died in early load
 attempt 1 never_live delivered=True {'steam_overlay': 'not_observed', ...}
```

The second is the honest-negative path: those attempts sampled *inside* the injection race and correctly reported `not_observed` rather than claiming absence. Exactly the asymmetry the encoding exists for.

`make ci-fast` green. 19 new tests, including a deliberately non-vacuous block-exclusion case (without the change that block yields a real onset difference of 6 rather than dropping).

## Not in scope

The physical 16-reboot A/B itself — still gated on operator sign-off for the two settings plus rig time (#625). This makes that investment trustworthy before it is spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
