### PR TITLE
fix(harness): falsify self-play iterations whose flying laps are not repeatable (#746)

### DIFF
--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -360,7 +360,9 @@ def _batch(*lap_ms, valid=True):
 
 
 def test_evaluate_selfplay_iteration_falsification_branches():
-    ok_payloads = [_archive_payload(1), _archive_payload(2)]
+    # The archives must reproduce the reported timed laps; the oracle checks that since #746
+    # round 8, so these fixtures carry the same times the stage reports.
+    ok_payloads = _batch(95000, 93000)
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), ok_payloads)
     assert valid and "AC-valid" in reason
 
@@ -368,7 +370,7 @@ def test_evaluate_selfplay_iteration_falsification_branches():
     assert not valid and "report missing" in reason
 
     valid, reason = evaluate_selfplay_iteration(
-        1, _stage_outcome([95000], stage="drive", error="boom"), ok_payloads
+        1, _stage_outcome([95000], stage="drive", error="boom"), _batch(95000)
     )
     assert not valid and "exit 1" in reason and "boom" in reason
 
@@ -376,12 +378,12 @@ def test_evaluate_selfplay_iteration_falsification_branches():
     # `error` alone rendered a real physics falsification as "error=None" (#746).
     vetoed = _stage_outcome([177161], recoveries=7)
     vetoed["report"]["reason"] = "recovery cap (6) exceeded at 10366m"
-    valid, reason = evaluate_selfplay_iteration(1, vetoed, ok_payloads)
+    valid, reason = evaluate_selfplay_iteration(1, vetoed, _batch(177161))
     assert not valid and "recovery cap (6) exceeded at 10366m" in reason
     assert "error=None" not in reason
 
     valid, reason = evaluate_selfplay_iteration(
-        0, _stage_outcome([95000], recoveries=2), ok_payloads
+        0, _stage_outcome([95000], recoveries=2), _batch(95000)
     )
     assert not valid and "recovery" in reason
 
@@ -391,18 +393,19 @@ def test_evaluate_selfplay_iteration_falsification_branches():
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000]), [])
     assert not valid and "no lap archives" in reason
 
-    bad = [_archive_payload(1), _archive_payload(2, valid=False)]
+    bad = _batch(95000, 96000)
+    bad[1]["lap"]["is_valid"] = False
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 96000]), bad)
     assert not valid and "AC-invalid lap" in reason and "lap_n=2" in reason
 
     # A payload with no explicit lap-validity verdict fails CLOSED (#579 Qodo).
-    malformed = [_archive_payload(1), {"car": {"id": "car_a"}, "trace": {}}]
+    malformed = [_archive_payload(1, lap_ms=95000), {"car": {"id": "car_a"}, "trace": {}}]
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 96000]), malformed)
     assert not valid and "without a lap-validity verdict" in reason
 
     # A partial archive set leaves counted laps unverifiable -> falsified (#579 Codex P2).
     valid, reason = evaluate_selfplay_iteration(
-        0, _stage_outcome([95000, 93000, 92000]), [_archive_payload(1)]
+        0, _stage_outcome([95000, 93000, 92000]), [_archive_payload(1, lap_ms=95000)]
     )
     assert not valid and "archive count 1 < 3 timed laps" in reason
 
@@ -598,13 +601,15 @@ def test_non_positive_lap_numbers_are_malformed_not_silently_dropped():
 def test_oracle_uses_the_consistency_measurement_it_is_given():
     """The ladder measures once and passes it in, so report and verdict cannot diverge (#746)."""
     batch = _batch(106655, 81505, 81519)
-    measured = flying_lap_consistency(batch, expected_laps=3)
+    measured = flying_lap_consistency(batch, expected_lap_times_ms=[106655, 81505, 81519])
     valid, reason = evaluate_selfplay_iteration(
         0, _stage_outcome([106655, 81505, 81519]), batch, consistency=measured
     )
     assert valid and "spread 0.02%" in reason
     # A supplied measurement is authoritative: pass a falsifying one over the same laps.
-    injected = flying_lap_consistency(_batch(106655, 80791, 95122), expected_laps=3)
+    injected = flying_lap_consistency(
+        _batch(106655, 80791, 95122), expected_lap_times_ms=[106655, 80791, 95122]
+    )
     valid, reason = evaluate_selfplay_iteration(
         0, _stage_outcome([106655, 81505, 81519]), batch, consistency=injected
     )
@@ -840,7 +845,14 @@ class _SelfplayHarness:
             paths = []
             for n, valid in enumerate(archive_valids, start=1):
                 p = stage_dir / f"lap_{n}.json"
-                p.write_text(_json.dumps(_archive_payload(n, valid)), encoding="utf-8")
+                # A real drive archives the very laps it timed; the oracle now checks that
+                # correspondence, so the fake must honour it too (#746 round 8). An archive with
+                # no matching reported lap keeps a distinct time, which is exactly the
+                # unattributable shape some tests want.
+                lap_ms = lap_times[n - 1] if n - 1 < len(lap_times) else 90000
+                p.write_text(
+                    _json.dumps(_archive_payload(n, valid, lap_ms=lap_ms)), encoding="utf-8"
+                )
                 paths.append(str(p))
             payload = {
                 "report": {
@@ -915,15 +927,23 @@ def test_selfplay_ladder_alternates_one_knob_per_iteration(monkeypatch, tmp_path
     assert _json.loads(harness.plant_path.read_text(encoding="utf-8")) == {"v": "iter2"}
 
 
-def test_selfplay_reproduces_the_529_g2_recipe_unchanged(monkeypatch, tmp_path):
-    """The hand-run recipe that produced G2 must drive the SAME sequence after #703.
+def test_selfplay_stops_the_529_g2_recipe_at_its_unrepeatable_rung(monkeypatch, tmp_path):
+    """#746 deliberately CHANGES the recorded G2 ladder — this pins the new behaviour.
 
     Ladder 3 of the #529 Magione session ran ``--ggv-scale 1.0 --scale-step 0.15 --max-scale
-    1.15 --iterations 2 --laps 3`` and both iterations drove at 1.15 (the rung is capped at the
-    first step), with iteration 1's refit a no-op and iteration 2's real. That recipe IS a
-    decoupled ladder run by hand — capping the rung so the top step can never falsify is exactly
-    how the operator kept the refit — so decoupling must reproduce it rather than perturb the
-    configuration that broke the 82.7 s floor.
+    1.15 --iterations 2 --laps 3``; both iterations drove at the capped 1.15 rung, iteration 1's
+    refit was a no-op and iteration 2's was real. #703 pinned that the decoupled ladder drives
+    the same SEQUENCE, and it still does — the scales and step kinds below are unchanged.
+
+    What changes is the verdict on iteration 2. Its real stint was ``80.791 s`` then
+    ``95.122 s``: both AC-valid, zero recoveries, and a **17.7 % spread**. The pre-#746 oracle
+    called that VALID and the 86.27 s-floor plant was retained on it — which is the exact defect
+    this issue exists to fix. So the ladder that produced the headline G2 number would now STOP
+    at that rung and revert the plant.
+
+    That does not retract G2: ladder 2 of the same session ran ``81.505 / 81.519`` (14 ms apart,
+    repeatable) and also beat the 82.7 s floor. What #746 withdraws is the *retention of a plant
+    refined from an unrepeatable stint*, which is the thing that was never real.
     """
     no_op = {
         "lateral_bins_adopted": 0,
@@ -965,15 +985,18 @@ def test_selfplay_reproduces_the_529_g2_recipe_unchanged(monkeypatch, tmp_path):
     code, report = run_pipeline(args, run_stage=harness.runner())
     assert code == 0 and report["ok"]
     selfplay = report["selfplay"]
-    assert selfplay["stopped"] == "completed"
-    # Identical drive sequence to the recorded ladder: both iterations at the capped 1.15 rung.
+    # The SEQUENCE is unchanged (#703): both iterations at the capped 1.15 rung, envelope first.
     assert [entry["ggv_scale"] for entry in selfplay["iterations"]] == [1.15, 1.15]
-    # Iteration 1's no-op refit falls through to the rung; iteration 2 is the plant step that
-    # actually raised bins — and it is retained, exactly as the live ladder recorded.
     assert [entry["step_kind"] for entry in selfplay["iterations"]] == ["envelope", "plant"]
-    assert selfplay["refit_iterations"] == [2]
-    assert selfplay["best_lap_ms"] == 80791
-    assert _json.loads(harness.plant_path.read_text(encoding="utf-8")) == {"v": "iter1"}
+    # The VERDICT changes (#746): iteration 2's stint was 80.791 s then 95.122 s.
+    assert "falsified at iteration 2" in selfplay["stopped"]
+    assert "not repeatable" in selfplay["stopped"]
+    assert "17.7%" in selfplay["stopped"]
+    # Its refit is therefore never validated, and the plant is rolled back to the last valid fit.
+    assert selfplay["refit_iterations"] == []
+    assert _json.loads(harness.plant_path.read_text(encoding="utf-8")) == {"v": "original"}
+    # The best lap credited is iteration 1's repeatable 81.492 s, not the unrepeatable 80.791 s.
+    assert selfplay["best_lap_ms"] == 81492
 
 
 def test_selfplay_falsified_envelope_rung_keeps_the_validated_refit(monkeypatch, tmp_path):

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -1125,6 +1125,41 @@ def test_selfplay_base_drive_must_pass_the_oracle_to_seed_refinement(monkeypatch
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
 
 
+def test_unattributable_batch_stays_valid_but_is_withheld_from_refinement(monkeypatch, tmp_path):
+    """#746 Codex P1: non-falsifying must not mean usable as refit evidence.
+
+    An over-wide archive scan (more archives than timed laps) is a harness artifact, so it must
+    not falsify — a false falsification would revert the plant and stop the ladder. But the set
+    may carry a lap from another stint with a different tyre state, and `selfplay_refine_result`
+    merges strictly monotonically (raise-only), so feeding it would raise the plant PERMANENTLY
+    on evidence we just declared unattributable.
+    """
+    harness = _SelfplayHarness(
+        monkeypatch,
+        tmp_path,
+        stage_specs=[
+            (0, [95000], [True, True]),  # base: 1 timed lap but 2 archives -> not attributable
+            (0, [93000], [True]),  # iteration 1 drives; no refit batch to work from
+        ],
+    )
+    args = _args(
+        tmp_path, "--evidence-dir", str(tmp_path / "ev"), "--laps", "1", "--iterations", "1"
+    )
+    code, report = run_pipeline(args, run_stage=harness.runner())
+    assert code == 0
+    selfplay = report["selfplay"]
+    # Non-falsifying: the ladder ran on.
+    assert selfplay["base"]["valid"] is True
+    assert "not attributable" in selfplay["base"]["reason"]
+    # …but the archives never became refinement evidence.
+    assert "not attributable" in selfplay["base"]["refit_evidence_withheld"]
+    assert harness.refine_calls == []
+    assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
+    assert (
+        selfplay["iterations"][0]["refine"]["reason"] == "no lap archives from the previous drive"
+    )
+
+
 def test_selfplay_noop_refit_at_scale_cap_stops_instead_of_retrying(monkeypatch, tmp_path):
     # #579 Codex P2: a refit that changes nothing + a capped scale = the identical physical
     # envelope; the ladder must stop, and the no-op fit must not even be persisted.

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -605,6 +605,29 @@ def test_gapped_lap_numbers_falsify_even_when_the_times_line_up():
     assert valid
 
 
+def test_a_shifted_lap_window_cannot_invert_the_out_lap():
+    """A window starting past lap 1 flips which lap is treated as the out-lap (#746 round 10).
+
+    Codex's case: reported ``[96000, 80000, 95000]`` with archives ``(2,80000) (3,95000)
+    (4,96000)``. Multiset matches, lap numbers are contiguous — but the helper then drops lap 2
+    as the "out-lap" and reports a **1.1%** spread where the drive's real flying spread was
+    **18.8%**. The gate inverts into hiding precisely what it exists to catch.
+    """
+    shifted = [
+        _archive_payload(2, lap_ms=80000),
+        _archive_payload(3, lap_ms=95000),
+        _archive_payload(4, lap_ms=96000),
+    ]
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([96000, 80000, 95000]), shifted)
+    assert not valid, "a shifted window must not be judged as the batch"
+    assert "not 1" in reason and "shifted" in reason
+    # The same times, correctly anchored, expose the real 18.8% spread instead.
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([96000, 80000, 95000]), _batch(96000, 80000, 95000)
+    )
+    assert not valid and "not repeatable" in reason and "18.8%" in reason
+
+
 def test_non_positive_lap_numbers_are_malformed_not_silently_dropped():
     """A `lap_n <= 0` record sorts first and would be discarded as the out-lap (#746 round 6)."""
     for bad_n in (0, -1):
@@ -2474,9 +2497,9 @@ def test_selfplay_late_persist_error_cannot_return_green(monkeypatch, tmp_path):
 @pytest.mark.parametrize(
     ("baseline_laps", "candidate_laps", "expected_error"),
     [
-        (((1, 100_000), (2, 101_000)), ((3, 90_000), (4, 91_000)), None),
-        (((1, 100_000), (2, 101_000)), ((3, 90_000),), "candidate_batch_incomplete"),
-        (((1, 100_000),), ((3, 90_000), (4, 91_000)), "baseline_batch_unverifiable"),
+        (((1, 100_000), (2, 101_000)), ((1, 90_000), (2, 91_000)), None),
+        (((1, 100_000), (2, 101_000)), ((1, 90_000),), "candidate_batch_incomplete"),
+        (((1, 100_000),), ((1, 90_000), (2, 91_000)), "baseline_batch_unverifiable"),
     ],
 )
 def test_scientist_requires_requested_laps_before_persisting(
@@ -2696,7 +2719,7 @@ def _successful_candidate_pipeline_result(candidate_args) -> tuple[int, dict]:
     drive_dir = Path(candidate_args.evidence_dir) / "drive"
     drive_dir.mkdir(parents=True)
     paths = []
-    for lap_n, lap_ms in ((3, 90_000), (4, 91_000)):
+    for lap_n, lap_ms in ((1, 90_000), (2, 91_000)):
         path = drive_dir / f"lap_{lap_n}.json"
         path.write_text(
             _json.dumps(

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -540,13 +540,16 @@ def test_non_finite_lap_time_cannot_pass_as_a_positive_lap_ms():
     A NaN lap time yields a NaN spread, and `NaN > threshold` is also False, so the corrupt batch
     was reported VALID with "flying-lap spread nan%".
     """
-    for bad in (float("nan"), float("inf"), float("-inf")):
+    # An oversized Python int is the same class of corruption but a different failure: ints are
+    # arbitrary precision, so `math.isfinite(10**309)` RAISES OverflowError and would abort the
+    # pipeline rather than fail the batch closed (#746 Codex P2, round 4).
+    for bad in (float("nan"), float("inf"), float("-inf"), 10**309, 10**400, -(10**400)):
         batch = _batch(106655, 81505, 81519)
         batch[2]["lap"]["lap_ms"] = bad
         valid, reason = evaluate_selfplay_iteration(
             0, _stage_outcome([106655, 81505, 81519]), batch
         )
-        assert not valid, f"lap_ms={bad} must falsify, not be accepted"
+        assert not valid, f"lap_ms={bad!r} must falsify, not be accepted"
         assert "finite positive lap_ms" in reason
         assert "nan" not in reason.lower()
 

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -430,15 +430,15 @@ def test_flying_lap_spread_ignores_the_out_lap():
 def test_flying_lap_spread_is_unjudged_rather_than_falsified_when_it_cannot_be_measured():
     """Unjudgeable is not a falsification — the batch still faces every other gate (#746)."""
     # One flying lap after the out-lap: nothing to compare against.
-    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), _batch(95000, 93000))
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([95000, 93000]), _batch(95000, 93000)
+    )
     assert valid and "consistency unjudged" in reason and "need 2 to compare" in reason
 
     # A payload with no lap_n cannot identify the out-lap.
     no_lap_n = _batch(95000, 93000, 92000)
     del no_lap_n[1]["lap"]["lap_n"]
-    valid, reason = evaluate_selfplay_iteration(
-        0, _stage_outcome([95000, 93000, 92000]), no_lap_n
-    )
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), no_lap_n)
     assert valid and "no integer lap_n" in reason
 
     # A duplicate lap_n means "the lowest is the out-lap" no longer holds.

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -586,6 +586,25 @@ def test_batch_spanning_two_session_uuids_falsifies():
     assert valid
 
 
+def test_gapped_lap_numbers_falsify_even_when_the_times_line_up():
+    """A lap_n gap is an attribution failure even if the times match (#746 Codex P2, round 9).
+
+    Archives for lap_n 1, 2, 4 mean the counted lap 3's validity and telemetry are absent and
+    lap 4 stood in for it — so lap 4 would feed refinement in lap 3's place. Times can coincide
+    to the millisecond, so the multiset comparison alone does not catch it.
+    """
+    batch = _batch(106655, 81505, 81519)
+    batch[2]["lap"]["lap_n"] = 4  # lap 3 missing, a post-window lap stands in with the same time
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), batch)
+    assert not valid
+    assert "not contiguous" in reason
+    # The contiguous batch with identical times stays VALID.
+    valid, _ = evaluate_selfplay_iteration(
+        0, _stage_outcome([106655, 81505, 81519]), _batch(106655, 81505, 81519)
+    )
+    assert valid
+
+
 def test_non_positive_lap_numbers_are_malformed_not_silently_dropped():
     """A `lap_n <= 0` record sorts first and would be discarded as the out-lap (#746 round 6)."""
     for bad_n in (0, -1):

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -450,17 +450,20 @@ def test_flying_lap_spread_is_unjudged_rather_than_falsified_when_it_cannot_be_m
     # test_mixed_session_batch_falsifies_because_the_refit_would_consume_it (#746).
 
 
-def test_flying_lap_spread_ignores_archives_it_cannot_attribute_to_the_batch():
-    """An over-wide archive scan must not be judged as if it were the batch (#746 Qodo).
+def test_an_unattributable_batch_falsifies_rather_than_being_judged_as_the_batch():
+    """An over-wide archive scan validates NOTHING (#746 Codex P1, round 7).
 
     ``collect_lap_archives`` returns every combo-matching archive newer than ``since_epoch``,
-    which can exceed the timed-lap count. A stray lap from a neighbouring stint carries a
-    different tyre state, so judging it would falsify a perfectly repeatable batch.
+    which can exceed the timed-lap count. This was first modelled as "valid but withheld from the
+    refit" — a third state, neither validated nor rejected, that had to be re-defended at every
+    consumer (refit, scientist baseline, scientist candidate, rung counter, persisted plant
+    candidate); four of those were missed. A batch that cannot be shown to be this drive's own
+    evidence now takes the ordinary keep-last-valid path instead.
     """
     # Two repeatable flying laps (14 ms apart) plus a stray archive from another stint.
     payloads = _batch(106655, 81505, 81519, 95122)
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), payloads)
-    assert valid, reason
+    assert not valid
     assert "not attributable" in reason
     # Same laps, correctly attributed, stay judged and VALID.
     valid, reason = evaluate_selfplay_iteration(
@@ -487,12 +490,11 @@ def test_malformed_lap_evidence_falsifies_but_unjudgeable_evidence_does_not():
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), broken_ms)
     assert not valid and "unusable lap evidence" in reason and "finite positive lap_ms" in reason
 
-    # Well-formed but unjudgeable stays VALID — these must not become falsifications.
+    # The one genuinely unjudgeable case that must still stay VALID: a correctly attributed batch
+    # that simply does not have two flying laps to compare. Falsifying it would break every
+    # ordinary `--laps 2` ladder, which is what the G1b cold start runs.
     valid, _ = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), _batch(95000, 93000))
     assert valid, "an ordinary --laps 2 ladder must not be falsified for lacking a second flyer"
-    over_scan = _batch(106655, 81505, 81519, 95122)
-    valid, _ = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), over_scan)
-    assert valid, "an over-wide archive scan is a harness artifact, not corrupt data"
 
 
 def test_mixed_session_batch_falsifies_because_the_refit_would_consume_it():
@@ -1164,14 +1166,15 @@ def test_selfplay_base_drive_must_pass_the_oracle_to_seed_refinement(monkeypatch
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
 
 
-def test_unattributable_batch_stays_valid_but_is_withheld_from_refinement(monkeypatch, tmp_path):
-    """#746 Codex P1: non-falsifying must not mean usable as refit evidence.
+def test_unattributable_base_batch_validates_nothing(monkeypatch, tmp_path):
+    """#746 Codex P1, round 7: an unattributable batch may not seed refinement.
 
-    An over-wide archive scan (more archives than timed laps) is a harness artifact, so it must
-    not falsify — a false falsification would revert the plant and stop the ladder. But the set
-    may carry a lap from another stint with a different tyre state, and `selfplay_refine_result`
-    merges strictly monotonically (raise-only), so feeding it would raise the plant PERMANENTLY
-    on evidence we just declared unattributable.
+    An over-wide archive scan (more archives than timed laps) may carry a lap from another stint
+    with a different tyre state, and `selfplay_refine_result` merges strictly monotonically
+    (raise-only), so feeding it would raise the plant PERMANENTLY on evidence that was never
+    shown to belong to this drive. The batch therefore fails the oracle outright rather than
+    being carried as "valid but withheld" — but the ladder still RUNS ON, because each later
+    iteration changes the envelope and is falsification-gated in its own right.
     """
     harness = _SelfplayHarness(
         monkeypatch,
@@ -1187,13 +1190,14 @@ def test_unattributable_batch_stays_valid_but_is_withheld_from_refinement(monkey
     code, report = run_pipeline(args, run_stage=harness.runner())
     assert code == 0
     selfplay = report["selfplay"]
-    # Non-falsifying: the ladder ran on.
-    assert selfplay["base"]["valid"] is True
+    # The batch validates nothing: it fails the oracle and names why.
+    assert selfplay["base"]["valid"] is False
     assert "not attributable" in selfplay["base"]["reason"]
-    # …but the archives never became refinement evidence.
-    assert "not attributable" in selfplay["base"]["refit_evidence_withheld"]
+    # It never became refinement evidence, and the plant on disk is untouched.
     assert harness.refine_calls == []
     assert harness.plant_path.read_text(encoding="utf-8") == '{"v": "original"}'
+    # …but the ladder still ran its envelope step, which is gated on its own merits.
+    assert selfplay["iterations"][0]["valid"] is True
     assert (
         selfplay["iterations"][0]["refine"]["reason"] == "no lap archives from the previous drive"
     )

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -605,6 +605,29 @@ def test_gapped_lap_numbers_falsify_even_when_the_times_line_up():
     assert valid
 
 
+def test_a_permuted_lap_time_stream_is_not_attributable():
+    """Times must match IN LAP ORDER, not as a multiset (#746 Codex P2, round 11).
+
+    The report's `lap_times_ms` is the tap's ordered stream. Sorting both sides accepts archives
+    whose lap_n-to-time correspondence is scrambled — and since the out-lap is chosen by `lap_n`,
+    a permutation can move the slow lap out of position 1 and change which lap is discarded.
+    """
+    # Reported out-lap 106655 first; archives carry the same three times in a different order.
+    permuted = [
+        _archive_payload(1, lap_ms=81505),
+        _archive_payload(2, lap_ms=106655),
+        _archive_payload(3, lap_ms=81519),
+    ]
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), permuted)
+    assert not valid, "a permuted lap stream must not be judged as the batch"
+    assert "do not match" in reason
+    # In-order archives for the same reported stream stay VALID.
+    valid, _ = evaluate_selfplay_iteration(
+        0, _stage_outcome([106655, 81505, 81519]), _batch(106655, 81505, 81519)
+    )
+    assert valid
+
+
 def test_a_shifted_lap_window_cannot_invert_the_out_lap():
     """A window starting past lap 1 flips which lap is treated as the out-lap (#746 round 10).
 

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -12,6 +12,7 @@ from tools.ac_harness.auto_alien import (
     _build_arg_parser,
     drive_argv,
     evaluate_selfplay_iteration,
+    flying_lap_consistency,
     identify_argv,
     iteration_scale,
     load_stage_outcome,
@@ -343,12 +344,19 @@ def _stage_outcome(lap_times, *, recoveries=0, archives=(), stage="done", error=
     }
 
 
-def _archive_payload(lap_n=1, valid=True, car="car_a", track="trk"):
+def _archive_payload(lap_n=1, valid=True, car="car_a", track="trk", lap_ms=90000):
     return {
         "car": {"id": car},
         "track": {"id": track, "layout": None},
-        "lap": {"lap_n": lap_n, "lap_ms": 90000, "is_valid": valid},
+        "lap": {"lap_n": lap_n, "lap_ms": lap_ms, "is_valid": valid},
     }
+
+
+def _batch(*lap_ms, valid=True):
+    """A clean per-lap batch; the first entry is the standing-start out-lap."""
+    return [
+        _archive_payload(lap_n=i, valid=valid, lap_ms=ms) for i, ms in enumerate(lap_ms, start=1)
+    ]
 
 
 def test_evaluate_selfplay_iteration_falsification_branches():
@@ -389,6 +397,82 @@ def test_evaluate_selfplay_iteration_falsification_branches():
         0, _stage_outcome([95000, 93000, 92000]), [_archive_payload(1)]
     )
     assert not valid and "archive count 1 < 3 timed laps" in reason
+
+
+def test_flying_lap_spread_falsifies_an_unrepeatable_envelope():
+    """The #529 ladder-3 batch: drivable once, not reproducible -> must falsify (#746).
+
+    Real archives from 2026-07-26 (911 GT3 R @ Magione): out-lap 106.655 s then flying laps
+    80.791 s and 95.122 s, every lap AC-valid with zero recoveries. The pre-#746 oracle called
+    this VALID and the 86.27 s-floor plant was retained on it.
+    """
+    batch = _batch(106655, 80791, 95122)
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 80791, 95122]), batch)
+    assert not valid
+    assert "not repeatable" in reason
+    assert "17.7%" in reason  # (95.122 - 80.791) / 80.791
+    assert "80.791s" in reason and "95.122s" in reason
+
+
+def test_flying_lap_spread_ignores_the_out_lap():
+    """The out-lap is legitimately slow; counting it would falsify every healthy batch (#746)."""
+    # Ladder 2's stint: same shape, but the two FLYING laps are 14 ms apart.
+    batch = _batch(106655, 81505, 81519)
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), batch)
+    assert valid, reason
+    assert "spread 0.02%" in reason
+    # The out-lap alone is 31% slower than the flyers — proof it was excluded, not tolerated.
+    consistency = flying_lap_consistency(batch)
+    assert consistency["judged"] and consistency["out_lap_ms"] == 106655
+    assert consistency["flying_ms"] == [81505, 81519]
+
+
+def test_flying_lap_spread_is_unjudged_rather_than_falsified_when_it_cannot_be_measured():
+    """Unjudgeable is not a falsification — the batch still faces every other gate (#746)."""
+    # One flying lap after the out-lap: nothing to compare against.
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), _batch(95000, 93000))
+    assert valid and "consistency unjudged" in reason and "need 2 to compare" in reason
+
+    # A payload with no lap_n cannot identify the out-lap.
+    no_lap_n = _batch(95000, 93000, 92000)
+    del no_lap_n[1]["lap"]["lap_n"]
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([95000, 93000, 92000]), no_lap_n
+    )
+    assert valid and "no integer lap_n" in reason
+
+    # A duplicate lap_n means "the lowest is the out-lap" no longer holds.
+    dupes = _batch(95000, 93000, 92000)
+    dupes[2]["lap"]["lap_n"] = 2
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), dupes)
+    assert valid and "duplicate lap_n" in reason
+
+
+def test_flying_lap_spread_threshold_admits_every_healthy_historical_batch():
+    """No false positives against real rig history (#746).
+
+    Every self-play-era batch measured on the rig that had >=2 flying laps and a spread under
+    1% must stay VALID; the three measured pathologies must not.
+    """
+    healthy = [  # (out-lap, flying...) in ms, from journal/laps
+        (191890, 180366, 180387),  # huracan @ spa, 2026-08-10
+        (106655, 81505, 81519),  # 911 @ magione, ladder 2
+        (112002, 85072, 85132),  # 911 @ magione, 1.15 rung
+        (145361, 109110, 109107),  # 911 @ magione, 2026-07-14
+    ]
+    for laps in healthy:
+        valid, reason = evaluate_selfplay_iteration(0, _stage_outcome(list(laps)), _batch(*laps))
+        assert valid, f"{laps} should stay VALID but was falsified: {reason}"
+
+    pathological = [
+        (178873, 190068, 155763, 169388),  # amg_gtp @ spa, 22.0%
+        (106655, 80791, 95122),  # 911 @ magione, 17.7%
+        (189509, 167425, 159161),  # 911 @ spa, 5.2%
+    ]
+    for laps in pathological:
+        valid, reason = evaluate_selfplay_iteration(0, _stage_outcome(list(laps)), _batch(*laps))
+        assert not valid, f"{laps} should falsify but was accepted"
+        assert "not repeatable" in reason
 
 
 def test_stage_outcome_readers_round_trip(tmp_path):

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -485,7 +485,7 @@ def test_malformed_lap_evidence_falsifies_but_unjudgeable_evidence_does_not():
     broken_ms = _batch(95000, 93000, 92000)
     broken_ms[2]["lap"]["lap_ms"] = 0
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), broken_ms)
-    assert not valid and "unusable lap evidence" in reason and "no positive lap_ms" in reason
+    assert not valid and "unusable lap evidence" in reason and "finite positive lap_ms" in reason
 
     # Well-formed but unjudgeable stays VALID — these must not become falsifications.
     valid, _ = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), _batch(95000, 93000))
@@ -509,6 +509,46 @@ def test_mixed_session_batch_falsifies_because_the_refit_would_consume_it():
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), dupes)
     assert not valid
     assert "unusable lap evidence" in reason and "more than one session" in reason
+
+
+def test_corruption_is_checked_before_the_count_mismatch():
+    """Schema/duplicate checks must precede the count check (#746 Codex P2 + Qodo, round 3).
+
+    A retry that leaves one archive from the failed attempt alongside the final attempt's laps
+    produces BOTH a count mismatch and a duplicate `lap_n`. Returning on the count first labelled
+    that mixed-session batch `malformed=False`, so the oracle accepted it and `run_selfplay`
+    handed the whole list to the next refit — the exact contamination the duplicate check exists
+    to prevent.
+    """
+    # Count mismatch AND a duplicate lap_n: contamination must win over "not attributable".
+    mixed = _batch(95000, 93000, 92000)
+    mixed[2]["lap"]["lap_n"] = 2
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), mixed)
+    assert not valid, "a mixed-session batch must falsify even when the count also mismatches"
+    assert "more than one session" in reason
+
+    # Count mismatch AND corrupt lap evidence: corruption must win.
+    corrupt = _batch(95000, 93000, 92000)
+    del corrupt[1]["lap"]["lap_n"]
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), corrupt)
+    assert not valid and "unusable lap evidence" in reason
+
+
+def test_non_finite_lap_time_cannot_pass_as_a_positive_lap_ms():
+    """`NaN <= 0` is False, so NaN slipped the positivity check (#746 Codex P2).
+
+    A NaN lap time yields a NaN spread, and `NaN > threshold` is also False, so the corrupt batch
+    was reported VALID with "flying-lap spread nan%".
+    """
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        batch = _batch(106655, 81505, 81519)
+        batch[2]["lap"]["lap_ms"] = bad
+        valid, reason = evaluate_selfplay_iteration(
+            0, _stage_outcome([106655, 81505, 81519]), batch
+        )
+        assert not valid, f"lap_ms={bad} must falsify, not be accepted"
+        assert "finite positive lap_ms" in reason
+        assert "nan" not in reason.lower()
 
 
 def test_oracle_uses_the_consistency_measurement_it_is_given():

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -443,17 +443,11 @@ def test_flying_lap_spread_is_unjudged_rather_than_falsified_when_it_cannot_be_m
     )
     assert valid and "consistency unjudged" in reason and "need 2 to compare" in reason
 
-    # A payload with no lap_n cannot identify the out-lap.
-    no_lap_n = _batch(95000, 93000, 92000)
-    del no_lap_n[1]["lap"]["lap_n"]
-    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), no_lap_n)
-    assert valid and "no integer lap_n" in reason
+    # A payload with no lap_n is CORRUPT, not merely unjudgeable, and fails closed — see
+    # test_malformed_lap_evidence_falsifies_but_unjudgeable_evidence_does_not (#746).
 
-    # A duplicate lap_n means "the lowest is the out-lap" no longer holds.
-    dupes = _batch(95000, 93000, 92000)
-    dupes[2]["lap"]["lap_n"] = 2
-    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), dupes)
-    assert valid and "duplicate lap_n" in reason
+    # A duplicate lap_n is session CONTAMINATION and fails closed — see
+    # test_mixed_session_batch_falsifies_because_the_refit_would_consume_it (#746).
 
 
 def test_flying_lap_spread_ignores_archives_it_cannot_attribute_to_the_batch():
@@ -473,6 +467,64 @@ def test_flying_lap_spread_ignores_archives_it_cannot_attribute_to_the_batch():
         0, _stage_outcome([106655, 81505, 81519]), _batch(106655, 81505, 81519)
     )
     assert valid and "spread 0.02%" in reason
+
+
+def test_malformed_lap_evidence_falsifies_but_unjudgeable_evidence_does_not():
+    """Corrupt evidence fails CLOSED; merely-unjudgeable evidence does not (#746 self-hosted).
+
+    An archive that passed `is_valid` yet has no usable `lap_n`/`lap_ms` contradicts its own
+    schema — the refit consumes that same batch, so it must falsify. A two-lap ladder or an
+    over-wide archive scan is a known harness situation, not corrupt data, and falsifying it
+    would revert the plant and stop the ladder for no physical reason.
+    """
+    broken_n = _batch(95000, 93000, 92000)
+    del broken_n[1]["lap"]["lap_n"]
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), broken_n)
+    assert not valid and "unusable lap evidence" in reason and "no integer lap_n" in reason
+
+    broken_ms = _batch(95000, 93000, 92000)
+    broken_ms[2]["lap"]["lap_ms"] = 0
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), broken_ms)
+    assert not valid and "unusable lap evidence" in reason and "no positive lap_ms" in reason
+
+    # Well-formed but unjudgeable stays VALID — these must not become falsifications.
+    valid, _ = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000]), _batch(95000, 93000))
+    assert valid, "an ordinary --laps 2 ladder must not be falsified for lacking a second flyer"
+    over_scan = _batch(106655, 81505, 81519, 95122)
+    valid, _ = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), over_scan)
+    assert valid, "an over-wide archive scan is a harness artifact, not corrupt data"
+
+
+def test_mixed_session_batch_falsifies_because_the_refit_would_consume_it():
+    """A duplicate lap_n means two sessions in one batch — fail closed (#746 Codex P2).
+
+    When `auto_drive` retries after a sim death that already produced an archive,
+    `run_started_epoch` spans both attempts while the Lua session resets `lap_n`. The batch then
+    mixes sessions with different tyre states, and it also feeds `persist_selfplay_refinement`,
+    whose merge is strictly monotone — so a hotter session's grip would be adopted permanently.
+    Scoping archives to the batch at source is the real fix (#751); this is the safety net.
+    """
+    dupes = _batch(95000, 93000, 92000)
+    dupes[2]["lap"]["lap_n"] = 2
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), dupes)
+    assert not valid
+    assert "unusable lap evidence" in reason and "more than one session" in reason
+
+
+def test_oracle_uses_the_consistency_measurement_it_is_given():
+    """The ladder measures once and passes it in, so report and verdict cannot diverge (#746)."""
+    batch = _batch(106655, 81505, 81519)
+    measured = flying_lap_consistency(batch, expected_laps=3)
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([106655, 81505, 81519]), batch, consistency=measured
+    )
+    assert valid and "spread 0.02%" in reason
+    # A supplied measurement is authoritative: pass a falsifying one over the same laps.
+    injected = flying_lap_consistency(_batch(106655, 80791, 95122), expected_laps=3)
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([106655, 81505, 81519]), batch, consistency=injected
+    )
+    assert not valid and "not repeatable" in reason
 
 
 def test_flying_lap_spread_threshold_admits_every_healthy_historical_batch():

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -372,6 +372,14 @@ def test_evaluate_selfplay_iteration_falsification_branches():
     )
     assert not valid and "exit 1" in reason and "boom" in reason
 
+    # A VETOED drive finishes stage=done with error=None and the cause in `reason`; reporting
+    # `error` alone rendered a real physics falsification as "error=None" (#746).
+    vetoed = _stage_outcome([177161], recoveries=7)
+    vetoed["report"]["reason"] = "recovery cap (6) exceeded at 10366m"
+    valid, reason = evaluate_selfplay_iteration(1, vetoed, ok_payloads)
+    assert not valid and "recovery cap (6) exceeded at 10366m" in reason
+    assert "error=None" not in reason
+
     valid, reason = evaluate_selfplay_iteration(
         0, _stage_outcome([95000], recoveries=2), ok_payloads
     )
@@ -446,6 +454,25 @@ def test_flying_lap_spread_is_unjudged_rather_than_falsified_when_it_cannot_be_m
     dupes[2]["lap"]["lap_n"] = 2
     valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([95000, 93000, 92000]), dupes)
     assert valid and "duplicate lap_n" in reason
+
+
+def test_flying_lap_spread_ignores_archives_it_cannot_attribute_to_the_batch():
+    """An over-wide archive scan must not be judged as if it were the batch (#746 Qodo).
+
+    ``collect_lap_archives`` returns every combo-matching archive newer than ``since_epoch``,
+    which can exceed the timed-lap count. A stray lap from a neighbouring stint carries a
+    different tyre state, so judging it would falsify a perfectly repeatable batch.
+    """
+    # Two repeatable flying laps (14 ms apart) plus a stray archive from another stint.
+    payloads = _batch(106655, 81505, 81519, 95122)
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), payloads)
+    assert valid, reason
+    assert "not attributable" in reason
+    # Same laps, correctly attributed, stay judged and VALID.
+    valid, reason = evaluate_selfplay_iteration(
+        0, _stage_outcome([106655, 81505, 81519]), _batch(106655, 81505, 81519)
+    )
+    assert valid and "spread 0.02%" in reason
 
 
 def test_flying_lap_spread_threshold_admits_every_healthy_historical_batch():

--- a/tests/test_auto_alien.py
+++ b/tests/test_auto_alien.py
@@ -554,6 +554,45 @@ def test_non_finite_lap_time_cannot_pass_as_a_positive_lap_ms():
         assert "nan" not in reason.lower()
 
 
+def test_batch_spanning_two_session_uuids_falsifies():
+    """`session_uuid` is the direct attribution fact; unique lap_n is only a proxy (#746 round 6).
+
+    A missing current archive replaced by a uniquely-numbered lap from a neighbouring stint gives
+    the expected COUNT and unique lap numbers, so the duplicate check passes while the batch still
+    spans two sessions. Two distinct non-empty UUIDs prove contamination; absence proves nothing.
+    """
+    batch = _batch(106655, 81505, 81519)
+    for payload in batch:
+        payload["session_uuid"] = "aaaa1111"
+    batch[2]["session_uuid"] = "bbbb2222"
+    valid, reason = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), batch)
+    assert not valid
+    assert "spans 2 session_uuids" in reason
+
+    # One shared UUID is fine, and so is the legacy case where none carry one.
+    same = _batch(106655, 81505, 81519)
+    for payload in same:
+        payload["session_uuid"] = "aaaa1111"
+    valid, _ = evaluate_selfplay_iteration(0, _stage_outcome([106655, 81505, 81519]), same)
+    assert valid
+    valid, _ = evaluate_selfplay_iteration(
+        0, _stage_outcome([106655, 81505, 81519]), _batch(106655, 81505, 81519)
+    )
+    assert valid
+
+
+def test_non_positive_lap_numbers_are_malformed_not_silently_dropped():
+    """A `lap_n <= 0` record sorts first and would be discarded as the out-lap (#746 round 6)."""
+    for bad_n in (0, -1):
+        batch = _batch(106655, 81505, 81519)
+        batch[0]["lap"]["lap_n"] = bad_n
+        valid, reason = evaluate_selfplay_iteration(
+            0, _stage_outcome([106655, 81505, 81519]), batch
+        )
+        assert not valid, f"lap_n={bad_n} must falsify rather than be dropped as the out-lap"
+        assert "not a completed lap number" in reason
+
+
 def test_oracle_uses_the_consistency_measurement_it_is_given():
     """The ladder measures once and passes it in, so report and verdict cannot diverge (#746)."""
     batch = _batch(106655, 81505, 81519)

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -315,7 +315,7 @@ def combo_filter_payloads(
 
 
 def flying_lap_consistency(
-    archive_payloads: list[dict], *, expected_laps: int | None = None
+    archive_payloads: list[dict], *, expected_lap_times_ms: list[int] | None = None
 ) -> dict:
     """Lap-time spread across the batch's FLYING laps (pure; #746).
 
@@ -324,13 +324,19 @@ def flying_lap_consistency(
     (measured: including it turns a 0.02% median spread into a 19% one). So the out-lap is
     dropped and only the flying laps are compared.
 
-    ``expected_laps`` is the count of TIMED laps the stage reported. ``collect_lap_archives``
-    returns every combo-matching archive newer than ``since_epoch``, which can exceed the batch
-    (a drive may complete a lap after the tap stopped counting, or a neighbouring stint can fall
-    inside the window). An extra lap from a different stint carries a different tyre state, so
-    letting it into the spread could falsify a perfectly repeatable batch — so when the archive
-    count does not match the timed-lap count the batch is not attributable and goes UNJUDGED
-    rather than being judged on evidence that may not be its own (#746 Qodo).
+    ``expected_lap_times_ms`` is the list of TIMED lap times the stage itself reported, and the
+    archive set must reproduce it EXACTLY (as a multiset). ``collect_lap_archives`` returns every
+    combo-matching archive newer than ``since_epoch``, which need not be this batch: a lap can
+    complete after the tap stopped counting, an expected async archive can be missing, and a
+    neighbouring stint can fall inside the window.
+
+    Matching on count alone is not enough, and neither is count + single ``session_uuid`` +
+    unique ``lap_n`` (#746 Codex, round 8). Concrete counter-example: reported
+    ``[106655, 81505, 95122]`` against same-session archives ``lap_n`` 1, 2, 4 holding
+    ``[106655, 81505, 81519]`` satisfies every one of those heuristics, yet the *unrepeatable*
+    third lap has been silently replaced by a repeatable post-window one — and the batch is then
+    reported at a 0.02% spread, hiding the 17% the drive actually produced. Comparing the times
+    themselves is the identity check those proxies were standing in for.
 
     Returns ``{"judged": False, "malformed": bool, "reason": ...}`` whenever consistency cannot
     be established, and the two cases are NOT the same (#746 self-hosted review):
@@ -427,20 +433,24 @@ def flying_lap_consistency(
                 f"batch spans {len(sessions)} session_uuids (archives from more than one session)"
             ),
         }
-    # Only now, on a batch proven well-formed and single-session, is a count mismatch merely an
-    # attribution problem rather than possible contamination.
-    if expected_laps is not None and len(archive_payloads) != expected_laps:
-        return {
-            "judged": False,
-            "malformed": False,
-            # Non-falsifying, but the caller must not feed this to a refit: we have just said the
-            # set may contain a lap from another stint (#746 Codex P1).
-            "attributable": False,
-            "reason": (
-                f"{len(archive_payloads)} archive(s) for {expected_laps} timed lap(s) "
-                "— batch not attributable"
-            ),
-        }
+    # The archive set must REPRODUCE the times the stage reported, not merely have the same
+    # cardinality (#746 Codex, round 8). This subsumes the count check and closes the
+    # missing-archive-replaced-by-a-post-window-lap case that count + session + lap_n all pass.
+    if expected_lap_times_ms is not None:
+        observed = sorted(int(round(lap_ms)) for _, lap_ms in laps)
+        reported = sorted(int(round(value)) for value in expected_lap_times_ms)
+        if observed != reported:
+            return {
+                "judged": False,
+                "malformed": False,
+                # The caller FALSIFIES on this: a batch that is not demonstrably this drive's own
+                # evidence may not validate a rung, seed a refit, or feed the scientist (#746).
+                "attributable": False,
+                "reason": (
+                    f"archive lap times {observed} do not match the "
+                    f"{len(reported)} timed lap(s) {reported} — batch not attributable"
+                ),
+            }
     if len(laps) < 3:
         flying_count = max(0, len(laps) - 1)
         return {
@@ -534,7 +544,7 @@ def evaluate_selfplay_iteration(
     # in the ladder report cannot drift apart from two independent computations (#746
     # self-hosted review).
     if consistency is None:
-        consistency = flying_lap_consistency(archive_payloads, expected_laps=len(lap_times))
+        consistency = flying_lap_consistency(archive_payloads, expected_lap_times_ms=lap_times)
     # Corrupt evidence fails CLOSED, exactly like a payload with no validity verdict: an archive
     # that passed `is_valid` yet has no usable lap_n/lap_ms contradicts its own schema, and the
     # refit would consume that same batch.
@@ -849,7 +859,7 @@ def run_selfplay(
     base_payloads, base_foreign = combo_filter_payloads(
         base_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
     )
-    base_consistency = flying_lap_consistency(base_payloads, expected_laps=len(base_laps))
+    base_consistency = flying_lap_consistency(base_payloads, expected_lap_times_ms=base_laps)
     # Same fold as the iteration path: unreadable archives make the batch unverifiable, and that
     # fact lives out here rather than in the payloads the helper can see (#746 Qodo, round 6).
     if base_load_errors and base_consistency.get("attributable") is not False:
@@ -1233,7 +1243,7 @@ def run_selfplay(
         # verdict can never disagree (#746 self-hosted review). Recorded whether or not it
         # falsified, so a ladder can be audited after the fact for envelopes that were merely
         # survivable rather than repeatable.
-        consistency = flying_lap_consistency(archive_payloads, expected_laps=len(lap_times))
+        consistency = flying_lap_consistency(archive_payloads, expected_lap_times_ms=lap_times)
         # Unreadable archives are the same unattributability wearing a different hat (#746 Qodo,
         # round 6): `flying_lap_consistency` only ever sees payloads that LOADED, so an unreadable
         # expected archive plus a stray readable one "fills the count" and the batch looks
@@ -1673,7 +1683,7 @@ def run_scientist(
         # another stint's lap (#746 Codex P1, round 7). Attribution is now required, not just
         # sufficiency.
         baseline_attribution = flying_lap_consistency(
-            baseline_payloads, expected_laps=len(baseline_lap_times)
+            baseline_payloads, expected_lap_times_ms=baseline_lap_times
         )
         if (
             load_errors
@@ -1788,7 +1798,7 @@ def run_scientist(
             # Same one-sided gate as the baseline: too few archives failed, too many passed
             # (#746 Codex P1, round 7).
             candidate_attribution = flying_lap_consistency(
-                candidate_payloads, expected_laps=len(candidate_lap_times)
+                candidate_payloads, expected_lap_times_ms=candidate_lap_times
             )
             if (
                 candidate_outcome is None

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -362,6 +362,16 @@ def flying_lap_consistency(
                 "malformed": True,
                 "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)",
             }
+        # Completed in-game laps start at 1. A non-positive lap_n violates the archive contract
+        # and would sort FIRST, so a corrupt `-1` record would be silently dropped as the
+        # "out-lap" while the real flyers were compared — hiding the corruption rather than
+        # reporting it (#746 Codex P2, round 6).
+        if lap_n < 1:
+            return {
+                "judged": False,
+                "malformed": True,
+                "reason": f"lap_n={lap_n} is not a completed lap number (must be >= 1)",
+            }
         # Finiteness is load-bearing, not defensive: Python's json decoder accepts a bare `NaN`,
         # and every comparison with NaN is False — so `lap_ms <= 0` does NOT reject it. A NaN lap
         # time then produces a NaN spread, `spread > threshold` is False, and the corrupt batch
@@ -397,6 +407,25 @@ def flying_lap_consistency(
             "judged": False,
             "malformed": True,
             "reason": "duplicate lap_n in the batch (archives from more than one session)",
+        }
+    # `session_uuid` is the DIRECT attribution fact; unique lap numbers are only a proxy for it.
+    # A missing current archive replaced by a uniquely-numbered lap from a neighbouring stint
+    # yields the expected count AND unique lap_n, so the duplicate check above passes while the
+    # batch still spans two sessions (#746 Codex P2, round 6). Every in-game archive carries one
+    # (`src/ac_copilot_trainer/modules/lap_archive.lua`). Two distinct non-empty UUIDs PROVE
+    # contamination; absence proves nothing, so it is not treated as corruption here.
+    sessions = {
+        payload.get("session_uuid")
+        for payload in archive_payloads
+        if isinstance(payload.get("session_uuid"), str) and payload.get("session_uuid")
+    }
+    if len(sessions) > 1:
+        return {
+            "judged": False,
+            "malformed": True,
+            "reason": (
+                f"batch spans {len(sessions)} session_uuids (archives from more than one session)"
+            ),
         }
     # Only now, on a batch proven well-formed and single-session, is a count mismatch merely an
     # attribution problem rather than possible contamination.
@@ -835,7 +864,7 @@ def run_selfplay(
     # The base batch faces the same attribution test as every iteration: oracle-VALID is not
     # enough to make it refit evidence if the archive set could not be tied to this stage's own
     # timed laps (#746 Codex P1).
-    base_attributable = base_consistency.get("attributable") is not False
+    base_attributable = base_consistency.get("attributable") is not False and not base_load_errors
     prev_archives = stage_lap_archives(base_outcome) if (base_valid and base_attributable) else []
     if not base_valid:
         print(
@@ -843,7 +872,9 @@ def run_selfplay(
             "the ladder starts without a refit batch"
         )
     elif not base_attributable:
-        withheld = base_consistency.get("reason")
+        withheld = base_consistency.get("reason") or (
+            f"{len(base_load_errors)} archive(s) could not be read — batch unverifiable"
+        )
         selfplay["base"]["refit_evidence_withheld"] = withheld
         print(
             f"auto-alien: base drive archives withheld from refit — {withheld}; "
@@ -1501,9 +1532,22 @@ def run_selfplay(
         # otherwise fit from an archive we explicitly said might belong to another stint, and the
         # merge is strictly monotone (raise-only), so a different tyre state raises the plant
         # PERMANENTLY. Scoping archives to the batch at source is the real fix (#751).
+        #
+        # Unreadable archives are the same problem wearing a different hat (#746 Qodo, round 6):
+        # `flying_lap_consistency` sees only the payloads that LOADED, so if an expected archive
+        # is unreadable and a stray readable one fills the count, the batch looks attributable
+        # while being unverifiable. `load_errors` is the only evidence that happened.
+        withheld = None
         if consistency.get("attributable") is False:
             withheld = consistency.get("reason")
+        elif load_errors:
+            withheld = f"{len(load_errors)} archive(s) could not be read — batch unverifiable"
+        if withheld:
             entry["refit_evidence_withheld"] = withheld
+            # Bar it from the scientist too, not just the next refit: `_scientist_baseline_outcome`
+            # selects the newest oracle-valid entry, so without this it would compare and persist
+            # setup verdicts from archives we just declared unattributable (#746 Codex P1, round 6).
+            entry["usable_as_evidence"] = False
             print(f"auto-alien: iteration {index} archives withheld from refit — {withheld}")
             prev_archives = []
         else:

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -474,9 +474,15 @@ def flying_lap_consistency(
     # The archive set must REPRODUCE the times the stage reported, not merely have the same
     # cardinality (#746 Codex, round 8). This subsumes the count check and closes the
     # missing-archive-replaced-by-a-post-window-lap case that count + session + lap_n all pass.
+    #
+    # Matched IN LAP ORDER, not as a multiset (#746 Codex P2, round 11): the report's
+    # `lap_times_ms` is the tap's ordered stream, so sorting both sides accepts a PERMUTATION —
+    # archives whose lap_n↔time correspondence is scrambled relative to the drive. That matters
+    # because the out-lap is chosen by lap_n: a permutation can move the slow lap out of position
+    # 1 and change which lap is discarded, the same inversion round 10 closed for shifts.
     if expected_lap_times_ms is not None:
-        observed = sorted(int(round(lap_ms)) for _, lap_ms in laps)
-        reported = sorted(int(round(value)) for value in expected_lap_times_ms)
+        observed = [int(round(lap_ms)) for _, lap_ms in sorted(laps)]
+        reported = [int(round(value)) for value in expected_lap_times_ms]
         if observed != reported:
             return {
                 "judged": False,
@@ -1730,6 +1736,9 @@ def run_scientist(
             or len(baseline_lap_times) < args.laps
             or len(baseline_payloads) < args.laps
             or baseline_attribution.get("attributable") is False
+            # Corrupt / mixed-session candidate evidence must abort too, not only
+            # unattributable evidence (#746 Codex P2, round 11).
+            or baseline_attribution.get("malformed") is True
         ):
             raise ScientistError(
                 "scientist_baseline_batch_unverifiable:"
@@ -1845,6 +1854,7 @@ def run_scientist(
                 or candidate_load_errors
                 or candidate_foreign
                 or candidate_attribution.get("attributable") is False
+                or candidate_attribution.get("malformed") is True
             ):
                 raise ScientistError(
                     "scientist_candidate_batch_incomplete:"

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -433,6 +433,22 @@ def flying_lap_consistency(
                 f"batch spans {len(sessions)} session_uuids (archives from more than one session)"
             ),
         }
+    # A drive's timed laps are CONTIGUOUS, so a gap in lap_n is an observable attribution failure
+    # even when the times happen to line up: archives for lap_n 1, 2, 4 mean lap 3's validity and
+    # telemetry are absent and lap 4 stood in for it, so lap 4 would feed refinement in its place
+    # (#746 Codex P2, round 9). Cheaper and stricter than relying on the times alone, which can
+    # coincide to the millisecond.
+    lap_numbers = sorted(lap_n for lap_n, _ in laps)
+    if lap_numbers and lap_numbers[-1] - lap_numbers[0] != len(lap_numbers) - 1:
+        return {
+            "judged": False,
+            "malformed": False,
+            "attributable": False,
+            "reason": (
+                f"lap numbers {lap_numbers} are not contiguous — a counted lap is missing "
+                "and another stood in for it"
+            ),
+        }
     # The archive set must REPRODUCE the times the stage reported, not merely have the same
     # cardinality (#746 Codex, round 8). This subsumes the count check and closes the
     # missing-archive-replaced-by-a-post-window-lap case that count + session + lap_n all pass.

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -449,6 +449,28 @@ def flying_lap_consistency(
                 "and another stood in for it"
             ),
         }
+    # …and it must start at lap 1, because each stage launches a fresh session and drives from a
+    # standing start (#746 Codex P2, round 10). A SHIFTED window is worse than a gapped one: with
+    # reported [96000, 80000, 95000] and archives (2,80000) (3,95000) (4,96000), the multiset and
+    # contiguity checks both pass, the helper then drops lap 2 as the "out-lap", and an 18.8%
+    # flying spread is reported as 1.1% — the gate inverted into hiding exactly what it exists to
+    # catch.
+    #
+    # Measured cost, stated because it is not zero: 1 of 80 real self-play-era sessions on the
+    # rig starts at lap_n 3 (a coherent 145.4 s + 109.110/109.107 batch), and this rejects it.
+    # That failure is CONSERVATIVE — it stops a ladder and corrupts nothing — whereas the
+    # inversion above retains an unrepeatable envelope, which is the defect #746 exists to fix.
+    # #751's source-side scoping removes the guesswork entirely.
+    if lap_numbers and lap_numbers[0] != 1:
+        return {
+            "judged": False,
+            "malformed": False,
+            "attributable": False,
+            "reason": (
+                f"batch starts at lap_n={lap_numbers[0]}, not 1 — a standing-start stage's "
+                "laps begin at 1, so this window is shifted"
+            ),
+        }
     # The archive set must REPRODUCE the times the stage reported, not merely have the same
     # cardinality (#746 Codex, round 8). This subsumes the count check and closes the
     # missing-archive-replaced-by-a-post-window-lap case that count + session + lap_n all pass.

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -314,7 +314,9 @@ def combo_filter_payloads(
     return kept, len(payloads) - len(kept)
 
 
-def flying_lap_consistency(archive_payloads: list[dict]) -> dict:
+def flying_lap_consistency(
+    archive_payloads: list[dict], *, expected_laps: int | None = None
+) -> dict:
     """Lap-time spread across the batch's FLYING laps (pure; #746).
 
     The batch's lowest ``lap_n`` is the standing-start out-lap and is legitimately far slower
@@ -322,12 +324,29 @@ def flying_lap_consistency(archive_payloads: list[dict]) -> dict:
     (measured: including it turns a 0.02% median spread into a 19% one). So the out-lap is
     dropped and only the flying laps are compared.
 
+    ``expected_laps`` is the count of TIMED laps the stage reported. ``collect_lap_archives``
+    returns every combo-matching archive newer than ``since_epoch``, which can exceed the batch
+    (a drive may complete a lap after the tap stopped counting, or a neighbouring stint can fall
+    inside the window). An extra lap from a different stint carries a different tyre state, so
+    letting it into the spread could falsify a perfectly repeatable batch — so when the archive
+    count does not match the timed-lap count the batch is not attributable and goes UNJUDGED
+    rather than being judged on evidence that may not be its own (#746 Qodo).
+
     Returns ``{"judged": False, "reason": ...}`` whenever consistency cannot be established —
-    fewer than two flying laps, or an archive without the ``lap_n``/``lap_ms`` needed to
-    identify the out-lap and measure the spread. Unjudgeable is NOT a falsification: the batch
-    still faces every other gate, and inventing a verdict from data we do not have would be the
-    opposite of the fail-closed discipline everywhere else in this oracle.
+    an unattributable batch, fewer than two flying laps, or an archive without the
+    ``lap_n``/``lap_ms`` needed to identify the out-lap and measure the spread. Unjudgeable is
+    NOT a falsification: the batch still faces every other gate, and inventing a verdict from
+    data we do not have would be the opposite of the fail-closed discipline everywhere else in
+    this oracle.
     """
+    if expected_laps is not None and len(archive_payloads) != expected_laps:
+        return {
+            "judged": False,
+            "reason": (
+                f"{len(archive_payloads)} archive(s) for {expected_laps} timed lap(s) "
+                "— batch not attributable"
+            ),
+        }
     laps: list[tuple[int, float]] = []
     for payload in archive_payloads:
         lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
@@ -395,8 +414,14 @@ def evaluate_selfplay_iteration(
     report = outcome.get("report") if isinstance(outcome.get("report"), dict) else {}
     if exit_code != 0:
         stage = report.get("stage")
-        error = report.get("error")
-        return False, f"drive stage failed (exit {exit_code}, stage={stage}, error={error})"
+        # `error` is only set for an exception-shaped failure. A drive that ran and was VETOED —
+        # recovery cap, sim death, spawn trap — finishes `stage=done` with `error=None` and puts
+        # the cause in `reason`, so reporting `error` alone rendered a real physics falsification
+        # as "stage=done, error=None" and hid why the rung failed (#746, observed at ggv_scale
+        # 1.20: `recovery cap (6) exceeded at 10366m`, 7 recoveries).
+        drive_report = report.get("drive") if isinstance(report.get("drive"), dict) else {}
+        cause = report.get("error") or report.get("reason") or drive_report.get("reason")
+        return False, f"drive stage failed (exit {exit_code}, stage={stage}, cause={cause})"
     drive = report.get("drive") if isinstance(report.get("drive"), dict) else {}
     recoveries = drive.get("recoveries")
     if isinstance(recoveries, (int, float)) and recoveries > 0:
@@ -431,7 +456,7 @@ def evaluate_selfplay_iteration(
         )
     # Repeatability last: a batch that fails any gate above is already falsified for a more
     # specific reason, and naming the spread instead would hide it (#746).
-    consistency = flying_lap_consistency(archive_payloads)
+    consistency = flying_lap_consistency(archive_payloads, expected_laps=len(lap_times))
     if consistency["judged"] and consistency["spread"] > max_flying_lap_spread:
         flying = ", ".join(f"{ms / 1000.0:.3f}s" for ms in consistency["flying_ms"])
         return False, (
@@ -736,7 +761,9 @@ def run_selfplay(
         "valid": base_valid,
         "reason": base_reason,
         "lap_times_ms": base_laps,
-        "flying_lap_consistency": flying_lap_consistency(base_payloads),
+        "flying_lap_consistency": flying_lap_consistency(
+            base_payloads, expected_laps=len(base_laps)
+        ),
     }
     base_l3 = stage_l3_summary(base_outcome)
     if base_l3 is not None:
@@ -1102,7 +1129,9 @@ def run_selfplay(
         entry["reason"] = reason
         # Record the measured spread whether or not it falsified, so a ladder can be audited
         # after the fact for envelopes that were merely survivable rather than repeatable (#746).
-        entry["flying_lap_consistency"] = flying_lap_consistency(archive_payloads)
+        entry["flying_lap_consistency"] = flying_lap_consistency(
+            archive_payloads, expected_laps=len(lap_times)
+        )
         # The pre-drive check above narrows the window but cannot close it: `auto_drive` loads the
         # plant after taking the rig lock, which we do not hold. So confirm afterwards that the
         # step really did run the plant we expected, and refuse to attribute the verdict when it

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -334,18 +334,28 @@ def flying_lap_consistency(archive_payloads: list[dict]) -> dict:
         lap_n = lap.get("lap_n")
         lap_ms = lap.get("lap_ms")
         if not isinstance(lap_n, int) or isinstance(lap_n, bool):
-            return {"judged": False, "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)"}
+            return {
+                "judged": False,
+                "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)",
+            }
         if not isinstance(lap_ms, (int, float)) or isinstance(lap_ms, bool) or lap_ms <= 0:
-            return {"judged": False, "reason": f"lap_n={lap_n} has no positive lap_ms (cannot measure spread)"}
+            return {
+                "judged": False,
+                "reason": f"lap_n={lap_n} has no positive lap_ms (cannot measure spread)",
+            }
         laps.append((lap_n, float(lap_ms)))
     # Duplicate lap_n means the batch is not a clean per-lap set, so "the lowest is the out-lap"
     # no longer holds and dropping one entry would leave a duplicate flyer skewing the spread.
     if len({lap_n for lap_n, _ in laps}) != len(laps):
-        return {"judged": False, "reason": "duplicate lap_n in the batch (cannot identify the out-lap)"}
-    if len(laps) < 3:
         return {
             "judged": False,
-            "reason": f"only {max(0, len(laps) - 1)} flying lap(s) after the out-lap (need 2 to compare)",
+            "reason": "duplicate lap_n in the batch (cannot identify the out-lap)",
+        }
+    if len(laps) < 3:
+        flying_count = max(0, len(laps) - 1)
+        return {
+            "judged": False,
+            "reason": f"only {flying_count} flying lap(s) after the out-lap (need 2 to compare)",
         }
     laps.sort()
     flying = [lap_ms for _, lap_ms in laps[1:]]

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -404,6 +404,9 @@ def flying_lap_consistency(
         return {
             "judged": False,
             "malformed": False,
+            # Non-falsifying, but the caller must not feed this to a refit: we have just said the
+            # set may contain a lap from another stint (#746 Codex P1).
+            "attributable": False,
             "reason": (
                 f"{len(archive_payloads)} archive(s) for {expected_laps} timed lap(s) "
                 "— batch not attributable"
@@ -829,10 +832,21 @@ def run_selfplay(
     # An oracle-invalid base's laps are marked unusable by this very report — they must not seed
     # the performance summary either (#579 Codex P2).
     best: int | None = min(base_laps) if (base_laps and base_valid) else None
-    prev_archives = stage_lap_archives(base_outcome) if base_valid else []
+    # The base batch faces the same attribution test as every iteration: oracle-VALID is not
+    # enough to make it refit evidence if the archive set could not be tied to this stage's own
+    # timed laps (#746 Codex P1).
+    base_attributable = base_consistency.get("attributable") is not False
+    prev_archives = stage_lap_archives(base_outcome) if (base_valid and base_attributable) else []
     if not base_valid:
         print(
             f"auto-alien: base drive not usable as refinement evidence ({base_reason}) — "
+            "the ladder starts without a refit batch"
+        )
+    elif not base_attributable:
+        withheld = base_consistency.get("reason")
+        selfplay["base"]["refit_evidence_withheld"] = withheld
+        print(
+            f"auto-alien: base drive archives withheld from refit — {withheld}; "
             "the ladder starts without a refit batch"
         )
     prev_scale = resolved_base_scale
@@ -1481,7 +1495,19 @@ def run_selfplay(
         if step_kind == "envelope":
             rung += 1
         next_step_kind = "envelope" if step_kind == "plant" else "plant"
-        prev_archives = archives
+        # A batch we could not attribute to this stage's own timed laps stays VALID — the ladder
+        # continues, because a false falsification would revert the plant for a harness artifact
+        # — but it must NOT become refit evidence (#746 Codex P1). `selfplay_refine_result` would
+        # otherwise fit from an archive we explicitly said might belong to another stint, and the
+        # merge is strictly monotone (raise-only), so a different tyre state raises the plant
+        # PERMANENTLY. Scoping archives to the batch at source is the real fix (#751).
+        if consistency.get("attributable") is False:
+            withheld = consistency.get("reason")
+            entry["refit_evidence_withheld"] = withheld
+            print(f"auto-alien: iteration {index} archives withheld from refit — {withheld}")
+            prev_archives = []
+        else:
+            prev_archives = archives
         prev_scale = scale
 
     selfplay["best_lap_ms"] = best

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -64,6 +64,13 @@ StageRunner = Callable[[list[str]], int]
 
 DEFAULT_SIDECAR_URL = "ws://127.0.0.1:8765"
 
+# Flying-lap spread above which a self-play iteration is falsified as unrepeatable (#746).
+# Calibrated against every self-play-era batch on the rig: 31 oracle-passing batches, MEDIAN
+# spread 0.02% and only 4 above 1% — the deterministic controller normally repeats to within
+# milliseconds. 5% sits far above that noise floor and below the observed pathologies (5.2%,
+# 17.7%, 22.0%), so it separates "unrepeatable" from "normal" with room on both sides.
+SELFPLAY_MAX_FLYING_LAP_SPREAD = 0.05
+
 
 def _utc_stamp() -> str:
     return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
@@ -307,15 +314,71 @@ def combo_filter_payloads(
     return kept, len(payloads) - len(kept)
 
 
+def flying_lap_consistency(archive_payloads: list[dict]) -> dict:
+    """Lap-time spread across the batch's FLYING laps (pure; #746).
+
+    The batch's lowest ``lap_n`` is the standing-start out-lap and is legitimately far slower
+    than the rest — comparing it against the flyers would make every batch look inconsistent
+    (measured: including it turns a 0.02% median spread into a 19% one). So the out-lap is
+    dropped and only the flying laps are compared.
+
+    Returns ``{"judged": False, "reason": ...}`` whenever consistency cannot be established —
+    fewer than two flying laps, or an archive without the ``lap_n``/``lap_ms`` needed to
+    identify the out-lap and measure the spread. Unjudgeable is NOT a falsification: the batch
+    still faces every other gate, and inventing a verdict from data we do not have would be the
+    opposite of the fail-closed discipline everywhere else in this oracle.
+    """
+    laps: list[tuple[int, float]] = []
+    for payload in archive_payloads:
+        lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
+        lap_n = lap.get("lap_n")
+        lap_ms = lap.get("lap_ms")
+        if not isinstance(lap_n, int) or isinstance(lap_n, bool):
+            return {"judged": False, "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)"}
+        if not isinstance(lap_ms, (int, float)) or isinstance(lap_ms, bool) or lap_ms <= 0:
+            return {"judged": False, "reason": f"lap_n={lap_n} has no positive lap_ms (cannot measure spread)"}
+        laps.append((lap_n, float(lap_ms)))
+    # Duplicate lap_n means the batch is not a clean per-lap set, so "the lowest is the out-lap"
+    # no longer holds and dropping one entry would leave a duplicate flyer skewing the spread.
+    if len({lap_n for lap_n, _ in laps}) != len(laps):
+        return {"judged": False, "reason": "duplicate lap_n in the batch (cannot identify the out-lap)"}
+    if len(laps) < 3:
+        return {
+            "judged": False,
+            "reason": f"only {max(0, len(laps) - 1)} flying lap(s) after the out-lap (need 2 to compare)",
+        }
+    laps.sort()
+    flying = [lap_ms for _, lap_ms in laps[1:]]
+    best, worst = min(flying), max(flying)
+    return {
+        "judged": True,
+        "spread": (worst - best) / best,
+        "best_ms": best,
+        "worst_ms": worst,
+        "out_lap_ms": laps[0][1],
+        "flying_ms": flying,
+    }
+
+
 def evaluate_selfplay_iteration(
-    exit_code: int, outcome: dict | None, archive_payloads: list[dict]
+    exit_code: int,
+    outcome: dict | None,
+    archive_payloads: list[dict],
+    *,
+    max_flying_lap_spread: float = SELFPLAY_MAX_FLYING_LAP_SPREAD,
 ) -> tuple[bool, str]:
     """The keep-last-valid falsification oracle for one envelope step (pure; #577/#244).
 
     An iteration is VALID only when the drive stage passed, the car never needed a recovery,
-    at least one TIMED lap completed with its archive present, and no counted lap is AC-invalid.
-    Anything else falsifies the step — the caller reverts to the last-valid plant and reports
-    the named reason (never a silent retry of the same envelope).
+    at least one TIMED lap completed with its archive present, no counted lap is AC-invalid,
+    and — since #746 — the flying laps are REPEATABLE. Anything else falsifies the step: the
+    caller reverts to the last-valid plant and reports the named reason (never a silent retry
+    of the same envelope).
+
+    Why repeatability belongs here: validity + zero recoveries only prove the envelope was
+    *survivable* once. An envelope the controller cannot reproduce (measured: 80.791 s then
+    95.122 s in one clean stint, #529) was retained as VALID and compounded into the plant,
+    which is exactly the evidence the pace ladder is built on.
     """
     if outcome is None:
         return False, "stage report missing (drive stage did not produce report.json)"
@@ -356,7 +419,23 @@ def evaluate_selfplay_iteration(
             f"archive count {verifiable} < {len(lap_times)} timed laps "
             "(cannot verify every counted lap)"
         )
-    return True, (f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries")
+    # Repeatability last: a batch that fails any gate above is already falsified for a more
+    # specific reason, and naming the spread instead would hide it (#746).
+    consistency = flying_lap_consistency(archive_payloads)
+    if consistency["judged"] and consistency["spread"] > max_flying_lap_spread:
+        flying = ", ".join(f"{ms / 1000.0:.3f}s" for ms in consistency["flying_ms"])
+        return False, (
+            f"flying laps not repeatable at this envelope: spread "
+            f"{consistency['spread'] * 100:.1f}% > {max_flying_lap_spread * 100:.1f}% "
+            f"({flying}) — drivable once, not reproducible"
+        )
+    if consistency["judged"]:
+        suffix = f", flying-lap spread {consistency['spread'] * 100:.2f}%"
+    else:
+        suffix = f", consistency unjudged ({consistency['reason']})"
+    return True, (
+        f"{len(lap_times)} timed lap(s), all archived laps AC-valid, zero recoveries{suffix}"
+    )
 
 
 def iteration_scale(base: float, step: float, index: int, cap: float) -> float:
@@ -643,7 +722,12 @@ def run_selfplay(
         base_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
     )
     base_valid, base_reason = evaluate_selfplay_iteration(0, base_outcome, base_payloads)
-    selfplay["base"] = {"valid": base_valid, "reason": base_reason, "lap_times_ms": base_laps}
+    selfplay["base"] = {
+        "valid": base_valid,
+        "reason": base_reason,
+        "lap_times_ms": base_laps,
+        "flying_lap_consistency": flying_lap_consistency(base_payloads),
+    }
     base_l3 = stage_l3_summary(base_outcome)
     if base_l3 is not None:
         selfplay["base"]["l3"] = base_l3
@@ -1006,6 +1090,9 @@ def run_selfplay(
         valid, reason = evaluate_selfplay_iteration(code, outcome, archive_payloads)
         entry["valid"] = valid
         entry["reason"] = reason
+        # Record the measured spread whether or not it falsified, so a ladder can be audited
+        # after the fact for envelopes that were merely survivable rather than repeatable (#746).
+        entry["flying_lap_consistency"] = flying_lap_consistency(archive_payloads)
         # The pre-drive check above narrows the window but cannot close it: `auto_drive` loads the
         # plant after taking the rig lock, which we do not hold. So confirm afterwards that the
         # step really did run the plant we expected, and refuse to attribute the verdict when it

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -332,16 +332,22 @@ def flying_lap_consistency(
     count does not match the timed-lap count the batch is not attributable and goes UNJUDGED
     rather than being judged on evidence that may not be its own (#746 Qodo).
 
-    Returns ``{"judged": False, "reason": ...}`` whenever consistency cannot be established —
-    an unattributable batch, fewer than two flying laps, or an archive without the
-    ``lap_n``/``lap_ms`` needed to identify the out-lap and measure the spread. Unjudgeable is
-    NOT a falsification: the batch still faces every other gate, and inventing a verdict from
-    data we do not have would be the opposite of the fail-closed discipline everywhere else in
-    this oracle.
+    Returns ``{"judged": False, "malformed": bool, "reason": ...}`` whenever consistency cannot
+    be established, and the two cases are NOT the same (#746 self-hosted review):
+
+    * ``malformed=True`` — an archive contradicts its own schema: it carried ``is_valid: True``
+      (so it already passed the validity gate) yet has no integer ``lap_n`` or no positive
+      ``lap_ms``. That is corrupt evidence, and the caller FALSIFIES, matching how a payload
+      with no validity verdict is treated.
+    * ``malformed=False`` — the batch is well-formed but not judgeable *here*: too few flying
+      laps (an ordinary ``--laps 2`` run), a count mismatch, or a duplicate ``lap_n``. These are
+      known harness situations, not corrupt data. Falsifying them would revert the plant and
+      stop the ladder for no physical reason — and would break every two-lap ladder outright.
     """
     if expected_laps is not None and len(archive_payloads) != expected_laps:
         return {
             "judged": False,
+            "malformed": False,
             "reason": (
                 f"{len(archive_payloads)} archive(s) for {expected_laps} timed lap(s) "
                 "— batch not attributable"
@@ -355,25 +361,34 @@ def flying_lap_consistency(
         if not isinstance(lap_n, int) or isinstance(lap_n, bool):
             return {
                 "judged": False,
+                "malformed": True,
                 "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)",
             }
         if not isinstance(lap_ms, (int, float)) or isinstance(lap_ms, bool) or lap_ms <= 0:
             return {
                 "judged": False,
+                "malformed": True,
                 "reason": f"lap_n={lap_n} has no positive lap_ms (cannot measure spread)",
             }
         laps.append((lap_n, float(lap_ms)))
-    # Duplicate lap_n means the batch is not a clean per-lap set, so "the lowest is the out-lap"
-    # no longer holds and dropping one entry would leave a duplicate flyer skewing the spread.
+    # Duplicate lap_n is CONTAMINATION, not just an attribution nuisance (#746 Codex P2): when
+    # `auto_drive` retries after a sim death that already produced an archive, `run_started_epoch`
+    # spans both attempts while the Lua session resets `lap_n`, so the set mixes two sessions with
+    # DIFFERENT TYRE STATES. That batch also feeds `persist_selfplay_refinement`, whose merge is
+    # strictly monotone (raise-only) — so a hotter session's grip would be adopted permanently.
+    # Treating it as merely "unjudged" let exactly that through, so it fails closed.
+    # Scoping the archive set to the batch at the source is the real fix (#751).
     if len({lap_n for lap_n, _ in laps}) != len(laps):
         return {
             "judged": False,
-            "reason": "duplicate lap_n in the batch (cannot identify the out-lap)",
+            "malformed": True,
+            "reason": "duplicate lap_n in the batch (archives from more than one session)",
         }
     if len(laps) < 3:
         flying_count = max(0, len(laps) - 1)
         return {
             "judged": False,
+            "malformed": False,
             "reason": f"only {flying_count} flying lap(s) after the out-lap (need 2 to compare)",
         }
     laps.sort()
@@ -395,6 +410,7 @@ def evaluate_selfplay_iteration(
     archive_payloads: list[dict],
     *,
     max_flying_lap_spread: float = SELFPLAY_MAX_FLYING_LAP_SPREAD,
+    consistency: dict | None = None,
 ) -> tuple[bool, str]:
     """The keep-last-valid falsification oracle for one envelope step (pure; #577/#244).
 
@@ -456,7 +472,17 @@ def evaluate_selfplay_iteration(
         )
     # Repeatability last: a batch that fails any gate above is already falsified for a more
     # specific reason, and naming the spread instead would hide it (#746).
-    consistency = flying_lap_consistency(archive_payloads, expected_laps=len(lap_times))
+    #
+    # The caller may pass the measurement it already made, so the verdict and the value recorded
+    # in the ladder report cannot drift apart from two independent computations (#746
+    # self-hosted review).
+    if consistency is None:
+        consistency = flying_lap_consistency(archive_payloads, expected_laps=len(lap_times))
+    # Corrupt evidence fails CLOSED, exactly like a payload with no validity verdict: an archive
+    # that passed `is_valid` yet has no usable lap_n/lap_ms contradicts its own schema, and the
+    # refit would consume that same batch.
+    if consistency.get("malformed"):
+        return False, f"unusable lap evidence for repeatability: {consistency['reason']}"
     if consistency["judged"] and consistency["spread"] > max_flying_lap_spread:
         flying = ", ".join(f"{ms / 1000.0:.3f}s" for ms in consistency["flying_ms"])
         return False, (
@@ -756,14 +782,15 @@ def run_selfplay(
     base_payloads, base_foreign = combo_filter_payloads(
         base_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
     )
-    base_valid, base_reason = evaluate_selfplay_iteration(0, base_outcome, base_payloads)
+    base_consistency = flying_lap_consistency(base_payloads, expected_laps=len(base_laps))
+    base_valid, base_reason = evaluate_selfplay_iteration(
+        0, base_outcome, base_payloads, consistency=base_consistency
+    )
     selfplay["base"] = {
         "valid": base_valid,
         "reason": base_reason,
         "lap_times_ms": base_laps,
-        "flying_lap_consistency": flying_lap_consistency(
-            base_payloads, expected_laps=len(base_laps)
-        ),
+        "flying_lap_consistency": base_consistency,
     }
     base_l3 = stage_l3_summary(base_outcome)
     if base_l3 is not None:
@@ -1124,14 +1151,17 @@ def run_selfplay(
         lap_times = stage_lap_times_ms(outcome)
         entry["lap_times_ms"] = lap_times
         selfplay["lap_trajectory_ms"].append(lap_times)
-        valid, reason = evaluate_selfplay_iteration(code, outcome, archive_payloads)
+        # Measure once and hand the SAME dict to the oracle, so the recorded value and the
+        # verdict can never disagree (#746 self-hosted review). Recorded whether or not it
+        # falsified, so a ladder can be audited after the fact for envelopes that were merely
+        # survivable rather than repeatable.
+        consistency = flying_lap_consistency(archive_payloads, expected_laps=len(lap_times))
+        entry["flying_lap_consistency"] = consistency
+        valid, reason = evaluate_selfplay_iteration(
+            code, outcome, archive_payloads, consistency=consistency
+        )
         entry["valid"] = valid
         entry["reason"] = reason
-        # Record the measured spread whether or not it falsified, so a ladder can be audited
-        # after the fact for envelopes that were merely survivable rather than repeatable (#746).
-        entry["flying_lap_consistency"] = flying_lap_consistency(
-            archive_payloads, expected_laps=len(lap_times)
-        )
         # The pre-drive check above narrows the window but cannot close it: `auto_drive` loads the
         # plant after taking the rig lock, which we do not hold. So confirm afterwards that the
         # step really did run the plant we expected, and refuse to attribute the verdict when it

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -362,22 +362,29 @@ def flying_lap_consistency(
                 "malformed": True,
                 "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)",
             }
-        # `math.isfinite` is load-bearing, not defensive: Python's json decoder accepts a bare
-        # `NaN`, and every comparison with NaN is False — so `lap_ms <= 0` does NOT reject it.
-        # A NaN lap time then produces a NaN spread, `spread > threshold` is False, and the
-        # corrupt batch was reported VALID with "flying-lap spread nan%" (#746 Codex P2).
-        if (
-            not isinstance(lap_ms, (int, float))
-            or isinstance(lap_ms, bool)
-            or not math.isfinite(lap_ms)
-            or lap_ms <= 0
-        ):
+        # Finiteness is load-bearing, not defensive: Python's json decoder accepts a bare `NaN`,
+        # and every comparison with NaN is False — so `lap_ms <= 0` does NOT reject it. A NaN lap
+        # time then produces a NaN spread, `spread > threshold` is False, and the corrupt batch
+        # was reported VALID with "flying-lap spread nan%" (#746 Codex P2).
+        #
+        # The float() conversion must be GUARDED: Python ints are arbitrary precision, so a
+        # corrupt archive carrying `lap_ms: 10**309` makes `math.isfinite` raise OverflowError.
+        # That escapes this malformed-evidence return and aborts the whole self-play/scientist
+        # pipeline instead of failing the batch closed — the opposite of the intent (#746 Codex
+        # P2, round 4). Convert first, judge second, and treat an unconvertible value as corrupt.
+        lap_ms_value: float | None = None
+        if isinstance(lap_ms, (int, float)) and not isinstance(lap_ms, bool):
+            try:
+                lap_ms_value = float(lap_ms)
+            except (OverflowError, ValueError):
+                lap_ms_value = None
+        if lap_ms_value is None or not math.isfinite(lap_ms_value) or lap_ms_value <= 0:
             return {
                 "judged": False,
                 "malformed": True,
                 "reason": f"lap_n={lap_n} has no finite positive lap_ms (cannot measure spread)",
             }
-        laps.append((lap_n, float(lap_ms)))
+        laps.append((lap_n, lap_ms_value))
     # Duplicate lap_n is CONTAMINATION, not just an attribution nuisance (#746 Codex P2): when
     # `auto_drive` retries after a sim death that already produced an archive, `run_started_epoch`
     # spans both attempts while the Lua session resets `lap_n`, so the set mixes two sessions with

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -340,19 +340,17 @@ def flying_lap_consistency(
       ``lap_ms``. That is corrupt evidence, and the caller FALSIFIES, matching how a payload
       with no validity verdict is treated.
     * ``malformed=False`` — the batch is well-formed but not judgeable *here*: too few flying
-      laps (an ordinary ``--laps 2`` run), a count mismatch, or a duplicate ``lap_n``. These are
-      known harness situations, not corrupt data. Falsifying them would revert the plant and
-      stop the ladder for no physical reason — and would break every two-lap ladder outright.
+      laps (an ordinary ``--laps 2`` run) or a count mismatch. These are known harness
+      situations, not corrupt data. Falsifying them would revert the plant and stop the ladder
+      for no physical reason — and would break every two-lap ladder outright.
+
+    ORDER MATTERS. Schema and duplicate checks run BEFORE the count check (#746 Codex P2 +
+    Qodo, round 3). A retry that leaves one archive from the failed attempt alongside the final
+    attempt's laps produces BOTH a count mismatch and a duplicate ``lap_n``; returning on the
+    count first labelled that mixed-session batch ``malformed=False``, the oracle accepted it as
+    merely unjudged, and ``run_selfplay`` then handed the whole archive list to the next refit as
+    ``prev_archives`` — exactly the contamination the duplicate check exists to stop.
     """
-    if expected_laps is not None and len(archive_payloads) != expected_laps:
-        return {
-            "judged": False,
-            "malformed": False,
-            "reason": (
-                f"{len(archive_payloads)} archive(s) for {expected_laps} timed lap(s) "
-                "— batch not attributable"
-            ),
-        }
     laps: list[tuple[int, float]] = []
     for payload in archive_payloads:
         lap = payload.get("lap") if isinstance(payload.get("lap"), dict) else {}
@@ -364,11 +362,20 @@ def flying_lap_consistency(
                 "malformed": True,
                 "reason": "a lap archive has no integer lap_n (cannot identify the out-lap)",
             }
-        if not isinstance(lap_ms, (int, float)) or isinstance(lap_ms, bool) or lap_ms <= 0:
+        # `math.isfinite` is load-bearing, not defensive: Python's json decoder accepts a bare
+        # `NaN`, and every comparison with NaN is False — so `lap_ms <= 0` does NOT reject it.
+        # A NaN lap time then produces a NaN spread, `spread > threshold` is False, and the
+        # corrupt batch was reported VALID with "flying-lap spread nan%" (#746 Codex P2).
+        if (
+            not isinstance(lap_ms, (int, float))
+            or isinstance(lap_ms, bool)
+            or not math.isfinite(lap_ms)
+            or lap_ms <= 0
+        ):
             return {
                 "judged": False,
                 "malformed": True,
-                "reason": f"lap_n={lap_n} has no positive lap_ms (cannot measure spread)",
+                "reason": f"lap_n={lap_n} has no finite positive lap_ms (cannot measure spread)",
             }
         laps.append((lap_n, float(lap_ms)))
     # Duplicate lap_n is CONTAMINATION, not just an attribution nuisance (#746 Codex P2): when
@@ -383,6 +390,17 @@ def flying_lap_consistency(
             "judged": False,
             "malformed": True,
             "reason": "duplicate lap_n in the batch (archives from more than one session)",
+        }
+    # Only now, on a batch proven well-formed and single-session, is a count mismatch merely an
+    # attribution problem rather than possible contamination.
+    if expected_laps is not None and len(archive_payloads) != expected_laps:
+        return {
+            "judged": False,
+            "malformed": False,
+            "reason": (
+                f"{len(archive_payloads)} archive(s) for {expected_laps} timed lap(s) "
+                "— batch not attributable"
+            ),
         }
     if len(laps) < 3:
         flying_count = max(0, len(laps) - 1)

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -540,6 +540,16 @@ def evaluate_selfplay_iteration(
     # refit would consume that same batch.
     if consistency.get("malformed"):
         return False, f"unusable lap evidence for repeatability: {consistency['reason']}"
+    # An UNATTRIBUTABLE batch falsifies too (#746 Codex P1, round 7). This was first modelled as
+    # "valid but withheld from the refit", which is a third state — neither validated nor
+    # rejected — and it had to be re-defended at every consumer: the refit, the scientist
+    # baseline, the scientist candidate, the rung counter, the persisted plant candidate. Four of
+    # those were missed. If the batch cannot be shown to be this drive's own evidence, nothing it
+    # produced may validate anything, so it takes the ordinary keep-last-valid path: the plant
+    # reverts, the rung does not advance, and the ladder stops with a named reason. The cost is a
+    # wasted ladder on a harness artifact; the cost of the middle state was silent contamination.
+    if consistency.get("attributable") is False:
+        return False, f"batch not attributable to this drive: {consistency['reason']}"
     if consistency["judged"] and consistency["spread"] > max_flying_lap_spread:
         flying = ", ".join(f"{ms / 1000.0:.3f}s" for ms in consistency["flying_ms"])
         return False, (
@@ -840,6 +850,15 @@ def run_selfplay(
         base_payloads, car_id=args.car, track_id=args.track, layout=args.track_layout
     )
     base_consistency = flying_lap_consistency(base_payloads, expected_laps=len(base_laps))
+    # Same fold as the iteration path: unreadable archives make the batch unverifiable, and that
+    # fact lives out here rather than in the payloads the helper can see (#746 Qodo, round 6).
+    if base_load_errors and base_consistency.get("attributable") is not False:
+        base_consistency = {
+            **base_consistency,
+            "judged": False,
+            "attributable": False,
+            "reason": f"{len(base_load_errors)} archive(s) could not be read — batch unverifiable",
+        }
     base_valid, base_reason = evaluate_selfplay_iteration(
         0, base_outcome, base_payloads, consistency=base_consistency
     )
@@ -861,23 +880,12 @@ def run_selfplay(
     # An oracle-invalid base's laps are marked unusable by this very report — they must not seed
     # the performance summary either (#579 Codex P2).
     best: int | None = min(base_laps) if (base_laps and base_valid) else None
-    # The base batch faces the same attribution test as every iteration: oracle-VALID is not
-    # enough to make it refit evidence if the archive set could not be tied to this stage's own
-    # timed laps (#746 Codex P1).
-    base_attributable = base_consistency.get("attributable") is not False and not base_load_errors
-    prev_archives = stage_lap_archives(base_outcome) if (base_valid and base_attributable) else []
+    # No separate attribution flag is needed here any more: an unattributable or unverifiable
+    # base batch now fails the oracle itself, so `base_valid` already carries it (#746 round 7).
+    prev_archives = stage_lap_archives(base_outcome) if base_valid else []
     if not base_valid:
         print(
             f"auto-alien: base drive not usable as refinement evidence ({base_reason}) — "
-            "the ladder starts without a refit batch"
-        )
-    elif not base_attributable:
-        withheld = base_consistency.get("reason") or (
-            f"{len(base_load_errors)} archive(s) could not be read — batch unverifiable"
-        )
-        selfplay["base"]["refit_evidence_withheld"] = withheld
-        print(
-            f"auto-alien: base drive archives withheld from refit — {withheld}; "
             "the ladder starts without a refit batch"
         )
     prev_scale = resolved_base_scale
@@ -1226,6 +1234,19 @@ def run_selfplay(
         # falsified, so a ladder can be audited after the fact for envelopes that were merely
         # survivable rather than repeatable.
         consistency = flying_lap_consistency(archive_payloads, expected_laps=len(lap_times))
+        # Unreadable archives are the same unattributability wearing a different hat (#746 Qodo,
+        # round 6): `flying_lap_consistency` only ever sees payloads that LOADED, so an unreadable
+        # expected archive plus a stray readable one "fills the count" and the batch looks
+        # attributable while being unverifiable. `load_errors` is the only evidence that happened,
+        # and it lives out here — so fold it into the same verdict rather than inventing a second
+        # mechanism for it.
+        if load_errors and consistency.get("attributable") is not False:
+            consistency = {
+                **consistency,
+                "judged": False,
+                "attributable": False,
+                "reason": (f"{len(load_errors)} archive(s) could not be read — batch unverifiable"),
+            }
         entry["flying_lap_consistency"] = consistency
         valid, reason = evaluate_selfplay_iteration(
             code, outcome, archive_payloads, consistency=consistency
@@ -1526,32 +1547,7 @@ def run_selfplay(
         if step_kind == "envelope":
             rung += 1
         next_step_kind = "envelope" if step_kind == "plant" else "plant"
-        # A batch we could not attribute to this stage's own timed laps stays VALID — the ladder
-        # continues, because a false falsification would revert the plant for a harness artifact
-        # — but it must NOT become refit evidence (#746 Codex P1). `selfplay_refine_result` would
-        # otherwise fit from an archive we explicitly said might belong to another stint, and the
-        # merge is strictly monotone (raise-only), so a different tyre state raises the plant
-        # PERMANENTLY. Scoping archives to the batch at source is the real fix (#751).
-        #
-        # Unreadable archives are the same problem wearing a different hat (#746 Qodo, round 6):
-        # `flying_lap_consistency` sees only the payloads that LOADED, so if an expected archive
-        # is unreadable and a stray readable one fills the count, the batch looks attributable
-        # while being unverifiable. `load_errors` is the only evidence that happened.
-        withheld = None
-        if consistency.get("attributable") is False:
-            withheld = consistency.get("reason")
-        elif load_errors:
-            withheld = f"{len(load_errors)} archive(s) could not be read — batch unverifiable"
-        if withheld:
-            entry["refit_evidence_withheld"] = withheld
-            # Bar it from the scientist too, not just the next refit: `_scientist_baseline_outcome`
-            # selects the newest oracle-valid entry, so without this it would compare and persist
-            # setup verdicts from archives we just declared unattributable (#746 Codex P1, round 6).
-            entry["usable_as_evidence"] = False
-            print(f"auto-alien: iteration {index} archives withheld from refit — {withheld}")
-            prev_archives = []
-        else:
-            prev_archives = archives
+        prev_archives = archives
         prev_scale = scale
 
     selfplay["best_lap_ms"] = best
@@ -1671,18 +1667,28 @@ def run_scientist(
             0, baseline_outcome, baseline_payloads
         )
         baseline_lap_times = stage_lap_times_ms(baseline_outcome)
+        # These gates only ever caught TOO FEW archives, so an oversized batch — an extra
+        # same-combo archive from a neighbouring stint — reached `build_plan` /
+        # `evaluate_experiment` and could persist a durable setup verdict measured partly on
+        # another stint's lap (#746 Codex P1, round 7). Attribution is now required, not just
+        # sufficiency.
+        baseline_attribution = flying_lap_consistency(
+            baseline_payloads, expected_laps=len(baseline_lap_times)
+        )
         if (
             load_errors
             or foreign
             or not baseline_valid
             or len(baseline_lap_times) < args.laps
             or len(baseline_payloads) < args.laps
+            or baseline_attribution.get("attributable") is False
         ):
             raise ScientistError(
                 "scientist_baseline_batch_unverifiable:"
                 f"{baseline_reason}:requested_laps={args.laps}:"
                 f"timed_laps={len(baseline_lap_times)}:archives={len(baseline_payloads)}:"
-                f"load_errors={len(load_errors)}:foreign={foreign}"
+                f"load_errors={len(load_errors)}:foreign={foreign}:"
+                f"attributable={baseline_attribution.get('attributable') is not False}"
             )
         scope = {
             "mechanical_platform": args.scientist_mechanical_platform or args.car,
@@ -1779,19 +1785,26 @@ def run_scientist(
                 layout=args.track_layout,
             )
             candidate_lap_times = stage_lap_times_ms(candidate_outcome)
+            # Same one-sided gate as the baseline: too few archives failed, too many passed
+            # (#746 Codex P1, round 7).
+            candidate_attribution = flying_lap_consistency(
+                candidate_payloads, expected_laps=len(candidate_lap_times)
+            )
             if (
                 candidate_outcome is None
                 or len(candidate_lap_times) < args.laps
                 or len(candidate_payloads) < args.laps
                 or candidate_load_errors
                 or candidate_foreign
+                or candidate_attribution.get("attributable") is False
             ):
                 raise ScientistError(
                     "scientist_candidate_batch_incomplete:"
                     f"exit={code}:requested_laps={args.laps}:"
                     f"timed_laps={len(candidate_lap_times)}:"
                     f"archives={len(candidate_payloads)}:"
-                    f"load_errors={len(candidate_load_errors)}:foreign={candidate_foreign}"
+                    f"load_errors={len(candidate_load_errors)}:foreign={candidate_foreign}:"
+                    f"attributable={candidate_attribution.get('attributable') is not False}"
                 )
             candidate_valid, candidate_reason = evaluate_selfplay_iteration(
                 code, candidate_outcome, candidate_payloads


### PR DESCRIPTION
Closes #746. Part of EPIC #529 (G1 pace).

## Why

The keep-last-valid oracle `evaluate_selfplay_iteration` accepted an iteration on *drive passed + zero recoveries + every archived lap AC-valid*. Those establish that the envelope was **survivable once** — not that it is **repeatable**. So an envelope the controller cannot reproduce was retained and compounded into the plant, which is precisely the evidence #529's pace ladder is built on.

Observed on the rig 2026-07-26 (911 GT3 R @ Magione, ladder 3, [documented on #529](https://github.com/agorokh/ac-copilot-trainer/issues/529#issuecomment-5093142905)):

```
out-lap 106.655 s | flying 80.791 s and 95.122 s
both is_valid: true, recoveries=0, recovery_capped=false, sim_dead=false
-> iteration VALID -> 86.27 s-floor plant RETAINED
```

The car lost ~14 s without leaving the track or needing an intervention. Nothing was hidden — the oracle simply had no term that looked at it.

## Calibration (why 5%, and why the out-lap must go)

Measured over every self-play-era lap archive on the rig (`journal/laps`, `exported_at >= 2026-07-14`), restricted to batches satisfying the oracle's validity gate with >=2 flying laps:

```
n = 31 batches
median flying-lap spread   0.02 %     <- deterministic controller repeats to milliseconds
spread >= 1 %               4 / 31
spread >= 5 %               3 / 31
```

The **out-lap must be excluded**: it is a standing pit start and legitimately far slower. Including it turns that 0.02% median into ~19% and would falsify essentially every healthy batch. The threshold sits far above the 0.02% noise floor and below all three observed pathologies (5.2% / 17.7% / 22.0%), with room on both sides.

## What changed

- New pure helper `flying_lap_consistency()` — drops the batch's lowest `lap_n` (the out-lap) and measures spread across the remainder.
- Oracle falsifies when the flying-lap spread exceeds `SELFPLAY_MAX_FLYING_LAP_SPREAD` (5%), naming the spread and the offending lap times so the ladder report says *which* knob it falsified and why.
- **Unjudgeable is not falsification.** Fewer than two flying laps, a missing `lap_n`/`lap_ms`, or a duplicate `lap_n` records the reason and leaves the batch to the existing gates — inventing a verdict from absent data would invert the fail-closed discipline used everywhere else in this function.
- The measured spread is recorded on each iteration entry **and** on the base drive whether or not it falsified, so a ladder is auditable after the fact.
- Repeatability is checked **last**, so a batch failing any earlier gate still reports its more specific reason.

Because the oracle is shared, this also stops the scientist ([`auto_alien.py:1419`](https://github.com/agorokh/ac-copilot-trainer/blob/main/tools/ac_harness/auto_alien.py#L1419), [`:1545`](https://github.com/agorokh/ac-copilot-trainer/blob/main/tools/ac_harness/auto_alien.py#L1545)) promoting or falsifying a setup change from the difference of two means taken over a stint that was not repeatable.

## Verification

- 4 new tests, including the **real** 2026-07-26 batch as a falsification fixture and a no-false-positive guard replaying healthy historical batches (`huracan@spa 180.366/180.387`, `911@magione 81.505/81.519`, `85.072/85.132`, `109.110/109.107`) — all must stay VALID.
- `pytest tests/test_auto_alien.py tests/test_alien_scientist.py tests/test_alien_line.py` -> **118 passed**
- `pytest tests/test_auto_alien_stint_layers.py tests/test_ggv_profile.py tests/test_plant_id.py` -> **144 passed**
- Full `make ci-fast` runs in hosted CI; a local full run was deliberately deferred while a live rig ladder was driving, to avoid stealing CPU from the sim and perturbing the lap times being measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
