### PR TITLE
ci(actions): roll stale hub-action pins to current

### DIFF
--- a/.github/workflows/process-miner.yml
+++ b/.github/workflows/process-miner.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: agorokh/governance-hub
-          ref: 49cbd4b49cf6376d91c0b5a683d0396b1139d5a9  # pragma: allowlist secret (git SHA, not a secret)
+          ref: 7bab94b1618dd5f62d3ab0b17e596efc5a00263b  # pragma: allowlist secret (git SHA, not a secret)
           token: ${{ steps.hub-token.outputs.token }}
           path: .governance-hub
       - name: Run process miner

--- a/.github/workflows/steward-miner-rules.yml
+++ b/.github/workflows/steward-miner-rules.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: agorokh/governance-hub
-          ref: e9e5f352d44bd802b3da1150b9ab6da517b3df1d  # pragma: allowlist secret (git SHA, not a secret)
+          ref: 71eaa6f435ebb1eb2d5f60d0566cd5f5d7cec03f  # pragma: allowlist secret (git SHA, not a secret)
           token: ${{ steps.app-token.outputs.token }}
           path: .governance-hub
       - name: Adjudicate the miner-rules PR


### PR DESCRIPTION
Rolls every stale `governance-hub` composite-action pin in this repo to the hub commit that last
touched each action.

Found by `scripts/hub_pin_drift.py` (gov-hub#350), which enumerates callers **live**. These were
invisible because rollouts verified against the list they rolled from — the same failure that left
three spokes on a pre-#187 `vault-automerge` for a month (gov-hub#347, now closed).

Part of a 15-repo roll of 40 stale references. Canary: agent-factory.

## Safety analysis, done before rolling

gov-hub#347's lesson was that a **behavioural** change can couple to caller config while the input
signature is unchanged. So "no input change" was treated as insufficient, and each action was
checked across every pinned SHA in the fleet:

- **No required-input change** in any of the 6 actions.
- **No step-count change**, and no new wait/poll/timeout logic — the #347 coupling trap does not apply.
- **`check-private-runner-policy` becomes STRICTER** (it now rejects jobs calling reusable workflows
  with an opaque runner selector). Every affected spoke was pre-checked by running the **new**
  `check.py` against its real workflows: **13/13 repos, 149 workflows, zero violations.**

## Two bugs the roller hit, both caught by fail-closed checks

1. A bare-SHA replace also rolled **`process-miner-libs`**, which is *current* at `6e8554c1` — that
   is its own owning commit, across 23 fleet references. agent-factory's test asserting the libs pin
   caught it. Replacement is now scoped to `<action>@<pin>`, never the SHA alone.
2. PUBLIC spokes pin via `actions/checkout` + `ref:` rather than `uses:`, so those needed a
   different anchor. Handled, and ambiguous multi-checkout files are refused rather than guessed.

Refs: agorokh/governance-hub#350
