### PR TITLE
feat(harness): report WHICH thermal term emptied the refit cohort (#749)

### DIFF
--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1374,6 +1374,33 @@ def test_thermal_eligibility_reports_identity_and_measured_failures_together():
         assert "stability_below_min" in lap["failing_terms"]
 
 
+def test_thermal_eligibility_names_a_wheel_spread_at_the_rounded_limit():
+    """The reported spread is ROUNDED; the gate compares the raw value (#749 Codex P2, round 5).
+
+    A raw 15.0004 °C spread rejects the lap but arrives in the report as `15.000`, so a strict
+    `>` against the 15 °C cap would miss the very term that caused the rejection and fall back to
+    an unhelpful "other: outside thermal stability/validity gate".
+    """
+    from tools.ac_harness.plant_id import _failed_eligibility_terms
+
+    at_limit = {
+        "fit_eligible": False,
+        "reason": "outside thermal stability/validity gate",
+        "tag": "cold",
+        "sample_coverage_fraction": 1.0,
+        "thermal_stability_fraction": 1.0,
+        "wheel_spread_c": 15.0,  # rounded from a raw value just over the cap
+        "setup_hash": "setup-a",
+        "compound_index": 1,
+        "compound_name": "sv",
+    }
+    assert _failed_eligibility_terms({"is_valid": True}, at_limit) == ["wheel_spread_above_max"]
+
+    # A comfortably-inside spread is still not blamed; the real cause is reported instead.
+    inside = dict(at_limit, wheel_spread_c=7.0, thermal_stability_fraction=0.5)
+    assert _failed_eligibility_terms({"is_valid": True}, inside) == ["stability_below_min"]
+
+
 def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):
     from tools.ac_harness.ggv_profile import GGVModel as _GGV
     from tools.ac_harness.plant_id import selfplay_refine_result

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1251,7 +1251,7 @@ def test_selfplay_refine_reports_which_thermal_term_emptied_the_cohort():
     # The INDIVIDUAL predicate must be named. `observe_lap_tyre_state`'s own reason collapses
     # coverage / stability / wheel-spread / validity / unknown-tag into one string, so counting
     # that would report a low-coverage batch identically to this stability stall (#749 Codex P2).
-    assert report["dominant_term"] == "stability_below_min"
+    assert report["dominant_terms"] == ["stability_below_min"]
     assert report["failing_term_counts"] == {"stability_below_min": 2}
     # The thresholds are reported alongside the measurements, so the gap is readable in place.
     assert report["thresholds"]["min_stability_fraction"] == 0.80
@@ -1292,9 +1292,56 @@ def test_thermal_eligibility_distinguishes_coverage_from_stability_failures():
     assert report["eligible_count"] == 0
     # Named as coverage, NOT as the stability stall — the two are now separable.
     assert "coverage_below_min" in report["failing_term_counts"]
-    assert report["dominant_term"] != "stability_below_min"
+    assert "stability_below_min" not in report["dominant_terms"]
     for lap in report["laps"]:
         assert "coverage_below_min" in lap["failing_terms"]
+
+
+def test_thermal_eligibility_keeps_early_observer_reasons_and_reports_ties():
+    """Two ways the diagnostic could mislead, both closed (#749 Codex P2, round 3).
+
+    1. An early observer failure (missing trace) returns ZEROED measurements, so re-deriving
+       predicates from them would invent coverage + stability + tag + spread failures for what is
+       really one cause. The observer's own reason is authoritative there.
+    2. A tie between two causes must report BOTH — one low-coverage lap and one unstable lap is a
+       different situation from two unstable laps, and naming one sends the reader the wrong way.
+    """
+    from tools.ac_harness.plant_id import selfplay_refine_result
+
+    # 1. Missing trace on both laps.
+    blind = [
+        _selfplay_thermal_archive("no-trace-1", lateral_g=1.35, lap_n=1),
+        _selfplay_thermal_archive("no-trace-2", lateral_g=1.35, lap_n=2),
+    ]
+    for archive in blind:
+        archive["trace"] = {}
+    _, block = selfplay_refine_result(_selfplay_artifact(), blind, generic_gt3_ggv())
+    report = block["thermal_eligibility"]
+    for lap in report["laps"]:
+        assert lap["failing_terms"] == ["observer:missing trace"]
+        assert "coverage_below_min" not in lap["failing_terms"]
+        assert "stability_below_min" not in lap["failing_terms"]
+
+    # 2. One low-coverage lap and one unstable lap -> a genuine 1-1 tie.
+    mixed = [
+        _selfplay_thermal_archive("tie-coverage", lateral_g=1.35, lap_n=1),
+        _selfplay_thermal_archive("tie-stability", lateral_g=1.35, lap_n=2),
+    ]
+    cov_index = {name: i for i, name in enumerate(mixed[0]["trace"]["fields"])}
+    for sample in mixed[0]["trace"]["samples"][:400]:
+        for wheel in ("fl", "fr", "rl", "rr"):
+            sample[cov_index[f"tyreCoreTemp_{wheel}"]] = 0.0
+    stab_index = {name: i for i, name in enumerate(mixed[1]["trace"]["fields"])}
+    for n, sample in enumerate(mixed[1]["trace"]["samples"]):
+        for wheel in ("fl", "fr", "rl", "rr"):
+            sample[stab_index[f"tyreCoreTemp_{wheel}"]] = 90.0 + (12.0 if n % 2 else -12.0)
+
+    _, block = selfplay_refine_result(_selfplay_artifact(), mixed, generic_gt3_ggv())
+    report = block["thermal_eligibility"]
+    assert report["eligible_count"] == 0
+    assert report["dominant_count"] == 1
+    assert "coverage_below_min" in report["dominant_terms"]
+    assert "stability_below_min" in report["dominant_terms"]
 
 
 def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1216,6 +1216,50 @@ def test_selfplay_refine_requires_current_fit_and_archives():
     assert "no thermally consistent" in block["reason"]
 
 
+def test_selfplay_refine_reports_which_thermal_term_emptied_the_cohort():
+    """#749: a refused refit must name the failing term per lap, not just the symptom.
+
+    Reproduces the 2026-08-10 huracan@spa stall shape: every lap AC-valid with a real setup
+    identity and full sample coverage, but core temperatures swinging so the per-wheel stability
+    fraction falls under the 0.80 floor. Before this, the block carried only "no thermally
+    consistent valid lap archives" and the operator had to re-run the observer over the archives
+    by hand to learn which of the seven terms rejected them — while the ladder silently stopped
+    compounding.
+    """
+    from tools.ac_harness.plant_id import selfplay_refine_result
+
+    artifact = _selfplay_artifact()
+    archives = [
+        _selfplay_thermal_archive("unstable-1", lateral_g=1.35, lap_n=1),
+        _selfplay_thermal_archive("unstable-2", lateral_g=1.35, lap_n=2),
+    ]
+    # Swing each wheel far from its own median for most of the lap: stability collapses while
+    # coverage, compound identity, setup identity and lap validity all still pass.
+    for archive in archives:
+        index = {name: i for i, name in enumerate(archive["trace"]["fields"])}
+        for n, sample in enumerate(archive["trace"]["samples"]):
+            for wheel in ("fl", "fr", "rl", "rr"):
+                sample[index[f"tyreCoreTemp_{wheel}"]] = 90.0 + (12.0 if n % 2 else -12.0)
+
+    result, block = selfplay_refine_result(artifact, archives, generic_gt3_ggv())
+    assert result is None and block["ok"] is False
+    assert "no thermally consistent valid lap archives" in block["reason"]
+
+    report = block["thermal_eligibility"]
+    assert report["eligible_count"] == 0
+    assert report["dominant_count"] == 2
+    assert "thermal stability" in report["dominant_reason"]
+    # The thresholds are reported alongside the measurements, so the gap is readable in place.
+    assert report["thresholds"]["min_stability_fraction"] == 0.80
+    for lap in report["laps"]:
+        assert lap["fit_eligible"] is False
+        assert lap["thermal_stability_fraction"] < 0.80
+        # …and the terms that PASSED are shown too, so they need not be re-derived by hand.
+        assert lap["sample_coverage_fraction"] == 1.0
+        assert lap["setup_hash"]
+        assert lap["lap_n"] in (1, 2)
+
+
 def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):
     from tools.ac_harness.ggv_profile import GGVModel as _GGV
     from tools.ac_harness.plant_id import selfplay_refine_result

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1394,7 +1394,11 @@ def test_thermal_eligibility_names_a_wheel_spread_at_the_rounded_limit():
         "compound_index": 1,
         "compound_name": "sv",
     }
-    assert _failed_eligibility_terms({"is_valid": True}, at_limit) == ["wheel_spread_above_max"]
+    # Within the rounding envelope the report CANNOT say which side the raw value fell on, so it
+    # says exactly that instead of overclaiming either way.
+    assert _failed_eligibility_terms({"is_valid": True}, at_limit) == ["wheel_spread_at_limit"]
+    clearly_over = dict(at_limit, wheel_spread_c=15.6)
+    assert _failed_eligibility_terms({"is_valid": True}, clearly_over) == ["wheel_spread_above_max"]
 
     # A comfortably-inside spread is still not blamed; the real cause is reported instead.
     inside = dict(at_limit, wheel_spread_c=7.0, thermal_stability_fraction=0.5)

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1344,6 +1344,36 @@ def test_thermal_eligibility_keeps_early_observer_reasons_and_reports_ties():
     assert "stability_below_min" in report["dominant_terms"]
 
 
+def test_thermal_eligibility_reports_identity_and_measured_failures_together():
+    """An identity failure must not hide a co-occurring measured one (#749 Codex P2, round 4).
+
+    `observe_lap_tyre_state`'s reason names only the first term its conjunction tripped, so a lap
+    missing setup identity that ALSO fails stability reported identity alone — and fixing identity
+    would then surface stability with no warning. The measurements are valid whenever the
+    conjunction was reached, so every failing predicate is reported.
+    """
+    from tools.ac_harness.plant_id import selfplay_refine_result
+
+    archives = [
+        _selfplay_thermal_archive("identity-and-stability", lateral_g=1.35, lap_n=1),
+        _selfplay_thermal_archive("identity-and-stability-2", lateral_g=1.35, lap_n=2),
+    ]
+    for archive in archives:
+        archive["setup"] = {}  # strip setup identity
+        index = {name: i for i, name in enumerate(archive["trace"]["fields"])}
+        for n, sample in enumerate(archive["trace"]["samples"]):
+            for wheel in ("fl", "fr", "rl", "rr"):
+                sample[index[f"tyreCoreTemp_{wheel}"]] = 90.0 + (12.0 if n % 2 else -12.0)
+
+    _, block = selfplay_refine_result(_selfplay_artifact(), archives, generic_gt3_ggv())
+    report = block["thermal_eligibility"]
+    assert report["eligible_count"] == 0
+    for lap in report["laps"]:
+        assert "missing_setup_identity" in lap["failing_terms"]
+        # …and the measured failure is NOT hidden behind it.
+        assert "stability_below_min" in lap["failing_terms"]
+
+
 def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):
     from tools.ac_harness.ggv_profile import GGVModel as _GGV
     from tools.ac_harness.plant_id import selfplay_refine_result

--- a/tests/test_plant_id.py
+++ b/tests/test_plant_id.py
@@ -1248,16 +1248,53 @@ def test_selfplay_refine_reports_which_thermal_term_emptied_the_cohort():
     report = block["thermal_eligibility"]
     assert report["eligible_count"] == 0
     assert report["dominant_count"] == 2
-    assert "thermal stability" in report["dominant_reason"]
+    # The INDIVIDUAL predicate must be named. `observe_lap_tyre_state`'s own reason collapses
+    # coverage / stability / wheel-spread / validity / unknown-tag into one string, so counting
+    # that would report a low-coverage batch identically to this stability stall (#749 Codex P2).
+    assert report["dominant_term"] == "stability_below_min"
+    assert report["failing_term_counts"] == {"stability_below_min": 2}
     # The thresholds are reported alongside the measurements, so the gap is readable in place.
     assert report["thresholds"]["min_stability_fraction"] == 0.80
     for lap in report["laps"]:
         assert lap["fit_eligible"] is False
+        assert lap["failing_terms"] == ["stability_below_min"]
         assert lap["thermal_stability_fraction"] < 0.80
         # …and the terms that PASSED are shown too, so they need not be re-derived by hand.
         assert lap["sample_coverage_fraction"] == 1.0
         assert lap["setup_hash"]
         assert lap["lap_n"] in (1, 2)
+
+
+def test_thermal_eligibility_distinguishes_coverage_from_stability_failures():
+    """Distinct terms must not collapse into one dominant reason (#749 Codex P2).
+
+    `observe_lap_tyre_state` returns the same `outside thermal stability/validity gate` string
+    for coverage, stability, wheel-spread, validity and unknown-tag failures. If the report
+    counted that, a low-coverage batch would be indistinguishable from a stability stall — and
+    they demand different fixes.
+    """
+    from tools.ac_harness.plant_id import selfplay_refine_result
+
+    def _blank_coverage(archive: dict) -> dict:
+        index = {name: i for i, name in enumerate(archive["trace"]["fields"])}
+        for sample in archive["trace"]["samples"][:400]:
+            for wheel in ("fl", "fr", "rl", "rr"):
+                sample[index[f"tyreCoreTemp_{wheel}"]] = 0.0
+        return archive
+
+    archives = [
+        _blank_coverage(_selfplay_thermal_archive("low-coverage-1", lateral_g=1.35, lap_n=1)),
+        _blank_coverage(_selfplay_thermal_archive("low-coverage-2", lateral_g=1.35, lap_n=2)),
+    ]
+    _, block = selfplay_refine_result(_selfplay_artifact(), archives, generic_gt3_ggv())
+    assert block["ok"] is False
+    report = block["thermal_eligibility"]
+    assert report["eligible_count"] == 0
+    # Named as coverage, NOT as the stability stall — the two are now separable.
+    assert "coverage_below_min" in report["failing_term_counts"]
+    assert report["dominant_term"] != "stability_below_min"
+    for lap in report["laps"]:
+        assert "coverage_below_min" in lap["failing_terms"]
 
 
 def test_selfplay_refine_merges_monotonically_and_strips_stale_meta(tmp_path):

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -1165,12 +1165,21 @@ def run_selfplay(
                         # ladder that has silently stopped compounding is visible without
                         # re-analysing archives by hand (#749).
                         eligibility = block.get("thermal_eligibility")
-                        if isinstance(eligibility, dict) and eligibility.get("dominant_reason"):
+                        # Only claim an empty cohort when it IS empty. This branch runs for every
+                        # fit exception, so a batch with eligible laps that failed downstream —
+                        # too few friction rows, say — would otherwise be announced as a thermal
+                        # stall using a dominant term drawn from the ineligible minority, pointing
+                        # the next session at the wrong cause (#749 Codex P2).
+                        if (
+                            isinstance(eligibility, dict)
+                            and eligibility.get("eligible_count") == 0
+                            and eligibility.get("dominant_term")
+                        ):
                             lap_count = len(eligibility.get("laps") or [])
                             print(
                                 f"auto-alien: iteration {index} thermal cohort empty — "
                                 f"{eligibility['dominant_count']}/{lap_count} lap(s): "
-                                f"{eligibility['dominant_reason']}"
+                                f"{eligibility['dominant_term']}"
                             )
         except (OSError, RigSessionBusy) as exc:
             # Fail loud IN the report: keep-last-valid integrity can no longer be guaranteed

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -1161,6 +1161,17 @@ def run_selfplay(
                             f"auto-alien: iteration {index} refine FAILED — keeping the "
                             f"last-valid plant ({block.get('reason')})"
                         )
+                        # Name the term that actually rejected the cohort, on the console, so a
+                        # ladder that has silently stopped compounding is visible without
+                        # re-analysing archives by hand (#749).
+                        eligibility = block.get("thermal_eligibility")
+                        if isinstance(eligibility, dict) and eligibility.get("dominant_reason"):
+                            lap_count = len(eligibility.get("laps") or [])
+                            print(
+                                f"auto-alien: iteration {index} thermal cohort empty — "
+                                f"{eligibility['dominant_count']}/{lap_count} lap(s): "
+                                f"{eligibility['dominant_reason']}"
+                            )
         except (OSError, RigSessionBusy) as exc:
             # Fail loud IN the report: keep-last-valid integrity can no longer be guaranteed
             # once artifact I/O errors, so the ladder stops with the named reason.

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -1173,13 +1173,13 @@ def run_selfplay(
                         if (
                             isinstance(eligibility, dict)
                             and eligibility.get("eligible_count") == 0
-                            and eligibility.get("dominant_term")
+                            and eligibility.get("dominant_terms")
                         ):
                             lap_count = len(eligibility.get("laps") or [])
+                            terms = ", ".join(eligibility["dominant_terms"])
                             print(
                                 f"auto-alien: iteration {index} thermal cohort empty — "
-                                f"{eligibility['dominant_count']}/{lap_count} lap(s): "
-                                f"{eligibility['dominant_term']}"
+                                f"{eligibility['dominant_count']}/{lap_count} lap(s): {terms}"
                             )
         except (OSError, RigSessionBusy) as exc:
             # Fail loud IN the report: keep-last-valid integrity can no longer be guaranteed

--- a/tools/ac_harness/auto_alien.py
+++ b/tools/ac_harness/auto_alien.py
@@ -1170,10 +1170,14 @@ def run_selfplay(
                         # too few friction rows, say — would otherwise be announced as a thermal
                         # stall using a dominant term drawn from the ineligible minority, pointing
                         # the next session at the wrong cause (#749 Codex P2).
+                        # …and only when every lap was actually READ. A lap the observer could not
+                        # parse contributes no terms, so a headline drawn from the laps that did
+                        # parse would silently speak for the whole batch (#749 Codex P2, round 6).
                         if (
                             isinstance(eligibility, dict)
                             and eligibility.get("eligible_count") == 0
                             and eligibility.get("dominant_terms")
+                            and not eligibility.get("observer_error_count")
                         ):
                             lap_count = len(eligibility.get("laps") or [])
                             terms = ", ".join(eligibility["dominant_terms"])

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1586,6 +1586,9 @@ _CONJUNCTION_REASONS = frozenset(
         "outside thermal stability/validity gate",
     }
 )
+# `observe_lap_tyre_state` reports `wheel_spread_c` rounded to 3 dp while comparing the raw value,
+# so the reported number can sit a fraction below the cap that actually rejected the lap.
+_WHEEL_SPREAD_REPORT_LIMIT = DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C - 5e-4
 
 
 def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
@@ -1631,7 +1634,13 @@ def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
     spread = state.get("wheel_spread_c")
     if spread is None:
         terms.append("wheel_spread_unmeasurable")
-    elif isinstance(spread, (int, float)) and spread > DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C:
+    elif isinstance(spread, (int, float)) and spread >= _WHEEL_SPREAD_REPORT_LIMIT:
+        # The observer compares the RAW spread but reports it rounded to 3 dp, so a raw 15.0004
+        # arrives here as 15.000 and a strict `>` would miss the very rejection it caused. Half a
+        # milli-degree of slack covers the rounding. This only ever runs for a lap the observer
+        # already rejected, so the worst case is naming a genuinely-at-the-limit spread — with the
+        # measured value printed beside it — rather than falling back to an unhelpful
+        # "other: outside thermal stability/validity gate" (#749 Codex P2, round 5).
         terms.append("wheel_spread_above_max")
     if not terms:
         # Rejected by the conjunction for something not re-derived above. Never report "no

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1576,8 +1576,16 @@ def refine_ggv_from_lap_archives(
     return block
 
 
-# The one `observe_lap_tyre_state` reason that merges several distinct predicates.
-_COLLAPSED_THERMAL_REASON = "outside thermal stability/validity gate"
+# `observe_lap_tyre_state` reasons produced by its eligibility CONJUNCTION — i.e. reached after
+# the measurements were computed, so they are meaningful. Any other reason is an early exit whose
+# measurements are zeroed placeholders.
+_CONJUNCTION_REASONS = frozenset(
+    {
+        "missing tyre compound identity",
+        "missing setup identity",
+        "outside thermal stability/validity gate",
+    }
+)
 
 
 def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
@@ -1597,15 +1605,21 @@ def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
     if state.get("fit_eligible") is True:
         return []
     reason = str(state.get("reason") or "")
-    if reason == "missing tyre compound identity":
-        return ["missing_compound_identity"]
-    if reason == "missing setup identity":
-        return ["missing_setup_identity"]
-    if reason != _COLLAPSED_THERMAL_REASON:
-        # An early observer failure. Its own reason IS the specific one; keep it verbatim.
+    if reason not in _CONJUNCTION_REASONS:
+        # An early observer exit (missing trace / optimalTempC / tyre channels). Its measurements
+        # are ZEROED placeholders, so deriving predicates from them would invent failures. Its own
+        # reason is the specific one; keep it verbatim.
         return [f"observer:{reason}"]
 
+    # The observer got far enough to MEASURE, so every predicate below is meaningful — report all
+    # of them, not just the one the observer's reason happened to name. A lap missing setup
+    # identity that ALSO fails stability must say so, or fixing identity just surfaces stability
+    # next with no warning (#749 Codex P2, round 4).
     terms: list[str] = []
+    if state.get("compound_index") is None and state.get("compound_name") is None:
+        terms.append("missing_compound_identity")
+    if state.get("setup_hash") is None:
+        terms.append("missing_setup_identity")
     if lap.get("is_valid") is not True:
         terms.append("lap_not_ac_valid")
     if state.get("tag") == "unknown":

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -42,18 +42,23 @@ import math
 import os
 import re
 import uuid
+from collections import Counter
 from dataclasses import asdict, dataclass
 from dataclasses import replace as dc_replace
 from pathlib import Path
 
 from tools.ac_harness.ai_line import _horizontal
 from tools.ac_harness.ggv_profile import (
+    DEFAULT_THERMAL_COVERAGE_FRACTION,
+    DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C,
+    DEFAULT_THERMAL_STABILITY_FRACTION,
     GGVModel,
     blend_ggv_safe,
     fit_steer_feedforward,
     ggv_from_lap_archives,
     ggv_from_telemetry,
     merge_selfplay_model,
+    observe_lap_tyre_state,
     seg_lengths,
     signed_curvature_profile,
 )
@@ -1552,6 +1557,15 @@ def refine_ggv_from_lap_archives(
     except (ValueError, ZeroDivisionError, KeyError, TypeError) as exc:
         logger.exception("thermal uncertainty fit failed; ggv block degrades to the generic plant")
         block["reason"] = f"thermal uncertainty fit error: {type(exc).__name__}: {exc}"
+        # Say WHICH eligibility term rejected WHICH lap, and with what value (#749).
+        #
+        # The bare exception text ("no thermally consistent valid lap archives") names the symptom
+        # and nothing else, so diagnosing a refused refit meant re-running `observe_lap_tyre_state`
+        # over the archives by hand — which is how the 2026-08-10 huracan@spa stall was eventually
+        # traced to `stability` 0.41-0.62 against the 0.80 floor, with every other term passing.
+        # A ladder that silently stops compounding is the expensive failure here: the operator
+        # cannot see it from the report at all.
+        block["thermal_eligibility"] = _thermal_eligibility_report(matching)
         result["ggv"] = block
         return block
     block.update(summary)
@@ -1560,6 +1574,57 @@ def refine_ggv_from_lap_archives(
     block["reason"] = "ok"
     result["ggv"] = block
     return block
+
+
+def _thermal_eligibility_report(archives: list[dict]) -> dict:
+    """Per-lap thermal-eligibility diagnostics for a refit that found no usable cohort (#749).
+
+    `ggv_from_lap_archives` raises a single sentence naming the symptom — "no thermally consistent
+    valid lap archives" — and nothing about WHICH of the seven eligibility terms rejected WHICH
+    lap, or by how much. That silence is what makes a stalled ladder expensive: it stops
+    compounding and the report gives the operator no way to see why.
+
+    Purely diagnostic, and deliberately best-effort: an observer failure here must never replace
+    the real fit error that is already recorded on the block.
+    """
+    report: dict = {
+        "thresholds": {
+            "min_coverage_fraction": DEFAULT_THERMAL_COVERAGE_FRACTION,
+            "min_stability_fraction": DEFAULT_THERMAL_STABILITY_FRACTION,
+            "max_wheel_spread_c": DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C,
+        },
+        "laps": [],
+    }
+    failing: Counter[str] = Counter()
+    for archive in archives:
+        try:
+            state = observe_lap_tyre_state(archive)
+        except Exception as exc:  # noqa: BLE001 - diagnostics must not mask the fit error
+            report["laps"].append({"error": f"{type(exc).__name__}: {exc}"})
+            continue
+        lap = archive.get("lap") if isinstance(archive.get("lap"), dict) else {}
+        entry = {
+            "lap_n": lap.get("lap_n"),
+            "lap_ms": lap.get("lap_ms"),
+            "fit_eligible": state.get("fit_eligible"),
+            "reason": state.get("reason"),
+            "tag": state.get("tag"),
+            "core_temp_c": state.get("core_temp_c"),
+            "thermal_stability_fraction": state.get("thermal_stability_fraction"),
+            "sample_coverage_fraction": state.get("sample_coverage_fraction"),
+            "wheel_spread_c": state.get("wheel_spread_c"),
+            "setup_hash": state.get("setup_hash"),
+        }
+        report["laps"].append(entry)
+        if state.get("fit_eligible") is not True:
+            failing[str(state.get("reason"))] += 1
+    if failing:
+        # The headline: one line an operator can read without opening the archives.
+        report["dominant_reason"], report["dominant_count"] = failing.most_common(1)[0]
+    report["eligible_count"] = sum(
+        1 for entry in report["laps"] if entry.get("fit_eligible") is True
+    )
+    return report
 
 
 def selfplay_refine_result(

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1587,8 +1587,8 @@ _CONJUNCTION_REASONS = frozenset(
     }
 )
 # `observe_lap_tyre_state` reports `wheel_spread_c` rounded to 3 dp while comparing the raw value,
-# so the reported number can sit a fraction below the cap that actually rejected the lap.
-_WHEEL_SPREAD_REPORT_LIMIT = DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C - 5e-4
+# so within this envelope of the cap the report cannot establish which side the raw value fell on.
+_WHEEL_SPREAD_ROUNDING = 5e-4
 
 
 def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
@@ -1634,14 +1634,15 @@ def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
     spread = state.get("wheel_spread_c")
     if spread is None:
         terms.append("wheel_spread_unmeasurable")
-    elif isinstance(spread, (int, float)) and spread >= _WHEEL_SPREAD_REPORT_LIMIT:
-        # The observer compares the RAW spread but reports it rounded to 3 dp, so a raw 15.0004
-        # arrives here as 15.000 and a strict `>` would miss the very rejection it caused. Half a
-        # milli-degree of slack covers the rounding. This only ever runs for a lap the observer
-        # already rejected, so the worst case is naming a genuinely-at-the-limit spread — with the
-        # measured value printed beside it — rather than falling back to an unhelpful
-        # "other: outside thermal stability/validity gate" (#749 Codex P2, round 5).
-        terms.append("wheel_spread_above_max")
+    elif isinstance(spread, (int, float)):
+        # The observer compares the RAW spread but reports it rounded to 3 dp, so within half a
+        # milli-degree of the cap the report simply CANNOT say which side the raw value fell on.
+        # Claiming either is overreach, so that band gets its own honest term rather than being
+        # folded into "above max" (#749 Codex P2, rounds 5-6).
+        if spread > DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C + _WHEEL_SPREAD_ROUNDING:
+            terms.append("wheel_spread_above_max")
+        elif spread >= DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C - _WHEEL_SPREAD_ROUNDING:
+            terms.append("wheel_spread_at_limit")
     if not terms:
         # Rejected by the conjunction for something not re-derived above. Never report "no
         # failing terms" for an ineligible lap — say that it could not be classified.
@@ -1710,6 +1711,9 @@ def _thermal_eligibility_report(archives: list[dict]) -> dict:
     report["eligible_count"] = sum(
         1 for entry in report["laps"] if entry.get("fit_eligible") is True
     )
+    # Laps the observer could not read at all contribute no terms, so a headline drawn only from
+    # the laps that DID parse would silently speak for the whole batch (#749 Codex P2, round 6).
+    report["observer_error_count"] = sum(1 for entry in report["laps"] if "error" in entry)
     return report
 
 

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1576,6 +1576,40 @@ def refine_ggv_from_lap_archives(
     return block
 
 
+def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
+    """Which individual eligibility predicates this lap failed (#749).
+
+    Mirrors the conjunction in :func:`observe_lap_tyre_state`, which reports a single collapsed
+    `reason` for five distinct terms. Naming them separately is the whole point of the report:
+    "coverage 0.6 < 0.80" and "stability 0.5 < 0.80" demand different fixes.
+    """
+
+    def _below(value: object, floor: float) -> bool:
+        return isinstance(value, (int, float)) and not isinstance(value, bool) and value < floor
+
+    terms: list[str] = []
+    if lap.get("is_valid") is not True:
+        terms.append("lap_not_ac_valid")
+    if state.get("setup_hash") is None:
+        terms.append("missing_setup_identity")
+    if state.get("tag") == "unknown":
+        terms.append("unknown_thermal_tag")
+    if _below(state.get("sample_coverage_fraction"), DEFAULT_THERMAL_COVERAGE_FRACTION):
+        terms.append("coverage_below_min")
+    if _below(state.get("thermal_stability_fraction"), DEFAULT_THERMAL_STABILITY_FRACTION):
+        terms.append("stability_below_min")
+    spread = state.get("wheel_spread_c")
+    if spread is None:
+        terms.append("wheel_spread_unmeasurable")
+    elif isinstance(spread, (int, float)) and spread > DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C:
+        terms.append("wheel_spread_above_max")
+    if not terms and state.get("fit_eligible") is not True:
+        # The conjunction rejected it for something not re-derived above (e.g. missing tyre
+        # compound identity). Never report "no failing terms" for an ineligible lap — say so.
+        terms.append(f"other:{state.get('reason')}")
+    return terms
+
+
 def _thermal_eligibility_report(archives: list[dict]) -> dict:
     """Per-lap thermal-eligibility diagnostics for a refit that found no usable cohort (#749).
 
@@ -1615,12 +1649,19 @@ def _thermal_eligibility_report(archives: list[dict]) -> dict:
             "wheel_spread_c": state.get("wheel_spread_c"),
             "setup_hash": state.get("setup_hash"),
         }
+        # `observe_lap_tyre_state`'s own `reason` collapses coverage, stability, wheel spread,
+        # validity and the unknown-tag case into one string ("outside thermal stability/validity
+        # gate"), so counting it would merge distinct failures and report a low-coverage batch
+        # identically to the stability stall this exists to diagnose (#749 Codex P2). Re-derive
+        # the individual predicates from the reported measurements instead.
+        terms = _failed_eligibility_terms(lap, state)
+        entry["failing_terms"] = terms
         report["laps"].append(entry)
-        if state.get("fit_eligible") is not True:
-            failing[str(state.get("reason"))] += 1
+        failing.update(terms)
     if failing:
         # The headline: one line an operator can read without opening the archives.
-        report["dominant_reason"], report["dominant_count"] = failing.most_common(1)[0]
+        report["dominant_term"], report["dominant_count"] = failing.most_common(1)[0]
+        report["failing_term_counts"] = dict(failing)
     report["eligible_count"] = sum(
         1 for entry in report["laps"] if entry.get("fit_eligible") is True
     )

--- a/tools/ac_harness/plant_id.py
+++ b/tools/ac_harness/plant_id.py
@@ -1576,22 +1576,38 @@ def refine_ggv_from_lap_archives(
     return block
 
 
+# The one `observe_lap_tyre_state` reason that merges several distinct predicates.
+_COLLAPSED_THERMAL_REASON = "outside thermal stability/validity gate"
+
+
 def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
     """Which individual eligibility predicates this lap failed (#749).
 
-    Mirrors the conjunction in :func:`observe_lap_tyre_state`, which reports a single collapsed
-    `reason` for five distinct terms. Naming them separately is the whole point of the report:
-    "coverage 0.6 < 0.80" and "stability 0.5 < 0.80" demand different fixes.
+    :func:`observe_lap_tyre_state` reports its own specific reason for most branches and one
+    COLLAPSED string for five of them. So the observer's reason is authoritative wherever it is
+    specific, and the measurements are re-derived only for the collapsed case — re-deriving
+    unconditionally would invent misleading terms, because an early observer failure (missing
+    trace, missing `optimalTempC`, missing tyre channels) returns zeroed measurements that trip
+    coverage, stability, tag and spread all at once for what is really one cause (#749 Codex P2).
     """
 
     def _below(value: object, floor: float) -> bool:
         return isinstance(value, (int, float)) and not isinstance(value, bool) and value < floor
 
+    if state.get("fit_eligible") is True:
+        return []
+    reason = str(state.get("reason") or "")
+    if reason == "missing tyre compound identity":
+        return ["missing_compound_identity"]
+    if reason == "missing setup identity":
+        return ["missing_setup_identity"]
+    if reason != _COLLAPSED_THERMAL_REASON:
+        # An early observer failure. Its own reason IS the specific one; keep it verbatim.
+        return [f"observer:{reason}"]
+
     terms: list[str] = []
     if lap.get("is_valid") is not True:
         terms.append("lap_not_ac_valid")
-    if state.get("setup_hash") is None:
-        terms.append("missing_setup_identity")
     if state.get("tag") == "unknown":
         terms.append("unknown_thermal_tag")
     if _below(state.get("sample_coverage_fraction"), DEFAULT_THERMAL_COVERAGE_FRACTION):
@@ -1603,10 +1619,10 @@ def _failed_eligibility_terms(lap: dict, state: dict) -> list[str]:
         terms.append("wheel_spread_unmeasurable")
     elif isinstance(spread, (int, float)) and spread > DEFAULT_THERMAL_MAX_WHEEL_SPREAD_C:
         terms.append("wheel_spread_above_max")
-    if not terms and state.get("fit_eligible") is not True:
-        # The conjunction rejected it for something not re-derived above (e.g. missing tyre
-        # compound identity). Never report "no failing terms" for an ineligible lap — say so.
-        terms.append(f"other:{state.get('reason')}")
+    if not terms:
+        # Rejected by the conjunction for something not re-derived above. Never report "no
+        # failing terms" for an ineligible lap — say that it could not be classified.
+        terms.append(f"other:{reason}")
     return terms
 
 
@@ -1659,8 +1675,14 @@ def _thermal_eligibility_report(archives: list[dict]) -> dict:
         report["laps"].append(entry)
         failing.update(terms)
     if failing:
-        # The headline: one line an operator can read without opening the archives.
-        report["dominant_term"], report["dominant_count"] = failing.most_common(1)[0]
+        # The headline: one line an operator can read without opening the archives. Report ALL
+        # tied causes rather than letting Counter's insertion order pick a winner — one
+        # low-coverage lap and one unstable lap is a different situation from two unstable laps,
+        # and naming only one of them sends the next session down the wrong path (#749 Codex P2).
+        report["dominant_count"] = failing.most_common(1)[0][1]
+        report["dominant_terms"] = sorted(
+            term for term, count in failing.items() if count == report["dominant_count"]
+        )
         report["failing_term_counts"] = dict(failing)
     report["eligible_count"] = sum(
         1 for entry in report["laps"] if entry.get("fit_eligible") is True


### PR DESCRIPTION
Part of [#749](https://github.com/agorokh/ac-copilot-trainer/issues/749) — the **observability** increment only. Deliberately does **not** change any eligibility decision.

## Why

A refused refit recorded only the symptom:

```
auto-alien: iteration 2 refine FAILED — keeping the last-valid plant
  (thermal uncertainty fit error: ValueError: no thermally consistent valid lap archives)
```

Nothing about **which** of the seven eligibility terms rejected **which** lap, or by how much.

That silence is the expensive part. A ladder whose refits are refused stops compounding **silently** — the drives still pass, iterations still report VALID, and nothing in the report says the plant has stopped improving. Diagnosing the 2026-08-10 huracan@spa stall meant re-running `observe_lap_tyre_state` over the archives by hand to establish that `stability` (measured **0.41–0.62** against the **0.80** floor) was the *only* failing term, with wheel spread (9.9–12.0 vs a 15 °C cap), coverage (1.0), setup identity and lap validity all passing. That should have been readable from the report.

## What changed

- `selfplay_refine_result` attaches **`thermal_eligibility`** to the failure block: per lap the verdict, reason, and measured `sample_coverage_fraction` / `thermal_stability_fraction` / `wheel_spread_c` / `core_temp_c` / `setup_hash` — plus the **thresholds** they are judged against and the **dominant failing reason**.
- `auto_alien` prints that headline beside the refine-FAILED line, so a stalled ladder is visible in the console:

```
auto-alien: iteration 2 thermal cohort empty — 2/2 lap(s): outside thermal stability/validity gate
```

Reporting the terms that **passed** matters as much as the one that failed — that is what stops the next session re-deriving "is it wheel spread? coverage? setup identity?" by hand.

## Safety

Strictly diagnostic. Computed inside the existing `except` branch, per-lap observer calls individually guarded so a diagnostics failure can never mask the real fit error, and no eligibility decision is affected.

## Verification

- New test reproduces the **real stall shape**: every lap AC-valid with a real setup identity and full coverage, core temps swinging so per-wheel stability falls under the floor. Asserts `eligible_count == 0`, the dominant reason, the reported thresholds, and that each lap shows both the failing term *and* the passing ones.
- `pytest tests/test_plant_id.py tests/test_ggv_profile.py tests/test_auto_alien.py tests/test_alien_scientist.py` → **251 passed**
- `make ci-fast: OK` — **4053 passed, 73 skipped**

## Not in scope

The physics fix. #749's decision — temperature-tagged friction rows (option a) — changes the friction model and the plant schema and needs its own review. Option (c), a thermal settling budget, was **refuted by trace measurement** (temps cycle per lap and reset rather than climbing to a plateau), and my "the gate systematically rejects fast laps" framing was **withdrawn** after measuring 3/71 rejections across the full history. Both corrections are recorded on #749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)