### PR TITLE
feat(harness): screening stage for the #625 A/B — answer or close the spike in 4 boots instead of 16 (#724)

### DIFF
--- a/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
+++ b/docs/01_Vault/AcCopilotTrainer/03_Investigations/issue-625-boot-scoped-redesign-2026-07-28.md
@@ -17,6 +17,37 @@ relates_to:
 **This page replaces the v1 runbook.** The old one is archived at
 [[issue-625-init-perturber-ab-prepared-2026-07-22]] and its protocol **must not be run**.
 
+## START HERE — run the SCREEN first (#724), not the 16-boot design
+
+**Do not open with the confirmatory run.** #625 sat unrun for over a week because the cheapest
+question this tool could ask cost **16 physical reboots**: `MIN_BOOTS_PER_ARM = 6` makes it return
+`insufficient_sample` below 12 boots. Four sessions found real instrument defects
+(#657 → #708 → #710 → #719) and fixed every one; none of them moved that price, because the price
+was never a defect — it was the design being **confirmatory-only for a screening question**.
+
+The power target was also wrong for the decision. The 16-boot design separates onset ~14 from ~8, a
+*modest* shift. But #627's resilient launcher already retries past the freeze, so
+"disable the overlays permanently" is only worth adopting if it roughly **eliminates** the freeze.
+That is a large effect, and a large effect is visible in ~4 boots.
+
+```bash
+python -m tools.ac_harness.init_perturber_ab plan --screen --out .scratch/<name>.json
+# ... run the 4 printed boots (one reboot each) ...
+python -m tools.ac_harness.init_perturber_ab screen --plan .scratch/<name>.json --reports-dir .scratch
+```
+
+| screen verdict | what to do |
+|---|---|
+| `no_large_effect` | **Close #625.** The overlays are not a mitigation worth adopting over the existing retry. A **modest** effect is *not* ruled out — the screen cannot see one, by design. |
+| `large_effect_plausible` | Now spend the confirmatory 16 boots (`plan` without `--screen`). |
+| `ambiguous` / `insufficient_usable_boots` | Operator decides. |
+
+The screen **never computes a p-value** — at 2 blocks the permutation floor is `2/2**2 = 0.5`, so
+any number would be false precision. `analyze` and `screen` refuse each other's plan artifacts, in
+both directions, so neither can be scored by the wrong rule.
+
+Everything below describes the **confirmatory** stage, which is now stage 2.
+
 ## Why the v1 protocol was withdrawn
 
 v1 interleaved single launches inside **one** boot and compared a pooled per-launch freeze rate —

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -2267,3 +2267,58 @@ class TestScreenReviewRoundTwo:
         rationale = screen(self._screen_plan(), boots)["rationale"]
         assert "planned order" in rationale
         assert "Regenerate the screening plan" in rationale
+
+
+class TestScreenRecoveryAdviceIsConsistent:
+    """#724 review round 3 — every recovery path must respect the planned-order invariant.
+
+    `load_observations` rejects an experiment whose boots did not run in planned order, so any
+    instruction to "re-run that boot" is actively harmful: it costs a physical reboot and then
+    voids the run. Round 2 fixed this for `insufficient_usable_boots` but left the identical
+    wrong advice in the unverified-receipt path and in the renderer (Codex P2 + antigravity HIGH).
+    """
+
+    @staticmethod
+    def _screen_plan() -> dict:
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        return build_plan(2, screen=True, randomization_seed=625)
+
+    @staticmethod
+    def _unverified_boots() -> list:
+        return [
+            _boot(1, "overlays_off", _stable_then_freeze(12), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(3, "overlays_off", _stable_then_freeze(13), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_UNAVAILABLE_PERTURBERS),
+        ]
+
+    def test_unverified_rationale_sends_the_operator_to_a_full_regeneration(self):
+        from tools.ac_harness.init_perturber_ab import SCREEN_RECEIPT_UNVERIFIED, screen
+
+        result = screen(self._screen_plan(), self._unverified_boots())
+        assert result["verdict"] == SCREEN_RECEIPT_UNVERIFIED
+        rationale = result["rationale"]
+        assert "regenerate the screening plan" in rationale
+        assert "planned order" in rationale
+
+    def test_renderer_never_tells_the_operator_to_rerun_one_boot_in_place(self):
+        from tools.ac_harness.init_perturber_ab import render_screen_markdown, screen
+
+        rendered = render_screen_markdown(screen(self._screen_plan(), self._unverified_boots()))
+        assert "re-run all four boots in order" in rendered
+        # The exact advice that would cost a reboot and then void the run.
+        assert "re-run those boots rather than" not in rendered
+
+    def test_every_recovery_path_agrees_on_the_remedy(self):
+        """Both non-scoring verdicts must give the same, correct remedy — not two stories."""
+        from tools.ac_harness.init_perturber_ab import screen
+
+        unverified = screen(self._screen_plan(), self._unverified_boots())["rationale"]
+        insufficient = screen(
+            self._screen_plan(),
+            [_boot(1, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS)],
+        )["rationale"]
+        for text in (unverified, insufficient):
+            assert "planned order" in text
+            assert "regenerate the screening plan" in text.lower()

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -2266,7 +2266,7 @@ class TestScreenReviewRoundTwo:
         boots = [_boot(1, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS)]
         rationale = screen(self._screen_plan(), boots)["rationale"]
         assert "planned order" in rationale
-        assert "Regenerate the screening plan" in rationale
+        assert "regenerate the screening plan" in rationale.lower()
 
 
 class TestScreenRecoveryAdviceIsConsistent:
@@ -2322,3 +2322,68 @@ class TestScreenRecoveryAdviceIsConsistent:
         for text in (unverified, insufficient):
             assert "planned order" in text
             assert "regenerate the screening plan" in text.lower()
+
+
+class TestScreenPlanMetadataAndRecoveryNuance:
+    """#724 review round 4 — the plan must not pre-register two scoring stories."""
+
+    @staticmethod
+    def _screen_plan() -> dict:
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        return build_plan(2, screen=True, randomization_seed=625)
+
+    def test_screening_plan_does_not_preregister_the_permutation_endpoints(self):
+        """Codex P2 — the plan JSON IS the pre-registration; it cannot claim tests never run."""
+        plan = self._screen_plan()
+        endpoints = plan["endpoints"]
+        assert "permutation" not in endpoints["primary"]
+        assert endpoints["secondary"] is None
+        assert endpoints["sensitivity"] is None
+        # Confirmatory power metadata must not appear on a screen that computes no p-value.
+        assert plan["randomization_reference_set"] is None
+        assert plan["smallest_attainable_two_sided_p"] is None
+        assert "no_significance_test" in plan
+        # And the floor must describe the screen, not the confirmatory design.
+        assert plan["minimum_boots_per_arm"] == 2
+
+    def test_confirmatory_plan_keeps_its_permutation_endpoints(self):
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        plan = build_plan(6, randomization_seed=625)
+        assert "permutation" in plan["endpoints"]["primary"]
+        assert plan["endpoints"]["secondary"] is not None
+        assert plan["randomization_reference_set"] == 2**6
+        assert plan["minimum_boots_per_arm"] == 6
+        assert "no_significance_test" not in plan
+
+    def test_insufficient_advice_preserves_the_salvage_rerun_path(self):
+        """Codex P2 — an arm-contradicted boot leaves its planned name FREE on purpose.
+
+        `resolve_boot_report_path` documents that a successful re-run at the planned name
+        supersedes the salvage, so a blanket "regenerate everything" discards the intended
+        cheap recovery for the last boot.
+        """
+        from tools.ac_harness.init_perturber_ab import screen
+
+        boots = [_boot(1, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS)]
+        rationale = screen(self._screen_plan(), boots)["rationale"]
+        assert "salvage" in rationale
+        assert "re-run it in place" in rationale
+        # ...but the constraint that makes it safe must be stated, not dropped.
+        assert "LAST boot" in rationale
+        assert "planned order" in rationale
+
+    def test_unverified_advice_still_requires_regeneration(self):
+        """An unverified boot published a SUCCESSFUL report, so its planned name IS occupied."""
+        from tools.ac_harness.init_perturber_ab import screen
+
+        boots = [
+            _boot(1, "overlays_off", _stable_then_freeze(12), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(3, "overlays_off", _stable_then_freeze(13), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_UNAVAILABLE_PERTURBERS),
+        ]
+        rationale = screen(self._screen_plan(), boots)["rationale"]
+        assert "regenerate the screening plan" in rationale
+        assert "re-run it in place" not in rationale

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -2054,3 +2054,143 @@ class TestScreeningStage:
         assert "0.5" in rendered
         # The operator must be told what a null screen does NOT establish.
         assert "MODEST effect is NOT ruled out" in rendered
+
+
+class TestScreenReviewFindings:
+    """#724 review round 1 — Codex P1 + three P2s, plus the self-hosted daemon's MEDIUMs."""
+
+    @staticmethod
+    def _screen_plan() -> dict:
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        return build_plan(2, screen=True, randomization_seed=625)
+
+    def test_unverified_receipt_withholds_any_causal_verdict(self):
+        """Codex P1 — `no_large_effect` says 'close #625'; it must not fire unmeasured."""
+        from tools.ac_harness.init_perturber_ab import SCREEN_RECEIPT_UNVERIFIED, screen
+
+        # Every boot usable, onsets that would otherwise read as `no_large_effect` — but no
+        # perturber evidence at all, so nothing shows the overlays were ever off.
+        boots = [
+            _boot(1, "overlays_off", _stable_then_freeze(12), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(3, "overlays_off", _stable_then_freeze(13), perturbers=_UNAVAILABLE_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_UNAVAILABLE_PERTURBERS),
+        ]
+        result = screen(self._screen_plan(), boots)
+        assert result["verdict"] == SCREEN_RECEIPT_UNVERIFIED
+        # Non-vacuous: with receipt measured, the identical onsets DO yield the closing verdict.
+        from tools.ac_harness.init_perturber_ab import SCREEN_NO_LARGE_EFFECT
+
+        measured = [
+            _boot(1, "overlays_off", _stable_then_freeze(12), perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", _stable_then_freeze(13), perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_INJECTED_PERTURBERS),
+        ]
+        assert screen(self._screen_plan(), measured)["verdict"] == SCREEN_NO_LARGE_EFFECT
+
+    def test_promotion_requires_the_off_budget_to_outrun_the_on_onset(self):
+        """Codex P2 — censoring at 20 cycles says nothing about an ON boot that froze at 24."""
+        from tools.ac_harness.init_perturber_ab import (
+            SCREEN_AMBIGUOUS,
+            SCREEN_LARGE_EFFECT_PLAUSIBLE,
+            screen,
+        )
+
+        # OFF arm: never freezes, but the last 4 attempts never reached AC, so the boot is
+        # censored after only 16 DELIVERED cycles — its onset is known only to exceed 16.
+        clean = ["stable"] * _LAUNCHES
+        short_delivery = [True] * (_LAUNCHES - 4) + [False] * 4
+        # ON arm: freezes LATER than that bound, at delivered cycle 18.
+        late_freeze = ["stable"] * 17 + ["froze"] * (_LAUNCHES - 17)
+
+        boots = [
+            _boot(
+                1,
+                "overlays_off",
+                clean,
+                perturbers=_ABSENT_PERTURBERS,
+                delivered=short_delivery,
+            ),
+            _boot(2, "overlays_on", late_freeze, perturbers=_INJECTED_PERTURBERS),
+            _boot(
+                3,
+                "overlays_off",
+                clean,
+                perturbers=_ABSENT_PERTURBERS,
+                delivered=short_delivery,
+            ),
+            _boot(4, "overlays_on", late_freeze, perturbers=_INJECTED_PERTURBERS),
+        ]
+        # off is known only to exceed 16; on froze at 18 -> NOT separated.
+        assert screen(self._screen_plan(), boots)["verdict"] == SCREEN_AMBIGUOUS
+
+        # Non-vacuous: give the OFF arm its full 24-cycle budget and the same data promotes.
+        full = [
+            _boot(1, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_INJECTED_PERTURBERS),
+        ]
+        assert screen(self._screen_plan(), full)["verdict"] == SCREEN_LARGE_EFFECT_PLAUSIBLE
+
+    def test_hand_edited_screen_plan_cannot_grow_its_boot_count(self, tmp_path: Path):
+        """Codex P2 + cursor — canonical rule kept, plan size raised, previously accepted."""
+        from tools.ac_harness.init_perturber_ab import load_plan
+
+        plan = self._screen_plan()
+        plan["boots_per_arm"] = 3
+        plan["boots"].append(dict(plan["boots"][-1]))
+        plan["boots"].append(dict(plan["boots"][-1]))
+        path = tmp_path / "screen.json"
+        path.write_text(json.dumps(plan), encoding="utf-8")
+        with pytest.raises(ValueError, match="boots_per_arm"):
+            load_plan(path, expect_screen=True)
+
+    def test_screen_and_confirmatory_plans_never_share_report_names(self):
+        """cursor — the stage must enter the report namespace or the stages can collide."""
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        common = {
+            "launches_per_boot": 24,
+            "randomization_seed": 625,
+            "generated_at_utc": "2026-07-29T00:00:00Z",
+            "run_nonce": "",
+        }
+        screen_plan = build_plan(2, screen=True, **common)
+        confirm_plan = build_plan(2, allow_undersized=True, **common)
+        screen_reports = {boot["report"] for boot in screen_plan["boots"]}
+        confirm_reports = {boot["report"] for boot in confirm_plan["boots"]}
+        assert not (screen_reports & confirm_reports), (
+            "a screening and a confirmatory plan produced colliding report filenames; a shared "
+            "reports-dir would let one stage score the other's boots"
+        )
+
+    def test_screen_plan_supersedes_nothing(self):
+        """antigravity — the screen is a new first stage, not a successor lineage."""
+        assert self._screen_plan()["supersedes"] == []
+
+    def test_explicit_boots_per_arm_with_screen_is_rejected_not_overridden(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """antigravity — `plan --boots-per-arm 16 --screen` must fail, not silently emit 2."""
+        from tools.ac_harness.init_perturber_ab import main
+
+        monkeypatch.setattr(ab_mod, "repo_checkout_root", lambda: tmp_path)
+        out = tmp_path / ".scratch" / "screen.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        assert main(["plan", "--screen", "--boots-per-arm", "16", "--out", str(out)]) != 0, (
+            "an explicit size must reach build_plan and be refused, not be silently replaced"
+        )
+        assert not out.exists()
+
+    def test_screen_default_size_still_needs_no_flag(self, tmp_path: Path, monkeypatch):
+        """The passthrough must not make `plan --screen` require an explicit size."""
+        from tools.ac_harness.init_perturber_ab import main
+
+        monkeypatch.setattr(ab_mod, "repo_checkout_root", lambda: tmp_path)
+        out = tmp_path / ".scratch" / "screen.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        assert main(["plan", "--screen", "--out", str(out)]) == 0
+        assert json.loads(out.read_text(encoding="utf-8"))["boots_per_arm"] == 2

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -2194,3 +2194,76 @@ class TestScreenReviewFindings:
         out.parent.mkdir(parents=True, exist_ok=True)
         assert main(["plan", "--screen", "--out", str(out)]) == 0
         assert json.loads(out.read_text(encoding="utf-8"))["boots_per_arm"] == 2
+
+
+class TestScreenReviewRoundTwo:
+    """#724 review round 2 — horizon guard, censoring off-by-one, and rule/code agreement."""
+
+    @staticmethod
+    def _screen_plan(**kwargs) -> dict:
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        params = {"randomization_seed": 625, "screen": True}
+        params.update(kwargs)
+        return build_plan(2, **params)
+
+    def test_off_censored_on_the_same_cycle_the_on_arm_froze_still_promotes(self):
+        """cursor MEDIUM — a censored boot's onset EXCEEDS its delivered count.
+
+        The cleanest possible result: OFF runs the whole budget clean while ON freezes on the
+        final cycle. Comparing raw delivered counts with `>` called that ambiguous.
+        """
+        from tools.ac_harness.init_perturber_ab import SCREEN_LARGE_EFFECT_PLAUSIBLE, screen
+
+        clean = ["stable"] * _LAUNCHES  # censored at _LAUNCHES delivered cycles
+        froze_on_last = ["stable"] * (_LAUNCHES - 1) + ["froze"]  # onset == _LAUNCHES
+        boots = [
+            _boot(1, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", froze_on_last, perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", froze_on_last, perturbers=_INJECTED_PERTURBERS),
+        ]
+        assert screen(self._screen_plan(), boots)["verdict"] == SCREEN_LARGE_EFFECT_PLAUSIBLE
+
+    def test_a_short_screen_cannot_promote_a_modest_shift_as_elimination(self):
+        """Codex P2 — off censored at 9 vs on freezing at 8 separates, but never reaches 14."""
+        from tools.ac_harness.init_perturber_ab import SCREEN_AMBIGUOUS, screen
+
+        short = 9
+        clean = ["stable"] * short
+        froze_early = ["stable"] * 7 + ["froze"] * (short - 7)
+        plan = self._screen_plan(launches_per_boot=short, allow_undersized=True)
+        boots = [
+            _boot(1, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", froze_early, perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", froze_early, perturbers=_INJECTED_PERTURBERS),
+        ]
+        # Separated (10 > 8) but nowhere near the pre-registered baseline horizon of 14.
+        assert screen(plan, boots)["verdict"] == SCREEN_AMBIGUOUS
+
+    def test_persisted_rule_states_every_clause_the_code_applies(self):
+        """Codex P2 — the artifact IS the pre-registration; it must not under-describe itself."""
+        from tools.ac_harness.init_perturber_ab import (
+            BASELINE_ONSET_INDEX_GRACEFUL,
+            CANONICAL_SCREEN_RULE,
+        )
+
+        clause = CANONICAL_SCREEN_RULE["large_effect_plausible_when"]
+        # All three conjuncts the predicate actually enforces.
+        assert "censored" in clause
+        assert "baseline_onset_graceful" in clause
+        assert "delivered_cycles + 1" in clause
+        assert (
+            CANONICAL_SCREEN_RULE["min_delivered_cycles_for_elimination"]
+            == BASELINE_ONSET_INDEX_GRACEFUL
+        )
+
+    def test_insufficient_recovery_advice_does_not_suggest_an_out_of_order_rerun(self):
+        """Codex P2 — load_observations enforces planned order, so a single re-run is refused."""
+        from tools.ac_harness.init_perturber_ab import screen
+
+        boots = [_boot(1, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS)]
+        rationale = screen(self._screen_plan(), boots)["rationale"]
+        assert "planned order" in rationale
+        assert "Regenerate the screening plan" in rationale

--- a/tests/test_init_perturber_ab.py
+++ b/tests/test_init_perturber_ab.py
@@ -1904,3 +1904,153 @@ def test_unknown_perturber_evidence_value_is_rejected(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="invalid perturber evidence"):
         load_observations(plan, tmp_path, require_complete=False)
+
+
+class TestScreeningStage:
+    """#724 — the screen answers 'is there a LARGE effect?' for 4 boots, never a p-value."""
+
+    @staticmethod
+    def _screen_plan() -> dict:
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        return build_plan(2, screen=True, randomization_seed=625)
+
+    def test_screen_plan_is_two_per_arm_and_carries_the_rule(self):
+        from tools.ac_harness.init_perturber_ab import (
+            CANONICAL_SCREEN_RULE,
+            SCREEN_PLAN_SCHEMA,
+        )
+
+        plan = self._screen_plan()
+        assert plan["schema"] == SCREEN_PLAN_SCHEMA
+        assert plan["boots_per_arm"] == 2
+        assert len(plan["boots"]) == 4
+        # The rule is pre-registered INTO the artifact so the verdict cannot be chosen after
+        # the boots are in.
+        assert plan["screen_rule"] == dict(CANONICAL_SCREEN_RULE)
+        assert plan["screen_rule"]["claims_p_value"] is False
+
+    def test_confirmatory_plan_carries_no_screen_rule(self):
+        from tools.ac_harness.init_perturber_ab import PLAN_SCHEMA, build_plan
+
+        plan = build_plan(6, randomization_seed=625)
+        assert plan["schema"] == PLAN_SCHEMA
+        assert "screen_rule" not in plan
+
+    def test_a_screen_plan_may_not_be_scored_by_analyze(self, tmp_path: Path):
+        """Confirmatory scoring of 2 blocks would print a p-value floored at 0.5."""
+        from tools.ac_harness.init_perturber_ab import load_plan
+
+        path = tmp_path / "screen.json"
+        path.write_text(json.dumps(self._screen_plan()), encoding="utf-8")
+        with pytest.raises(ValueError, match="SCREENING plan"):
+            load_plan(path)
+
+    def test_a_confirmatory_plan_may_not_be_scored_by_screen(self, tmp_path: Path):
+        from tools.ac_harness.init_perturber_ab import build_plan, load_plan
+
+        path = tmp_path / "confirm.json"
+        path.write_text(json.dumps(build_plan(6, randomization_seed=625)), encoding="utf-8")
+        with pytest.raises(ValueError, match="CONFIRMATORY plan"):
+            load_plan(path, expect_screen=True)
+
+    def test_screen_plan_refuses_a_size_other_than_two_per_arm(self):
+        """The rule's meaning is tied to the size; letting it drift renames nothing."""
+        from tools.ac_harness.init_perturber_ab import build_plan
+
+        with pytest.raises(ValueError, match="boots_per_arm=2"):
+            build_plan(3, screen=True, randomization_seed=625)
+
+    def test_tampered_screen_rule_is_refused(self, tmp_path: Path):
+        from tools.ac_harness.init_perturber_ab import load_plan
+
+        plan = self._screen_plan()
+        plan["screen_rule"]["baseline_onset_graceful"] = 2
+        path = tmp_path / "screen.json"
+        path.write_text(json.dumps(plan), encoding="utf-8")
+        with pytest.raises(ValueError, match="does not match the canonical rule"):
+            load_plan(path, expect_screen=True)
+
+    # ------------------------------------------------------------------ verdicts
+
+    def test_an_off_boot_freezing_at_baseline_kills_the_mitigation(self):
+        """`no_large_effect`: overlays-off still freezes on a normal budget."""
+        from tools.ac_harness.init_perturber_ab import SCREEN_NO_LARGE_EFFECT, screen
+
+        boots = [
+            _boot(1, "overlays_off", _stable_then_freeze(12), perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", _stable_then_freeze(13), perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_INJECTED_PERTURBERS),
+        ]
+        result = screen(self._screen_plan(), boots)
+        assert result["verdict"] == SCREEN_NO_LARGE_EFFECT
+        assert result["claims_p_value"] is False
+        # It must NOT overclaim: a modest effect (12/13 vs 8/9 here) is left unrefuted.
+        assert "does not say" not in result["rationale"].lower()
+        assert "not a mitigation worth adopting" in result["rationale"]
+
+    def test_clean_separation_promotes_to_the_confirmatory_run(self):
+        from tools.ac_harness.init_perturber_ab import SCREEN_LARGE_EFFECT_PLAUSIBLE, screen
+
+        clean = ["stable"] * _LAUNCHES  # never freezes -> censored
+        boots = [
+            _boot(1, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_INJECTED_PERTURBERS),
+        ]
+        result = screen(self._screen_plan(), boots)
+        assert result["verdict"] == SCREEN_LARGE_EFFECT_PLAUSIBLE
+        assert "NOT conclusive" in result["rationale"]
+
+    def test_both_arms_clean_is_ambiguous_not_a_promotion(self):
+        """If the ON arm never froze either, the boots show nothing about the overlays."""
+        from tools.ac_harness.init_perturber_ab import SCREEN_AMBIGUOUS, screen
+
+        clean = ["stable"] * _LAUNCHES
+        boots = [
+            _boot(1, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", clean, perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", clean, perturbers=_INJECTED_PERTURBERS),
+        ]
+        assert screen(self._screen_plan(), boots)["verdict"] == SCREEN_AMBIGUOUS
+
+    def test_a_contradicted_boot_is_excluded_and_blocks_a_verdict(self):
+        """#719 exclusion applies unchanged; the screen must not score a corrupted arm."""
+        from tools.ac_harness.init_perturber_ab import SCREEN_INSUFFICIENT, screen
+
+        clean = ["stable"] * _LAUNCHES
+        boots = [
+            # Planned OFF but the overlay was demonstrably injected -> excluded.
+            _boot(1, "overlays_off", clean, perturbers=_INJECTED_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_INJECTED_PERTURBERS),
+        ]
+        result = screen(self._screen_plan(), boots)
+        assert result["verdict"] == SCREEN_INSUFFICIENT
+        excluded = {item["boot"] for item in result["excluded_boots"]}
+        assert 1 in excluded
+        # Non-vacuous: with boot 1's treatment honoured this would have promoted instead.
+        fixed = list(boots)
+        fixed[0] = _boot(1, "overlays_off", clean, perturbers=_ABSENT_PERTURBERS)
+        from tools.ac_harness.init_perturber_ab import SCREEN_LARGE_EFFECT_PLAUSIBLE
+
+        assert screen(self._screen_plan(), fixed)["verdict"] == SCREEN_LARGE_EFFECT_PLAUSIBLE
+
+    def test_render_states_plainly_that_no_p_value_is_claimed(self):
+        from tools.ac_harness.init_perturber_ab import render_screen_markdown, screen
+
+        boots = [
+            _boot(1, "overlays_off", _stable_then_freeze(12), perturbers=_ABSENT_PERTURBERS),
+            _boot(2, "overlays_on", _stable_then_freeze(8), perturbers=_INJECTED_PERTURBERS),
+            _boot(3, "overlays_off", _stable_then_freeze(13), perturbers=_ABSENT_PERTURBERS),
+            _boot(4, "overlays_on", _stable_then_freeze(9), perturbers=_INJECTED_PERTURBERS),
+        ]
+        rendered = render_screen_markdown(screen(self._screen_plan(), boots))
+        assert "NOT run" in rendered
+        assert "0.5" in rendered
+        # The operator must be told what a null screen does NOT establish.
+        assert "MODEST effect is NOT ruled out" in rendered

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -179,6 +179,39 @@ BASELINE_POST_ONSET_BURST_RATE = 0.44
 #: baseline-onset boot contributes no secondary observation at all.
 MIN_LAUNCHES_PER_BOOT = BASELINE_ONSET_INDEX_GRACEFUL + POST_ONSET_WINDOW
 DEFAULT_LAUNCHES_PER_BOOT = 24
+
+#: ---------------------------------------------------------------------------------------
+#: Screening stage (#724)
+#: ---------------------------------------------------------------------------------------
+#: The confirmatory design costs 16 physical reboots because it is powered to separate a MODEST
+#: shift (graceful onset ~14 vs ~8). That is the wrong target for the decision at hand: #627's
+#: resilient launcher already retries past the freeze, so "disable the overlays permanently" is
+#: only worth adopting if it roughly ELIMINATES the freeze — a large effect, detectable with ~4
+#: boots. #625 sat unrun for over a week because the cheapest question the tool could ask cost
+#: 16 reboots; the screen exists so the spike can be answered, or closed, at that price instead.
+SCREEN_PLAN_SCHEMA = "init-perturber-ab-screen-plan/v1"
+SCREEN_SCHEMA = "init-perturber-ab-screen/v1"
+#: 2 blocks is enough to SEE a large effect and is honestly labelled descriptive — the smallest
+#: attainable two-sided p at 2 blocks is 2/2**2 = 0.5, so the screen never runs the permutation
+#: test and never reports significance.
+SCREEN_BOOTS_PER_ARM = 2
+SCREEN_NO_LARGE_EFFECT = "no_large_effect"
+SCREEN_LARGE_EFFECT_PLAUSIBLE = "large_effect_plausible"
+SCREEN_AMBIGUOUS = "ambiguous"
+SCREEN_INSUFFICIENT = "insufficient_usable_boots"
+#: Pre-registered screening rule, persisted into the plan so the verdict cannot be chosen after
+#: the boots are in. Mirrors :data:`CANONICAL_TREATMENT_RECEIPT`'s exact-match discipline.
+CANONICAL_SCREEN_RULE: dict[str, object] = {
+    "enabled": True,
+    "boots_per_arm": SCREEN_BOOTS_PER_ARM,
+    "no_large_effect_when": "any overlays_off boot froze at or before the graceful baseline onset",
+    "large_effect_plausible_when": (
+        "every overlays_off boot censored and at least one overlays_on boot froze"
+    ),
+    "baseline_onset_graceful": BASELINE_ONSET_INDEX_GRACEFUL,
+    "claims_p_value": False,
+    "promotes_to_confirmatory": True,
+}
 #: Above this share of **undelivered** launches the boot measured Content Manager's delivery
 #: failures, not the accumulator; it is reported and excluded rather than silently scored.
 #: Scoped to undelivered attempts since #710: a ``never_live`` that DID start acs.exe consumed a
@@ -535,6 +568,7 @@ def build_plan(
     generated_at_utc: str | None = None,
     run_nonce: str | None = None,
     allow_undersized: bool = False,
+    screen: bool = False,
 ) -> dict[str, Any]:
     """Build a boot-scoped experiment plan; settings remain operator-owned.
 
@@ -578,7 +612,14 @@ def build_plan(
         )
     if boots_per_arm <= 0 or launches_per_boot <= 0:
         raise ValueError("boots_per_arm and launches_per_boot must be > 0")
-    if boots_per_arm < MIN_BOOTS_PER_ARM and not allow_undersized:
+    if screen and boots_per_arm != SCREEN_BOOTS_PER_ARM:
+        # The screen's decision rule is written for exactly this size. Letting the count drift
+        # would silently change what `no_large_effect` means without changing its name.
+        raise ValueError(
+            f"a screening plan must use boots_per_arm={SCREEN_BOOTS_PER_ARM} "
+            f"(got {boots_per_arm}); the confirmatory design is the mode that scales"
+        )
+    if not screen and boots_per_arm < MIN_BOOTS_PER_ARM and not allow_undersized:
         raise ValueError(
             f"boots_per_arm must be >= {MIN_BOOTS_PER_ARM} "
             f"(the design-based test draws from 2**blocks orders, so its smallest attainable "
@@ -641,7 +682,7 @@ def build_plan(
         for index, condition in enumerate(sequence, start=1)
     ]
     return {
-        "schema": PLAN_SCHEMA,
+        "schema": SCREEN_PLAN_SCHEMA if screen else PLAN_SCHEMA,
         # Every schema this plan supersedes, oldest first — rejected by `load_plan`, so the
         # migration path is recorded rather than implied (#710 self-hosted reviewer MEDIUM).
         "supersedes": [
@@ -664,6 +705,9 @@ def build_plan(
         # signed up for (Codex P2 on #721). ``exclude_on`` is only ``contradicted``: ``unverified``
         # falls back to the planned label because no information must not manufacture missingness.
         "treatment_receipt": dict(CANONICAL_TREATMENT_RECEIPT),
+        # Present ONLY on a screening plan, so `analyze` and `screen` can each refuse the other's
+        # artifact by shape as well as by schema string (#724).
+        **({"screen_rule": dict(CANONICAL_SCREEN_RULE)} if screen else {}),
         "launch": {
             "car": car,
             "track": track,
@@ -753,7 +797,7 @@ def _require_mapping(value: object, *, where: str) -> dict[str, Any]:
     return value
 
 
-def load_plan(path: Path) -> dict[str, Any]:
+def load_plan(path: Path, *, expect_screen: bool = False) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -782,8 +826,43 @@ def load_plan(path: Path) -> dict[str, Any]:
             f"{PLAN_SCHEMA!r} before analyze; reusing a v3 plan would apply a receipt rule the "
             "operator never pre-registered"
         )
-    if schema != PLAN_SCHEMA:
-        raise ValueError(f"plan schema must be {PLAN_SCHEMA!r}")
+    # Cross-mode refusal (#724). A screening plan carries 2 blocks and a descriptive decision
+    # rule; the confirmatory analysis would run the block permutation test on it and report a
+    # p-value floored at 2/2**2 = 0.5, and the screen would misread a 16-boot confirmatory run
+    # as its own 4-boot rule. Neither artifact may be scored by the other's command.
+    expected = SCREEN_PLAN_SCHEMA if expect_screen else PLAN_SCHEMA
+    if expect_screen and schema == PLAN_SCHEMA:
+        raise ValueError(
+            f"plan {path} is a CONFIRMATORY plan ({PLAN_SCHEMA!r}); run `analyze`, not `screen` "
+            "— the screening rule is written for exactly "
+            f"{SCREEN_BOOTS_PER_ARM} boots per arm and would misread this run"
+        )
+    if not expect_screen and schema == SCREEN_PLAN_SCHEMA:
+        raise ValueError(
+            f"plan {path} is a SCREENING plan ({SCREEN_PLAN_SCHEMA!r}); run `screen`, not "
+            "`analyze` — the confirmatory test would report a p-value whose floor at "
+            f"{SCREEN_BOOTS_PER_ARM} blocks is {2 / 2**SCREEN_BOOTS_PER_ARM:g}, which can never "
+            "reach alpha and must not be presented as a result"
+        )
+    if schema != expected:
+        raise ValueError(f"plan schema must be {expected!r}")
+    if expect_screen:
+        rule = plan.get("screen_rule")
+        if not isinstance(rule, dict) or set(rule) != set(CANONICAL_SCREEN_RULE):
+            raise ValueError(
+                f"screening plan {path} must pre-register the canonical screen_rule key set; "
+                "regenerate the plan"
+            )
+        for key, value in CANONICAL_SCREEN_RULE.items():
+            if rule.get(key) != value:
+                raise ValueError(
+                    f"screening plan screen_rule.{key}={rule.get(key)!r} does not match the "
+                    f"canonical rule {value!r}; regenerate the plan"
+                )
+    elif "screen_rule" in plan:
+        raise ValueError(
+            f"confirmatory plan {path} carries a screen_rule block; regenerate the plan"
+        )
     receipt = plan.get("treatment_receipt")
     if not isinstance(receipt, dict) or receipt.get("enabled") is not True:
         raise ValueError(
@@ -1860,6 +1939,149 @@ def _format_optional(value: float | None, spec: str) -> str:
     return "n/a" if value is None else format(value, spec)
 
 
+def screen(
+    plan: dict[str, Any],
+    observations: Sequence[BootObservation],
+) -> dict[str, Any]:
+    """Score the 4-boot screening stage against its pre-registered rule (#724).
+
+    Deliberately NOT the confirmatory test. It reuses :func:`summarize_boot` — the same onset,
+    the same delivered-cycle counting, the same #719 treatment-receipt exclusion — and then
+    applies a rule that can only ever answer "is there a LARGE effect here?". It never runs the
+    block permutation test and never emits a p-value: with 2 blocks the smallest attainable
+    two-sided p is 0.5, so any number printed here would be false precision.
+
+    What the verdicts mean:
+
+    * ``no_large_effect`` — an ``overlays_off`` boot still froze on a normal budget. Disabling
+      the overlays is therefore not the mitigation #625 was looking for. This does **not** say
+      "no effect": a modest real shift survives this screen unrefuted, and that is accepted,
+      because a modest shift does not justify adopting the mitigation over the existing retry.
+    * ``large_effect_plausible`` — a promotion signal, not a result. Worth the confirmatory run.
+    * ``ambiguous`` / ``insufficient_usable_boots`` — honest outcomes, not failures.
+    """
+
+    summaries = [summarize_boot(observation) for observation in observations]
+    usable = [item for item in summaries if item.usable and not item.onset_ambiguous]
+    excluded = [
+        {
+            "boot": item.boot,
+            "condition": item.condition,
+            "reason": item.unusable_reason or ("onset_ambiguous" if item.onset_ambiguous else None),
+            "treatment": item.treatment,
+            "treatment_detail": item.treatment_detail,
+        }
+        for item in summaries
+        if item not in usable
+    ]
+    off = [item for item in usable if item.condition == "overlays_off"]
+    on = [item for item in usable if item.condition == "overlays_on"]
+
+    if len(off) < SCREEN_BOOTS_PER_ARM or len(on) < SCREEN_BOOTS_PER_ARM:
+        verdict = SCREEN_INSUFFICIENT
+        rationale = (
+            f"the screen needs {SCREEN_BOOTS_PER_ARM} usable boots per arm; got "
+            f"{len(on)} overlays_on and {len(off)} overlays_off. A boot excluded for a "
+            "contradicted treatment (#719) or an ambiguous onset cannot be replaced by "
+            "re-scoring — it needs another reboot"
+        )
+    elif any(
+        not item.onset_censored
+        and item.onset_cycle is not None
+        and item.onset_cycle <= BASELINE_ONSET_INDEX_GRACEFUL
+        for item in off
+    ):
+        verdict = SCREEN_NO_LARGE_EFFECT
+        rationale = (
+            "at least one overlays_off boot froze at or before the pre-registered graceful "
+            f"baseline onset ({BASELINE_ONSET_INDEX_GRACEFUL} delivered cycles), so disabling "
+            "the overlays does not eliminate the freeze. #627's launcher retry already covers "
+            "the residual, so this is not a mitigation worth adopting"
+        )
+    elif all(item.onset_censored for item in off) and any(not item.onset_censored for item in on):
+        verdict = SCREEN_LARGE_EFFECT_PLAUSIBLE
+        rationale = (
+            "every overlays_off boot ran its full delivered budget without freezing while at "
+            "least one overlays_on boot froze. Suggestive, NOT conclusive — promote to the "
+            "confirmatory 16-boot design for a design-based p-value"
+        )
+    else:
+        verdict = SCREEN_AMBIGUOUS
+        rationale = (
+            "the boots neither refute a large effect nor show the clean separation that would "
+            "justify the confirmatory run; the operator decides whether to spend it"
+        )
+
+    return {
+        "schema": SCREEN_SCHEMA,
+        "issue": 625,
+        "stage": "screen",
+        "verdict": verdict,
+        "rationale": rationale,
+        "claims_p_value": False,
+        "not_a_significance_test": (
+            f"the block permutation test is NOT run here: at {SCREEN_BOOTS_PER_ARM} blocks its "
+            f"smallest attainable two-sided p is {2 / 2**SCREEN_BOOTS_PER_ARM:g}"
+        ),
+        "screen_rule": dict(CANONICAL_SCREEN_RULE),
+        "boots": [
+            {
+                "boot": item.boot,
+                "condition": item.condition,
+                "onset_cycle": item.onset_cycle,
+                "onset_censored": item.onset_censored,
+                "delivered_cycles": item.delivered_cycles,
+                "treatment": item.treatment,
+            }
+            for item in summaries
+        ],
+        "excluded_boots": excluded,
+        "run_id": plan.get("run_id"),
+    }
+
+
+def render_screen_markdown(result: dict[str, Any]) -> str:
+    """Operator-facing screen result — states plainly what it does and does not claim."""
+
+    lines = [
+        "# #625 init-perturber screen (stage 1 of 2)",
+        "",
+        f"**Verdict:** `{result['verdict']}`",
+        "",
+        result["rationale"],
+        "",
+        f"> {result['not_a_significance_test']}.",
+        "",
+        "| boot | arm | onset (delivered cycles) | censored | treatment |",
+        "|---|---|---|---|---|",
+    ]
+    for boot in result["boots"]:
+        onset = "—" if boot["onset_cycle"] is None else boot["onset_cycle"]
+        lines.append(
+            f"| {boot['boot']} | {boot['condition']} | {onset} | "
+            f"{'yes' if boot['onset_censored'] else 'no'} | {boot['treatment']} |"
+        )
+    if result["excluded_boots"]:
+        lines += ["", "**Excluded boots**", ""]
+        for item in result["excluded_boots"]:
+            lines.append(
+                f"- boot {item['boot']} ({item['condition']}): {item['reason']}"
+                + (f" — {item['treatment_detail']}" if item.get("treatment_detail") else "")
+            )
+    lines += [
+        "",
+        "## What happens next",
+        "",
+        f"- `{SCREEN_NO_LARGE_EFFECT}` → close #625: the overlays are not a mitigation worth "
+        "adopting over the existing launcher retry. A MODEST effect is NOT ruled out — this "
+        "stage cannot see one, by design.",
+        f"- `{SCREEN_LARGE_EFFECT_PLAUSIBLE}` → run the confirmatory 16-boot design "
+        "(`plan` without `--screen`).",
+        f"- `{SCREEN_AMBIGUOUS}` / `{SCREEN_INSUFFICIENT}` → operator decides.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def render_markdown(analysis: dict[str, Any]) -> str:
     arms = analysis["arms"]
     boots = analysis.get("boots") or []
@@ -2138,6 +2360,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             "reproduce a known plan."
         ),
     )
+    plan_parser.add_argument(
+        "--screen",
+        action="store_true",
+        help=(
+            f"screening stage (#724): {SCREEN_BOOTS_PER_ARM} boots per arm = "
+            f"{SCREEN_BOOTS_PER_ARM * 2} reboots instead of 16, scored by a pre-registered "
+            "LARGE-effect rule instead of the permutation test. Answers 'is disabling the "
+            "overlays a mitigation worth adopting?' — the only outcome that changes what we do, "
+            "since the launcher already retries past the freeze. Score it with `screen`, never "
+            "`analyze`"
+        ),
+    )
     plan_parser.add_argument("--car", default=DEFAULT_CAR)
     plan_parser.add_argument("--track", default=DEFAULT_TRACK)
     plan_parser.add_argument("--layout", default=None)
@@ -2147,11 +2381,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     analyze_parser.add_argument("--plan", required=True, type=Path)
     analyze_parser.add_argument("--reports-dir", required=True, type=Path)
     analyze_parser.add_argument("--json", type=Path, default=None, dest="json_path")
+    screen_parser = subparsers.add_parser(
+        "screen",
+        help="score the 4-boot screening stage (#724) — descriptive, never a p-value",
+    )
+    screen_parser.add_argument("--plan", required=True, type=Path)
+    screen_parser.add_argument("--reports-dir", required=True, type=Path)
+    screen_parser.add_argument("--json", type=Path, default=None, dest="json_path")
     args = parser.parse_args(argv)
     try:
         if args.command == "plan":
             plan = build_plan(
-                args.boots_per_arm,
+                SCREEN_BOOTS_PER_ARM if args.screen else args.boots_per_arm,
+                screen=args.screen,
                 launches_per_boot=args.launches_per_boot,
                 randomization_seed=args.seed,
                 car=args.car,
@@ -2198,22 +2440,46 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "it. REBOOT AGAIN before re-running that boot — a plain retry restarts launch "
                 "numbering at 1 and silently offsets the onset index."
             )
-            print(
-                f"Endpoint floor is {MIN_BOOTS_PER_ARM} usable blocks "
-                f"(scheduled {args.boots_per_arm}/arm = {2 * args.boots_per_arm} boots and "
-                f"reboots, {args.launches_per_boot} launches each). The randomization draws "
-                f"1 of {2**args.boots_per_arm} arm orders, so the smallest two-sided p this "
-                f"run can attain is {2 / 2**args.boots_per_arm:.4g}. Pre-registered graceful "
-                f"onset ~{BASELINE_ONSET_INDEX_GRACEFUL}, post-onset burst "
-                f"~{BASELINE_POST_ONSET_BURST_RATE:.0%}."
-            )
-            print(
-                "POWER NOTE: only blocks whose two arms differ carry information — a block "
-                "where both onsets tie contributes nothing to the test. Every tie effectively "
-                f"costs one block, so a run scheduled at exactly {MIN_BOOTS_PER_ARM}/arm "
-                "reports insufficient_sample as soon as one block ties. Schedule headroom "
-                f"(the default is {DEFAULT_BOOTS_PER_ARM}/arm) rather than re-running."
-            )
+            if args.screen:
+                # A screening plan must never carry the confirmatory power note: quoting a
+                # p-value floor on a run that will not compute one is the exact false-precision
+                # this stage exists to avoid.
+                print(
+                    f"SCREENING STAGE ({SCREEN_BOOTS_PER_ARM}/arm = "
+                    f"{2 * SCREEN_BOOTS_PER_ARM} boots and reboots, "
+                    f"{args.launches_per_boot} launches each). This stage answers ONE question: "
+                    "does disabling the overlays roughly ELIMINATE the freeze? That is the only "
+                    "outcome that changes what we do, because #627's launcher already retries "
+                    "past it."
+                )
+                print(
+                    "NO P-VALUE IS COMPUTED. The block permutation test is not run at "
+                    f"{SCREEN_BOOTS_PER_ARM} blocks (its floor is "
+                    f"{2 / 2**SCREEN_BOOTS_PER_ARM:g}). Score with `screen`, never `analyze` — "
+                    "the tool refuses the wrong one."
+                )
+                print(
+                    f"Verdicts: `{SCREEN_NO_LARGE_EFFECT}` -> close #625 (a MODEST effect is "
+                    f"NOT ruled out); `{SCREEN_LARGE_EFFECT_PLAUSIBLE}` -> run the confirmatory "
+                    f"16-boot design; `{SCREEN_AMBIGUOUS}` -> operator decides."
+                )
+            else:
+                print(
+                    f"Endpoint floor is {MIN_BOOTS_PER_ARM} usable blocks "
+                    f"(scheduled {args.boots_per_arm}/arm = {2 * args.boots_per_arm} boots and "
+                    f"reboots, {args.launches_per_boot} launches each). The randomization draws "
+                    f"1 of {2**args.boots_per_arm} arm orders, so the smallest two-sided p this "
+                    f"run can attain is {2 / 2**args.boots_per_arm:.4g}. Pre-registered graceful "
+                    f"onset ~{BASELINE_ONSET_INDEX_GRACEFUL}, post-onset burst "
+                    f"~{BASELINE_POST_ONSET_BURST_RATE:.0%}."
+                )
+                print(
+                    "POWER NOTE: only blocks whose two arms differ carry information — a block "
+                    "where both onsets tie contributes nothing to the test. Every tie effectively "
+                    f"costs one block, so a run scheduled at exactly {MIN_BOOTS_PER_ARM}/arm "
+                    "reports insufficient_sample as soon as one block ties. Schedule headroom "
+                    f"(the default is {DEFAULT_BOOTS_PER_ARM}/arm) rather than re-running."
+                )
             print(
                 "Paste each command on the Windows rig from that checkout's root "
                 "(cd to the rig's ac-copilot-trainer clone first; report paths are "
@@ -2226,6 +2492,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "— apply settings, REBOOT, then:"
                 )
                 print(command)
+            return 0
+        if args.command == "screen":
+            plan = load_plan(args.plan, expect_screen=True)
+            observations = load_observations(plan, args.reports_dir)
+            result = screen(plan, observations)
+            if args.json_path is not None:
+                destination = _output_path(args.json_path)
+                _write_new_json(destination, result)
+                print(f"screen -> {destination}")
+            print(render_screen_markdown(result))
             return 0
         plan = load_plan(args.plan)
         observations = load_observations(plan, args.reports_dir)

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -719,11 +719,29 @@ def build_plan(
         "boots_per_arm": boots_per_arm,
         "blocks": boots_per_arm,
         "launches_per_boot": launches_per_boot,
-        "minimum_boots_per_arm": MIN_BOOTS_PER_ARM,
+        # Confirmatory-only metadata. On a SCREENING plan these describe a test that `screen()`
+        # explicitly never runs, so emitting them verbatim would leave the artifact carrying two
+        # contradictory accounts of how its four boots will be scored — and the plan JSON IS the
+        # pre-registration (#724 review, Codex P2).
+        "minimum_boots_per_arm": SCREEN_BOOTS_PER_ARM if screen else MIN_BOOTS_PER_ARM,
         "randomization_seed": randomization_seed,
         "run_id": run_id,
-        "randomization_reference_set": 2**boots_per_arm,
-        "smallest_attainable_two_sided_p": 2 / 2**boots_per_arm,
+        **(
+            {
+                "randomization_reference_set": None,
+                "smallest_attainable_two_sided_p": None,
+                "no_significance_test": (
+                    "the screening stage runs no permutation test; at "
+                    f"{SCREEN_BOOTS_PER_ARM} blocks its floor would be "
+                    f"{2 / 2**SCREEN_BOOTS_PER_ARM:g}, which can never reach alpha"
+                ),
+            }
+            if screen
+            else {
+                "randomization_reference_set": 2**boots_per_arm,
+                "smallest_attainable_two_sided_p": 2 / 2**boots_per_arm,
+            }
+        ),
         # Pre-registered with the plan so analyze cannot invent a receipt rule the operator never
         # signed up for (Codex P2 on #721). ``exclude_on`` is only ``contradicted``: ``unverified``
         # falls back to the planned label because no information must not manufacture missingness.
@@ -775,23 +793,37 @@ def build_plan(
                 "not the accumulator, and is unusable"
             ),
         },
-        "endpoints": {
-            "primary": (
-                "onset DELIVERED-CYCLE index (first freeze in the boot, counted in launch cycles "
-                "that actually reached AC), right-censored at the boot's delivered-cycle count; "
-                "exact block permutation test over the 2**blocks randomization reference set. A "
-                "censoring surrogate enters the statistic only when its bound establishes the "
-                "sign of the block's difference (#710)"
-            ),
-            "secondary": (
-                f"post-onset burst rate over a fixed {POST_ONSET_WINDOW}-DELIVERED-CYCLE window "
-                "from onset, one rate per boot, same block permutation test"
-            ),
-            "sensitivity": (
-                "exact sign test over blocks; plus an assumption-dependent rank-sum "
-                "permutation test on onset, reported for information and never gating"
-            ),
-        },
+        "endpoints": (
+            {
+                # The screen's ONLY endpoint. Stating the confirmatory permutation endpoints here
+                # would pre-register tests this artifact's own `screen_rule` says are never run.
+                "primary": (
+                    "onset DELIVERED-CYCLE index, right-censored at the boot's delivered-cycle "
+                    "count — evaluated against the pre-registered screen_rule, NOT by any "
+                    "significance test. See screen_rule.large_effect_plausible_when"
+                ),
+                "secondary": None,
+                "sensitivity": None,
+            }
+            if screen
+            else {
+                "primary": (
+                    "onset DELIVERED-CYCLE index (first freeze in the boot, counted in launch "
+                    "cycles that actually reached AC), right-censored at the boot's "
+                    "delivered-cycle count; exact block permutation test over the 2**blocks "
+                    "randomization reference set. A censoring surrogate enters the statistic "
+                    "only when its bound establishes the sign of the block's difference (#710)"
+                ),
+                "secondary": (
+                    f"post-onset burst rate over a fixed {POST_ONSET_WINDOW}-DELIVERED-CYCLE "
+                    "window from onset, one rate per boot, same block permutation test"
+                ),
+                "sensitivity": (
+                    "exact sign test over blocks; plus an assumption-dependent rank-sum "
+                    "permutation test on onset, reported for information and never gating"
+                ),
+            }
+        ),
         "prereg_baselines": {
             "onset_index_graceful": BASELINE_ONSET_INDEX_GRACEFUL,
             "onset_index_hard_kill": BASELINE_ONSET_INDEX_HARD_KILL,
@@ -2022,13 +2054,16 @@ def screen(
         verdict = SCREEN_INSUFFICIENT
         rationale = (
             f"the screen needs {SCREEN_BOOTS_PER_ARM} usable boots per arm; got "
-            f"{len(on)} overlays_on and {len(off)} overlays_off. Recovery is NOT 'reboot and "
-            "re-run that one boot': its planned report name is already taken (reports are "
-            "published exclusively), AND load_observations requires boots to have run in "
-            "planned order — so a replacement for an EARLY boot would carry a timestamp later "
-            "than the boots that followed it and the whole experiment would be refused. "
-            "Regenerate the screening plan (it draws a new nonce, hence fresh report names) and "
-            "run the four boots again in order; keep the old reports as evidence"
+            f"{len(on)} overlays_on and {len(off)} overlays_off. Recovery depends on WHY the "
+            "boot is unusable. An arm-contradicted boot published to a salvage name and left "
+            "its planned path free, so if it is the LAST boot that ran you may reboot and "
+            "re-run it in place — a successful report at the planned name supersedes the "
+            "salvage. Otherwise (the planned path holds a successful report, or later boots "
+            "have already run) re-running is not possible: reports publish exclusively and "
+            "load_observations enforces planned order, so a replacement for an earlier boot "
+            "would invert the timestamps and void the run. Then regenerate the screening plan "
+            "(it draws a new nonce, hence fresh report names) and run the four boots again in "
+            "order; keep the old reports as evidence"
         )
     elif unverified:
         # A boot whose receipt is UNVERIFIED is still `usable` by `summarize_boot` — the

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -199,6 +199,9 @@ SCREEN_NO_LARGE_EFFECT = "no_large_effect"
 SCREEN_LARGE_EFFECT_PLAUSIBLE = "large_effect_plausible"
 SCREEN_AMBIGUOUS = "ambiguous"
 SCREEN_INSUFFICIENT = "insufficient_usable_boots"
+#: No causal statement is available because a scored boot's treatment was never measured. Named
+#: to match the confirmatory path's conclusion for the same condition.
+SCREEN_RECEIPT_UNVERIFIED = "treatment_receipt_unverified"
 #: Pre-registered screening rule, persisted into the plan so the verdict cannot be chosen after
 #: the boots are in. Mirrors :data:`CANONICAL_TREATMENT_RECEIPT`'s exact-match discipline.
 CANONICAL_SCREEN_RULE: dict[str, object] = {
@@ -670,6 +673,11 @@ def build_plan(
         stability_window=stability_window,
         go_live_timeout=go_live_timeout,
         run_nonce=run_nonce,
+        # The stage is a plan input like any other (#724 review, cursor MEDIUM). Without it a
+        # screening plan and an allow_undersized confirmatory plan sharing boots_per_arm=2, the
+        # same seed/launch config and a pinned stamp emit IDENTICAL boot-*.json names, so a
+        # shared reports-dir lets one stage silently score the other's boots.
+        schema=SCREEN_PLAN_SCHEMA if screen else PLAN_SCHEMA,
     )
     boots = [
         asdict(
@@ -685,11 +693,18 @@ def build_plan(
         "schema": SCREEN_PLAN_SCHEMA if screen else PLAN_SCHEMA,
         # Every schema this plan supersedes, oldest first — rejected by `load_plan`, so the
         # migration path is recorded rather than implied (#710 self-hosted reviewer MEDIUM).
-        "supersedes": [
-            WITHDRAWN_PLAN_SCHEMA,
-            SUPERSEDED_PLAN_SCHEMA,
-            PRE_TREATMENT_PLAN_SCHEMA,
-        ],
+        # A SCREENING plan supersedes nothing: it is a new first stage, not a successor to the
+        # confirmatory lineage, and claiming otherwise would assert a migration path that does
+        # not exist (#724 review, antigravity MEDIUM).
+        "supersedes": (
+            []
+            if screen
+            else [
+                WITHDRAWN_PLAN_SCHEMA,
+                SUPERSEDED_PLAN_SCHEMA,
+                PRE_TREATMENT_PLAN_SCHEMA,
+            ]
+        ),
         "issue": 625,
         "generated_at_utc": stamp,
         "design": "randomized block; one boot per unit, two boots (one per arm) per block",
@@ -859,6 +874,23 @@ def load_plan(path: Path, *, expect_screen: bool = False) -> dict[str, Any]:
                     f"screening plan screen_rule.{key}={rule.get(key)!r} does not match the "
                     f"canonical rule {value!r}; regenerate the plan"
                 )
+        # The rule matching is not enough on its own: a hand-edited artifact can keep the
+        # canonical screen_rule (which says boots_per_arm 2) while raising the plan's OWN
+        # boots_per_arm and boot list. `screen` only requires >= 2 usable boots per arm and then
+        # applies any/all across every usable boot, so the scored N would drift while the output
+        # still claimed the canonical 4-boot screen (#724 review, Codex P2 + cursor MEDIUM).
+        if plan.get("boots_per_arm") != SCREEN_BOOTS_PER_ARM:
+            raise ValueError(
+                f"screening plan boots_per_arm={plan.get('boots_per_arm')!r} must be "
+                f"{SCREEN_BOOTS_PER_ARM}; the pre-registered rule is written for exactly that "
+                "size, so a larger plan would be scored under a rule it never registered"
+            )
+        boots = plan.get("boots")
+        if not isinstance(boots, list) or len(boots) != 2 * SCREEN_BOOTS_PER_ARM:
+            raise ValueError(
+                f"screening plan must list exactly {2 * SCREEN_BOOTS_PER_ARM} boots; "
+                f"got {len(boots) if isinstance(boots, list) else boots!r}"
+            )
     elif "screen_rule" in plan:
         raise ValueError(
             f"confirmatory plan {path} carries a screen_rule block; regenerate the plan"
@@ -1977,13 +2009,30 @@ def screen(
     off = [item for item in usable if item.condition == "overlays_off"]
     on = [item for item in usable if item.condition == "overlays_on"]
 
+    unverified = [item for item in usable if item.treatment == TREATMENT_UNVERIFIED]
     if len(off) < SCREEN_BOOTS_PER_ARM or len(on) < SCREEN_BOOTS_PER_ARM:
         verdict = SCREEN_INSUFFICIENT
         rationale = (
             f"the screen needs {SCREEN_BOOTS_PER_ARM} usable boots per arm; got "
-            f"{len(on)} overlays_on and {len(off)} overlays_off. A boot excluded for a "
-            "contradicted treatment (#719) or an ambiguous onset cannot be replaced by "
-            "re-scoring — it needs another reboot"
+            f"{len(on)} overlays_on and {len(off)} overlays_off. Re-running an excluded boot "
+            "is NOT just a reboot: its planned report name is already taken and "
+            "resilient_launch publishes reports exclusively, so move the existing report aside "
+            "(it is evidence — do not delete it) or regenerate the screening plan, which draws "
+            "a new nonce and therefore a fresh set of report names"
+        )
+    elif unverified:
+        # A boot whose receipt is UNVERIFIED is still `usable` by `summarize_boot` — the
+        # confirmatory path handles this by refusing a causal conclusion rather than by
+        # excluding it. The screen must do the same, or a run with no perturber evidence at all
+        # could return `no_large_effect` and instruct the operator to CLOSE #625 with nothing
+        # showing the overlays were ever off (#724 review, Codex P1).
+        verdict = SCREEN_RECEIPT_UNVERIFIED
+        names = ", ".join(f"boot {item.boot} ({item.condition})" for item in unverified)
+        rationale = (
+            f"treatment receipt is unverified for {names}, so no causal statement about the "
+            "overlays is available from this screen. Re-run those boots with perturber "
+            "sampling working (64-bit Python on the rig; go_live_timeout above the injection "
+            "race) — a verdict here would rest on an unmeasured treatment"
         )
     elif any(
         not item.onset_censored
@@ -1998,12 +2047,26 @@ def screen(
             "the overlays does not eliminate the freeze. #627's launcher retry already covers "
             "the residual, so this is not a mitigation worth adopting"
         )
-    elif all(item.onset_censored for item in off) and any(not item.onset_censored for item in on):
+    elif (
+        all(item.onset_censored for item in off)
+        and any(not item.onset_censored for item in on)
+        # Censoring alone does NOT establish separation: an off boot censored after only 20
+        # delivered cycles (four attempts never reached AC) is known only to exceed 20, which
+        # says nothing about an on boot that froze at 24. Every off boot must have out-run the
+        # LATEST on-arm onset for the arms to be genuinely separated (#724 review, Codex P2).
+        and min(item.delivered_cycles for item in off)
+        > max(
+            item.onset_cycle
+            for item in on
+            if not item.onset_censored and item.onset_cycle is not None
+        )
+    ):
         verdict = SCREEN_LARGE_EFFECT_PLAUSIBLE
         rationale = (
-            "every overlays_off boot ran its full delivered budget without freezing while at "
-            "least one overlays_on boot froze. Suggestive, NOT conclusive — promote to the "
-            "confirmatory 16-boot design for a design-based p-value"
+            "every overlays_off boot ran its full delivered budget without freezing, and that "
+            "budget out-runs the latest overlays_on onset, so the arms are genuinely separated "
+            "under censoring. Suggestive, NOT conclusive — promote to the confirmatory 16-boot "
+            "design for a design-based p-value"
         )
     else:
         verdict = SCREEN_AMBIGUOUS
@@ -2077,6 +2140,8 @@ def render_screen_markdown(result: dict[str, Any]) -> str:
         "stage cannot see one, by design.",
         f"- `{SCREEN_LARGE_EFFECT_PLAUSIBLE}` → run the confirmatory 16-boot design "
         "(`plan` without `--screen`).",
+        f"- `{SCREEN_RECEIPT_UNVERIFIED}` → the treatment was never measured on at least one "
+        "scored boot; re-run those boots rather than reading anything into the onsets.",
         f"- `{SCREEN_AMBIGUOUS}` / `{SCREEN_INSUFFICIENT}` → operator decides.",
     ]
     return "\n".join(lines) + "\n"
@@ -2339,9 +2404,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     plan_parser.add_argument(
         "--boots-per-arm",
         type=int,
-        default=DEFAULT_BOOTS_PER_ARM,
+        # Sentinel rather than DEFAULT_BOOTS_PER_ARM so `--screen` can supply its own default
+        # WITHOUT silently discarding an explicit operator value: `plan --boots-per-arm 16
+        # --screen` must be rejected by build_plan, not quietly turned into a 2-boot plan
+        # (#724 review, antigravity MEDIUM).
+        default=None,
         help=(
-            f"boots per arm (= blocks); minimum {MIN_BOOTS_PER_ARM}, maximum {MAX_BOOTS_PER_ARM}"
+            f"boots per arm (= blocks); minimum {MIN_BOOTS_PER_ARM}, maximum "
+            f"{MAX_BOOTS_PER_ARM} (default {DEFAULT_BOOTS_PER_ARM}). With --screen the only "
+            f"accepted value is {SCREEN_BOOTS_PER_ARM}"
         ),
     )
     plan_parser.add_argument(
@@ -2391,8 +2462,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         if args.command == "plan":
+            # Resolve the DEFAULT per stage; an explicit value is passed straight through so the
+            # domain layer rejects it rather than the CLI silently overriding it.
+            if args.boots_per_arm is None:
+                boots_per_arm = SCREEN_BOOTS_PER_ARM if args.screen else DEFAULT_BOOTS_PER_ARM
+            else:
+                boots_per_arm = args.boots_per_arm
+            args.boots_per_arm = boots_per_arm
             plan = build_plan(
-                SCREEN_BOOTS_PER_ARM if args.screen else args.boots_per_arm,
+                boots_per_arm,
                 screen=args.screen,
                 launches_per_boot=args.launches_per_boot,
                 randomization_seed=args.seed,

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -208,10 +208,18 @@ CANONICAL_SCREEN_RULE: dict[str, object] = {
     "enabled": True,
     "boots_per_arm": SCREEN_BOOTS_PER_ARM,
     "no_large_effect_when": "any overlays_off boot froze at or before the graceful baseline onset",
+    # The persisted rule IS the pre-registration, so it must state the predicate the code
+    # actually applies — all three clauses, not just the first. An artifact that promised
+    # promotion on censoring alone while `screen()` also demanded a horizon and a censoring-aware
+    # separation would mis-describe its own experiment (#724 review, Codex P2).
     "large_effect_plausible_when": (
-        "every overlays_off boot censored and at least one overlays_on boot froze"
+        "every overlays_off boot censored AND at least one overlays_on boot froze AND every "
+        "overlays_off boot delivered at least baseline_onset_graceful cycles AND the smallest "
+        "overlays_off censoring surrogate (delivered_cycles + 1) exceeds the latest overlays_on "
+        "onset"
     ),
     "baseline_onset_graceful": BASELINE_ONSET_INDEX_GRACEFUL,
+    "min_delivered_cycles_for_elimination": BASELINE_ONSET_INDEX_GRACEFUL,
     "claims_p_value": False,
     "promotes_to_confirmatory": True,
 }
@@ -2014,11 +2022,13 @@ def screen(
         verdict = SCREEN_INSUFFICIENT
         rationale = (
             f"the screen needs {SCREEN_BOOTS_PER_ARM} usable boots per arm; got "
-            f"{len(on)} overlays_on and {len(off)} overlays_off. Re-running an excluded boot "
-            "is NOT just a reboot: its planned report name is already taken and "
-            "resilient_launch publishes reports exclusively, so move the existing report aside "
-            "(it is evidence — do not delete it) or regenerate the screening plan, which draws "
-            "a new nonce and therefore a fresh set of report names"
+            f"{len(on)} overlays_on and {len(off)} overlays_off. Recovery is NOT 'reboot and "
+            "re-run that one boot': its planned report name is already taken (reports are "
+            "published exclusively), AND load_observations requires boots to have run in "
+            "planned order — so a replacement for an EARLY boot would carry a timestamp later "
+            "than the boots that followed it and the whole experiment would be refused. "
+            "Regenerate the screening plan (it draws a new nonce, hence fresh report names) and "
+            "run the four boots again in order; keep the old reports as evidence"
         )
     elif unverified:
         # A boot whose receipt is UNVERIFIED is still `usable` by `summarize_boot` — the
@@ -2050,11 +2060,19 @@ def screen(
     elif (
         all(item.onset_censored for item in off)
         and any(not item.onset_censored for item in on)
-        # Censoring alone does NOT establish separation: an off boot censored after only 20
-        # delivered cycles (four attempts never reached AC) is known only to exceed 20, which
-        # says nothing about an on boot that froze at 24. Every off boot must have out-run the
-        # LATEST on-arm onset for the arms to be genuinely separated (#724 review, Codex P2).
-        and min(item.delivered_cycles for item in off)
+        # HORIZON. "Eliminates the freeze" is a claim about out-running the pre-registered
+        # baseline, so an off boot must actually reach it. Without this, a short boot (the
+        # public `allow_undersized` escape hatch, or a hand-edited launch budget) promotes a
+        # MODEST shift as elimination: off censored at 9 delivered cycles vs on freezing at 8
+        # satisfies any separation test while never approaching cycle 14 (#724 review, Codex P2).
+        and min(item.delivered_cycles for item in off) >= BASELINE_ONSET_INDEX_GRACEFUL
+        # SEPARATION, expressed in the module's own censoring surrogate. A censored boot's onset
+        # is strictly GREATER than its delivered count (`onset_value = delivered_cycles + 1`), so
+        # surviving N delivered cycles already beats an on-arm freeze AT cycle N. Comparing raw
+        # delivered counts with `>` was off by one against that semantics and refused to promote
+        # the cleanest possible result — off clean through the whole budget while on froze on the
+        # final cycle (#724 review, cursor MEDIUM).
+        and min(item.onset_value for item in off)
         > max(
             item.onset_cycle
             for item in on
@@ -2063,10 +2081,12 @@ def screen(
     ):
         verdict = SCREEN_LARGE_EFFECT_PLAUSIBLE
         rationale = (
-            "every overlays_off boot ran its full delivered budget without freezing, and that "
-            "budget out-runs the latest overlays_on onset, so the arms are genuinely separated "
-            "under censoring. Suggestive, NOT conclusive — promote to the confirmatory 16-boot "
-            "design for a design-based p-value"
+            "every overlays_off boot ran its full delivered budget without freezing, that "
+            f"budget reached the pre-registered baseline horizon "
+            f"({BASELINE_ONSET_INDEX_GRACEFUL} delivered cycles), and it out-runs the latest "
+            "overlays_on onset — so the arms are genuinely separated under censoring. "
+            "Suggestive, NOT conclusive — promote to the confirmatory 16-boot design for a "
+            "design-based p-value"
         )
     else:
         verdict = SCREEN_AMBIGUOUS

--- a/tools/ac_harness/init_perturber_ab.py
+++ b/tools/ac_harness/init_perturber_ab.py
@@ -2040,9 +2040,13 @@ def screen(
         names = ", ".join(f"boot {item.boot} ({item.condition})" for item in unverified)
         rationale = (
             f"treatment receipt is unverified for {names}, so no causal statement about the "
-            "overlays is available from this screen. Re-run those boots with perturber "
-            "sampling working (64-bit Python on the rig; go_live_timeout above the injection "
-            "race) — a verdict here would rest on an unmeasured treatment"
+            "overlays is available from this screen — a verdict here would rest on an "
+            "unmeasured treatment. Recovery is the SAME as for insufficient boots, and for the "
+            "same two reasons: the affected boots' reports already occupy their planned paths, "
+            "and load_observations enforces planned order, so re-running one boot in place "
+            "would invert the timestamps and void the whole experiment. Fix perturber sampling "
+            "first (64-bit Python on the rig; go_live_timeout above the injection race), then "
+            "regenerate the screening plan and run all four boots again in order"
         )
     elif any(
         not item.onset_censored
@@ -2161,7 +2165,9 @@ def render_screen_markdown(result: dict[str, Any]) -> str:
         f"- `{SCREEN_LARGE_EFFECT_PLAUSIBLE}` → run the confirmatory 16-boot design "
         "(`plan` without `--screen`).",
         f"- `{SCREEN_RECEIPT_UNVERIFIED}` → the treatment was never measured on at least one "
-        "scored boot; re-run those boots rather than reading anything into the onsets.",
+        "scored boot. Read nothing into the onsets: fix perturber sampling, then **regenerate "
+        "the plan and re-run all four boots in order** — re-running a single boot in place "
+        "inverts the planned timestamps and voids the experiment.",
         f"- `{SCREEN_AMBIGUOUS}` / `{SCREEN_INSUFFICIENT}` → operator decides.",
     ]
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
Closes #724. Unblocks #625.

## Why #625 has looped for a week

Not the instrument defects. Four sessions found real ones — [#657](https://github.com/agorokh/ac-copilot-trainer/issues/657) (driver), [#708](https://github.com/agorokh/ac-copilot-trainer/pull/708) (boot-scoped redesign), [#710](https://github.com/agorokh/ac-copilot-trainer/issues/710) (delivered cycles), [#719](https://github.com/agorokh/ac-copilot-trainer/issues/719) (treatment receipt) — and fixed every one. **None of them moved what actually blocks the run.**

The tool is **confirmatory-only, applied to a screening question**. `MIN_BOOTS_PER_ARM = 6` makes it return `insufficient_sample` below 12 boots, so the cheapest question it can ask costs **16 physical reboots** plus operator sign-off on two settings. Every session meets that price, finds a defect instead, and the price stays 16. The instrument got better four times; the cost never moved.

**The power target is also wrong for the decision.** The 16-boot design separates onset ~14 from ~8 — a *modest* shift. But #627's resilient launcher already retries past the freeze, so "disable the overlays permanently" is only worth adopting if it roughly **eliminates** it. That is a large effect, and a large effect is visible in ~4 boots. We were paying confirmatory cost to answer a screening question.

## What this adds

`plan --screen` (2 boots/arm = 4 reboots) and a `screen` command that scores it against a rule **pre-registered into the plan artifact**, so the verdict cannot be chosen after the boots are in — the same exact-match discipline `CANONICAL_TREATMENT_RECEIPT` already uses.

| verdict | condition | action |
|---|---|---|
| `no_large_effect` | any `overlays_off` boot froze at or before the graceful baseline (14 delivered cycles) | **close #625** |
| `large_effect_plausible` | all `overlays_off` censored **and** ≥1 `overlays_on` froze | spend the confirmatory 16 |
| `ambiguous` / `insufficient_usable_boots` | otherwise | operator decides |

## What it refuses to claim

- **No p-value, ever.** At 2 blocks the permutation floor is `2/2**2 = 0.5`. The screen does not run the test, and the rendered output says so.
- **`no_large_effect` is not "no effect".** A modest real shift survives this screen unrefuted, and the renderer states that explicitly — accepted, because a modest shift does not justify adopting the mitigation over the existing retry.
- **`large_effect_plausible` is a promotion signal, not a result.**
- `analyze` and `screen` **refuse each other's plans in both directions**, by schema string *and* by artifact shape (`screen_rule` present/absent), so neither can be scored by the wrong rule:

```
$ … analyze --plan screen-smoke.json …
ERROR: plan is a SCREENING plan ('init-perturber-ab-screen-plan/v1'); run `screen`, not
`analyze` — the confirmatory test would report a p-value whose floor at 2 blocks is 0.5,
which can never reach alpha and must not be presented as a result
```

The screening plan also suppresses the confirmatory power note; quoting a p-value floor on a run that will not compute one is exactly the false precision this stage exists to avoid.

## Not a fork of the scorer

Reuses `summarize_boot`, `load_observations`, and the #719 treatment-receipt exclusion unchanged — same onset, same delivered-cycle counting, same contradicted-boot handling. Only the decision rule differs. A contradicted boot still drops, and the screen reports `insufficient_usable_boots` rather than scoring a corrupted arm.

`make ci-fast` green. 12 new tests, including a **non-vacuous** exclusion case: with the contradicted boot's treatment honoured the identical data promotes to `large_effect_plausible` instead of stalling.

## What this does not do

It does not run the experiment — that still needs the operator's settings sign-off and rig time. It changes the ask from *16 error-prone cycles nobody has run in a week* to **4 guided cycles that can end the issue**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
