### PR TITLE
ci(vault-automerge): roll hub action pin to f5d9a87 (loud failure)

### DIFF
--- a/.github/workflows/vault-automerge.yml
+++ b/.github/workflows/vault-automerge.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: agorokh/governance-hub
-          ref: 0db37554f20e8ddbbfdc6f8a622ce845faf4dd06  # pragma: allowlist secret (git SHA, not a secret)
+          ref: f5d9a873dfe1a0893ecc6d2b77935ca27a2c2d0f  # pragma: allowlist secret (git SHA, not a secret)
           token: ${{ steps.app-token.outputs.token }}
           path: .governance-hub
       - uses: ./.governance-hub/.github/actions/vault-automerge


### PR DESCRIPTION
Rolls this repo's pinned `governance-hub` **vault-automerge** composite action from
`0db37554` (pre-#344) to **`f5d9a873dfe1a0893ecc6d2b77935ca27a2c2d0f`** — hub `main` head,
verified live at roll time.

## What changes behaviourally

At the old pin, a `Vault auto-merge` run that hit the full mergeability timeout concluded
**`success`** with the PR still open — the exact silent stall of gov-hub#343 (observed live on
`mcp-servers#398`). Nothing then retried the merge: checks going green fires no `pull_request`
event, so the vault SAVE sat open until a human noticed.

gov-hub#344 changed the contract: **every terminal path that leaves the PR open and unmerged now
comments for a human AND fails the step (exit 1)**. A green `Vault auto-merge` run means the
handoff actually landed. The only exit-0 outcomes are merged, deferred to a newer head's own run,
or the PR already closed.

Expect this to surface as **red runs on saturation days where today they are silently green**.
That is the point, and it is truthful: the hub's scheduled `vault-pr-sweep.yml` (every 15 min,
from hub `main` — no spoke pin involved) re-runs the same action against the stalled PR and heals
it within a cycle. The pin also brings the optional `expected-head` input (unused by this
event-driven caller) and gov-hub#346's late-review-race fix.

## Budget check (unchanged, re-verified)

The action merges **synchronously** and waits in-run, so `timeout-minutes` must exceed the
worst-case wait. This caller's budget already clears it — see the table in gov-hub#347.

## Scope

One line. No caller semantics change: same trigger, same `vault-only` label gate, same
permissions, same inputs.

Refs: agorokh/governance-hub#347
