### PR TITLE
fix(harness): retry the setup re-bake race with a fresh launch cycle (#737)

### DIFF
--- a/tests/test_ac_harness_auto_drive.py
+++ b/tests/test_ac_harness_auto_drive.py
@@ -62,6 +62,7 @@ from tools.ac_harness.auto_drive import (
     rig_press_session_start,
     run_auto_drive,
     run_auto_drive_with_sim_retries,
+    setup_ack_fuel_mismatch,
     should_try_line_teleport_on_recovery,
     verify_setup_ack,
     write_evidence,
@@ -1102,6 +1103,242 @@ def test_programmatic_sim_death_retry_budget_rejects_negative_values():
                 tap=_tap_returning(CONTINUOUS),
             )
         )
+
+
+# --------------------------------------------------------------------- #737 setup re-bake race
+_RACE_MISS_ACK = {
+    "ok": False,
+    "name": "exp_fuel40",
+    "path": "x/exp_fuel40.ini",
+    "error": "fuel 30.0L != setup FUEL 40.0L (±2.5)",
+    "expected_fuel": 40.0,
+    "observed_fuel": 30.0,
+}
+_VERIFIED_ACK = {
+    "ok": True,
+    "name": "exp_fuel40",
+    "path": "x/exp_fuel40.ini",
+    "detail": "fuel 40.0L matches setup FUEL 40.0L",
+    "expected_fuel": 40.0,
+    "observed_fuel": 40.0,
+}
+
+
+def _race_cfg(**kw) -> AutoDriveConfig:
+    base = dict(setup="exp_fuel40", track_id="magione", car_id="ks_porsche_911_gt3_r_2016")
+    base.update(kw)
+    return _cfg(**base)
+
+
+def _correct_combo(config):  # noqa: ANN001
+    return ("magione", "ks_porsche_911_gt3_r_2016")
+
+
+def test_setup_race_miss_retries_full_launch_and_recovers():
+    # #737: the launch-bake lost CM's race.ini regeneration race (#466) — fuel verification
+    # honestly missed on the CORRECT combo. One fresh full launch re-bakes the setup and the run
+    # completes; the failed attempt stays in report.attempts as evidence.
+    launches: list[int] = []
+    acks = iter([dict(_RACE_MISS_ACK), dict(_VERIFIED_ACK)])
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    async def _apply(config):  # noqa: ANN001
+        return next(acks)
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _race_cfg(setup_verify_retries=1),
+            launch=_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive_returning(DriveStats(drove=True, total_distance_m=900.0), {}),
+            tap=_tap_returning(CONTINUOUS),
+            apply_setup=_apply,
+            verify_track=_correct_combo,
+        )
+    )
+
+    assert report.ok is True
+    assert report.setup_applied is True
+    assert len(launches) == 2  # one fresh relaunch, then verified
+    assert len(report.attempts) == 2
+    assert report.attempts[0]["ok"] is False
+    assert report.attempts[0]["stage"] == "setup"
+    assert report.attempts[0]["setup_race_suspected"] is True
+    assert report.attempts[1]["ok"] is True
+
+
+def test_setup_race_retry_budget_exhaustion_still_fails_the_verify_gate():
+    # #737 bound: a PERSISTENT fuel mismatch exhausts the budget and still FAILs at
+    # stage="setup" — the retry re-arms the verify gate on a fresh launch, never weakens it.
+    launches: list[int] = []
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    async def _apply(config):  # noqa: ANN001
+        return dict(_RACE_MISS_ACK)
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _race_cfg(setup_verify_retries=1),
+            launch=_launch,
+            hijack=lambda c: pytest.fail("must not hijack an unverified setup"),
+            drive=lambda *a: pytest.fail("must not drive"),
+            tap=_tap_returning(CONTINUOUS),
+            apply_setup=_apply,
+            verify_track=_correct_combo,
+        )
+    )
+
+    assert report.ok is False
+    assert report.stage == "setup"
+    assert report.setup_applied is False
+    assert len(launches) == 2  # bounded: initial + 1 setup retry
+    assert len(report.attempts) == 2
+    assert all(attempt["setup_race_suspected"] is True for attempt in report.attempts)
+
+
+@pytest.mark.parametrize(
+    "config_kwargs,ack",
+    [
+        # Deterministic wiring failure: no expected_fuel in the ack — not the re-bake race.
+        ({}, {"ok": False, "error": "setup ini unreadable: boom"}),
+        # skip_launch has no launch leg to repeat; re-verifying the same session reads the
+        # same fuel, so the wrapper must not burn cycles on it (mirrors the sim-death rule).
+        ({"skip_launch": True}, dict(_RACE_MISS_ACK)),
+    ],
+)
+def test_setup_race_retry_refuses_non_retryable_setup_failures(config_kwargs, ack):
+    applies: list[int] = []
+    launches: list[int] = []
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    async def _apply(config):  # noqa: ANN001
+        applies.append(1)
+        return dict(ack)
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _race_cfg(setup_verify_retries=2, **config_kwargs),
+            launch=_launch,
+            hijack=lambda c: pytest.fail("must not hijack"),
+            drive=lambda *a: pytest.fail("must not drive"),
+            tap=_tap_returning(CONTINUOUS),
+            apply_setup=_apply,
+            verify_track=_correct_combo,
+        )
+    )
+
+    assert report.ok is False
+    assert report.stage == "setup"
+    assert len(report.attempts) == 1  # no retry burned on a non-retryable failure
+    assert len(applies) == 1
+    assert len(launches) == (0 if config_kwargs.get("skip_launch") else 1)
+
+
+def test_setup_race_retry_not_spent_on_cached_session_mismatch():
+    # #537 exhaustion is a DIFFERENT failure class: the loaded combo positively mismatched and
+    # the in-loop relaunch budget already ran (with CM restarts). The wrapper must not extend
+    # it — #737 stays scoped to the correct-combo re-bake race.
+    launches: list[int] = []
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    async def _apply(config):  # noqa: ANN001
+        return {**_RACE_MISS_ACK, "error": "fuel 60.0L != setup FUEL 40.0L (±2.5)"}
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _race_cfg(max_launches=2, setup_verify_retries=3),
+            launch=_launch,
+            hijack=lambda c: pytest.fail("must not hijack the wrong session"),
+            drive=lambda *a: pytest.fail("must not drive"),
+            tap=_tap_returning(CONTINUOUS),
+            apply_setup=_apply,
+            verify_track=lambda c: ("spa", "ks_porsche_911_gt3_r_2016"),  # always cached spa
+        )
+    )
+
+    assert report.ok is False
+    assert report.stage == "setup"
+    assert "cached session" in (report.error or "")
+    assert len(report.attempts) == 1  # the wrapper did NOT extend the exhausted #537 budget
+    assert len(launches) == 2  # only the bounded in-loop relaunches ran
+    assert report.attempts[0]["setup_race_suspected"] is False
+
+
+def test_setup_race_and_sim_death_budgets_are_independent():
+    # One setup-race miss AND one sim death in the same run: each retries on its OWN budget of 1,
+    # so the run recovers twice and every attempt is retained.
+    launches: list[int] = []
+    acks = iter([dict(_RACE_MISS_ACK), dict(_VERIFIED_ACK), dict(_VERIFIED_ACK)])
+    outcomes = iter(
+        [
+            DriveStats(drove=True, sim_dead=True, reason="acs.exe died on packet 41"),
+            DriveStats(drove=True, laps=1, total_distance_m=900.0),
+        ]
+    )
+
+    def _launch(config):  # noqa: ANN001
+        launches.append(1)
+        return True, "live"
+
+    async def _apply(config):  # noqa: ANN001
+        return next(acks)
+
+    def _drive(controller, config, stop):  # noqa: ANN001
+        stop.wait(timeout=2.0)
+        return next(outcomes)
+
+    report = asyncio.run(
+        run_auto_drive_with_sim_retries(
+            _race_cfg(sim_death_retries=1, setup_verify_retries=1),
+            launch=_launch,
+            hijack=lambda c: FakeController(),
+            drive=_drive,
+            tap=_tap_returning(CONTINUOUS),
+            apply_setup=_apply,
+            verify_track=_correct_combo,
+        )
+    )
+
+    assert report.ok is True
+    assert len(launches) == 3
+    assert len(report.attempts) == 3
+    assert report.attempts[0]["stage"] == "setup"
+    assert report.attempts[0]["setup_race_suspected"] is True
+    assert report.attempts[1]["drive"]["sim_dead"] is True
+    assert report.attempts[2]["ok"] is True
+
+
+def test_programmatic_setup_verify_retry_budget_rejects_negative_values():
+    with pytest.raises(ValueError, match="setup_verify_retries must be >= 0"):
+        asyncio.run(
+            run_auto_drive_with_sim_retries(
+                _cfg(setup_verify_retries=-1),
+                launch=_ok_launch,
+                hijack=lambda c: FakeController(),
+                drive=_drive_returning(DriveStats(drove=True), {}),
+                tap=_tap_returning(CONTINUOUS),
+            )
+        )
+
+
+def test_setup_ack_fuel_mismatch_classifier():
+    # Only a genuine failed fuel-verify (ok not true + parsed expected_fuel present) qualifies.
+    assert setup_ack_fuel_mismatch(dict(_RACE_MISS_ACK)) is True
+    assert setup_ack_fuel_mismatch(None) is False
+    assert setup_ack_fuel_mismatch({"ok": False, "error": "setup ini unreadable: x"}) is False
+    assert setup_ack_fuel_mismatch(dict(_VERIFIED_ACK)) is False  # verified — no miss
 
 
 def test_drive_exception_closes_controller_and_reports_drive_stage():
@@ -3992,6 +4229,8 @@ def test_cli_new_flags_map_to_config(tmp_path):
             "8",
             "--sim-death-retries",
             "2",
+            "--setup-verify-retries",
+            "3",
             "--no-spawn-line",
         ]
     )
@@ -4003,13 +4242,15 @@ def test_cli_new_flags_map_to_config(tmp_path):
     assert cfg.max_recoveries == 3
     assert cfg.progress_stall_seconds == 8.0
     assert cfg.sim_death_retries == 2
+    assert cfg.setup_verify_retries == 3
     assert cfg.spawn_to_line is False
 
 
+@pytest.mark.parametrize("flag", ["--sim-death-retries", "--setup-verify-retries"])
 @pytest.mark.parametrize("bad", ["-1", "1.5", "nan"])
-def test_cli_rejects_invalid_sim_death_retry_budgets(bad):
+def test_cli_rejects_invalid_retry_budgets(flag, bad):
     with pytest.raises(SystemExit):
-        _build_arg_parser().parse_args(["--track", "spa", "--sim-death-retries", bad])
+        _build_arg_parser().parse_args(["--track", "spa", flag, bad])
 
 
 # --------------------------------------------------------------------------- #577 flying-lap window

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -2448,6 +2448,68 @@ def test_scientist_candidate_retry_exhaustion_aborts_batch_honestly(monkeypatch,
     assert not (user_dir / "journal" / "alien_scientist" / "experiments.jsonl").exists()
 
 
+def test_scientist_setup_race_retry_composes_boundedly_with_real_pipeline(monkeypatch, tmp_path):
+    # Codex P2 (PR #740): the earlier retry tests mock run_pipeline, so they cannot see the
+    # composed budget. This drives the REAL run_pipeline (scripted run_stage) for a candidate
+    # whose identify stage persistently fails with the race signature: the scientist enters the
+    # pipeline exactly TWICE (initial + one retry) and then aborts — the pipeline-level bound is
+    # enforced; the per-stage launch bound is proven by the auto_drive wrapper tests, so the
+    # composed worst case is 2 * (1 + setup_verify_retries) launches.
+    user_dir, baseline_setup, base_outcome = _scientist_batch_env(monkeypatch, tmp_path)
+    _usable_plant(monkeypatch, False)  # every candidate pipeline requires identification
+    stage_calls: list[list[str]] = []
+
+    def run_stage(argv: list[str]) -> int:
+        stage_calls.append(list(argv))
+        evidence_dir = Path(argv[argv.index("--evidence-dir") + 1])
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        (evidence_dir / "report.json").write_text(
+            _json.dumps(
+                {
+                    "report": {
+                        "ok": False,
+                        "stage": "setup",
+                        "setup_race_suspected": True,
+                        "error": "setup not applied: fuel 30.0L != setup FUEL 40.0L (±2.5)",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 1
+
+    args = _args(
+        user_dir, "--setup", str(baseline_setup), "--laps", "2", "--iterations", "1", "--scientist"
+    )
+    result = run_scientist(
+        args,
+        run_stage=run_stage,
+        evidence_root=tmp_path / "evidence",
+        user_dir=user_dir,
+        setup_ini=baseline_setup,
+        selfplay={"base": {"valid": True}, "iterations": [], "stopped": "pace plateau"},
+        base_outcome=base_outcome,
+    )
+
+    assert result["ok"] is False
+    assert "scientist_candidate_batch_incomplete" in result["error"]
+    # The real pipeline ran exactly twice: identify failed in the initial attempt and in the one
+    # retry — no third pipeline entry, so the composed budget cannot grow beyond 2 attempts.
+    assert len(stage_calls) == 2
+    assert all("handshake" in call for call in stage_calls)  # both were identify stages
+    assert "candidate_01" in " ".join(stage_calls[0])
+    assert "candidate_01_retry" in " ".join(stage_calls[1])
+    assert result["setup_race_retries"] == [
+        {
+            "candidate": 1,
+            "stage": "identify",
+            "first_evidence_root": str(tmp_path / "evidence" / "scientist" / "candidate_01"),
+            "evidence_root": str(tmp_path / "evidence" / "scientist" / "candidate_01_retry"),
+            "recovered": False,
+        }
+    ]
+
+
 def test_scientist_candidate_non_race_failure_does_not_retry(monkeypatch, tmp_path):
     # Any other candidate failure keeps the pre-#737 contract: no retry, honest abort.
     nested_calls = []

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -2269,3 +2269,205 @@ def test_scientist_requires_requested_laps_before_persisting(
     else:
         assert expected_error in result["error"]
         assert not (user_dir / "journal" / "alien_scientist" / "experiments.jsonl").exists()
+
+
+# --------------------------------------------------------------------- #737 setup re-bake race
+def _scientist_lap_payload(lap_n: int, lap_ms: int, *, wing: int, path: Path) -> dict:
+    """A combo-matched, valid archived lap for the #737 candidate-retry tests (pure)."""
+    return {
+        "schema_version": 1,
+        "lap_uuid": f"lap-{wing}-{lap_n}",
+        "session_uuid": f"session-{wing}",
+        "exported_at": f"2026-08-09T00:00:0{lap_n}Z",
+        "car": {"id": "car_a"},
+        "track": {"id": "trk", "layout": None},
+        "lap": {"lap_n": lap_n, "lap_ms": lap_ms, "is_valid": True},
+        "setup": {
+            "hash": f"setup-{wing}",
+            "path": str(path),
+            "snapshot": {"WING_2.VALUE": wing, "FRONT_BIAS.VALUE": 60},
+        },
+    }
+
+
+def _scientist_batch_env(monkeypatch, tmp_path):
+    """Schema + verifiable 2-lap baseline batch shared by the #737 candidate-retry tests."""
+    from tools.ai_sidecar import car_schema
+    from tools.ai_sidecar.car_schema import CarSetupSchema
+
+    user_dir = tmp_path / "Assetto Corsa"
+    baseline_setup = user_dir / "setups" / "car_a" / "trk" / "baseline.ini"
+    baseline_setup.parent.mkdir(parents=True)
+    baseline_setup.write_text("[WING_2]\nVALUE=10\n\n[FRONT_BIAS]\nVALUE=60\n", encoding="utf-8")
+    schema = CarSetupSchema.from_spinners_dump(
+        "car_a",
+        [
+            {"name": "WING_2", "min": 0, "max": 20, "step": 1},
+            {"name": "FRONT_BIAS", "min": 50, "max": 70, "step": 1},
+        ],
+    )
+    monkeypatch.setattr(car_schema, "load_latest_schema", lambda car: schema)
+
+    baseline_paths = []
+    for lap_n, lap_ms in ((1, 100_000), (2, 101_000)):
+        path = tmp_path / f"baseline_lap_{lap_n}.json"
+        path.write_text(
+            _json.dumps(_scientist_lap_payload(lap_n, lap_ms, wing=10, path=baseline_setup)),
+            encoding="utf-8",
+        )
+        baseline_paths.append(str(path))
+    base_outcome = {
+        "report": {"lap_times_ms": [100_000, 101_000], "drive": {"recoveries": 0}},
+        "lap_archives": baseline_paths,
+    }
+    return user_dir, baseline_setup, base_outcome
+
+
+def _race_failed_pipeline_result(candidate_args) -> tuple[int, dict]:
+    """A candidate pipeline failure carrying the auto_drive #737 race signature."""
+    identify_dir = Path(candidate_args.evidence_dir) / "identify"
+    identify_dir.mkdir(parents=True)
+    (identify_dir / "report.json").write_text(
+        _json.dumps(
+            {
+                "report": {
+                    "ok": False,
+                    "stage": "setup",
+                    "setup_race_suspected": True,
+                    "error": "setup not applied: fuel 30.0L != setup FUEL 40.0L (±2.5)",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return 1, {
+        "stages": {"identify": {"exit_code": 1, "evidence_dir": str(identify_dir)}},
+        "ok": False,
+        "error": "identification stage failed (exit 1)",
+    }
+
+
+def _run_scientist_with_fake_pipeline(monkeypatch, tmp_path, fake_nested_pipeline):
+    user_dir, baseline_setup, base_outcome = _scientist_batch_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(auto_alien, "run_pipeline", fake_nested_pipeline)
+    args = _args(
+        user_dir, "--setup", str(baseline_setup), "--laps", "2", "--iterations", "1", "--scientist"
+    )
+    result = run_scientist(
+        args,
+        run_stage=lambda argv: 0,
+        evidence_root=tmp_path / "evidence",
+        user_dir=user_dir,
+        setup_ini=baseline_setup,
+        selfplay={"base": {"valid": True}, "iterations": [], "stopped": "pace plateau"},
+        base_outcome=base_outcome,
+    )
+    return result, user_dir
+
+
+def _successful_candidate_pipeline_result(candidate_args) -> tuple[int, dict]:
+    """A complete 2-lap candidate batch faster than the baseline (promotable)."""
+    drive_dir = Path(candidate_args.evidence_dir) / "drive"
+    drive_dir.mkdir(parents=True)
+    paths = []
+    for lap_n, lap_ms in ((3, 90_000), (4, 91_000)):
+        path = drive_dir / f"lap_{lap_n}.json"
+        path.write_text(
+            _json.dumps(
+                _scientist_lap_payload(lap_n, lap_ms, wing=9, path=Path(candidate_args.setup))
+            ),
+            encoding="utf-8",
+        )
+        paths.append(str(path))
+    (drive_dir / "report.json").write_text(
+        _json.dumps(
+            {
+                "report": {"lap_times_ms": [90_000, 91_000], "drive": {"recoveries": 0}},
+                "lap_archives": paths,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return 0, {"stages": {"drive": {"evidence_dir": str(drive_dir)}}, "ok": True}
+
+
+def test_scientist_candidate_retries_once_on_setup_race_and_completes(monkeypatch, tmp_path):
+    # #737: candidate 1's identify stage lost the setup re-bake race. The batch must NOT abort —
+    # one fresh pipeline cycle recovers, and the completed baseline + verdict persist normally.
+    nested_calls = []
+
+    def fake_nested_pipeline(candidate_args, *, run_stage):
+        del run_stage
+        nested_calls.append(candidate_args)
+        if len(nested_calls) == 1:
+            return _race_failed_pipeline_result(candidate_args)
+        return _successful_candidate_pipeline_result(candidate_args)
+
+    result, user_dir = _run_scientist_with_fake_pipeline(
+        monkeypatch, tmp_path, fake_nested_pipeline
+    )
+
+    assert result["ok"] is True
+    assert len(nested_calls) == 2
+    assert str(nested_calls[0].evidence_dir).endswith("candidate_01")
+    assert str(nested_calls[1].evidence_dir).endswith("candidate_01_retry")
+    assert nested_calls[1].setup == nested_calls[0].setup  # the same candidate file retries
+    assert result["setup_race_retries"] == [
+        {
+            "candidate": 1,
+            "stage": "identify",
+            "first_evidence_root": str(tmp_path / "evidence" / "scientist" / "candidate_01"),
+            "evidence_root": str(tmp_path / "evidence" / "scientist" / "candidate_01_retry"),
+            "recovered": True,
+        }
+    ]
+    assert result["outcomes"][0]["evidence_root"].endswith("candidate_01_retry")
+    assert result["outcomes"][0]["promoted"] is True
+    assert Path(result["run_path"]).is_file()
+    assert Path(result["ledger_path"]).is_file()
+
+
+def test_scientist_candidate_retry_exhaustion_aborts_batch_honestly(monkeypatch, tmp_path):
+    # #737 bound: a candidate that loses the race twice still aborts the batch — the retry never
+    # launders a persistently unverifiable candidate into the ledger.
+    nested_calls = []
+
+    def fake_nested_pipeline(candidate_args, *, run_stage):
+        del run_stage
+        nested_calls.append(candidate_args)
+        return _race_failed_pipeline_result(candidate_args)
+
+    result, user_dir = _run_scientist_with_fake_pipeline(
+        monkeypatch, tmp_path, fake_nested_pipeline
+    )
+
+    assert result["ok"] is False
+    assert "scientist_candidate_batch_incomplete" in result["error"]
+    assert len(nested_calls) == 2  # exactly one retry — bounded
+    assert result["setup_race_retries"][0]["recovered"] is False
+    assert not (user_dir / "journal" / "alien_scientist" / "experiments.jsonl").exists()
+
+
+def test_scientist_candidate_non_race_failure_does_not_retry(monkeypatch, tmp_path):
+    # Any other candidate failure keeps the pre-#737 contract: no retry, honest abort.
+    nested_calls = []
+
+    def fake_nested_pipeline(candidate_args, *, run_stage):
+        del run_stage
+        nested_calls.append(candidate_args)
+        stage_dir = Path(candidate_args.evidence_dir) / "identify"
+        return 1, {
+            # No report.json on disk — the failure carries no race signature.
+            "stages": {"identify": {"exit_code": 1, "evidence_dir": str(stage_dir)}},
+            "ok": False,
+            "error": "identification stage failed (exit 1)",
+        }
+
+    result, user_dir = _run_scientist_with_fake_pipeline(
+        monkeypatch, tmp_path, fake_nested_pipeline
+    )
+
+    assert result["ok"] is False
+    assert "scientist_candidate_batch_incomplete" in result["error"]
+    assert len(nested_calls) == 1  # no retry burned on a non-race failure
+    assert "setup_race_retries" not in result

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -1344,6 +1344,37 @@ def _load_scientist_proposals(path: Path | None) -> list[dict] | None:
     return payload
 
 
+def _candidate_setup_race_stage(candidate_report: dict) -> str | None:
+    """Failed stage name when a scientist candidate died on the transient setup re-bake race.
+
+    A candidate that lost the #466 CM race.ini regeneration race fails its identify/drive stage
+    at ``stage="setup"`` with ``setup_race_suspected`` set in the stage report (#737).  Exactly
+    that signature is worth ONE fresh pipeline cycle; every other failure keeps aborting the
+    batch honestly, so a persistent mismatch can never launder a half-run into the ledger.
+    """
+    stages = candidate_report.get("stages")
+    if not isinstance(stages, dict):
+        return None
+    for name, stage in stages.items():
+        if not isinstance(stage, dict):
+            continue
+        exit_code = stage.get("exit_code")
+        if not isinstance(exit_code, int) or exit_code == 0:
+            continue
+        evidence_dir = stage.get("evidence_dir")
+        if not evidence_dir:
+            continue
+        outcome = load_stage_outcome(Path(evidence_dir))
+        stage_report = (outcome or {}).get("report")
+        if (
+            isinstance(stage_report, dict)
+            and stage_report.get("stage") == "setup"
+            and stage_report.get("setup_race_suspected") is True
+        ):
+            return str(name)
+    return None
+
+
 def run_scientist(
     args: argparse.Namespace,
     *,
@@ -1446,6 +1477,33 @@ def run_scientist(
             (candidate_root / "alien_report.json").write_text(
                 json.dumps(candidate_report, indent=2), encoding="utf-8"
             )
+            if code != 0 and (race_stage := _candidate_setup_race_stage(candidate_report)):
+                # #737: the candidate lost the #466 setup re-bake race — a confirmed
+                # intermittent rig condition, not a verdict about the setup.  One fresh
+                # pipeline cycle instead of discarding the completed baseline and any earlier
+                # candidates; a second miss still aborts the batch honestly below.
+                retry_root = evidence_root / "scientist" / f"candidate_{index:02d}_retry"
+                print(
+                    f"auto-alien: scientist candidate {index} lost the setup re-bake race "
+                    f"at the {race_stage} stage — retrying one fresh launch cycle (#737)"
+                )
+                retry_args = argparse.Namespace(**vars(candidate_args))
+                retry_args.evidence_dir = retry_root
+                code, candidate_report = run_pipeline(retry_args, run_stage=run_stage)
+                retry_root.mkdir(parents=True, exist_ok=True)
+                (retry_root / "alien_report.json").write_text(
+                    json.dumps(candidate_report, indent=2), encoding="utf-8"
+                )
+                result.setdefault("setup_race_retries", []).append(
+                    {
+                        "candidate": index,
+                        "stage": race_stage,
+                        "first_evidence_root": str(candidate_root),
+                        "evidence_root": str(retry_root),
+                        "recovered": code == 0,
+                    }
+                )
+                candidate_root = retry_root
             drive_stage = candidate_report.get("stages", {}).get("drive", {})
             candidate_outcome = (
                 load_stage_outcome(Path(drive_stage["evidence_dir"]))

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -1481,7 +1481,15 @@ def run_scientist(
                 # #737: the candidate lost the #466 setup re-bake race — a confirmed
                 # intermittent rig condition, not a verdict about the setup.  One fresh
                 # pipeline cycle instead of discarding the completed baseline and any earlier
-                # candidates; a second miss still aborts the batch honestly below.
+                # candidates; a second pipeline-level miss still aborts the batch honestly
+                # below.  Two scopes on purpose (Codex P2, PR #740): auto_drive's
+                # setup_verify_retries is the CHEAP in-stage relaunch for one transient miss;
+                # this branch saves the whole batch when a stage exhausted that budget (both
+                # launches lost the race).  The budgets therefore compose: each pipeline
+                # attempt may burn 1 + setup_verify_retries launches, so a persistently
+                # mismatching candidate costs at most 2 * (1 + setup_verify_retries) launches
+                # (4 with defaults) before the abort — bounded, and far cheaper than
+                # discarding a completed baseline batch on an intermittent rig condition.
                 retry_root = evidence_root / "scientist" / f"candidate_{index:02d}_retry"
                 print(
                     f"auto-alien: scientist candidate {index} lost the setup re-bake race "

--- a/tools/ac_harness/auto_drive.py
+++ b/tools/ac_harness/auto_drive.py
@@ -249,6 +249,11 @@ class AutoDriveConfig:
     # the entire launch->hijack->drive attempt once by default; the wrapper retains every attempt
     # in report.json so a recovered crash is measured rather than hidden.
     sim_death_retries: int = 1
+    # #737: the launch-time setup re-bake can lose CM's race.ini regeneration race (#466) even on
+    # the CORRECT combo — the car spawns on default fuel and setup verification honestly fails.
+    # That miss is confirmed intermittent, so it earns the same fresh-full-launch treatment as a
+    # sim death: bounded retries with every attempt retained in report.json.  0 disables.
+    setup_verify_retries: int = 1
     skip_launch: bool = False
 
 
@@ -445,6 +450,11 @@ class AutoDriveReport:
     setup_requested: str | None = None
     setup_applied: bool | None = None  # None = no setup requested
     setup_ack: dict | None = None  # the in-sim `setup.load.ack` (name/path/error)
+    # #737: True exactly when setup fuel-verification missed while the loaded combo was NOT
+    # positively mismatched — the #466 CM race.ini re-bake race signature.  The retry wrapper
+    # treats only this terminal state as worth a fresh launch cycle; wiring failures and
+    # exhausted cached-session mismatches (#537) stay non-retryable.
+    setup_race_suspected: bool = False
     # #596 Part B: complete per-attempt reports from the bounded sim-death retry wrapper.  The
     # final report stays at the top level for backward compatibility; this list makes a recovered
     # crash visible and preserves its control trace/checks instead of laundering it into PASS.
@@ -525,8 +535,12 @@ class AutoDriveReport:
                 if isinstance(attempt.get("drive"), dict)
                 and attempt["drive"].get("sim_dead") is True
             )
+            setup_races = sum(
+                1 for attempt in self.attempts if attempt.get("setup_race_suspected") is True
+            )
             lines.append(
                 f"  attempts: {len(self.attempts)} (detected sim deaths={sim_deaths}, "
+                f"setup races={setup_races}, "
                 f"retry budget={max(len(self.attempts) - 1, 0)} used)"
             )
         if self.lap_times_ms:
@@ -804,6 +818,18 @@ def verify_setup_ack(ack: dict | None, requested: str) -> tuple[bool, str]:
     return False, f"ack names a different setup: name={ack.get('name')!r} path={path!r}"
 
 
+def setup_ack_fuel_mismatch(ack: dict | None) -> bool:
+    """Pure check that a failed setup ack is a genuine fuel-verify miss (#737).
+
+    Only the rig leg's fuel verification failing qualifies: ``ok`` is not true AND the parsed
+    ``expected_fuel`` is present — the leg read the setup's ``[FUEL]`` and the live physics fuel
+    refused to match within the tolerance window.  Deterministic failures (no ack, unresolved or
+    unreadable setup ini, an ack naming a different setup) must NOT look like the transient
+    re-bake race: retrying them wastes a full launch cycle on a wiring bug.
+    """
+    return isinstance(ack, dict) and ack.get("ok") is not True and "expected_fuel" in ack
+
+
 class ProgressWatchdog:
     """No-forward-progress detector — driver-agnostic stall recovery trigger (#459 Part D).
 
@@ -1019,6 +1045,13 @@ async def run_auto_drive(
                         setup_requested=setup_requested,
                         setup_applied=False,
                         setup_ack=setup_ack,
+                        # #737: a fuel-verify miss WITHOUT a positive combo mismatch is the #466
+                        # re-bake race signature — the one setup failure the retry wrapper may
+                        # answer with a fresh launch cycle.  A cached-session mismatch already
+                        # consumed the in-loop relaunch budget above and stays terminal.
+                        setup_race_suspected=(
+                            combo_mismatch is None and setup_ack_fuel_mismatch(setup_ack)
+                        ),
                         error=(
                             f"setup not applied: {detail}"
                             + (
@@ -1487,25 +1520,40 @@ async def run_auto_drive_with_sim_retries(
     cleanup_failure: CleanupFailureFn | None = None,
     press_start: Callable[[], Awaitable[dict | None]] | None = None,
 ) -> AutoDriveReport:
-    """Run the full attempt again after a detected ``acs.exe`` death, bounded and evidenced.
+    """Run the full attempt again after a transient rig failure, bounded and evidenced.
 
-    A frozen main-physics packet is already the harness's authoritative death oracle.  Retrying
-    inside the drive loop would reuse a dead controller/shared-memory session and blur two runs;
-    instead, this coordinator lets :func:`run_auto_drive` finish its normal controller teardown and
-    starts the complete launch->hijack->drive->tap path again.  The caller holds the machine-global
-    rig lock across this wrapper, so no peer worktree can claim the rig between attempts.
+    Two intermittent, launch-curable failure classes are retryable, each on its own budget:
 
-    Only a pure sim death is retryable.  A session replacement means another launch took ownership;
-    a recovery cap is a controller/track failure; a pipeline failure is an assertion failure; and
-    ``--skip-launch`` has no launch leg to repeat.  Those remain honest terminal failures.
+    * **Sim death** (``sim_death_retries``, #596 Part B).  A frozen main-physics packet is already
+      the harness's authoritative death oracle.  Retrying inside the drive loop would reuse a dead
+      controller/shared-memory session and blur two runs; instead, this coordinator lets
+      :func:`run_auto_drive` finish its normal controller teardown and starts the complete
+      launch->hijack->drive->tap path again.
+    * **Setup re-bake race** (``setup_verify_retries``, #737).  The launch-time setup bake can lose
+      CM's race.ini regeneration race (#466) on the CORRECT combo; the car spawns on default fuel
+      and verification honestly FAILs at ``stage="setup"``.  Exactly that terminal state
+      (``setup_race_suspected``) earns a fresh launch cycle — the relaunch re-bakes the setup.
+
+    The caller holds the machine-global rig lock across this wrapper, so no peer worktree can
+    claim the rig between attempts.  Everything else remains an honest terminal failure: a session
+    replacement means another launch took ownership; a recovery cap is a controller/track failure;
+    a pipeline failure is an assertion failure; a wiring/cached-session setup failure is not the
+    race; and ``--skip-launch`` has no launch leg to repeat (a re-verify of the same session would
+    read the same fuel).  A persistent setup mismatch still FAILs after the budget — the verify
+    gate is never weakened, only re-armed on a fresh launch.
     """
 
-    retry_budget = int(config.sim_death_retries)
-    if retry_budget < 0:
+    sim_death_budget = int(config.sim_death_retries)
+    if sim_death_budget < 0:
         raise ValueError("sim_death_retries must be >= 0")
+    setup_retry_budget = int(config.setup_verify_retries)
+    if setup_retry_budget < 0:
+        raise ValueError("setup_verify_retries must be >= 0")
     attempt_reports: list[dict[str, Any]] = []
     cleanup_holds: list[Controller] = []
-    for attempt_idx in range(retry_budget + 1):
+    sim_deaths_used = 0
+    setup_retries_used = 0
+    while True:
         try:
             report = await run_auto_drive(
                 config,
@@ -1536,19 +1584,26 @@ async def run_auto_drive_with_sim_retries(
             and not report.drive.recovery_capped
             and report.error is None
         )
-        can_retry = sim_death and not config.skip_launch and attempt_idx < retry_budget
-        if can_retry:
+        if sim_death and not config.skip_launch and sim_deaths_used < sim_death_budget:
+            sim_deaths_used += 1
             _log(
                 "sim death: retrying a fresh full launch "
-                f"(attempt {attempt_idx + 2}/{retry_budget + 1})"
+                f"(sim-death retry {sim_deaths_used}/{sim_death_budget})"
+            )
+            continue
+        setup_race = bool(not report.ok and report.stage == "setup" and report.setup_race_suspected)
+        if setup_race and not config.skip_launch and setup_retries_used < setup_retry_budget:
+            setup_retries_used += 1
+            _log(
+                "setup verify: fuel mismatch on the requested combo (#466 re-bake race) — "
+                "retrying a fresh full launch cycle "
+                f"(setup retry {setup_retries_used}/{setup_retry_budget})"
             )
             continue
         for retained_controller in cleanup_holds:
             report.retain_cleanup_controller(retained_controller)
         report.attempts = attempt_reports
         return report
-
-    raise AssertionError("sim-death retry loop exhausted without returning a report")
 
 
 def _attempt_snapshot(report: AutoDriveReport) -> dict[str, Any]:
@@ -3927,6 +3982,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="fresh full-launch retries after acs.exe death (default: 1; 0 disables)",
     )
     p.add_argument(
+        "--setup-verify-retries",
+        type=_nonneg_int,
+        default=AutoDriveConfig.setup_verify_retries,
+        help="fresh full-launch retries after a setup fuel-verify miss on the correct combo "
+        "(the #466 race.ini re-bake race; default: 1; 0 disables)",
+    )
+    p.add_argument(
         "--no-spawn-line",
         action="store_true",
         help="do not teleport a pit-box spawn onto the racing line (use the OUT-phase pit exit)",
@@ -3989,6 +4051,7 @@ def _config_from_args(args: argparse.Namespace) -> AutoDriveConfig:
         max_recoveries=args.max_recoveries,
         progress_stall_seconds=args.progress_stall_seconds,
         sim_death_retries=args.sim_death_retries,
+        setup_verify_retries=args.setup_verify_retries,
         spawn_to_line=not args.no_spawn_line,
     )
     if args.ac_root is not None:


### PR DESCRIPTION
Closes #737.

## Problem

The launch-time setup bake races CM's `race.ini` regeneration (#466, characterized). When the re-bake loses on the **correct combo**, the car spawns on default fuel and `auto_drive` FAILs at `stage=setup` with **no retry budget** — unlike sim death (`--sim-death-retries`). For the #529 P4 scientist, one transient miss aborted the entire candidate batch (`scientist_candidate_batch_incomplete`), discarding a completed baseline (first real P4 rig batch, 2026-08-08: r2 lost the race with the candidate file correct on disk; identical command r3 won it — confirmed intermittent).

## Fix

**`tools/ac_harness/auto_drive.py`** — the sim-death retry wrapper gains an independent `setup_verify_retries` budget (default 1; `--setup-verify-retries`, 0 disables). Retryable is exactly the race signature, reported machine-readably as `setup_race_suspected` in `report.json`:

- setup fuel-verify FAILED (`expected_fuel` present in the ack — a genuine fuel miss, per the new pure `setup_ack_fuel_mismatch`), AND
- the loaded combo was **not** positively mismatched (`loaded_combo_mismatch is None`).

Non-retryable (unchanged terminal behavior): wiring failures (no `apply_setup` leg, unreadable/unresolved setup ini, ack naming a different setup), cached-session mismatch exhaustion (#537 — its in-loop relaunch budget already ran), `--skip-launch` (no launch leg to repeat), and a persistent mismatch after the budget — **the verify gate is never weakened, only re-armed on a fresh launch**. Every attempt is retained in `report.attempts` (the #596 pattern); `summary()` now also counts `setup races=N`.

**`tools/ac_harness/auto_alien.py`** — `run_scientist` retries a candidate's pipeline **once** (fresh `candidate_NN_retry` evidence root, same candidate file) when the failed stage's report carries `setup_race_suspected`, recording the retry under `setup_race_retries` (candidate, stage, both evidence roots, recovered). Any other candidate failure — and a second **pipeline-level** race miss — keeps aborting the batch honestly, so a persistently unverifiable candidate can never launder into the ledger.

**Composed budget (deliberate two-scope design, made explicit after Codex P2):** the stage budget is the *cheap in-run relaunch* for one transient miss; the batch-level retry saves the baseline when a stage exhausted that budget (both launches lost the race — the p² case). The budgets compose: each pipeline attempt may burn `1 + setup_verify_retries` launches, so a persistently mismatching candidate costs at most **`2 × (1 + setup_verify_retries)` launches (4 with defaults)** before the honest abort — bounded, and far cheaper than discarding a completed baseline batch on an intermittent rig condition. The retry-branch comment states this bound, and a composition test drives the REAL `run_pipeline` to pin exactly two pipeline entries.

## Acceptance criteria → evidence

| Criterion | Test |
|---|---|
| `stage=setup` fuel-mismatch triggers ≥1 fresh relaunch (configurable, default ≥1) | `test_setup_race_miss_retries_full_launch_and_recovers`, `test_cli_new_flags_map_to_config` |
| Transient candidate miss doesn't discard baseline/earlier candidates | `test_scientist_candidate_retries_once_on_setup_race_and_completes` |
| Regression: first-attempt mismatch → relaunch attempted → subsequent success passes | `test_setup_race_miss_retries_full_launch_and_recovers` (asserts 2 launches, failed attempt retained) |
| Verify gate not weakened — persistent mismatch still FAILs | `test_setup_race_retry_budget_exhaustion_still_fails_the_verify_gate`, `test_scientist_candidate_retry_exhaustion_aborts_batch_honestly`, `test_setup_race_retry_refuses_non_retryable_setup_failures`, `test_setup_race_retry_not_spent_on_cached_session_mismatch` |
| Composed budget bounded at 2 pipeline attempts (Codex P2) | `test_scientist_setup_race_retry_composes_boundedly_with_real_pipeline` (REAL `run_pipeline`, scripted stage runner) |

Also: `test_setup_race_and_sim_death_budgets_are_independent` (both budgets in one run), `test_setup_ack_fuel_mismatch_classifier`, negative-budget validation, CLI rejection of invalid budgets, and `test_scientist_candidate_non_race_failure_does_not_retry`.

**Reality reconciliation:** the classifier chain was executed against the *actual* 2026-08-08 evidence bundles — `setup_ack_fuel_mismatch(real r2 ack)` = True (fuel 30.0 vs 40.0, `expected_fuel` present, correct combo, no cached-session clause), `= False` on the recovered r3 ack, and `_candidate_setup_race_stage` returns `identify` on the real r2 candidate report once it carries the new marker.

`make ci-fast`: OK locally (full suite).

Refs #529 · #466 · #537 · #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)