### PR TITLE
fix(harness): falsify self-play iterations whose flying laps are not repeatable (#746)

### DIFF
--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -12,6 +12,7 @@ from tools.ac_harness.auto_alien import (
     _build_arg_parser,
     drive_argv,
     evaluate_selfplay_iteration,
+    flying_lap_consistency,
     identify_argv,
     iteration_scale,
     load_stage_outcome,
@@ -343,12 +344,19 @@ def _stage_outcome(lap_times, *, recoveries=0, archives=(), stage="done", error=
     }
 
 
-def _archive_payload(lap_n=1, valid=True, car="car_a", track="trk"):
+def _archive_payload(lap_n=1, valid=True, car="car_a", track="trk", lap_ms=90000):
     return {
         "car": {"id": car},
         "track": {"id": track, "layout": None},
-        "lap": {"lap_n": lap_n, "lap_ms": 90000, "is_valid": valid},
+        "lap": {"lap_n": lap_n, "lap_ms": lap_ms, "is_valid": valid},
     }
+
+
+def _batch(*lap_ms, valid=True):
+    """A clean per-lap batch; the first entry is the standing-start out-lap."""
+    return [
+        _archive_payload(lap_n=i, valid=valid, lap_ms=ms) for i, ms in enumerate(lap_ms, start=1)
+    ]
 
 
 def test_evaluate_selfplay_iteration_falsification_branches():
@@ -389,6 +397,82 @@ def test_evaluate_selfplay_iteration_falsification_branches():
         0, _stage_outcome([95000, 93000, 92000]), [_archive_payload(1)]
     )
     assert not valid and "archive count 1 < 3 timed laps" in reason
+
+
+def test_flying_lap_spread_falsifies_an_unrepeatable_envelope():
+    """The #529 ladder-3 batch: drivable once, not reproducible -> must falsify (#746).
+
+    Real archives from 2026-07-26 (911 GT3 R @ Magione): out-lap 106.655 s then flying laps
+    80.791 s and 95.122 s, every lap AC-valid with zero recoveries. The pre-#746 oracle called
+    this VALID and the 86.27 s-floor plant was retained on it.
+    """
+    batch = _batch(106655, 80791, 95122)
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 80791, 95122]), batch)
+    assert not valid
+    assert "not repeatable" in reason
+    assert "17.7%" in reason  # (95.122 - 80.791) / 80.791
+    assert "80.791s" in reason and "95.122s" in reason
+
+
+def test_flying_lap_spread_ignores_the_out_lap():
+    """The out-lap is legitimately slow; counting it would falsify every healthy batch (#746)."""
+    # Ladder 2's stint: same shape, but the two FLYING laps are 14 ms apart.
+    batch = _batch(106655, 81505, 81519)
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), batch)
+    assert valid, reason
+    assert "spread 0.02%" in reason
+    # The out-lap alone is 31% slower than the flyers — proof it was excluded, not tolerated.
+    consistency = flying_lap_consistency(batch)
+    assert consistency["judged"] and consistency["out_lap_ms"] == 106655
+    assert consistency["flying_ms"] == [81505, 81519]
+
+
+def test_flying_lap_spread_is_unjudged_rather_than_falsified_when_it_cannot_be_measured():
+    """Unjudgeable is not a falsification — the batch still faces every other gate (#746)."""
+    # One flying lap after the out-lap: nothing to compare against.
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), _batch(95000, 93000))
+    assert valid and "consistency unjudged" in reason and "need 2 to compare" in reason
+
+    # A payload with no lap_n cannot identify the out-lap.
+    no_lap_n = _batch(95000, 93000, 92000)
+    del no_lap_n[1]["lap"]["lap_n"]
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([95000, 93000, 92000]), no_lap_n
+    )
+    assert valid and "no integer lap_n" in reason
+
+    # A duplicate lap_n means "the lowest is the out-lap" no longer holds.
+    dupes = _batch(95000, 93000, 92000)
+    dupes[2]["lap"]["lap_n"] = 2
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), dupes)
+    assert valid and "duplicate lap_n" in reason
+
+
+def test_flying_lap_spread_threshold_admits_every_healthy_historical_batch():
+    """No false positives against real rig history (#746).
+
+    Every self-play-era batch measured on the rig that had >=2 flying laps and a spread under
+    1% must stay VALID; the three measured pathologies must not.
+    """
+    healthy = [  # (out-lap, flying...) in ms, from journal/laps
+        (191890, 180366, 180387),  # huracan @ spa, 2026-08-10
+        (106655, 81505, 81519),  # 911 @ magione, ladder 2
+        (112002, 85072, 85132),  # 911 @ magione, 1.15 rung
+        (145361, 109110, 109107),  # 911 @ magione, 2026-07-14
+    ]
+    for laps in healthy:
+        valid, reason = evaluate_selfplay_iteration(0, _stage_outcome(list(laps)), _batch(*laps))
+        assert valid, f"{laps} should stay VALID but was falsified: {reason}"
+
+    pathological = [
+        (178873, 190068, 155763, 169388),  # amg_gtp @ spa, 22.0%
+        (106655, 80791, 95122),  # 911 @ magione, 17.7%
+        (189509, 167425, 159161),  # 911 @ spa, 5.2%
+    ]
+    for laps in pathological:
+        valid, reason = evaluate_selfplay_iteration(0, _stage_outcome(list(laps)), _batch(*laps))
+        assert not valid, f"{laps} should falsify but was accepted"
+        assert "not repeatable" in reason
 
 
 def test_stage_outcome_readers_round_trip(tmp_path):

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -64,6 +64,13 @@ StageRunner = Callable[[list[str]], int]
 
 DEFAULT_SIDECAR_URL = "ws://127.0.0.1:8765"
 
+# Flying-lap spread above which a self-play iteration is falsified as unrepeatable (#746).
+# Calibrated against every self-play-era batch on the rig: 31 oracle-passing batches, MEDIAN
+# spread 0.02% and only 4 above 1% — the deterministic controller normally repeats to within
+# milliseconds. 5% sits far above that noise floor and below the observed pathologies (5.2%,
+# 17.7%, 22.0%), so it separates "unrepeatable" from "normal" with room on both sides.
+SELFPLAY_MAX_FLYING_LAP_SPREAD = 0.05
+
 
 def _utc_stamp() -> str:
     return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
@@ -307,15 +314,71 @@ def combo_filter_payloads(
     return kept, len(payloads) - len(kept)
 
 
+def flying_lap_consistency(archive_payloads: list[dict]) -> dict:
+    """Lap-time spread across the batch's FLYING laps (pure; #746).
+
+    The batch's lowest ``lap_n`` is the standing-start out-lap and is legitimately far slower
+    than the rest — comparing it against the flyers would make every batch look inconsistent
+    (measured: including it turns a 0.02% median spread into a 19% one). So the out-lap is
+    dropped and only the flying laps are compared.
+
+    Returns ``{"judged": False, "reason": ...}`` whenever consistency cannot be established —
+    fewer than two flying laps, or an archive without the ``lap_n``/``lap_ms`` needed to
+    identify the out-lap and measure the spread. Unjudgeable is NOT a falsification: the batch
+    still faces every other gate, and inventing a verdict from data we do not have would be the
+    opposite of the fail-closed discipline everywhere else in this oracle.
+    """
+    laps: list[tuple[int, float]] = []
+    for payload in archive_payloads:
+        lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
+        lap_n = lap.get("lap_n")
+        lap_ms = lap.get("lap_ms")
+        if not isinstance(lap_n, int) or isinstance(lap_n, bool):
+            return {"judged": False, "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)"}
+        if not isinstance(lap_ms, (int, float)) or isinstance(lap_ms, bool) or lap_ms <= 0:
+            return {"judged": False, "reason": f"lap_n={lap_n} has no positive lap_ms (cannot measure spread)"}
+        laps.append((lap_n, float(lap_ms)))
+    # Duplicate lap_n means the batch is not a clean per-lap set, so "the lowest is the out-lap"
+    # no longer holds and dropping one entry would leave a duplicate flyer skewing the spread.
+    if len({lap_n for lap_n, _ in laps}) != len(laps):
+        return {"judged": False, "reason": "duplicate lap_n in the batch (cannot identify the out-lap)"}
+    if len(laps) < 3:
+        return {
+            "judged": False,
+            "reason": f"only {max(0, len(laps) - 1)} flying lap(s) after the out-lap (need 2 to compare)",
+        }
+    laps.sort()
+    flying = [lap_ms for _, lap_ms in laps[1:]]
+    best, worst = min(flying), max(flying)
+    return {
+        "judged": True,
+        "spread": (worst - best) / best,
+        "best_ms": best,
+        "worst_ms": worst,
+        "out_lap_ms": laps[0][1],
+        "flying_ms": flying,
+    }
+
+
 def evaluate_selfplay_iteration(
-    exit_code: int, outcome: dict | None, archive_payloads: list[dict]
+    exit_code: int,
+    outcome: dict | None,
+    archive_payloads: list[dict],
+    *,
+    max_flying_lap_spread: float = SELFPLAY_MAX_FLYING_LAP_SPREAD,
 ) -> tuple[bool, str]:
     """The keep-last-valid falsification oracle for one envelope step (pure; #577/#244).
 
     An iteration is VALID only when the drive stage passed, the car never needed a recovery,
-    at least one TIMED lap completed with its archive present, and no counted lap is AC-invalid.
-    Anything else falsifies the step — the caller reverts to the last-valid plant and reports
-    the named reason (never a silent retry of the same envelope).
+    at least one TIMED lap completed with its archive present, no counted lap is AC-invalid,
+    and — since #746 — the flying laps are REPEATABLE. Anything else falsifies the step: the
+    caller reverts to the last-valid plant and reports the named reason (never a silent retry
+    of the same envelope).
+
+    Why repeatability belongs here: validity + zero recoveries only prove the envelope was
+    *survivable* once. An envelope the controller cannot reproduce (measured: 80.791 s then
+    95.122 s in one clean stint, #529) was retained as VALID and compounded into the plant,
+    which is exactly the evidence the pace ladder is built on.
     """
     if outcome is None:
         return False, "stage report missing (drive stage did not produce report.json)"
@@ -356,7 +419,23 @@ def evaluate_selfplay_iteration(
             f"archive count {verifiable} < {len(lap_times)} timed laps "
             "(cannot verify every counted lap)"
         )
-    return True, (f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries")
+    # Repeatability last: a batch that fails any gate above is already falsified for a more
+    # specific reason, and naming the spread instead would hide it (#746).
+    consistency = flying_lap_consistency(archive_payloads)
+    if consistency["judged"] and consistency["spread"] > max_flying_lap_spread:
+        flying = ", ".join(f"{ms / 1000.0:.3f}s" for ms in consistency["flying_ms"])
+        return False, (
+            f"flying laps not repeatable at this envelope: spread "
+            f"{consistency['spread'] * 100:.1f}% > {max_flying_lap_spread * 100:.1f}% "
+            f"({flying}) — drivable once, not reproducible"
+        )
+    if consistency["judged"]:
+        suffix = f", flying-lap spread {consistency['spread'] * 100:.2f}%"
+    else:
+        suffix = f", consistency unjudged ({consistency['reason']})"
+    return True, (
+        f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries{suffix}"
+    )
 
 
 def iteration_scale(base: float, step: float, index: int, cap: float) -> float:
@@ -643,7 +722,12 @@ def run_selfplay(
         base_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
     )
     base_valid, base_reason = evaluate_selfplay_iteration(0, base_outcome, base_payloads)
-    selfplay["base"] = {"valid": base_valid, "reason": base_reason, "lap_times_ms": base_laps}
+    selfplay["base"] = {
+        "valid": base_valid,
+        "reason": base_reason,
+        "lap_times_ms": base_laps,
+        "flying_lap_consistency": flying_lap_consistency(base_payloads),
+    }
     base_l3 = stage_l3_summary(base_outcome)
     if base_l3 is not None:
         selfplay["base"]["l3"] = base_l3
@@ -1006,6 +1090,9 @@ def run_selfplay(
         valid, reason = evaluate_selfplay_iteration(code, outcome, archive_payloads)
         entry["valid"] = valid
         entry["reason"] = reason
+        # Record the measured spread whether or not it falsified, so a ladder can be audited
+        # after the fact for envelopes that were merely survivable rather than repeatable (#746).
+        entry["flying_lap_consistency"] = flying_lap_consistency(archive_payloads)
         # The pre-drive check above narrows the window but cannot close it: `auto_drive` loads the
         # plant after taking the rig lock, which we do not hold. So confirm afterwards that the
         # step really did run the plant we expected, and refuse to attribute the verdict when it


### PR DESCRIPTION
Closes #746. Part of EPIC #529 (G1 pace).

## Why

The keep-last-valid oracle `evaluate_selfplay_iteration` accepted an iteration on *drive passed + zero recoveries + every archived lap AC-valid*. Those establish that the envelope was **survivable once** — not that it is **repeatable**. So an envelope the controller cannot reproduce was retained and compounded into the plant, which is precisely the evidence #529's pace ladder is built on.

Observed on the rig 2026-07-26 (911 GT3 R @ Magione, ladder 3, [documented on #529](https://github.com/agorokh/ac-copilot-trainer/issues/529#issuecomment-5093142905)):

```
out-lap 106.655 s | flying 80.791 s and 95.122 s
both is_valid: true, recoveries=0, recovery_capped=false, sim_dead=false
-> iteration VALID -> 86.27 s-floor plant RETAINED
```

The car lost ~14 s without leaving the track or needing an intervention. Nothing was hidden — the oracle simply had no term that looked at it.

## Calibration (why 5%, and why the out-lap must go)

Measured over every self-play-era lap archive on the rig (`journal/laps`, `exported_at >= 2026-07-14`), restricted to batches satisfying the oracle's validity gate with >=2 flying laps:

```
n = 31 batches
median flying-lap spread   0.02 %     <- deterministic controller repeats to milliseconds
spread >= 1 %               4 / 31
spread >= 5 %               3 / 31
```

The **out-lap must be excluded**: it is a standing pit start and legitimately far slower. Including it turns that 0.02% median into ~19% and would falsify essentially every healthy batch. The threshold sits far above the 0.02% noise floor and below all three observed pathologies (5.2% / 17.7% / 22.0%), with room on both sides.

## What changed

- New pure helper `flying_lap_consistency()` — drops the batch's lowest `lap_n` (the out-lap) and measures spread across the remainder.
- Oracle falsifies when the flying-lap spread exceeds `SELFPLAY_MAX_FLYING_LAP_SPREAD` (5%), naming the spread and the offending lap times so the ladder report says *which* knob it falsified and why.
- **Unjudgeable is not falsification.** Fewer than two flying laps, a missing `lap_n`/`lap_ms`, or a duplicate `lap_n` records the reason and leaves the batch to the existing gates — inventing a verdict from absent data would invert the fail-closed discipline used everywhere else in this function.
- The measured spread is recorded on each iteration entry **and** on the base drive whether or not it falsified, so a ladder is auditable after the fact.
- Repeatability is checked **last**, so a batch failing any earlier gate still reports its more specific reason.

Because the oracle is shared, this also stops the scientist ([`auto_alien.py:1419`](https://github.com/agorokh/ac-copilot-trainer/blob/main/tools/ac_harness/auto_alien.py#L1419), [`:1545`](https://github.com/agorokh/ac-copilot-trainer/blob/main/tools/ac_harness/auto_alien.py#L1545)) promoting or falsifying a setup change from the difference of two means taken over a stint that was not repeatable.

## Verification

- 4 new tests, including the **real** 2026-07-26 batch as a falsification fixture and a no-false-positive guard replaying healthy historical batches (`huracan@spa 180.366/180.387`, `911@magione 81.505/81.519`, `85.072/85.132`, `109.110/109.107`) — all must stay VALID.
- `pytest tests/test_auto_alien.py tests/test_alien_scientist.py tests/test_alien_line.py` -> **118 passed**
- `pytest tests/test_auto_alien_stint_layers.py tests/test_ggv_profile.py tests/test_plant_id.py` -> **144 passed**
- Full `make ci-fast` runs in hosted CI; a local full run was deliberately deferred while a live rig ladder was driving, to avoid stealing CPU from the sim and perturbing the lap times being measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)