### PR TITLE
perf(app): stop parsing the entire lap journal on every reference refresh

### DIFF
--- a/src/ac_copilot_trainer/ac_copilot_trainer.lua
+++ b/src/ac_copilot_trainer/ac_copilot_trainer.lua
@@ -1544,9 +1544,26 @@ refreshActiveReference = function()
     return
   end
   restoreLocalReferenceState()
+  -- #627: `bestImportedReference` SCANS AND FULLY PARSES every `lap_*.json` in the journal to
+  -- find an imported MoTeC reference. Lua evaluates call arguments eagerly, so passing it inline
+  -- ran that scan even when `useImportedReference` is false -- which is the DEFAULT, and which
+  -- makes `chooseImportedReference` discard the result unread on its very first line.
+  --
+  -- Measured on the rig 2026-07-30: 401 archives / 480.5 MB, of which **0** were `imported`. The
+  -- scan cost a ~20 s main-thread stall on every session load and every lap-end reference refresh,
+  -- to compute a value that was then thrown away. It also grew without bound as archives
+  -- accumulated, which is why this read as a slowly-worsening "long time problem".
+  --
+  -- Its RIPs land in CSP's number parser (`accRenderingAdv` divide-by-100 loop), so each archive's
+  -- float fields are parsed through the same slow path as the #627 wedge -- the scan is what feeds
+  -- it. Gate the scan on the flag instead of relying on the consumer to discard it.
+  local importedCandidate = nil
+  if config.useImportedReference == true then
+    importedCandidate = persistence.bestImportedReference(car, sim)
+  end
   local imported = persistence.chooseImportedReference(
     state.bestLapMs,
-    persistence.bestImportedReference(car, sim),
+    importedCandidate,
     config.useImportedReference == true
   )
   if imported then

--- a/tests/test_design_conformance.py
+++ b/tests/test_design_conformance.py
@@ -206,6 +206,31 @@ class TestSessionControl:
         assert "wsBridge.startSidecarIfNeeded(appDir, dt)" in menu_branch
         assert "pendingSessionReview ~= nil and wsBridge" not in menu_branch
 
+    def test_imported_reference_scan_is_gated_on_its_feature_flag(self) -> None:
+        """SC-04: the whole-journal imported-reference scan never runs when the feature is off.
+
+        ``persistence.bestImportedReference`` scans and FULLY PARSES every ``lap_*.json`` in the
+        journal. Lua evaluates call arguments eagerly, so passing it inline to
+        ``chooseImportedReference`` ran that scan even though ``useImportedReference`` defaults to
+        false and the consumer discards the result on its first line.
+
+        Measured on the rig 2026-07-30: 401 archives / 480.5 MB, **0** of them ``imported`` — a
+        ~20 s main-thread stall per session load and per lap-end refresh, for a value thrown away,
+        growing without bound as archives accumulate.
+        """
+        src = _entry_text()
+        start = src.index("refreshActiveReference = function()")
+        body = src[start : src.index("\nlocal function ", start)]
+
+        # The scan must be behind the flag, never an inline argument.
+        assert "persistence.bestImportedReference(car, sim),\n" not in body, (
+            "bestImportedReference is passed as an eager argument again — the whole-journal scan "
+            "will run even with useImportedReference disabled"
+        )
+        guard = body.index("if config.useImportedReference == true then")
+        call = body.index("persistence.bestImportedReference(")
+        assert guard < call, "the journal scan must be guarded by the feature flag"
+
     def test_session_start_is_explicitly_armed_and_lua_identified(self) -> None:
         """SC-03: human app loads never auto-press Start; the relay targets authenticated Lua."""
         entry = _entry_text()


### PR DESCRIPTION
Refs #627. **Fixes the operator's long-standing "loading is delayed 5–15 s" and "after every lap the video freezes 5–10 s while the game keeps running".** It is our code, and it was doing the work for nothing.

## The bug

`refreshActiveReference` passed the scan **inline as an argument**:

```lua
local imported = persistence.chooseImportedReference(
    state.bestLapMs,
    persistence.bestImportedReference(car, sim),   -- eagerly evaluated
    config.useImportedReference == true
)
```

Lua evaluates arguments eagerly, so the scan ran unconditionally — while `chooseImportedReference`'s **first line** is:

```lua
if enabled ~= true or type(importedRef) ~= table then return nil end
```

…and `useImportedReference` defaults to **false**. The result was discarded unread.

## What that cost — measured on the rig, 2026-07-30

`bestImportedReference` runs `io.scanDir(dir, lap_*.json)` and then **fully parses every hit**:

| | |
|---|---|
| archives | **401** |
| total | **480.5 MB** (~250 KB each, 2000 float samples/lap) |
| of which `source == "imported"` | **0** |
| parse cost | **9.8 s in Python with C-speed JSON** — far worse in Lua through CSP's parser |

It is **unbounded**: every lap ever driven makes it slower. That is exactly why this read as a slowly-worsening "long time problem" rather than a regression.

## Attribution is measured, not inferred

`freeze_forensics` caught the stall live. Its RIPs land at `DWrite+0x14e7169` and `+0x14e7162` — inside the ÷100 loop in CSP's `accRenderingAdv.dll` that #627 already identified as a **decimal→float parser**. So each archive's floats go through the same slow path as the #627 wedge: **this scan is what feeds it.** Two symptoms, one loop.

## The fix

Gate the scan on the flag instead of relying on the consumer to discard it. With the default configuration the journal is **never opened**.

## Before / after — same car, same track, lap completed both times

Largest gap between consecutive app log lines across a whole session (the app logs unconditionally every ~3 s, so a gap is a main-thread stall):

| | largest gap |
|---|---|
| before | **21,945 ms (21.9 s)** |
| after | **3,017 ms (3.0 s)** |

Every remaining gap is exactly ~3.01 s — the app's own `RT-DIAG` cadence, i.e. **no stall left**. Drive result unchanged: `PASS, laps=1, 210.7 km/h, 2766 m, recoveries=0`.

## Guard

**SC-04** in `tests/test_design_conformance.py`, in the existing source-conformance idiom. **Mutation-checked**: reverting to the eager form fails the test.

`make ci-fast` OK.

## Note

This does not make the 480 MB scan itself fast — users who *enable* imported references will still pay it. The discriminating `"source"` key sits at byte ~255,834 of ~256,241, i.e. at the very end of each file, so a cheap header prefilter is not possible; a tail read or a small index is the follow-up. Out of scope here: the default path is the one that was stalling every session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)